### PR TITLE
Clarify comments for generating momentums based on temperature

### DIFF
--- a/include/picongpu/particles/manipulators/unary/Temperature.def
+++ b/include/picongpu/particles/manipulators/unary/Temperature.def
@@ -24,8 +24,6 @@
 #include <pmacc/random/distributions/Normal.hpp>
 #include <pmacc/nvidia/functors/Add.hpp>
 
-#include <boost/mpl/integral_c.hpp>
-
 
 namespace picongpu
 {
@@ -56,13 +54,11 @@ namespace param
     };
 } // namespace param
 
-    /** change particle's momentum based on a temperature
-     *
-     * allow to change the temperature (randomly normal distributed)
-     * of a particle.
+    /** Modify particle momentum based on temperature
      *
      * @tparam T_ParamClass param::TemperatureCfg, configuration parameter
-     * @tparam T_ValueFunctor pmacc::nvidia::functors::*,  binary functor type to manipulate the momentum attribute
+     * @tparam T_ValueFunctor pmacc::nvidia::functors::*, binary functor type to
+     *                        add a new momentum to an old one
      */
     template<
         typename T_ParamClass = param::TemperatureCfg,


### PR DESCRIPTION
During investigation of #3377 , for a brief moment I thought that the temperature was applied incorrectly. It turned out to be not the case, just some comments were not full. This PR clarifies it, specifies this is only valid for the non-relativistic case and makes it more obvious the used random numbers are normally distributed.