### PR TITLE
Remove enum picongpu::CommunicationTag

### DIFF
--- a/include/picongpu/fields/EMFieldBase.hpp
+++ b/include/picongpu/fields/EMFieldBase.hpp
@@ -51,12 +51,18 @@ namespace picongpu
          *
          * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
          * ISimulationData.
+         *
+         * @tparam T_DerivedField derived field type
          */
+        template<typename T_DerivedField>
         class EMFieldBase
             : public SimulationFieldHelper<MappingDesc>
             , public ISimulationData
         {
         public:
+            //! Derived field type
+            using DerivedField = T_DerivedField;
+
             //! Type of each field value
             using ValueType = float3_X;
 
@@ -74,19 +80,10 @@ namespace picongpu
 
             /** Create a field
              *
-             * @tparam T_tag communication tag value
-             *
              * @param cellDescription mapping for kernels
              * @param id unique id
-             * @param commTag MPI communication tag
-             * @param tag helper parameter for T_tag deduction (not for MPI, but for field traits)
              */
-            template<CommunicationTag T_tag>
-            HINLINE EMFieldBase(
-                MappingDesc const& cellDescription,
-                pmacc::SimulationDataId const& id,
-                uint32_t commTag,
-                std::integral_constant<CommunicationTag, T_tag> tag);
+            HINLINE EMFieldBase(MappingDesc const& cellDescription, pmacc::SimulationDataId const& id);
 
             //! Get a reference to the host-device buffer for the field values
             HINLINE Buffer& getGridBuffer();

--- a/include/picongpu/fields/EMFieldBase.tpp
+++ b/include/picongpu/fields/EMFieldBase.tpp
@@ -36,6 +36,7 @@
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/traits/GetUniqueTypeId.hpp>
 
 #include <boost/mpl/accumulate.hpp>
 
@@ -48,12 +49,8 @@ namespace picongpu
 {
     namespace fields
     {
-        template<CommunicationTag T_tag>
-        EMFieldBase::EMFieldBase(
-            MappingDesc const& cellDescription,
-            pmacc::SimulationDataId const& id,
-            uint32_t const commTag,
-            std::integral_constant<CommunicationTag, T_tag>)
+        template<typename T_DerivedField>
+        EMFieldBase<T_DerivedField>::EMFieldBase(MappingDesc const& cellDescription, pmacc::SimulationDataId const& id)
             : SimulationFieldHelper<MappingDesc>(cellDescription)
             , id(id)
         {
@@ -71,10 +68,10 @@ namespace picongpu
                 pmacc::math::CT::max<bmpl::_1, GetUpperMargin<GetInterpolation<bmpl::_2>>>>::type;
 
             /* Calculate the maximum Neighbors we need from MAX(ParticleShape, FieldSolver) */
-            using LowerMarginSolver = typename GetMargin<fields::Solver, T_tag>::LowerMargin;
+            using LowerMarginSolver = typename traits::GetMargin<fields::Solver, DerivedField>::LowerMargin;
             using LowerMarginInterpolationAndSolver =
                 typename pmacc::math::CT::max<LowerMarginInterpolation, LowerMarginSolver>::type;
-            using UpperMarginSolver = typename GetMargin<fields::Solver, T_tag>::UpperMargin;
+            using UpperMarginSolver = typename traits::GetMargin<fields::Solver, DerivedField>::UpperMargin;
             using UpperMarginInterpolationAndSolver =
                 typename pmacc::math::CT::max<UpperMarginInterpolation, UpperMarginSolver>::type;
 
@@ -108,53 +105,63 @@ namespace picongpu
                 DataSpace<simDim> guardingCells;
                 for(uint32_t d = 0; d < simDim; ++d)
                     guardingCells[d] = (relativeMask[d] == -1 ? originGuard[d] : endGuard[d]);
+                auto const commTag = pmacc::traits::GetUniqueTypeId<DerivedField>::uid();
                 buffer->addExchange(GUARD, i, guardingCells, commTag);
             }
         }
 
-        EMFieldBase::Buffer& EMFieldBase::getGridBuffer()
+        template<typename T_DerivedField>
+        typename EMFieldBase<T_DerivedField>::Buffer& EMFieldBase<T_DerivedField>::getGridBuffer()
         {
             return *buffer;
         }
 
-        GridLayout<simDim> EMFieldBase::getGridLayout()
+        template<typename T_DerivedField>
+        GridLayout<simDim> EMFieldBase<T_DerivedField>::getGridLayout()
         {
             return cellDescription.getGridLayout();
         }
 
-        EMFieldBase::DataBoxType EMFieldBase::getHostDataBox()
+        template<typename T_DerivedField>
+        typename EMFieldBase<T_DerivedField>::DataBoxType EMFieldBase<T_DerivedField>::getHostDataBox()
         {
             return buffer->getHostBuffer().getDataBox();
         }
 
-        EMFieldBase::DataBoxType EMFieldBase::getDeviceDataBox()
+        template<typename T_DerivedField>
+        typename EMFieldBase<T_DerivedField>::DataBoxType EMFieldBase<T_DerivedField>::getDeviceDataBox()
         {
             return buffer->getDeviceBuffer().getDataBox();
         }
 
-        EventTask EMFieldBase::asyncCommunication(EventTask serialEvent)
+        template<typename T_DerivedField>
+        EventTask EMFieldBase<T_DerivedField>::asyncCommunication(EventTask serialEvent)
         {
             EventTask eB = buffer->asyncCommunication(serialEvent);
             return eB;
         }
 
-        void EMFieldBase::reset(uint32_t)
+        template<typename T_DerivedField>
+        void EMFieldBase<T_DerivedField>::reset(uint32_t)
         {
             buffer->getHostBuffer().reset(true);
             buffer->getDeviceBuffer().reset(false);
         }
 
-        void EMFieldBase::syncToDevice()
+        template<typename T_DerivedField>
+        void EMFieldBase<T_DerivedField>::syncToDevice()
         {
             buffer->hostToDevice();
         }
 
-        void EMFieldBase::synchronize()
+        template<typename T_DerivedField>
+        void EMFieldBase<T_DerivedField>::synchronize()
         {
             buffer->deviceToHost();
         }
 
-        pmacc::SimulationDataId EMFieldBase::getUniqueId()
+        template<typename T_DerivedField>
+        pmacc::SimulationDataId EMFieldBase<T_DerivedField>::getUniqueId()
         {
             return id;
         }

--- a/include/picongpu/fields/FieldB.hpp
+++ b/include/picongpu/fields/FieldB.hpp
@@ -40,7 +40,7 @@ namespace picongpu
      * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
      * ISimulationData.
      */
-    class FieldB : public fields::EMFieldBase
+    class FieldB : public fields::EMFieldBase<FieldB>
     {
     public:
         /** Create a field

--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -25,8 +25,6 @@
 #include "picongpu/simulation_types.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
-#include <pmacc/traits/GetUniqueTypeId.hpp>
-
 #include <string>
 #include <vector>
 #include <type_traits>
@@ -34,12 +32,7 @@
 
 namespace picongpu
 {
-    FieldB::FieldB(MappingDesc const& cellDescription)
-        : fields::EMFieldBase(
-            cellDescription,
-            getName(),
-            pmacc::traits::GetUniqueTypeId<FieldB>::uid(),
-            std::integral_constant<CommunicationTag, FIELD_B>{})
+    FieldB::FieldB(MappingDesc const& cellDescription) : fields::EMFieldBase<FieldB>(cellDescription, getName())
     {
     }
 

--- a/include/picongpu/fields/FieldE.hpp
+++ b/include/picongpu/fields/FieldE.hpp
@@ -40,7 +40,7 @@ namespace picongpu
      * Implements interfaces defined by SimulationFieldHelper< MappingDesc > and
      * ISimulationData.
      */
-    class FieldE : public fields::EMFieldBase
+    class FieldE : public fields::EMFieldBase<FieldE>
     {
     public:
         /** Create a field

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -25,8 +25,6 @@
 #include "picongpu/simulation_types.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
-#include <pmacc/traits/GetUniqueTypeId.hpp>
-
 #include <string>
 #include <vector>
 #include <type_traits>
@@ -34,12 +32,7 @@
 
 namespace picongpu
 {
-    FieldE::FieldE(MappingDesc const& cellDescription)
-        : fields::EMFieldBase(
-            cellDescription,
-            getName(),
-            pmacc::traits::GetUniqueTypeId<FieldE>::uid(),
-            std::integral_constant<CommunicationTag, FIELD_E>{})
+    FieldE::FieldE(MappingDesc const& cellDescription) : fields::EMFieldBase<FieldE>(cellDescription, getName())
     {
     }
 

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -92,8 +92,8 @@ namespace picongpu
         typedef pmacc::math::CT::max<SpeciesLowerMargin, FieldTmpLowerMargin>::type SpeciesFieldTmpLowerMargin;
 
         typedef pmacc::math::CT::max<
-            GetMargin<fields::Solver, FIELD_B>::LowerMargin,
-            GetMargin<fields::Solver, FIELD_E>::LowerMargin>::type FieldSolverLowerMargin;
+            GetMargin<fields::Solver, FieldB>::LowerMargin,
+            GetMargin<fields::Solver, FieldE>::LowerMargin>::type FieldSolverLowerMargin;
 
         typedef pmacc::math::CT::max<SpeciesFieldTmpLowerMargin, FieldSolverLowerMargin>::type LowerMargin;
 
@@ -113,8 +113,8 @@ namespace picongpu
         typedef pmacc::math::CT::max<SpeciesUpperMargin, FieldTmpUpperMargin>::type SpeciesFieldTmpUpperMargin;
 
         typedef pmacc::math::CT::max<
-            GetMargin<fields::Solver, FIELD_B>::UpperMargin,
-            GetMargin<fields::Solver, FIELD_E>::UpperMargin>::type FieldSolverUpperMargin;
+            GetMargin<fields::Solver, FieldB>::UpperMargin,
+            GetMargin<fields::Solver, FieldE>::UpperMargin>::type FieldSolverUpperMargin;
 
         typedef pmacc::math::CT::max<SpeciesFieldTmpUpperMargin, FieldSolverUpperMargin>::type UpperMargin;
 

--- a/include/picongpu/fields/MaxwellSolver/None/None.def
+++ b/include/picongpu/fields/MaxwellSolver/None/None.def
@@ -32,22 +32,4 @@ namespace picongpu
 
         } // namespace maxwellSolver
     } // namespace fields
-
-    namespace traits
-    {
-        template<>
-        struct GetMargin<picongpu::fields::maxwellSolver::None, FIELD_B>
-        {
-            using LowerMargin = typename pmacc::math::CT::make_Int<simDim, 0>::type;
-            using UpperMargin = LowerMargin;
-        };
-
-        template<>
-        struct GetMargin<picongpu::fields::maxwellSolver::None, FIELD_E>
-        {
-            using LowerMargin = typename pmacc::math::CT::make_Int<simDim, 0>::type;
-            using UpperMargin = LowerMargin;
-        };
-
-    } // namespace traits
 } // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/MaxwellSolver/None/None.def"
 #include "picongpu/fields/cellType/Yee.hpp"
+#include "picongpu/traits/GetMargin.hpp"
 
 #include <pmacc/types.hpp>
 
@@ -88,4 +89,19 @@ namespace picongpu
 
         } // namespace maxwellSolver
     } // namespace fields
+
+    namespace traits
+    {
+        /** Get margin for any field access in the None solver
+         *
+         * @tparam T_Field field type
+         */
+        template<typename T_Field>
+        struct GetMargin<picongpu::fields::maxwellSolver::None, T_Field>
+        {
+            using LowerMargin = typename pmacc::math::CT::make_Int<simDim, 0>::type;
+            using UpperMargin = LowerMargin;
+        };
+    } // namespace traits
+
 } // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -152,18 +152,28 @@ namespace picongpu
 
     namespace traits
     {
-        template<class CurlE, class CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::Yee<CurlE, CurlB>, FIELD_B>
+        /** Get margin for B field access in the Yee solver
+         *
+         * @tparam T_CurlE functor to compute curl of E
+         * @tparam T_CurlB functor to compute curl of B
+         */
+        template<typename T_CurlE, typename T_CurlB>
+        struct GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldB>
         {
-            using LowerMargin = typename CurlB::LowerMargin;
-            using UpperMargin = typename CurlB::UpperMargin;
+            using LowerMargin = typename T_CurlB::LowerMargin;
+            using UpperMargin = typename T_CurlB::UpperMargin;
         };
 
-        template<class CurlE, class CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::Yee<CurlE, CurlB>, FIELD_E>
+        /** Get margin for E field access in the Yee solver
+         *
+         * @tparam T_CurlE functor to compute curl of E
+         * @tparam T_CurlB functor to compute curl of B
+         */
+        template<typename T_CurlE, typename T_CurlB>
+        struct GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldE>
         {
-            using LowerMargin = typename CurlE::LowerMargin;
-            using UpperMargin = typename CurlE::UpperMargin;
+            using LowerMargin = typename T_CurlE::LowerMargin;
+            using UpperMargin = typename T_CurlE::UpperMargin;
         };
 
     } // namespace traits

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.def
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.def
@@ -34,20 +34,4 @@ namespace picongpu
 
         } // namespace maxwellSolver
     } // namespace fields
