### PR TITLE
Update Hemera profiles to load the git module

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -16,6 +16,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # General modules #############################################################
 #
 module purge
+module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
 module load openmpi/2.1.2

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -16,6 +16,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # General modules #############################################################
 #
 module purge
+module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
 module load cuda/10.2

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -16,6 +16,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # General modules #############################################################
 #
 module purge
+module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
 module load cuda/10.2

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -16,6 +16,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # General modules #############################################################
 #
 module purge
+module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
 module load cuda/10.2

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -16,6 +16,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # General modules #############################################################
 #
 module purge
+module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
 module load cuda/10.2


### PR DESCRIPTION
Previously, there was system git avaialble without loading the module, but it was just removed following support ticket submitted by @BrianMarre . And rightfully so, as that standard version was really outdated.
So update the profiles to load the `git` module and so keep the workflow described in the docs (which includes cloning repository) intact.