### PR TITLE
fix collision compile error

### DIFF
--- a/include/picongpu/unitless/collision.unitless
+++ b/include/picongpu/unitless/collision.unitless
@@ -22,6 +22,8 @@
 #include "picongpu/unitless/precision.unitless"
 #include "picongpu/param/collision.param"
 
+#include <pmacc/math/Vector.hpp>
+
 namespace picongpu
 {
     namespace particles
@@ -36,7 +38,7 @@ namespace picongpu
                     return float_COLL(x);
                 }
 
-                using float3_COLL = float3_64;
+                using float3_COLL = pmacc::math::Vector<float_COLL, 3>;
                 const float_COLL DELTA_T_COLL = static_cast<float_COLL>(DELTA_T);
                 const float_COLL EPS0_COLL = static_cast<float_COLL>(EPS0);
                 const float_COLL WEIGHT_NORM_COLL

--- a/share/picongpu/tests/CollisionsThermalisation/cmakeFlags
+++ b/share/picongpu/tests/CollisionsThermalisation/cmakeFlags
@@ -32,6 +32,8 @@
 flags[0]="-DPARAM_OVERWRITES:LIST='-DPARAM_START_IONS=Quiet5000ppc;-DPARAM_START_ELECTRONS=Quiet5000ppc'"
 flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_START_IONS=Quiet1000ppc;-DPARAM_START_ELECTRONS=Quiet5000ppc'"
 flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_START_IONS=Quiet5000ppc;-DPARAM_START_ELECTRONS=Quiet1000ppc'"
+# test support for 32bit precision
+flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_START_IONS=Quiet5000ppc;-DPARAM_START_ELECTRONS=Quiet1000ppc;-DPARAM_COLLISION_PRECISION=float_32'"
 
 ################################################################################
 # execution

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/collision.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/collision.param
@@ -21,6 +21,9 @@
 
 #include "picongpu/particles/collision/collision.def"
 
+#ifndef PARAM_COLLISION_PRECISION
+#    define PARAM_COLLISION_PRECISION float_64
+#endif
 
 namespace picongpu
 {
@@ -30,7 +33,7 @@ namespace picongpu
         {
             namespace precision
             {
-                using float_COLL = float_64;
+                using float_COLL = PARAM_COLLISION_PRECISION;
             } // namespace precision
             /** CollisionPipeline defines in which order species interact with each other
              *


### PR DESCRIPTION
Fix #3584 It is not possible to change the precision for collision.

CI: Test compilation with 32bit collision precision.
