### PR TITLE
remove interface `DataConnector::releaseData()`

### DIFF
--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -271,8 +271,6 @@ namespace picongpu
             buffer.getDeviceBuffer().getDataBox(),
             myCurrentInterpolationFunctor,
             mapper);
-        dc.releaseData(FieldE::getName());
-        dc.releaseData(FieldB::getName());
     }
 
     void FieldJ::bashField(uint32_t exchangeType)

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -106,8 +106,6 @@ namespace picongpu
                 DensityFunctor densityFunctor(currentStep);
                 PositionFunctor positionFunctor(currentStep);
                 speciesPtr->initDensityProfile(densityFunctor, positionFunctor, currentStep);
-
-                dc.releaseData(FrameType::getName());
             }
         };
 
@@ -167,9 +165,6 @@ namespace picongpu
                 SrcFilterInterfaced srcFilter(currentStep);
 
                 speciesPtr->deviceDeriveFrom(*srcSpeciesPtr, filteredManipulator, srcFilter);
-
-                dc.releaseData(DestFrameType::getName());
-                dc.releaseData(SrcFrameType::getName());
             }
         };
 
@@ -219,7 +214,6 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
                 auto speciesPtr = dc.get<SpeciesType>(FrameType::getName(), true);
                 speciesPtr->fillAllGaps();
-                dc.releaseData(FrameType::getName());
             }
         };
 

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -361,9 +361,6 @@ namespace picongpu
             FrameSolver(),
             mapper);
 
-        dc.releaseData(FieldE::getName());
-        dc.releaseData(FieldB::getName());
-
         ParticlesBaseType::template shiftParticles<CORE + BORDER>();
     }
 

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -65,7 +65,6 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
                 auto species = dc.get<SpeciesType>(FrameType::getName(), true);
                 species = nullptr;
-                dc.releaseData(FrameType::getName());
             }
         };
 
@@ -126,7 +125,6 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
                 auto species = dc.get<SpeciesType>(FrameType::getName(), true);
                 species->reset(currentStep);
-                dc.releaseData(FrameType::getName());
             }
         };
 
@@ -194,7 +192,6 @@ namespace picongpu
 
                 __startTransaction(eventInt);
                 species->update(currentStep);
-                dc.releaseData(FrameType::getName());
                 EventTask ev = __endTransaction();
                 updateEvent.push_back(ev);
             }
@@ -222,8 +219,6 @@ namespace picongpu
 
                 updateEventList.pop_front();
                 commEventList.push_back(communication::asyncCommunication(*species, updateEvent));
-
-                dc.releaseData(FrameType::getName());
             }
         };
 
@@ -313,9 +308,6 @@ namespace picongpu
                  * the last frame is not completely filled but every other before is full
                  */
                 electronsPtr->fillAllGaps();
-
-                dc.releaseData(FrameType::getName());
-                dc.releaseData(DestFrameType::getName());
             }
         };
 
@@ -414,9 +406,6 @@ namespace picongpu
                     *photonSpeciesPtr,
                     bremsstrahlungFunctor,
                     cellDesc);
-
-                dc.releaseData(ElectronFrameType::getName());
-                dc.releaseData(PhotonFrameType::getName());
             }
         };
 #endif
@@ -463,9 +452,6 @@ namespace picongpu
                     synchrotronFunctions.getCursor(SynchrotronFunctions::second));
 
                 creation::createParticlesFromSpecies(*electronSpeciesPtr, *photonSpeciesPtr, photonCreator, cellDesc);
-
-                dc.releaseData(ElectronFrameType::getName());
-                dc.releaseData(PhotonFrameType::getName());
             }
         };
 

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -68,7 +68,6 @@ namespace picongpu
                 using DensitySolver = typename particleToGrid::
                     CreateFieldTmpOperation<T_IonSpecies, particleToGrid::derivedAttributes::Density>::type::Solver;
                 fieldIonDensity->template computeValue<CORE + BORDER, DensitySolver>(*ionSpecies, currentStep);
-                dc.releaseData(T_IonSpecies::FrameType::getName());
 
                 /* initialize device-side tmp-field databoxes */
                 this->ionDensityBox = fieldIonDensity->getDeviceDataBox();

--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -362,10 +362,6 @@ namespace picongpu
                         coulombLog,
                         Filter0(),
                         Filter1());
