### PR TITLE
Update required openPMD version to 0.12.0

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 ################################################################################
 
 # find openPMD installation
-find_package(openPMD 0.11.0 CONFIG COMPONENTS MPI)
+find_package(openPMD 0.12.0 CONFIG COMPONENTS MPI)
 
 if(openPMD_FOUND)
     if(openPMD_HAVE_ADIOS2 OR openPMD_HAVE_HDF5)


### PR DESCRIPTION
The openPMD plugin has always required features from that version (configuring backends via JSON), but CMake still lists the older version since 0.12.0 hadn't been released yet at the time of merging the openPMD plugin. 

(The reason why version 0.11.0 on Hemera was apparently able to be used for the plugin was that that module was not actually taken from a release, but from the dev-branch of the openPMD API)