### PR TITLE
Cleanup particle shape structs

### DIFF
--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -47,7 +47,7 @@ namespace currentSolver
             /* VillaBune: field to particle interpolation _requires_ the CIC shape */
             PMACC_CASSERT_MSG_TYPE(currentSolverVillaBune_requires_shapeCIC_in_particleConfig,
                         T_ParticleShape,
-                        T_ParticleShape::support == 2);
+                        T_ParticleShape::assignmentFunctionOrder == 1);
 
             // normalize deltaPos to innerCell units [0.; 1.)
             //   that means: dx_real   = v.x() * dt

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -22,8 +22,11 @@
 #include <pmacc/types.hpp>
 #include "picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def"
 #include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/shapes/CIC.hpp"
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/math/Vector.hpp>
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -47,7 +50,7 @@ namespace currentSolver
             /* VillaBune: field to particle interpolation _requires_ the CIC shape */
             PMACC_CASSERT_MSG_TYPE(currentSolverVillaBune_requires_shapeCIC_in_particleConfig,
                         T_ParticleShape,
-                        T_ParticleShape::assignmentFunctionOrder == 1);
+                        std::is_same<T_ParticleShape, particles::shapes::CIC>::value);
 
             // normalize deltaPos to innerCell units [0.; 1.)
             //   that means: dx_real   = v.x() * dt

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -35,11 +35,12 @@ namespace detail
 
     struct CIC
     {
-        /**
-         * width of the support of this form_factor. This is the area where the function
-         * is non-zero.
+        /** Support of the assignment function in cells
+         *
+         * Specifies width of the area where the function can be non-zero.
+         * Is the same for all directions
          */
-        static constexpr int support = 2;
+        static constexpr uint32_t support = 2;
     };
 
 } // namespace detail
@@ -53,7 +54,7 @@ namespace detail
     {
 
         //! Order of the assignment function spline
-        static constexpr uint32_t assignmentFunctionOrder = 1u;
+        static constexpr uint32_t assignmentFunctionOrder = detail::CIC::support - 1u;
 
         struct ChargeAssignment : public detail::CIC
         {

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -27,64 +27,64 @@ namespace particles
 {
 namespace shapes
 {
-namespace shared_CIC
+namespace detail
 {
 
-struct CIC
-{
-    /**
-     * width of the support of this form_factor. This is the area where the function
-     * is non-zero.
-     */
-    static constexpr int support = 2;
-};
-
-}//namespace shared_CIC
-
-struct CIC : public shared_CIC::CIC
-{
-
-    struct ChargeAssignment : public shared_CIC::CIC
+    struct CIC
     {
-
-        HDINLINE float_X operator()( float_X const x )
-        {
-            /*       -
-             *       |  1-|x|           if |x|<1
-             * W(x)=<|
-             *       |  0               otherwise
-             *       -
-             */
-            float_X const abs_x = math::abs( x );
-
-            bool const below_1 = abs_x < 1.0_X;
-            float_X const onSupport = 1.0_X - abs_x;
-
-            float_X result( 0.0 );
-            if( below_1 )
-                result = onSupport;
-
-            return result;
-        }
-    };
-
-    struct ChargeAssignmentOnSupport : public shared_CIC::CIC
-    {
-
-        /** form factor of this particle shape.
-         * \param x has to be within [-support/2, support/2]
+        /**
+         * width of the support of this form_factor. This is the area where the function
+         * is non-zero.
          */
-        HDINLINE float_X operator()( float_X const x )
-        {
-            /*
-             * W(x)=1-|x|
-             */
-            return 1.0_X - math::abs( x );
-        }
-
+        static constexpr int support = 2;
     };
 
-};
+} // namespace detail
+
+    struct CIC : public detail::CIC
+    {
+
+        struct ChargeAssignment : public detail::CIC
+        {
+
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*       -
+                 *       |  1-|x|           if |x|<1
+                 * W(x)=<|
+                 *       |  0               otherwise
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
+
+                bool const below_1 = abs_x < 1.0_X;
+                float_X const onSupport = 1.0_X - abs_x;
+
+                float_X result( 0.0 );
+                if( below_1 )
+                    result = onSupport;
+
+                return result;
+            }
+        };
+
+        struct ChargeAssignmentOnSupport : public detail::CIC
+        {
+
+            /** form factor of this particle shape.
+             * \param x has to be within [-support/2, support/2]
+             */
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*
+                 * W(x)=1-|x|
+                 */
+                return 1.0_X - math::abs( x );
+            }
+
+        };
+
+    };
 
 } // namespace shapes
 } // namespace particles

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -41,6 +41,11 @@ namespace detail
 
 } // namespace detail
 
