### PR TITLE
Save, for reference, the used cmakeFlags setup.

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2021 Axel Huebl, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -165,6 +165,14 @@ if [ -f "$extension_param/cmakeFlags" ] ; then
         echo "       Is the file executable? (chmod u+x cmakeFlags)" >&2
         exit 2
     fi
+    # save the cmakeFlags setup number for future reference
+    if [ -f "$extension_param/cmakeFlagsSetup" ] ; then
+      rm $extension_param/cmakeFlagsSetup
+    fi
+    touch $extension_param/cmakeFlagsSetup
+    echo "Last configured cmakeFlags setup was the setup No.: $cmakeFlagsNr" > $extension_param/cmakeFlagsSetup
+    echo $cmake_flags >> $extension_param/cmakeFlagsSetup
+
 fi
 
 # legacy check: we removed simulation_defines/ after PIConGPU 0.3.X

--- a/etc/picongpu/submitAction.sh
+++ b/etc/picongpu/submitAction.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -45,6 +45,10 @@ fi
 if [ -f $TBG_projectPath/cmakeFlags ]
 then
   cp -a $TBG_projectPath/cmakeFlags input
+fi
+if [ -f $TBG_projectPath/cmakeFlagsSetup ]
+then
+  cp -a $TBG_projectPath/cmakeFlagsSetup input
 fi
 cp -a $TBG_cfgPath/openib.conf tbg
 cp -a $TBG_cfgPath/cuda.filter tbg


### PR DESCRIPTION
This introduces a new file `cmakeFlagsSetup` generated by `pic-configure` if there's `cmakeFlags` in the input directory. It stores the setup number used from `cmakeFlags`. `cmakeFlagsSetup` is copied to `<output directory>/input` for reference.  