### PR TITLE
openPMD support for `plot_chargeConservation_overTime.py`

### DIFF
--- a/src/tools/bin/plot_chargeConservation_overTime.py
+++ b/src/tools/bin/plot_chargeConservation_overTime.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 Richard Pausch, Axel Huebl
+# Copyright 2015-2021 Richard Pausch, Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #
@@ -20,20 +20,17 @@
 #
 
 # import system interface modules
-import os
-import re
-import sys
 import argparse
 
 # import data analysis and plotting modules
 import numpy as np
-import h5py
 import matplotlib.pyplot as plt
 from matplotlib.ticker import LinearLocator, FormatStrFormatter
+import openpmd_api as io
 
 __doc__ = """
 This program reads electric field and charge density data
-from all hdf5 files created by a PIConGPU simulation and
+from all openPMD files created by a PIConGPU simulation and
 plots a variety of values to check charge conservation
 over time.
 
@@ -41,74 +38,47 @@ All plotted values show the difference $d = div(E)*epsilon_0 - rho$
 normalized to the maximum [per-species] charge in the first
 simulation time step.
 
-Developer: Richard Pausch
+Developer: Richard Pausch, Rene Widera
 """
 
 
-def get_list_of_hdf5_files(base_directory):
+def deviation_charge_conservation(series, iteration):
     """
-    Returns a list of hdf5 files (`*_<step>.h5`)
-    listed in sub-directory `simOutput/h5/`
-
-    Parameters:
-    base_directory: string
-        directory path where to find simOutput/h5/
-
-    Return:
-    list of strings with hdf5 file names found
-    """
-    h5_list = []  # empty list for hdf5 files
-    h5_dir = base_directory + "/simOutput/h5/"
-    if not os.path.isdir(h5_dir):
-        raise Exception(("Error: {} does not contain" +
-                         " a simOutput/h5/ directory").format(directory))
-
-    for filename in os.listdir(h5_dir):
-        if os.path.isfile(h5_dir+filename):
-            if re.search(r".+_[0-9]+\.h5", filename):
-                h5_list.append(h5_dir + filename)
-    return h5_list
-
-
-def deviation_charge_conservation(h5file):
-    """
-    read field data from hdf5 files
+    read field data from openPMD file
     compute d = div(E)*epsilon_0 - rho
 
     Parameters:
-    h5file: file name
-        file name and path to hdf5 data from PIConGPU
+    series: file name
+        openPMD file series pattern e.g. simData_%%T.bp
+
+    iteration:
+        openPMD iteration object
 
     Return:
-    list of floats: [timestep, max(abs(d)),
-        mean(abs(d)), std(d), norm]
+    list of floats: [max(abs(d)), mean(abs(d)), std(d), norm]
     """
-    # load hdf5 file
-    f = h5py.File(h5file, "r")
-
-    # read time step (python 2 and 3 save)
-    timestep = -1
-    for i in f["/data"].keys():
-        timestep = i
 
     # load physics constants and simulation parameters
-    EPS0 = f["/data/{}".format(timestep)].attrs["eps0"]
+    EPS0 = iteration.get_attribute("eps0")
     is2D = False
 
     # load electric field
-    Ex = np.array(f["/data/{}/fields/E/x".format(timestep)])
-    Ey = np.array(f["/data/{}/fields/E/y".format(timestep)])
-    Ez = np.array(f["/data/{}/fields/E/z".format(timestep)])
+    Ex = iteration.meshes["E"]["x"][:]
+    Ey = iteration.meshes["E"]["y"][:]
+    Ez = iteration.meshes["E"]["z"][:]
+
+    series.flush()
 
     # load and add charge density
     charge = np.zeros_like(Ex)
     norm = 0.0
-    for field_name in f["/data/{}/fields/".format(timestep)].keys():
-        if field_name[-14:] == "_chargeDensity":
+    for fieldName in iteration.meshes:
+        if fieldName[-14:] == "_chargeDensity":
             # load species density
-            species_Density_pointer = f["/data/{}/fields/".format(timestep) +
-                                        field_name]
-            species_Density = np.array(species_Density_pointer)
+            # load species density
+            species_Density = \
+                iteration.meshes[fieldName][io.Mesh_Record_Component.SCALAR][:]
+            series.flush()
             # choose norm to be the maximal charge density of all species
             norm = np.max([norm, np.amax(np.abs(species_Density))])
             # add charge density to total charge density
@@ -119,16 +89,16 @@ def deviation_charge_conservation(h5file):
             # a 2D simulation, the size of the z or [2]-component is 1, which
             # is <2. The code changes the 2D3D flag if one Density data set is
             # 2D.
-            if species_Density_pointer.attrs['_size'][2] < 2:
+            if species_Density.ndim == 2:
                 is2D = True
 
     # load cell size and compute cell volume
-    CELL_WIDTH = f["/data/{}".format(timestep)].attrs["cell_width"]
-    CELL_HEIGHT = f["/data/{}".format(timestep)].attrs["cell_height"]
-    CELL_DEPTH = f["/data/{}".format(timestep)].attrs["cell_depth"]
+    CELL_WIDTH = iteration.get_attribute("cell_width")
+    CELL_HEIGHT = iteration.get_attribute("cell_height")
+    CELL_DEPTH = iteration.get_attribute("cell_depth")
 
