### PR TITLE
Switch internal handling of current deposition from compile-time to run-time

### DIFF
--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -154,12 +154,12 @@ namespace picongpu
         /** Smooth current density and add it to the electric field
          *
          * @tparam T_area area to operate on
-         * @tparam T_CurrentInterpolation current interpolation type
+         * @tparam T_CurrentInterpolationFunctor current interpolation functor type
          *
-         * @param myCurrentInterpolation current interpolation
+         * @param myCurrentInterpolationFunctor current interpolation functor
          */
-        template<uint32_t T_area, class T_CurrentInterpolation>
-        HINLINE void addCurrentToEMF(T_CurrentInterpolation& myCurrentInterpolation);
+        template<uint32_t T_area, class T_CurrentInterpolationFunctor>
+        HINLINE void addCurrentToEMF(T_CurrentInterpolationFunctor myCurrentInterpolationFunctor);
 
         /** Bash field in a direction.
          *

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -236,13 +236,13 @@ namespace picongpu
         template<uint32_t T_numWorkers>
         struct KernelAddCurrentToEMF
         {
-            template<typename T_CurrentInterpolation, typename T_Mapping, typename T_Acc>
+            template<typename T_CurrentInterpolationFunctor, typename T_Mapping, typename T_Acc>
             DINLINE void operator()(
                 T_Acc const& acc,
                 typename FieldE::DataBoxType fieldE,
                 typename FieldB::DataBoxType fieldB,
                 typename FieldJ::DataBoxType fieldJ,
-                T_CurrentInterpolation currentInterpolation,
+                T_CurrentInterpolationFunctor currentInterpolationFunctor,
                 T_Mapping mapper) const
             {
                 using namespace mappings::threads;
@@ -250,8 +250,8 @@ namespace picongpu
                 /* Caching of fieldJ */
                 typedef SuperCellDescription<
                     SuperCellSize,
-                    typename T_CurrentInterpolation::LowerMargin,
-                    typename T_CurrentInterpolation::UpperMargin>
+                    typename T_CurrentInterpolationFunctor::LowerMargin,
+                    typename T_CurrentInterpolationFunctor::UpperMargin>
                     BlockArea;
 
                 constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
@@ -285,7 +285,7 @@ namespace picongpu
                         //   Change of the dE = - j / EPS0 * dt
                         //                        j = current density (= current per area)
                         //                          = fieldJ
-                        currentInterpolation(fieldE.shift(cell), fieldB.shift(cell), cachedJ.shift(cellIdx));
+                        currentInterpolationFunctor(fieldE.shift(cell), fieldB.shift(cell), cachedJ.shift(cellIdx));
                     });
             }
         };

--- a/include/picongpu/fields/currentInterpolation/Binomial/Binomial.def
+++ b/include/picongpu/fields/currentInterpolation/Binomial/Binomial.def
@@ -24,7 +24,7 @@ namespace picongpu
 {
     namespace currentInterpolation
     {
-        /** 2nd order Binomial filter
+        /** 2nd order Binomial filter functor
          *
          * Smooths the current before assignment in staggered grid.
          * Updates E & breaks local charge conservation slightly.

--- a/include/picongpu/fields/currentInterpolation/Binomial/Binomial.hpp
+++ b/include/picongpu/fields/currentInterpolation/Binomial/Binomial.hpp
@@ -34,7 +34,6 @@ namespace picongpu
             template<uint32_t T_dim>
             struct Binomial;
 
-
             //! Specialization for 3D
             template<>
             struct Binomial<DIM3>

--- a/include/picongpu/fields/currentInterpolation/CurrentInterpolation.hpp
+++ b/include/picongpu/fields/currentInterpolation/CurrentInterpolation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2021 Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -17,6 +17,77 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
 #include "picongpu/fields/currentInterpolation/None/None.hpp"
 #include "picongpu/fields/currentInterpolation/Binomial/Binomial.hpp"
+
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/traits/GetStringProperties.hpp>
+
+
+namespace picongpu
+{
+    namespace currentInterpolation
+    {
+        /** Singleton to represent current interpolation kind
+         *
+         * It does not perform interpolation itself, that is done by functors None and Binomial.
+         * Provides run-time utilities to get margin values and string properties.
+         *
+         * Note: for now it is called CurrentInterpolationInfo to not conflict with CurrentInterpolation type alias
+         * used in standard .param files. Will be renamed to just CurrentInterpolation after a transition to a
+         * run-time parameter
+         */
+        struct CurrentInterpolationInfo
+        {
+        public:
+            //! Supported interpolation kinds
+            enum class Kind
+            {
+                None,
+                Binomial
+            };
+
+            //! Interpolation kind used in the simulation
+            Kind kind = Kind::None;
+
+            //! Get the single instance of the current interpolation object
+            static CurrentInterpolationInfo& get()
+            {
+                static CurrentInterpolationInfo instance;
+                return instance;
+            }
+
+            //! Get string properties
+            static pmacc::traits::StringProperty getStringProperties()
+            {
+                return get().kind == Kind::None ? None::getStringProperties() : Binomial::getStringProperties();
+            }
+
+            //! Get the lower margin of the used interpolation functor
+            static pmacc::math::Vector<int, simDim> getLowerMargin()
+            {
+                return get().kind == Kind::None ? None::LowerMargin::toRT() : Binomial::LowerMargin::toRT();
+            }
+
+            //! Get the upper margin of the used interpolation functor
+            static pmacc::math::Vector<int, simDim> getUpperMargin()
+            {
+                return get().kind == Kind::None ? None::UpperMargin::toRT() : Binomial::UpperMargin::toRT();
+            }
+
+            //! Copy construction is forbidden
+            CurrentInterpolationInfo(CurrentInterpolationInfo const&) = delete;
+
+            //! Assignment is forbidden
+            CurrentInterpolationInfo& operator=(CurrentInterpolationInfo const&) = delete;
+
+        private:
+            CurrentInterpolationInfo() = default;
+            ~CurrentInterpolationInfo() = default;
+        };
+
+    } // namespace currentInterpolation
+
+} // namespace picongpu

