### PR TITLE
disable async device streams for CPU backends

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -64,22 +64,22 @@ get_backend_flags()
             result+=" -DALPAKA_CUDA_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "omp2b" ] ; then
-        result+=" -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON"
+        result+=" -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON -DCUPLA_STREAM_ASYNC_ENABLE=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "serial" ] ; then
-        result+=" -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON"
+        result+=" -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DCUPLA_STREAM_ASYNC_ENABLE=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "tbb" ] ; then
-        result+=" -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON"
+        result+=" -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON -DCUPLA_STREAM_ASYNC_ENABLE=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "threads" ] ; then
-        result+=" -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON"
+        result+=" -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON -DCUPLA_STREAM_ASYNC_ENABLE=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi


### PR DESCRIPTION
When enabling asynchronous CPU backends in alpaka/cupla PIConGPU will block one core per MPI rank to poll for the task (alpaka kernel,memcopy) state. This will block one core and also an asynchronous will oversubscribe the CPU which results mostly in bad performance.

By switching to synchronous task execution, by setting the cmake flag `-DCUPLA_STREAM_ASYNC_ENABLE` we can get up to 30% more performance (example KHI).
MPI calls will still be asynchronous executed.

Since the year 2020 is ending and was definitely not the best year, compared to the years before, I would give this improvement to our CPU user-community. :christmas_tree: 