-
-                    // Release particle data:
-                    dc.releaseData(FrameType0::getName());
-                    dc.releaseData(FrameType1::getName());
                 }
             };
 

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -243,8 +243,6 @@ namespace picongpu
                         CollisionFunctor(currentStep),
                         coulombLog,
                         Filter());
-
-                    dc.releaseData(FrameType::getName());
                 }
             };
 

--- a/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
@@ -71,8 +71,6 @@ namespace picongpu
                             using Density = particleToGrid::
                                 ComputeGridValuePerFrame<ShapeType, particleToGrid::derivedAttributes::Density>;
                             fieldTmp->template computeValue<CORE + BORDER, Density>(*speciesTmp, currentStep);
-
-                            dc.releaseData(FrameType::getName());
                         }
                     };
                 } // namespace detail
@@ -134,10 +132,6 @@ namespace picongpu
                             fieldTmp->getDeviceDataBox().shift(SuperCellSize::toRT() * GuardSize::toRT()),
                             // start in border (has no GUARD area)
                             nlocal->getGridBuffer().getDeviceBuffer().getDataBox());
-
-                        // release fields
-                        dc.releaseData(FieldTmp::getUniqueId(0));
-                        dc.releaseData(helperFields::LocalDensity::getName(speciesGroup));
                     }
                 };
 

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
@@ -92,8 +92,6 @@ namespace picongpu
                                 minEnergy,
                                 maxEnergy,
                                 mapper);
-
-                            dc.releaseData(FrameType::getName());
                         }
                     };
                 } // namespace detail
@@ -143,9 +141,6 @@ namespace picongpu
                         /* note: for average != supercell the BORDER region would need to be
                          *       build up via communication accordingly
                          */
-
-                        // release fields
-                        dc.releaseData(helperFields::LocalEnergyHistogram::getName(speciesGroup));
                     }
                 };
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -146,7 +146,7 @@ namespace picongpu
                     using DensitySolver = typename particleToGrid::
                         CreateFieldTmpOperation_t<SrcSpecies, particleToGrid::derivedAttributes::Density>::Solver;
                     density->template computeValue<CORE + BORDER, DensitySolver>(*srcSpecies, currentStep);
-                    dc.releaseData(SrcSpecies::FrameType::getName());
+
                     EventTask densityEvent = density->asyncCommunication(__getTransactionEvent());
                     densityEvent += density->asyncCommunicationGather(densityEvent);
 
@@ -162,7 +162,6 @@ namespace picongpu
                         DestSpecies,
                         particleToGrid::derivedAttributes::EnergyDensityCutoff<CutoffMaxEnergy>>::Solver;
                     eneKinDens->template computeValue<CORE + BORDER, EnergyDensitySolver>(*destSpecies, currentStep);
-                    dc.releaseData(DestSpecies::FrameType::getName());
                     EventTask eneKinEvent = eneKinDens->asyncCommunication(__getTransactionEvent());
                     eneKinEvent += eneKinDens->asyncCommunicationGather(eneKinEvent);
 

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -485,7 +485,6 @@ namespace picongpu
                 currentStep,
                 bindKernel);
 
-            dc.releaseData(ParticlesType::FrameType::getName());
             gBins->deviceToHost();
 
             reduce(

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -181,7 +181,6 @@ namespace picongpu
                     particles::particleToGrid::derivedAttributes::ChargeDensity>::Solver;
 
                 fieldTmp->computeValue<area, ChargeDensitySolver>(*speciesTmp, currentStep);
-                dc.releaseData(SpeciesType::FrameType::getName());
             }
         };
 

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -180,7 +180,6 @@ namespace picongpu
                 DataSpace<simDim>(),
                 localSize,
                 parFilter);
-            dc.releaseData(ParticlesType::FrameType::getName());
 
             uint64_cu reducedValueMax;
             if(picLog::log_level & picLog::CRITICAL::lvl)

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -548,8 +548,6 @@ namespace picongpu
                 currentStep,
                 binaryKernel);
 
-            dc.releaseData(ParticlesType::FrameType::getName());
-
             // get gSum, ... from GPU
             gSumMom2->deviceToHost();
             gSumPos2->deviceToHost();

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -406,8 +406,6 @@ namespace picongpu
                 currentStep,
                 binaryKernel);
 
