### PR TITLE
Extend reminder to load environment in the docs with instructions for spack

### DIFF
--- a/USAGE.rst
+++ b/USAGE.rst
@@ -2,7 +2,7 @@
 
 .. seealso::
 
-   You need to have an :ref:`environment loaded <install-profile>` (``source $HOME/picongpu.profile``) that provides all :ref:`PIConGPU dependencies <install-dependencies>` to complete this chapter.
+   You need to have an :ref:`environment loaded <install-profile>` (``source $HOME/picongpu.profile`` when installing from source or ``spack load picongpu`` when using spack) that provides all :ref:`PIConGPU dependencies <install-dependencies>` to complete this chapter.
 
 .. warning::
 


### PR DESCRIPTION
The goal is to help explaining that regardless of how PIConGPU was installed, it is used uniformly.
This is what some recent users via spack, and some developers as well, seem to have missed from the docs.

Not sure if this addition is enough, but it's at least something.