### PR TITLE
Fix complex math abs and abs2 issues

### DIFF
--- a/include/pmacc/algorithms/math/floatMath/trigo.tpp
+++ b/include/pmacc/algorithms/math/floatMath/trigo.tpp
@@ -56,7 +56,7 @@ struct Sinc<float>
     HDINLINE float operator( )(const float& value )
     {
         if(cupla::math::abs(value) < FLT_EPSILON)
-            return 1.0;
+            return 1.0f;
         else
             return cupla::math::sin( value )/value;
     }

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -107,7 +107,10 @@ namespace math
         }
     };
 
-    /*  Specialize abs2() for complex numbers. */
+    /** Specialize abs2() for complex numbers.
+     *
+     * Note: Abs is specialized in alpaka::math below
+     */
     template<typename T_Type>
     struct Abs2< ::pmacc::math::Complex<T_Type> >
     {
@@ -216,11 +219,12 @@ namespace traits
         ALPAKA_FN_HOST_ACC static auto abs(
             T_Ctx const & mathConcept,
             ::pmacc::math::Complex< T_Type > const & other
-        ) -> ::pmacc::math::Complex< T_Type >
+        ) -> T_Type
         {
-            using type = T_Type;
-            return alpaka::math::abs( mathConcept, other.get_real() )
-                + alpaka::math::abs( mathConcept, other.get_imag() );
+            /* It is not possible to use alpaka::math::sqrt( mathConcept, ... )
+             * here, as the mathConcept would not match, so go around via cupla
+             */
+            return cupla::math::sqrt( pmacc::math::abs2( other ) );
         }
     };
 


### PR DESCRIPTION
The issues were introduced in #3245 and went unnoriced until #3379 .

Fix wrong formula in `Abs` implementation.
Make return types of `Abs` and `Abs2` real, as they were before that change.

Fixes #3379 .