-            dc.releaseData(ParticlesType::FrameType::getName());
-
             // get energy from GPU
             gEnergy->deviceToHost();
 

--- a/include/picongpu/plugins/IntensityPlugin.hpp
+++ b/include/picongpu/plugins/IntensityPlugin.hpp
@@ -369,8 +369,6 @@ namespace picongpu
                 localMaxIntensity->getDeviceBuffer().getDataBox(),
                 localIntegratedIntensity->getDeviceBuffer().getDataBox());
 
-            dc.releaseData(FieldE::getName());
-
             localMaxIntensity->deviceToHost();
             localIntegratedIntensity->deviceToHost();
         }

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -92,7 +92,6 @@ namespace picongpu
                     }
                     typename FieldType::DataBoxType dataBox = pField->getDeviceDataBox();
                     shifted = dataBox.shift(guarding);
-                    dc.releaseData(FieldType::getName());
                     /* avoid deadlock between not finished pmacc tasks and potential blocking operations
                      * within ISAAC
                      */
@@ -154,8 +153,6 @@ namespace picongpu
                     __setTransactionEvent(fieldTmpEvent);
                     __getTransactionEvent().waitForFinished();
 
-                    dc.releaseData(ParticleType::FrameType::getName());
-
                     DataSpace<simDim> guarding = SuperCellSize::toRT() * cellDescription->getGuardingSuperCells();
                     if(movingWindow)
                     {
@@ -168,7 +165,6 @@ namespace picongpu
                     }
                     typename FieldTmp::DataBoxType dataBox = fieldTmp->getDeviceDataBox();
                     shifted = dataBox.shift(guarding);
-                    dc.releaseData(FieldTmp::getUniqueId(0));
                 }
             }
 
@@ -315,7 +311,6 @@ namespace picongpu
                                     / (float) MappingDesc::SuperCellSize::toRT()[i]));
                         }
                     }
-                    dc.releaseData(ParticlesType::FrameType::getName());
                 }
             }
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -236,8 +236,6 @@ namespace picongpu
             m_help->filter.get(m_id),
             currentStep,
             bindFunctor);
-
-        dc.releaseData(Species::FrameType::getName());
     }
 
     template<class AssignmentFunction, class Species>

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -260,7 +260,6 @@ namespace picongpu
             (mapper.getGridDim(),
              block)(particles->getDeviceParticlesBox(), gParticle->getDeviceBuffer().getBasePointer(), mapper);
 
-            dc.releaseData(ParticlesType::FrameType::getName());
             gParticle->deviceToHost();
 
             DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -181,8 +181,6 @@ namespace picongpu
             (mapper.getGridDim(),
              block)(fieldJ->getDeviceDataBox(), sumcurrents->getDeviceBuffer().getBasePointer(), mapper);
 
-            dc.releaseData(FieldJ::getName());
-
             sumcurrents->deviceToHost();
             return sumcurrents->getHostBuffer().getDataBox()[0];
         }

--- a/include/picongpu/plugins/adios/ADIOSWriter.hpp
+++ b/include/picongpu/plugins/adios/ADIOSWriter.hpp
@@ -347,8 +347,6 @@ namespace picongpu
                         T_Field::getName(),
                         field->getHostDataBox().getPointer(),
                         isDomainBound);
-
-                    dc.releaseData(T_Field::getName());
 #endif
                 }
             };
@@ -407,7 +405,6 @@ namespace picongpu
                     __setTransactionEvent(fieldTmpEvent);
                     /* copy data to host that we can write same to disk*/
                     fieldTmp->getGridBuffer().deviceToHost();
-                    dc.releaseData(Species::FrameType::getName());
                     /*## finish update field ##*/
 
                     const uint32_t components = GetNComponents<ValueType>::value;
@@ -424,8 +421,6 @@ namespace picongpu
                         getName(),
                         fieldTmp->getHostDataBox().getPointer(),
                         isDomainBound);
-
-                    dc.releaseData(FieldTmp::getUniqueId(0));
                 }
             };
 
@@ -466,7 +461,6 @@ namespace picongpu
                     DataConnector& dc = Environment<>::get().DataConnector();
                     auto field = dc.get<T_Field>(T_Field::getName());
                     fieldsSizeDims = precisionCast<uint64_t>(field->getGridLayout().getDataSpaceWithoutGuarding());