--- a/include/picongpu/fields/currentInterpolation/None/None.def
+++ b/include/picongpu/fields/currentInterpolation/None/None.def
@@ -24,7 +24,7 @@ namespace picongpu
 {
     namespace currentInterpolation
     {
-        /* None interpolated current assignment
+        /* None interpolated current assignment functor
          *
          * Default for staggered grids/Yee-scheme.
          * Updates field E only.

--- a/include/picongpu/plugins/adios/WriteMeta.hpp
+++ b/include/picongpu/plugins/adios/WriteMeta.hpp
@@ -291,7 +291,7 @@ namespace picongpu
 
                 writeMeta::OfAllSpecies<>()(threadParams, fullMeshesPath);
 
-                GetStringProperties<typename fields::Solver::CurrentInterpolation> currentSmoothingProp;
+                GetStringProperties<currentInterpolation::CurrentInterpolationInfo> currentSmoothingProp;
                 const std::string currentSmoothing(currentSmoothingProp["name"].value);
                 ADIOS_CMD(adios_define_attribute_byvalue(
                     threadParams->adiosGroupHandle,

--- a/include/picongpu/plugins/openPMD/WriteMeta.hpp
+++ b/include/picongpu/plugins/openPMD/WriteMeta.hpp
@@ -177,7 +177,7 @@ namespace picongpu
 
                 writeMeta::OfAllSpecies<>()(threadParams);
 
-                GetStringProperties<typename fields::Solver::CurrentInterpolation> currentSmoothingProp;
+                GetStringProperties<currentInterpolation::CurrentInterpolationInfo> currentSmoothingProp;
                 const std::string currentSmoothing(currentSmoothingProp["name"].value);
                 meshes.setAttribute("currentSmoothing", currentSmoothing);
 

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -321,6 +321,9 @@ namespace picongpu
         {
             namespace nvmem = pmacc::nvidia::memory;
 
+            // This has to be called before initFields()
+            currentInterpolationAndAdditionToEMF.init();
+
             DataConnector& dc = Environment<>::get().DataConnector();
             initFields(dc);
 
@@ -555,7 +558,7 @@ namespace picongpu
             __setTransactionEvent(commEvent);
             CurrentBackground{*cellDescription}(currentStep);
             CurrentDeposition{}(currentStep);
-            CurrentInterpolationAndAdditionToEMF{}(currentStep);
+            currentInterpolationAndAdditionToEMF(currentStep);
             myFieldSolver->update_afterCurrent(currentStep);
         }
 
@@ -624,6 +627,7 @@ namespace picongpu
         std::shared_ptr<DeviceHeap> deviceHeap;
 
         fields::Solver* myFieldSolver;
+        simulation::stage::CurrentInterpolationAndAdditionToEMF currentInterpolationAndAdditionToEMF;
 
 #if(PMACC_CUDA_ENABLED == 1)
         // creates lookup tables for the bremsstrahlung effect

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -35,6 +35,8 @@
 #include <boost/mpl/count.hpp>
 
 #include <cstdint>
+#include <stdexcept>
+#include <type_traits>
 
 
 namespace picongpu
@@ -46,10 +48,28 @@ namespace picongpu
             /** Functor for the stage of the PIC loop performing current interpolation
              *  and addition to grid values of the electromagnetic field
              */
-            struct CurrentInterpolationAndAdditionToEMF
+            class CurrentInterpolationAndAdditionToEMF
             {
-                /** Compute the current created by particles and add it to the current
-                 *  density
+            public:
+                /** Initialize the current interpolation stage
+                 *
+                 * This method has to be called during initialization of the simulation.
+                 * Before this method is called, the instance of CurrentInterpolation cannot be used safely.
+                 */
+                void init()
+                {
+                    // Convert compile-time current interpolation set in the field solver to a runtime value
+                    using namespace currentInterpolation;
+                    auto& interpolation = CurrentInterpolationInfo::get();
+                    if(std::is_same<fields::Solver::CurrentInterpolation, None>::value)
+                        interpolation.kind = CurrentInterpolationInfo::Kind::None;
+                    else if(std::is_same<fields::Solver::CurrentInterpolation, Binomial>::value)
+                        interpolation.kind = CurrentInterpolationInfo::Kind::Binomial;
+                    else
+                        throw std::runtime_error("Unsupported current interpolation type used in the field solver");
+                }
+
+                /** Compute the current created by particles and add it to the current density
                  *
                  * @param step index of time iteration
                  */
@@ -66,20 +86,19 @@ namespace picongpu
                     DataConnector& dc = Environment<>::get().DataConnector();
                     auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
                     auto eRecvCurrent = fieldJ.asyncCommunication(__getTransactionEvent());
-                    using CurrentInterpolation = fields::Solver::CurrentInterpolation;
-                    CurrentInterpolation currentInterpolation;
-                    using Margin = traits::GetMargin<CurrentInterpolation>;
-                    DataSpace<simDim> const currentRecvLower(Margin::LowerMargin().toRT());
-                    DataSpace<simDim> const currentRecvUpper(Margin::UpperMargin().toRT());
+                    auto& interpolation = currentInterpolation::CurrentInterpolationInfo::get();
+                    auto const currentRecvLower = interpolation.getLowerMargin();
+                    auto const currentRecvUpper = interpolation.getUpperMargin();
 
                     /* without interpolation, we do not need to access the FieldJ GUARD
-                     * and can therefore overlap communication of GUARD->(ADD)BORDER & computation of CORE */
+                     * and can therefore overlap communication of GUARD->(ADD)BORDER & computation of CORE
+                     */
                     if(currentRecvLower == DataSpace<simDim>::create(0)
                        && currentRecvUpper == DataSpace<simDim>::create(0))
                     {
-                        fieldJ.addCurrentToEMF<type::CORE>(currentInterpolation);
+                        addCurrentToEMF<type::CORE>(fieldJ);
                         __setTransactionEvent(eRecvCurrent);
-                        fieldJ.addCurrentToEMF<type::BORDER>(currentInterpolation);
+                        addCurrentToEMF<type::BORDER>(fieldJ);
                     }
                     else
                     {
@@ -91,9 +110,30 @@ namespace picongpu
                          * \todo split the last `receive` part in a separate method to
                          *       allow already a computation of CORE */
                         __setTransactionEvent(eRecvCurrent);
-                        fieldJ.addCurrentToEMF<type::CORE + type::BORDER>(currentInterpolation);
+                        addCurrentToEMF<type::CORE + type::BORDER>(fieldJ);
                     }
                     dc.releaseData(FieldJ::getName());
+                }
+
+            private:
+                /* Call addCurrentToEMF method of fieldJ for the given area
+                 *
+                 * This function performs a transition from the run-time realm of CurrentInterpolation into the
+                 * template realm of fieldJ.addCurrentToEMF() operating with interpolation functors.
+                 *
+                 * @tparam T_area area to operate once
+                 *
+                 * @param fieldJ object representing the current field
+                 */
+                template<std::uint32_t T_area>
+                void addCurrentToEMF(FieldJ& fieldJ) const
+                {
+                    using currentInterpolation::CurrentInterpolationInfo;
+                    auto const kind = CurrentInterpolationInfo::get().kind;
+                    if(kind == CurrentInterpolationInfo::Kind::None)
+                        fieldJ.addCurrentToEMF<T_area>(currentInterpolation::None{});
+                    else
+                        fieldJ.addCurrentToEMF<T_area>(currentInterpolation::Binomial{});
                 }
             };
 


### PR DESCRIPTION
As we discussed on the VC, I split the transition into run-time current interpolation parameters into two PRs.

This PR only does the internal stuff and does *not* change the user interface of PIConGPU.
The only difference is that custom current deposition functors declared in `.param` files are no longer allowed (but I am not aware of such a use case at all).
It made internal changes necessary for a full transition of this parameter towards run-time, to be done in a following PR.

To avoid confusion, I renamed names and template parameter names of old instances of current interpolation into functors (which they were already and remain that way). Also due to a name conflict with .param file naming the new class is called `CurrentInterpolationInfo`, to be renamed into `CurrentInterpolation` in the follow-up PR.