### PR TITLE
update summit profile to include openPMD

### DIFF
--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -32,6 +32,9 @@ module load boost/1.66.0
 # plugins (optional) ##########################################################
 module load hdf5/1.10.3
 module load adios/1.13.1-py2 c-blosc zfp sz lz4
+module load ums
+module load ums-aph114
+module load openpmd-api/0.12.0
 
 # optionally download libSplash and compile it yourself from
 #   https://github.com/ComputationalRadiationPhysics/libSplash/


### PR DESCRIPTION
This pull request updates out example profile for summit/ORNL. The modules loaded now includes adios2 2.6.0 and openPMD-api 0.12.0. This was set up by @ax3l for https://github.com/ECP-WarpX/WarpX/pull/1369 and reported in #3382. 