### PR TITLE
CI: latest container v1.1

### DIFF
--- a/share/ci/bash.profile
+++ b/share/ci/bash.profile
@@ -26,6 +26,11 @@ export CMAKE_PREFIX_PATH=$ADIOS1_ROOT:$CMAKE_PREFIX_PATH
 export PATH=$ADIOS1_ROOT/bin:$PATH
 export LD_LIBRARY_PATH=$ADIOS1_ROOT/lib:$LD_LIBRARY_PATH
 
+export ADIOS2_ROOT=/opt/adios/2.6.0
+export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
+export PATH=$ADIOS2_ROOT/bin:$PATH
+export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib:$LD_LIBRARY_PATH
+
 export ICET_ROOT=/opt/icet/2.9.0
 export CMAKE_PREFIX_PATH=$ICET_ROOT/lib:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$ICET_ROOT/lib:$LD_LIBRARY_PATH
@@ -34,12 +39,9 @@ export JANSSON_ROOT=/opt/jansson/2.9.0/
 export CMAKE_PREFIX_PATH=$JANSSON_ROOT/lib/cmake:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$JANSSON_ROOT/lib:$LD_LIBRARY_PATH
 
-# disabled:
-#   - test container are shipped with the wrong issac version
-#   - issac must be tested with different compilers
-#export ISAAC_ROOT=/opt/isaac/1.6.0-dev
-#export CMAKE_PREFIX_PATH=$ISAAC_ROOT:$CMAKE_PREFIX_PATH
-#export LD_LIBRARY_PATH=$ISAAC_ROOT/lib:$LD_LIBRARY_PATH
+export ISAAC_ROOT=/opt/isaac/1.6.0-dev
+export CMAKE_PREFIX_PATH=$ISAAC_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$ISAAC_ROOT/lib:$LD_LIBRARY_PATH
 
 export OPENPMD_ROOT=/opt/openPMD-api/0.12.0
 export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -2,13 +2,13 @@
 #   [clang++-X] : X = {4.0, 5.0, 6.0, 7, 8, 9, 10, 11}
 
 .base_clang:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:clangPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-clang-pic:1.1
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
   script:
     - apt update
-    - apt install -y curl
+    - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -8,7 +8,7 @@
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
   script:
     - apt update
-    - apt install -y curl
+    - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
@@ -18,13 +18,13 @@
     - x86_64 
 
 .base_clangCuda_cuda_9.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2ClangPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda92-clangpic:1.1
   extends: .base_cuda_clang
   
 .base_clangCuda_cuda_10.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0ClangPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda100-clangpic:1.1
   extends: .base_cuda_clang
 
 .base_clangCuda_cuda_10.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1ClangPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda101-clangpic:1.1
   extends: .base_cuda_clang

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -2,12 +2,12 @@
 #   [g++-X] : X = {5, 6, 7, 8, 9 ,10}
 
 .base_gcc:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:gccPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-gcc-pic:1.1
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   script:
     - apt update
-    - apt install -y curl
+    - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -9,7 +9,7 @@
     - nvcc --version
   script:
     - apt update
-    - apt install -y curl
+    - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
@@ -19,21 +19,21 @@
     - x86_64 
     
 .base_nvcc_cuda_9.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda9.2gccPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda92-gccpic:1.1
   extends: .base_nvcc
 
 .base_nvcc_cuda_10.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.0gccPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda100-gccpic:1.1
   extends: .base_nvcc
   
 .base_nvcc_cuda_10.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.1gccPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda101-gccpic:1.1
   extends: .base_nvcc
 
 .base_nvcc_cuda_10.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda10.2gccPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda102-gccpic:1.1
   extends: .base_nvcc
 
 .base_nvcc_cuda_11.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci:cuda11.0gccPic
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda110-gccpic:1.1
   extends: .base_nvcc


### PR DESCRIPTION
- switch to conatiner v1.1
- activate ISAAC 1.6.0-dev tests
- fix silently disabled openPMD tests

ISAAC code should now be fixed to be able to compile together with PIConGPU.