### PR TITLE
add SPEC benchmark example

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ pull-request-validation:
 #                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
 generate-reduced-matrix:
   variables:
-    PIC_INPUTS: "examples tests"
+    PIC_INPUTS: "examples tests benchmarks"
     TEST_TUPLE_NUM_ELEM: 1
   extends: ".base_generate-reduced-matrix"
 

--- a/share/ci/generate_reduced_matrix.sh
+++ b/share/ci/generate_reduced_matrix.sh
@@ -28,7 +28,7 @@ fi
 
 folders=()
 for CASE in ${PIC_INPUTS}; do
-  if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] ; then
+  if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] || [  "$CASE" == "benchmarks"  ] ; then
       all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
   else
       all_cases=$(find $CASE -maxdepth 0 -type d)

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -67,7 +67,7 @@ echo "accelerator                 -> ${PIC_BACKEND}"
 echo "input set                   -> ${PIC_TEST_CASE_FOLDER}"
 echo -e "/////////////////////////////////////////////////// \033[0m \n\n"
 
-if [ "$PIC_TEST_CASE_FOLDER" == "examples/" ] || [ "$PIC_TEST_CASE_FOLDER" == "tests/" ] ; then
+if [ "$PIC_TEST_CASE_FOLDER" == "examples/" ] || [ "$PIC_TEST_CASE_FOLDER" == "tests/" ] ||  [ "$PIC_TEST_CASE_FOLDER" == "benchmarks/" ] ; then
     extended_compile_options="-l"
 fi
 

