### PR TITLE
fix pic-compile

### DIFF
--- a/bin/pic-compile
+++ b/bin/pic-compile
@@ -131,7 +131,7 @@ do
             $picongpu_prefix/buildsystem/CompileSuite/compileSet.sh \
                 "$example_name" "$testFlagNr" "$globalCMakeOptions" \
                 "$tmpRun_path" "$buildDir" "$examples_path" \
-                "$quiet_run" | tee $buildDir"/compile.log" || exit $?
+                "$quiet_run"  &> $buildDir"/compile.log"
         fi
 
         testFlagNr=$(( testFlagNr + 1 ))


### PR DESCRIPTION
The error code handling differ for parallel and non parallel builds.

- unifying the error handling