### PR TITLE
Add option to duplicate field storage for FieldBackground aka superPusher

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -109,6 +109,10 @@ TBG_stopWindow="--stopWindow 1337"
 # Supported values: none (default), binomial
 TBG_currentInterpolation="--currentInterpolation binomial"
 
+
+# Duplicate E and B field storage inside field background to improve performance at cost of additional memory
+TBG_fieldBackground="--fieldBackground.duplicateFields"
+
 ################################################################################
 ## Placeholder for multi data plugins:
 ##

--- a/include/picongpu/fields/background/cellwiseOperation.hpp
+++ b/include/picongpu/fields/background/cellwiseOperation.hpp
@@ -124,16 +124,9 @@ namespace picongpu
              * @tparam OpFunctor A manipulating functor like pmacc::nvidia::functors::add
              */
             template<typename T_Field, typename T_OpFunctor, typename T_ValFunctor>
-            void operator()(
-                T_Field field,
-                T_OpFunctor opFunctor,
-                T_ValFunctor valFunctor,
-                uint32_t const currentStep,
-                const bool enabled = true) const
+            void operator()(T_Field field, T_OpFunctor opFunctor, T_ValFunctor valFunctor, uint32_t const currentStep)
+                const
             {
-                if(!enabled)
-                    return;
-
                 SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
                 // offset to the local domain relative to the origin of the global domain
                 DataSpace<simDim> totalDomainOffset(subGrid.getLocalDomain().offset);

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -491,8 +491,6 @@ namespace picongpu
 
                     initialiserController->restart((uint32_t) this->restartStep, this->restartDirectory);
                     step = this->restartStep;
-
-                    fieldBackground.fillSimulation(step);
                 }
                 else
                 {

--- a/include/picongpu/simulation/stage/CurrentBackground.hpp
+++ b/include/picongpu/simulation/stage/CurrentBackground.hpp
@@ -58,17 +58,15 @@ namespace picongpu
                  */
                 void operator()(uint32_t const step) const
                 {
+                    if(!FieldBackgroundJ::activated)
+                        return;
+
                     using namespace pmacc;
                     DataConnector& dc = Environment<>::get().DataConnector();
                     auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
                     using CurrentBackground = cellwiseOperation::CellwiseOperation<type::CORE + type::BORDER>;
                     CurrentBackground currentBackground(cellDescription);
-                    currentBackground(
-                        &fieldJ,
-                        nvidia::functors::Add(),
-                        FieldBackgroundJ(fieldJ.getUnit()),
-                        step,
-                        FieldBackgroundJ::activated);
+                    currentBackground(&fieldJ, nvidia::functors::Add(), FieldBackgroundJ(fieldJ.getUnit()), step);
                     dc.releaseData(FieldJ::getName());
                 }
 

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -21,15 +21,19 @@
 
 #pragma once
 
+#include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/background/cellwiseOperation.hpp"
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/fields/FieldE.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/Environment.hpp>
+#include <pmacc/nvidia/functors/Add.hpp>
+#include <pmacc/nvidia/functors/Sub.hpp>
 #include <pmacc/type/Area.hpp>
 
 #include <cstdint>
+#include <stdexcept>
 
 
 namespace picongpu
@@ -38,55 +42,171 @@ namespace picongpu
     {
         namespace stage
         {
+            namespace detail
+            {
+                /* Functor to apply the given field background to the given field
+                 *
+                 * @tparam T_Field field affected, e.g. picongpu::FieldE
+                 * @tparam T_FieldBackground field background to apply, e.g. picongpu::FieldBackgroundE
+                 */
+                template<typename T_Field, typename T_FieldBackground>
+                class ApplyFieldBackground
+                {
+                public:
+                    //! Field affected
+                    using Field = T_Field;
+
+                    //! Field background to apply
+                    using FieldBackground = T_FieldBackground;
+
+                    /** Create a functor to apply the background
+                     *
+                     * @param cellDescription mapping for kernels
+                     */
+                    ApplyFieldBackground(MappingDesc const cellDescription)
+                        : cellDescription(cellDescription)
+                        , isEnabled(FieldBackground::InfluenceParticlePusher)
+                    {
+                    }
+
+                    /** Apply the given functor to the field background in the given area
+                     *
+                     * @tparam T_area area to operate on
+                     * @tparam T_Functor functor type compatible to pmacc::nvidia::functors
+                     *
+                     * @param step index of time iteration
+                     * @param functor functor to apply
+                     */
+                    template<uint32_t T_area, typename T_Functor>
+                    void operator()(uint32_t const step, T_Functor functor) const
+                    {
+                        if(!isEnabled)
+                            return;
+                        using namespace pmacc;
+                        using CallBackground = cellwiseOperation::CellwiseOperation<T_area>;
+                        CallBackground callBackground(cellDescription);
+                        DataConnector& dc = Environment<>::get().DataConnector();
+                        auto field = dc.get<Field>(Field::getName(), true);
+                        callBackground(field, functor, FieldBackground(field->getUnit()), step);
+                        dc.releaseData(Field::getName());
+                    }
+
+                private:
+                    //! Is the field background enabled
+                    bool isEnabled;
+
+                    //! Mapping for kernels
+                    MappingDesc const cellDescription;
+                };
+            } // namespace detail
+
             //! Functor for the stage of the PIC loop applying field background
             class FieldBackground
             {
             public:
-                /** Create a field background functor
+                /** Register program options for field background
                  *
-                 * Having this in constructor is a temporary solution.
+                 * @param desc boost::program_options::options_description
+                 */
+                void registerHelp(po::options_description& desc)
+                {
+                    desc.add_options()(
+                        "fieldBackground.useExtraMemory",
+                        po::value<bool>(&useExtraMemory)->zero_tokens(),
+                        "use extra fields for field background to improve precision and potentially avoid some "
+                        "numerical noise");
+                }
+
+                /** Initialize field background stage
+                 *
+                 * This method must be called once before calling add(), subtract() and fillSimulation().
+                 * The initialization has to be delayed for this class as it needs registerHelp() like the plugins do.
                  *
                  * @param cellDescription mapping for kernels
                  */
-                FieldBackground(MappingDesc const cellDescription) : cellDescription(cellDescription)
+                void init(MappingDesc const cellDescription)
                 {
+                    applyE = std::make_unique<ApplyE>(cellDescription);
+                    applyB = std::make_unique<ApplyB>(cellDescription);
                 }
 
-                /** Add the field background to the current density
+                /** Add field background to the electromagnetic field
                  *
-                 * @tparam T_Functor functor type compatible to nvidia::functors
+                 * Affects data sets named FieldE::getName(), FieldB::getName().
+                 * As the result of this operation, they will have a sum of old values and background values.
                  *
                  * @param step index of time iteration
-                 * @param functor functor to apply to the background
                  */
-                template<typename T_Functor>
-                void operator()(uint32_t const step, T_Functor functor) const
+                void add(uint32_t const step) const
                 {
-                    using namespace pmacc;
-                    DataConnector& dc = Environment<>::get().DataConnector();
-                    auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-                    auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
-                    using Background = cellwiseOperation::CellwiseOperation<CORE + BORDER + GUARD>;
-                    Background background(cellDescription);
-                    background(
-                        fieldE,
-                        functor,
-                        FieldBackgroundE(fieldE->getUnit()),
-                        step,
-                        FieldBackgroundE::InfluenceParticlePusher);
-                    background(
-                        fieldB,
-                        functor,
-                        FieldBackgroundB(fieldB->getUnit()),
-                        step,
-                        FieldBackgroundB::InfluenceParticlePusher);
-                    dc.releaseData(FieldE::getName());
-                    dc.releaseData(FieldB::getName());
+                    apply<CORE + BORDER + GUARD>(step, pmacc::nvidia::functors::Add{});
+                }
+
+                /** Subtract field background from the electromagnetic field
+                 *
+                 * Affects data sets named FieldE::getName(), FieldB::getName().
+                 * As the result of this operation, they will have values like before calling add().
+                 *
+                 * Warning: when fieldBackground.useExtraMemory is enabled, the fields are assumed to not have changed
+                 * since the call to add(). Having fieldBackground.useExtraMemory disabled does not rely on this.
+                 *
+                 * @param step index of time iteration
+                 */
+                void subtract(uint32_t const step) const
+                {
+                    apply<CORE + BORDER + GUARD>(step, pmacc::nvidia::functors::Sub{});
+                }
+
+                /** Set field background to a consistent initial state for starting or resuming a simulation
+                 *
+                 * This method must be called during filling the simulation.
+                 *
+                 * @param step index of time iteration
+                 */
+                void fillSimulation(uint32_t const step) const
+                {
+                    /* restore background fields in GUARD
+                     *
+                     * loads the outer GUARDS of the global domain for absorbing/open boundary condtions
+                     *
+                     * @todo as soon as we add GUARD fields to the checkpoint data, e.g. for PML boundary
+                     *       conditions, this section needs to be removed
+                     */
+                    apply<GUARD>(step, pmacc::nvidia::functors::Add());
                 }
 
             private:
-                //! Mapping for kernels
-                MappingDesc cellDescription;
+                /** Apply the given functor to E and B field backgrounds in the given area
+                 *
+                 * @tparam T_area area to operate on
+                 * @tparam T_Functor functor type compatible to pmacc::nvidia::functors
+                 *
+                 * @param step index of time iteration
+                 * @param functor functor to apply
+                 */
+                template<uint32_t T_area, typename T_Functor>
+                void apply(uint32_t const step, T_Functor functor) const
+                {
+                    if(!applyE || !applyB)
+                        throw std::runtime_error("simulation::stage::FieldBackground used without init() called");
+                    applyE->operator()<T_area>(step, functor);
+                    applyB->operator()<T_area>(step, functor);
+                }
+
+                //! Functor type to apply background to field E
+                using ApplyE = detail::ApplyFieldBackground<FieldE, FieldBackgroundE>;
+
+                //! Functor to apply background to field E
+                std::unique_ptr<ApplyE> applyE;
+
+                //! Functor type to apply background to field B
+                using ApplyB = detail::ApplyFieldBackground<FieldB, FieldBackgroundB>;
+
+                //! Functor to apply background to field B
+                std::unique_ptr<ApplyB> applyB;
+
+                //! Whether to use extra fields to store activated background fields
+                bool useExtraMemory = false;
             };
 
         } // namespace stage

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -99,7 +99,6 @@ namespace picongpu
                         {
                             auto& gridBuffer = field.getGridBuffer();
                             duplicateBuffer->copyFrom(gridBuffer.getDeviceBuffer());
-                            __getTransactionEvent().waitForFinished();
                             restoreFromDuplicateField = true;
                         }
                         apply(step, pmacc::nvidia::functors::Add(), field);
@@ -124,7 +123,6 @@ namespace picongpu
                         {
                             auto& gridBuffer = field.getGridBuffer();
                             gridBuffer.getDeviceBuffer().copyFrom(*duplicateBuffer);
-                            __getTransactionEvent().waitForFinished();
                             restoreFromDuplicateField = false;
                         }
                         else

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -65,15 +65,15 @@ namespace picongpu
                     /** Create an object to apply the background
                      *
                      * @param cellDescription mapping for kernels
-                     * @param TODO
+                     * @param useDuplicateField flag to store duplicate of the field
                      */
-                    ApplyFieldBackground(MappingDesc const cellDescription, bool const duplicateField)
+                    ApplyFieldBackground(MappingDesc const cellDescription, bool const useDuplicateField)
                         : cellDescription(cellDescription)
-                        , duplicateField(duplicateField)
+                        , useDuplicateField(useDuplicateField)
                         , restoreFromDuplicateField(false)
                         , isEnabled(FieldBackground::InfluenceParticlePusher)
                     {
-                        if(isEnabled && duplicateField)
+                        if(isEnabled && useDuplicateField)
                         {
                             // Allocate a duplicate field buffer and copy the values
                             DataConnector& dc = Environment<>::get().DataConnector();
@@ -95,7 +95,7 @@ namespace picongpu
                         DataConnector& dc = Environment<>::get().DataConnector();
                         auto& field = *dc.get<Field>(Field::getName(), true);
                         // Always add to the field, conditionally make a copy of the old values first
-                        if(duplicateField)
+                        if(useDuplicateField)
                         {
                             auto& gridBuffer = field.getGridBuffer();
                             duplicateBuffer->copyFrom(gridBuffer.getDeviceBuffer());
@@ -116,7 +116,7 @@ namespace picongpu
                         DataConnector& dc = Environment<>::get().DataConnector();
                         auto& field = *dc.get<Field>(Field::getName(), true);
                         /* Either restore from the pre-made copy or subtract.
-                         * Note that here it is not sufficient to check for duplicateField as it
+                         * Note that here it is not sufficient to check for useDuplicateField as it
                          * is not necessarily up-to-date, e.g. right after loading from a checkpoint.
                          */
                         if(restoreFromDuplicateField)
@@ -135,7 +135,7 @@ namespace picongpu
                     bool isEnabled;
 
                     //! Flag to store duplicate of field when the background is enabled
-                    bool duplicateField;
+                    bool useDuplicateField;
 
                     //! Flag to restore from the duplicate field: true if it is enabled and up-to-date
                     bool restoreFromDuplicateField;
@@ -143,7 +143,7 @@ namespace picongpu
                     //! Buffer type to store duplicated values
                     using DeviceBuffer = typename Field::Buffer::DBuffer;
 
-                    //! Buffer to store duplicated values, only used when duplicateField is true
+                    //! Buffer to store duplicated values, only used when useDuplicateField is true
                     std::unique_ptr<DeviceBuffer> duplicateBuffer;
 
                     //! Mapping for kernels

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -29,6 +29,9 @@
 #include "pmacc/memory/Array.hpp"
 #include "pmacc/assert.hpp"
 
+#include <memory>
+
+
 namespace pmacc
 {
     /**
@@ -310,5 +313,26 @@ namespace pmacc
         cuplaPitchedPtr data;
         bool useOtherMemory;
     };
+
+    /** Factory for a new heap-allocated DeviceBufferIntern buffer object that is a deep copy of the given device
+     * buffer
+     *
+     * @tparam TYPE value type
+     * @tparam DIM index dimensionality
+     *
+     * @param source source device buffer
+     */
+    template<class TYPE, unsigned DIM>
+    HINLINE std::unique_ptr<DeviceBufferIntern<TYPE, DIM>> makeDeepCopy(DeviceBuffer<TYPE, DIM>& source)
+    {
+        auto result = std::make_unique<DeviceBufferIntern<TYPE, DIM>>(
+            source,
+            source.getDataSpace(),
+            DataSpace<DIM>::create(0));
+        result->copyFrom(source);
+        // Wait for copy to finish, so that the resulting object is safe to use after return
+        __getTransactionEvent().waitForFinished();
+        return result;
+    }
 
 } // namespace pmacc


### PR DESCRIPTION
This is a, so far draft, implementation of another mode of field background operation #3521. The switch between old and new mode is done as a command-line flag `--fieldBackground.duplicateFields`, by default not set which corresponds to old behaviour (since it does not increase memory footprint then).

Implementation is more or less complete, but not properly tested yet. I will proceed with that tomorrow. I can do a technical setup and test that it didn't break the old mode, and the new one works the same, also that it operates fine with checkpoints.

For a real, physically meaningful test, however we do not have any standard example relying on field background. Perhaps to measure performance change and maybe effects on accuracy (although that should be a really long simulation than) you could share one of your setups @BeyondEspresso ?