+    /** Cloud-in-cell particle shape
+     *
+     * Cloud density form: piecewise constant
+     * Assignment function: first order B-spline
+     */
     struct CIC : public detail::CIC
     {
 

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -43,7 +43,6 @@ struct CIC
 
 struct CIC : public shared_CIC::CIC
 {
-    using CloudShape = picongpu::particles::shapes::NGP;
 
     struct ChargeAssignment : public shared_CIC::CIC
     {

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2020 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,9 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
 
 namespace picongpu
 {
@@ -46,8 +49,11 @@ namespace detail
      * Cloud density form: piecewise constant
      * Assignment function: first order B-spline
      */
-    struct CIC : public detail::CIC
+    struct CIC
     {
+
+        //! Order of the assignment function spline
+        static constexpr uint32_t assignmentFunctionOrder = 1u;
 
         struct ChargeAssignment : public detail::CIC
         {

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -35,15 +35,15 @@ namespace detail
 
     struct Counter
     {
-        /**
-         * width of the support of this form_factor. This is the area where the function
-         * is non-zero.
+        /** Support of the assignment function in cells
          *
+         * Specifies width of the area where the function can be non-zero.
+         * Is the same for all directions.
          * Note that the support is actually 1, but this shape is used only for
          * certain operations and not as the main simulation shape, and so for
          * enabling more generic implementations is set to one.
          */
-        static constexpr int support = 0;
+        static constexpr uint32_t support = 0;
     };
 
 } // namespace detail
@@ -58,7 +58,11 @@ namespace detail
     struct Counter
     {
 
-        //! Order of the assignment function spline
+        /** Order of the assignment function spline
+         *
+         * Note that here the detail::Counter::support - 1u expression would
+         * not work, as the support of that shape is artificially set to 0
+         */
         static constexpr uint32_t assignmentFunctionOrder = 0u;
 
         struct ChargeAssignment : public detail::Counter
@@ -83,7 +87,7 @@ namespace detail
         {
 
             /** form factor of this particle shape.
-             * \param x has to be within [-support/2, support/2)
+             * \param x has to be within [0, 1)
              */
             HDINLINE float_X operator()( float_X const x )
             {

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -21,6 +21,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include <cstdint>
+
 
 namespace picongpu
 {
@@ -36,6 +38,10 @@ namespace detail
         /**
          * width of the support of this form_factor. This is the area where the function
          * is non-zero.
+         *
+         * Note that the support is actually 1, but this shape is used only for
+         * certain operations and not as the main simulation shape, and so for
+         * enabling more generic implementations is set to one.
          */
         static constexpr int support = 0;
     };
@@ -49,8 +55,11 @@ namespace detail
      * Cloud density form: delta function, shifted by half cell
      * Assignment function: zero order B-spline, shifted by half cell
      */
-    struct Counter : public detail::Counter
+    struct Counter
     {
+
+        //! Order of the assignment function spline
+        static constexpr uint32_t assignmentFunctionOrder = 0u;
 
         struct ChargeAssignment : public detail::Counter
         {

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -42,6 +42,13 @@ namespace detail
 
 } // namespace detail
 
+    /** Version of nearest grid point particle shape used for counting particles
+     *
+     * Not to be used as a general particle shape in a simulation
+     *
+     * Cloud density form: delta function, shifted by half cell
+     * Assignment function: zero order B-spline, shifted by half cell
+     */
     struct Counter : public detail::Counter
     {
 

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -17,10 +17,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
 
 namespace picongpu
 {
@@ -28,25 +28,24 @@ namespace particles
 {
 namespace shapes
 {
+namespace detail
+{
 
-    namespace shared_Counter
+    struct Counter
+    {
+        /**
+         * width of the support of this form_factor. This is the area where the function
+         * is non-zero.
+         */
+        static constexpr int support = 0;
+    };
+
+} // namespace detail
+
+    struct Counter : public detail::Counter
     {
 
-        struct Counter
-        {
-            /**
-             * width of the support of this form_factor. This is the area where the function
-             * is non-zero.
-             */
-            static constexpr int support = 0;
-        };
-
-    } // namespace shared_Counter
-
-    struct Counter : public shared_Counter::Counter
-    {
-
-        struct ChargeAssignment : public shared_Counter::Counter
+        struct ChargeAssignment : public detail::Counter
         {
 
             HDINLINE float_X operator()( float_X const x )
@@ -64,7 +63,7 @@ namespace shapes
             }
         };
 
-        struct ChargeAssignmentOnSupport : public shared_Counter::Counter
+        struct ChargeAssignmentOnSupport : public detail::Counter
         {
 
             /** form factor of this particle shape.

--- a/include/picongpu/particles/shapes/NGP.hpp
+++ b/include/picongpu/particles/shapes/NGP.hpp
@@ -42,6 +42,11 @@ namespace detail
 
 } // namespace detail
 
+    /** Nearest grid point particle shape
+     *
+     * Cloud density form: delta function
+     * Assignment function: zero order B-spline
+     */
     struct NGP : public detail::NGP
     {
 

--- a/include/picongpu/particles/shapes/NGP.hpp
+++ b/include/picongpu/particles/shapes/NGP.hpp
@@ -35,11 +35,12 @@ namespace detail
 
     struct NGP
     {
-        /**
-         * width of the support of this form_factor. This is the area where the function
-         * is non-zero.
+        /** Support of the assignment function in cells
+         *
+         * Specifies width of the area where the function can be non-zero.
+         * Is the same for all directions
          */
-        static constexpr int support = 1;
+        static constexpr uint32_t support = 1;
     };
 
 } // namespace detail
@@ -53,7 +54,7 @@ namespace detail
     {
 
         //! Order of the assignment function spline
-        static constexpr uint32_t assignmentFunctionOrder = 0u;
+        static constexpr uint32_t assignmentFunctionOrder = detail::NGP::support - 1u;
 
         struct ChargeAssignment : public detail::NGP
         {

--- a/include/picongpu/particles/shapes/NGP.hpp
+++ b/include/picongpu/particles/shapes/NGP.hpp
@@ -17,10 +17,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
 
 namespace picongpu
 {
@@ -28,25 +28,24 @@ namespace particles
 {
 namespace shapes
 {
+namespace detail
+{
 
-    namespace shared_NGP
+    struct NGP
+    {
+        /**
+         * width of the support of this form_factor. This is the area where the function
+         * is non-zero.
+         */
+        static constexpr int support = 1;
+    };
+
+} // namespace detail
+
+    struct NGP : public detail::NGP
     {
 
-        struct NGP
-        {
-            /**
-             * width of the support of this form_factor. This is the area where the function
-             * is non-zero.
-             */
-            static constexpr int support = 1;
-        };
-
-    } // namespace shared_NGP
-
-    struct NGP : public shared_NGP::NGP
-    {
-
-        struct ChargeAssignment : public shared_NGP::NGP
+        struct ChargeAssignment : public detail::NGP
         {
 
             HDINLINE float_X operator()( float_X const x )
@@ -64,7 +63,7 @@ namespace shapes
             }
         };
 
-        struct ChargeAssignmentOnSupport : public shared_NGP::NGP
+        struct ChargeAssignmentOnSupport : public detail::NGP
         {
 
             /** form factor of this particle shape.

--- a/include/picongpu/particles/shapes/NGP.hpp
+++ b/include/picongpu/particles/shapes/NGP.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,8 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
 
 
 namespace picongpu
@@ -47,8 +49,11 @@ namespace detail
      * Cloud density form: delta function
      * Assignment function: zero order B-spline
      */
-    struct NGP : public detail::NGP
+    struct NGP
     {
+
+        //! Order of the assignment function spline
+        static constexpr uint32_t assignmentFunctionOrder = 0u;
 
         struct ChargeAssignment : public detail::NGP
         {

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -27,128 +27,127 @@ namespace particles
 {
 namespace shapes
 {
-
-namespace shared_P4S
+namespace detail
 {
 
-struct P4S
-{
-    static constexpr int support = 5;
-
-    HDINLINE static float_X ff_1st_radius( float_X const x )
+    struct P4S
     {
-        /*
-         * W(x)= 115/192 - 5/8 * x^2 + 1/4 * x^4
-         *     = 115/192 + x^2 * (-5/8 + 1/4 * x^2)
-         */
-        float_X const square_x = x * x;
-        return 115._X / 192._X + square_x * (
-            -5._X / 8._X +
-            1.0_X / 4.0_X * square_x
-        );
-    }
+        static constexpr int support = 5;
 
-    HDINLINE static float_X ff_2nd_radius( float_X const x )
-    {
-        /*
-         * W(x)= 1/96 * (55 + 20 * x - 120 * x^2 + 80 * x^3 - 16 * x^4)
-         *     = 1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x))))
-         */
-        return 1._X / 96._X * (
-            55._X + 4._X * x * (
-                5._X - 2._X * x * (
-                    15._X + 2._X * x * (
-                        -5._X + x
+        HDINLINE static float_X ff_1st_radius( float_X const x )
+        {
+            /*
+             * W(x)= 115/192 - 5/8 * x^2 + 1/4 * x^4
+             *     = 115/192 + x^2 * (-5/8 + 1/4 * x^2)
+             */
+            float_X const square_x = x * x;
+            return 115._X / 192._X + square_x * (
+                -5._X / 8._X +
+                1.0_X / 4.0_X * square_x
+            );
+        }
+
+        HDINLINE static float_X ff_2nd_radius( float_X const x )
+        {
+            /*
+             * W(x)= 1/96 * (55 + 20 * x - 120 * x^2 + 80 * x^3 - 16 * x^4)
+             *     = 1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x))))
+             */
+            return 1._X / 96._X * (
+                55._X + 4._X * x * (
+                    5._X - 2._X * x * (
+                        15._X + 2._X * x * (
+                            -5._X + x
+                        )
                     )
                 )
-            )
-        );
-    }
-
-    HDINLINE static float_X ff_3rd_radius( float_X const x )
-    {
-        /*
-         * W(x)=1/384 * (5 - 2*x)^4
-         */
-        float_X const tmp = 5._X - 2._X * x;
-        float_X const square_tmp = tmp * tmp;
-        float_X const biquadratic_tmp = square_tmp * square_tmp;
-
-        return 1._X / 384._X * biquadratic_tmp;
-    }
-};
-
-} //namespace shared_P4S
-
-/** particle assignment shape `piecewise biquadratic spline`
- */
-struct P4S : public shared_P4S::P4S
-{
-
-    struct ChargeAssignmentOnSupport : public shared_P4S::P4S
-    {
-
-        HDINLINE float_X operator()( float_X const x )
-        {
-            /*       -
-             *       |  115/192 + x^2 * (-5/8 + 1/4 * x^2)                          if -1/2 < x < 1/2
-             * W(x)=<|
-             *       |  1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x)))) if 1/2 <= |x| < 3/2
-             *       |
-             *       |  1/384 * (5 - 2 * x)^4                                       if 3/2 <= |x| < 5/2
-             *       -
-             */
-            float_X const abs_x = math::abs( x );
-
-            bool const below_2nd_radius = abs_x < 1.5_X;
-            bool const below_1st_radius = abs_x < 0.5_X;
-
-            float_X const rad1 = ff_1st_radius( abs_x );
-            float_X const rad2 = ff_2nd_radius( abs_x );
-            float_X const rad3 = ff_3rd_radius( abs_x );
-
-            float_X result = rad3;
-            if( below_1st_radius )
-                result = rad1;
-            else if( below_2nd_radius )
-                result = rad2;
-
-            return result;
+            );
         }
 
-    };
-
-    struct ChargeAssignment : public shared_P4S::P4S
-    {
-
-        HDINLINE float_X operator()( float_X const x )
+        HDINLINE static float_X ff_3rd_radius( float_X const x )
         {
-
-            /*       -
-             *       |  115/192 + x^2 * (-5/8 + 1/4 * x^2)                          if -1/2 < x < 1/2
-             * W(x)=<|
-             *       |  1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x)))) if 1/2 <= |x| < 3/2
-             *       |
-             *       |  1/384 * (5 - 2*x)^4                                         if 3/2 <= |x| < 5/2
-             *       |
-             *       |  0                                                           otherwise
-             *       -
+            /*
+             * W(x)=1/384 * (5 - 2*x)^4
              */
-            float_X const abs_x = math::abs( x );
+            float_X const tmp = 5._X - 2._X * x;
+            float_X const square_tmp = tmp * tmp;
+            float_X const biquadratic_tmp = square_tmp * square_tmp;
 
-            bool const below_max = abs_x < 2.5_X;
-
-            float_X const onSupport = ChargeAssignmentOnSupport()( abs_x );
-
-            float_X result( 0.0 );
-            if( below_max )
-                result = onSupport;
-
-            return result;
+            return 1._X / 384._X * biquadratic_tmp;
         }
     };
-};
+
+} // namespace detail
+
+    /** particle assignment shape `piecewise biquadratic spline`
+     */
+    struct P4S : public detail::P4S
+    {
+
+        struct ChargeAssignmentOnSupport : public detail::P4S
+        {
+
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*       -
+                 *       |  115/192 + x^2 * (-5/8 + 1/4 * x^2)                          if -1/2 < x < 1/2
+                 * W(x)=<|
+                 *       |  1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x)))) if 1/2 <= |x| < 3/2
+                 *       |
+                 *       |  1/384 * (5 - 2 * x)^4                                       if 3/2 <= |x| < 5/2
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
+
+                bool const below_2nd_radius = abs_x < 1.5_X;
+                bool const below_1st_radius = abs_x < 0.5_X;
+
+                float_X const rad1 = ff_1st_radius( abs_x );
+                float_X const rad2 = ff_2nd_radius( abs_x );
+                float_X const rad3 = ff_3rd_radius( abs_x );
+
+                float_X result = rad3;
+                if( below_1st_radius )
+                    result = rad1;
+                else if( below_2nd_radius )
+                    result = rad2;
+
+                return result;
+            }
+
+        };
+
+        struct ChargeAssignment : public detail::P4S
+        {
+
+            HDINLINE float_X operator()( float_X const x )
+            {
+
+                /*       -
+                 *       |  115/192 + x^2 * (-5/8 + 1/4 * x^2)                          if -1/2 < x < 1/2
+                 * W(x)=<|
+                 *       |  1/96 * (55 + 4 * x * (5 - 2 * x * (15 + 2 * x * (-5 + x)))) if 1/2 <= |x| < 3/2
+                 *       |
+                 *       |  1/384 * (5 - 2*x)^4                                         if 3/2 <= |x| < 5/2
+                 *       |
+                 *       |  0                                                           otherwise
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
+
+                bool const below_max = abs_x < 2.5_X;
+
+                float_X const onSupport = ChargeAssignmentOnSupport()( abs_x );
+
+                float_X result( 0.0 );
+                if( below_max )
+                    result = onSupport;
+
+                return result;
+            }
+        };
+    };
 
 } // namespace shapes
-} //namespace particles
-} //namespace picongpu
+} // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -79,7 +79,14 @@ namespace detail
 
 } // namespace detail
 
-    /** particle assignment shape `piecewise biquadratic spline`
+    /** Piecewise cubic cloud particle shape
+     *
+     * Note that this shape name does not follow the NGP / CIC / TSC notation
+     * which names the cloud density. Rather, P4S is the name of the
+     * corresponding assignment function, same as for the PCS shape.
+     *
+     * Cloud density form: piecewise cubic
+     * Assignment function: fourth order B-spline
      */
     struct P4S : public detail::P4S
     {

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2020 Rene Widera, Axel Huebl
+/* Copyright 2015-2020 Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,9 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
 
 namespace picongpu
 {
@@ -88,8 +91,11 @@ namespace detail
      * Cloud density form: piecewise cubic
      * Assignment function: fourth order B-spline
      */
-    struct P4S : public detail::P4S
+    struct P4S
     {
+
+        //! Order of the assignment function spline
+        static constexpr uint32_t assignmentFunctionOrder = 4u;
 
         struct ChargeAssignmentOnSupport : public detail::P4S
         {

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -35,7 +35,12 @@ namespace detail
 
     struct P4S
     {
-        static constexpr int support = 5;
+        /** Support of the assignment function in cells
+         *
+         * Specifies width of the area where the function can be non-zero.
+         * Is the same for all directions
+         */
+        static constexpr uint32_t support = 5;
 
         HDINLINE static float_X ff_1st_radius( float_X const x )
         {
@@ -95,7 +100,7 @@ namespace detail
     {
 
         //! Order of the assignment function spline
-        static constexpr uint32_t assignmentFunctionOrder = 4u;
+        static constexpr uint32_t assignmentFunctionOrder = detail::P4S::support - 1u;
 
         struct ChargeAssignmentOnSupport : public detail::P4S
         {

--- a/include/picongpu/particles/shapes/P4S.hpp
+++ b/include/picongpu/particles/shapes/P4S.hpp
@@ -84,7 +84,6 @@ struct P4S
  */
 struct P4S : public shared_P4S::P4S
 {
-    using CloudShape = picongpu::particles::shapes::PCS;
 
     struct ChargeAssignmentOnSupport : public shared_P4S::P4S
     {

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -60,7 +60,6 @@ struct PCS
 } //namespace shared_PCS
 struct PCS : public shared_PCS::PCS
 {
-    using CloudShape = picongpu::particles::shapes::TSC;
 
     struct ChargeAssignment : public shared_PCS::PCS
     {

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2020 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -20,6 +20,9 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
 
 namespace picongpu
 {
@@ -67,8 +70,11 @@ namespace detail
      * Cloud density form: piecewise quadratic
      * Assignment function: third order B-spline
      */
-    struct PCS : public detail::PCS
+    struct PCS
     {
+
+        //! Order of the assignment function spline
+        static constexpr uint32_t assignmentFunctionOrder = 3u;
 
         struct ChargeAssignment : public detail::PCS
         {

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -57,6 +57,16 @@ namespace detail
 
 } // namespace detail
 
+    /** Piecewise quadratic cloud particle shape
+     *
+     * Note that this shape name does not follow the NGP / CIC / TSC notation
+     * which names the cloud density. Rather, PCS is the name of the
+     * corresponding assignment function. While the cloud-shape-based name
+     * would be PQS.
+     *
+     * Cloud density form: piecewise quadratic
+     * Assignment function: third order B-spline
+     */
     struct PCS : public detail::PCS
     {
 

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -27,102 +27,101 @@ namespace particles
 {
 namespace shapes
 {
-
-namespace shared_PCS
-{
-struct PCS
-{
-    static constexpr int support = 4;
-
-
-
-    HDINLINE static float_X ff_1st_radius( float_X const x )
-    {
-        /*
-         * W(x)=1/6*(4 - 6*x^2 + 3*|x|^3)
-         */
-        float_X const square_x = x * x;
-        float_X const triple_x = square_x * x;
-        return 1.0_X / 6.0_X * ( 4.0_X - 6.0_X * square_x + 3.0_X * triple_x );
-    }
-
-    HDINLINE static float_X ff_2nd_radius( float_X const x )
-    {
-        /*
-         * W(x)=1/6*(2 - |x|)^3
-         */
-        float_X const tmp = 2.0_X - x;
-        float_X const triple_tmp = tmp * tmp * tmp;
-        return 1.0_X / 6.0_X * triple_tmp;
-    }
-};
-
-} //namespace shared_PCS
-struct PCS : public shared_PCS::PCS
+namespace detail
 {
 
-    struct ChargeAssignment : public shared_PCS::PCS
+    struct PCS
     {
+        static constexpr int support = 4;
 
-        HDINLINE float_X operator()( float_X const x )
+        HDINLINE static float_X ff_1st_radius( float_X const x )
         {
-            /*       -
-             *       |  1/6*(4 - 6*x^2 + 3*|x|^3)   if 0<=|x|<1
-             * W(x)=<|  1/6*(2 - |x|)^3             if 1<=|x|<2
-             *       |  0                           otherwise
-             *       -
+            /*
+             * W(x)=1/6*(4 - 6*x^2 + 3*|x|^3)
              */
-            float_X const abs_x = math::abs( x );
+            float_X const square_x = x * x;
+            float_X const triple_x = square_x * x;
+            return 1.0_X / 6.0_X * ( 4.0_X - 6.0_X * square_x + 3.0_X * triple_x );
+        }
 
-            bool const below_1 = abs_x < 1.0_X;
-            bool const below_2 = abs_x < 2.0_X;
-
-            float_X const rad1 = ff_1st_radius( abs_x );
-            float_X const rad2 = ff_2nd_radius( abs_x );
-
-            float_X result( 0.0 );
-            if( below_1 )
-                result = rad1;
-            else if( below_2 )
-                result = rad2;
-
-            return result;
+        HDINLINE static float_X ff_2nd_radius( float_X const x )
+        {
+            /*
+             * W(x)=1/6*(2 - |x|)^3
+             */
+            float_X const tmp = 2.0_X - x;
+            float_X const triple_tmp = tmp * tmp * tmp;
+            return 1.0_X / 6.0_X * triple_tmp;
         }
     };
 
-    struct ChargeAssignmentOnSupport : public shared_PCS::PCS
+} // namespace detail
+
+    struct PCS : public detail::PCS
     {
 
-        HDINLINE float_X operator()( float_X const x )
+        struct ChargeAssignment : public detail::PCS
         {
-            /*       -
-             *       |  1/6*(4 - 6*x^2 + 3*|x|^3)   if 0<=|x|<1
-             * W(x)=<|
-             *       |  1/6*(2 - |x|)^3             if 1<=|x|<2
-             *       -
-             */
-            float_X const abs_x = math::abs( x );
 
-            bool const below_1 = abs_x < 1.0_X;
-            float_X const rad1 = ff_1st_radius( abs_x );
-            float_X const rad2 = ff_2nd_radius( abs_x );
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*       -
+                 *       |  1/6*(4 - 6*x^2 + 3*|x|^3)   if 0<=|x|<1
+                 * W(x)=<|  1/6*(2 - |x|)^3             if 1<=|x|<2
+                 *       |  0                           otherwise
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
 
-            float_X result = rad2;
-            if( below_1 )
-                result = rad1;
+                bool const below_1 = abs_x < 1.0_X;
+                bool const below_2 = abs_x < 2.0_X;
 
-            return result;
+                float_X const rad1 = ff_1st_radius( abs_x );
+                float_X const rad2 = ff_2nd_radius( abs_x );
 
-            /* Semantics:
-            if( abs_x < 1.0_X )
-                return ff_1st_radius( abs_x );
-            return ff_2nd_radius( abs_x );
-             */
-        }
+                float_X result( 0.0 );
+                if( below_1 )
+                    result = rad1;
+                else if( below_2 )
+                    result = rad2;
+
+                return result;
+            }
+        };
+
+        struct ChargeAssignmentOnSupport : public detail::PCS
+        {
+
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*       -
+                 *       |  1/6*(4 - 6*x^2 + 3*|x|^3)   if 0<=|x|<1
+                 * W(x)=<|
+                 *       |  1/6*(2 - |x|)^3             if 1<=|x|<2
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
+
+                bool const below_1 = abs_x < 1.0_X;
+                float_X const rad1 = ff_1st_radius( abs_x );
+                float_X const rad2 = ff_2nd_radius( abs_x );
+
+                float_X result = rad2;
+                if( below_1 )
+                    result = rad1;
+
+                return result;
+
+                /* Semantics:
+                if( abs_x < 1.0_X )
+                    return ff_1st_radius( abs_x );
+                return ff_2nd_radius( abs_x );
+                 */
+            }
+
+        };
 
     };
-
-};
 
 } // namespace shapes
 } // namespace particles

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -35,7 +35,12 @@ namespace detail
 
     struct PCS
     {
-        static constexpr int support = 4;
+        /** Support of the assignment function in cells
+         *
+         * Specifies width of the area where the function can be non-zero.
+         * Is the same for all directions
+         */
+        static constexpr uint32_t support = 4;
 
         HDINLINE static float_X ff_1st_radius( float_X const x )
         {
@@ -74,7 +79,7 @@ namespace detail
     {
 
         //! Order of the assignment function spline
-        static constexpr uint32_t assignmentFunctionOrder = 3u;
+        static constexpr uint32_t assignmentFunctionOrder = detail::PCS::support - 1u;
 
         struct ChargeAssignment : public detail::PCS
         {

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -63,6 +63,11 @@ namespace detail
 
 } // namespace detail
 
+    /** Triagle-shaped cloud particle shape
+     *
+     * Cloud density form: piecewise linear
+     * Assignment function: second order B-spline
+     */
     struct TSC : public detail::TSC
     {
 

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -65,7 +65,6 @@ struct TSC
 
 struct TSC : public shared_TSC::TSC
 {
-    using CloudShape = picongpu::particles::shapes::CIC;
 
     struct ChargeAssignment : public shared_TSC::TSC
     {

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -37,12 +37,12 @@ namespace detail
 
     struct TSC
     {
-        /**
-         * width of the support of this form_factor. This is the area where the function
-         * is non-zero.
+        /** Support of the assignment function in cells
+         *
+         * Specifies width of the area where the function can be non-zero.
+         * Is the same for all directions
          */
-        static constexpr int support = 3;
-
+        static constexpr uint32_t support = 3;
 
         HDINLINE static float_X ff_1st_radius( float_X const x )
         {
@@ -75,7 +75,7 @@ namespace detail
     {
 
         //! Order of the assignment function spline
-        static constexpr uint32_t assignmentFunctionOrder = 2u;
+        static constexpr uint32_t assignmentFunctionOrder = detail::TSC::support - 1u;
 
         struct ChargeAssignment : public detail::TSC
         {

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -29,104 +29,104 @@ namespace particles
 namespace shapes
 {
 
-namespace shared_TSC
+namespace detail
 {
 
-struct TSC
-{
-    /**
-     * width of the support of this form_factor. This is the area where the function
-     * is non-zero.
-     */
-    static constexpr int support = 3;
-
-
-    HDINLINE static float_X ff_1st_radius( float_X const x )
+    struct TSC
     {
-        /*
-         * W(x)=3/4 - x^2
+        /**
+         * width of the support of this form_factor. This is the area where the function
+         * is non-zero.
          */
-        float_X const square_x = x * x;
-        return 0.75_X - square_x;
-    }
+        static constexpr int support = 3;
 
-    HDINLINE static float_X ff_2nd_radius( float_X const x )
-    {
-        /*
-         * W(x)=1/2*(3/2 - |x|)^2
-         */
-        float_X const tmp = 3.0_X / 2.0_X - x;
-        float_X const square_tmp = tmp * tmp;
-        return 0.5_X * square_tmp;
-    }
-};
 
-} //namespace shared_TSC
-
-struct TSC : public shared_TSC::TSC
-{
-
-    struct ChargeAssignment : public shared_TSC::TSC
-    {
-
-        HDINLINE float_X operator()( float_X const x )
+        HDINLINE static float_X ff_1st_radius( float_X const x )
         {
-            /*       -
-             *       |  3/4 - x^2                  if |x|<1/2
-             * W(x)=<|  1/2*(3/2 - |x|)^2          if 1/2<=|x|<3/2
-             *       |  0                          otherwise
-             *       -
+            /*
+             * W(x)=3/4 - x^2
              */
-            float_X const abs_x = math::abs( x );
+            float_X const square_x = x * x;
+            return 0.75_X - square_x;
+        }
 
-            bool const below_05 = abs_x < 0.5_X;
-            bool const below_1_5 = abs_x < 1.5_X;
-
-            float_X const rad1 = ff_1st_radius( abs_x );
-            float_X const rad2 = ff_2nd_radius( abs_x );
-
-            float_X result( 0.0 );
-            if( below_05 )
-                result = rad1;
-            else if( below_1_5 )
-                result = rad2;
-
-            return result;
-
+        HDINLINE static float_X ff_2nd_radius( float_X const x )
+        {
+            /*
+             * W(x)=1/2*(3/2 - |x|)^2
+             */
+            float_X const tmp = 3.0_X / 2.0_X - x;
+            float_X const square_tmp = tmp * tmp;
+            return 0.5_X * square_tmp;
         }
     };
 
-    struct ChargeAssignmentOnSupport : public shared_TSC::TSC
+} // namespace detail
+
+    struct TSC : public detail::TSC
     {
 
-        /** form factor of this particle shape.
-         * \param x has to be within [-support/2, support/2]
-         */
-        HDINLINE float_X operator()( float_X const x )
+        struct ChargeAssignment : public detail::TSC
         {
-            /*       -
-             *       |  3/4 - x^2                  if |x|<1/2
-             * W(x)=<|
-             *       |  1/2*(3/2 - |x|)^2          if 1/2<=|x|<3/2
-             *       -
+
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*       -
+                 *       |  3/4 - x^2                  if |x|<1/2
+                 * W(x)=<|  1/2*(3/2 - |x|)^2          if 1/2<=|x|<3/2
+                 *       |  0                          otherwise
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
+
+                bool const below_05 = abs_x < 0.5_X;
+                bool const below_1_5 = abs_x < 1.5_X;
+
+                float_X const rad1 = ff_1st_radius( abs_x );
+                float_X const rad2 = ff_2nd_radius( abs_x );
+
+                float_X result( 0.0 );
+                if( below_05 )
+                    result = rad1;
+                else if( below_1_5 )
+                    result = rad2;
+
+                return result;
+
+            }
+        };
+
+        struct ChargeAssignmentOnSupport : public detail::TSC
+        {
+
+            /** form factor of this particle shape.
+             * \param x has to be within [-support/2, support/2]
              */
-            float_X const abs_x = math::abs( x );
+            HDINLINE float_X operator()( float_X const x )
+            {
+                /*       -
+                 *       |  3/4 - x^2                  if |x|<1/2
+                 * W(x)=<|
+                 *       |  1/2*(3/2 - |x|)^2          if 1/2<=|x|<3/2
+                 *       -
+                 */
+                float_X const abs_x = math::abs( x );
 
-            bool const below_05 = abs_x < 0.5_X;
+                bool const below_05 = abs_x < 0.5_X;
 
-            float_X const rad1 = ff_1st_radius( abs_x );
-            float_X const rad2 = ff_2nd_radius( abs_x );
+                float_X const rad1 = ff_1st_radius( abs_x );
+                float_X const rad2 = ff_2nd_radius( abs_x );
 
-            float_X result = rad2;
-            if( below_05 )
-                result = rad1;
+                float_X result = rad2;
+                if( below_05 )
+                    result = rad1;
 
-            return result;
-        }
+                return result;
+            }
+
+        };
 
     };
-
-};
 
 } // namespace shapes
 } // namespace partciles

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2020 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2020 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -21,6 +21,9 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
 
 namespace picongpu
 {
@@ -68,8 +71,11 @@ namespace detail
      * Cloud density form: piecewise linear
      * Assignment function: second order B-spline
      */
-    struct TSC : public detail::TSC
+    struct TSC
     {
+
+        //! Order of the assignment function spline
+        static constexpr uint32_t assignmentFunctionOrder = 2u;
 
         struct ChargeAssignment : public detail::TSC
         {

--- a/include/picongpu/plugins/adios/ADIOSCountParticles.hpp
+++ b/include/picongpu/plugins/adios/ADIOSCountParticles.hpp
@@ -141,7 +141,7 @@ public:
 
         /* openPMD ED-PIC: additional attributes */
         traits::PICToAdios<float_64> adiosDoubleType;
-        const float_64 particleShape( GetShape<ThisSpecies>::type::support - 1 );
+        const float_64 particleShape( GetShape<ThisSpecies>::type::assignmentFunctionOrder );
         ADIOS_CMD(adios_define_attribute_byvalue(params->adiosGroupHandle,
             "particleShape", speciesPath.c_str(),
             adiosDoubleType.type, 1, (void*)&particleShape ));

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -337,7 +337,7 @@ namespace openPMD
         setParticleAttributes( ::openPMD::Iteration & iteration )
         {
             const float_64 particleShape(
-                GetShape< ThisSpecies >::type::support - 1 );
+                GetShape< ThisSpecies >::type::assignmentFunctionOrder );
             iteration.setAttribute( "particleShape", particleShape );
 
             traits::GetSpeciesFlagName< ThisSpecies, current<> >


### PR DESCRIPTION
This PR introduces some cleanup of the particle shapes in a few directions. The implementation is not changed, just slightly modernized and better documented. Hopefully, this avoids confusion like I had when discussing it with @psychocoderHPC a couple of days ago. Along the way, it fixes a bug with the `Counter` shape used in the SAXS test that resulted in output shape being -1.