-                    dc.releaseData(T_Field::getName());
 
                     /* Scan the PML buffer local size along all local domains
                      * This code is based on the same operation in hdf5::Field::writeField(),
@@ -690,7 +684,6 @@ namespace picongpu
                         DataConnector& dc = Environment<>::get().DataConnector();
                         auto field = dc.get<T>(T::getName());
                         localSize = field->getGridLayout().getDataSpaceWithoutGuarding();
-                        dc.releaseData(T::getName());
                     }
 
                     // adios buffer size for this dataset (all components)
@@ -777,7 +770,7 @@ namespace picongpu
                         DataConnector& dc = Environment<>::get().DataConnector();
                         auto field = dc.get<FieldTmp>(FieldTmp::getName());
                         localSize = field->getGridLayout().getDataSpaceWithoutGuarding();
-                        dc.releaseData(FieldTmp::getName());
+                        ;
                     }
 
                     // adios buffer size for this dataset (all components)
@@ -1171,7 +1164,6 @@ namespace picongpu
                     meta::ForEach<FileCheckpointParticles, CopySpeciesToHost<bmpl::_1>> copySpeciesToHost;
                     copySpeciesToHost();
                     lastSpeciesSyncStep = currentStep;
-                    dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
                 }
 
                 beginAdios(mThreadParams.adiosFilename);

--- a/include/picongpu/plugins/adios/WriteSpecies.hpp
+++ b/include/picongpu/plugins/adios/WriteSpecies.hpp
@@ -160,8 +160,6 @@ namespace picongpu
                         mapper,
                         particleFilter);
 
-                    dc.releaseData(MallocMCBuffer<DeviceHeap>::getName());
-
                     /* this costs a little bit of time but adios writing is slower */
                     PMACC_ASSERT((uint64_cu) globalParticleOffset == totalNumParticles);
                 }

--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -244,8 +244,6 @@ namespace picongpu
                     T_Field::getName(),
                     tp,
                     isDomainBound);
-
-                dc.releaseData(T_Field::getName());
 #endif
             }
         };

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -210,8 +210,6 @@ namespace picongpu
                 localResult->getDeviceBuffer().getDataBox(),
                 mapper);
 
-            dc.releaseData(ParticlesType::FrameType::getName());
-
             localResult->deviceToHost();
 
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -480,8 +480,6 @@ Please pick either of the following:
                         std::move(inCellPosition),
                         timeOffset,
                         isDomainBound);
-
-                    dc.releaseData(T_Field::getName());
 #endif
                 }
             };
@@ -549,7 +547,6 @@ Please pick either of the following:
                     __setTransactionEvent(fieldTmpEvent);
                     /* copy data to host that we can write same to disk*/
                     fieldTmp->getGridBuffer().deviceToHost();
-                    dc.releaseData(Species::FrameType::getName());
                     /*## finish update field ##*/
 
                     const uint32_t components = GetNComponents<ValueType>::value;
@@ -582,8 +579,6 @@ Please pick either of the following:
                         std::move(inCellPosition),
                         timeOffset,
                         isDomainBound);
-
-                    dc.releaseData(FieldTmp::getUniqueId(0));
                 }
             };
 
@@ -964,7 +959,6 @@ Please pick either of the following:
 
                     DataConnector& dc = Environment<>::get().DataConnector();
                     fieldsSizeDims = precisionCast<uint64_t>(params->gridLayout.getDataSpaceWithoutGuarding());
-                    dc.releaseData(name);
 
                     /* Scan the PML buffer local size along all local domains
                      * This code is based on the same operation in hdf5::Field::writeField(),

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -219,8 +219,6 @@ namespace picongpu
                     T_Field::getName(),
                     tp,
                     isDomainBound);
-
-                dc.releaseData(T_Field::getName());
 #endif
             }
         };

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -105,7 +105,6 @@ namespace picongpu
             /* DataConnector copies data to host */
             DataConnector& dc = Environment<>::get().DataConnector();
             dc.get<SpeciesType>(SpeciesType::FrameType::getName());
-            dc.releaseData(SpeciesType::FrameType::getName());
         }
     };
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -562,8 +562,6 @@ namespace picongpu
                 currentStep,
                 unaryKernel);
 