-
-    namespace traits
-    {
-        template<typename T_CurlE, typename T_CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, FIELD_B>
-            : public GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FIELD_B>
-        {
-        };
-
-        template<typename T_CurlE, typename T_CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, FIELD_E>
-            : public GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FIELD_E>
-        {
-        };
-
-    } // namespace traits
 } // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -461,6 +461,33 @@ namespace picongpu
 
         } // namespace maxwellSolver
     } // namespace fields
+
+    namespace traits
+    {
+        /** Get margin for B field access in the YeePML solver
+         *
+         * @tparam T_CurlE functor to compute curl of E
+         * @tparam T_CurlB functor to compute curl of B
+         */
+        template<typename T_CurlE, typename T_CurlB>
+        struct GetMargin<picongpu::fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, FieldB>
+            : public GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldB>
+        {
+        };
+
+        /** Get margin for E field access in the YeePML solver
+         *
+         * @tparam T_CurlE functor to compute curl of E
+         * @tparam T_CurlB functor to compute curl of B
+         */
+        template<typename T_CurlE, typename T_CurlB>
+        struct GetMargin<picongpu::fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, FieldE>
+            : public GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldE>
+        {
+        };
+
+    } // namespace traits
+
 } // namespace picongpu
 
 #include "picongpu/fields/MaxwellSolver/YeePML/Field.tpp"

