### PR TITLE
Scale particle exchange buf

### DIFF
--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -26,12 +26,12 @@
 #pragma once
 
 #include "picongpu/param/dimension.param"
+#include "picongpu/param/precision.param"
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
 #    include "picongpu/param/mallocMC.param"
 #endif
 #include "picongpu/param/memory.param"
 #include "picongpu/param/random.param"
-#include "picongpu/param/precision.param"
 #include "picongpu/param/physicalConstants.param"
 #include "picongpu/param/flylite.param"
 #include "picongpu/param/speciesConstants.param"

--- a/include/picongpu/param/memory.param
+++ b/include/picongpu/param/memory.param
@@ -30,6 +30,8 @@
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 
+#include <array>
+
 
 namespace picongpu
 {
@@ -82,6 +84,21 @@ namespace picongpu
         static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB
         static constexpr uint32_t BYTES_EDGES = 32 * 1024; // 32 kiB
         static constexpr uint32_t BYTES_CORNER = 8 * 1024; // 8 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
     };
 
     /** number of scalar fields that are reserved as temporary fields */

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -211,6 +211,8 @@ namespace picongpu
      *     static constexpr uint32_t BYTES_EXCHANGE_Z = 5 * 1024 * 1024;
      *     static constexpr uint32_t BYTES_CORNER = 16 * 1024;
      *     static constexpr uint32_t BYTES_EDGES = 16 * 1024;
+     *     using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+     *     const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
      * };
      * @endcode
      */

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -192,6 +192,13 @@ namespace picongpu
     private:
         SimulationDataId m_datasetID;
 
+        /** Get exchange memory size.
+         *
+         * @param ex exchange index calculated from pmacc::typ::ExchangeType, valid range: [0;27)
+         * @return exchange size in bytes
+         */
+        size_t exchangeMemorySize(uint32_t ex) const;
+
         FieldE* fieldE;
         FieldB* fieldB;
     };

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -48,11 +48,143 @@
 #include <iostream>
 #include <limits>
 #include <memory>