-    # close hdf5 file
-    f.close()
+    # close iteration
+    iteration.close()
 
     if is2D:
         # compute divergence of electric field according to Yee scheme
@@ -149,7 +119,7 @@ def deviation_charge_conservation(h5file):
         # density
         diff = (div * EPS0 - charge[1:, 1:, 1:])
 
-    return float(timestep), np.amax(np.abs(diff)), np.mean(np.abs(diff)), \
+    return np.amax(np.abs(diff)), np.mean(np.abs(diff)), \
         np.std(diff), norm
 
 
@@ -160,13 +130,29 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__,
         epilog="For further questions please contact Richard Pausch."
-        )
+    )
+
+    parser.add_argument("--start",
+                        dest="start_timestep",
+                        help='first timstep',
+                        action='store',
+                        default=0,
+                        type=int)
+
+    parser.add_argument("--last",
+                        dest="last_timestep",
+                        help='last timstep',
+                        action='store',
+                        default=-1,
+                        type=int)
 
     parser.add_argument(metavar="simulation directories",
-                        dest="directories",
-                        help="simulation base directories",
+                        dest="file_pattern",
+                        help="openPMD series pattern with PIConGPU "
+                             "data e.g. simData_%%T.bp",
                         action="store",
-                        nargs="+")
+                        nargs="+"
+                        )
 
     parser.add_argument("--export",
                         metavar="file name",
@@ -176,7 +162,7 @@ if __name__ == "__main__":
                              "(disable interactive window)")
 
     args = parser.parse_args()
-    directories = args.directories
+    file_patterns = args.file_pattern
 
     # prepare plot of data
     plt.figure(figsize=(10, 5))
@@ -214,35 +200,26 @@ if __name__ == "__main__":
     # underscore labels)
     sim_dir_counter = 1
 
-    for directory in directories:
-        # do the data reading and catch errors
-        try:
-            # test if directory is a directory
-            if not os.path.isdir(directory):
-                raise Exception("Error: {} is not a directory".format(
-                                directory))
+    for pattern in file_patterns:
+        series = io.Series(pattern, io.Access.read_only)
 
-            # check if any hdf5 files were found
-            h5_file_list = get_list_of_hdf5_files(directory)
-            if len(h5_file_list) == 0:
-                raise Exception("No hdf5 files found in {}".format(
-                                directory + "simOutput/h5/"))
+        first_step = args.start_timestep
+        last_step = args.last_timestep
 
-        except Exception as error_msg:
-            print("{}".format(error_msg))
-            sys.exit(1)
-
-        # collect data from all found hdf5 files
         collect_results = None
-        print("Read files:")
-        for f in h5_file_list:
-            print(f)
-            t, cc_max, mean_abs, std, norm = deviation_charge_conservation(f)
-            data_tmp = np.array([[t, cc_max, mean_abs, std, norm]])
-            if collect_results is None:
-                collect_results = data_tmp
-            else:
-                collect_results = np.append(collect_results, data_tmp, axis=0)
+
+        for iteration in series.iterations:
+            if (iteration >= first_step and
+                    (iteration <= last_step or last_step == -1)):
+                print("load iteration {:d}".format(iteration))
+                cc_max, mean_abs, std, norm = deviation_charge_conservation(
+                    series, series.iterations[iteration])
+                data_tmp = np.array([[iteration, cc_max, mean_abs, std, norm]])
+                if collect_results is None:
+                    collect_results = data_tmp
+                else:
+                    collect_results = np.append(
+                        collect_results, data_tmp, axis=0)
 
         # sort data temporally
         collect_results = np.sort(collect_results, axis=0)
@@ -255,19 +232,20 @@ if __name__ == "__main__":
         norm = collect_results[0, 4]  # first (t=0) norm
 
         # generate plot label based on directory and avoid underscore bug
-        plot_label = ("{:d}. ".format(sim_dir_counter) +
-                      os.path.normpath(directory).split("/")[-1])
+        plot_label = ("{:s}".format(pattern))
         sim_dir_counter += 1
 
         # add plot for maximum difference
-        ax1.plot(t, max_diff/norm,
+        ax1.plot(t, max_diff / norm,
                  linestyle="-", lw=3,
                  marker="+", ms=15, markeredgewidth=3,
                  label=plot_label)
 
         # add plot for mean difference and std
-        ax2.errorbar(t, mean_abs/norm, yerr=std/norm, lw=3, markeredgewidth=3,
-                     label=plot_label)
+        ax2.errorbar(t, mean_abs / norm, yerr=std / norm, lw=3,
+                     markeredgewidth=3, label=plot_label)
+
+        del series
 
     # finish plots
     ax1.legend(loc=0)


### PR DESCRIPTION
- use openPMD-api
- add command line parameter `--start` and `--last` to define used iterations
- the usage changed a little bit: instead of pass folder you give openPMD file names in
  ```
  plot_chargeConservation_overTime.py  --start 1200 ./simData_%T.bp ./test2/simData_%T.bp
  ```

I disabled CI compile time checks for this PR, code style is still checked e.g. flake8 and pep8.