### PR TITLE
fix deprecation warnings

### DIFF
--- a/include/picongpu/plugins/output/GatherSlice.hpp
+++ b/include/picongpu/plugins/output/GatherSlice.hpp
@@ -125,7 +125,7 @@ namespace picongpu
                 header.sim.size.x() * sizeof(ValueType)));
 
             MessageHeader* fakeHeader = MessageHeader::create();
-            memcpy(fakeHeader, &header, sizeof(MessageHeader));
+            *fakeHeader = header;
 
             char* recvHeader = new char[MessageHeader::bytes * numRanks];
 

--- a/include/picongpu/plugins/output/header/MessageHeader.hpp
+++ b/include/picongpu/plugins/output/header/MessageHeader.hpp
@@ -149,6 +149,8 @@ namespace picongpu
             __deleteArray(obj);
         }
 
+        MessageHeader& operator=(MessageHeader const&) = default;
+
         DataHeader data;
         SimHeader sim;
         WindowHeader window;

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -54,6 +54,8 @@ namespace pmacc
             }
         }
 
+        constexpr HDINLINE DataSpace& operator=(const DataSpace&) = default;
+
         /**
          * constructor.
          * Sets size of all dimensions from cuda dim3.

--- a/include/pmacc/eventSystem/events/EventTask.hpp
+++ b/include/pmacc/eventSystem/events/EventTask.hpp
@@ -43,6 +43,8 @@ namespace pmacc
          */
         EventTask(id_t taskId);
 
+        constexpr EventTask(const pmacc::EventTask&) = default;
+
         /**
          * Constructor.
          */

--- a/include/pmacc/mappings/simulation/Selection.hpp
+++ b/include/pmacc/mappings/simulation/Selection.hpp
@@ -52,12 +52,8 @@ namespace pmacc
 
         /**
          * Copy constructor
-         *
-         * @param other Selection to copy information from
          */
-        Selection(const Selection<DIM>& other) : size(other.size), offset(other.offset)
-        {
-        }
+        constexpr Selection(const Selection&) = default;
 
         /**
          * Constructor

--- a/include/pmacc/mappings/simulation/SubGrid.hpp
+++ b/include/pmacc/mappings/simulation/SubGrid.hpp
@@ -40,6 +40,8 @@ namespace pmacc
     public:
         typedef DataSpace<DIM> Size;
 
+        constexpr SubGrid& operator=(const SubGrid&) = default;
+
         /**
          * Initialize SubGrid instance
          *

--- a/include/pmacc/math/complex/Complex.hpp
+++ b/include/pmacc/math/complex/Complex.hpp
@@ -38,6 +38,8 @@ namespace pmacc
             {
             }
 
+            constexpr HDINLINE Complex(const Complex& other) = default;
+
             // constructor (Complex<T_OtherType>)
             template<typename T_OtherType>
             HDINLINE explicit Complex(const Complex<T_OtherType>& other)

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -52,6 +52,8 @@ namespace pmacc
                 {
                 }
 
+                constexpr Vector_components& operator=(const Vector_components&) = default;
+
                 /*align full vector*/
                 PMACC_ALIGN(v[dim], type);
 
@@ -239,6 +241,8 @@ namespace pmacc
 
                 return invertedVector;
             }
+
+            constexpr HDINLINE Vector& operator=(const Vector&) = default;
 
             template<typename T_OtherAccessor, typename T_OtherNavigator, template<typename, int> class T_OtherStorage>
             HDINLINE This& operator=(const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -26,6 +26,7 @@
 #include "pmacc/eventSystem/tasks/Factory.hpp"
 #include "pmacc/memory/buffers/DeviceBuffer.hpp"
 #include "pmacc/memory/boxes/DataBox.hpp"
+#include "pmacc/memory/Array.hpp"
 #include "pmacc/assert.hpp"
 
 namespace pmacc
@@ -103,15 +104,11 @@ namespace pmacc
             __startOperation(ITask::TASK_DEVICE);
             if(!preserveData)
             {
-                TYPE value;
-                /* using `uint8_t` for byte-wise looping through tmp var value of `TYPE` */
-                uint8_t* valuePtr = reinterpret_cast<uint8_t*>(&value);
-                for(size_t b = 0; b < sizeof(TYPE); ++b)
-                {
-                    valuePtr[b] = static_cast<uint8_t>(0);
-                }
-                /* set value with zero-ed `TYPE` */
-                setValue(value);
+                // Using Array is a workaround for types without default constructor
+                memory::Array<TYPE, 1> tmp;
+                memset(reinterpret_cast<void*>(tmp.data()), 0, sizeof(tmp));
+                // use first element to avoid issue because Array is aligned (sizeof can be larger than component type)
+                setValue(tmp[0]);
             }
         }
 

--- a/include/pmacc/memory/buffers/HostBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/HostBufferIntern.hpp
@@ -26,6 +26,7 @@
 #include "pmacc/eventSystem/tasks/Factory.hpp"
 #include "pmacc/eventSystem/EventSystem.hpp"
 #include "pmacc/memory/boxes/DataBoxDim1Access.hpp"
+#include "pmacc/memory/Array.hpp"
 #include "pmacc/assert.hpp"
 
 namespace pmacc
@@ -102,18 +103,18 @@ namespace pmacc
                  * that the physical memory is contiguous
                  */
                 if(ownPointer)
-                    memset(pointer, 0, this->getDataSpace().productOfComponents() * sizeof(TYPE));
+                    memset(
+                        reinterpret_cast<void*>(pointer),
+                        0,
+                        this->getDataSpace().productOfComponents() * sizeof(TYPE));
                 else
                 {
-                    TYPE value;
-                    /* using `uint8_t` for byte-wise looping through tmp var value of `TYPE` */
-                    uint8_t* valuePtr = (uint8_t*) &value;
-                    for(size_t b = 0; b < sizeof(TYPE); ++b)
-                    {
-                        valuePtr[b] = static_cast<uint8_t>(0);
-                    }
-                    /* set value with zero-ed `TYPE` */
-                    setValue(value);
+                    // Using Array is a workaround for types without default constructor
+                    memory::Array<TYPE, 1> tmp;
+                    memset(reinterpret_cast<void*>(tmp.data()), 0, sizeof(tmp));
+                    // use first element to avoid issue because Array is aligned (sizeof can be larger than component
+                    // type)
+                    setValue(tmp[0]);
                 }
             }
         }


### PR DESCRIPTION
With gcc 9.3 I saw we got many warnings about deprecated behaviors.
The warning will be fixed by adding explicit `constexpr` copy constructors and assignment constructors.
The second type of warning was coming from *memset* usage which can be removed by casting the pointer given to *memset* to `void*`

e.g.
```
warning: implicitly-declared ‘constexpr pmacc::EventTask::EventTask(const pmacc::EventTask&)’ 
is deprecated [-Wdeprecated-copy]
```
