### PR TITLE
Remove unused enum picongpu::FieldType

### DIFF
--- a/include/picongpu/simulation_types.hpp
+++ b/include/picongpu/simulation_types.hpp
@@ -46,16 +46,6 @@ namespace picongpu
         SPECIES_FIRSTTAG = 42u
     };
 
-
-    //! defines field types some various methods (e.g. Laser::manipulate)
-
-    enum FieldType
-    {
-        FIELD_TYPE_E,
-        FIELD_TYPE_B,
-        FIELD_TYPE_TMP
-    };
-
     namespace precision32Bit
     {
         using precisionType = float;


### PR DESCRIPTION
Was probably removed previously with another change, and left out.