--- a/include/picongpu/simulation_types.hpp
+++ b/include/picongpu/simulation_types.hpp
@@ -34,16 +34,6 @@
 
 namespace picongpu
 {
-    /** Legacy communication tags
-     *
-     * Now only used for some field traits, to be removed soon
-     */
-    enum CommunicationTag
-    {
-        FIELD_B = 1u,
-        FIELD_E = 2u
-    };
-
     namespace precision32Bit
     {
         using precisionType = float;

--- a/include/picongpu/traits/GetMargin.hpp
+++ b/include/picongpu/traits/GetMargin.hpp
@@ -31,10 +31,10 @@ namespace picongpu
          * \tparam Solver solver which needs ghost cells for solving a problem
          *         if solver not define `LowerMargin` and `UpperMargin` this trait (GetMargin)
          *         must be specialized
-         * \tparam SubSetName a optional name (id) if solver needs different ghost cells
+         * \tparam T_Parameter an optional parameter type
          * for different objects
          */
-        template<class Solver, unsigned int SubSetName = 0>
+        template<class Solver, typename T_Parameter = void>
         struct GetMargin
         {
             using LowerMargin = typename Solver::LowerMargin;


### PR DESCRIPTION
This was noticed during work on #3558. But since that one was a bugfix and to be backported, while the removal required some refactoring as well I separated it into this PR. Said removal required modifying and modernizing several places. I didn't split this modernizing part into several commits or PRs as I didn't initially estimate how many changes were required. There are two more cleanup things I will do as follow-ups, will mark it in the code.