### PR TITLE
Update hemera-hzdr profiles

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -19,7 +19,8 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load openmpi/2.1.2
+module load cuda/11.2
+module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -27,10 +28,12 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load adios/1.13.1
-module load hdf5-parallel/1.8.20
-module load libsplash/1.7.0
+module load hdf5-parallel/1.12.0-cuda112
 module load python/3.6.5
+module load libfabric/1.11.1-co79
+module load adios/1.13.1-cuda112
+module load adios2/2.7.1-cuda112
+module load openpmd/0.13.2-cuda112-adios271
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -19,8 +19,8 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.2
-module load openmpi/2.1.2-cuda102
+module load cuda/11.2
+module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -28,12 +28,12 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load hdf5-parallel/1.8.20-cuda102
-module load libsplash/1.7.0-cuda102
+module load hdf5-parallel/1.12.0-cuda112
 module load python/3.6.5
-module load adios/1.13.1-cuda102
-module load adios2/2.6.0-cuda102
-module load openpmd/0.12.0-cuda102
+module load libfabric/1.11.1-co79
+module load adios/1.13.1-cuda112
+module load adios2/2.7.1-cuda112
+module load openpmd/0.13.2-cuda112-adios271
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -19,8 +19,8 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.2
-module load openmpi/2.1.2-cuda102
+module load cuda/11.2
+module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -28,12 +28,12 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load hdf5-parallel/1.8.20-cuda102
-module load libsplash/1.7.0-cuda102
+module load hdf5-parallel/1.12.0-cuda112
 module load python/3.6.5
-module load adios/1.13.1-cuda102
-module load adios2/2.6.0-cuda102
-module load openpmd/0.12.0-cuda102
+module load libfabric/1.11.1-co79
+module load adios/1.13.1-cuda112
+module load adios2/2.7.1-cuda112
+module load openpmd/0.13.2-cuda112-adios271
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -19,8 +19,8 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.2
-module load openmpi/2.1.2-cuda102
+module load cuda/11.2
+module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -28,12 +28,12 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load hdf5-parallel/1.8.20-cuda102
-module load libsplash/1.7.0-cuda102
+module load hdf5-parallel/1.12.0-cuda112
 module load python/3.6.5
-module load adios/1.13.1-cuda102
-module load adios2/2.6.0-cuda102
-module load openpmd/0.12.0-cuda102
+module load libfabric/1.11.1-co79
+module load adios/1.13.1-cuda112
+module load adios2/2.7.1-cuda112
+module load openpmd/0.13.2-cuda112-adios271
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -19,8 +19,8 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.15.2
-module load cuda/10.2
-module load openmpi/2.1.2-cuda102
+module load cuda/11.2
+module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 
 # Other Software ##############################################################
@@ -28,12 +28,12 @@ module load boost/1.68.0
 module load zlib/1.2.11
 module load c-blosc/1.14.4
 
-module load hdf5-parallel/1.8.20-cuda102
-module load libsplash/1.7.0-cuda102
+module load hdf5-parallel/1.12.0-cuda112
 module load python/3.6.5
-module load adios/1.13.1-cuda102
-module load adios2/2.6.0-cuda102
-module load openpmd/0.12.0-cuda102
+module load libfabric/1.11.1-co79
+module load adios/1.13.1-cuda112
+module load adios2/2.7.1-cuda112
+module load openpmd/0.13.2-cuda112-adios271
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0


### PR DESCRIPTION
Upgrade to newer versions of modules:
* cuda/11.2
* openmpi/4.0.4-cuda112
* hdf5-parallel/1.12.0-cuda112
* libfabric/1.11.1-co79
* adios2/2.7.1-cuda112
* openpmd/0.13.2-cuda112-adios271

Remove module
* libsplash/1.7.0-cuda102

since it does not compile against hdf5 anymore and we are in the process of abandoning it, see #3357.

Upgrade to the newer versions of CUDA and openMPI came with a requested upgrade of openPMD and ADIOS2 in order to use blosc compression, see #3506 and #3530.

I added the `CI:no-compile` label as I think the CI won't make use of the profile anyway, correct?