### PR TITLE
Add a version of GetTrait taking only field solver type as a parameter

### DIFF
--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -91,9 +91,7 @@ namespace picongpu
 
         typedef pmacc::math::CT::max<SpeciesLowerMargin, FieldTmpLowerMargin>::type SpeciesFieldTmpLowerMargin;
 
-        typedef pmacc::math::CT::max<
-            GetMargin<fields::Solver, FieldB>::LowerMargin,
-            GetMargin<fields::Solver, FieldE>::LowerMargin>::type FieldSolverLowerMargin;
+        using FieldSolverLowerMargin = GetLowerMargin<fields::Solver>::type;
 
         typedef pmacc::math::CT::max<SpeciesFieldTmpLowerMargin, FieldSolverLowerMargin>::type LowerMargin;
 
@@ -112,9 +110,7 @@ namespace picongpu
 
         typedef pmacc::math::CT::max<SpeciesUpperMargin, FieldTmpUpperMargin>::type SpeciesFieldTmpUpperMargin;
 
-        typedef pmacc::math::CT::max<
-            GetMargin<fields::Solver, FieldB>::UpperMargin,
-            GetMargin<fields::Solver, FieldE>::UpperMargin>::type FieldSolverUpperMargin;
+        using FieldSolverUpperMargin = GetUpperMargin<fields::Solver>::type;
 
         typedef pmacc::math::CT::max<SpeciesFieldTmpUpperMargin, FieldSolverUpperMargin>::type UpperMargin;
 

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -32,6 +32,7 @@
 
 #include <pmacc/nvidia/functors/Assign.hpp>
 #include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/math/vector/compile-time/Vector.hpp>
 #include <pmacc/memory/boxes/CachedBox.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 
@@ -158,7 +159,7 @@ namespace picongpu
          * @tparam T_CurlB functor to compute curl of B
          */
         template<typename T_CurlE, typename T_CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldB>
+        struct GetMargin<fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldB>
         {
             using LowerMargin = typename T_CurlB::LowerMargin;
             using UpperMargin = typename T_CurlB::UpperMargin;
@@ -170,10 +171,30 @@ namespace picongpu
          * @tparam T_CurlB functor to compute curl of B
          */
         template<typename T_CurlE, typename T_CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldE>
+        struct GetMargin<fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldE>
         {
             using LowerMargin = typename T_CurlE::LowerMargin;
             using UpperMargin = typename T_CurlE::UpperMargin;
+        };
+
+        /** Get margin for both fields access in the Yee solver
+         *
+         * @tparam T_CurlE functor to compute curl of E
+         * @tparam T_CurlB functor to compute curl of B
+         */
+        template<typename T_CurlE, typename T_CurlB>
+        struct GetMargin<fields::maxwellSolver::Yee<T_CurlE, T_CurlB>>
+        {
+        private:
+            using Solver = fields::maxwellSolver::Yee<T_CurlE, T_CurlB>;
+
+        public:
+            using LowerMargin = typename pmacc::math::CT::max<
+                typename GetLowerMargin<Solver, FieldB>::type,
+                typename GetLowerMargin<Solver, FieldE>::type>::type;
+            using UpperMargin = typename pmacc::math::CT::max<
+                typename GetUpperMargin<Solver, FieldB>::type,
+                typename GetUpperMargin<Solver, FieldE>::type>::type;
         };
 
     } // namespace traits

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -464,25 +464,17 @@ namespace picongpu
 
     namespace traits
     {
-        /** Get margin for B field access in the YeePML solver
+        /** Get margin for given field access in the YeePML solver
+         *
+         * It is always the same as the regular Yee solver with the given curl operators.
          *
          * @tparam T_CurlE functor to compute curl of E
          * @tparam T_CurlB functor to compute curl of B
+         * @tparam T_Field field type
          */
-        template<typename T_CurlE, typename T_CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, FieldB>
-            : public GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldB>
-        {
-        };
-
-        /** Get margin for E field access in the YeePML solver
-         *
-         * @tparam T_CurlE functor to compute curl of E
-         * @tparam T_CurlB functor to compute curl of B
-         */
-        template<typename T_CurlE, typename T_CurlB>
-        struct GetMargin<picongpu::fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, FieldE>
-            : public GetMargin<picongpu::fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, FieldE>
+        template<typename T_CurlE, typename T_CurlB, typename T_Field>
+        struct GetMargin<fields::maxwellSolver::YeePML<T_CurlE, T_CurlB>, T_Field>
+            : public GetMargin<fields::maxwellSolver::Yee<T_CurlE, T_CurlB>, T_Field>
         {
         };
 


### PR DESCRIPTION
It gives margins for the solver as a whole, so max of its E and B update margins.

This is the final part of refactoring of this part, started with #3561 and then #3564.