### PR TITLE
Fix openPMD plugin for non-GPU builds

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -130,8 +130,6 @@ namespace picongpu
                 log<picLog::INPUT_OUTPUT>("openPMD:   (begin) copy particle host (with hierarchy) to "
                                           "host (without hierarchy): %1%")
                     % name;
-                auto mallocMCBuffer
-                    = rp.dc.template get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName(), true);
 
                 int globalParticleOffset = 0;
                 AreaMapping<CORE + BORDER, MappingDesc> mapper(*(rp.params.cellDescription));
@@ -139,7 +137,10 @@ namespace picongpu
                 pmacc::particles::operations::ConcatListOfFrames<simDim> concatListOfFrames(mapper.getGridDim());
 
 #if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+                auto mallocMCBuffer
+                    = rp.dc.template get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName(), true);
                 auto particlesBox = rp.speciesTmp->getHostParticlesBox(mallocMCBuffer->getOffset());
+                rp.dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
 #else
                 /* This separate code path is only a workaround until
                  * MallocMCBuffer is alpaka compatible.
@@ -167,7 +168,6 @@ namespace picongpu
                     mapper,
                     rp.particleFilter);
 
-                rp.dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
 
                 /* this costs a little bit of time but writing to external is
                  * slower in general */

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -140,7 +140,6 @@ namespace picongpu
                 auto mallocMCBuffer
                     = rp.dc.template get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName(), true);
                 auto particlesBox = rp.speciesTmp->getHostParticlesBox(mallocMCBuffer->getOffset());
-                rp.dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
 #else
                 /* This separate code path is only a workaround until
                  * MallocMCBuffer is alpaka compatible.

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -808,6 +808,7 @@ Please pick either of the following:
                     }
                 }
 
+#if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 /* copy species only one time per timestep to the host */
                 if(mThreadParams.strategy == WriteSpeciesStrategy::ADIOS && lastSpeciesSyncStep != currentStep)
                 {
@@ -827,6 +828,7 @@ Please pick either of the following:
 
                     dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
                 }
+#endif
 
                 TimeIntervall timer;
                 timer.toggleStart();

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -825,8 +825,6 @@ Please pick either of the following:
                     meta::ForEach<FileCheckpointParticles, CopySpeciesToHost<bmpl::_1>> copySpeciesToHost;
                     copySpeciesToHost();
                     lastSpeciesSyncStep = currentStep;
-
-                    dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
                 }
 #endif
 


### PR DESCRIPTION
GPU-only code was executed also when building non-GPU Alpaka backends.

Fix #3576