### PR TITLE
fix EOF whitespace test

### DIFF
--- a/test/hasEOLwhiteSpace
+++ b/test/hasEOLwhiteSpace
@@ -33,7 +33,7 @@ files=()
 pattern="\.def$|\.h$|\.cpp$|\.cu$|\.hpp$|\.tpp$|\.kernel$|\.loader$|"\
 "\.param$|\.unitless$|\.sh$|\.bash$|\.cfg$|\.tpl$|\.conf$|"\
 "\.awk$|\.gnuplot$|\.cmake$|\.profile$|\.example$|\.py$|"\
-"cmakeFlags|CMakeLists\.txt|src/tools/bin"
+"cmakeFlags$|CMakeLists\.txt|src/tools/bin"
 
 for i in $(find . \
                 -not -path "./.git/*" \


### PR DESCRIPTION
Fix that each file that contains `cmakeFlags` within the name is checked for EOF white spaces.
In #3416 png files were checked, the result is a failing CI. [see here](https://gitlab.com/hzdr/crp/picongpu/-/jobs/1101705190#L1938)

I disabled compile tests because those are not nessesary to validate the change. `hasEOLwhiteSpace` is tested even if we disable compile tests.