### PR TITLE
Add missing artibrary order solver to the list of PML-enabled field solvers

### DIFF
--- a/include/picongpu/param/pml.param
+++ b/include/picongpu/param/pml.param
@@ -21,7 +21,7 @@
  *
  * Configure the Perfectly Matched Layer absorbing boundary conditions (PML).
  *
- * To enable PML use YeePML or LehePML field solver.
+ * To enable PML use YeePML, LehePML or ArbitraryOrderFDTDPML field solver.
  */
 
 #pragma once

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/pml.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/pml.param
@@ -21,7 +21,7 @@
  *
  * Configure the perfectly matched layer (PML).
  *
- * To enable PML use YeePML or LehePML field solver.
+ * To enable PML use YeePML, LehePML or ArbitraryOrderFDTDPML field solver.
  */
 
 #pragma once


### PR DESCRIPTION
That was probably just forgotten when this solver was added. I made a fix, since this file is included to readthedocs.