### PR TITLE
HIP: fix RNG method XorMin

### DIFF
--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -61,12 +61,17 @@ namespace pmacc
                     {
                     }
 
-                    DINLINE StateType(NativeStateType const& other) : d(other.d)
+                    DINLINE StateType(NativeStateType const& other)
                     {
 #    if(BOOST_LANG_HIP)
-                        auto const* nativeStateArray = other.x;
-                        PMACC_STATIC_ASSERT_MSG(sizeof(v) == sizeof(other.x), Unexpected_sizes);
+                        // @todo avoid using pointer casts to copy the rng state
+                        auto baseObjectPtr
+                            = reinterpret_cast<typename NativeStateType::xorwow_state const* const>(&other);
+                        d = baseObjectPtr->d;
+                        auto const* nativeStateArray = baseObjectPtr->x;
+                        PMACC_STATIC_ASSERT_MSG(sizeof(v) == sizeof(baseObjectPtr->x), Unexpected_sizes);
 #    elif(BOOST_LANG_CUDA)
+                        d = other.d;
                         auto const* nativeStateArray = other.v;
                         PMACC_STATIC_ASSERT_MSG(sizeof(v) == sizeof(other.v), Unexpected_sizes);
 #    endif


### PR DESCRIPTION
fix bug introduced with # #3356

The HIP state `hiprandStateXORWOW_t` is not giving access to the underlaying protected *rocrand* state.