### PR TITLE
add both adios and adios2 module on hemera

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -30,7 +30,8 @@ module load c-blosc/1.14.4
 module load hdf5-parallel/1.8.20-cuda102
 module load libsplash/1.7.0-cuda102
 module load python/3.6.5
-module load adios/2.6.0-cuda102
+module load adios/1.13.1-cuda102
+module load adios2/2.6.0-cuda102
 module load openpmd/0.12.0-cuda102
 
 module load libpng/1.6.35

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -30,7 +30,8 @@ module load c-blosc/1.14.4
 module load hdf5-parallel/1.8.20-cuda102
 module load libsplash/1.7.0-cuda102
 module load python/3.6.5
-module load adios/2.6.0-cuda102
+module load adios/1.13.1-cuda102
+module load adios2/2.6.0-cuda102
 module load openpmd/0.12.0-cuda102
 
 module load libpng/1.6.35

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -30,7 +30,8 @@ module load c-blosc/1.14.4
 module load hdf5-parallel/1.8.20-cuda102
 module load libsplash/1.7.0-cuda102
 module load python/3.6.5
-module load adios/2.6.0-cuda102
+module load adios/1.13.1-cuda102
+module load adios2/2.6.0-cuda102
 module load openpmd/0.12.0-cuda102
 
 module load libpng/1.6.35

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -30,7 +30,8 @@ module load c-blosc/1.14.4
 module load hdf5-parallel/1.8.20-cuda102
 module load libsplash/1.7.0-cuda102
 module load python/3.6.5
-module load adios/2.6.0-cuda102
+module load adios/1.13.1-cuda102
+module load adios2/2.6.0-cuda102
 module load openpmd/0.12.0-cuda102
 
 module load libpng/1.6.35


### PR DESCRIPTION
This pull request solves the issue #3409. The IT department separated the adios modules to an adios and and an adios2 base module. Both adios(1) and adios2 can thus be loaded in parallel. 