### PR TITLE
Rename picongpu::MySimulation to picongpu::Simulation

### DIFF
--- a/docs/source/dev/picongpu.rst
+++ b/docs/source/dev/picongpu.rst
@@ -3,10 +3,10 @@ Important PIConGPU Classes
 
 This is very, very small selection of classes of interest to get you started.
 
-MySimulation
-------------
+Simulation
+----------
 
-.. doxygenclass:: picongpu::MySimulation
+.. doxygenclass:: picongpu::Simulation
    :project: PIConGPU
    :members:
    :undoc-members:

--- a/include/picongpu/param/components.param
+++ b/include/picongpu/param/components.param
@@ -34,7 +34,7 @@ namespace picongpu
      *
      * Simulation Starter Selection:
      * This value does usually not need to be changed. Change only if you want to
-     * implement your own `SimulationHelper` (e.g. `MySimulation`) class.
+     * implement your own `SimulationHelper` (e.g. `Simulation`) class.
      *  - defaultPIConGPU         : default PIConGPU configuration
      */
     namespace simulation_starter = defaultPIConGPU;

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -164,7 +164,7 @@ namespace picongpu
             /** Creates a `ScaledSpectrum` instance for a given electron species
              * and stores it in a map<atomic number, ScaledSpectrum> object.
              *
-             * This functor is called from MySimulation::init() to generate lookup tables.
+             * This functor is called from Simulation::init() to generate lookup tables.
              *
              * @tparam T_ElectronSpecies type or name as boost::mpl::string of the electron species
              */

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -115,13 +115,13 @@ namespace picongpu
      *
      * @tparam DIM the dimension (2-3) for the simulation
      */
-    class MySimulation : public SimulationHelper<simDim>
+    class Simulation : public SimulationHelper<simDim>
     {
     public:
         /**
          * Constructor
          */
-        MySimulation()
+        Simulation()
             : myFieldSolver(nullptr)
             , cellDescription(nullptr)
             , initialiserController(nullptr)

--- a/include/picongpu/unitless/starter.unitless
+++ b/include/picongpu/unitless/starter.unitless
@@ -21,7 +21,7 @@
 
 #include "picongpu/initialization/InitialiserController.hpp"
 #include "picongpu/plugins/PluginController.hpp"
-#include "picongpu/simulation/control/MySimulation.hpp"
+#include "picongpu/simulation/control/Simulation.hpp"
 #include "picongpu/simulation/control/SimulationStarter.hpp"
 
 
@@ -33,9 +33,7 @@ namespace picongpu
          *
          * etc.: using SimStarter = MyOwnStarterClass;
          */
-        using SimStarter = ::picongpu::SimulationStarter<
-            ::picongpu::InitialiserController,
-            ::picongpu::PluginController,
-            ::picongpu::MySimulation>;
+        using SimStarter = ::picongpu::
+            SimulationStarter<::picongpu::InitialiserController, ::picongpu::PluginController, ::picongpu::Simulation>;
     } // namespace defaultPIConGPU
 } // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
@@ -22,7 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 #include <pmacc/Environment.hpp>
 
-#include "picongpu/simulation/control/MySimulation.hpp"
+#include "picongpu/simulation/control/Simulation.hpp"
 
 #include <pmacc/simulationControl/SimulationHelper.hpp>
 
@@ -59,16 +59,16 @@ namespace picongpu
 {
     using namespace pmacc;
 
-    class ThermalTestSimulation : public MySimulation
+    class ThermalTestSimulation : public Simulation
     {
     public:
-        ThermalTestSimulation() : MySimulation()
+        ThermalTestSimulation() : Simulation()
         {
         }
 
         void init()
         {
-            MySimulation::init();
+            Simulation::init();
 
             using namespace ::pmacc::math;
 
@@ -88,12 +88,12 @@ namespace picongpu
 
         void pluginRegisterHelp(po::options_description& desc)
         {
-            MySimulation::pluginRegisterHelp(desc);
+            Simulation::pluginRegisterHelp(desc);
         }
 
         void pluginLoad()
         {
-            MySimulation::pluginLoad();
+            Simulation::pluginLoad();
         }
 
         virtual ~ThermalTestSimulation()
@@ -154,7 +154,7 @@ namespace picongpu
          */
         void runOneStep(uint32_t currentStep)
         {
-            MySimulation::runOneStep(currentStep);
+            Simulation::runOneStep(currentStep);
 
             if(currentStep > this->collectTimesteps + firstTimestep)
                 return;


### PR DESCRIPTION
This is not a big or important change at all. Just to me personally `MySimulation` always felt like a name associated with throwaway code like used in small code snippets to test smth e.g. in online compilers.