### PR TITLE
Fix some outdated docs regarding output and checkpoint backends

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -23,6 +23,7 @@
 ## These variables basically wrap PIConGPU command line flags.
 ## To see all flags available for your PIConGPU binary, run
 ## picongpu --help. The avalable flags depend on your configuration flags.
+## Note that this is not meant to be a complete and functioning .cfg file.
 ##
 ## Flags that target a specific species e.g. electrons (--e_png) or ions
 ## (--i_png) must only be used if the respective species is activated (configure flags).
@@ -181,7 +182,6 @@ TBG_<species>_histogram="--<species>_energyHistogram.period 500 --<species>_ener
 
 
 # Calculate a 2D phase space
-# - requires parallel libSplash for HDF5 output
 # - momentum range in m_<species> c
 TBG_<species>_PSxpx="--<species>_phaseSpace.period 10 --<species>_phaseSpace.filter all --<species>_phaseSpace.space x --<species>_phaseSpace.momentum px --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
 TBG_<species>_PSxpz="--<species>_phaseSpace.period 10 --<species>_phaseSpace.filter all --<species>_phaseSpace.space x --<species>_phaseSpace.momentum pz --<species>_phaseSpace.min -1.0 --<species>_phaseSpace.max 1.0"
@@ -264,8 +264,8 @@ TBG_checkpoint="--checkpoint.period 1000"
 # Restart the simulation from checkpoint created using TBG_checkpoint
 TBG_restart="--checkpoint.restart"
 # Select the backend for the restart (must fit the created checkpoint)
-#    --checkpoint.restart.backend adios
-#                                 hdf5
+#    --checkpoint.restart.backend openPMD
+#                                 adios
 # By default, the last checkpoint is restarted if not specified via
 #   --checkpoint.restart.step 1000
 # To restart in a new run directory point to the old run where to start from

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -210,6 +210,8 @@ TBG_countPerSuper="--<species>_macroParticlesPerSuperCell.period 100 --<species>
 
 # Dump simulation data (fields and particles) to ADIOS files.
 # Data is dumped every .period steps to the fileset .file.
+# Warning: we do not recommend using the ADIOS plugin for output,
+# but the openPMD plugin with ADIOS (2) backend instead, see TBG_openPMD below.
 TBG_adios="--adios.period 100 --adios.file simData --adios.source 'species_all,fields_all'"
 # see 'adios_config -m', e.g., for on-the-fly zlib compression
 #     (compile ADIOS with --with-zlib=<ZLIB_ROOT>)
@@ -247,10 +249,10 @@ TBG_openPMD="--openPMD.period 100   \
 # Create a checkpoint that is restartable every --checkpoint.period steps
 #   http://git.io/PToFYg
 TBG_checkpoint="--checkpoint.period 1000"
-# Select the backend for the checkpoint, available are hdf5 and adios
-#    --checkpoint.backend adios
-#                         hdf5
-# Available backend options are exactly as in --adios.* and --hdf5.* and can be set
+# Select the backend for the checkpoint, available are openPMD and adios
+#    --checkpoint.backend openPMD
+#                         adios
+# Available backend options are exactly as in --openPMD.* and --adios.* and can be set
 # via:
 #   --checkpoint.<IO-backend>.* <value>
 # e.g.:

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -62,7 +62,6 @@ PIConGPU command line option                  Description
 Depending on the available external dependencies (see above), the options for the ``<IO-backend>`` are:
 
 * :ref:`openPMD <usage-plugins-openPMD>`
-* :ref:`hdf5 <usage-plugins-HDF5>`
 * :ref:`adios <usage-plugins-ADIOS>` (keep in mind the :ref:`note on meta-files <usage-plugins-ADIOS-meta>` for restarts)
 
 Interacting Manually with Checkpoint Data

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -21,12 +21,12 @@ What is the format of the created files?
 
 We write our fields and particles in an open markup called :ref:`openPMD <pp-openPMD>`.
 
-For further details, see the according sections in :ref:`the openPMD API <usage-plugins-openPMD>`, :ref:`HDF5 <usage-plugins-HDF5>` and :ref:`ADIOS <usage-plugins-ADIOS>`.
+For further details, see the according sections in :ref:`the openPMD API <usage-plugins-openPMD>` and :ref:`ADIOS <usage-plugins-ADIOS>`.
 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-The plugin is available as soon as the :ref:`openPMD API, libSplash (HDF5) or ADIOS libraries <install-dependencies>` are compiled in.
+The plugin is available as soon as the :ref:`openPMD API or ADIOS libraries <install-dependencies>` are compiled in.
 
 .cfg file
 ^^^^^^^^^
@@ -59,7 +59,7 @@ PIConGPU command line option                  Description
 ``--checkpoint.<IO-backend>.*``               Additional options to control the IO-backend
 ============================================= ======================================================================================
 
-Depending on the available external dependencies (see above), the options for the ``<IO-backend>`` are:
+Depending on the available external dependencies (see above), the options for the `<IO-backend>` are:
 
 * :ref:`openPMD <usage-plugins-openPMD>`
 * :ref:`adios <usage-plugins-ADIOS>` (keep in mind the :ref:`note on meta-files <usage-plugins-ADIOS-meta>` for restarts)


### PR DESCRIPTION
This was noticed during a mattermost discussion on checkpoints.