### PR TITLE
Add a new compile-time test suite to test all particle pushers

### DIFF
--- a/share/picongpu/tests/compileParticlePusher/README.rst
+++ b/share/picongpu/tests/compileParticlePusher/README.rst
@@ -1,0 +1,4 @@
+Compile Test for Particle Pushers
+=================================
+
+This test compiles all particle pushers, each for one particle shape.

--- a/share/picongpu/tests/compileParticlePusher/cmakeFlags
+++ b/share/picongpu/tests/compileParticlePusher/cmakeFlags
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2020 Axel Huebl, Rene Widera, Sergei Bastrakov
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+# Pushers are generally independent from particle shapes, so do not attempt to
+# test all possible combinations, just all pushers except Boris (tested in examples)
+flags[0]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=HigueraCary;-DPARAM_PARTICLESHAPE=NGP'"
+flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Vay;-DPARAM_PARTICLESHAPE=CIC'"
+flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz;-DPARAM_PARTICLESHAPE=TSC'"
+flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Boris;-DPARAM_COMPOSITEPUSHER=1;-DPARAM_PARTICLESHAPE=PCS'"
+flags[4]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=HigueraCary;-DPARAM_COMPOSITEPUSHER=1;-DPARAM_PARTICLESHAPE=P4S'"
+flags[5]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Free;-DPARAM_PARTICLESHAPE=CIC'"
+flags[6]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Photon;-DPARAM_PARTICLESHAPE=TSC'"
+flags[7]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Probe;-DPARAM_PARTICLESHAPE=PCS'"
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/density.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/density.param
@@ -1,0 +1,46 @@
+/* Copyright 2013-2020 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/densityProfiles/profiles.def"
+
+
+namespace picongpu
+{
+namespace SI
+{
+    /** Base density in particles per m^3 in the density profiles.
+     *
+     * This is often taken as reference maximum density in normalized profiles.
+     * Individual particle species can define a `densityRatio` flag relative
+     * to this value.
+     *
+     * unit: ELEMENTS/m^3
+     */
+    constexpr float_64 BASE_DENSITY_SI = 1.e25;
+}
+
+namespace densityProfiles
+{
+    /* definition of homogenous profile */
+    using Homogenous = HomogenousImpl;
+}
+}

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/dimension.param
@@ -1,0 +1,31 @@
+/* Copyright 2014-2020 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef PARAM_DIMENSION
+#define PARAM_DIMENSION DIM3
+#endif
+
+#define SIMDIM PARAM_DIMENSION
+
+namespace picongpu
+{
+    constexpr uint32_t simDim = SIMDIM;
+} // namespace picongpu

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/fileOutput.param
@@ -1,0 +1,57 @@
+/* Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt,
+ *                     Benjamin Worpitz, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
+/* some forward declarations we need */
+#include "picongpu/fields/Fields.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+#include <boost/mpl/vector.hpp>
+
+
+namespace picongpu
+{
+
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<>;
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+
+    /** Possible native fields: FieldE, FieldB, FieldJ
+     */
+    using NativeFileOutputFields = MakeSeq_t<>;
+
+    using FileOutputFields = MakeSeq_t<>;
+
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to disable particle output set to
+     *   using FileOutputParticles = MakeSeq_t< >;
+     */
+    using FileOutputParticles = MakeSeq_t<>;
+
+}

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/isaac.param
@@ -1,0 +1,58 @@
+/* Copyright 2016-2020 Alexander Matthes
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Definition which native fields and density fields of particles will be
+ * visualizable with ISAAC. ISAAC is an in-situ visualization library with which
+ * the PIC simulation can be observed while it is running avoiding the time
+ * consuming writing and reading of simulation data for the classical post
+ * processing of data.
+ *
+ * ISAAC can directly visualize natives fields like the E or B field, but
+ * density fields of particles need to be calculated from PIConGPU on the fly
+ * which slightly increases the runtime and the memory consumption. Every
+ * particle density field will reduce the amount of memory left for PIConGPUs
+ * particles and fields.
+ *
+ * To get best performance, ISAAC defines an exponential amount of different
+ * visualization kernels for every combination of (at runtime) activated
+ * fields. So furthermore a lot of fields will increase the compilation time.
+ *
+ */
+
+#pragma once
+
+namespace picongpu
+{
+namespace isaacP
+{
+
+    /** Intermediate list of native particle species of PIConGPU which shall be
+     *  visualized. */
+    using Particle_Seq = MakeSeq_t<>;
+
+
+    /** Compile time sequence of all fields which shall be visualized. Basically
+     *  the join of Native_Seq and Density_Seq. */
+    using Fields_Seq = MakeSeq_t<>;
+
+
+} // namespace isaacP
+} // namespace picongpu

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/particle.param
@@ -1,0 +1,97 @@
+/* Copyright 2013-2020 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/startPosition/functors.def"
+#include "picongpu/particles/manipulators/manipulators.def"
+#include "picongpu/particles/filter/filter.def"
+
+#include <pmacc/nvidia/functors/Assign.hpp>
+
+namespace picongpu
+{
+namespace particles
+{
+    namespace startPosition
+    {
+        struct QuietParam25ppc
+        {
+            /** Count of particles per cell per direction at initial state
+             *  unit: none
+             */
+            using numParticlesPerDimension = typename mCT::shrinkTo<
+                mCT::Int<
+                    5,
+                    5,
+                    1
+                >,
+                simDim
+            >::type;
+        };
+        using Quiet25ppc = QuietImpl< QuietParam25ppc >;
+
+    } // namespace startPosition
+
+    /** a particle with a weighting below MIN_WEIGHTING will not
+     *      be created / will be deleted
+     *  unit: none
+     */
+    constexpr float_X MIN_WEIGHTING = 10.0;
+
+    /** During unit normalization, we assume this is a typical
+     *  number of particles per cell for normalization of weighted
+     *  particle attributes.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = mCT::volume<
+        startPosition::QuietParam25ppc::numParticlesPerDimension
+    >::type::value;
+
+namespace manipulators
+{
+
+    CONST_VECTOR(float_X,3,DriftParamPositive_direction,1.0,0.0,0.0);
+    struct DriftParamPositive
+    {
+        /** Initial particle drift velocity for electrons and ions
+         *  Examples:
+         *    - No drift is equal to 1.0
+         *  unit: none
+         */
+        static constexpr float_64 gamma = 1.021;
+        const DriftParamPositive_direction_t direction;
+    };
+    using AssignXDriftPositive = unary::Drift<
+        DriftParamPositive,
+        nvidia::functors::Assign
+    >;
+
+    struct TemperatureParam
+    {
+        /* Initial temperature
+         *  unit: keV
+         */
+        static constexpr float_64 temperature = 0.0005;
+    };
+    using AddTemperature = unary::Temperature< TemperatureParam >;
+
+} // namespace manipulators
+} // namespace particles
+} // namespace picongpu

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/precision.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/precision.param
@@ -1,0 +1,60 @@
+/* Copyright 2013-2020 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define the precision of typically used floating point types in the
+ * simulation.
+ *
+ * PIConGPU normalizes input automatically, allowing to use single-precision by
+ * default for the core algorithms. Note that implementations of various
+ * algorithms (usually plugins or non-core components) might still decide to
+ * hard-code a different (mixed) precision for some critical operations.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+
+/*! Select a precision for the simulation data
+ *  - precision32Bit : use 32Bit floating point numbers
+ *                     [significant digits 7 to 8]
+ *  - precision64Bit : use 64Bit floating point numbers
+ *                     [significant digits 15 to 16]
+ */
+#ifndef PARAM_PRECISION
+#   define PARAM_PRECISION precision32Bit
+#endif
+namespace precisionPIConGPU      = PARAM_PRECISION;
+
+/*! Select a precision special operations (can be different from simulation precision)
+ *  - precisionPIConGPU : use precision which is selected on top (precisionPIConGPU)
+ *  - precision32Bit    : use 32Bit floating point numbers
+ *  - precision64Bit    : use 64Bit floating point numbers
+ */
+namespace precisionSqrt          = precisionPIConGPU;
+namespace precisionExp           = precisionPIConGPU;
+namespace precisionTrigonometric = precisionPIConGPU;
+
+
+} // namespace picongpu
+
+#include "picongpu/unitless/precision.unitless"

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
@@ -1,0 +1,109 @@
+/* Copyright 2014-2020 Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/shapes.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolationNative.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
+#include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
+
+#include "picongpu/particles/flylite/NonLTE.def"
+#include "picongpu/fields/currentDeposition/Solver.def"
+
+
+namespace picongpu
+{
+/*---------------------------- generic solver---------------------------------*/
+
+/*! Particle Shape definitions -------------------------------------------------
+ *  - particles::shapes::CIC : 1st order
+ *  - particles::shapes::TSC : 2nd order
+ *  - particles::shapes::PCS : 3rd order
+ *  - particles::shapes::P4S : 4th order
+ *
+ *  example: using UsedParticleShape = particles::shapes::CIC;
+ */
+#ifndef PARAM_PARTICLESHAPE
+#define PARAM_PARTICLESHAPE TSC
+#endif
+using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
+
+/* define which interpolation method is used to interpolate fields to particle*/
+using UsedField2Particle = FieldToParticleInterpolation< UsedParticleShape, AssignedTrilinearInterpolation >;
+
+/*! select current solver method
+ * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+ * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PCS, P4S (1st to 4th order)
+ *
+ * For development purposes:
+ * - currentSolver::currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
+ *   without optimization (~4x slower and needs more shared memory)
+ *
+ * STRATEGY (optional):
+ * - currentSolver::strategy::StridedCachedSupercells
+ * - currentSolver::strategy::CachedSupercells
+ * - currentSolver::strategy::NonCachedSupercells
+ */
+using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+
+/*! particle pusher configuration ----------------------------------------------
+ *
+ * Defining a pusher is optional for particles
+ *
+ * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+ * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+ * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
+ * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+ *                                              with classical radiation reaction
+ * - particles::pusher::Composite : composite of two given pushers,
+ *                                  switches between using one (or none) of those
+ *
+ * For diagnostics & modeling: ------------------------------------------------
+ * - particles::pusher::Free : free propagation, ignore fields
+ *                             (= free stream model)
+ * - particles::pusher::Photon : propagate with c in direction of normalized mom.
+ * - particles::pusher::Probe : Probe particles that interpolate E & B
+ * For development purposes: --------------------------------------------------
+ * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
+ */
+#ifndef PARAM_PARTICLEPUSHER
+#define PARAM_PARTICLEPUSHER Boris
+#endif
+
+/* To avoid issues with commas in macro definitions,
+ * pass composite pushers via a special flag
+ */
+#ifndef PARAM_COMPOSITEPUSHER
+#define PARAM_COMPOSITEPUSHER 0
+#endif
+
+#if PARAM_COMPOSITEPUSHER
+#define PUSHER particles::pusher::Composite<particles::pusher::Vay, \
+    particles::pusher::PARAM_PARTICLEPUSHER,                        \
+    particles::pusher::CompositeBinarySwitchActivationFunctor<10>   \
+>
+#else
+#define PUSHER particles::pusher::PARAM_PARTICLEPUSHER
+#endif
+
+using UsedParticlePusher = PUSHER;
+
+} // namespace picongpu

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,83 @@
+/* Copyright 2013-2020 Rene Widera, Benjamin Worpitz, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/meta/String.hpp>
+
+
+namespace picongpu
+{
+
+/*########################### define particle attributes #####################*/
+
+/** describe attributes of a particle*/
+using DefaultParticleAttributes = MakeSeq_t<
+    position< position_pic >,
+    momentum,
+    weighting,
+    probeE,
+    probeB
+>;
+
+/*########################### end particle attributes ########################*/
+
+/*########################### define species #################################*/
+
+/*--------------------------- electrons --------------------------------------*/
+
+/* ratio relative to BASE_CHARGE and BASE_MASS */
+value_identifier( float_X, MassRatioElectrons, 1.0 );
+value_identifier( float_X, ChargeRatioElectrons, 1.0 );
+
+using ParticleFlagsElectrons = MakeSeq_t<
+    particlePusher< UsedParticlePusher >,
+    shape< UsedParticleShape >,
+    interpolation< UsedField2Particle >,
+    current< UsedParticleCurrentSolver >,
+    massRatio< MassRatioElectrons >,
+    chargeRatio< ChargeRatioElectrons >
+>;
+
+/* define species electrons */
+using PIC_Electrons = Particles<
+    PMACC_CSTRING( "e" ),
+    ParticleFlagsElectrons,
+    DefaultParticleAttributes
+>;
+
+/*########################### end species ####################################*/
+
+/** All known particle species of the simulation
+ *
+ * List all defined particle species from above in this list
+ * to make them available to the PIC algorithm.
+ */
+using VectorAllSpecies = MakeSeq_t<
+    PIC_Electrons
+>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesInitialization.param
@@ -1,0 +1,55 @@
+/* Copyright 2015-2020 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Initialize particles inside particle species. This is the final step in
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+namespace particles
+{
+    /** InitPipeline define in which order species are initialized
+     *
+     * the functors are called in order (from first to last functor)
+     */
+    using InitPipeline = bmpl::vector<
+        CreateDensity<
+            densityProfiles::Homogenous,
+            startPosition::Quiet25ppc,
+            PIC_Electrons
+        >,
+        Manipulate<
+            manipulators::AddTemperature,
+            PIC_Electrons
+        >
+    >;
+
+} // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Some pushers were not enabled in any example, and so were not compile-time tested.