### PR TITLE
expose HIP backend

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -39,8 +39,8 @@ help()
     echo "                       (default is <inputDirectory>)"
     echo "-b | --backend       - set compute backend and optionally the architecture"
     echo "                       syntax: backend[:architecture]"
-    echo "                       supported backends: cuda, omp2b, serial, tbb, threads"
-    echo "                       (e.g.: \"cuda:20;35;37;52;60\" or \"omp2b:native\" or \"omp2b\")"
+    echo "                       supported backends: cuda, hip, omp2b, serial, tbb, threads"
+    echo "                       (e.g.: \"cuda:35;37;52;60\" or \"omp2b:native\" or \"omp2b\")"
     echo "                       default: \"cuda\" if not set via environment variable PIC_BACKEND"
     echo "                       note: architecture names are compiler dependent"
     echo "-c | --cmake         - overwrite options for cmake"
@@ -82,6 +82,11 @@ get_backend_flags()
         result+=" -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+        fi
+    elif [ "${backend_cfg[0]}" == "hip" ] ; then
+        result+=" -DALPAKA_ACC_GPU_HIP_ENABLE=ON -DALPAKA_ACC_GPU_HIP_ONLY_MODE=ON"
+        if [ $num_options -eq 2 ] ; then
+            result+=" -DALPAKA_HIP_ARCH=\"${backend_cfg[1]}\""
         fi
     else
         echo "unsupported backend given '$1'" >&2


### PR DESCRIPTION
Update `pic-build` to support `-b hip`.

#3455 is required to compile the HIP backend succesfully.