### PR TITLE
fix: HIP random number generator compile

### DIFF
--- a/include/pmacc/random/distributions/normal/Normal_double.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_double.hpp
@@ -43,7 +43,7 @@ namespace pmacc
 /* XorMin and MRG32k3aMin uses the alpaka RNG as fallback for CPU accelerators
  * therefore we are not allowed to add a specialization for those RNG methods
  */
-#if(PMACC_CUDA_ENABLED == 1)
+#if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 //! specialization for XorMin
                 template<typename T_Acc>
                 struct Normal<double, methods::XorMin<T_Acc>, void> : public MullerBox<double, methods::XorMin<T_Acc>>

--- a/include/pmacc/random/distributions/normal/Normal_float.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_float.hpp
@@ -43,7 +43,7 @@ namespace pmacc
 /* XorMin and MRG32k3aMin uses the alpaka RNG as fallback for CPU accelerators
  * therefore we are not allowed to add a specialization for those RNG methods
  */
-#if(PMACC_CUDA_ENABLED == 1)
+#if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 //! specialization for XorMin
                 template<typename T_Acc>
                 struct Normal<float, methods::XorMin<T_Acc>, void> : public MullerBox<float, methods::XorMin<T_Acc>>


### PR DESCRIPTION
Using RNG in PIConGPU on AMD devices results into a compile error.

Add missing condition to use `XorMin` together with HIP.