### PR TITLE
Added Performance class for collecting task timing info.

### DIFF
--- a/include/picongpu/Perf.cpp
+++ b/include/picongpu/Perf.cpp
@@ -1,0 +1,57 @@
+// perf.cc
+#include "pmacc/eventSystem/Perf.hpp"
+#include <vector>
+#include <tuple>
+#include <map>
+#include <cmath>
+
+namespace Performance {
+    using d2 = std::tuple<double,double>;
+
+    static bool tracing = false;
+    static std::map<std::string,std::map<d2,PerfAvg>> events;
+
+    void Timers::append(const std::string &label, PerfData &datum) {
+        if(!tracing) return;
+        auto it = events.find(label);
+        d2 key(datum.bytes, datum.flops);
+        if (it == events.end()) {
+            auto v = std::map<d2,PerfAvg>();
+            v.emplace(key, PerfAvg(datum.t1-datum.t0));
+            events[label] = v;
+        } else {
+            auto &et = it->second;
+            auto ev = et.find(key);
+            if (ev == et.end()) {
+                et.emplace(key, PerfAvg(datum.t1-datum.t0));
+            } else {
+                ev->second.add(datum.t1-datum.t0);
+            }
+        }
+    }
+    void Timers::on() { tracing = true; }
+    void Timers::off() { tracing = false; }
+
+    void Timers::show(std::ostream &os) {
+        const char hdr1[] = "{ ";
+        const char hdr2[] = ", ";
+
+        const char *bhdr = hdr1;
+        for(auto et : events) { // all events for thread
+            os << bhdr << "'" << et.first << "' : [" << std::endl;
+            bhdr = hdr2;
+            for(auto ev : et.second) { // all map values
+                auto x = ev.second;
+                os << "      { 'Bytes': " << std::get<0>(ev.first) << std::endl
+                   << "      , 'Flops': " << std::get<1>(ev.first) << std::endl
+                   << "      , 'Calls': " << x.n << std::endl
+                   << "      , 'Min': "   << x.min << std::endl
+                   << "      , 'Max': "   << x.max << std::endl
+                   << "      , 'Avg': "   << x.s/x.n << std::endl
+                   << "      , 'Stddev': " << std::sqrt(x.v/x.n) << " }," << std::endl;
+            }
+            os << "    ]" << std::endl;
+        }
+        os << "  }" << std::endl;
+    }
+}

--- a/include/pmacc/eventSystem/Manager.tpp
+++ b/include/pmacc/eventSystem/Manager.tpp
@@ -24,6 +24,7 @@
 #include "pmacc/eventSystem/streams/StreamController.hpp"
 #include "pmacc/eventSystem/EventSystem.hpp"
 #include "pmacc/eventSystem/Manager.hpp"
+#include "pmacc/eventSystem/Perf.hpp"
 #include "pmacc/assert.hpp"
 
 #include <cstdlib>
@@ -73,8 +74,9 @@ namespace pmacc
             if(counter == 500000)
                 std::cout << taskPtr->toString() << " " << passiveTasks.size() << std::endl;
 #endif
