### PR TITLE
Add support for Alpaka OpenMP target/OpenACC

### DIFF
--- a/include/pmacc/particles/IdProvider.hpp
+++ b/include/pmacc/particles/IdProvider.hpp
@@ -34,6 +34,12 @@ namespace pmacc
     namespace idDetail
     {
         DEVICEONLY uint64_cu nextId;
+#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
+#    pragma acc declare device_resident(::pmacc::idDetail::nextId)
+#endif
+#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+#    pragma omp declare target(::pmacc::idDetail::nextId)
+#endif
 
         struct KernelSetNextId
         {

--- a/include/pmacc/traits/GetNumWorkers.hpp
+++ b/include/pmacc/traits/GetNumWorkers.hpp
@@ -64,5 +64,23 @@ namespace pmacc
             static constexpr uint32_t value = 1u;
         };
 #endif
+#if(ALPAKA_ACC_ANY_BT_OMP5_ENABLED == 1) && defined ALPAKA_OFFLOAD_MAX_BLOCK_SIZE && ALPAKA_OFFLOAD_MAX_BLOCK_SIZE > 0
+        template<uint32_t T_maxWorkers, typename... T_Args>
+        struct GetNumWorkers<T_maxWorkers, alpaka::AccOmp5<T_Args...>>
+        {
+            static constexpr uint32_t value = ALPAKA_OFFLOAD_MAX_BLOCK_SIZE;
+        };
+#endif
+#if(ALPAKA_ACC_ANY_BT_OACC_ENABLED == 1)
+        template<uint32_t T_maxWorkers, typename... T_Args>
+        struct GetNumWorkers<T_maxWorkers, alpaka::AccOacc<T_Args...>>
+        {
+#    ifdef ALPAKA_OFFLOAD_MAX_BLOCK_SIZE
+            static constexpr uint32_t value = ALPAKA_OFFLOAD_MAX_BLOCK_SIZE;
+#    else
+            static constexpr uint32_t value = 1;
+#    endif
+        };
+#endif
     } // namespace traits
 } // namespace pmacc


### PR DESCRIPTION
This PR adds preliminary support for picongpu to run on Alpaka's [OpenMP 5 target offload](https://github.com/alpaka-group/alpaka/pull/1126) and (experimental) [OpenACC](https://github.com/alpaka-group/alpaka/pull/1127) backends.

### Main Changes
* add specializations of `pmacc::GetNumWorkers` for OpenMP5 and OpenACC
* declare global variable `pmacc::idDetail::nextId`as OpenMP/OpenACC device variable
* explicitly map `pmacc::ConstVector` types to target device (it is debatable whether this is a workaround neccessitated by lacking compiler support or required by the OpenMP/OpenACC standards)

### State of testing

[SPEC benchmark example](https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/benchmarks/SPEC):
* OpenMP target: compiles an runs correctly using clang 11 with x86_64 as target device
* OpenACC: compiles with NVHPC, may fails to link or with a symbol-related runtime error