### PR TITLE
add device side assert macro

### DIFF
--- a/include/pmacc/assert.hpp
+++ b/include/pmacc/assert.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2021 Rene Widera, Pawel Ordyna
  *
  * This file is part of PMacc.
  *
@@ -24,6 +24,8 @@
 
 #include "pmacc/debug/abortWithError.hpp"
 
+#include <cassert>
+
 #ifdef NDEBUG
 // debug mode is disabled
 
@@ -31,23 +33,30 @@
 #    define PMACC_ASSERT(expr) ((void) 0)
 
 /* `(void)0` force a semicolon after the macro function */
+#    define PMACC_DEVICE_ASSERT(expr) ((void) 0)
+
+/* `(void)0` force a semicolon after the macro function */
 #    define PMACC_ASSERT_MSG(expr, msg) ((void) 0)
+
+// debug mode is disabled
+/* `(void)0` force a semicolon after the macro function */
+#    define PMACC_DEVICE_ASSERT_MSG(expr, ...) ((void) 0)
 
 #else
 
 // debug mode is enabled
 
-/** assert check
+/** assert check (host side only)
  *
- * if `NDEBUG` is not defined: macro expands to (void)0
+ * if `NDEBUG` is defined: macro expands to (void)0
  *
  * @param expr expression to be evaluated
  */
 #    define PMACC_ASSERT(expr) (!!(expr)) ? ((void) 0) : pmacc::abortWithError(#    expr, __FILE__, __LINE__)
 
-/** assert check with message
+/** assert check with message (host side only)
  *
- * if `NDEBUG` is not defined: macro expands to (void)0
+ * if `NDEBUG` is defined: macro expands to (void)0
  *
  * @param expr expression to be evaluated
  * @param msg output message (of type `std::string`) which is printed if the
@@ -55,4 +64,25 @@
  */
 #    define PMACC_ASSERT_MSG(expr, msg) (!!(expr)) ? ((void) 0) : pmacc::abortWithError(#    expr, __FILE__, __LINE__, msg)
 
+/** assert check for kernels (device side)
+ *
+ * if `NDEBUG` is defined: macro expands to (void)0
+ * @param expr expression to be evaluated
+ */
+#    define PMACC_DEVICE_ASSERT(expr) assert(expr)
+
+/** assert check with message (device side)
+ *
+ * if `NDEBUG` is defined: macro expands to (void)0
+ *
+ * Beside the usual assert message an additional message is printed to stdout with `printf`.
+ * Pass your `printf` arguments after the evaluated expression, for example to print some local variables:
+ * @code{.cpp}
+ * PMACC_DEVICE_ASSERT_MSG((x > 0), "x was %e, a was %e", x, a);
+ * @endcode
+ *
+ * @param expr expression to be evaluated
+ * @param ... parameters passed to printf
+ */
+#    define PMACC_DEVICE_ASSERT_MSG(expr, ...) (!!(expr)) ? ((void) 0) : (printf(__VA_ARGS__), assert(expr))
 #endif


### PR DESCRIPTION
Since cuda supports assertion checks ((https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#assertion)), for compute compatibility 2.x and higher, I thought it would be nice to have something similar to `PMACC_ASSERT` that works on device side. So this PR would introduce `PMACC_DEVICE_ASSERT` that basicaly just renames the standard `assert` macro from the `assert.h`. I just added a little compatibility check for older cuda devices. According to the [HIP documentation](https://rocmdocs.amd.com/en/latest/Programming_Guides/HIP-GUIDE.html#assert) asserts are supported in the latest release but maybe we need to check the version  for HIP as well, no idea :sweat_smile: . I tried this out with a dummy assert in `ParticlesInit.kernel` with the `defq_picongpu.profile` and `k80_picongpu.profile` and it aborts and prints the assert message as expected. Maybe someone can check if it works on AMD as well.  What do you think? :smile: @ComputationalRadiationPhysics/picongpu-maintainers 

P.S. For testing I was compiling it without the `-NDEBUG`  flag (but still release target) and with `PMACC_BLOCKING_KERNEL=ON` . 
