### PR TITLE
fix particle loss with MPI direct

### DIFF
--- a/include/pmacc/eventSystem/tasks/TaskReceive.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceive.hpp
@@ -43,6 +43,13 @@ namespace pmacc
         virtual void init()
         {
             state = WaitForReceived;
+            if(Environment<>::get().isMpiDirectEnabled())
+            {
+                /* Wait to be sure that all device work is finished before MPI is triggered.
+                 * MPI will not wait for work in our device streams
+                 */
+                __getTransactionEvent().waitForFinished();
+            }
             Environment<>::get().Factory().createTaskReceiveMPI(exchange, this);
         }
 


### PR DESCRIPTION
- add missing synchronization

I was able to reproduce particle loss with the KHI
  - memory.param set all buffers to 6 MiB
  - particles.param set drift in z direction
  - run on two nodes, each with 4 GPUs

Since the bug is a data race I was performing 100 test runs with this PR
```
for((i=0;i<100;++i)) ; do  srun -N 2 -n 8 -p PARTITIONNAME --exclusive ./bin/picongpu -d 1 1 8 -g 128 128  64  -s 2000 -p 5 --periodic 1 1 1 --e_macroParticlesCount.perio 100 --i_macroParticlesCount.perio 100 --mpiDirect 2>/dev/null 1>/dev/null ; grep -v 39321600 e_macroParticlesCount.dat | grep -v step; grep -v 39321600 i_macroParticlesCount.dat | grep -v step; echo $i; done
```