-
+#include <utility>
 
 namespace picongpu
 {
     using namespace pmacc;
+
+    namespace detail
+    {
+        /* Helper to check if a member exists
+         *
+         * Derived from C++17 std::void_t.
+         * This implementation will be removed with Void provided by alpaka 0.6.0 release (not included in the 0.6.0rc3
+         * we currently using).
+         */
+        template<class...>
+        using Void = void;
+
+        /** Calculate the scaling factor for each direction.
+         *
+         * The scaling factor is derived from the reference size of the local domain and a scaling factor provided by
+         * the user.
+         *
+         * @tparam T_ExchangeMemCfg exchange configuration for a species
+         * @tparam T_Sfinae Type for conditionally specialization (no input parameter)
+         * @{
+         */
+        template<typename T_ExchangeMemCfg, typename T_Sfinae = void>
+        struct DirScalingFactor
+        {
+            //! @return factor to scale the amount of memory for each direction
+            static floatD_64 get()
+            {
+                return floatD_64::create(1.0);
+            }
+        };
+
+        /** Specialization for species with exchange memory information which provides
+         * DIR_SCALING_FACTOR and REF_LOCAL_DOM_SIZE
+         */
+        template<typename T_ExchangeMemCfg>
+        struct DirScalingFactor<
+            T_ExchangeMemCfg,
+            Void<
+                decltype(std::declval<T_ExchangeMemCfg>().DIR_SCALING_FACTOR),
+                typename T_ExchangeMemCfg::REF_LOCAL_DOM_SIZE>>
+        {
+            static floatD_64 get()
+            {
+                auto baseLocalCells = T_ExchangeMemCfg::REF_LOCAL_DOM_SIZE::toRT();
+                auto userScalingFactor = T_ExchangeMemCfg{}.DIR_SCALING_FACTOR;
+
+                auto localDomSize = Environment<simDim>::get().SubGrid().getLocalDomain().size;
+                // set too local domain size in case there is no base volume defined
+                for(uint32_t d = 0; d < simDim; ++d)
+                {
+                    if(baseLocalCells[d] <= 0)
+                        baseLocalCells[d] = localDomSize[d];
+                }
+
+                auto scale = floatD_64::create(1.0);
+                for(uint32_t d = 0; d < simDim; ++d)
+                {
+                    auto dir1 = (d + 1) % simDim;
+                    auto dir2 = (d + 2) % simDim;
+                    // precision: numbers are small, therefore the usage of double is fine
+                    auto scaleDirection = std::ceil(
+                        float_64(localDomSize[dir1]) / float_64(baseLocalCells[dir1]) * float_64(localDomSize[dir2])
+                        / float_64(baseLocalCells[dir2]));
+                    float_64 scalingFactor = scaleDirection * userScalingFactor[d];
+                    // do not scale down
+                    scale[d] = std::max(scalingFactor, 1.0);
+                }
+
+                return scale;
+            }
+        };
+
+        //! @}
+    } // namespace detail
+    template<typename T_Name, typename T_Flags, typename T_Attributes>
+    size_t Particles<T_Name, T_Flags, T_Attributes>::exchangeMemorySize(uint32_t ex) const
+    {
+        // no communication direction
+        if(ex == 0u)
+            return 0u;
+
+        using ExchangeMemCfg = GetExchangeMemCfg_t<Particles>;
+        // scaling factor for each direction
+        auto dirScalingFactors = picongpu::detail::DirScalingFactor<ExchangeMemCfg>::get();
+
+        /* type of the exchange direction
+         * 1 = plane
+         * 2 = edge
+         * 3 = corner
+         */
+        uint32_t relDirType = 0u;
+
+        // scaling factor for the current exchange
+        float_64 exchangeScalingFactor = 1.0;
+
+        auto relDir = Mask::getRelativeDirections<simDim>(ex);
+        for(uint32_t d = 0; d < simDim; ++d)
+        {
+            // calculate the exchange type
+            relDirType += std::abs(relDir[d]);
+            exchangeScalingFactor *= relDir[d] != 0 ? dirScalingFactors[d] : 1.0;
+        }
+        size_t exchangeBytes = 0;
+
+        using ExchangeMemCfg = GetExchangeMemCfg_t<Particles>;
+
+        // it is a exachange
+        if(relDirType == 1u)
+        {
+            // x, y, z, edge, corner
+            pmacc::math::Vector<uint32_t, 3> requiredMem(
+                ExchangeMemCfg::BYTES_EXCHANGE_X,
+                ExchangeMemCfg::BYTES_EXCHANGE_Y,
+                ExchangeMemCfg::BYTES_EXCHANGE_Z);
+
+            for(uint32_t d = 0; d < simDim; ++d)
+                if(std::abs(relDir[d]) == 1)
+                {
+                    exchangeBytes = requiredMem[d];
+                    break;
+                }
+        }
+        // it is an edge
+        else if(relDirType == 2u)
+            exchangeBytes = ExchangeMemCfg::BYTES_EDGES;
+        // it is a corner
+        else
+            exchangeBytes = ExchangeMemCfg::BYTES_CORNER;
+
+        // using double to calculate the memory size is fine, double can precise store integer values up too 2^53
+        return exchangeBytes * exchangeScalingFactor;
+    }
 
     template<typename T_Name, typename T_Flags, typename T_Attributes>
     Particles<T_Name, T_Flags, T_Attributes>::Particles(
@@ -62,63 +194,23 @@ namespace picongpu
         : ParticlesBase<SpeciesParticleDescription, picongpu::MappingDesc, DeviceHeap>(heap, cellDescription)
         , m_datasetID(datasetID)
     {
-        using ExchangeMemCfg = GetExchangeMemCfg_t<Particles>;
-
         size_t sizeOfExchanges = 0u;
 
         const uint32_t commTag = pmacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() + SPECIES_FIRSTTAG;
         log<picLog::MEMORY>("communication tag for species %1%: %2%") % FrameType::getName() % commTag;
 
-        this->particlesBuffer->addExchange(Mask(LEFT) + Mask(RIGHT), ExchangeMemCfg::BYTES_EXCHANGE_X, commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_EXCHANGE_X * 2u;
+        auto const numExchanges = NumberOfExchanges<simDim>::value;
+        for(uint32_t exchange = 1u; exchange < numExchanges; ++exchange)
+        {
+            auto mask = Mask(exchange);
+            auto mem = exchangeMemorySize(exchange);
 
-        this->particlesBuffer->addExchange(Mask(TOP) + Mask(BOTTOM), ExchangeMemCfg::BYTES_EXCHANGE_Y, commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_EXCHANGE_Y * 2u;
-
-        // edges of the simulation area
-        this->particlesBuffer->addExchange(
-            Mask(RIGHT + TOP) + Mask(LEFT + TOP) + Mask(LEFT + BOTTOM) + Mask(RIGHT + BOTTOM),
-            ExchangeMemCfg::BYTES_EDGES,
-            commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_EDGES * 4u;
-
-#if(SIMDIM == DIM3)
-        this->particlesBuffer->addExchange(Mask(FRONT) + Mask(BACK), ExchangeMemCfg::BYTES_EXCHANGE_Z, commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_EXCHANGE_Z * 2u;
-
-        // edges of the simulation area
-        this->particlesBuffer->addExchange(
-            Mask(FRONT + TOP) + Mask(BACK + TOP) + Mask(FRONT + BOTTOM) + Mask(BACK + BOTTOM),
-            ExchangeMemCfg::BYTES_EDGES,
-            commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_EDGES * 4u;
-
-        this->particlesBuffer->addExchange(
-            Mask(FRONT + RIGHT) + Mask(BACK + RIGHT) + Mask(FRONT + LEFT) + Mask(BACK + LEFT),
-            ExchangeMemCfg::BYTES_EDGES,
-            commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_EDGES * 4u;
-
-        // corner of the simulation area
-        this->particlesBuffer->addExchange(
-            Mask(TOP + FRONT + RIGHT) + Mask(TOP + BACK + RIGHT) + Mask(BOTTOM + FRONT + RIGHT)
-                + Mask(BOTTOM + BACK + RIGHT),
-            ExchangeMemCfg::BYTES_CORNER,
-            commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_CORNER * 4u;
-
-        this->particlesBuffer->addExchange(
-            Mask(TOP + FRONT + LEFT) + Mask(TOP + BACK + LEFT) + Mask(BOTTOM + FRONT + LEFT)
-                + Mask(BOTTOM + BACK + LEFT),
-            ExchangeMemCfg::BYTES_CORNER,
-            commTag);
-        sizeOfExchanges += ExchangeMemCfg::BYTES_CORNER * 4u;
-#endif
-
-        /* The buffer size must be multiplied by two because PMacc generates a send
-         * and receive buffer for each direction.
-         */
-        sizeOfExchanges *= 2u;
+            this->particlesBuffer->addExchange(mask, mem, commTag);
+            /* The buffer size must be multiplied by two because PMacc generates a send
+             * and receive buffer for each direction.
+             */
+            sizeOfExchanges += mem * 2u;
+        };
 
         constexpr size_t byteToMiB = 1024u * 1024u;
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -31,6 +31,7 @@
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 
+#include <array>
 
 namespace picongpu
 {
@@ -83,6 +84,21 @@ namespace picongpu
         static constexpr uint32_t BYTES_EXCHANGE_Z = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EDGES = 128 * 1024; // 128 kiB
         static constexpr uint32_t BYTES_CORNER = 32 * 1024; // 32 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
     };
 
     /** number of scalar fields that are reserved as temporary fields */

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
@@ -31,6 +31,7 @@
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 
+#include <array>
 
 namespace picongpu
 {
@@ -83,6 +84,21 @@ namespace picongpu
         static constexpr uint32_t BYTES_EXCHANGE_Z = 2 * 1024 * 1024; // 2 MiB
         static constexpr uint32_t BYTES_EDGES = 64 * 1024; // 64 kiB
         static constexpr uint32_t BYTES_CORNER = 16 * 1024; // 16 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
     };
 
     /** number of scalar fields that are reserved as temporary fields */

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
@@ -31,6 +31,7 @@
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 
+#include <array>
 
 namespace picongpu
 {
@@ -83,6 +84,21 @@ namespace picongpu
         static constexpr uint32_t BYTES_EXCHANGE_Z = 40 * 1024 * 1024; // 40 MiB
         static constexpr uint32_t BYTES_EDGES = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_CORNER = 800 * 1024; // 800 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
     };
 
     /** number of scalar fields that are reserved as temporary fields */

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
@@ -31,6 +31,8 @@
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 
+#include <array>
+
 namespace picongpu
 {
     /* We have to hold back 350MiB for gpu-internal operations:
@@ -82,6 +84,21 @@ namespace picongpu
         static constexpr uint32_t BYTES_EXCHANGE_Z = 64 * 1024 * 1024; // 64 MiB
         static constexpr uint32_t BYTES_EDGES = 2 * 1024 * 1024; // 2 MiB
         static constexpr uint32_t BYTES_CORNER = 512 * 1024; // 512 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
     };
 
     /** number of scalar fields that are reserved as temporary fields */


### PR DESCRIPTION
Add support to scale the particle exchange size at runtime automatically based on the local domain size and a reference size.
This feature is required for the upcoming SPEC benchmark example.

This feature allows that we can also fine-tune the required memory for particle exchanges depending on the example. Currently, we need to configure the particle exchanges for the largest config file of an example.

- Add `REF_LOCAL_DOM_SIZE` and `DIR_SCALING_FACTOR` to exchange configurations. The new attributes are optional and therefore backward compatible. This means that old param files still work.
- change the param include order to support PIConGPU float types in `memory.param`