### PR TITLE
fix jump on uninitialized variable

### DIFF
--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -463,7 +463,7 @@ namespace pmacc
         }
 
     private:
-        bool output;
+        bool output = false;
 
         uint16_t progress;
         uint32_t showProgressAnyStep;


### PR DESCRIPTION
valgrind reported a conditional jump based on an uninitialized variable.