### PR TITLE
introduce filtered particleToGrid algorithm

### DIFF
--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch,
- *                     Benjamin Worpitz
+ *                     Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -22,6 +22,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/fields/Fields.def"
+#include "picongpu/particles/filter/filter.def"
 
 #include <pmacc/fields/SimulationFieldHelper.hpp>
 #include <pmacc/dataManagement/ISimulationData.hpp>
@@ -152,11 +153,13 @@ namespace picongpu
          *
          * @tparam T_area area to compute currents in
          * @tparam T_Species particle species type
+         * @tparam Filter particle filter used to filter contributing particles
+         *         (default is all particles contribute)
          *
          * @param species particle species
          * @param currentStep index of time iteration
          */
-        template<uint32_t AREA, class FrameSolver, class ParticlesClass>
+        template<uint32_t AREA, class FrameSolver, typename Filter = particles::filter::All, class ParticlesClass>
         HINLINE void computeValue(ParticlesClass& parClass, uint32_t currentStep);
 
         /** Bash particles in a direction.

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten
+/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -57,18 +57,27 @@ namespace picongpu
          * @tparam T_ParBox pmacc::ParticlesBox, particle box type
          * @tparam T_FrameSolver functor type to operate on a particle frame
          * @tparam T_Mapping mapper functor type
+         * @tparam T_ParticleFilter particle filter type
          *
          * @param fieldJ field with particle current
          * @param boxPar particle memory
          * @param frameSolver functor to calculate the current for a frame
          * @param mapper functor to map a block to a supercell
+         * @param particleFilter filter used to choose particles contributing to field value
          */
-        template<typename T_TmpBox, typename T_ParBox, typename T_FrameSolver, typename T_Mapping, typename T_Acc>
+        template<
+            typename T_TmpBox,
+            typename T_ParBox,
+            typename T_FrameSolver,
+            typename T_Mapping,
+            typename T_Acc,
+            typename T_ParticleFilter>
         DINLINE void operator()(
             T_Acc const& acc,
             T_TmpBox fieldTmp,
             T_ParBox boxPar,
             T_FrameSolver frameSolver,
+            T_ParticleFilter particleFilter,
             T_Mapping mapper) const
         {
             using namespace mappings::threads;
@@ -82,7 +91,8 @@ namespace picongpu
             uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
-
+            auto accFilter
+                = particleFilter(acc, block - mapper.getGuardingSuperCells(), WorkerCfg<numWorkers>{workerIdx});
             FramePtr frame;
             lcellId_t particlesInSuperCell;
 
@@ -106,7 +116,7 @@ namespace picongpu
                     [&](uint32_t const linearIdx, uint32_t const) {
                         if(linearIdx < particlesInSuperCell)
                         {
-                            frameSolver(acc, *frame, linearIdx, SuperCellSize::toRT(), cachedVal);
+                            frameSolver(acc, *frame, linearIdx, SuperCellSize::toRT(), accFilter, cachedVal);
                         }
                     });
 

--- a/include/picongpu/fields/Fields.def
+++ b/include/picongpu/fields/Fields.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Axel Huebl
+/* Copyright 2013-2021 Rene Widera, Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -19,21 +19,25 @@
 
 #pragma once
 
+#include "picongpu/particles/filter/filter.def"
+
 namespace picongpu
 {
     /** Define which operation is used to fill up FieldTmp
      *
-     * This is better than use of boost::mtl::pair because
-     * we can use this special struct to define functors
-     * only for FieldTmp. If we create a second FieldTmp, for example
-     * with three components, we can create a new struct (like this)
-     * and build a special functor to handle the type.
+     * It stores also the particle filter used to filter
+     * particles attributing to FieldTmp.
+     *
+     * @tparam T_Solver solver used to fill up FieldTmp
+     * @tparam T_Species particle species contributing to the FieldTmp
+     * @tparam T_Filter particle filter used to choose the contributing particles
      */
