### PR TITLE
Fix Ionization Current

### DIFF
--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
@@ -58,11 +58,15 @@ namespace ionization
         HDINLINE void
         operator()(IonizerReturn retValue, float_X const weighting, T_JBox jBoxPar, ValueType_E eField, T_Acc const & acc, floatD_X const pos)
         {
-            auto ionizationEnergy = weighting * retValue.ionizationEnergy * SI::ATOMIC_UNIT_ENERGY / UNIT_ENERGY; // convert to PIConGPU units
-            /* calculate ionization current at particle position */
-            float3_X jIonizationPar = JIonizationCalc{}(ionizationEnergy, eField);
-            /* assign ionization current to grid points */
-            JIonizationAssignment<T_Acc, T_DestSpecies, simDim>{}(acc, jIonizationPar, pos, jBoxPar);
+            /* If there is no ionization, the ionization energy is zero. In that case, there is no need for an ionization current. */
+            if(retValue.ionizationEnergy != 0.0_X)
+            {
+                auto ionizationEnergy = weighting * retValue.ionizationEnergy * SI::ATOMIC_UNIT_ENERGY / UNIT_ENERGY; // convert to PIConGPU units
+                /* calculate ionization current at particle position */
+                float3_X jIonizationPar = JIonizationCalc{}(ionizationEnergy, eField);
+                /* assign ionization current to grid points */
+                JIonizationAssignment<T_Acc, T_DestSpecies, simDim>{}(acc, jIonizationPar, pos, jBoxPar);
+            }
         }
     };
 

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
@@ -31,7 +31,9 @@ namespace ionization
      */
     struct JIonizationCalc
     {
-        /** functor calculating ionization current
+        /** Functor calculating ionization current.
+         * Is only called if ionization energy is not zero,
+         * thus we ensure the field is different from zero.
          */
         HDINLINE float3_X
         operator()( float_X const ionizationEnergy, float3_X const eField )


### PR DESCRIPTION
There was an issue with the ionization current where there was a division by zero. When the electric field was zero (such as before a laser pulse), the ionization current was still called with ionization energy being zero. I fixed with an if-else-statement as you can see in the IonizationCurrent.hpp. The ionization current is now working (tested).