### PR TITLE
Fix and modernize the generation scheme for MPI communication tags

### DIFF
--- a/include/picongpu/fields/EMFieldBase.hpp
+++ b/include/picongpu/fields/EMFieldBase.hpp
@@ -78,12 +78,14 @@ namespace picongpu
              *
              * @param cellDescription mapping for kernels
              * @param id unique id
-             * @param tag helper parameter for T_tag deduction
+             * @param commTag MPI communication tag
+             * @param tag helper parameter for T_tag deduction (not for MPI, but for field traits)
              */
             template<CommunicationTag T_tag>
             HINLINE EMFieldBase(
                 MappingDesc const& cellDescription,
                 pmacc::SimulationDataId const& id,
+                uint32_t commTag,
                 std::integral_constant<CommunicationTag, T_tag> tag);
 
             //! Get a reference to the host-device buffer for the field values

--- a/include/picongpu/fields/EMFieldBase.tpp
+++ b/include/picongpu/fields/EMFieldBase.tpp
@@ -39,6 +39,7 @@
 
 #include <boost/mpl/accumulate.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <type_traits>
 
@@ -51,6 +52,7 @@ namespace picongpu
         EMFieldBase::EMFieldBase(
             MappingDesc const& cellDescription,
             pmacc::SimulationDataId const& id,
+            uint32_t const commTag,
             std::integral_constant<CommunicationTag, T_tag>)
             : SimulationFieldHelper<MappingDesc>(cellDescription)
             , id(id)
@@ -106,7 +108,7 @@ namespace picongpu
                 DataSpace<simDim> guardingCells;
                 for(uint32_t d = 0; d < simDim; ++d)
                     guardingCells[d] = (relativeMask[d] == -1 ? originGuard[d] : endGuard[d]);
-                buffer->addExchange(GUARD, i, guardingCells, T_tag);
+                buffer->addExchange(GUARD, i, guardingCells, commTag);
             }
         }
 

--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -25,6 +25,8 @@
 #include "picongpu/simulation_types.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
+#include <pmacc/traits/GetUniqueTypeId.hpp>
+
 #include <string>
 #include <vector>
 #include <type_traits>