-    template<typename T_Solver, typename T_Species>
+    template<typename T_Solver, typename T_Species, typename T_Filter = particles::filter::All>
     struct FieldTmpOperation
     {
         using Solver = T_Solver;
         using Species = T_Species;
+        using Filter = T_Filter;
 
         using LowerMargin = typename Solver::LowerMargin;
         using UpperMargin = typename Solver::UpperMargin;
@@ -42,6 +46,8 @@ namespace picongpu
         {
             std::stringstream str;
             str << T_Species::FrameType::getName();
+            str << "_";
+            str << T_Filter::getName();
             str << "_";
             str << T_Solver::getName();
             return str.str();

--- a/include/picongpu/param/fileOutput.param
+++ b/include/picongpu/param/fileOutput.param
@@ -1,5 +1,5 @@
 /* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
- *                     Benjamin Worpitz, Richard Pausch
+ *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -25,6 +25,7 @@
 /* some forward declarations we need */
 #include "picongpu/fields/Fields.def"
 #include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+#include "picongpu/particles/filter/filter.def"
 
 #include <boost/mpl/vector.hpp>
 
@@ -59,6 +60,20 @@ namespace picongpu
      *       density * charge * velocity_component
      *   - Counter: counts point like particles per cell
      *   - MacroCounter: counts point like macro particles per cell
+     *
+     * Filtering:
+     *   You can create derived fields from filtered particles. Only particles passing
+     *   the filter will contribute to the field quantity.
+     *   For that you need to define your filters in `particleFilters.param` and pass a
+     *   filter as the 3rd (optional) template argument in `CreateEligible_t`.
+     *
+     *   Example: This will create charge density field for all species that are
+     *   eligible for the this attribute and the chosen filter.
+     *   @code{.cpp}
+     *   using ChargeDensity_Seq
+         = deriveField::CreateEligible_t< VectorAllSpecies,
+         deriveField::derivedAttributes::ChargeDensity, filter::FilterOfYourChoice>;
+     *   @endcode
      */
     namespace deriveField = particles::particleToGrid;
 

--- a/include/picongpu/param/isaac.param
+++ b/include/picongpu/param/isaac.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Matthes
+/* Copyright 2016-2021 Alexander Matthes, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -19,7 +19,7 @@
 
 /** @file
  *
- * Definition which native fields and density fields of particles will be
+ * Definition which native fields and density fields of (filtered) particles will be
  * visualizable with ISAAC. ISAAC is an in-situ visualization library with which
  * the PIC simulation can be observed while it is running avoiding the time
  * consuming writing and reading of simulation data for the classical post
@@ -54,6 +54,15 @@ namespace picongpu
         /** Intermediate list of particle species, from which density fields
          *  shall be created at runtime to visualize them. */
         using Density_Seq = deriveField::CreateEligible_t<Particle_Seq, deriveField::derivedAttributes::Density>;
+        /** Intermediate list of filtered particle species, from which density fields
+         *  shall be created at runtime to visualize them.
+         *
+         *  You can create such densities from filtered particles by passing a particle
+         *  filter as the third template argument (`filter::All` by default). Don't forget
+         *  to add your filtered densities to the `Fields_Seq` below.
+         *  */
+        //  using Density_Seq_Filtered = deriveField::CreateEligible_t<Particle_Seq,
+        //      deriveField::derivedAttributes::Density, filter::All>;
 
         /** Compile time sequence of all fields which shall be visualized. Basically
          *  the join of Native_Seq and Density_Seq. */

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.def
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.def
@@ -19,6 +19,9 @@
 
 
 #pragma once
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+
+#include <pmacc/traits/HasIdentifiers.hpp>
 
 namespace picongpu
 {
@@ -56,5 +59,14 @@ namespace picongpu
             struct RelativeGlobalDomainPosition;
 
         } // namespace filter
+        namespace traits
+        {
+            template<typename T_Species, typename T_Params>
+            struct SpeciesEligibleForSolver<T_Species, filter::RelativeGlobalDomainPosition<T_Params>>
+            {
+                using type = typename pmacc::traits::
+                    HasIdentifiers<typename T_Species::FrameType, MakeSeq_t<localCellIdx>>::type;
+            };
+        } // namespace traits
     } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -22,9 +22,6 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/filter/RelativeGlobalDomainPosition.def"
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-
-#include <pmacc/traits/HasIdentifiers.hpp>
 
 
 namespace picongpu
@@ -146,15 +143,5 @@ namespace picongpu
             };
 
         } // namespace filter
