### PR TITLE
Improve output of kernel errors in PMacc with PMACC_BLOCKING_KERNEL=ON

### DIFF
--- a/include/pmacc/cuplaHelper/ValidateCall.hpp
+++ b/include/pmacc/cuplaHelper/ValidateCall.hpp
@@ -1,6 +1,6 @@
 /* Copyright 2013-2020 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
- *                     Alexander Grund
+ *                     Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -24,11 +24,10 @@
 #pragma once
 
 #include <cupla.hpp>
+
 #include <iostream>
 #include <stdexcept>
 
-namespace pmacc
-{
 
 /**
  * Print a cupla error message including file/line info to stderr
@@ -50,8 +49,30 @@ namespace pmacc
  */
 #define CUDA_CHECK(cmd) {cuplaError_t error = cmd; if(error!=cuplaSuccess){ PMACC_PRINT_CUPLA_ERROR_AND_THROW(error, ""); }}
 
-#define CUDA_CHECK_MSG(cmd,msg) {cuplaError_t error = cmd; if(error!=cuplaSuccess){ PMACC_PRINT_CUPLA_ERROR_AND_THROW(error, msg); }}
+/** Capture error, report and throw
+ *
+ * This macro is only used when PMACC_SYNC_KERNEL == 1 to wrap all
+ * kernel calls. Since alpaka may throw inside cmd, everything is
+ * wrapped up in another try-catch level.
+ *
+ * This macro will always throw in case of an error, either by
+ * producing a new exception or propagating an existing one
+ */
+#define CUDA_CHECK_MSG(cmd,msg)                                \
+{                                                              \
+    try                                                        \
+    {                                                          \
+        cuplaError_t error = cmd;                              \
+        if(error!=cuplaSuccess)                                \
+        {                                                      \
+            PMACC_PRINT_CUPLA_ERROR_AND_THROW(error, msg);     \
+        }                                                      \
+    }                                                          \
+    catch( ... )                                               \
+    {                                                          \
+        PMACC_PRINT_CUPLA_ERROR(msg);                          \
+        throw;                                                 \
+    }                                                          \
+}
 
 #define CUDA_CHECK_NO_EXCEPT(cmd) {cuplaError_t error = cmd; if(error!=cuplaSuccess){ PMACC_PRINT_CUPLA_ERROR(""); }}
-
-} // namespace pmacc


### PR DESCRIPTION
Now in this mode it catches exceptions that cupla + alpaka can throw, prints kernel information and re-throws.

This change should hopefully help debugging crashes like #3381 by providing proper kernel name and file + line details.