-            dc.releaseData(ParticlesType::FrameType::getName());
-
             /* copy to host */
             *this->hBufCalorimeter = *this->dBufCalorimeter;
 
@@ -609,8 +607,6 @@ namespace picongpu
                 m_help->filter.get(m_id),
                 Environment<>::get().SimulationDescription().getCurrentStep(),
                 unaryKernel);
-
-            dc.releaseData(speciesName);
         }
 
     private:

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -1218,8 +1218,6 @@ namespace picongpu
                         freqFkt,
                         subGrid.getGlobalDomain().size);
 
-                    dc.releaseData(ParticlesType::FrameType::getName());
-
                     if(dumpPeriod != 0 && currentStep % dumpPeriod == 0)
                     {
                         collectDataGPUToMaster();

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -536,8 +536,6 @@ namespace picongpu
                         *cellDescription,
                         freqFkt,
                         subGrid.getGlobalDomain().size);
-
-                    dc.releaseData(T_ParticlesType::FrameType::getName());
                 }
             };
 

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -500,8 +500,6 @@ namespace picongpu
                     using ElectronDensitySolver = typename DetermineElectronDensitySolver<T_ParticlesType>::type;
                     // Calculate density.
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
-                    // Release particle data.
-                    dc.releaseData(T_ParticlesType::FrameType::getName());
                     // Get the field data box.
                     FieldTmp::DataBoxType tmpFieldBox = tmpField->getGridBuffer().getDeviceBuffer().getDataBox();
                     return tmpFieldBox;
@@ -656,8 +654,7 @@ namespace picongpu
                     {
                         runKernelInMirrorMode(cellsGrid, fieldTmpNoGuard, globalOffset, numBlocks, fieldPos);
                     }
-                    // Release density data.
-                    dc.releaseData(FieldTmp::getUniqueId(0));
+
                     // Write to disk.
                     if(pluginSystem::containsStep(outputPeriod, currentStep))
                         writeOutput();

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -511,9 +511,6 @@ namespace picongpu
             EventTask eRfieldB = fieldB->asyncCommunication(__getTransactionEvent());
             __setTransactionEvent(eRfieldB);
 
-            dc.releaseData(FieldE::getName());
-            dc.releaseData(FieldB::getName());
-
             return step;
         }
 
@@ -679,7 +676,6 @@ namespace picongpu
                     auto field = std::dynamic_pointer_cast<FieldHelper>(dc.get<ISimulationData>(name, true));
                     if(field)
                         field->reset(currentStep);
-                    dc.releaseData(name);
                 }
             };
 

--- a/include/picongpu/simulation/stage/CurrentBackground.hpp
+++ b/include/picongpu/simulation/stage/CurrentBackground.hpp
@@ -66,7 +66,6 @@ namespace picongpu
                         using CurrentBackground = cellwiseOperation::CellwiseOperation<type::CORE + type::BORDER>;
                         CurrentBackground currentBackground(cellDescription);
                         currentBackground(&fieldJ, nvidia::functors::Add(), FieldBackgroundJ(fieldJ.getUnit()), step);
-                        dc.releaseData(FieldJ::getName());
                     }
                 }
 

--- a/include/picongpu/simulation/stage/CurrentDeposition.hpp
+++ b/include/picongpu/simulation/stage/CurrentDeposition.hpp
@@ -51,7 +51,6 @@ namespace picongpu
                     {
                         auto species = dc.get<SpeciesType>(FrameType::getName(), true);
                         fieldJ.computeCurrent<T_Area::value, SpeciesType>(*species, currentStep);
-                        dc.releaseData(FrameType::getName());
                     }
                 };
 
@@ -77,7 +76,6 @@ namespace picongpu
                         detail::CurrentDeposition<bmpl::_1, bmpl::int_<type::CORE + type::BORDER>>>
                         depositCurrent;
                     depositCurrent(step, fieldJ, dc);
-                    dc.releaseData(FieldJ::getName());
                 }
             };
 

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -124,7 +124,6 @@ namespace picongpu
                             __setTransactionEvent(eRecvCurrent);
                             addCurrentToEMF<type::CORE + type::BORDER>(fieldJ);
                         }
