### PR TITLE
[WIP] Mixed-precision radiation module

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -676,7 +676,8 @@ private:
       hdf5DataFile.open(filename.str().c_str(), fAttr);
 
       typename PICToSplash<float_64>::type radSplashType;
-
+      typename PICToSplash<float_32>::type radDirSplashType;
+      typename PICToSplash<float_32>::type radFreqSplashType;
 
       splash::Dimensions bufferSize(Amplitude<>::numComponents,
                                     radiation_frequencies::N_omega,
@@ -690,7 +691,7 @@ private:
 
       /* get the radiation amplitude unit */
       Amplitude<> UnityAmplitude(1., 0., 0., 0., 0., 0.);
-      const picongpu::float_32 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
+      const picongpu::float_64 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME ;
 
       typedef PICToSplash<float_X>::type SplashFloatXType;
       SplashFloatXType splashFloatXType;
@@ -756,7 +757,7 @@ private:
                                       strideDetector);
 
           hdf5DataFile.write(currentStep,
-                             radSplashType,
+                             radDirSplashType,
                              3,
                              dataSelection,
                              (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
@@ -798,7 +799,7 @@ private:
                                       strideOmega);
 
       hdf5DataFile.write(currentStep,
-                         radSplashType,
+                         radFreqSplashType,
                          3,
                          dataSelection,
                          (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
@@ -1078,7 +1079,8 @@ private:
                                            parameters::N_observer);
 
           const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
-          picongpu::float_64* tmpBuffer = new picongpu::float_64[N_tmpBuffer];
+          //picongpu::float_64* tmpBuffer = new picongpu::float_64[N_tmpBuffer];
+          Amplitude<>::complex_T::type* tmpBuffer = new picongpu::float_64[N_tmpBuffer];
 
           for(uint32_t ampIndex=0; ampIndex < Amplitude<>::numComponents; ++ampIndex)
           {
@@ -1090,7 +1092,7 @@ private:
               for(int copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
               {
                   /* convert data directly because Amplitude is just 6 float_32 */
-                  ((picongpu::float_32*)values)[ampIndex + Amplitude<>::numComponents*copyIndex] = tmpBuffer[copyIndex];
+                  ((Amplitude<>::complex_T::type*)values)[ampIndex + Amplitude<>::numComponents*copyIndex] = tmpBuffer[copyIndex];
               }
 
           }

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -430,7 +430,8 @@ namespace radiation
                         /* storage for amplitude (complex 3D vector)
                          * it  is initialized with zeros (  0 +  i 0 )
                          */
-                        Amplitude amplitude = Amplitude::zero();
+			// ACCUMULATOR! Ensure double precision
+                        Amplitude<> amplitude = Amplitude<>::zero();
 
                         // compute frequency "omega" using for-loop-index "o"
                         picongpu::float_64 const omega = freqFkt( o );
@@ -466,13 +467,14 @@ namespace radiation
                                     );
 
                                 // complex amplitude for j-th particle
-                                Amplitude amplitude_add(
+                                // LOCAL can be single precision
+                                Amplitude<picongpu::float_32> amplitude_add(
                                     weighted_real_amp,
                                     t_ret_s[ j ] * omega
                                 );
 
                                 // add this single amplitude those previously considered
-                                amplitude += amplitude_add;
+                                amplitude += precisionCast<picongpu::float_64>(amplitude_add);
 
                             }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
 

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -145,7 +145,7 @@ namespace radiation
             constexpr int blockSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
             // vectorial part of the integrand in the Jackson formula
-            PMACC_SMEM( acc, real_amplitude_s, memory::Array< vector_64, blockSize > );
+            PMACC_SMEM( acc, real_amplitude_s, memory::Array< vector_32, blockSize > );
 
             // retarded time
             PMACC_SMEM( acc, t_ret_s, memory::Array< picongpu::float_64, blockSize > );
@@ -365,7 +365,7 @@ namespace radiation
                                         // set up amplitude calculator
                                         using Calc_Amplitude_n_sim_1 = Calc_Amplitude<
                                             Retarded_time_1,
-                                            Old_DFT
+                                            New_DFT
                                         >;
 
                                         // calculate amplitude
@@ -430,7 +430,7 @@ namespace radiation
                         /* storage for amplitude (complex 3D vector)
                          * it  is initialized with zeros (  0 +  i 0 )
                          */
-			// ACCUMULATOR! Ensure double precision
+                        // ACCUMULATOR! Ensure double precision
                         Amplitude<> amplitude = Amplitude<>::zero();
 
                         // compute frequency "omega" using for-loop-index "o"
@@ -457,7 +457,7 @@ namespace radiation
                                  ****************************************************/
 
                                 // calulate the form factor's' influences to the real amplitude
-                                vector_64 const weighted_real_amp = real_amplitude_s[ j ] *
+                                vector_32 const weighted_real_amp = real_amplitude_s[ j ] *
                                     precisionCast< float_64 >(
                                         myRadFormFactor(
                                             radWeighting_s[ j ],

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -148,7 +148,7 @@ namespace radiation
             PMACC_SMEM( acc, real_amplitude_s, memory::Array< vector_64, blockSize > );
 
             // retarded time
-            PMACC_SMEM( acc, t_ret_s, memory::Array< picongpu::float_64, blockSize > );
+            PMACC_SMEM( acc, t_ret_s, memory::Array< picongpu::float_32, blockSize > );
 
             // storage for macro particle weighting needed if
             // the coherent and incoherent radiation of a single
@@ -165,12 +165,12 @@ namespace radiation
             int const theta_idx = cupla::blockIdx(acc).x; //cupla::blockIdx(acc).x is used to determine theta
 
             // simulation time (needed for retarded time)
-            picongpu::float_64 const t(
-                picongpu::float_64( currentStep ) * picongpu::float_64( DELTA_T)
+            picongpu::float_32 const t(
+                picongpu::float_32( currentStep ) * picongpu::float_32( DELTA_T)
             );
 
             // looking direction (needed for observer) used in the thread
-            vector_64 const look = radiation_observer::observation_direction( theta_idx );
+            vector_32 const look = radiation_observer::observation_direction( theta_idx );
 
             // get extent of guarding super cells (needed to ignore them)
             DataSpace< simDim > const guardingSuperCells = mapper.getGuardingSuperCells();
@@ -434,7 +434,7 @@ namespace radiation
                         Amplitude<> amplitude = Amplitude<>::zero();
 
                         // compute frequency "omega" using for-loop-index "o"
-                        picongpu::float_64 const omega = freqFkt( o );
+                        picongpu::float_32 const omega = freqFkt( o );
 
                         // create a form factor object
                         radFormFactor::radFormFactor const myRadFormFactor{ };

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -468,14 +468,14 @@ namespace radiation
 
                                 // complex amplitude for j-th particle
                                 // LOCAL can be single precision
-                                Amplitude<picongpu::float_32> amplitude_add(
+                                Amplitude<> amplitude_add(
                                     weighted_real_amp,
                                     t_ret_s[ j ] * omega
                                 );
 
                                 // add this single amplitude those previously considered
-                                amplitude += precisionCast<picongpu::float_64>(amplitude_add);
-                                //amplitude += amplitude_add;
+                                //amplitude += precisionCast<picongpu::float_64>(amplitude_add);
+                                amplitude += amplitude_add;
 
                             }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
 

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -148,7 +148,7 @@ namespace radiation
             PMACC_SMEM( acc, real_amplitude_s, memory::Array< vector_64, blockSize > );
 
             // retarded time
-            PMACC_SMEM( acc, t_ret_s, memory::Array< picongpu::float_32, blockSize > );
+            PMACC_SMEM( acc, t_ret_s, memory::Array< picongpu::float_64, blockSize > );
 
             // storage for macro particle weighting needed if
             // the coherent and incoherent radiation of a single
@@ -165,10 +165,10 @@ namespace radiation
             int const theta_idx = cupla::blockIdx(acc).x; //cupla::blockIdx(acc).x is used to determine theta
 
             // simulation time (needed for retarded time)
-            picongpu::float_32 const t(
-                picongpu::float_32( currentStep ) * picongpu::float_32( DELTA_T)
-            );
-
+            //picongpu::float_64 const t(
+            //    picongpu::float_64( currentStep ) * picongpu::float_64( DELTA_T)
+            //);
+            picongpu::float_32 const t(currentStep * DELTA_T);
             // looking direction (needed for observer) used in the thread
             vector_32 const look = radiation_observer::observation_direction( theta_idx );
 
@@ -475,6 +475,7 @@ namespace radiation
 
                                 // add this single amplitude those previously considered
                                 amplitude += precisionCast<picongpu::float_64>(amplitude_add);
+                                //amplitude += amplitude_add;
 
                             }// END: check Nyquist-limit for each particle "j" and each frequency "omega"
 

--- a/include/picongpu/plugins/radiation/VectorTypes.hpp
+++ b/include/picongpu/plugins/radiation/VectorTypes.hpp
@@ -33,6 +33,7 @@ namespace radiation
     using vector_X = cuda_vec< picongpu::float3_X, picongpu::float_X >;
     using vector_32 = /*__align__(16)*/ cuda_vec< picongpu::float3_32, picongpu::float_32 >;
     using vector_64 = /*__align__(32)*/ cuda_vec< picongpu::float3_64, picongpu::float_64 >;
+    using vector_32_64 = cuda_vec< picongpu::float3_32, picongpu::float_64 >;
 } // namespace radiation
 } // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -49,7 +49,7 @@ public:
    * Arguments:
    * - vector_64: real 3D vector
    * - float: complex phase */
-  DINLINE Amplitude(vector_64 vec, picongpu::float_X phase)
+  DINLINE Amplitude(vector_X vec, picongpu::float_X phase)
   {
       picongpu::float_X cosValue;
       picongpu::float_X sinValue;
@@ -201,9 +201,9 @@ namespace precisionCast
                         picongpu::plugins::radiation::Amplitude<CastToType>
                         >
                         {
-                                using result = const picongpu::plugins::radiation::Amplitude<CastToType>&;
+                                using result_T = const picongpu::plugins::radiation::Amplitude<CastToType>&;
 
-                                HDINLINE result operator( )( result amplitude ) const
+                                HDINLINE result_T operator( )( result_T amplitude ) const
                                 {
                                         return amplitude;
                                 }
@@ -216,14 +216,14 @@ namespace precisionCast
                         picongpu::plugins::radiation::Amplitude<OldType>
                         >
                         {
-                                using result = picongpu::plugins::radiation::Amplitude<CastToType>;
+                                using result_T = picongpu::plugins::radiation::Amplitude<CastToType>;
                                 using ParamType = picongpu::plugins::radiation::Amplitude<OldType>;
-                                HDINLINE result operator( )(const ParamType& amplitude ) const
+                                HDINLINE result_T operator( )( const ParamType& amplitude ) const
                                 {       
-                                        result Result( 
-                                                    precisionCast<result::complex_T::type >(amplitude.getXcomponent()),
-                                                    precisionCast< result::complex_T::type>(amplitude.getYcomponent()),
-                                                    precisionCast< result::complex_T::type>(amplitude.getZcomponent()) );
+                                        result_T Result( 
+                                                    precisionCast<result_T::complex_T::type>(amplitude.getXcomponent()),
+                                                    precisionCast<result_T::complex_T::type>(amplitude.getYcomponent()),
+                                                    precisionCast<result_T::complex_T::type>(amplitude.getZcomponent()) );
                                         return Result;
                                 }
                         };

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -72,9 +72,9 @@ public:
    *
    * Arguments:
    * - 6x float: Re(x), Im(x), Re(y), Im(y), Re(z), Im(z) */
-  HDINLINE Amplitude(const picongpu::float_64 x_re, const picongpu::float_64 x_im,
-                     const picongpu::float_64 y_re, const picongpu::float_64 y_im,
-                     const picongpu::float_64 z_re, const picongpu::float_64 z_im)
+  HDINLINE Amplitude(const base_dtype x_re, const base_dtype x_im,
+                     const base_dtype y_re, const base_dtype y_im,
+                     const base_dtype z_re, const base_dtype z_im)
       : amp_x(x_re, x_im), amp_y(y_re, y_im), amp_z(z_re, z_im)
   {
 
@@ -126,11 +126,11 @@ public:
   /** calculate radiation from *this amplitude
    *
    * Returns: \f$\frac{d^2 I}{d \Omega d \omega} = const*Amplitude^2\f$ */
-  HDINLINE picongpu::float_64 calc_radiation(void)
+  HDINLINE base_dtype calc_radiation(void)
   {
       // const SI factor radiation
-      const picongpu::float_64 factor = 1.0 /
-        (16. * util::cube(pmacc::math::Pi< picongpu::float_64 >::value) * picongpu::EPS0 * picongpu::SPEED_OF_LIGHT);
+      const base_dtype factor = 1.0 /
+        (16. * util::cube(pmacc::math::Pi< base_dtype >::value) * picongpu::EPS0 * picongpu::SPEED_OF_LIGHT);
 
       return factor * (pmacc::math::abs2(amp_x) + pmacc::math::abs2(amp_y) + pmacc::math::abs2(amp_z));
   }
@@ -139,7 +139,7 @@ public:
   /** debugging method
    *
    * Returns: real-x-value */
-  HDINLINE picongpu::float_64 debug(void)
+  HDINLINE base_dtype debug(void)
   {
       return amp_x.get_real();
   }

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -201,9 +201,9 @@ namespace precisionCast
                         picongpu::plugins::radiation::Amplitude<CastToType>
                         >
                         {
-                                using result_T = const picongpu::plugins::radiation::Amplitude<CastToType>&;
+                                using result = const picongpu::plugins::radiation::Amplitude<CastToType>&;
 
-                                HDINLINE result_T operator( )( result_T amplitude ) const
+                                HDINLINE result operator( )( result amplitude ) const
                                 {
                                         return amplitude;
                                 }
@@ -216,14 +216,14 @@ namespace precisionCast
                         picongpu::plugins::radiation::Amplitude<OldType>
                         >
                         {
-                                using result_T = picongpu::plugins::radiation::Amplitude<CastToType>;
+                                using result = picongpu::plugins::radiation::Amplitude<CastToType>;
                                 using ParamType = picongpu::plugins::radiation::Amplitude<OldType>;
-                                HDINLINE result_T operator( )( const ParamType& amplitude ) const
+                                HDINLINE result operator( )( const ParamType& amplitude ) const
                                 {       
-                                        result_T Result( 
-                                                    precisionCast<result_T::complex_T::type>(amplitude.getXcomponent()),
-                                                    precisionCast<result_T::complex_T::type>(amplitude.getYcomponent()),
-                                                    precisionCast<result_T::complex_T::type>(amplitude.getZcomponent()) );
+                                        result Result( 
+                                                    precisionCast<result::complex_T::type>(amplitude.getXcomponent()),
+                                                    precisionCast<result::complex_T::type>(amplitude.getYcomponent()),
+                                                    precisionCast<result::complex_T::type>(amplitude.getZcomponent()));
                                         return Result;
                                 }
                         };

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -75,7 +75,7 @@ struct One_minus_beta_times_n
         else
         {
             //const vector_32 beta(particle.get_beta<When::now > ()); // calculate v/c=beta
-            const vector_32_64 beta(particle.get_beta<When::now > ()); // calculate v/c=beta
+            const vector_64 beta(particle.get_beta<When::now > ()); // calculate v/c=beta
             return  (1.0 - beta.dot( n ));
         }
 

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -157,7 +157,7 @@ public:
 
     // get retarded time
 
-    HDINLINE picongpu::float_64 get_t_ret(const vector_64 look_direction) const
+    HDINLINE picongpu::float_32 get_t_ret(const vector_32 look_direction) const
     {
         TimeCalc timeC;
         return timeC(m_t_sim, look_direction, m_particle);

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -91,7 +91,7 @@ struct Retarded_time_1
     HDINLINE picongpu::float_64 operator()(const picongpu::float_32 t,
                                 const vector_32& n, const Particle & particle) const
     {
-        const vector_32_64 r(particle.get_location<When::now > ()); // location
+        const vector_64 r(particle.get_location<When::now > ()); // location
         //return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
         return (picongpu::float_64) (t - r.dot(n) / (picongpu::SPEED_OF_LIGHT));
     }

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -70,7 +70,7 @@ struct One_minus_beta_times_n
         {
             const picongpu::float_64 cos_theta(particle.get_cos_theta<When::now > (n)); // cosine between looking vector and momentum of particle
             const picongpu::float_64 taylor_approx(cos_theta * Taylor()(gamma_inv_square) + (1.0 - cos_theta));
-            return  (taylor_approx);
+            return  taylor_approx;
         }
         else
         {
@@ -87,11 +87,13 @@ struct Retarded_time_1
     // contains more parameters than needed to have the
     // same interface as 'Retarded_time_2'
 
-    HDINLINE picongpu::float_64 operator()(const picongpu::float_64 t,
-                                const vector_64& n, const Particle & particle) const
+    HDINLINE picongpu::float_64 operator()(const picongpu::float_32 t,
+                                const vector_32& n, const Particle & particle) const
     {
         const vector_64 r(particle.get_location<When::now > ()); // location
-        return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
+        //return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
+        return (picongpu::float_64) (t - r.dot(n) / (picongpu::SPEED_OF_LIGHT));
+
     }
 
 };
@@ -117,7 +119,6 @@ struct Old_Method
 };
 
 // typedef of all possible forms of Old_Method
-//typedef Old_Method<util::Cube<picongpu::float_64> > Old_FFT;
 typedef Old_Method<util::Square<picongpu::float_64> > Old_DFT;
 
 
@@ -140,15 +141,15 @@ public:
     // of base classes
 
     HDINLINE Calc_Amplitude(const Particle& particle,
-                           const picongpu::float_64 delta_t,
-                           const picongpu::float_64 t_sim)
+                           const picongpu::float_32 delta_t,
+                           const picongpu::float_32 t_sim)
     : m_particle(particle), m_delta_t(delta_t), m_t_sim(t_sim)
     {
     }
 
     // get real vector part of amplitude
 
-    HDINLINE vector_64 get_vector(const vector_64& n) const
+    HDINLINE vector_64 get_vector(const vector_32& n) const
     {
         const vector_64 look_direction(n.unit_vec()); // make sure look_direction is a unit vector
         VecCalc vecC;
@@ -157,20 +158,17 @@ public:
 
     // get retarded time
 
-    HDINLINE picongpu::float_32 get_t_ret(const vector_32 look_direction) const
+    HDINLINE picongpu::float_64 get_t_ret(const vector_32 look_direction) const
     {
         TimeCalc timeC;
         return timeC(m_t_sim, look_direction, m_particle);
-
-        //  const vector_64 r = particle.get_location<When::now > (); // location
-        //  return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
     }
 
 private:
     // data:
     const Particle& m_particle; // one particle
-    const picongpu::float_64 m_delta_t; // length of one time step in simulation
-    const picongpu::float_64 m_t_sim; // simulation time (for methods not using index*delta_t )
+    const picongpu::float_32 m_delta_t; // length of one time step in simulation
+    const picongpu::float_32 m_t_sim; // simulation time (for methods not using index*delta_t )
 
 
 };

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -75,11 +75,11 @@ public:
     // getters:
 
     template<unsigned int when>
-    HDINLINE vector_64 get_location(void) const;
+    HDINLINE vector_X get_location(void) const;
     // get location at time when
 
     template<unsigned int when>
-    HDINLINE vector_64 get_momentum(void) const;
+    HDINLINE vector_X get_momentum(void) const;
     // get momentum at time when
 
     template<unsigned int when>
@@ -156,19 +156,19 @@ private:
 
 
 template<>
-HDINLINE vector_64 Particle::get_location<When::now>(void) const
+HDINLINE vector_X Particle::get_location<When::now>(void) const
 {
     return location_now;
 } // get location at time when
 
 template<>
-HDINLINE vector_64 Particle::get_momentum<When::now>(void) const
+HDINLINE vector_X Particle::get_momentum<When::now>(void) const
 {
     return momentum_now;
 } // get momentum at time when
 
 template<>
-HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
+HDINLINE vector_X Particle::get_momentum<When::old>(void) const
 {
     return momentum_old;
 } // get momentum at time when

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -83,7 +83,7 @@ public:
     // get momentum at time when
 
     template<unsigned int when>
-    HDINLINE vector_64 get_beta(void) const
+    HDINLINE vector_X get_beta(void) const
     {
         return calc_beta(get_momentum<when > ());
     } // get beta at time when except:
@@ -114,7 +114,7 @@ private:
     //////////////////////////////////////////////////////////////////
     // private methods:
 
-    HDINLINE vector_64 calc_beta(const vector_X& momentum) const
+    HDINLINE vector_X calc_beta(const vector_X& momentum) const
     {
         // returns beta=v/c
         const picongpu::float_32 gamma1 = calc_gamma(momentum);

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -114,6 +114,18 @@ struct cuda_vec : public V
         return this->x() * other.x() + this->y() * other.y() + this->z() * other.z();
     }
 
+    HDINLINE picongpu::float_64 dot(const cuda_vec<V, T>& other) const
+    {
+        return this->x() * other.x() + this->y() * other.y() + this->z() * other.z();
+    }
+    HDINLINE picongpu::float_64 dotAcc(const cuda_vec<V, T>& other) const
+    {
+        picongpu::float_64 result(0.0); //doesn't make a difference
+        result += this->x() * other.x();
+        result += this->y() * other.y();
+        result += this->z() * other.z();
+        return result;;
+    }
     // scalar multiplication
 
     HDINLINE cuda_vec<V, T> operator*(const T scalar) const

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -144,7 +144,7 @@ struct cuda_vec : public V
 
     HDINLINE cuda_vec<V, T> operator%(const cuda_vec<V, T>& other) const
     {
-        return cuda_vec(this->y() * other.z() - this->z() * other.y(), this->z() * other.x() - this->x() * other.z(), this->x() * other.y() - this->y() * other.x());
+return cuda_vec(this->y() * other.z() - this->z() * other.y(), this->z() * other.x() - this->x() * other.z(), this->x() * other.y() - this->y() * other.x());
     }
 
     // magnitude of vector (length of vector)
@@ -181,6 +181,18 @@ struct cuda_vec : public V
         this->z() *= scalar;
     }
 
+    // assign cross product
+
+    HDINLINE void operator%=(const cuda_vec<V, T>& other)
+    {
+        T tmpX, tmpY, tmpZ;
+        tmpX = this->y() * other.z() - this->z() * other.y();
+        tmpY = this->z() * other.x() - this->x() * other.z();
+        tmpZ = this->x() * other.y() - this->y() * other.x();
+        this->x() = tmpX;
+        this->y() = tmpY;
+        this->z() = tmpZ;
+    }
 };
 
 } // namespace radiation


### PR DESCRIPTION
## Intent
### Current problem
Quantities such as position `r` and observer direction `n` are up-cast by default to 64 bit precision.
The detector direction `n` is computed using 32 bit precision in `radiationObserver.param` but converted to `picongpu::float_64` vector at the end.

### Proposal
The intent of the changes is to introduce mixed (single/double) precision computations into the radiation module of PIConGPU.

Ideally the usage of only _sufficient_ precision for each separate computation will reduce register and memory consumption and allow more thread blocks to run in parallel.

Formal analysis suggests that most of the quantities can be kept in 32 bit precision (`float_X`) and at best only the accumulators of inner products and the results have to remain in 64 bit precision.

## Implementation

The basic data type of the `Amplitude` class is templated such that it can be switched as desired.
Arguments to the functions that compute the separate parts of the amplitude are adapted to take positions and observation direction of 32 bit precision.

The only quantity that has to be stored in double precision is the retarded time `t_ret_s`, even if it is computed from input quantities of lower precision.

**Changing `r` to a `vector_32` type in `Retarded_time_1` *will* inctroduce large errors.**

Usage of different precision for accumulated amplitude values, frequencies and observation directions requires different `radSplashType` definitions in `writeHDF5file`, lest the values are computed properly, but stored with a type-mismatch (which will lead to confusing outputs).

## Tests
### Correctness

A first check of corretness was performed using the single-particle configuration of the `Bunch` example of PIConGPU.
It was run for 7000 time steps, with radiation enabled from 2800 to 3000.

The quality of the computed amplitudes was tested by computing (for arbitrarily chosen steps 2900 and 3000) the maximum relative errors of the complex amplitudes in 2 and inf norms

<img src="https://render.githubusercontent.com/render/math?math=\max_{\vec{n},\omega} \left( \Vert \vec{A}_{new} - \vec{A}_{ref} \Vert_{2,\infty} / \Vert \vec{A}_{ref} \Vert_{2,\infty} \right)">

as well as maximum deviation w.r.t. the maximum achieved norm of the reference amplitude:

<img src="https://render.githubusercontent.com/render/math?math=\max_{\vec{n},\omega} \left( \Vert \vec{A}_{new} - \vec{A}_{ref} \Vert_{2,\infty} \right) / \max_{\vec{n},\omega} \left( \Vert \vec{A}_{ref} \Vert_{2,\infty} \right)">

This latter test does not emphasize deviations from reference solution in the regions of the spectrum where the intensity is negligible anyway.

The following errors were observed for the commit 50c0f50a at time step 3000:
```
    |A_tgt - A_ref|_2  3.8007873728778394e-22
    |A_tgt - A_ref|_inf  3.799745971153532e-22
    |A_ref|_2  2.507966173029181e-17
    |A_ref|_inf  2.507966173029181e-17
    |A_tgt|_2  2.5079660813987757e-17
    |A_tgt|_inf  2.5079660813987754e-17
    |A_tgt - A_ref|_2 / |A_ref|_2 0.006734829014505873
    |A_tgt - A_ref|_inf / |A_ref|_inf 0.006737196156335815
    max(|A_tgt - A_ref|_2) / max(|A_ref|_2) 1.5154858999900937e-05
    max(|A_tgt - A_ref|_inf) / max(|A_ref|_inf) 1.5150706624420332e-05
```

Hence the proper relative error is <img src="https://render.githubusercontent.com/render/math?math=6.73\cdot 10^{-3}">, whereas the error in units of maximum amplitude is <img src="https://render.githubusercontent.com/render/math?math=1.52\cdot 10^{-5}">.

### Performance

Performance of the implementation was tested using a thermal plasma (E = 0.511 [keV]) of density `2e23` with a grid of `1024 x 384 x 1024` cells distributed to 4 GPUs of _one_ V100 node according (`2 1 2` distribution) and 2 particles per cell. The simulation runs for 27 time steps with radiation enabled from the start. Only step 0 is written to disk.

The reference code required `1h 41min 48sec 233msec = 6108 sec` to complete the calculation.
The proposed changes reduce this to `1h 21min 10sec 663msec = 4870 sec` calculation time. 

A reduction of run time of ~20% and a **speed-up** of `~1.25x`.

This comes with **two observed caveats**:

1. Increasing the number of jobs for the reduction in the radiation kernel `--e_radiation.numJobs 4` will
result in the mixed-precision version taking longer to complete the same calculation as the reference version.
REF (4 jobs): ` 55 % =       15 | time elapsed:      40min 38sec 168msec | avg time per step:  2min 52sec 536msec`
MPRAD (4 jobs): ` 55 % =       15 | time elapsed:      42min 17sec 728msec | avg time per step:  2min 59sec 703msec`

2. Usage of a 32 bit `amplitude_add` in `Radiation.kernel` while working will slow the computation down
significantly:
REF (2 jobs): `55 % =       15 | time elapsed:      52min 31sec 526msec | avg time per step:  3min 47sec 368msec`
MPRAD (2 jobs, 64 bit increment): `55 % =       15 | time elapsed:      42min 16sec 466msec | avg time per step:  2min 59sec 564msec`
MPRAD (2 jobs, 32 bit increment): `55 % =       15 | time elapsed:   1h  5min 57sec 342msec | avg time per step:  4min 49sec 640msec`
This is likely due to the need to cast an `Amplitude` object from 32 bit to 64 bit immediately after it is created, using `precisionCast`. The latter produces a temporary `Amplitude` object with 64 bit precision of the components and constitutes an overhead.