### PR TITLE
fix CI

### DIFF
--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -5,11 +5,12 @@
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-clang-pic:1.2
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    DISABLE_ISAAC: "yes"
   script:
     - apt update
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - $CI_PROJECT_DIR/share/ci/bash.profile
+    - source $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
     - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
   # x86_64 tag is used to get a multi-core CPU for the tests

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -6,11 +6,12 @@
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang"
+    DISABLE_ISAAC: "yes"
   script:
     - apt update
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - $CI_PROJECT_DIR/share/ci/bash.profile
+    - source $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
     - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
   tags:

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -5,11 +5,12 @@
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-gcc-pic:1.2
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    DISABLE_ISAAC: "yes"
   script:
     - apt update
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - $CI_PROJECT_DIR/share/ci/bash.profile
+    - source $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
     - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
   # x86_64 tag is used to get a multi-core CPU for the tests

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -20,7 +20,7 @@
     - apt update
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - $CI_PROJECT_DIR/share/ci/bash.profile
+    - source $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
     - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
   tags:

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -4,6 +4,7 @@
 .base_nvcc:
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    DISABLE_ISAAC: "yes"
   before_script:
     - nvidia-smi
     - nvcc --version
@@ -11,7 +12,7 @@
     - apt update
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - $CI_PROJECT_DIR/share/ci/bash.profile
+    - source $CI_PROJECT_DIR/share/ci/bash.profile
     - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
     - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
   tags:


### PR DESCRIPTION
Most dependencies are not checked because the environment was not configured correctly.
The script to set the environment was executed/called instead of source, therefore variables configured not propagated to the test cases.

Temporary disable ISAAC because of compile issues. This will be fixed with #3545.