-
-        namespace traits
-        {
-            template<typename T_Species, typename T_Params>
-            struct SpeciesEligibleForSolver<T_Species, filter::RelativeGlobalDomainPosition<T_Params>>
-            {
-                using type = typename pmacc::traits::
-                    HasIdentifiers<typename T_Species::FrameType, MakeSeq_t<localCellIdx>>::type;
-            };
-        } // namespace traits
     } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/manipulators/binary/DensityWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/DensityWeighting.def
@@ -64,8 +64,10 @@ namespace picongpu
                         template<typename T_DesParticle, typename T_SrcParticle, typename... T_Args>
                         HDINLINE void operator()(T_DesParticle& particleDes, T_SrcParticle const&, T_Args&&...)
                         {
-                            const float_X densityRatioDes = traits::GetDensityRatio<T_DesParticle>::type::getValue();
-                            const float_X densityRatioSrc = traits::GetDensityRatio<T_SrcParticle>::type::getValue();
+                            const float_X densityRatioDes
+                                = picongpu::traits::GetDensityRatio<T_DesParticle>::type::getValue();
+                            const float_X densityRatioSrc
+                                = picongpu::traits::GetDensityRatio<T_SrcParticle>::type::getValue();
 
                             particleDes[weighting_] *= densityRatioDes / densityRatioSrc;
                         }

--- a/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
@@ -60,7 +60,7 @@ namespace picongpu
                         HDINLINE void operator()(T_DesParticle& particleDest, T_SrcParticle const&, T_Args&&...)
                         {
                             float_X const protonNumber
-                                = traits::GetAtomicNumbers<T_SrcParticle>::type::numberOfProtons;
+                                = picongpu::traits::GetAtomicNumbers<T_SrcParticle>::type::numberOfProtons;
                             particleDest[weighting_] *= protonNumber;
                         }
                     };

--- a/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
@@ -63,7 +63,7 @@ namespace picongpu
                             T_Args&&...)
                         {
                             float_X const protonNumber
-                                = traits::GetAtomicNumbers<T_SrcParticle>::type::numberOfProtons;
+                                = picongpu::traits::GetAtomicNumbers<T_SrcParticle>::type::numberOfProtons;
                             float_X const boundElectrons = particleSrc[boundElectrons_];
                             float_X const freeElectrons = protonNumber - boundElectrons;
                             particleDest[weighting_] *= freeElectrons;

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -1,5 +1,5 @@
 /* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
- *                     Marco Garten
+ *                     Marco Garten, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -33,9 +33,11 @@
 
 #include "picongpu/simulation_defines.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+#include "picongpu/particles/particleToGrid/FilteredDerivedAttribute.hpp"
 #include "picongpu/fields/Fields.def"
 #include "picongpu/particles/traits/GetShape.hpp"
 #include "picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp"
+#include "picongpu/particles/filter/filter.def"
 
 #include <pmacc/meta/conversion/ToSeq.hpp>
 
@@ -86,12 +88,18 @@ namespace picongpu
                  */
                 HINLINE static std::string getName();
 
-                template<typename FrameType, typename TVecSuperCell, typename BoxTmp, typename T_Acc>
+                template<
+                    typename FrameType,
+                    typename TVecSuperCell,
+                    typename BoxTmp,
+                    typename T_Acc,
+                    typename T_AccFilter>
                 DINLINE void operator()(
                     T_Acc const& acc,
                     FrameType& frame,
                     const int localIdx,
                     const TVecSuperCell superCell,
+                    T_AccFilter& accFilter,
                     BoxTmp& tmpBox);
             };
 
@@ -126,7 +134,7 @@ namespace picongpu
 
             /** Solver Operation for Particle to Grid Projections
              *
-             * Derives a scalar field from a particle species at runtime.
+             * Derives a scalar field from a (filtered) particle species at runtime.
              * Values are mapped to cells according either according to the
              * species' spatial shape or a specifically overwritten (counter) shape
              * depending on the implementation of the derived attribute
@@ -136,19 +144,22 @@ namespace picongpu
              *
              * @tparam T_DerivedAttribute a derived particle attribute from
              *         picongpu::particles::particleToGrid::derivedAttributes
+             *         @tparam T_Filter particle filter used to filter contributing particles
+             *         (default is all particles contribute)
              *
              * @typedef defines a FieldTmpOperation class
              */
