### PR TITLE
Fix the name of probe fieldE and fieldB attribute in docs

### DIFF
--- a/docs/source/usage/workflows/probeParticles.rst
+++ b/docs/source/usage/workflows/probeParticles.rst
@@ -16,7 +16,7 @@ Self-consistently interacting particles are usually called :ref:`tracer particle
 Workflow
 """"""""
 
-* ``speciesDefinition.param``: create a species specifically for probes and add ``fieldE`` and ``fieldB`` attributes to it for storing interpolated fields
+* ``speciesDefinition.param``: create a species specifically for probes and add ``probeE`` and ``probeB`` attributes to it for storing interpolated fields
 
 .. code-block:: cpp
 


### PR DESCRIPTION
It did not match to implementation, while the exact names are required by probe pusher