### PR TITLE
changes to support HIP

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -379,6 +379,21 @@ else(ISAAC_FOUND)
 endif(ISAAC_FOUND)
 
 ################################################################################
+# PIConGPU Workarounds
+################################################################################
+
+set(PIC_COMPUTE_CURRENT_THREAD_LIMITER_DEFAULT OFF)
+if(ALPAKA_ACC_GPU_HIP_ENABLE)
+    set(PIC_COMPUTE_CURRENT_THREAD_LIMITER_DEFAULT ON)
+endif()
+option(PIC_COMPUTE_CURRENT_THREAD_LIMITER "Compute current results with HIP alpaka backend are wrong when more threads than particles in a frame will be used (possible compiler BUG).\
+ ON means the number of threads will be limited to number of particles in a frame." ${PIC_COMPUTE_CURRENT_THREAD_LIMITER_DEFAULT})
+
+if(PIC_COMPUTE_CURRENT_THREAD_LIMITER)
+    add_definitions(-DPIC_COMPUTE_CURRENT_THREAD_LIMITER=1)
+endif()
+
+################################################################################
 # Check if PIC_EXTENSION_PATH is relative or absolute
 ################################################################################
 

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -230,10 +230,15 @@ void FieldJ::assign( ValueType value )
 template<uint32_t T_area, class T_Species>
 void FieldJ::computeCurrent( T_Species & species, uint32_t )
 {
+#if BOOST_COMP_HIP && PIC_COMPUTE_CURRENT_THREAD_LIMITER
+    // HIP-clang creates wrong results if more threads than particles in a frame will be used
+    constexpr int workerMultiplier = 1;
+#else
     /* tuning parameter to use more workers than cells in a supercell
     * valid domain: 1 <= workerMultiplier
     */
-    const int workerMultiplier = 2;
+    constexpr int workerMultiplier = 2;
+#endif
 
     using FrameType = typename T_Species::FrameType;
     typedef typename pmacc::traits::Resolve<

--- a/include/pmacc/nvidia/memory/MemoryInfo.hpp
+++ b/include/pmacc/nvidia/memory/MemoryInfo.hpp
@@ -77,7 +77,7 @@ public:
     /** Returns true if the memory pool is shared by host and device */
     bool isSharedMemoryPool()
     {
-#if( PMACC_CUDA_ENABLED != 1 )
+#if(PMACC_CUDA_ENABLED != 1 && PMACC_HIP_ENABLED != 1)
         return true;
 #else
         size_t freeInternal = 0;


### PR DESCRIPTION
Required changes to support HIP.

Note: HIP can currently not enabled via `pic-build`, this will be
allowed when all requirements (alpaka, cupla and mallocMC) support the latest HIP version.

- update few defines to support HIP
- add CMake flag `PIC_COMPUTE_CURRENT_THREAD_LIMITER` to work around a compiler bug in HIP-clang