-                        dc.releaseData(FieldJ::getName());
                     }
                 }
 

--- a/include/picongpu/simulation/stage/CurrentReset.hpp
+++ b/include/picongpu/simulation/stage/CurrentReset.hpp
@@ -49,7 +49,6 @@ namespace picongpu
                     auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
                     FieldJ::ValueType zeroJ(FieldJ::ValueType::create(0._X));
                     fieldJ.assign(zeroJ);
-                    dc.releaseData(FieldJ::getName());
                 }
             };
 

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -80,7 +80,6 @@ namespace picongpu
                             auto field = dc.get<Field>(Field::getName(), true);
                             auto const& gridBuffer = field->getGridBuffer();
                             duplicateBuffer = pmacc::makeDeepCopy(gridBuffer.getDeviceBuffer());
-                            dc.releaseData(Field::getName());
                         }
                     }
 
@@ -102,7 +101,6 @@ namespace picongpu
                             restoreFromDuplicateField = true;
                         }
                         apply(step, pmacc::nvidia::functors::Add(), field);
-                        dc.releaseData(Field::getName());
                     }
 
                     /** Subtract the field background in the whole local domain
@@ -127,7 +125,6 @@ namespace picongpu
                         }
                         else
                             apply(step, pmacc::nvidia::functors::Sub(), field);
-                        dc.releaseData(Field::getName());
                     }
 
                 private:

--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -154,8 +154,6 @@ namespace pmacc
          * Reference to data in Dataset with identifier id and type TYPE is returned.
          * If the Dataset status in invalid, it is automatically synchronized.
          * Increments the reference counter to the dataset specified by id.
-         * This reference has to be released after all read/write operations
-         * before the next synchronize()/getData() on this data are done using releaseData().
          *
          * @tparam TYPE if of the data to load
          * @param id id of the Dataset to load from
@@ -181,16 +179,6 @@ namespace pmacc
             }
 
             return std::static_pointer_cast<TYPE>(*it);
-        }
-
-        /** Indicate a data set gotten temporarily via @see getData is not used anymore
-         *
-         * @todo not implemented
-         *
-         * @param id id for the dataset previously acquired using getData()
-         */
-        void releaseData(SimulationDataId)
-        {
         }
 
     private:

--- a/include/pmacc/particles/algorithm/CallForEach.hpp
+++ b/include/pmacc/particles/algorithm/CallForEach.hpp
@@ -60,8 +60,6 @@ namespace pmacc
                     auto species = dc.get<Species>(FrameType::getName(), true);
 
                     forEach(*species, UnaryFunctor(currentStep));
-
-                    dc.releaseData(FrameType::getName());
                 }
             };
 

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -97,7 +97,6 @@ namespace pmacc
         {
             auto provider = Environment<>::get().DataConnector().get<RNGProvider>(id, true);
             Handle result(provider->getDeviceDataBox());
-            Environment<>::get().DataConnector().releaseData(id);
             return result;
         }
 

--- a/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
@@ -82,8 +82,6 @@ namespace picongpu
             this->eField_zt[0] = std::make_unique<container::HostBuffer<float, 2>>(
                 Size_t<2>(fieldE_coreBorder.size().z(), this->collectTimesteps));
             this->eField_zt[1] = std::make_unique<container::HostBuffer<float, 2>>(this->eField_zt[0]->size());
-
-            dc.releaseData(FieldE::getName());
         }
 
         void pluginRegisterHelp(po::options_description& desc)
@@ -179,8 +177,6 @@ namespace picongpu
                         nvidia::functors::Add());
                 }
             }
-
-            dc.releaseData(FieldE::getName());
 
             if(currentStep == this->collectTimesteps + firstTimestep)
                 writeOutput();


### PR DESCRIPTION
Remove the interface method `DataConnector::releaseData()`.
The usage and meaning of this function are not clear or defined.
It is not clear how this function should be used in an asynchronous context.
In the past where we introduced this interface, it was designed as the counterpart operation of `DataConnector::get()` but was always unimplemented.

In case we would like to introduce a `releaseDate` function later we need to dive to all `get()` anyway and check the object lifetime, ...
Never the less I think this will not happen because I assume we will solve the issue when we introduce [redGrapes](https://github.com/ComputationalRadiationPhysics/redGrapes) in PIConGPU.