-            template<typename T_Species, typename T_DerivedAttribute>
+            template<typename T_Species, typename T_DerivedAttribute, typename T_Filter = filter::All>
             struct CreateFieldTmpOperation
             {
                 using shapeType = detail::GetAttributeShape_t<T_Species, T_DerivedAttribute>;
 
                 using OperationPerFrame = ComputeGridValuePerFrame<shapeType, T_DerivedAttribute>;
-                using type = FieldTmpOperation<OperationPerFrame, T_Species>;
+                using type = FieldTmpOperation<OperationPerFrame, T_Species, T_Filter>;
             };
-            template<typename T_Species, typename T_DerivedAttribute>
-            using CreateFieldTmpOperation_t = typename CreateFieldTmpOperation<T_Species, T_DerivedAttribute>::type;
+            template<typename T_Species, typename T_DerivedAttribute, typename T_Filter = filter::All>
+            using CreateFieldTmpOperation_t =
+                typename CreateFieldTmpOperation<T_Species, T_DerivedAttribute, T_Filter>::type;
 
             /** Create a list solvers for derived fields for eligible species
              *
@@ -156,26 +167,29 @@ namespace picongpu
              *
              * @tparam T_SeqSpecies a sequence of particle species to check if they are
              *                      eligible to derive the attribute T_DerivedAttribute
+             *                      and to be filter with T_Filter
              *                      from, also allows a single type instead of a sequence
              * @tparam T_DerivedAttribute a derived attribute to map to the field grid,
              *                            see defines in
              *                            picongpu::particles::particleToGrid::derivedAttributes
+             * @tparam T_Filter  particle filter used to filter contributing particles
+             *         (default is all particles contribute)
              */
-            template<typename T_SeqSpecies, typename T_DerivedAttribute>
+            template<typename T_SeqSpecies, typename T_DerivedAttribute, typename T_Filter = filter::All>
             struct CreateEligible
             {
                 // wrap single arguments to sequence
                 using SeqSpecies = typename pmacc::ToSeq<T_SeqSpecies>::type;
-                using DerivedAttribute = T_DerivedAttribute;
+                using FilteredAttribute = FilteredDerivedAttribute<T_DerivedAttribute, T_Filter>;
 
                 using type = typename traits::GenerateSolversIfSpeciesEligible<
-                    CreateFieldTmpOperation<bmpl::_1, DerivedAttribute>,
+                    CreateFieldTmpOperation<bmpl::_1, T_DerivedAttribute, T_Filter>,
                     SeqSpecies,
-                    DerivedAttribute>::type;
+                    FilteredAttribute>::type;
             };
 
-            template<typename T_SeqSpecies, typename T_DerivedAttribute>
-            using CreateEligible_t = typename CreateEligible<T_SeqSpecies, T_DerivedAttribute>::type;
+            template<typename T_SeqSpecies, typename T_DerivedAttribute, typename T_Filter = filter::All>
+            using CreateEligible_t = typename CreateEligible<T_SeqSpecies, T_DerivedAttribute, T_Filter>::type;
 
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -57,69 +57,73 @@ namespace picongpu
             }
 
             template<class T_ParticleShape, class T_DerivedAttribute>
