### PR TITLE
fix restart with openPMD

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -464,6 +464,9 @@ namespace picongpu
                     numParticles.resetDataset(ds);
                     numParticlesOffset.resetDataset(ds);
 
+                    /* It is safe to use the mpi rank to write the data even if the rank can differ between simulation
+                     * runs. During the restart the plugin is using patch information to find the corresponding data.
+                     */
                     numParticles.store<index_t>(mpiRank, myNumParticles);
                     numParticlesOffset.store<index_t>(mpiRank, myParticleOffset);
 


### PR DESCRIPTION
The old implementation assumed that the MPI rank can be used to find the
particle information in the OpenPMD file.
This is wrong because there is no guarantee that the rank is the same.

Fix: use openPMD particle patch information to find particles that correspond
to the local domain.

This patch is backward compatible, which means you can restart with data written before this patch.

Note: It would also be possible to use the linearized position of the simulation domain within the simulation volume during the write and load of particle data but the provided fix is already the base to implement loading from a simulation that was running with a different number of devices.

# Tests

I tested the patch with a 2D and 3D LWFA.