### PR TITLE
remove openPMD 0.11.0 module for defq

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -30,7 +30,6 @@ module load adios/1.13.1
 module load hdf5-parallel/1.8.20
 module load libsplash/1.7.0
 module load python/3.6.5
-module load openpmd/0.11.1
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0


### PR DESCRIPTION
The openPMD 0.11.0 module used for the defq example setup leads to a compile error. 
Most likely version 0.12.0 is required. @psychocoderHPC and @sbastrakov do we check the openPMD version in the CMake file?

The error is:
```
In file included from /.../picongpu/include/picongpu/plugins/PluginController.hpp:50:0,
                 from /.../picongpu/include/picongpu/unitless/starter.unitless:23,
                 from /.../picongpu/include/picongpu/simulation_defines.hpp:53,
                 from /.../picongpu/include/picongpu/main.cpp:27:
/.../picongpu/include/picongpu/plugins/openPMD/openPMDWriter.hpp: In member function ‘void picongpu::openPMD::openPMDWriter::write(picongpu::openPMD::ThreadParams*, std::__cxx11::string)’:
/.../picongpu/include/picongpu/plugins/openPMD/openPMDWriter.hpp:1192:84:error: ‘using mapped_type = std::map<long unsigned int, openPMD::Iteration, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, openPMD::Iteration> > >::mapped_type {aka class openPMD::Iteration}’ has no member named ‘close’
                 mThreadParams.openPMDSeries->iterations[mThreadParams.currentStep].close();
                                                                                    ^~~~~
make[2]: *** [CMakeFiles/picongpu.dir/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/picongpu.dir/all] Error 2
make: *** [all] Error 2

ERROR: Could not successfully run make install in build directory:
       .build    
``` 

Removing the module solves the issue.
Currently no 0.12.0 module exists for CPU jobs. 