-            template<class FrameType, class TVecSuperCell, class BoxTmp, typename T_Acc>
+            template<class FrameType, class TVecSuperCell, class BoxTmp, typename T_Acc, typename T_AccFilter>
             DINLINE void ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::operator()(
                 T_Acc const& acc,
                 FrameType& frame,
                 const int localIdx,
                 const TVecSuperCell superCell,
+                T_AccFilter& accFilter,
                 BoxTmp& tmpBox)
             {
                 /* \todo in the future and if useful, the functor can be a parameter */
                 T_DerivedAttribute particleAttribute;
 
                 auto particle = frame[localIdx];
-
-                /* particle attributes: in-cell position and generic, derived attribute */
-                const floatD_X pos = particle[position_];
-                const auto particleAttr = particleAttribute(particle);
-
-                /** Shift to the cell the particle belongs to
-                 * range of particleCell: [DataSpace<simDim>::create(0), TVecSuperCell]
-                 */
-                const int particleCellIdx = particle[localCellIdx_];
-                const DataSpace<TVecSuperCell::dim> particleCell(
-                    DataSpaceOperations<TVecSuperCell::dim>::map(superCell, particleCellIdx));
-                auto fieldTmpShiftToParticle = tmpBox.shift(particleCell);
-
-                /* loop around the particle's cell (according to shape) */
-                const DataSpace<simDim> lowMargin(LowerMargin().toRT());
-                const DataSpace<simDim> upMargin(UpperMargin().toRT());
-
-                const DataSpace<simDim> marginSpace(upMargin + lowMargin + 1);
-
-                const int numWriteCells = marginSpace.productOfComponents();
-
-                for(int i = 0; i < numWriteCells; ++i)
+                // Only particles passing the filter contribute
+                if(accFilter(acc, particle))
                 {
-                    /** for the current cell i the multi dimensional index currentCell is only positive:
-                     * allowed range = [DataSpace<simDim>::create(0), LowerMargin+UpperMargin]
-                     */
-                    const DataSpace<simDim> currentCell = DataSpaceOperations<simDim>::map(marginSpace, i);
+                    /* particle attributes: in-cell position and generic, derived attribute */
+                    const floatD_X pos = particle[position_];
+                    const auto particleAttr = particleAttribute(particle);
 
-                    /** calculate the offset between the current cell i with simDim index currentCell
-                     * and the cell of the particle (particleCell) in cells
+                    /** Shift to the cell the particle belongs to
+                     * range of particleCell: [DataSpace<simDim>::create(0), TVecSuperCell]
                      */
-                    const DataSpace<simDim> offsetParticleCellToCurrentCell = currentCell - lowMargin;
+                    const int particleCellIdx = particle[localCellIdx_];
+                    const DataSpace<TVecSuperCell::dim> particleCell(
+                        DataSpaceOperations<TVecSuperCell::dim>::map(superCell, particleCellIdx));
+                    auto fieldTmpShiftToParticle = tmpBox.shift(particleCell);
 
-                    /** assign particle contribution component-wise to the lower left corner of
-                     * the cell i
-                     * \todo take care of non-yee cells
-                     */
-                    float_X assign(1.0);
-                    for(uint32_t d = 0; d < simDim; ++d)
-                        assign *= AssignmentFunction()(float_X(offsetParticleCellToCurrentCell[d]) - pos[d]);
+                    /* loop around the particle's cell (according to shape) */
+                    const DataSpace<simDim> lowMargin(LowerMargin().toRT());
+                    const DataSpace<simDim> upMargin(UpperMargin().toRT());
 
-                    /** add contribution of the particle times the generic attribute
-                     * to cell i
-                     * note: the .x() is used because FieldTmp is a scalar field with only
-                     * one "x" component
-                     */
-                    cupla::atomicAdd(
-                        acc,
-                        &(fieldTmpShiftToParticle(offsetParticleCellToCurrentCell).x()),
-                        assign * particleAttr,
-                        ::alpaka::hierarchy::Threads{});
+                    const DataSpace<simDim> marginSpace(upMargin + lowMargin + 1);
+
+                    const int numWriteCells = marginSpace.productOfComponents();
+
+                    for(int i = 0; i < numWriteCells; ++i)
+                    {
+                        /** for the current cell i the multi dimensional index currentCell is only positive:
+                         * allowed range = [DataSpace<simDim>::create(0), LowerMargin+UpperMargin]
+                         */
+                        const DataSpace<simDim> currentCell = DataSpaceOperations<simDim>::map(marginSpace, i);
+
+                        /** calculate the offset between the current cell i with simDim index currentCell
+                         * and the cell of the particle (particleCell) in cells
+                         */
+                        const DataSpace<simDim> offsetParticleCellToCurrentCell = currentCell - lowMargin;
+
+                        /** assign particle contribution component-wise to the lower left corner of
+                         * the cell i
+                         * \todo take care of non-yee cells
+                         */
+                        float_X assign(1.0);
+                        for(uint32_t d = 0; d < simDim; ++d)
+                            assign *= AssignmentFunction()(float_X(offsetParticleCellToCurrentCell[d]) - pos[d]);
+
+                        /** add contribution of the particle times the generic attribute
+                         * to cell i
+                         * note: the .x() is used because FieldTmp is a scalar field with only
+                         * one "x" component
+                         */
+                        cupla::atomicAdd(
+                            acc,
+                            &(fieldTmpShiftToParticle(offsetParticleCellToCurrentCell).x()),
+                            assign * particleAttr,
+                            ::alpaka::hierarchy::Threads{});
+                    }
                 }
             }
 

