### PR TITLE
enable IO possibility for HIP

### DIFF
--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -51,9 +51,7 @@
 #include <pmacc/pluginSystem/PluginConnector.hpp>
 #include "picongpu/simulation/control/MovingWindow.hpp"
 #include <pmacc/math/Vector.hpp>
-#if(PMACC_CUDA_ENABLED == 1)
-#    include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
-#endif
+#include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
 #include <pmacc/traits/Limits.hpp>
 
 #include "picongpu/plugins/output/IIOBackend.hpp"
@@ -1163,10 +1161,9 @@ namespace picongpu
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
 
-#if(PMACC_CUDA_ENABLED == 1)
                     /* synchronizes the MallocMCBuffer to the host side */
                     dc.get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName());
-#endif
+
                     /* here we are copying all species to the host side since we
                      * can not say at this point if this time step will need all of them
                      * for sure (checkpoint) or just some user-defined species (dump)
@@ -1174,9 +1171,7 @@ namespace picongpu
                     meta::ForEach<FileCheckpointParticles, CopySpeciesToHost<bmpl::_1>> copySpeciesToHost;
                     copySpeciesToHost();
                     lastSpeciesSyncStep = currentStep;
-#if(PMACC_CUDA_ENABLED == 1)
                     dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
-#endif
                 }
 
                 beginAdios(mThreadParams.adiosFilename);

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -50,9 +50,8 @@
 #include <pmacc/pluginSystem/PluginConnector.hpp>
 #include <pmacc/simulationControl/TimeInterval.hpp>
 #include <pmacc/static_assert.hpp>
-#if(PMACC_CUDA_ENABLED == 1)
-#    include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
-#endif
+#include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
+
 #include "picongpu/plugins/misc/SpeciesFilter.hpp"
 #include "picongpu/plugins/openPMD/NDScalars.hpp"
 #include "picongpu/plugins/openPMD/WriteMeta.hpp"
@@ -800,10 +799,9 @@ Please pick either of the following:
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
 
-#if(PMACC_CUDA_ENABLED == 1)
                     /* synchronizes the MallocMCBuffer to the host side */
                     dc.get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName());
-#endif
+
                     /* here we are copying all species to the host side since we
                      * can not say at this point if this time step will need all of
                      * them for sure (checkpoint) or just some user-defined species
@@ -812,9 +810,8 @@ Please pick either of the following:
                     meta::ForEach<FileCheckpointParticles, CopySpeciesToHost<bmpl::_1>> copySpeciesToHost;
                     copySpeciesToHost();
                     lastSpeciesSyncStep = currentStep;
-#if(PMACC_CUDA_ENABLED == 1)
+
                     dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
-#endif
                 }
 
                 TimeIntervall timer;

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -58,6 +58,8 @@ namespace picongpu
             {
 #if(PMACC_CUDA_ENABLED == 1)
                 CUDA_CHECK((cuplaError_t) cudaHostAlloc(&ptr, size * sizeof(type), cudaHostAllocMapped));
+#elif(ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+                CUDA_CHECK((cuplaError_t) hipHostMalloc((void**) &ptr, size * sizeof(type), hipHostRegisterMapped));
 #else
                 ptr = new type[size];
 #endif
@@ -121,6 +123,8 @@ namespace picongpu
             {
 #if(PMACC_CUDA_ENABLED == 1)
                 CUDA_CHECK((cuplaError_t) cudaHostGetDevicePointer(&ptr, srcPtr, 0));
+#elif(ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+                CUDA_CHECK((cuplaError_t) hipHostGetDevicePointer((void**) &ptr, srcPtr, 0));
 #else
                 ptr = srcPtr;
 #endif
@@ -156,6 +160,8 @@ namespace picongpu
                 CUDA_CHECK((cuplaError_t) cudaFreeHost(ptr));
 // re-introduce the cupla macro
 #    define cudaFreeHost(...) cuplaFreeHost(__VA_ARGS__)
+#elif(ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+                CUDA_CHECK((cuplaError_t) hipHostFree(ptr));
 #else
                 __deleteArray(ptr);
 #endif

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -91,9 +91,7 @@
 #include <pmacc/meta/ForEach.hpp>
 #include "picongpu/particles/ParticlesFunctors.hpp"
 #include "picongpu/particles/InitFunctors.hpp"
-#if(PMACC_CUDA_ENABLED == 1)
-#    include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
-#endif
+#include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/particles/traits/FilterByIdentifier.hpp>
 #include <pmacc/particles/IdProvider.hpp>
@@ -425,10 +423,10 @@ namespace picongpu
                 nativeCudaStream,
                 heapSize);
             cuplaStreamSynchronize(0);
-#    if(PMACC_CUDA_ENABLED == 1)
+
             auto mallocMCBuffer = std::make_unique<MallocMCBuffer<DeviceHeap>>(deviceHeap);
             dc.consume(std::move(mallocMCBuffer));
-#    endif
+
 #endif
 
             meta::ForEach<VectorAllSpecies, particles::LogMemoryStatisticsForSpecies<bmpl::_1>>

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -21,13 +21,15 @@
 
 #pragma once
 
-
 #include "pmacc/dataManagement/ISimulationData.hpp"
 
-#include <mallocMC/mallocMC.hpp>
-
 #include <string>
-#include <memory>
+#include <cstdint>
+
+#if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+
+#    include <mallocMC/mallocMC.hpp>
+#    include <memory>
 
 namespace pmacc
 {
@@ -67,4 +69,39 @@ namespace pmacc
 
 } // namespace pmacc
 
-#include "pmacc/particles/memory/buffers/MallocMCBuffer.tpp"
+#    include "pmacc/particles/memory/buffers/MallocMCBuffer.tpp"
+
+#else
+
+namespace pmacc
+{
+    template<typename T_DeviceHeap>
+    class MallocMCBuffer : public ISimulationData
+    {
+    public:
+        MallocMCBuffer(const std::shared_ptr<T_DeviceHeap>&);
+
+        virtual ~MallocMCBuffer() = default;
+
+        SimulationDataId getUniqueId() override
+        {
+            return getName();
+        }
+
+        static std::string getName()
+        {
+            return std::string("MallocMCBuffer");
+        }
+
+        int64_t getOffset()
+        {
+            return 0u;
+        }
+
+        void synchronize() override
+        {
+        }
+    };
+
+} // namespace pmacc
+#endif


### PR DESCRIPTION
Until now it was not possible to dump data with ADIOS or OpenPMD-api if HIP was enabled.
This PR provides the required fixed to enable IO support.

note: Missing abstractions in cupla require the usage of native API calls to HIP, similar to what we do with CUDA.

I restructure the `MallocMCBuffer` to minimize the usage of `#ifdef` precompiled guards in the code.