### PR TITLE
guard ASSERT macros

### DIFF
--- a/include/pmacc/assert.hpp
+++ b/include/pmacc/assert.hpp
@@ -26,25 +26,16 @@
 
 #include <cassert>
 
-#ifdef NDEBUG
-// debug mode is disabled
+// disabled for no-debug mode or for the device compile path
+#if defined(NDEBUG) || (CUPLA_DEVICE_COMPILE == 1)
 
 /* `(void)0` force a semicolon after the macro function */
 #    define PMACC_ASSERT(expr) ((void) 0)
 
 /* `(void)0` force a semicolon after the macro function */
-#    define PMACC_DEVICE_ASSERT(expr) ((void) 0)
-
-/* `(void)0` force a semicolon after the macro function */
 #    define PMACC_ASSERT_MSG(expr, msg) ((void) 0)
 
-// debug mode is disabled
-/* `(void)0` force a semicolon after the macro function */
-#    define PMACC_DEVICE_ASSERT_MSG(expr, ...) ((void) 0)
-
 #else
-
-// debug mode is enabled
 
 /** assert check (host side only)
  *
@@ -63,6 +54,20 @@
  *            expression is evaluated to false
  */
 #    define PMACC_ASSERT_MSG(expr, msg) (!!(expr)) ? ((void) 0) : pmacc::abortWithError(#    expr, __FILE__, __LINE__, msg)
+
+#endif
+
+// disabled for no-debug mode or for the host compile path
+#if defined(NDEBUG) || (CUPLA_DEVICE_COMPILE == 0)
+
+/* `(void)0` force a semicolon after the macro function */
+#    define PMACC_DEVICE_ASSERT(expr) ((void) 0)
+
+// debug mode is disabled
+/* `(void)0` force a semicolon after the macro function */
+#    define PMACC_DEVICE_ASSERT_MSG(expr, ...) ((void) 0)
+
+#else
 
 /** assert check for kernels (device side)
  *


### PR DESCRIPTION
When using pmacc assert macros in host/device methods compile can fail.
This PR is adding guards to avoid macro evaluation of device assert macros on host and vice versa.

This will avoid that https://github.com/ComputationalRadiationPhysics/picongpu/blob/be3986413fcdbae7cbff8c6558604c013526e9ac/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Weights.hpp#L66-L70 will break compiling with hipcc.