### PR TITLE
expose compute current worker multiplier 

### DIFF
--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -222,16 +222,6 @@ namespace picongpu
     template<uint32_t T_area, class T_Species>
     void FieldJ::computeCurrent(T_Species& species, uint32_t)
     {
-#if BOOST_COMP_HIP && PIC_COMPUTE_CURRENT_THREAD_LIMITER
-        // HIP-clang creates wrong results if more threads than particles in a frame will be used
-        constexpr int workerMultiplier = 1;
-#else
-        /* tuning parameter to use more workers than cells in a supercell
-         * valid domain: 1 <= workerMultiplier
-         */
-        constexpr int workerMultiplier = 2;
-#endif
-
         using FrameType = typename T_Species::FrameType;
         typedef typename pmacc::traits::Resolve<typename GetFlagType<FrameType, current<>>::type>::type
             ParticleCurrentSolver;
@@ -245,10 +235,10 @@ namespace picongpu
             typename GetMargin<ParticleCurrentSolver>::UpperMargin>
             BlockArea;
 
-        constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
-            pmacc::math::CT::volume<SuperCellSize>::type::value * workerMultiplier>::value;
-
         using Strategy = currentSolver::traits::GetStrategy_t<FrameSolver>;
+
+        constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
+            pmacc::math::CT::volume<SuperCellSize>::type::value * Strategy::workerMultiplier>::value;
 
         auto const depositionKernel = currentSolver::KernelComputeCurrent<numWorkers, BlockArea>{};
 

--- a/include/picongpu/fields/currentDeposition/Strategy.def
+++ b/include/picongpu/fields/currentDeposition/Strategy.def
@@ -30,6 +30,25 @@ namespace picongpu
     {
         namespace strategy
         {
+            namespace detail
+            {
+                /** Validate and adjust worker multiplier
+                 *
+                 * @param multiplicator Number used as multiplier to oversubscribe the number of threads for the
+                 * compute current task/kernel.
+                 * @return valid multiplier
+                 */
+                constexpr int validateAndAdjustWorkerMultiplier(int const multiplicator)
+                {
+#if BOOST_COMP_HIP && PIC_COMPUTE_CURRENT_THREAD_LIMITER
+                    // HIP-clang creates wrong results if more threads than particles in a frame will be used
+                    return 1;
+#else
+                    return multiplicator >= 1 ? multiplicator : 1;
+#endif
+                }
+            } // namespace detail
+
             /** Work on strided supercell domains with local caching strategy
              *
              * The current for each particle will be reduced with atomic operations into a supercell
@@ -40,6 +59,8 @@ namespace picongpu
              * To utilize the device fully you should have enough supercells
              *   - 2D: minimum multiprocessor count * 9 * 4
              *   - 3D: minimum multiprocessor count * 27 * 4
+             *
+             * @{
              */
             struct StridedCachedSupercells
             {
@@ -47,7 +68,23 @@ namespace picongpu
                 static constexpr bool stridedMapping = true;
                 using BlockReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Threads>;
                 using GridReductionOp = nvidia::functors::Add;
+                static constexpr int workerMultiplier = 1;
             };
+
+            /** @tparam T_workerMultiplier Oversubscribe the number of workers used to compute the current by the given
+             * multiplier. Can be used to optimize the device occupancy.
+             */
+            template<int T_workerMultiplier>
+            struct StridedCachedSupercellsScaled
+            {
+                static constexpr bool useBlockCache = true;
+                static constexpr bool stridedMapping = true;
+                using BlockReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Threads>;
+                using GridReductionOp = nvidia::functors::Add;
+                static constexpr int workerMultiplier = detail::validateAndAdjustWorkerMultiplier(T_workerMultiplier);
+            };
+
+            /** @} */
 
             /** Local caching strategy
              *
@@ -55,6 +92,8 @@ namespace picongpu
              * local cache. The cache will be flushed with atomic operations to the global memory.
              *
              * Suggestion: Use this strategy if block local and global atomics are fast.
+             *
+             * @{
              */
             struct CachedSupercells
             {
@@ -62,7 +101,23 @@ namespace picongpu
                 static constexpr bool stridedMapping = false;
                 using BlockReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Threads>;
                 using GridReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Blocks>;
+                static constexpr int workerMultiplier = 1;
             };
+
+            /** @tparam T_workerMultiplier Oversubscribe the number of workers used to compute the current by the given
+             * multiplier. Can be used to optimize the device occupancy.
+             */
+            template<int T_workerMultiplier>
+            struct CachedSupercellsScaled
+            {
+                static constexpr bool useBlockCache = true;
+                static constexpr bool stridedMapping = false;
+                using BlockReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Threads>;
+                using GridReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Blocks>;
+                static constexpr int workerMultiplier = detail::validateAndAdjustWorkerMultiplier(T_workerMultiplier);
+            };
+
+            /** @} */
 
             /** Non cached strategy
              *
@@ -71,6 +126,8 @@ namespace picongpu
              *
              * Suggestion: Use this strategy if global atomics are fast and random memory access
              * to a large range in memory is not a bottle neck.
+             *
+             * @{
              */
             struct NonCachedSupercells
             {
@@ -79,7 +136,24 @@ namespace picongpu
                 using BlockReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Blocks>;
                 // dummy which produces a compile time error if used
                 using GridReductionOp = void;
+                static constexpr int workerMultiplier = 1;
             };
+
+            /** @tparam T_workerMultiplier Oversubscribe the number of workers used to compute the current by the given
+             * multiplier. Can be used to optimize the device occupancy.
+             */
+            template<int T_workerMultiplier>
+            struct NonCachedSupercellsScaled
+            {
+                static constexpr bool useBlockCache = false;
+                static constexpr bool stridedMapping = false;
+                using BlockReductionOp = nvidia::functors::Atomic<::alpaka::AtomicAdd, ::alpaka::hierarchy::Blocks>;
+                // dummy which produces a compile time error if used
+                using GridReductionOp = void;
+                static constexpr int workerMultiplier = detail::validateAndAdjustWorkerMultiplier(T_workerMultiplier);
+            };
+
+            /** @} */
 
         } // namespace strategy
 

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -72,8 +72,11 @@ namespace picongpu
      *
      * STRATEGY (optional):
      * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
     using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
@@ -72,8 +72,11 @@ namespace picongpu
      *
      * STRATEGY (optional):
      * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
     using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
 

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -72,8 +72,11 @@ namespace picongpu
      *
      * STRATEGY (optional):
      * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
     using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
@@ -72,8 +72,11 @@ namespace picongpu
      *
      * STRATEGY (optional):
      * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
     using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
@@ -64,20 +64,23 @@ namespace picongpu
      */
     using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
 
-/*! select current solver method
- * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
- * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
- * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
- *
- * For development purposes:
- * - currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
- *   without optimization (~4x slower and needs more shared memory)
- *
- * STRATEGY (optional):
- * - currentSolver::strategy::StridedCachedSupercells
- * - currentSolver::strategy::CachedSupercells
- * - currentSolver::strategy::NonCachedSupercells
- */
+    /*! select current solver method
+     * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::VillaBune< SHAPE, STRATEGY > : particle shapes - CIC (1st order) only
+     * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     *
+     * For development purposes:
+     * - currentSolver::EsirkepovNative< SHAPE, STRATEGY > : generic version of currentSolverEsirkepov
+     *   without optimization (~4x slower and needs more shared memory)
+     *
+     * STRATEGY (optional):
+     * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
+     */
 #ifndef PARAM_CURRENTSOLVER
 #    define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>
 #endif

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
@@ -75,8 +75,11 @@ namespace picongpu
      *
      * STRATEGY (optional):
      * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
      * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
     using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
 


### PR DESCRIPTION
Allow the user to tune the number of worker/threads uses to compute the current.
The worker multiplier is now part of the strategy used to configure the compute current task and kernel behavior.

The default for CUDA devices is changed from `2` to `1` with this PR.
This will result in better performance for all devices with compute architecture 6.0+. 
On Kepler the performance will be slightly reduced.

note: It is not possible, without increasing the compile-time, to switch automatically based on the GPU used between the old and the new default number for the multiplier.

- add new compute current strategies
- update doxygen documentation

This PR will **not** break existing param files. The implementation is backward compatible. 