--- a/include/picongpu/particles/particleToGrid/FilteredDerivedAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/FilteredDerivedAttribute.hpp
@@ -1,0 +1,64 @@
+/* Copyright 2014-2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+#include "picongpu/particles/filter/filter.def"
+
+#include <boost/mpl/and.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            /** Combine derived field and a particle filter
+             *
+             * This struct is used for combining  SpeciesEligibleForSolver tests for a solver and a particle filter
+             * in one. This enables generating only the TmpField operations that pass both tests.
+             * @tparam T_DerivedAttribute derived attribute used in a `FieldTmpOperation`
+             * @tparam T_Filter particle filter used in a `FieldTmpOperation`
+             */
+            template<typename T_DerivedAttribute, typename T_Filter>
+            struct FilteredDerivedAttribute
+            {
+                using DerivedAttribute = T_DerivedAttribute;
+                using Filter = T_Filter;
+            };
+        } // namespace particleToGrid
+        namespace traits
+        {
+            template<typename T_Species, typename T_DerivedAttribute, typename T_Filter>
+            struct SpeciesEligibleForSolver<
+                T_Species,
+                particleToGrid::FilteredDerivedAttribute<T_DerivedAttribute, T_Filter>>
+            {
+                using EligibleForDerivedAttribute =
+                    typename particles::traits::SpeciesEligibleForSolver<T_Species, T_DerivedAttribute>::type;
+                using EligibleForFilter =
+                    typename particles::traits::SpeciesEligibleForSolver<T_Species, T_Filter>::type;
+                using type = typename bmpl::and_<EligibleForDerivedAttribute, EligibleForFilter>;
+            };
+        } // namespace traits
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 Alexander Matthes,
+ * Copyright 2013-2021 Alexander Matthes, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -109,8 +109,8 @@ namespace picongpu
         };
 
         ISAAC_NO_HOST_DEVICE_WARNING
