### PR TITLE
Change SharedMemAllocator function qualifiers from DEVICEONLY to DINLINE

### DIFF
--- a/include/pmacc/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -46,7 +46,7 @@ namespace pmacc
                 typedef cursor::CT::BufferCursor<type, math::CT::UInt32<>> Cursor;
 
                 template<typename T_Acc>
-                DEVICEONLY static Cursor allocate(T_Acc const& acc)
+                DINLINE static Cursor allocate(T_Acc const& acc)
                 {
                     auto& shMem = pmacc::memory::shared::
                         allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(acc);
@@ -63,7 +63,7 @@ namespace pmacc
                 typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
                 template<typename T_Acc>
-                DEVICEONLY static Cursor allocate(T_Acc const& acc)
+                DINLINE static Cursor allocate(T_Acc const& acc)
                 {
                     auto& shMem = pmacc::memory::shared::
                         allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(acc);
@@ -81,7 +81,7 @@ namespace pmacc
                 typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
                 template<typename T_Acc>
-                DEVICEONLY static Cursor allocate(T_Acc const& acc)
+                DINLINE static Cursor allocate(T_Acc const& acc)
                 {
                     auto& shMem = pmacc::memory::shared::
                         allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(acc);


### PR DESCRIPTION
Now it matches the rest of the code. Previously used `DEVICEONLY` is for variables, probably is a leftover.

Found accidentally, while looking at another thing.