### PR TITLE
fix access to temporary variable

### DIFF
--- a/include/picongpu/particles/densityProfiles/FromHDF5Impl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromHDF5Impl.hpp
@@ -81,7 +81,7 @@ namespace picongpu
                 deviceDataBox = fieldBuffer.getDeviceBuffer().getDataBox();
 
                 GridController<simDim>& gc = Environment<simDim>::get().GridController();
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(0);
                 const uint32_t maxOpenFilesPerNode = 1;
 

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -623,7 +623,7 @@ namespace picongpu
                  * ATTENTION: splash offset are globalSlideOffset + picongpu offsets
                  */
                 DataSpace<simDim> globalSlideOffset;
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
                 globalSlideOffset.y() += numSlides * localDomain.size.y();
 
@@ -1144,7 +1144,7 @@ namespace picongpu
              */
             void dumpData(uint32_t currentStep)
             {
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 mThreadParams.cellDescription = m_cellDescription;
                 mThreadParams.currentStep = currentStep;
 
@@ -1341,7 +1341,7 @@ namespace picongpu
                 threadParams->adiosGroupSize = 0;
 
                 /* y direction can be negative for first gpu */
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 DataSpace<simDim> particleOffset(localDomain.offset);
                 particleOffset.y() -= threadParams->window.globalDimensions.offset.y();
 

--- a/include/picongpu/plugins/adios/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/adios/restart/LoadSpecies.hpp
@@ -92,7 +92,7 @@ namespace picongpu
 
                 std::string particlePath
                     = params->adiosBasePath + std::string(ADIOS_PATH_PARTICLES) + speciesName + std::string("/");
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
                 /* load particle without copying particle data to host */
                 auto speciesTmp = dc.get<ThisSpecies>(FrameType::getName(), true);

--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -66,7 +66,7 @@ namespace picongpu
                 const auto componentNames = plugins::misc::getComponentNames(numComponents);
                 const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
 
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
                 using ValueType = typename Data::ValueType;
                 field.getHostBuffer().setValue(ValueType::create(0.0));

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -781,7 +781,7 @@ Please pick either of the following:
             void dumpData(uint32_t currentStep)
             {
                 // local offset + extent
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 mThreadParams.cellDescription = m_cellDescription;
                 mThreadParams.currentStep = currentStep;
 
@@ -881,7 +881,7 @@ Please pick either of the following:
                  * ATTENTION: splash offset are globalSlideOffset + picongpu offsets
                  */
                 DataSpace<simDim> globalSlideOffset;
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(params->currentStep);
                 globalSlideOffset.y() += numSlides * localDomain.size.y();
 
@@ -1084,7 +1084,7 @@ Please pick either of the following:
             void write(ThreadParams* threadParams, std::string mpiTransportParams)
             {
                 /* y direction can be negative for first gpu */
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 DataSpace<simDim> particleOffset(localDomain.offset);
                 particleOffset.y() -= threadParams->window.globalDimensions.offset.y();
 

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -94,7 +94,7 @@ namespace picongpu
                     = series.iterations[params->currentStep].particles;
                 ::openPMD::ParticleSpecies particleSpecies = particles[speciesName];
 
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
                 /* load particle without copying particle data to host */
                 auto speciesTmp = dc.get<ThisSpecies>(FrameType::getName(), true);

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -65,7 +65,7 @@ namespace picongpu
                 auto const name_lookup_tpl = plugins::misc::getComponentNames(numComponents);
                 const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
 
-                const pmacc::Selection<simDim>& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
                 using ValueType = typename Data::ValueType;
                 field.getHostBuffer().setValue(ValueType::create(0.0));


### PR DESCRIPTION
The returned object from `getGlobalDomain()` and `getLocalDomain()` is accessed inside of PIConGPU over a references which is pointing on a temporary object.

It looks like it is a copy past issue we have since years inside our codebase :-(