### PR TITLE
Use Streaming API in openPMD plugin

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -328,7 +328,7 @@ ADIOS
 
 openPMD API
 """""""""""
-- 0.12.0+ (yet to be released, requires *MPI*)
+- 0.12.0+ (bare minimum) / 0.13.0+ (for streaming IO)
 - *Spack*: ``spack install openpmd-api``
 - *from source:*
 

--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -9,6 +9,7 @@ External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
 The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
+If the openPMD API is found in version 0.13.0 or greater, PIConGPU will support streaming IO via openPMD.
 
 .param file
 ^^^^^^^^^^^
@@ -40,14 +41,17 @@ The openPMD API will parse the file name to decide the chosen backend and iterat
 In order to set defaults for these value, two further options control the filename:
 
 * ``--openPMD.ext`` sets the filename extension.
-  Possible extensions include ``.bp`` for the ADIOS backends (default).
+  Possible extensions include ``bp`` for the ADIOS backends (default), ``h5`` for HDF5 and ``sst`` for Streaming via ADIOS2/SST.
   If the openPMD API has been built with support for the ADIOS1 and ADIOS2 backends, ADIOS2 will take precedence over ADIOS1.
   This behavior can be overridden by setting the environment variable ``OPENPMD_BP_BACKEND=ADIOS1``.
-  The extension for the HDF5 backend is ``.h5``.
-  (The version of ADIOS will depend on the compile-time configuration of the openPMD API.)
 * ``--openPMD.infix`` sets the filename pattern that controls the iteration layout, default is "_06T" for a six-digit number specifying the iteration.
   Leave empty to pick group-based iteration layout.
   Since passing an empty string may be tricky in some workflows, specifying ``--openPMD.infix=NULL`` is also possible.
+
+  Note that streaming IO requires group-based iteration layout in openPMD, i.e. ``--openPMD.infix=NULL`` is mandatory.
+  If PIConGPU detects a streaming backend (e.g. by ``--openPMD.ext=sst``), it will automatically set ``--openPMD.infix=NULL``, overriding the user's choice.
+  Note however that the ADIOS2 backend can also be selected via ``--openPMD.json`` and via environment variables which PIConGPU does not check.
+  It is hence recommended to set ``--openPMD.infix=NULL`` explicitly.
 
 For example, ``--openPMD.period 128 --openPMD.file simData --openPMD.source 'species_all'`` will write only the particle species data to files of the form ``simData_000000.bp``, ``simData_000128.bp`` in the default simulation output directory every 128 steps.
 Note that this plugin will only be available if the openPMD API is found during compile configuration.

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 ################################################################################
 
 # find openPMD installation
-find_package(openPMD 0.13.0 CONFIG COMPONENTS MPI)
+find_package(openPMD 0.12.0 CONFIG COMPONENTS MPI)
 
 if(openPMD_FOUND)
     if(openPMD_HAVE_ADIOS2 OR openPMD_HAVE_HDF5)

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 ################################################################################
 
 # find openPMD installation
-find_package(openPMD 0.12.0 CONFIG COMPONENTS MPI)
+find_package(openPMD 0.13.0 CONFIG COMPONENTS MPI)
 
 if(openPMD_FOUND)
     if(openPMD_HAVE_ADIOS2 OR openPMD_HAVE_HDF5)

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -85,7 +85,7 @@ namespace picongpu
 
                 ::openPMD::Series& series = *params.openPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
-                    = series.iterations[params.currentStep].meshes[baseName + "_" + group][dataset];
+                    = series.writeIterations()[params.currentStep].meshes[baseName + "_" + group][dataset];
 
                 if(!attrName.empty())
                 {

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/plugins/openPMD/openPMDVersion.def"
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/types.hpp>
@@ -85,7 +86,7 @@ namespace picongpu
 
                 ::openPMD::Series& series = *params.openPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
-                    = series.writeIterations()[params.currentStep].meshes[baseName + "_" + group][dataset];
+                    = series.WRITE_ITERATIONS[params.currentStep].meshes[baseName + "_" + group][dataset];
 
                 if(!attrName.empty())
                 {

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2019 Alexander Grund, Franz Poeschel
+/* Copyright 2016-2021 Alexander Grund, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/WriteMeta.hpp
+++ b/include/picongpu/plugins/openPMD/WriteMeta.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/fields/currentInterpolation/CurrentInterpolation.hpp"
 #include "picongpu/plugins/common/stringHelpers.hpp"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/plugins/openPMD/openPMDVersion.def"
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
@@ -76,7 +77,7 @@ namespace picongpu
                     }
 
                     ::openPMD::Iteration iteration
-                        = threadParams->openPMDSeries->writeIterations()[threadParams->currentStep];
+                        = threadParams->openPMDSeries->WRITE_ITERATIONS[threadParams->currentStep];
                     iteration.setAttribute("particleBoundary", listParticleBoundary);
                     iteration.setAttribute("particleBoundaryParameters", listParticleBoundaryParam);
                 }
@@ -134,7 +135,7 @@ namespace picongpu
                 const std::string date = helper::getDateString("%F %T %z");
                 series.setDate(date);
 
-                ::openPMD::Iteration iteration = series.writeIterations()[threadParams->currentStep];
+                ::openPMD::Iteration iteration = series.WRITE_ITERATIONS[threadParams->currentStep];
                 ::openPMD::Container<::openPMD::Mesh>& meshes = iteration.meshes;
 
                 // iteration-level attributes

--- a/include/picongpu/plugins/openPMD/WriteMeta.hpp
+++ b/include/picongpu/plugins/openPMD/WriteMeta.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2019 Axel Huebl, Franz Poeschel
+/* Copyright 2013-2021 Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/WriteMeta.hpp
+++ b/include/picongpu/plugins/openPMD/WriteMeta.hpp
@@ -76,7 +76,7 @@ namespace picongpu
                     }
 
                     ::openPMD::Iteration iteration
-                        = threadParams->openPMDSeries->iterations[threadParams->currentStep];
+                        = threadParams->openPMDSeries->writeIterations()[threadParams->currentStep];
                     iteration.setAttribute("particleBoundary", listParticleBoundary);
                     iteration.setAttribute("particleBoundaryParameters", listParticleBoundaryParam);
                 }
@@ -134,7 +134,7 @@ namespace picongpu
                 const std::string date = helper::getDateString("%F %T %z");
                 series.setDate(date);
 
-                ::openPMD::Iteration iteration = series.iterations[threadParams->currentStep];
+                ::openPMD::Iteration iteration = series.writeIterations()[threadParams->currentStep];
                 ::openPMD::Container<::openPMD::Mesh>& meshes = iteration.meshes;
 
                 // iteration-level attributes

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -290,7 +290,7 @@ namespace picongpu
                 const std::string speciesGroup(T_Species::getName());
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Iteration iteration = series.iterations[params->currentStep];
+                ::openPMD::Iteration iteration = series.writeIterations()[params->currentStep];
 
                 // enforce that the filter interface is fulfilled
                 particles::filter::IUnary<typename T_SpeciesFilter::Filter> particleFilter{params->currentStep};

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/plugins/ISimulationPlugin.hpp"
 #include "picongpu/plugins/kernel/CopySpecies.kernel"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
+#include "picongpu/plugins/openPMD/openPMDVersion.def"
 #include "picongpu/plugins/openPMD/writer/ParticleAttribute.hpp"
 #include "picongpu/plugins/output/WriteSpeciesCommon.hpp"
 #include "picongpu/simulation_defines.hpp"
@@ -290,7 +291,7 @@ namespace picongpu
                 const std::string speciesGroup(T_Species::getName());
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Iteration iteration = series.writeIterations()[params->currentStep];
+                ::openPMD::Iteration iteration = series.WRITE_ITERATIONS[params->currentStep];
 
                 // enforce that the filter interface is fulfilled
                 particles::filter::IUnary<typename T_SpeciesFilter::Filter> particleFilter{params->currentStep};

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2019 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2014-2021 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Alexander Grund, Franz Poeschel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/openPMD/openPMDVersion.def
+++ b/include/picongpu/plugins/openPMD/openPMDVersion.def
@@ -1,3 +1,22 @@
+/* Copyright 2020 Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "openPMD/openPMD.hpp"
 
 #if OPENPMDAPI_VERSION_GE(0, 13, 0)
@@ -6,4 +25,4 @@
 #else
 // Not available, don't use it
 #define WRITE_ITERATIONS iterations
-#endif 
+#endif

--- a/include/picongpu/plugins/openPMD/openPMDVersion.def
+++ b/include/picongpu/plugins/openPMD/openPMDVersion.def
@@ -1,0 +1,9 @@
+#include "openPMD/openPMD.hpp"
+
+#if OPENPMDAPI_VERSION_GE(0, 13, 0)
+// Streaming API is available, use it
+#define WRITE_ITERATIONS writeIterations()
+#else
+// Not available, don't use it
+#define WRITE_ITERATIONS iterations
+#endif 

--- a/include/picongpu/plugins/openPMD/openPMDVersion.def
+++ b/include/picongpu/plugins/openPMD/openPMDVersion.def
@@ -1,4 +1,4 @@
-/* Copyright 2020 Franz Poeschel
+/* Copyright 2020-2021 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/openPMDVersion.def
+++ b/include/picongpu/plugins/openPMD/openPMDVersion.def
@@ -21,8 +21,8 @@
 
 #if OPENPMDAPI_VERSION_GE(0, 13, 0)
 // Streaming API is available, use it
-#define WRITE_ITERATIONS writeIterations()
+#    define WRITE_ITERATIONS writeIterations()
 #else
 // Not available, don't use it
-#define WRITE_ITERATIONS iterations
+#    define WRITE_ITERATIONS iterations
 #endif

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -101,6 +101,8 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset; /** offset from local moving
                                                             window to local domain */
 
+            std::vector<double> times;
+
             ::openPMD::Series& openSeries(::openPMD::Access at);
 
             void closeSeries();

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2019 Felix Schmitt, Axel Huebl, Franz Poeschel
+/* Copyright 2014-2021 Felix Schmitt, Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2019 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz, Alexander Grund, Franz Poeschel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -211,8 +211,10 @@ Please pick either of the following:
             plugins::multi::Option<std::string> fileNameInfix
                 = {"infix",
                    "openPMD filename infix (use to pick file- or group-based "
-                   "layout in openPMD)\nset to NULL to keep empty (e.g. to pick"
-                   " group-based iteration layout)",
+                   "layout in openPMD)\nSet to NULL to keep empty (e.g. to pick"
+                   " group-based iteration layout). Parameter will be ignored"
+                   " if a streaming backend is detected in 'ext' parameter and"
+                   " an empty string will be assumed instead.",
                    "_%06T"};
 
             plugins::multi::Option<std::string> jsonConfig
@@ -352,7 +354,10 @@ Please pick either of the following:
         {
             fileExtension = help.fileNameExtension.get(id);
             fileInfix = help.fileNameInfix.get(id);
-            if(fileInfix == "NULL")
+            /*
+             * Enforce group-based iteration layout for streaming backends
+             */
+            if(fileInfix == "NULL" || fileExtension == "sst")
             {
                 fileInfix = "";
             }

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -56,6 +56,7 @@
 #include "picongpu/plugins/misc/SpeciesFilter.hpp"
 #include "picongpu/plugins/openPMD/NDScalars.hpp"
 #include "picongpu/plugins/openPMD/WriteMeta.hpp"
+#include "picongpu/plugins/openPMD/openPMDVersion.def"
 #include "picongpu/plugins/openPMD/WriteSpecies.hpp"
 #include "picongpu/plugins/openPMD/restart/LoadSpecies.hpp"
 #include "picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp"
@@ -918,7 +919,7 @@ Please pick either of the following:
                 const bool fieldTypeCorrect(boost::is_same<ComponentType, float_X>::value);
                 PMACC_CASSERT_MSG(Precision_mismatch_in_Field_Components__ADIOS, fieldTypeCorrect);
 
-                ::openPMD::Iteration iteration = params->openPMDSeries->writeIterations()[params->currentStep];
+                ::openPMD::Iteration iteration = params->openPMDSeries->WRITE_ITERATIONS[params->currentStep];
                 ::openPMD::Mesh mesh = iteration.meshes[name];
 
                 // set mesh attributes
@@ -1199,7 +1200,7 @@ Please pick either of the following:
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 __getTransactionEvent().waitForFinished();
-                mThreadParams.openPMDSeries->writeIterations()[mThreadParams.currentStep].close();
+                mThreadParams.openPMDSeries->WRITE_ITERATIONS[mThreadParams.currentStep].close();
 
                 return;
             }


### PR DESCRIPTION
[openPMD API 0.13.0 beta](https://openpmd-api.readthedocs.io/en/0.13.0/) has been released yesterday, including support for streaming IO. This PR applies this to the openPMD plugin.

Also adds some timing output which I found to be useful.

TODO
- [x] Documentation
- [ ] Use openPMD API 0.13.0 in CI containers 
    EDIT: Not strictly necessary since we will further support openPMD API 0.12.0
- [x] Automatically set `--openPMD.infix=NULL` if `openPMD.ext==sst` 
- [ ] Update versions in cluster environments (get new version installed on Hemera, update profiles)
    EDIT: Not strictly necessary since we will further support openPMD API 0.12.0