### PR TITLE
HIP: fix memory allocation

### DIFF
--- a/include/pmacc/nvidia/memory/MemoryInfo.hpp
+++ b/include/pmacc/nvidia/memory/MemoryInfo.hpp
@@ -75,7 +75,7 @@ namespace pmacc
                 /** Returns true if the memory pool is shared by host and device */
                 bool isSharedMemoryPool()
                 {
-#if(PMACC_CUDA_ENABLED != 1 && PMACC_HIP_ENABLED != 1)
+#if(PMACC_CUDA_ENABLED != 1 && ALPAKA_ACC_GPU_HIP_ENABLED != 1)
                     return true;
 #else
                     size_t freeInternal = 0;


### PR DESCRIPTION
A nonexisting define was used to select if a HIP GPU is used.

The result of this BUG is that on AMD devices only half GPU main memory was used which results in crashes if the problem size of the simulation is too large.