### PR TITLE
Fix return value of main() in mpiInfo

### DIFF
--- a/include/mpiInfo/mpiInfo.cpp
+++ b/include/mpiInfo/mpiInfo.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv)
     if(vm.count("help"))
     {
         std::cerr << desc << "\n";
-        return false;
+        return 0;
     }
 
     MPI_CHECK(MPI_Init(&argc, &argv));


### PR DESCRIPTION
The previously used return false rightfully triggered clang `warning: bool literal returned from 'main' [-Wmain]`. Change it to 0.