### PR TITLE
CI: skip compile

### DIFF
--- a/share/ci/generate_reduced_matrix.sh
+++ b/share/ci/generate_reduced_matrix.sh
@@ -17,6 +17,15 @@ echo "  - local: '/share/ci/compiler_nvcc_cuda.yml'"
 echo "  - local: '/share/ci/compiler_clang_cuda.yml'"
 echo ""
 
+# handle CI actions
+has_label=$($CI_PROJECT_DIR/share/ci/pr_has_label.sh "CI:no-compile" && echo "0" || echo "1")
+if [ "$has_label" == "0" ] ; then
+  echo "skip-compile:"
+  echo "  script:"
+  echo "    - echo \"CI action - 'CI:no-compile' -> skip compile/runtime tests\""
+  exit 0
+fi
+
 folders=()
 for CASE in ${PIC_INPUTS}; do
   if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] ; then

--- a/share/ci/pr_has_label.sh
+++ b/share/ci/pr_has_label.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+github_group_repo="ComputationalRadiationPhysics/picongpu"
+
+pr_id=$(echo "$CI_BUILD_REF_NAME" | cut -d"/" -f1 | cut -d"-" -f2)
+# used a token without any rights from psychocoderHPC to avoid API query limitations
+curl_data=$(curl -u psychocoderHPC:$GITHUB_TOKEN -X GET https://api.github.com/repos/${github_group_repo}/pulls/${pr_id} 2>/dev/null)
+# get the destination branch
+all_labels=$(echo "$curl_data" | python3 -c 'import json,sys;obj=json.loads(sys.stdin.read());x = obj["labels"];labels = list(i["name"] for i in x); print(labels)')
+echo "search for label: '$1'" >&2
+echo "labels: '${all_labels}'" >&2
+label_found=$(echo "$all_labels" | grep -q "$1" && echo 0 || echo 1)
+
+exit $label_found


### PR DESCRIPTION
CI is checking the pull request labels and is skipping compile/runtime tests if the label `CI:no-compile` is pinned.

Currently, our CI is only performing actions when the code is updated by a push/force push.
Therefore the label should be set before the PR is opened or a force push to update the PR is required after the label is set.
By adding the label and later removing it is easy to pass the CI without any compile tests. This can be used to sneak broken code into the mainline. Labels can only be set by maintainers and I assume they will not abuse the flag to bypass the CI.

The flag should be used for documentation updates where compile tests are useless.

**Note:** My original idea was to parse the PR description for actions e.g. `CI:no-compile, CI:reduced-tests, CI:test:examples/FoilLCT`.
Since everyone can change the PR description and we do not perform CI actions in this case I will not introduce this feature until gitlab can work with github pull request without the current CI-bot workaround we are using at HZDR.