### PR TITLE
documentation: add support for boost 1.74.0

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -89,7 +89,7 @@ zlib
 
 boost
 """""
-- 1.65.1 - 1.70.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
+- 1.65.1 - 1.74.0 (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``


### PR DESCRIPTION
@PrometheusPi found that we missed updating our documentation with the latest supported boost version.
https://github.com/ComputationalRadiationPhysics/picongpu/pull/3341#discussion_r519823002

The CI is already testing boot 1.74.0: https://github.com/ComputationalRadiationPhysics/picongpu/blob/a9306d2eb2dfd7c93503dd48a507fda91b35c83c/share/ci/n_wise_generator.py#L191