--- a/share/picongpu/benchmarks/SPEC/etc/picongpu/1.cfg
+++ b/share/picongpu/benchmarks/SPEC/etc/picongpu/1.cfg
@@ -1,0 +1,72 @@
+# Copyright 2013-2019 Rene Widera, Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="02:00:00"
+
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
+
+TBG_gridSize="128 128 128"
+TBG_steps="1000"
+
+TBG_periodic="--periodic 1 1 1"
+
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+TBG_plugins=" --p_macroParticlesCount.period 100          \
+              --e_macroParticlesCount.period 100          \
+              --fields_energy.period 100                  \
+              --e_energy.period 100 --e_energy.filter all \
+              --p_energy.period 100 --p_energy.filter all"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/density.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/density.param
@@ -1,0 +1,46 @@
+/* Copyright 2013-2019 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/densityProfiles/profiles.def"
+
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** Base density in particles per m^3 in the density profiles.
+         *
+         * This is often taken as reference maximum density in normalized profiles.
+         * Individual particle species can define a `densityRatio` flag relative
+         * to this value.
+         *
+         * unit: ELEMENTS/m^3
+         */
+        constexpr float_64 BASE_DENSITY_SI = 1.e25;
+    } // namespace SI
+
+    namespace densityProfiles
+    {
+        /* definition of homogenous density profile */
+        using Homogenous = HomogenousImpl;
+    } // namespace densityProfiles
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/fileOutput.param
@@ -1,0 +1,50 @@
+/* Copyright 2013-2020 Axel Huebl, Rene Widera, Felix Schmitt,
+ *                     Benjamin Worpitz, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
+/* some forward declarations we need */
+#include "picongpu/fields/Fields.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+#include <boost/mpl/vector.hpp>
+
+
+namespace picongpu
+{
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<>;
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+    using FileOutputFields = MakeSeq_t<>;
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to disable particle output set to
+     *   using FileOutputParticles = MakeSeq_t< >;
+     */
+    using FileOutputParticles = MakeSeq_t<>;
+
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/grid.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/grid.param
@@ -1,0 +1,81 @@
+/* Copyright 2013-2019 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** Duration of one timestep
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = 3.0e-17;
+
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = 1.8e-8;
+        /** equals Y
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = 1.8e-8;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = 1.8e-8;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+    } // namespace SI
+
+    //! Defines the size of the absorbing zone (in cells)
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
+        {0, 0}, /*x direction [negative,positive]*/
+        {0, 0}, /*y direction [negative,positive]*/
+        {0, 0} /*z direction [negative,positive]*/
+    }; // unit: number of cells
+
+    //! Define the strength of the absorber for any direction
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
+        {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+        {1.0e-3, 1.0e-3} /*z direction [negative,positive]*/
+    }; // unit: none
+
+    /** When to move the co-moving window.
+     *  An initial pseudo particle, flying with the speed of light,
+     *  is fired at the begin of the simulation.
+     *  When it reaches movePoint % of the absolute(*) simulation area,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
+     *            when you use the co-moving window
+     *  0.75 means only 75% of simulation area is used for real simulation
+     */
+    constexpr float_64 movePoint = 0.90;
+
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/isaac.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/isaac.param
@@ -1,0 +1,64 @@
+/* Copyright 2016-2020 Alexander Matthes
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Definition which native fields and density fields of particles will be
+ * visualizable with ISAAC. ISAAC is an in-situ visualization library with which
+ * the PIC simulation can be observed while it is running avoiding the time
+ * consuming writing and reading of simulation data for the classical post
+ * processing of data.
+ *
+ * ISAAC can directly visualize natives fields like the E or B field, but
+ * density fields of particles need to be calculated from PIConGPU on the fly
+ * which slightly increases the runtime and the memory consumption. Every
+ * particle density field will reduce the amount of memory left for PIConGPUs
+ * particles and fields.
+ *
+ * To get best performance, ISAAC defines an exponential amount of different
+ * visualization kernels for every combination of (at runtime) activated
+ * fields. So furthermore a lot of fields will increase the compilation time.
+ *
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace isaacP
+    {
+        /** Intermediate list of native particle species of PIConGPU which shall be
+         *  visualized. */
+        using Particle_Seq = MakeSeq_t<>;
+
+        /** Intermediate list of native fields of PIConGPU which shall be
+         *  visualized. */
+        using Native_Seq = MakeSeq_t<>;
+
+        /** Intermediate list of particle species, from which density fields
+         *  shall be created at runtime to visualize them. */
+        using Density_Seq = MakeSeq_t<>;
+
+        /** Compile time sequence of all fields which shall be visualized. Basically
+         *  the join of Native_Seq and Density_Seq. */
+        using Fields_Seq = MakeSeq_t<>;
+
+
+    } // namespace isaacP
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/memory.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/memory.param
@@ -1,0 +1,115 @@
+/* Copyright 2013-2019 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
+#pragma once
+
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/mappings/kernel/MappingDescription.hpp>
+
+namespace picongpu
+{
+    /* We have to hold back 350MiB for gpu-internal operations:
+     *   - random number generator
+     *   - reduces
+     *   - ...
+     */
+    constexpr size_t reservedGpuMemorySize = 400 * 1024 * 1024;
+
+    /* short namespace*/
+    namespace mCT = pmacc::math::CT;
+    /** size of a superCell
+     *
+     * volume of a superCell must be <= 1024
+     */
+    using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
+
+    /** define the object for mapping superCells to cells*/
+    using MappingDesc = MappingDescription<simDim, SuperCellSize>;
+
+    /** define the size of the core, border and guard area
+     *
+     * PIConGPU uses spatial domain-decomposition for parallelization
+     * over multiple devices with non-shared memory architecture.
+     * The global spatial domain is organized per device in three
+     * sections: the GUARD area contains copies of neighboring
+     * devices (also known as "halo"/"ghost").
+     * The BORDER area is the outermost layer of cells of a device,
+     * equally to what neighboring devices see as GUARD area.
+     * The CORE area is the innermost area of a device. In union with
+     * the BORDER area it defines the "active" spatial domain on a device.
+     *
+     * GuardSize is defined in units of SuperCellSize per dimension.
+     */
+    using GuardSize = typename mCT::shrinkTo<mCT::Int<1, 1, 1>, simDim>::type;
+
+    /** bytes reserved for species exchange buffer
+     *
+     * This is the default configuration for species exchanges buffer sizes.
+     * The default exchange buffer sizes can be changed per species by adding
+     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
+     * to its flag list.
+     */
+    struct DefaultExchangeMemCfg
+    {
+        // memory used for a direction
+        static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 4 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Y = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 6 * 1024 * 1024; // 6 MiB
+        static constexpr uint32_t BYTES_EDGES = 512 * 1024; // 512 kiB
+        static constexpr uint32_t BYTES_CORNER = 256 * 1024; // 256 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<128, 128, 128>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, DIM3> DIR_SCALING_FACTOR = {0.5, 0.5, 1.0};
+    };
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 1;
+
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = false;
+
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/particle.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/particle.param
@@ -1,0 +1,101 @@
+/* Copyright 2013-2019 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/startPosition/functors.def"
+#include "picongpu/particles/manipulators/manipulators.def"
+
+#include <pmacc/nvidia/functors/Add.hpp>
+#include <pmacc/nvidia/functors/Assign.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        /** a particle with a weighting below MIN_WEIGHTING will not
+         *      be created / will be deleted
+         *  unit: none
+         */
+        constexpr float_X MIN_WEIGHTING = 1.0;
+
+        namespace manipulators
+        {
+            CONST_VECTOR(float_X, 3, DriftParamElectrons_direction, 0.0, 0.0, 1.0);
+            struct DriftParamElectrons
+            {
+                /** Initial particle drift velocity
+                 *  unit: none
+                 */
+                static constexpr float_64 gamma = 5.0;
+                const DriftParamElectrons_direction_t direction;
+            };
+            using AssignZDriftElectrons = unary::Drift<DriftParamElectrons, nvidia::functors::Assign>;
+
+            CONST_VECTOR(float_X, 3, DriftParamPositrons_direction, 0.0, 0.0, -1.0);
+            struct DriftParamPositrons
+            {
+                /** Initial particle drift velocity
+                 *  unit: none
+                 */
+                static constexpr float_64 gamma = 5.0;
+                const DriftParamPositrons_direction_t direction;
+            };
+            // definition of SetDrift start
+            using AssignZDriftPositrons = unary::Drift<DriftParamPositrons, nvidia::functors::Assign>;
+
+        } // namespace manipulators
+
+        namespace startPosition
+        {
+            struct QuietParamElectrons
+            {
+                /** Count of particles per cell per direction at initial state
+                 *  unit: none
+                 */
+                using numParticlesPerDimension = mCT::shrinkTo<mCT::Int<1, 2, 4>, simDim>::type;
+            };
+
+            // definition of quiet particle start
+            using QuietElectrons = QuietImpl<QuietParamElectrons>;
+
+            struct QuietParamPositrons
+            {
+                /** Count of particles per cell per direction at initial state
+                 *  unit: none
+                 */
+                using numParticlesPerDimension = mCT::shrinkTo<mCT::Int<4, 1, 2>, simDim>::type;
+            };
+
+            // definition of quiet particle start
+            using QuietPositrons = QuietImpl<QuietParamPositrons>;
+
+        } // namespace startPosition
+
+        /** During unit normalization, we assume this is a typical
+         *  number of particles per cell for normalization of weighted
+         *  particle attributes.
+         */
+        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL
+            = mCT::volume<startPosition::QuietParamElectrons::numParticlesPerDimension>::type::value;
+
+    } // namespace particles
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
@@ -1,0 +1,103 @@
+/* Copyright 2014-2020 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Particle shape, field to particle interpolation, current solver, and particle pusher
+ * can be declared here for usage in `speciesDefinition.param`.
+ *
+ * @see
+ *   **MODELS / Hierarchy of Charge Assignment Schemes**
+ *   in the online documentation for information on particle shapes.
+ *
+ *
+ * \attention
+ * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
+ *     * PQS is the name of the 3rd order assignment function (instead of PCS)
+ *     * PCS is the name of the 4th order assignment function (instead of P4S)
+ *     * P4S does not exist anymore
+ */
+
+#pragma once
+
+#include "picongpu/particles/shapes.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolationNative.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
+#include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
+#include "picongpu/particles/flylite/NonLTE.def"
+#include "picongpu/fields/currentDeposition/Solver.def"
+
+
+namespace picongpu
+{
+    /** select macroparticle shape
+     *
+     * **WARNING** the shape names are redefined and diverge from PIConGPU versions before 0.6.0.
+     *
+     *  - particles::shapes::CIC : Assignment function is a piecewise linear spline
+     *  - particles::shapes::TSC : Assignment function is a piecewise quadratic spline
+     *  - particles::shapes::PQS : Assignment function is a piecewise cubic spline
+     *  - particles::shapes::PCS : Assignment function is a piecewise quartic spline
+     */
+    using UsedParticleShape = particles::shapes::PQS;
+
+    /** select interpolation method to be used for interpolation of grid-based field values to particle positions
+     */
+    using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
+
+    /*! select current solver method
+     * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+     * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     *
+     * For development purposes:
+     * - currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
+     *   without optimization (~4x slower and needs more shared memory)
+     *
+     * STRATEGY (optional):
+     * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::NonCachedSupercells
+     */
+    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+
+    /** particle pusher configuration
+     *
+     * Defining a pusher is optional for particles
+     *
+     * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+     * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+     * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
+     * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+     *                                              with classical radiation reaction
+     * - particles::pusher::Composite : composite of two given pushers,
+     *                                  switches between using one (or none) of those
+     *
+     * For diagnostics & modeling: ------------------------------------------------
+     * - particles::pusher::Acceleration : Accelerate particles by applying a constant electric field
+     * - particles::pusher::Free : free propagation, ignore fields
+     *                             (= free stream model)
+     * - particles::pusher::Photon : propagate with c in direction of normalized mom.
+     * - particles::pusher::Probe : Probe particles that interpolate E & B
+     * For development purposes: --------------------------------------------------
+     * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
+     */
+    using UsedParticlePusher = particles::pusher::Boris;
+
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,86 @@
+/* Copyright 2013-2019 Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/meta/String.hpp>
+
+
+namespace picongpu
+{
+    /*########################### define particle attributes #####################*/
+
+    /** describe attributes of a particle */
+    using DefaultParticleAttributes = MakeSeq_t<position<position_pic>, momentum, weighting>;
+
+    /*########################### end particle attributes ########################*/
+
+    /*########################### define species #################################*/
+
+
+    /*--------------------------- electrons --------------------------------------*/
+
+    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    value_identifier(float_X, MassRatioElectrons, 1.0);
+    value_identifier(float_X, ChargeRatioElectrons, 1.0);
+
+    using ParticleFlagsElectrons = MakeSeq_t<
+        particlePusher<UsedParticlePusher>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        current<UsedParticleCurrentSolver>,
+        massRatio<MassRatioElectrons>,
+        chargeRatio<ChargeRatioElectrons>>;
+
+    /* define species electrons */
+    using PIC_Electrons = Particles<PMACC_CSTRING("e"), ParticleFlagsElectrons, DefaultParticleAttributes>;
+
+    /*--------------------------- positrons -------------------------------------------*/
+
+    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    value_identifier(float_X, MassRatioPositrons, 1.0);
+    value_identifier(float_X, ChargeRatioPositrons, -1.0);
+
+    /* ratio relative to BASE_DENSITY */
+    value_identifier(float_X, DensityRatioPositrons, 1.0);
+
+    using ParticleFlagsPositrons = MakeSeq_t<
+        particlePusher<UsedParticlePusher>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        current<UsedParticleCurrentSolver>,
+        massRatio<MassRatioPositrons>,
+        chargeRatio<ChargeRatioPositrons>,
+        densityRatio<DensityRatioPositrons>>;
+
+    /*define specie ions*/
+    using PIC_Positrons = Particles<PMACC_CSTRING("p"), ParticleFlagsPositrons, DefaultParticleAttributes>;
+
+    /*########################### end species ####################################*/
+
+    using VectorAllSpecies = MakeSeq_t<PIC_Electrons, PIC_Positrons>;
+
+} // namespace picongpu

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesInitialization.param
@@ -1,0 +1,49 @@
+/* Copyright 2015-2019 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Initialize particles inside particle species. This is the final step in
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        /** InitPipeline define in which order species are initialized
+         *
+         * the functors are called in order (from first to last functor)
+         */
+        using InitPipeline = bmpl::vector<
+            CreateDensity<densityProfiles::Homogenous, startPosition::QuietElectrons, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::QuietPositrons, PIC_Positrons>,
+            Manipulate<manipulators::AssignZDriftPositrons, PIC_Positrons>,
+            Manipulate<manipulators::AssignZDriftElectrons, PIC_Electrons>>;
+
+    } // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
- [x] depends and include #3465

- Add benchmark case used in SPEC benchmarks.
- Check `benchmarks` examples with the CI

Note: In the original SPEC benchmark PIConGPU is manipulated that the random number generator will not be initialized. This means that the overall runtime between a benchmark with the SPEC benchmark suite and native PIConGPU will differ.

@jkelling The param files for the SPEC example are differing slightly from the example we currently use in SPEC. The difference is in the name of the second species. Instead of the name the species `i` for ions the name is now correct and called `p` for positions. The runtime parameter to create the energy files are therefore different.

```
              --p_macroParticlesCount.period 100        
              --e_macroParticlesCount.period 100         
              --fields_energy.period 100                 
              --e_energy.period 100 --e_energy.filter all 
              --p_energy.period 100 --p_energy.filter all"
```


# Review

The last two commits correspond to this PR, all others are from #3465