-            if(taskPtr->execute())
+            if(taskPtr->execute()) // Looks like the only place in code calling taskPtr->execute().
             {
+		Performance::Timers::append(taskPtr->toString(), taskPtr->perfInfo);
                 /*test if task is deleted by other stackdeep*/
                 if(getActiveITaskIfNotFinished(id) == taskPtr)
                 {
@@ -135,7 +137,7 @@ namespace pmacc
         return nullptr;
     }
 
-    inline void Manager::waitForFinished(id_t taskId)
+    inline void Manager::waitForFinished(id_t taskId) // DMR: TODO
     {
         if(taskId == 0)
             return;

--- a/include/pmacc/eventSystem/Perf.hpp
+++ b/include/pmacc/eventSystem/Perf.hpp
@@ -1,0 +1,71 @@
+// perf.hh
+#ifndef PERF_HH
+#define PERF_HH
+#include <stdint.h>
+#include <iostream>
+
+#ifdef _OPENMP
+#  include <omp.h>
+#else
+// mini-openmp compatibility layer
+#include <mpi.h>
+inline double omp_get_wtime() {
+    return MPI_Wtime();
+}
+#endif
+
+namespace Performance {
+struct PerfData {
+    double t0, t1;
+    double bytes, flops;
+    PerfData(double _t0, uint64_t _bytes, uint64_t _flops)
+        : t0(_t0), bytes(_bytes), flops(_flops) {}
+};
+
+struct PerfAvg {
+    /** Accumulates:
+     *
+     *   min = min_i x_i
+     *   max = max_i x_i
+     *   s = \sum_i x_i
+     *   v = \sum_i (x_i - s/n)^2
+     *   n = \sum_i 1
+     */
+    PerfAvg(double x) : min(x), max(x), s(x), v(0.0), n(1) { }
+    void add(const double x) {
+        // Old Trick From: https://manual.gromacs.org/2020/reference-manual/averages.html
+        if(x < min) min = x;
+        if(x > max) max = x;
+        v += (s - n*x)*(s - n*x) / (n*(n+1.0));
+        s += x;
+        n += 1;
+    }
+    double min, max, s, v;
+    int n;
+};
+
+struct Timers {
+    /**
+     *  This class is declared (global) inside the perf.cc and must exist only there.
+     */
+    static void append(const std::string &label, PerfData &datum);
+    static void show(std::ostream &os);
+    static void on();
+    static void off();
+};
+
+class Timed {
+    public:
+        Timed(const std::string &_label, uint64_t bytes, uint64_t flops)
+            : label(_label), datum(omp_get_wtime(),
+                                    bytes, flops) {}
+        ~Timed() {
+            datum.t1 = omp_get_wtime();
+            Timers::append(label, datum);
+        }
+    private:
+        const std::string label;
+        PerfData datum;
+};
+}
+#endif

--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -189,7 +189,7 @@ namespace pmacc
     }
 
     /**
-     * Creates a new TaskGetCurrentSizeFromDevic.
+     * Creates a new TaskGetCurrentSizeFromDevice.
      * @param buffer DeviceBuffer to get current size from
      * @param registeringTask optional pointer to an ITask which should be registered at the new task as an observer
      */


### PR DESCRIPTION
These additions place timers into each ITask and appear to add minimal overhead.  One issue that needs to be resolved is where to place `include/pmacc/eventSystem/Perf.cpp` (currently sitting in` include/picongpu/Perf.cpp` because I don't know how to get the build system to pick it up otherwise).

Running the old version (using commit ID d2cfb8) on LaserWakefield using 4 v100 cards produced the following a few months back:
```
Running program...
4
PIConGPU: 0.5.0-dev
  Build-Type: Release

Third party:
  OS:         Linux-4.18.0-193.14.3.el8_2.x86_64
  arch:       x86_64
  CXX:        GNU (9.2.0)
  CMake:      3.17.0
  CUDA:       11.0.221
  mallocMC:   2.6.0
  Boost:      1.72.0
  MPI:        
    standard: 3.1
    flavor:   OpenMPI (4.1.0)
  PNGwriter:  NOTFOUND
  libSplash:  NOTFOUND (Format NOTFOUND)
  ADIOS:      NOTFOUND
  openPMD:    NOTFOUND
PIConGPUVerbose PHYSICS(1) | Sliding Window is ON
PIConGPUVerbose PHYSICS(1) | used Random Number Generator: RNGProvider3XorMin seed: 42
PIConGPUVerbose PHYSICS(1) | Courant c*dt <= 1.00229 ? 1
PIConGPUVerbose PHYSICS(1) | Resolving plasma oscillations?
   Estimates are based on DensityRatio to BASE_DENSITY of each species
   (see: density.param, speciesDefinition.param).
   It and does not cover other forms of initialization
PIConGPUVerbose PHYSICS(1) | species e: omega_p * dt <= 0.1 ? 0.0247974
PIConGPUVerbose PHYSICS(1) | y-cells per wavelength: 18.0587
PIConGPUVerbose PHYSICS(1) | macro particles per device: 16777216
PIConGPUVerbose PHYSICS(1) | typical macro particle weighting: 6955.06
PIConGPUVerbose PHYSICS(1) | UNIT_SPEED 2.99792e+08
PIConGPUVerbose PHYSICS(1) | UNIT_TIME 1.39e-16
PIConGPUVerbose PHYSICS(1) | UNIT_LENGTH 4.16712e-08
PIConGPUVerbose PHYSICS(1) | UNIT_MASS 6.33563e-27
PIConGPUVerbose PHYSICS(1) | UNIT_CHARGE 1.11432e-15
PIConGPUVerbose PHYSICS(1) | UNIT_EFIELD 1.22627e+13
PIConGPUVerbose PHYSICS(1) | UNIT_BFIELD 40903.8
PIConGPUVerbose PHYSICS(1) | UNIT_ENERGY 5.69418e-10
initialization time: 34sec  48msec = 34 sec
  0 % =        0 | time elapsed:                    0msec | avg time per step:   0msec
  4 % =      102 | time elapsed:             1sec 166msec | avg time per step:  11msec
  9 % =      204 | time elapsed:             2sec 335msec | avg time per step:  11msec
 14 % =      306 | time elapsed:             3sec 640msec | avg time per step:  12msec
 19 % =      408 | time elapsed:             5sec 117msec | avg time per step:  14msec
 24 % =      510 | time elapsed:             6sec 776msec | avg time per step:  16msec
 29 % =      612 | time elapsed:             8sec 637msec | avg time per step:  18msec
 34 % =      714 | time elapsed:            10sec 661msec | avg time per step:  19msec
 39 % =      816 | time elapsed:            12sec 882msec | avg time per step:  21msec
 44 % =      918 | time elapsed:            15sec 189msec | avg time per step:  22msec
 49 % =     1020 | time elapsed:            17sec 416msec | avg time per step:  21msec
 54 % =     1122 | time elapsed:            19sec 661msec | avg time per step:  22msec
 59 % =     1224 | time elapsed:            22sec  77msec | avg time per step:  23msec
 64 % =     1326 | time elapsed:            24sec 619msec | avg time per step:  24msec
 69 % =     1428 | time elapsed:            27sec  70msec | avg time per step:  24msec
 74 % =     1530 | time elapsed:            29sec 536msec | avg time per step:  24msec
 79 % =     1632 | time elapsed:            31sec 961msec | avg time per step:  23msec
 84 % =     1734 | time elapsed:            34sec 430msec | avg time per step:  24msec
 89 % =     1836 | time elapsed:            36sec 927msec | avg time per step:  24msec
 94 % =     1938 | time elapsed:            39sec 347msec | avg time per step:  23msec
 99 % =     2040 | time elapsed:            41sec 772msec | avg time per step:  23msec
calculation  simulation time: 41sec 966msec = 41 sec
full simulation time:  1min 16sec 337msec = 76 sec
```

Running this version in the same configuration produces the following:
```
Running program...
1
PIConGPU: 0.5.0-dev
  Build-Type: Release

Third party:
  OS:         Linux-4.18.0-193.14.3.el8_2.x86_64
  arch:       x86_64
  CXX:        GNU (9.2.0)
  CMake:      3.17.0
  CUDA:       11.0.221
  mallocMC:   2.6.0
  Boost:      1.72.0
  MPI:        
    standard: 3.1
    flavor:   OpenMPI (4.1.0)
  PNGwriter:  NOTFOUND
  libSplash:  NOTFOUND (Format NOTFOUND)
  ADIOS:      NOTFOUND
  openPMD:    NOTFOUND
PIConGPUVerbose PHYSICS(1) | Sliding Window is ON
PIConGPUVerbose PHYSICS(1) | used Random Number Generator: RNGProvider3XorMin seed: 42
PIConGPUVerbose PHYSICS(1) | Courant c*dt <= 1.00229 ? 1
PIConGPUVerbose PHYSICS(1) | Resolving plasma oscillations?
   Estimates are based on DensityRatio to BASE_DENSITY of each species
   (see: density.param, speciesDefinition.param).
   It and does not cover other forms of initialization
PIConGPUVerbose PHYSICS(1) | species e: omega_p * dt <= 0.1 ? 0.0247974
PIConGPUVerbose PHYSICS(1) | y-cells per wavelength: 18.0587
PIConGPUVerbose PHYSICS(1) | macro particles per device: 16777216
PIConGPUVerbose PHYSICS(1) | typical macro particle weighting: 6955.06
PIConGPUVerbose PHYSICS(1) | UNIT_SPEED 2.99792e+08
PIConGPUVerbose PHYSICS(1) | UNIT_TIME 1.39e-16
PIConGPUVerbose PHYSICS(1) | UNIT_LENGTH 4.16712e-08
PIConGPUVerbose PHYSICS(1) | UNIT_MASS 6.33563e-27
PIConGPUVerbose PHYSICS(1) | UNIT_CHARGE 1.11432e-15
PIConGPUVerbose PHYSICS(1) | UNIT_EFIELD 1.22627e+13
PIConGPUVerbose PHYSICS(1) | UNIT_BFIELD 40903.8
PIConGPUVerbose PHYSICS(1) | UNIT_ENERGY 5.69418e-10
initialization time: 35sec 197msec = 35 sec
  0 % =        0 | time elapsed:                    0msec | avg time per step:   0msec
  4 % =      102 | time elapsed:             1sec 193msec | avg time per step:  11msec
  9 % =      204 | time elapsed:             2sec 324msec | avg time per step:  11msec
 14 % =      306 | time elapsed:             3sec 586msec | avg time per step:  12msec
 19 % =      408 | time elapsed:             4sec 984msec | avg time per step:  13msec
 24 % =      510 | time elapsed:             6sec 531msec | avg time per step:  15msec
 29 % =      612 | time elapsed:             8sec 241msec | avg time per step:  16msec
 34 % =      714 | time elapsed:            10sec  97msec | avg time per step:  18msec
 39 % =      816 | time elapsed:            12sec 150msec | avg time per step:  20msec
 44 % =      918 | time elapsed:            14sec 293msec | avg time per step:  21msec
 49 % =     1020 | time elapsed:            16sec 334msec | avg time per step:  20msec
 54 % =     1122 | time elapsed:            18sec 349msec | avg time per step:  19msec
 59 % =     1224 | time elapsed:            20sec 587msec | avg time per step:  21msec
 64 % =     1326 | time elapsed:            22sec 947msec | avg time per step:  23msec
 69 % =     1428 | time elapsed:            25sec 221msec | avg time per step:  22msec
 74 % =     1530 | time elapsed:            27sec 506msec | avg time per step:  22msec
 79 % =     1632 | time elapsed:            29sec 719msec | avg time per step:  21msec
 84 % =     1734 | time elapsed:            32sec   4msec | avg time per step:  22msec
 89 % =     1836 | time elapsed:            34sec 335msec | avg time per step:  22msec
 94 % =     1938 | time elapsed:            36sec 562msec | avg time per step:  21msec
 99 % =     2040 | time elapsed:            38sec 794msec | avg time per step:  21msec
calculation  simulation time: 38sec 973msec = 38 sec
{ 'Finalize' : [
      { 'Bytes': 1
      , 'Flops': 1
      , 'Calls': 1
      , 'Min': 0.114346
      , 'Max': 0.114346
      , 'Avg': 0.114346
      , 'Stddev': 0 },
    ]
, 'Load' : [
      { 'Bytes': 1
      , 'Flops': 1
      , 'Calls': 1
      , 'Min': 1.58011
      , 'Max': 1.58011
      , 'Avg': 1.58011
      , 'Stddev': 0 },
    ]
, 'Start' : [
      { 'Bytes': 1
      , 'Flops': 1
      , 'Calls': 1
      , 'Min': 72.5714
      , 'Max': 72.5714
      , 'Avg': 72.5714
      , 'Stddev': 0 },
    ]
, 'TaskCopyDeviceToDevice' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 32496
      , 'Min': 0
      , 'Max': 21
      , 'Avg': 0.476859
      , 'Stddev': 0.952733 },
    ]
, 'TaskCopyDeviceToHost' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 1
      , 'Min': 0
      , 'Max': 0
      , 'Avg': 0
      , 'Stddev': 0 },
    ]
, 'TaskFieldReceiveAndInsert' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 2048
      , 'Min': 3
      , 'Max': 29
      , 'Avg': 8.04541
      , 'Stddev': 2.03158 },
    ]
, 'TaskFieldReceiveAndInsertExchange/3' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 4061
      , 'Min': 0
      , 'Max': 29
      , 'Avg': 6.96553
      , 'Stddev': 2.46578 },
    ]
, 'TaskFieldSend' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 2048
      , 'Min': 3
      , 'Max': 29
      , 'Avg': 6.53271
      , 'Stddev': 2.68312 },
    ]
, 'TaskFieldSendExchange' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 4061
      , 'Min': 3
      , 'Max': 29
      , 'Avg': 6.49347
      , 'Stddev': 2.6852 },
    ]
, 'TaskGetCurrentSizeFromDevice' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 12235
      , 'Min': 0
      , 'Max': 1
      , 'Avg': 0.0662852
      , 'Stddev': 0.24878 },
    ]
, 'TaskKernel NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 155850
      , 'Min': 0
      , 'Max': 19881
      , 'Avg': 2.5069
      , 'Stddev': 50.4218 },
    ]
, 'TaskParticlesReceive' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 2048
      , 'Min': 4
      , 'Max': 16
      , 'Avg': 8.07129
      , 'Stddev': 2.68946 },
    ]
, 'TaskParticlesSend' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 2048
      , 'Min': 3
      , 'Max': 15
      , 'Avg': 6.95215
      , 'Stddev': 2.75384 },
    ]
, 'TaskReceive 5' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 24370
      , 'Min': 0
      , 'Max': 170
      , 'Avg': 3.52573
      , 'Stddev': 3.67702 },
    ]
, 'TaskReceiveMPI exchange type=3' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 12290
      , 'Min': 0
      , 'Max': 170
      , 'Avg': 2.99683
      , 'Stddev': 3.67499 },
    ]
, 'TaskReceiveMPI exchange type=6' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 12080
      , 'Min': 0
      , 'Max': 128
      , 'Avg': 3.3548
      , 'Stddev': 3.55689 },
    ]
, 'TaskReceiveParticlesExchange' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 4061
      , 'Min': 0
      , 'Max': 16
      , 'Avg': 5.97168
      , 'Stddev': 2.27292 },
    ]
, 'TaskSend 4' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 24370
      , 'Min': 0
      , 'Max': 128
      , 'Avg': 0.667091
      , 'Stddev': 1.60876 },
    ]
, 'TaskSendMPI exchange type=3' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 12290
      , 'Min': 0
      , 'Max': 122
      , 'Avg': 0.357282
      , 'Stddev': 1.53134 },
    ]
, 'TaskSendMPI exchange type=6' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 12080
      , 'Min': 0
      , 'Max': 118
      , 'Avg': 0.346192
      , 'Stddev': 1.44525 },
    ]
, 'TaskSendParticlesExchange' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 4061
      , 'Min': 0
      , 'Max': 15
      , 'Avg': 3.99828
      , 'Stddev': 3.68867 },
    ]
, 'TaskSetCurrentSizeOnDevice' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 8226
      , 'Min': 0
      , 'Max': 1
      , 'Avg': 0.242888
      , 'Stddev': 0.428828 },
    ]
, 'TaskSetValue' : [
      { 'Bytes': 0
      , 'Flops': 0
      , 'Calls': 2529
      , 'Min': 0
      , 'Max': 19881
      , 'Avg': 13.4816
      , 'Stddev': 470.512 },
    ]
, 'Unload' : [
      { 'Bytes': 1
      , 'Flops': 1
      , 'Calls': 1
      , 'Min': 0.241191
      , 'Max': 0.241191
      , 'Avg': 0.241191
      , 'Stddev': 0 },
    ]
  }
```