### PR TITLE
Change rad plugin from libSplash to openPMD

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -286,7 +286,6 @@ Command line option                       Description
                                           This allows for a localization of specific spectral features.
 ``--<species>_radiation.folderRadPerGPU`` Name of the folder, where the GPU specific spectra are stored.
                                           Default: ``radPerGPU``
-``--<species>_radiation.compression``     If set, the hdf5 output is compressed.
 ``--<species>_radiation.numJobs``         Number of independent jobs used for the radiation calculation.
                                           This option is used to increase the utilization of the device by producing more independent work.
                                           This option enables accumulation of data in parallel into multiple temporary arrays, thereby increasing the utilization of

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -30,12 +30,14 @@ Variable                       Meaning
 ============================== ================================================================================
 
 Currently this allows to predict the emitted radiation from plasma if it can be described by classical means.
-Not considered are emissions from ionization, Compton scattering or any bremsstrahlung that originate from scattering on scales smaller than the PIC cell size. 
+Not considered are emissions from ionization, Compton scattering or any bremsstrahlung that originate from scattering on scales smaller than the PIC cell size.
 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <install-dependencies>` are compiled in.
+The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
+(Currently it is fixed to use the hdf5 backend until the radiation python module is converted from ``h5py`` to ``openPMD-api``.
+Therefore, an openPMD API which supports the HDF5 backend is required.)
 
 .param files
 ^^^^^^^^^^^^
@@ -68,18 +70,18 @@ namespace                     Description
 
 All three options require variable definitions in the according namespaces as described below:
 
-For the **linear frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::linear_frequencies`` namespace. 
+For the **linear frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::linear_frequencies`` namespace.
 The number of total sample frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``.
 In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
 
-For the **logarithmic frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::log_frequencies`` namespace. 
-Equivalently to the linear case, three variables need to be defined: 
+For the **logarithmic frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::log_frequencies`` namespace.
+Equivalently to the linear case, three variables need to be defined:
 The number of total sample frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``.
 In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
 
 For the **file-based frequency** definition,  all definitions need to be in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace.
 The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values in units of :math:`\mathrm{[s^{-1}]}` needs to be given as ``constexpr const char * listLocation = "/path/to/frequency_list";``.
-The frequency values in the file can be separated by newlines, spaces, tabs, or any other whitespace. The numbers should be given in such a way, that c++ standard ``std::ifstream`` can interpret the number e.g., as ``2.5344e+16``. 
+The frequency values in the file can be separated by newlines, spaces, tabs, or any other whitespace. The numbers should be given in such a way, that c++ standard ``std::ifstream`` can interpret the number e.g., as ``2.5344e+16``.
 
 .. note::
 
@@ -93,14 +95,14 @@ Observation directions
 The number of observation directions ``N_theta`` is defined in :ref:`radiation.param <usage-params-plugins>`, but the distribution of observation directions is given in :ref:`radiationObserver.param <usage-params-plugins>`)
 There, the function ``observation_direction`` defines the observation directions.
 
-This function returns the x,y and z component of a **unit vector** pointing in the observation direction. 
+This function returns the x,y and z component of a **unit vector** pointing in the observation direction.
 
 .. code:: cpp
 
    DINLINE vector_64
    observation_direction( int const observation_id_extern )
    {
-       /* use the scalar index const int observation_id_extern to compute an 
+       /* use the scalar index const int observation_id_extern to compute an
         * observation direction (x,y,y) */
        return vector_64( x , y , z );
    }
@@ -116,9 +118,9 @@ Nyquist limit
 
 A major limitation of discrete Fourier transform is the limited frequency resolution due to the discrete time steps of the temporal signal.
 (see `Nyquist-Shannon sampling theorem <https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem>`_)
-Due to the consideration of relativistic delays, the sampling of the emitted radiation is not equidistantly sampled. 
-The plugin has the option to ignore any frequency contributions that lies above the frequency resolution given by the Nyquist-Shannon sampling theorem. 
-Because performing this check costs computation time, it can be switched off. 
+Due to the consideration of relativistic delays, the sampling of the emitted radiation is not equidistantly sampled.
+The plugin has the option to ignore any frequency contributions that lies above the frequency resolution given by the Nyquist-Shannon sampling theorem.
+Because performing this check costs computation time, it can be switched off.
 This is done via a precompiler pragma:
 
 .. code:: cpp
@@ -138,8 +140,8 @@ Additionally, the maximally resolvable frequency compared to the Nyquist frequen
        const float NyquistFactor = 0.5;
    }
 
-This allows to make a save margin to the hard limit of the Nyquist frequency. 
-By using ``NyquistFactor = 0.5`` for periodic boundary conditions, particles that jump from one border to another and back can still be considered. 
+This allows to make a save margin to the hard limit of the Nyquist frequency.
+By using ``NyquistFactor = 0.5`` for periodic boundary conditions, particles that jump from one border to another and back can still be considered.
 
 
 Form factor
@@ -176,7 +178,7 @@ Reducing the particle sample
 """"""""""""""""""""""""""""
 
 In order to save computation time, only a random subset of all macro particles can be used to compute the emitted radiation.
-In order to do that, the radiating particle species needs the attribute ``radiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.  
+In order to do that, the radiating particle species needs the attribute ``radiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.
 
 
 .. note::
@@ -208,7 +210,7 @@ Using a filter functor as:
     >;
 
 (see Bunch or Kelvin Helmholtz example for details)
-sets the flag to true is a particle fulfills the gamma condition.  
+sets the flag to true is a particle fulfills the gamma condition.
 
 .. note::
 
@@ -252,7 +254,7 @@ There are several different window function available:
    namespace radWindowFunctionGauss { }
 
    namespace radWindowFunction = radWindowFunctionTriangle;
- 
+
 By setting ``radWindowFunction`` a specific window function is selected.
 
 More details can be found in [Pausch2019]_.
@@ -260,7 +262,7 @@ More details can be found in [Pausch2019]_.
 .cfg file
 ^^^^^^^^^
 
-For a specific (charged) species ``<species>`` e.g. ``e``, the radiation can be computed by the following commands.  
+For a specific (charged) species ``<species>`` e.g. ``e``, the radiation can be computed by the following commands.
 
 ========================================= ==============================================================================================================================
 Command line option                       Description
@@ -321,9 +323,9 @@ Command line flag                        Output description
                                          The spectral intensity is stored in the units :math:`\mathrm{[Js]}`.
 ``--<species>_radiation.lastRadiation``  has the same format as the output of *totalRadiation*.
                                          The spectral intensity is only summed over the last radiation ``dump`` period.
-``--<species>_radiation.radPerGPU``      Same output as *totalRadiation* but only summed over each GPU. 
+``--<species>_radiation.radPerGPU``      Same output as *totalRadiation* but only summed over each GPU.
                                          Because each GPU specifies a spatial region, the origin of radiation signatures can be distinguished.
-*radiationHDF5*                          In the folder  ``radiationHDF5``, hdf5 files for each radiation dump and species are stored.
+*radiationOpenPMD*                       In the folder  ``radiationOpenPMD``, openPMD files (currently hdf5) for each radiation dump and species are stored.
                                          These are complex amplitudes in units used by *PIConGPU*.
                                          These are for restart purposes and for more complex data analysis.
 ======================================== ========================================================================================================================
@@ -332,7 +334,7 @@ Command line flag                        Output description
 Text-based output
 """""""""""""""""
 
-The text-based output of ``lastRadiation`` and ``totalRadiation`` contains the intensity values in SI-units :math:`\mathrm{[Js]}`. Intensity values for different frequencies are separated by spaces, while newlines separate values for different observation directions. 
+The text-based output of ``lastRadiation`` and ``totalRadiation`` contains the intensity values in SI-units :math:`\mathrm{[Js]}`. Intensity values for different frequencies are separated by spaces, while newlines separate values for different observation directions.
 
 
 In order to read and plot the text-based radiation data, a python script as follows could be used:
@@ -386,10 +388,10 @@ In order to read and plot the text-based radiation data, a python script as foll
     plt.show()
 
 
-HDF5 output
-"""""""""""
+openPMD output
+""""""""""""""
 
-The hdf5 based data contains the following data structure in ``/data/{iteration}/DetectorMesh/`` according to the openPMD standard:
+The openPMD based data contains the following data structure in ``/data/{iteration}/DetectorMesh/`` according to the openPMD standard:
 
 **Amplitude (Group):**
 
@@ -408,8 +410,8 @@ Dataset  Description                                           Dimensions
 
    Please be aware, that despite the fact, that the SI-unit of each amplitude entry is :math:`\mathrm{[\sqrt{Js}]}`, the stored ``unitSI`` attribute returns :math:`\mathrm{[Js]}`.
    This inconsistency will be fixed in the future.
-   Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units. 
-   
+   Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units.
+
 
 **DetectorDirection (Group):**
 
@@ -430,22 +432,24 @@ Dataset    Description                                             Dimensions
 ========== ======================================================= ===============================
 
 
-Please be aware that all datasets in the hdf5 output are given in the PIConGPU-intrinsic unit system. In order to convert, for example, the frequencies :math:`\omega` to SI-units one has to multiply with the dataset-attribute `unitSI`. 
+Please be aware that all datasets in the openPMD output are given in the PIConGPU-intrinsic unit system. In order to convert, for example, the frequencies :math:`\omega` to SI-units one has to multiply with the dataset-attribute `unitSI`.
 
 .. code:: python
 
    import h5py
    f = h5py.File("e_radAmplitudes_2800_0_0_0.h5", "r")
    omega_handler = f['/data/2800/DetectorMesh/DetectorFrequency/omega']
-   omega = omega_handler[0, :, 0] * omega_handler.attrs['unitSI'] 
+   omega = omega_handler[0, :, 0] * omega_handler.attrs['unitSI']
    f.close()
 
-In order to extract the radiation data from the HDF5 datasets, PIConGPU provides a python module to read the data and obtain the result in SI-units. An example python script is given below:
+In order to extract the radiation data from the openPMD datasets, PIConGPU provides a python module to read the data and obtain the result in SI-units.
+An example python script is given below.
+This currently assumes hdf5 output and will soon become openPMD agnostic.
 
 .. code:: python
 
     import numpy as np
-    import matplotlib.pyplot as plt 
+    import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
 
     from picongpu.plugins.data import RadiationData
@@ -460,7 +464,7 @@ In order to extract the radiation data from the HDF5 datasets, PIConGPU provides
 
     vec_n = radData.get_vector_n()
     gamma = 5.0
-    theta_norm = np.arctan(vec_n[:, 0]/vec_n[:, 1]) * gamma 
+    theta_norm = np.arctan(vec_n[:, 0]/vec_n[:, 1]) * gamma
 
     # get spectrum over observation angle
     spectrum = radData.get_Spectra()
@@ -504,7 +508,7 @@ Method                       Description
 
 .. note::
 
-   Modules for visualizing radiation data and a widget interface to explore the data interactively will be developed in the future. 
+   Modules for visualizing radiation data and a widget interface to explore the data interactively will be developed in the future.
 
 Analyzing tools
 ^^^^^^^^^^^^^^^
@@ -526,7 +530,7 @@ Tool                           Description
 Known Issues
 ^^^^^^^^^^^^
 
-The plugin supports multiple radiation species but spectra (frequencies and observation directions) are the same for all species. 
+The plugin supports multiple radiation species but spectra (frequencies and observation directions) are the same for all species.
 
 
 References

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -69,7 +69,8 @@
 #    include "picongpu/plugins/IsaacPlugin.hpp"
 #endif
 
-#if(ENABLE_HDF5 == 1)
+#if((ENABLE_OPENPMD == 1) && (openPMD_HAVE_HDF5 == 1))
+// needs to be openPMD-api only in the future to support adios
 #    include "picongpu/plugins/radiation/Radiation.hpp"
 #    include "picongpu/plugins/radiation/VectorTypes.hpp"
 #endif
@@ -194,13 +195,11 @@ namespace picongpu
             plugins::multi::Master<BinEnergyParticles<bmpl::_1>>,
             CountParticles<bmpl::_1>,
             PngPlugin<Visualisation<bmpl::_1, PngCreator>>,
-            plugins::transitionRadiation::TransitionRadiation<bmpl::_1>
-#if(ENABLE_HDF5 == 1)
-            ,
-            plugins::radiation::Radiation<bmpl::_1>
+            plugins::transitionRadiation::TransitionRadiation<bmpl::_1>,
+#if((ENABLE_OPENPMD == 1) && (openPMD_HAVE_HDF5 == 1))
+            plugins::radiation::Radiation<bmpl::_1>,
 #endif
 #if(ENABLE_OPENPMD == 1)
-            ,
             plugins::xrayScattering::XrayScattering<bmpl::_1>,
             plugins::multi::Master<ParticleCalorimeter<bmpl::_1>>,
             plugins::multi::Master<PhaseSpace<particles::shapes::Counter::ChargeAssignment, bmpl::_1>>

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#if(ENABLE_HDF5 != 1)
-#    error The activated radiation plugin (radiation.param) requires HDF5
+#if(ENABLE_OPENPMD * openPMD_HAVE_HDF5 != 1)
+#    error The activated radiation plugin (radiation.param) requires openPMD-api with a HDF5 backend
 #endif
 
 #include "picongpu/simulation_defines.hpp"
@@ -31,8 +31,6 @@
 #include "picongpu/plugins/common/stringHelpers.hpp"
 #include "picongpu/plugins/radiation/ExecuteParticleFilter.hpp"
 #include "picongpu/plugins/radiation/Radiation.kernel"
-#include "picongpu/traits/PICToSplash.hpp"
-#include "picongpu/traits/SplashToPIC.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
@@ -51,7 +49,7 @@
 #include <string>
 #include <vector>
 
-#include <splash/splash.h>
+#include <openPMD/openPMD.hpp>
 
 namespace picongpu
 {
@@ -137,10 +135,8 @@ namespace picongpu
 
                 std::string pathRestart;
                 std::string meshesPathName;
-                std::string particlesPathName;
 
                 mpi::MPIReduce reduce;
-                bool compressionOn;
                 static const int numberMeshRecords = 3;
 
             public:
@@ -159,8 +155,6 @@ namespace picongpu
                     , radPerGPU(false)
                     , lastStep(0)
                     , meshesPathName("DetectorMesh/")
-                    , particlesPathName("DetectorParticle/")
-                    , compressionOn(false)
                 {
                     Environment<>::get().PluginConnector().registerPlugin(this);
                 }
@@ -232,9 +226,6 @@ namespace picongpu
                         (pluginPrefix + ".folderRadPerGPU").c_str(),
                         po::value<std::string>(&folderRadPerGPU)->default_value("radPerGPU"),
                         "folder in which the radiation of each GPU is written")(
-                        (pluginPrefix + ".compression").c_str(),
-                        po::bool_switch(&compressionOn),
-                        "enable compression of hdf5 output")(
                         (pluginPrefix + ".numJobs").c_str(),
                         po::value<int>(&numJobs)->default_value(2),
                         "Number of independent jobs used for the radiation calculation.");
@@ -262,9 +253,9 @@ namespace picongpu
                     if(isMaster)
                     {
                         // this will lead to wrong lastRad output right after the checkpoint if the restart point is
-                        // not a dump point. The correct lastRad data can be reconstructed from hdf5 data
+                        // not a dump point. The correct lastRad data can be reconstructed from openPMD data
                         // since text based lastRad output will be obsolete soon, this is not a problem
-                        readHDF5file(
+                        readOpenPMDfile(
                             timeSumArray,
                             restartDirectory + "/" + speciesName + std::string("_radRestart_"),
                             timeStep);
@@ -287,7 +278,9 @@ namespace picongpu
                     // write backup file
                     if(isMaster)
                     {
-                        writeHDF5file(tmp_result, restartDirectory + "/" + speciesName + std::string("_radRestart_"));
+                        writeOpenPMDfile(
+                            tmp_result,
+                            restartDirectory + "/" + speciesName + std::string("_radRestart_"));
                     }
                 }
 
@@ -356,8 +349,8 @@ namespace picongpu
 
                         if(isMaster)
                         {
-                            fs.createDirectory("radiationHDF5");
-                            fs.setDirectoryPermissions("radiationHDF5");
+                            fs.createDirectory("radiationOpenPMD");
+                            fs.setDirectoryPermissions("radiationOpenPMD");
                         }
 
 
@@ -534,14 +527,14 @@ namespace picongpu
                 }
 
 
-                /** write total radiation data as HDF5 file */
-                void writeAmplitudesToHDF5()
+                /** write total radiation data as openPMD file */
+                void writeAmplitudesToOpenPMD()
                 {
                     if(isMaster)
                     {
-                        writeHDF5file(
+                        writeOpenPMDfile(
                             timeSumArray,
-                            std::string("radiationHDF5/") + speciesName + std::string("_radAmplitudes_"));
+                            std::string("radiationOpenPMD/") + speciesName + std::string("_radAmplitudes_"));
                     }
                 }
 
@@ -563,11 +556,11 @@ namespace picongpu
                     saveRadPerGPU(currentGPUpos);
                     writeLastRadToText();
                     writeTotalRadToText();
-                    writeAmplitudesToHDF5();
+                    writeAmplitudesToOpenPMD();
                 }
 
 
-                /** This method returns hdf5 data structure names for amplitudes
+                /** This method returns openPMD data structure names for amplitudes
                  *
                  *  Arguments:
                  *  int index - index of Amplitude
@@ -580,7 +573,7 @@ namespace picongpu
                  */
                 static const std::string dataLabels(int index)
                 {
-                    const std::string path("Amplitude/");
+                    const std::string path("Amplitude");
 
                     /* return record name if handed -1 */
                     if(index == -1)
@@ -588,10 +581,10 @@ namespace picongpu
 
                     const std::string dataLabelsList[] = {"x_Re", "x_Im", "y_Re", "y_Im", "z_Re", "z_Im"};
 
-                    return path + dataLabelsList[index];
+                    return dataLabelsList[index];
                 }
 
-                /** This method returns hdf5 data structure names for detector directions
+                /** This method returns openPMD data structure names for detector directions
                  *
                  *  Arguments:
                  *  int index - index of detector
@@ -604,7 +597,7 @@ namespace picongpu
                  */
                 static const std::string dataLabelsDetectorDirection(int index)
                 {
-                    const std::string path("DetectorDirection/");
+                    const std::string path("DetectorDirection");
 
                     /* return record name if handed -1 */
                     if(index == -1)
@@ -612,11 +605,11 @@ namespace picongpu
 
                     const std::string dataLabelsList[] = {"x", "y", "z"};
 
-                    return path + dataLabelsList[index];
+                    return dataLabelsList[index];
                 }
 
 
-                /** This method returns hdf5 data structure names for detector frequencies
+                /** This method returns openPMD data structure names for detector frequencies
                  *
                  *  Arguments:
                  *  int index - index of detector
@@ -629,7 +622,7 @@ namespace picongpu
                  */
                 static const std::string dataLabelsDetectorFrequency(int index)
                 {
-                    const std::string path("DetectorFrequency/");
+                    const std::string path("DetectorFrequency");
 
                     /* return record name if handed -1 */
                     if(index == -1)
@@ -637,10 +630,10 @@ namespace picongpu
 
                     const std::string dataLabelsList[] = {"omega"};
 
-                    return path + dataLabelsList[index];
+                    return dataLabelsList[index];
                 }
 
-                /** This method returns hdf5 data structure names for all mesh records
+                /** This method returns openPMD data structure names for all mesh records
                  *
                  *  Arguments:
                  *  int index - index of record
@@ -664,396 +657,195 @@ namespace picongpu
                 }
 
 
-                /** Write Amplitude data to HDF5 file
+                /** Write Amplitude data to openPMD file
                  *
                  * Arguments:
                  * Amplitude* values - array of complex amplitude values
                  * std::string name - path and beginning of file name to store data to
                  */
-                void writeHDF5file(std::vector<Amplitude>& values, std::string name)
+                void writeOpenPMDfile(std::vector<Amplitude>& values, std::string name)
                 {
-                    splash::SerialDataCollector hdf5DataFile(1);
-                    splash::DataCollector::FileCreationAttr fAttr;
-
-                    splash::DataCollector::initFileCreationAttr(fAttr);
-                    fAttr.enableCompression = compressionOn;
-
                     std::ostringstream filename;
-                    filename << name << currentStep;
+                    // TODO: needs to be changed to ".h5" and also support adios
+                    filename << name << "%T_0_0_0.h5";
 
-                    hdf5DataFile.open(filename.str().c_str(), fAttr);
+                    ::openPMD::Series openPMDdataFile = ::openPMD::Series(filename.str(), ::openPMD::Access::CREATE);
+                    ::openPMD::Iteration openPMDdataFileIteration = openPMDdataFile.iterations[currentStep];
+                    openPMDdataFile.setMeshesPath(meshesPathName);
 
-                    typename PICToSplash<Amplitude::complex_T::type>::type radSplashType;
+                    // begin: write amplitude data
+                    ::openPMD::Mesh mesh_amp = openPMDdataFileIteration.meshes[dataLabels(-1)];
 
-
-                    splash::Dimensions bufferSize(
-                        Amplitude::numComponents,
-                        radiation_frequencies::N_omega,
-                        parameters::N_observer);
-
-                    splash::Dimensions componentSize(1, radiation_frequencies::N_omega, parameters::N_observer);
-
-                    splash::Dimensions stride(Amplitude::numComponents, 1, 1);
+                    mesh_amp.setGeometry(::openPMD::Mesh::Geometry::cartesian); // set be default
+                    mesh_amp.setDataOrder(::openPMD::Mesh::DataOrder::C);
+                    mesh_amp.setGridSpacing(std::vector<double>{1.0, 1.0, 1.0});
+                    mesh_amp.setGridGlobalOffset(std::vector<double>{0.0, 0.0, 0.0});
+                    mesh_amp.setGridUnitSI(1.0);
+                    mesh_amp.setAxisLabels(
+                        std::vector<std::string>{"detector direction index", "detector frequency index", "None"});
+                    mesh_amp.setUnitDimension(std::map<::openPMD::UnitDimension, double>{
+                        {::openPMD::UnitDimension::L, 2.0},
+                        {::openPMD::UnitDimension::M, 1.0},
+                        {::openPMD::UnitDimension::T, -1.0}});
 
                     /* get the radiation amplitude unit */
                     Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
                     const picongpu::float_64 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME;
 
-                    typedef PICToSplash<float_X>::type SplashFloatXType;
-                    SplashFloatXType splashFloatXType;
-
-                    for(uint32_t ampIndex = 0; ampIndex < Amplitude::numComponents; ++ampIndex)
                     {
-                        splash::Dimensions offset(ampIndex, 0, 0);
-                        splash::Selection dataSelection(bufferSize, componentSize, offset, stride);
+                        // buffer for data re-arangement
+                        const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
+                        std::vector<float_64> tmpBuffer(N_tmpBuffer);
 
-                        /* save data for each x/y/z * Re/Im amplitude */
-                        hdf5DataFile.write(
-                            currentStep,
-                            radSplashType,
-                            3,
-                            dataSelection,
-                            (meshesPathName + dataLabels(ampIndex)).c_str(),
-                            values.data());
+                        // reshape abstract MeshRecordComponent
+                        ::openPMD::Datatype datatype_amp = ::openPMD::determineDatatype<float_64>();
+                        ::openPMD::Extent extent_amp = {parameters::N_observer, radiation_frequencies::N_omega, 1};
+                        ::openPMD::Offset offset_amp = {0, 0, 0};
 
-                        /* save SI unit as attribute together with data set */
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            radSplashType,
-                            (meshesPathName + dataLabels(ampIndex)).c_str(),
-                            "unitSI",
-                            &factor);
+                        for(uint32_t ampIndex = 0; ampIndex < Amplitude::numComponents; ++ampIndex)
+                        {
+                            std::string dir = dataLabels(ampIndex);
+                            mesh_amp[dir].setUnitSI(factor);
+                            mesh_amp[dir].setPosition(std::vector<double>{0.0, 0.0, 0.0});
+                            ::openPMD::Dataset dataset_amp = ::openPMD::Dataset(datatype_amp, extent_amp);
+                            mesh_amp[dir].resetDataset(dataset_amp);
 
-                        /* position */
-                        std::vector<float_X> positionMesh(simDim, 0.0); /* there is no offset - zero */
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            splashFloatXType,
-                            (meshesPathName + dataLabels(ampIndex)).c_str(),
-                            "position",
-                            1u,
-                            splash::Dimensions(simDim, 0, 0),
-                            &(*positionMesh.begin()));
+                            // select data
+                            for(int copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
+                            {
+                                tmpBuffer[copyIndex]
+                                    = ((picongpu::float_64*)
+                                           values.data())[ampIndex + Amplitude::numComponents * copyIndex];
+                            }
+                            // write actual data
+                            mesh_amp[dir].storeChunk(tmpBuffer, offset_amp, extent_amp);
+                            openPMDdataFile.flush();
+                        }
                     }
+                    // end: write amplitude data
 
-                    /* save SI unit as attribute in the Amplitude group (for convenience) */
-                    hdf5DataFile.writeAttribute(
-                        currentStep,
-                        radSplashType,
-                        (meshesPathName + std::string("Amplitude")).c_str(),
-                        "unitSI",
-                        &factor);
 
-                    /* save detector position / observation direction */
-                    splash::Dimensions bufferSizeDetector(3, 1, parameters::N_observer);
+                    // start: write observer
+                    // prepare n meshes
+                    ::openPMD::Mesh mesh_n = openPMDdataFileIteration.meshes[dataLabelsDetectorDirection(-1)];
+                    // write mesh attributes
+                    mesh_n.setGeometry(::openPMD::Mesh::Geometry::cartesian); // set be default
+                    mesh_n.setDataOrder(::openPMD::Mesh::DataOrder::C);
+                    mesh_n.setGridSpacing(std::vector<double>{1.0, 1.0, 1.0});
+                    mesh_n.setGridGlobalOffset(std::vector<double>{0.0, 0.0, 0.0});
+                    mesh_n.setGridUnitSI(1.0);
+                    mesh_n.setAxisLabels(std::vector<std::string>{"detector direction index", "None", "None"});
+                    mesh_n.setUnitDimension(std::map<::openPMD::UnitDimension, double>{});
 
-                    splash::Dimensions componentSizeDetector(1, 1, parameters::N_observer);
-
-                    splash::Dimensions strideDetector(3, 1, 1);
-
-                    for(uint32_t detectorDim = 0; detectorDim < 3; ++detectorDim)
                     {
-                        splash::Dimensions offset(detectorDim, 0, 0);
-                        splash::Selection dataSelection(
-                            bufferSizeDetector,
-                            componentSizeDetector,
-                            offset,
-                            strideDetector);
+                        std::vector<float_64> tmpBuffer(parameters::N_observer);
 
-                        hdf5DataFile.write(
-                            currentStep,
-                            radSplashType,
-                            3,
-                            dataSelection,
-                            (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
-                            detectorPositions.data());
+                        // reshape abstract MeshRecordComponent
+                        ::openPMD::Datatype datatype_n = ::openPMD::determineDatatype<float_64>();
+                        ::openPMD::Extent extent_n = {parameters::N_observer, 1, 1};
+                        ::openPMD::Offset offset_n = {0, 0, 0};
 
-                        /* save SI unit as attribute together with data set */
                         const picongpu::float_64 factorDirection = 1.0;
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            radSplashType,
-                            (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
-                            "unitSI",
-                            &factorDirection);
 
-                        /* position */
-                        std::vector<float_X> positionMesh(simDim, 0.0); /* there is no offset - zero */
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            splashFloatXType,
-                            (meshesPathName + dataLabelsDetectorDirection(detectorDim)).c_str(),
-                            "position",
-                            1u,
-                            splash::Dimensions(simDim, 0, 0),
-                            &(*positionMesh.begin()));
+                        for(uint32_t detectorDim = 0; detectorDim < 3; ++detectorDim)
+                        {
+                            std::string dir = dataLabelsDetectorDirection(detectorDim);
+                            mesh_n[dir].setUnitSI(factorDirection);
+                            mesh_n[dir].setPosition(std::vector<double>{0.0, 0.0, 0.0});
+                            ::openPMD::Dataset dataset_n = ::openPMD::Dataset(datatype_n, extent_n);
+                            mesh_n[dir].resetDataset(dataset_n);
+
+                            // select data
+                            for(int copyIndex = 0; copyIndex < parameters::N_observer; ++copyIndex)
+                            {
+                                tmpBuffer[copyIndex]
+                                    = ((picongpu::float_64*) detectorPositions.data())[detectorDim + 3 * copyIndex];
+                            }
+
+                            // write actual data
+                            mesh_n[dir].storeChunk(tmpBuffer, offset_n, extent_n);
+                            openPMDdataFile.flush();
+                        }
                     }
 
+                    // end: write observer
 
-                    /* save detector frequencies */
-                    splash::Dimensions bufferSizeOmega(1, radiation_frequencies::N_omega, 1);
 
-                    splash::Dimensions strideOmega(1, 1, 1);
+                    // start: write frequencies
+                    // prepare omega mesh
+                    ::openPMD::Mesh mesh_omega = openPMDdataFileIteration.meshes[dataLabelsDetectorFrequency(-1)];
+                    // write mesh attributes
+                    mesh_omega.setGeometry(::openPMD::Mesh::Geometry::cartesian); // set be default
+                    mesh_omega.setDataOrder(::openPMD::Mesh::DataOrder::C);
+                    mesh_omega.setGridSpacing(std::vector<double>{1.0, 1.0, 1.0});
+                    mesh_omega.setGridGlobalOffset(std::vector<double>{0.0, 0.0, 0.0});
+                    mesh_omega.setGridUnitSI(1.0);
+                    mesh_omega.setAxisLabels(std::vector<std::string>{"None", "detector frequency index", "None"});
+                    std::map<::openPMD::UnitDimension, double> const unitDimensions_omega{
+                        {::openPMD::UnitDimension::T, -1.0}};
+                    mesh_omega.setUnitDimension(unitDimensions_omega);
 
-                    splash::Dimensions offset(0, 0, 0);
-                    splash::Selection dataSelection(bufferSizeOmega, bufferSizeOmega, offset, strideOmega);
-
-                    hdf5DataFile.write(
-                        currentStep,
-                        radSplashType,
-                        3,
-                        dataSelection,
-                        (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
-                        detectorFrequencies.data());
-
-                    /* save SI unit as attribute together with data set */
+                    // write mesh attributes
+                    ::openPMD::MeshRecordComponent omega_mrc = mesh_omega[dataLabelsDetectorFrequency(0)];
                     const picongpu::float_64 factorOmega = 1.0 / UNIT_TIME;
-                    hdf5DataFile.writeAttribute(
-                        currentStep,
-                        radSplashType,
-                        (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
-                        "unitSI",
-                        &factorOmega);
+                    omega_mrc.setUnitSI(factorOmega);
+                    omega_mrc.setPosition(std::vector<double>{0.0, 0.0, 0.0});
 
-                    /* position */
-                    std::vector<float_X> positionMesh(simDim, 0.0); /* there is no offset - zero */
-                    hdf5DataFile.writeAttribute(
-                        currentStep,
-                        splashFloatXType,
-                        (meshesPathName + dataLabelsDetectorFrequency(0)).c_str(),
-                        "position",
-                        1u,
-                        splash::Dimensions(simDim, 0, 0),
-                        &(*positionMesh.begin()));
+                    // reshape abstract MeshRecordComponent
+                    ::openPMD::Datatype datatype_omega
+                        = ::openPMD::determineDatatype<decltype(detectorFrequencies)::value_type>();
+                    ::openPMD::Extent extent_omega = {1, radiation_frequencies::N_omega, 1};
+                    ::openPMD::Dataset dataset_omega = ::openPMD::Dataset(datatype_omega, extent_omega);
+                    omega_mrc.resetDataset(dataset_omega);
 
+                    // write actual data
+                    ::openPMD::Offset offset_omega = {0, 0, 0};
+                    omega_mrc.storeChunk(detectorFrequencies, offset_omega, extent_omega);
+                    // end: write frequencies
 
                     /* begin openPMD attributes */
                     /* begin required openPMD global attributes */
-                    std::string openPMDversion("1.0.0");
-                    splash::ColTypeString ctOpenPMDversion(openPMDversion.length());
-                    hdf5DataFile.writeGlobalAttribute(ctOpenPMDversion, "openPMD", openPMDversion.c_str());
 
-                    const uint32_t openPMDextension = 0; // no extension
-                    splash::ColTypeUInt32 ctUInt32;
-                    hdf5DataFile.writeGlobalAttribute(ctUInt32, "openPMDextension", &openPMDextension);
-
-                    std::string basePath("/data/%T/");
-                    splash::ColTypeString ctBasePath(basePath.length());
-                    hdf5DataFile.writeGlobalAttribute(ctBasePath, "basePath", basePath.c_str());
-
-                    splash::ColTypeString ctMeshesPath(meshesPathName.length());
-                    hdf5DataFile.writeGlobalAttribute(ctMeshesPath, "meshesPath", meshesPathName.c_str());
-
-
-                    splash::ColTypeString ctParticlesPath(particlesPathName.length());
-                    hdf5DataFile.writeGlobalAttribute(ctParticlesPath, "particlesPath", particlesPathName.c_str());
-
-                    std::string iterationEncoding("fileBased");
-                    splash::ColTypeString ctIterationEncoding(iterationEncoding.length());
-                    hdf5DataFile.writeGlobalAttribute(
-                        ctIterationEncoding,
-                        "iterationEncoding",
-                        iterationEncoding.c_str());
-
-                    /* the ..._0_0_0... extension comes from the current filename
-                       formating of the serial data colector in libSplash */
-                    const int indexCutDirectory = name.rfind('/');
-                    std::string iterationFormat(name.substr(indexCutDirectory + 1) + std::string("%T_0_0_0.h5"));
-                    splash::ColTypeString ctIterationFormat(iterationFormat.length());
-                    hdf5DataFile.writeGlobalAttribute(ctIterationFormat, "iterationFormat", iterationFormat.c_str());
-
-                    hdf5DataFile.writeAttribute(currentStep, splashFloatXType, nullptr, "dt", &DELTA_T);
+                    openPMDdataFileIteration.setDt<float_X>(DELTA_T);
                     const float_X time = float_X(currentStep) * DELTA_T;
-                    hdf5DataFile.writeAttribute(currentStep, splashFloatXType, nullptr, "time", &time);
-                    splash::ColTypeDouble ctDouble;
-                    hdf5DataFile.writeAttribute(currentStep, ctDouble, nullptr, "timeUnitSI", &UNIT_TIME);
-
+                    openPMDdataFileIteration.setTime(time);
+                    openPMDdataFileIteration.setTimeUnitSI(UNIT_TIME);
                     /* end required openPMD global attributes */
 
                     /* begin recommended openPMD global attributes */
-
-                    std::string author = Environment<>::get().SimulationDescription().getAuthor();
-                    if(author.length() > 0)
-                    {
-                        splash::ColTypeString ctAuthor(author.length());
-                        hdf5DataFile.writeGlobalAttribute(ctAuthor, "author", author.c_str());
-                    }
-
-                    std::string software("PIConGPU");
-                    splash::ColTypeString ctSoftware(software.length());
-                    hdf5DataFile.writeGlobalAttribute(ctSoftware, "software", software.c_str());
-
+                    const std::string software("PIConGPU");
                     std::stringstream softwareVersion;
                     softwareVersion << PICONGPU_VERSION_MAJOR << "." << PICONGPU_VERSION_MINOR << "."
                                     << PICONGPU_VERSION_PATCH;
                     if(!std::string(PICONGPU_VERSION_LABEL).empty())
                         softwareVersion << "-" << PICONGPU_VERSION_LABEL;
-                    splash::ColTypeString ctSoftwareVersion(softwareVersion.str().length());
-                    hdf5DataFile.writeGlobalAttribute(
-                        ctSoftwareVersion,
-                        "softwareVersion",
-                        softwareVersion.str().c_str());
+                    openPMDdataFile.setSoftware(software, softwareVersion.str());
+
+                    std::string author = Environment<>::get().SimulationDescription().getAuthor();
+                    if(author.length() > 0)
+                        openPMDdataFile.setAuthor(author);
 
                     std::string date = helper::getDateString("%F %T %z");
-                    splash::ColTypeString ctDate(date.length());
-                    hdf5DataFile.writeGlobalAttribute(ctDate, "date", date.c_str());
-
+                    openPMDdataFile.setDate(date);
                     /* end recommended openPMD global attributes */
 
-                    /* begin required openPMD attributes for meshes records */
-
-                    for(int i = 0; i < numberMeshRecords; ++i)
-                    {
-                        /* timeOffset */
-                        const float_X timeOffset = 0.0;
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            splashFloatXType,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "timeOffset",
-                            &timeOffset);
-
-                        /* gridGlobalOffset */
-                        std::vector<float_64> gridGlobalOffset(simDim, 0.0); /* there is no offset - zero */
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            ctDouble,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "gridGlobalOffset",
-                            1u,
-                            splash::Dimensions(simDim, 0, 0),
-                            &(*gridGlobalOffset.begin()));
-
-                        /* gridUnit */
-                        /* ALL grids have indices as axises - thus no unit conversion */
-                        const double unitNone = 1.0;
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            ctDouble,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "gridUnitSI",
-                            &unitNone);
-
-                        /* geometry */
-                        const std::string geometry("cartesian");
-                        splash::ColTypeString ctGeometry(geometry.length());
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            ctGeometry,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "geometry",
-                            geometry.c_str());
-
-                        /* dataOrder */
-                        const std::string dataOrder("C");
-                        splash::ColTypeString ctDataOrder(dataOrder.length());
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            ctDataOrder,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "dataOrder",
-                            dataOrder.c_str());
-
-                        std::vector<float_X> gridSpacing(simDim, 0.0);
-                        for(uint32_t d = 0; d < simDim; ++d)
-                            gridSpacing.at(d) = float_X(1.0);
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            splashFloatXType,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "gridSpacing",
-                            1u,
-                            splash::Dimensions(simDim, 0, 0),
-                            &(*gridSpacing.begin()));
-
-                        /* axisLabels */
-                        std::list<std::string> myListOfStr;
-                        if(i == idLabels::Amplitude) /* amplitude record */
-                        {
-                            myListOfStr.push_back("detector direction index");
-                            myListOfStr.push_back("detector frequency index");
-                        }
-                        else if(i == idLabels::Detector) /* detector direction record */
-                        {
-                            myListOfStr.push_back("detector direction index");
-                            myListOfStr.push_back("None");
-                        }
-                        else if(i == idLabels::Frequency) /* detector frequency record */
-                        {
-                            myListOfStr.push_back("None");
-                            myListOfStr.push_back("detector frequency index");
-                        }
-                        myListOfStr.push_back("None");
-
-                        // convert to splash format
-                        helper::GetSplashArrayOfString getSplashArrayOfString;
-                        helper::GetSplashArrayOfString::Result myArrOfStr;
-                        myArrOfStr = getSplashArrayOfString(myListOfStr);
-                        splash::ColTypeString ctSomeListOfStr(myArrOfStr.maxLen);
-
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            ctSomeListOfStr,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "axisLabels",
-                            1u, /* ndims: 1D array */
-                            splash::Dimensions(myListOfStr.size(), 0, 0), /* size of 1D array */
-                            &(myArrOfStr.buffers.at(0)));
-
-
-                        /* unitDimension */
-                        std::vector<float_64> unitDimension(traits::NUnitDimension, 0.0);
-                        if(i == idLabels::Amplitude) /* amplitude record */
-                        {
-                            /* units Joule seconds -> Length^2 * Time^-1 * Mass^1 */
-                            unitDimension[traits::SIBaseUnits::length] = 2.0;
-                            unitDimension[traits::SIBaseUnits::time] = -1.0;
-                            unitDimension[traits::SIBaseUnits::mass] = 1.0;
-                        }
-                        else if(i == idLabels::Detector) /* detector direction record */
-                        {
-                            /* units none */
-                        }
-                        else if(i == idLabels::Frequency) /* detector frequency record */
-                        {
-                            /* units 1./second -> Time^-1  */
-                            unitDimension[traits::SIBaseUnits::time] = -1.0;
-                        }
-                        hdf5DataFile.writeAttribute(
-                            currentStep,
-                            ctDouble,
-                            (meshesPathName + meshRecordLabels(i)).c_str(),
-                            "unitDimension",
-                            1u,
-                            splash::Dimensions(traits::NUnitDimension, 0, 0),
-                            &(*unitDimension.begin()));
-                    }
-                    /* end required openPMD attributes for meshes */
-                    /* end openPMD attributes */
-
-                    hdf5DataFile.close();
+                    openPMDdataFileIteration.close();
+                    openPMDdataFile.flush();
                 }
 
 
-                /** Read Amplitude data from HDF5 file
+                /** Read Amplitude data from openPMD file
                  *
                  * Arguments:
                  * Amplitude* values - array of complex amplitudes to store data in
                  * std::string name - path and beginning of file name with data stored in
                  * const int timeStep - time step to read
                  */
-                void readHDF5file(std::vector<Amplitude>& values, std::string name, const int timeStep)
+                void readOpenPMDfile(std::vector<Amplitude>& values, std::string name, const int timeStep)
                 {
-                    splash::SerialDataCollector hdf5DataFile(1);
-                    splash::DataCollector::FileCreationAttr fAttr;
-
-                    splash::DataCollector::initFileCreationAttr(fAttr);
-
-                    fAttr.fileAccType = splash::DataCollector::FAT_READ;
-
                     std::ostringstream filename;
                     /* add to standard ending added by libSplash for SerialDataCollector */
-                    filename << name << timeStep << "_0_0_0.h5";
+                    filename << name << timeStep << ".h5";
 
                     /* check if restart file exists */
                     if(!boost::filesystem::exists(filename.str()))
@@ -1064,22 +856,23 @@ namespace picongpu
                     }
                     else
                     {
-                        hdf5DataFile.open(filename.str().c_str(), fAttr);
-
-                        typename PICToSplash<float_64>::type radSplashType;
-
-                        splash::Dimensions componentSize(1, radiation_frequencies::N_omega, parameters::N_observer);
+                        ::openPMD::Series openPMDdataFile
+                            = ::openPMD::Series(filename.str(), ::openPMD::Access::READ_ONLY);
 
                         const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
                         picongpu::float_64* tmpBuffer = new picongpu::float_64[N_tmpBuffer];
 
                         for(uint32_t ampIndex = 0; ampIndex < Amplitude::numComponents; ++ampIndex)
                         {
-                            hdf5DataFile.read(
-                                timeStep,
-                                (meshesPathName + dataLabels(ampIndex)).c_str(),
-                                componentSize,
-                                tmpBuffer);
+                            ::openPMD::MeshRecordComponent dataset
+                                = openPMDdataFile.iterations[timeStep]
+                                      .meshes[dataLabels(-1).c_str()][dataLabels(ampIndex).c_str()];
+                            ::openPMD::Extent extent = dataset.getExtent();
+                            ::openPMD::Offset offset(extent.size(), 0);
+
+                            dataset.loadChunk(std::shared_ptr<double>{tmpBuffer, [](auto const*) {}}, offset, extent);
+
+                            openPMDdataFile.flush();
 
                             for(int copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
                             {
@@ -1090,9 +883,9 @@ namespace picongpu
                         }
 
                         delete[] tmpBuffer;
-                        hdf5DataFile.close();
+                        openPMDdataFile.iterations[timeStep].close();
 
-                        log<picLog::INPUT_OUTPUT>("Radiation (%1%): read radiation data from HDF5") % speciesName;
+                        log<picLog::INPUT_OUTPUT>("Radiation (%1%): read radiation data from openPMD") % speciesName;
                     }
                 }
 


### PR DESCRIPTION
This pull request changes the use of libSplash in the radiation plugin from libSplash to openPMD-api as requested in #3357. 

Be aware that this is still a draft.

**ToDo:**
 - [x] merge #3688
 - [x] compare data attributes and layout in hdf5 files
 - [x] run time test on bunch example