### PR TITLE
remove usage of `atomicAddNoRet` for HIP 4.1

### DIFF
--- a/include/pmacc/nvidia/atomic.hpp
+++ b/include/pmacc/nvidia/atomic.hpp
@@ -69,7 +69,7 @@ namespace pmacc
                 }
             };
 
-#if(!defined(__CUDA__) && ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+#if(!defined(__CUDA__) && ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) < 401)
             /** HIP backend specialization for atomic add
              *
              * Uses the intrinsic atomicAddNoRet available for AMD gpus only.


### PR DESCRIPTION
`atomicAddNoRet` is deprecated with HIP 4.1.
see: https://github.com/ROCm-Developer-Tools/HIP/commit/019c556c7d5e90c248767b8b4fa897ca08f85616

This PR keeps the usage of `atomicAddNoRet` for older HIP versions. The reason is that I would keep the class `AtomicOpNoRet` for now to test some self-implemented atomics without changing too much code. 
I assume that we will remove `AtomicOpNoRet` in the future.