@@ -33,7 +35,11 @@
 namespace picongpu
 {
     FieldB::FieldB(MappingDesc const& cellDescription)
-        : fields::EMFieldBase(cellDescription, getName(), std::integral_constant<CommunicationTag, FIELD_B>{})
+        : fields::EMFieldBase(
+            cellDescription,
+            getName(),
+            pmacc::traits::GetUniqueTypeId<FieldB>::uid(),
+            std::integral_constant<CommunicationTag, FIELD_B>{})
     {
     }
 

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -25,6 +25,8 @@
 #include "picongpu/simulation_types.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
+#include <pmacc/traits/GetUniqueTypeId.hpp>
+
 #include <string>
 #include <vector>
 #include <type_traits>
@@ -33,7 +35,11 @@
 namespace picongpu
 {
     FieldE::FieldE(MappingDesc const& cellDescription)
-        : fields::EMFieldBase(cellDescription, getName(), std::integral_constant<CommunicationTag, FIELD_E>{})
+        : fields::EMFieldBase(
+            cellDescription,
+            getName(),
+            pmacc::traits::GetUniqueTypeId<FieldE>::uid(),
+            std::integral_constant<CommunicationTag, FIELD_E>{})
     {
     }
 

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -55,11 +55,11 @@ namespace picongpu
     {
         /* Since this class is instantiated for each temporary field slot,
          * use getNextId( ) directly to get unique tags for each instance.
-         * Add SPECIES_FIRSTTAG to avoid collisions with the tags for
-         * other fields.
+         *
+         * Warning: this usage relies on the same order of calls to getNextId() on all MPI ranks
          */
-        m_commTagScatter = pmacc::traits::getNextId() + SPECIES_FIRSTTAG;
-        m_commTagGather = pmacc::traits::getNextId() + SPECIES_FIRSTTAG;
+        m_commTagScatter = pmacc::traits::getNextId();
+        m_commTagGather = pmacc::traits::getNextId();
 
         using Buffer = GridBuffer<ValueType, simDim>;
         fieldTmp = std::make_unique<Buffer>(cellDescription.getGridLayout());

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -196,7 +196,7 @@ namespace picongpu
     {
         size_t sizeOfExchanges = 0u;
 
-        const uint32_t commTag = pmacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid() + SPECIES_FIRSTTAG;
+        const uint32_t commTag = pmacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid();
         log<picLog::MEMORY>("communication tag for species %1%: %2%") % FrameType::getName() % commTag;
 
         auto const numExchanges = NumberOfExchanges<simDim>::value;

--- a/include/picongpu/simulation_types.hpp
+++ b/include/picongpu/simulation_types.hpp
@@ -34,16 +34,14 @@
 
 namespace picongpu
 {
-    //! define all elements which can send and resive
-
+    /** Legacy communication tags
+     *
+     * Now only used for some field traits, to be removed soon
+     */
     enum CommunicationTag
     {
-        NO_COMMUNICATION = 0u,
         FIELD_B = 1u,
-        FIELD_E = 2u,
-        FIELD_J = 3u,
-        FIELD_JRECV = 4u,
-        SPECIES_FIRSTTAG = 42u
+        FIELD_E = 2u
     };
 
 

--- a/include/pmacc/memory/buffers/GridBuffer.hpp
+++ b/include/pmacc/memory/buffers/GridBuffer.hpp
@@ -192,6 +192,8 @@ namespace pmacc
          * @param receive a Mask which describes the directions for the exchange
          * @param guardingCells number of guarding cells in each dimension
          * @param communicationTag unique tag/id for communication
+         *        has to be the same when this method is called multiple times for the same object
+         *        (with non-overlapping masks)
          * @param sizeOnDeviceSend if true, internal send buffers must store their
          *        size additionally on the device
          *        (as we keep this information coherent with the host, it influences
@@ -222,6 +224,9 @@ namespace pmacc
             {
                 if(send.isSet(ex))
                 {
+                    /* This operation relies on communicationTag being relatively small, so that the resulting
+                     * uniqCommunicationTag fits the range of valid tags
+                     */
                     uint32_t uniqCommunicationTag = (communicationTag << 5) | ex;
 
                     if(!hasOneExchange && !privateGridBuffer::UniquTag::getInstance().isTagUniqu(uniqCommunicationTag))
@@ -329,6 +334,9 @@ namespace pmacc
                 {
                     if(send.isSet(ex))
                     {
+                        /* This operation relies on communicationTag being relatively small, so that the resulting
+                         * uniqCommunicationTag fits the range of valid tags
+                         */
                         uint32_t uniqCommunicationTag = (communicationTag << 5) | ex;
                         if(!hasOneExchange
                            && !privateGridBuffer::UniquTag::getInstance().isTagUniqu(uniqCommunicationTag))

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -47,6 +47,7 @@
 #include <boost/mpl/pair.hpp>
 #include "pmacc/particles/ParticleDescription.hpp"
 #include "pmacc/particles/memory/dataTypes/ListPointer.hpp"
+#include "pmacc/traits/GetUniqueTypeId.hpp"
 
 #include <memory>
 
@@ -196,12 +197,15 @@ namespace pmacc
             framesExchanges
                 ->addExchangeBuffer(receive, DataSpace<DIM1>(numFrameTypeBorders), communicationTag, true, false);
 
-            exchangeMemoryIndexer->addExchangeBuffer(
-                receive,
-                DataSpace<DIM1>(numFrameTypeBorders),
-                communicationTag | (1u << (20 - 5)),
-                true,
-                false);
+            /* Generate a new tag from this type
+             *
+             * The tag is the same each time this method is called (per instantiation of this template).
+             * Here it is fine, as there is the only instance object, and
+             * exchangeMemoryIndexer->addExchangeBuffer() requires the same tag on each call
+             */
+            auto const newTag = traits::GetUniqueTypeId<ParticlesBuffer, uint32_t>::uid();
+            exchangeMemoryIndexer
+                ->addExchangeBuffer(receive, DataSpace<DIM1>(numFrameTypeBorders), newTag, true, false);
         }
 
         /**

--- a/include/pmacc/traits/GetUniqueTypeId.hpp
+++ b/include/pmacc/traits/GetUniqueTypeId.hpp
@@ -72,7 +72,9 @@ namespace pmacc
 
         /** Get next available type id
          *
-         * Warning: is not thread-safe.
+         * \warning is not thread-safe.
+         * \warning when using it to generate matching tags from multiple MPI ranks, ensure the same call order.
+         *          For type-unique ids, GetUniqueTypeId<> is preferable as it is not dependent on the call order
          */
         uint64_t getNextId()
         {


### PR DESCRIPTION
The old scheme was causing some tags to be outside of the valid range #982.
Apply fixes and modernization of the tag generation scheme.
Document the requirements of the new scheme.

The remaining pieces of `picongpu::CommunicationTag` are no longer used for communication.
But they are left to keep the field solver traits, to be fixed in a following PR.

Resolves #982.
@jprotze thanks for reporting the issue. Hopefully this PR solves it, but I haven't tested it fully yet, will continue tomorrow.