-        template<typename FrameSolver, typename ParticleType>
-        class TFieldSource<FieldTmpOperation<FrameSolver, ParticleType>>
+        template<typename FrameSolver, typename ParticleType, typename ParticleFilter>
+        class TFieldSource<FieldTmpOperation<FrameSolver, ParticleType, ParticleFilter>>
         {
         public:
             static const size_t feature_dim = 1;
@@ -132,7 +132,8 @@ namespace picongpu
 
             static std::string getName()
             {
-                return ParticleType::FrameType::getName() + std::string(" ") + FrameSolver().getName();
+                return ParticleType::FrameType::getName() + std::string(" ") + ParticleFilter::getName()
+                    + std::string(" ") + FrameSolver().getName();
             }
 
             void update(bool enabled, void* pointer)
@@ -148,7 +149,9 @@ namespace picongpu
                     auto particles = dc.get<ParticleType>(ParticleType::FrameType::getName(), true);
 
                     fieldTmp->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
-                    fieldTmp->template computeValue<CORE + BORDER, FrameSolver>(*particles, *currentStep);
+                    fieldTmp->template computeValue<CORE + BORDER, FrameSolver, ParticleFilter>(
+                        *particles,
+                        *currentStep);
                     EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
 
                     __setTransactionEvent(fieldTmpEvent);

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -1,5 +1,6 @@
 /* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov,
+ *                     Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -353,13 +354,13 @@ namespace picongpu
                 }
             };
 
-            /** Calculate FieldTmp with given solver and particle species
+            /** Calculate FieldTmp with given solver, particle species, and filter
              * and write them to adios.
              *
              * FieldTmp is calculated on device and than dumped to adios.
              */
-            template<typename Solver, typename Species>
-            struct GetFields<FieldTmpOperation<Solver, Species>>
+            template<typename Solver, typename Species, typename Filter>
+            struct GetFields<FieldTmpOperation<Solver, Species, Filter>>
             {
                 /*
                  * This is only a wrapper function to allow disable nvcc warnings.
@@ -384,7 +385,7 @@ namespace picongpu
                  */
                 static std::string getName()
                 {
-                    return FieldTmpOperation<Solver, Species>::getName();
+                    return FieldTmpOperation<Solver, Species, Filter>::getName();
                 }
 
                 HINLINE void operator_impl(ThreadParams* params)
@@ -401,7 +402,7 @@ namespace picongpu
 
                     fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
                     /*run algorithm*/
-                    fieldTmp->template computeValue<CORE + BORDER, Solver>(*speciesTmp, params->currentStep);
+                    fieldTmp->template computeValue<CORE + BORDER, Solver, Filter>(*speciesTmp, params->currentStep);
 
                     EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
                     __setTransactionEvent(fieldTmpEvent);
@@ -732,8 +733,8 @@ namespace picongpu
              * Collect field sizes to set adios group size.
              * Specialization.
              */
-            template<typename Solver, typename Species>
-            struct CollectFieldsSizes<FieldTmpOperation<Solver, Species>>
+            template<typename Solver, typename Species, typename Filter>
+            struct CollectFieldsSizes<FieldTmpOperation<Solver, Species, Filter>>
             {
             public:
                 PMACC_NO_NVCC_HDWARNING
@@ -751,7 +752,7 @@ namespace picongpu
                  */
                 static std::string getName()
                 {
-                    return FieldTmpOperation<Solver, Species>::getName();
+                    return FieldTmpOperation<Solver, Species, Filter>::getName();
                 }
 
                 /** Get the unit for the result from the solver*/

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1,5 +1,6 @@
 /* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Benjamin Worpitz, Alexander Grund, Franz Poeschel
+ *                     Benjamin Worpitz, Alexander Grund, Franz Poeschel,
+ *                     Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -486,13 +487,13 @@ Please pick either of the following:
                 }
             };
 
-            /** Calculate FieldTmp with given solver and particle species
+            /** Calculate FieldTmp with given solver, particle species, and filter
              * and write them to openPMD.
              *
              * FieldTmp is calculated on device and then dumped to openPMD.
              */
-            template<typename Solver, typename Species>
-            struct GetFields<FieldTmpOperation<Solver, Species>>
+            template<typename Solver, typename Species, typename Filter>
+            struct GetFields<FieldTmpOperation<Solver, Species, Filter>>
             {
                 /*
                  * This is only a wrapper function to allow disable nvcc warnings.
@@ -526,7 +527,7 @@ Please pick either of the following:
                  */
                 static std::string getName()
                 {
-                    return FieldTmpOperation<Solver, Species>::getName();
+                    return FieldTmpOperation<Solver, Species, Filter>::getName();
                 }
 
                 HINLINE void operator_impl(ThreadParams* params)
@@ -543,7 +544,7 @@ Please pick either of the following:
 
                     fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
                     /*run algorithm*/
-                    fieldTmp->template computeValue<CORE + BORDER, Solver>(*speciesTmp, params->currentStep);
+                    fieldTmp->template computeValue<CORE + BORDER, Solver, Filter>(*speciesTmp, params->currentStep);
 
                     EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
                     __setTransactionEvent(fieldTmpEvent);

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/particle.param
@@ -65,7 +65,7 @@ namespace picongpu
                     using Particle = T_Particle;
 
                     // number of bound electrons at initialization state of the neutral atom
-                    float_X const protonNumber = traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;
+                    float_X const protonNumber = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;
 
                     particle[boundElectrons_] = protonNumber;
                 }


### PR DESCRIPTION
This PR introduces derived fields of filtered species. See #3554.  `CreateEligible_t` used in `fileOutput.param` has now an additional template argument that defaults to `filter::All`. The filter is optional and by default `All` in all other relevant structs and methods (like `FieldTmp::computeValue`) so it shouldn't brake any code that is not using filters.  

I did a quick test with the Kelvin-Helmholtz example and it compiles and works as excepted with the `openPMD` plugin  when I use one of the filters from `particleFilter.param` in `fileOutput.param`.  Maybe someone can verify that it works with `isaac` too?  I've never used it before.

Also I did move  `SpeciesEligibleForSolver` in the `RelativeGlobalDomainPosition` to the `.def` file so I don't have to include the `.hpp` file too early an brake the compilation.

@ComputationalRadiationPhysics/picongpu-maintainers