### PR TITLE
Incident field generation (aka laser antenna)

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -59,6 +59,14 @@ laser.param
 
    laser/profiles.rst
 
+incidentField.param
+^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: incidentField.param
+   :project: PIConGPU
+   :path: include/picongpu/param/incidentField.param
+   :no-link:
+
 pml.param
 ^^^^^^^^^
 

--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -41,6 +41,7 @@
 #include "picongpu/param/synchrotronPhotons.param"
 #include "picongpu/param/grid.param"
 #include "picongpu/param/pusher.param"
+#include "picongpu/param/incidentField.param"
 #include "picongpu/param/ionizer.param"
 #include "picongpu/param/ionizationEnergies.param"
 #include "picongpu/param/density.param"

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -27,8 +27,8 @@
 #include "picongpu/fields/MaxwellSolver/YeePML/YeePML.kernel"
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/cellType/Yee.hpp"
-#include "picongpu/traits/GetMargin.hpp"
 #include "picongpu/fields/incidentField/Solver.hpp"
+#include "picongpu/traits/GetMargin.hpp"
 
 #include <pmacc/traits/GetStringProperties.hpp>
 

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2019-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
- *                Sergei Bastrakov, Klaus Steiniger
+ *                     Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *
@@ -28,6 +28,7 @@
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/cellType/Yee.hpp"
 #include "picongpu/traits/GetMargin.hpp"
+#include "picongpu/fields/incidentField/Solver.hpp"
 
 #include <pmacc/traits/GetStringProperties.hpp>
 
@@ -386,7 +387,7 @@ namespace picongpu
                 using CurlE = T_CurlE;
                 using CurlB = T_CurlB;
 
-                YeePML(MappingDesc const cellDescription) : solver(cellDescription)
+                YeePML(MappingDesc const cellDescription) : cellDescription(cellDescription), solver(cellDescription)
                 {
                 }
 
@@ -413,10 +414,16 @@ namespace picongpu
                      * to-be-absorbed components.
                      */
                     solver.template updateBSecondHalf<CORE + BORDER>(currentStep);
+                    auto incidentFieldSolver = fields::incidentField::Solver{cellDescription};
+                    // update B by half step, to step = currentStep + 0.5, so step for E_inc = currentStep
+                    incidentFieldSolver.updateBHalf(static_cast<float_X>(currentStep));
                     auto& fieldB = solver.getFieldB();
                     EventTask eRfieldB = fieldB.asyncCommunication(__getTransactionEvent());
 
                     solver.template updateE<CORE>(currentStep);
+                    // Incident field solver update does not use exchanged B, so does not have to wait for it
+                    // update E by full step, to step = currentStep + 1, so step for B_inc = currentStep + 0.5
+                    incidentFieldSolver.updateE(static_cast<float_X>(currentStep) + 0.5_X);
                     __setTransactionEvent(eRfieldB);
                     solver.template updateE<BORDER>(currentStep);
                 }
@@ -438,6 +445,11 @@ namespace picongpu
                     if(laserProfiles::Selected::INIT_TIME > 0.0_X)
                         LaserPhysics{}(currentStep);
 
+                    // Incident field solver update does not use exchanged E, so does not have to wait for it
+                    auto incidentFieldSolver = fields::incidentField::Solver{cellDescription};
+                    // update B by half step, to step currentStep + 1.5, so step for E_inc = currentStep + 1
+                    incidentFieldSolver.updateBHalf(static_cast<float_X>(currentStep) + 1.0_X);
+
                     auto& fieldE = solver.getFieldE();
                     EventTask eRfieldE = fieldE.asyncCommunication(__getTransactionEvent());
 
@@ -457,6 +469,7 @@ namespace picongpu
                 }
 
             private:
+                MappingDesc const cellDescription;
                 yeePML::detail::Solver<CurlE, CurlB> solver;
             };
 

--- a/include/picongpu/fields/incidentField/Profiles.def
+++ b/include/picongpu/fields/incidentField/Profiles.def
@@ -1,0 +1,44 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            //! No incident field at a boundary
+            struct None;
+
+            /** Incident field source at a boundary
+             *
+             * @tparam T_FunctorIncidentE functor for the incident E field, follows the interface of
+             *                            FunctorIncidentFieldConcept (defined in .hpp file)
+             * @tparam T_FunctorIncidentB functor for the incident B field, follows the interface of
+             *                            FunctorIncidentFieldConcept (defined in .hpp file)
+             */
+            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+            struct Source;
+
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/Profiles.hpp
+++ b/include/picongpu/fields/incidentField/Profiles.hpp
@@ -44,11 +44,12 @@ namespace picongpu
                  * Note that component matching the source boundary (e.g. the y component for YMin and YMax boundaries)
                  * will not be used, and so should be zero.
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  * @return incident field value in internal units
                  */
-                HDINLINE float3_X operator()(floatD_X const& cellIdx, float_X currentStep) const;
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx, float_X currentStep) const;
             };
 
             template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>

--- a/include/picongpu/fields/incidentField/Profiles.hpp
+++ b/include/picongpu/fields/incidentField/Profiles.hpp
@@ -19,8 +19,9 @@
 
 #pragma once
 
-#include "picongpu/fields/incidentField/Profiles.def"
 #include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Profiles.def"
 
 
 namespace picongpu

--- a/include/picongpu/fields/incidentField/Profiles.hpp
+++ b/include/picongpu/fields/incidentField/Profiles.hpp
@@ -1,0 +1,66 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/incidentField/Profiles.def"
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            //! Concept defining interface of incident field functors for E and B
+            struct FunctorIncidentFieldConcept
+            {
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorIncidentFieldConcept(float3_64 unitField);
+
+                /** Return incident field for the given position and time.
+                 *
+                 * Note that component matching the source boundary (e.g. the y component for YMin and YMax boundaries)
+                 * will not be used, and so should be zero.
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 * @return incident field value in internal units
+                 */
+                HDINLINE float3_X operator()(floatD_X const& cellIdx, float_X currentStep) const;
+            };
+
+            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+            struct Source
+            {
+                //! Incident E field functor
+                using FunctorIncidentE = T_FunctorIncidentE;
+
+                //! Incident B field functor
+                using FunctorIncidentB = T_FunctorIncidentB;
+            };
+
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -1,0 +1,511 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/absorber/Absorber.hpp"
+#include "picongpu/fields/Fields.hpp"
+#include "picongpu/fields/incidentField/Solver.kernel"
+#include "picongpu/fields/incidentField/Profiles.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/MaxwellSolver/Solvers.def"
+
+#include <pmacc/math/Vector.hpp>
+
+#include <cstdint>
+#include <type_traits>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace detail
+            {
+                /** Internally used parameters of the incident field generation normal to the given axis
+                 *
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 */
+                template<uint32_t T_axis>
+                struct Parameters
+                {
+                    /** Create a parameters instance
+                     *
+                     * @param cellDescription cell description for kernels
+                     */
+                    Parameters(MappingDesc const cellDescription) : cellDescription(cellDescription)
+                    {
+                    }
+
+                    /** Offset of the Huygens surface from min border of the global domain
+                     *
+                     * The offset is from the start of CORE + BORDER area.
+                     * Counted in full cells, the surface is additionally offset by 0.75 cells
+                     */
+                    pmacc::DataSpace<simDim> offsetMinBorder;
+
+                    /** Offset of the Huygens surface from max border of the global domain
+                     *
+                     * The offset is from the start of CORE + BORDER area.
+                     * Counted in full cells, the surface is additionally offset by 0.75 cells
+                     */
+                    pmacc::DataSpace<simDim> offsetMaxBorder;
+
+                    /** Direction of the incident field propagation
+                     *
+                     * +1._X is positive direction (from the min boundary inwards).
+                     * -1._X is negative direction (from the max boundary inwards)
+                     */
+                    float_X direction;
+
+                    //! Time iteration at which the source incident field values will be calculated
+                    float_X sourceTimeIteration;
+
+                    //! Time increment in the target field, in iterations
+                    float_X timeIncrementIteration;
+
+                    //! Cell description for kernels
+                    MappingDesc const cellDescription;
+                };
+
+                /** Update a field with the given incident field normally to the given axis
+                 *
+                 * @tparam T_UpdatedField updated field type (FieldE or FieldB)
+                 * @tparam T_IncidentField incident field type (FieldB or FieldE)
+                 * @tparam T_FunctorIncidentField incident field source functor type
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 *
+                 * @param parameters parameters
+                 * @param curlCoefficient coefficient in front of the curl(incidentField) in the Maxwell's equations
+                 */
+                template<
+                    typename T_UpdatedField,
+                    typename T_IncidentField,
+                    typename T_FunctorIncidentField,
+                    uint32_t T_axis>
+                inline void updateField(Parameters<T_axis> const& parameters, float_X const curlCoefficient)
+                {
+                    /* Whether the field values we are updating are in the total- or scattered-field region:
+                     * total field when x component is not on the x cell border,
+                     * scattered field when x component is on the x cell border
+                     */
+                    auto updatedFieldPositions = traits::FieldPosition<cellType::Yee, T_UpdatedField>{}();
+                    bool isUpdatedFieldTotal = (updatedFieldPositions[0][0] != 0.0_X);
+
+                    /* Start and end of the source area in the user global coordinates
+                     * (the coordinate system in which a user functor is expressed, no guards)
+                     */
+                    auto beginUserIdx = parameters.offsetMinBorder;
+                    /* Total field in positive direction needs to have the begin adjusted by one to get the first
+                     * index inside the respective region
+                     */
+                    if(isUpdatedFieldTotal && parameters.direction > 0)
+                        beginUserIdx += pmacc::DataSpace<simDim>::create(1);
+                    auto const& subGrid = Environment<simDim>::get().SubGrid();
+                    auto endUserIdx = subGrid.getGlobalDomain().size - parameters.offsetMaxBorder;
+                    if(parameters.direction > 0)
+                        endUserIdx[T_axis] = beginUserIdx[T_axis] + 1;
+                    else
+                        beginUserIdx[T_axis] = endUserIdx[T_axis] - 1;
+
+                    // Convert to the local domain indices
+                    using Index = pmacc::DataSpace<simDim>;
+                    using IntVector = pmacc::math::Vector<int, simDim>;
+                    auto const localDomain = subGrid.getLocalDomain();
+                    auto const globalCellOffset = localDomain.offset;
+                    auto const beginLocalUserIdx
+                        = Index{pmacc::math::max(IntVector{beginUserIdx - globalCellOffset}, IntVector::create(0))};
+                    auto const endLocalUserIdx = Index{
+                        pmacc::math::min(IntVector{endUserIdx - globalCellOffset}, IntVector{localDomain.size})};
+
+                    // Check if we have any active cells in the local domain
+                    bool areAnyCellsInLocalDomain = true;
+                    for(uint32_t d = 0; d < simDim; d++)
+                        areAnyCellsInLocalDomain
+                            = areAnyCellsInLocalDomain && (beginLocalUserIdx[d] < endLocalUserIdx[d]);
+                    if(!areAnyCellsInLocalDomain)
+                        return;
+
+                    // The block-thread organization is same as used for the laser kernel
+                    using PlaneSizeInSuperCells = typename pmacc::math::CT::AssignIfInRange<
+                        typename SuperCellSize::vector_type,
+                        bmpl::integral_c<uint32_t, T_axis>,
+                        bmpl::integral_c<int, 1>>::type;
+                    auto const superCellSize = SuperCellSize::toRT();
+                    auto const gridBlocks
+                        = (endLocalUserIdx - beginLocalUserIdx + superCellSize - Index::create(1)) / superCellSize;
+                    constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
+                        pmacc::math::CT::volume<PlaneSizeInSuperCells>::type::value>::value;
+
+                    // Shift by guard size to go to the in-kernel coordinate system
+                    pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper{parameters.cellDescription};
+                    auto numGuardCells = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+                    auto beginGridIdx = beginLocalUserIdx + numGuardCells;
+                    auto endGridIdx = endLocalUserIdx + numGuardCells;
+
+                    // Indexing is done, now prepare the update functor
+                    DataConnector& dc = Environment<>::get().DataConnector();
+                    auto& updatedField = *dc.get<T_UpdatedField>(T_UpdatedField::getName(), true);
+                    auto dataBox = updatedField.getDeviceDataBox();
+                    auto const& incidentField = *dc.get<T_IncidentField>(T_IncidentField::getName(), true);
+                    UpdateFunctor<decltype(dataBox), T_FunctorIncidentField> functor(incidentField.getUnit());
+                    functor.updatedField = dataBox;
+                    functor.currentStep = parameters.sourceTimeIteration;
+                    /* Shift between local grid idx and fractional global user idx:
+                     * global user idx = local grid idx + idxShift
+                     */
+                    functor.gridIdxShift = globalCellOffset - numGuardCells;
+
+                    /* Compute which components of the incident field are used,
+                     * which components of the updated field they contribute to and with which coefficients.
+                     */
+
+                    // dir0 is boundary normal axis, dir1 and dir2 are two other axes
+                    constexpr auto dir0 = T_axis;
+                    constexpr auto dir1 = (dir0 + 1) % 3;
+                    constexpr auto dir2 = (dir0 + 2) % 3;
+
+                    /* Incident field components to be used for the two terms.
+                     * Note the intentional cross combination here, the following calculations rely on it
+                     */
+                    functor.incidentComponent1 = dir2;
+                    functor.incidentComponent2 = dir1;
+
+                    // Coefficients for the respective terms
+                    float_X const coeffBase = curlCoefficient / cellSize[T_axis];
+                    functor.coeff1[dir1] = coeffBase;
+                    functor.coeff2[dir2] = -coeffBase;
+
+                    /* When updating the total field, the incident field is added to scattered field terms for
+                     * external neighbors which are half-cell shifted to the outside.
+                     * When updating the scattered field, the incident field is subtracted from total field terms for
+                     * internal neighbors which are half-cell shifted to the inside.
+                     */
+                    auto incidentFieldBaseShift = floatD_X::create(0.0_X);
+                    if(isUpdatedFieldTotal)
+                        incidentFieldBaseShift[dir0] = -0.5_X * parameters.direction;
+                    else
+                        incidentFieldBaseShift[dir0] = 0.5_X * parameters.direction;
+                    auto incidentFieldPositions = traits::FieldPosition<cellType::Yee, T_IncidentField>{}();
+                    functor.inCellShift1 = incidentFieldBaseShift + incidentFieldPositions[dir1];
+                    functor.inCellShift2 = incidentFieldBaseShift + incidentFieldPositions[dir2];
+
+                    PMACC_KERNEL(ApplyIncidentFieldKernel<numWorkers, PlaneSizeInSuperCells>{})
+                    (gridBlocks, numWorkers)(functor, beginGridIdx, endGridIdx);
+                }
+
+                /** Check preprequisites and update a field with the given incident field normally to the given axis
+                 *
+                 * Checks that the field solver type is supported.
+                 * After the sliding window started moving, does nothing.
+                 *
+                 * @tparam T_UpdatedField updated field type (FieldE or FieldB)
+                 * @tparam T_IncidentField incident field type (FieldB or FieldE)
+                 * @tparam T_FunctorIncidentField incident field source functor type
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 *
+                 * @param parameters parameters
+                 * @param curlCoefficient coefficient in front of the curl(incidentField) in the Maxwell's equations
+                 */
+                template<
+                    typename T_UpdatedField,
+                    typename T_IncidentField,
+                    typename T_FunctorIncidentField,
+                    uint32_t T_axis>
+                inline void callUpdateField(Parameters<T_axis> const& parameters, float_X const curlCoefficient)
+                {
+                    // Only Yee and YeePML with default curls are supported so far
+                    PMACC_CASSERT_MSG(
+                        _error_field_solver_does_not_support_incident_field,
+                        std::is_same<Solver, maxwellSolver::Yee<>>::value
+                            || std::is_same<Solver, maxwellSolver::YeePML<>>::value);
+
+                    // The implementation assumes the layout of the Yee grid where Ex is at (i + 0.5) cells in x
+                    auto const exPosition = traits::FieldPosition<cellType::Yee, FieldE>{}()[0];
+                    PMACC_VERIFY_MSG(
+                        exPosition[0] == 0.5_X,
+                        "incident field source does not support the Yee grid layout");
+
+                    // Incident field generation cannot be performed once the window started moving
+                    const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(
+                        static_cast<uint32_t>(parameters.sourceTimeIteration));
+                    bool const boxHasSlided = (numSlides != 0);
+                    if(!boxHasSlided)
+                        updateField<T_UpdatedField, T_IncidentField, T_FunctorIncidentField>(
+                            parameters,
+                            curlCoefficient);
+                }
+
+                /** Functor to apply contribution of the incident field source to the E field
+                 *
+                 * @tparam T_Source source type: Source<...> or None
+                 */
+                template<typename T_Source>
+                struct UpdateE;
+
+                //! Functor to apply contribution of the None incident field to the E field
+                template<>
+                struct UpdateE<None>
+                {
+                    /** Apply contribution of the None incident field to the E field
+                     *
+                     * @tparam T_Parameters parameters type
+                     */
+                    template<typename T_Parameters>
+                    void operator()(T_Parameters const&)
+                    {
+                    }
+                };
+
+                /** Functor to apply contribution of the incident field source to the E field
+                 *
+                 * @tparam T_FunctorIncidentE functor for the incident E field (not used)
+                 * @tparam T_FunctorIncidentB functor for the incident B field
+                 */
+                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+                struct UpdateE<Source<T_FunctorIncidentE, T_FunctorIncidentB>>
+                {
+                    /** Apply contribution of the incident field source to the E field
+                     *
+                     * @tparam T_Parameters parameters type
+                     *
+                     * @param parameters parameters
+                     */
+                    template<typename T_Parameters>
+                    void operator()(T_Parameters const& parameters)
+                    {
+                        auto const timeIncrement = parameters.timeIncrementIteration * DELTA_T;
+                        /* The update is structurally
+                         * E(t + timeIncrement) = E(t) + timeIncrement * c2 * curl(B(t + timeIncrement/2))
+                         */
+                        constexpr auto c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
+                        auto const curlCoefficient = timeIncrement * c2;
+                        using UpdatedField = picongpu::FieldE;
+                        using IncidentField = picongpu::FieldB;
+                        callUpdateField<UpdatedField, IncidentField, T_FunctorIncidentB>(parameters, curlCoefficient);
+                    }
+                };
+
+                /** Functor to apply contribution of the incident field source to the B field
+                 *
+                 * @tparam T_Source source type: Source<...> or None
+                 */
+                template<typename T_Source>
+                struct UpdateB;
+
+                //! Functor to apply contribution of the None incident field to the B field
+                template<>
+                struct UpdateB<None>
+                {
+                    /** Apply contribution of the None incident field to the B field
+                     *
+                     * @tparam T_Parameters parameters type
+                     */
+                    template<typename T_Parameters>
+                    void operator()(T_Parameters const&)
+                    {
+                    }
+                };
+
+                /** Functor to apply contribution of the incident field source to the B field
+                 *
+                 * @tparam T_FunctorIncidentE functor for the incident E field
+                 * @tparam T_FunctorIncidentB functor for the incident B field (not used)
+                 */
+                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+                struct UpdateB<Source<T_FunctorIncidentE, T_FunctorIncidentB>>
+                {
+                    /** Apply contribution of the incident field source to the B field
+                     *
+                     * @tparam T_Parameters parameters type
+                     *
+                     * @param parameters parameters
+                     */
+                    template<typename T_Parameters>
+                    void operator()(T_Parameters const& parameters)
+                    {
+                        auto const timeIncrement = parameters.timeIncrementIteration * DELTA_T;
+                        /* The update is structurally
+                         * B(t + timeIncrement) = B(t) - timeIncrement * curl(E(t + timeIncrement/2))
+                         */
+                        auto const curlCoefficient = -timeIncrement;
+                        using UpdatedField = picongpu::FieldB;
+                        using IncidentField = picongpu::FieldE;
+                        callUpdateField<UpdatedField, IncidentField, T_FunctorIncidentE>(parameters, curlCoefficient);
+                    }
+                };
+
+            } // namespace detail
+
+            /** Solver for incident fields to be called inside an FDTD Maxwell's solver
+             *
+             * It uses the total field / scattered field technique for FDTD solvers.
+             * Implementation is based on
+             * M. Potter, J.-P. Berenger. A Review of the Total Field/Scattered Field Technique for the FDTD Method.
+             * FERMAT, Volume 19, Article 1, 2017.
+             *
+             * The simulation area is virtually divided into two regions with a so-called Huygens surface.
+             * It is composed of six axis-aligned plane segments in 3d or four axis-aligned line segments in 2d.
+             * So it is parallel to the interface between the absorber area and internal non-absorbing area.
+             * The position of the Huygens surface is controlled by offset from the interface inwards.
+             * This offset is a sum of the user-specified gap and 0.75 of a cell into the internal area from each side.
+             * (The choice of 0.75 is arbitrary by this implementation, only required to be not in full or half cells).
+             * All gaps >= 0 are supported if the surface covers an internal volume of at least one full cell.
+             *
+             * In the internal volume bounded by the Huygens surface, the E and B fields are so-called full fields.
+             * They are a combined result of incoming incident fields and the internally happening dynamics.
+             * So these are normal fields used in a PIC simulation.
+             * Outside of the surface, the fields do not have the incident part, they are so-called scattered fields.
+             * Thus, there should normally be no relevant field-related physics happening there.
+             * Practically, for interpretation of the output a user could view this area as if the absorber was thicker
+             * in a way that the fields there are not immediately related to the fields in the internal area.
+             */
+            class Solver
+            {
+            public:
+                /** Create a solver instance
+                 *
+                 * @param cellDescription cell description for kernels
+                 */
+                Solver(MappingDesc const cellDescription) : cellDescription(cellDescription)
+                {
+                    /* Compute offsets from global domain borders, without guards.
+                     * These can end up being outside of the local domain, it is handled later.
+                     */
+                    absorber::Thickness absorberThickness = absorber::getGlobalThickness();
+                    for(uint32_t axis = 0u; axis < simDim; ++axis)
+                    {
+                        offsetMinBorder[axis] = absorberThickness(axis, 0) + GAP_FROM_ABSORBER[axis][0];
+                        offsetMaxBorder[axis] = absorberThickness(axis, 1) + GAP_FROM_ABSORBER[axis][1];
+                    }
+                }
+
+                /** Apply contribution of the incident B field to the E field update by one time step
+                 *
+                 * Must be called together with the updateE in the field solver.
+                 *
+                 * @param sourceTimeIteration time iteration at which the source incident B field
+                 *                            (not the target E field!) values will be calculated
+                 */
+                void updateE(float_X const sourceTimeIteration)
+                {
+                    updateE<0, XMin, XMax>(sourceTimeIteration);
+                    updateE<1, YMin, YMax>(sourceTimeIteration);
+                    updateE<2, ZMin, ZMax>(sourceTimeIteration);
+                }
+
+                /** Apply contribution of the incident E field to the B field update by half a time step
+                 *
+                 * Must be called together with the updateBHalf in the field solver.
+                 *
+                 * @param sourceTimeIteration time iteration at which the source incident E field
+                 *                            (not the target B field!) values will be calculated
+                 * @warning when calling this method for the second half of the B field update, the sourceTimeIteration
+                 *          value must be the same as for the first half. Otherwise the halves would not match each
+                 *          other, and it will cause errors by a similar mechanism as #3418 did for PML.
+                 */
+                void updateBHalf(float_X const sourceTimeIteration)
+                {
+                    updateBHalf<0, XMin, XMax>(sourceTimeIteration);
+                    updateBHalf<1, YMin, YMax>(sourceTimeIteration);
+                    updateBHalf<2, ZMin, ZMax>(sourceTimeIteration);
+                }
+
+            private:
+                /** Apply contribution of the incident B field to the E field update by one time step
+                 *
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_MinSource source type for the min boundary along the axis: Source<...> or None
+                 * @tparam T_MaxSource source type for the max boundary along the axis: Source<...> or None
+                 *
+                 * @param sourceTimeIteration time iteration at which the source incident B field
+                 *                            (not the target E field!) values will be calculated
+                 */
+                template<uint32_t T_axis, typename T_MinSource, typename T_MaxSource>
+                void updateE(float_X const sourceTimeIteration)
+                {
+                    auto parameters = detail::Parameters<T_axis>{cellDescription};
+                    parameters.offsetMinBorder = offsetMinBorder;
+                    parameters.offsetMaxBorder = offsetMaxBorder;
+                    parameters.direction = 1.0_X;
+                    parameters.sourceTimeIteration = sourceTimeIteration;
+                    parameters.timeIncrementIteration = 1.0_X;
+                    using UpdateMin = typename detail::UpdateE<T_MinSource>;
+                    UpdateMin{}(parameters);
+                    parameters.direction = -1.0_X;
+                    using UpdateMax = typename detail::UpdateE<T_MaxSource>;
+                    UpdateMax{}(parameters);
+                }
+
+                /** Apply contribution of the incident E field to the B field update by half a time step
+                 *
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_MinSource source type for the min boundary along the axis: Source<...> or None
+                 * @tparam T_MaxSource source type for the max boundary along the axis: Source<...> or None
+                 *
+                 * @param sourceTimeIteration time iteration at which the source incident E field
+                 *                            (not the target B field!) values will be calculated
+                 */
+                template<uint32_t T_axis, typename T_MinSource, typename T_MaxSource>
+                void updateBHalf(float_X const sourceTimeIteration)
+                {
+                    auto parameters = detail::Parameters<T_axis>{cellDescription};
+                    parameters.offsetMinBorder = offsetMinBorder;
+                    parameters.offsetMaxBorder = offsetMaxBorder;
+                    parameters.direction = 1.0_X;
+                    parameters.sourceTimeIteration = sourceTimeIteration;
+                    parameters.timeIncrementIteration = 0.5_X;
+                    using UpdateMin = typename detail::UpdateB<T_MinSource>;
+                    UpdateMin{}(parameters);
+                    parameters.direction = -1.0_X;
+                    using UpdateMax = typename detail::UpdateB<T_MaxSource>;
+                    UpdateMax{}(parameters);
+                }
+
+                //! ZMin type to be used, shadows ZMin from .param on purpose to handle 2d and 3d uniformly
+                using ZMin = detail::ZMin;
+
+                //! ZMax type to be used, shadows ZMax from .param on purpose to handle 2d and 3d uniformly
+                using ZMax = detail::ZMax;
+
+                /** Offset of the Huygens surface from min border of the global domain
+                 *
+                 * The offset is from the start of CORE + BORDER area.
+                 * Counted in full cells, the surface is additionally offset by 0.75 cells
+                 */
+                pmacc::DataSpace<simDim> offsetMinBorder;
+
+                /** Offset of the Huygens surface from max border of the global domain
+                 *
+                 * The offset is from the end of CORE + BORDER area.
+                 * Counted in full cells, the surface is additionally offset by 0.75 cells
+                 */
+                pmacc::DataSpace<simDim> offsetMaxBorder;
+
+                //! Cell description for kernels
+                MappingDesc const cellDescription;
+            };
+
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -21,12 +21,12 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/Fields.hpp"
-#include "picongpu/fields/incidentField/Solver.kernel"
-#include "picongpu/fields/incidentField/Profiles.hpp"
-#include "picongpu/fields/incidentField/Traits.hpp"
 #include "picongpu/fields/MaxwellSolver/Solvers.def"
+#include "picongpu/fields/absorber/Absorber.hpp"
+#include "picongpu/fields/incidentField/Profiles.hpp"
+#include "picongpu/fields/incidentField/Solver.kernel"
+#include "picongpu/fields/incidentField/Traits.hpp"
 
 #include <pmacc/math/Vector.hpp>
 

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -235,11 +235,15 @@ namespace picongpu
                     uint32_t T_axis>
                 inline void callUpdateField(Parameters<T_axis> const& parameters, float_X const curlCoefficient)
                 {
-                    // Only Yee and YeePML with default curls are supported so far
+                    /* Only Yee and YeePML with default curls are supported so far.
+                     * Make the condition depend on the template parameters so that it is only compile-time checked
+                     * when this part is instantiated, i.e. for non-None sources.
+                     */
                     PMACC_CASSERT_MSG(
                         _error_field_solver_does_not_support_incident_field,
-                        std::is_same<Solver, maxwellSolver::Yee<>>::value
-                            || std::is_same<Solver, maxwellSolver::YeePML<>>::value);
+                        (std::is_same<Solver, maxwellSolver::Yee<>>::value
+                         || std::is_same<Solver, maxwellSolver::YeePML<>>::value)
+                            && (sizeof(T_UpdatedField*) != 0));
 
                     // The implementation assumes the layout of the Yee grid where Ex is at (i + 0.5) cells in x
                     auto const exPosition = traits::FieldPosition<cellType::Yee, FieldE>{}()[0];

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -1,0 +1,147 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace detail
+            {
+                /** Helper functor for in-kernel update of the given field using the given incident field functor
+                 *
+                 * Performs update by adding two terms with the incident field.
+                 * The positions, indices and coefficients for these terms are determined by members.
+                 *
+                 * @tparam T_UpdatedFieldBox updated field box type
+                 * @tparam T_FunctorIncidentField incident field source functor type
+                 */
+                template<typename T_UpdatedFieldBox, typename T_FunctorIncidentField>
+                struct UpdateFunctor
+                {
+                    /** Create an update functor instance
+                     *
+                     * @param unitField conversion factor from SI to internal units,
+                     *                  field_internal = field_SI / unitField
+                     */
+                    HDINLINE UpdateFunctor(float3_64 const unitField)
+                        : functorIncidentField(unitField)
+                        , coeff1(float3_X::create(0.0_X))
+                        , coeff2(float3_X::create(0.0_X))
+                    {
+                    }
+
+                    /** Update field at the given grid index
+                     *
+                     * @param gridIdx grid index in the local domain, including guards
+                     */
+                    HDINLINE void operator()(pmacc::DataSpace<simDim> const& gridIdx)
+                    {
+                        // fractional since the later shift is fractional
+                        auto const cellIdx
+                            = pmacc::algorithms::precisionCast::precisionCast<float_X>(gridIdx + gridIdxShift);
+                        auto const incidentField
+                            = coeff1 * functorIncidentField(cellIdx + inCellShift1, currentStep)[incidentComponent1]
+                            + coeff2 * functorIncidentField(cellIdx + inCellShift2, currentStep)[incidentComponent2];
+                        updatedField(gridIdx) += incidentField;
+                    }
+
+                    //! Updated field box
+                    T_UpdatedFieldBox updatedField;
+
+                    //! Incident field functor
+                    T_FunctorIncidentField functorIncidentField;
+
+                    //! Indices of the incident field components for the two terms
+                    uint32_t incidentComponent1, incidentComponent2;
+
+                    //! Coefficients for two functorIncidentField invocations
+                    float3_X coeff1, coeff2;
+
+                    //! Shifts inside the cell for two functorIncidentField invocations, in cells
+                    floatD_X inCellShift1, inCellShift2;
+
+                    //! Index shift: user cell idx = gridIdx + gridIdxShirt
+                    pmacc::DataSpace<simDim> gridIdxShift;
+
+                    //! Current time step, in iterations; can be fractional
+                    float_X currentStep;
+                };
+
+
+                /** Kernel to apply incident field
+                 *
+                 * @tparam T_numWorkers number of workers
+                 * @tparam T_BlockDescription domain description
+                 */
+                template<uint32_t T_numWorkers, typename T_BlockDescription>
+                struct ApplyIncidentFieldKernel
+                {
+                    /** Run the incident field kernel
+                     *
+                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_UpdateFunctor update functor type
+                     *
+                     * @param acc alpaka accelerator
+                     * @param functor update functor
+                     * @param beginGridIdx begin active grid index, in the local domain with guards
+                     * @param endGridIdx end active grid index, in the local domain with guards
+                     */
+                    template<typename T_Acc, typename T_UpdateFunctor>
+                    HDINLINE void operator()(
+                        T_Acc& acc,
+                        T_UpdateFunctor functor,
+                        DataSpace<simDim> beginGridIdx,
+                        DataSpace<simDim> endGridIdx) const
+                    {
+                        constexpr uint32_t planeSize = pmacc::math::CT::volume<T_BlockDescription>::type::value;
+                        const uint32_t workerIdx = cupla::threadIdx(acc).x;
+
+                        // Offset of the superCell (in cells, without any guards) to the origin of the local domain
+                        DataSpace<simDim> supercellOffsetCells
+                            = DataSpace<simDim>(cupla::blockIdx(acc)) * SuperCellSize::toRT();
+
+                        mappings::threads::ForEachIdx<mappings::threads::IdxConfig<planeSize, T_numWorkers>>{
+                            workerIdx}([&](uint32_t const linearIdx, uint32_t const) {
+                            auto cellIdxInSuperCell
+                                = DataSpaceOperations<simDim>::template map<T_BlockDescription>(linearIdx);
+                            auto const gridIdx = beginGridIdx + supercellOffsetCells + cellIdxInSuperCell;
+
+                            // The index may be outside since the active area is not generally a multiple of block size
+                            bool isInside = true;
+                            for(uint32_t d = 0; d < simDim; d++)
+                                isInside = isInside && (gridIdx[d] < endGridIdx[d]);
+                            if(isInside)
+                                functor(gridIdx);
+                        });
+                    }
+                };
+
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -85,7 +85,7 @@ namespace picongpu
                     //! Shifts inside the cell for two functorIncidentField invocations, in cells
                     floatD_X inCellShift1, inCellShift2;
 
-                    //! Index shift: user cell idx = gridIdx + gridIdxShirt
+                    //! Index shift: totalCellIdx (that a user functor gets) = gridIdx + gridIdxShirt
                     pmacc::DataSpace<simDim> gridIdxShift;
 
                     //! Current time step, in iterations; can be fractional

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
+
 #include "picongpu/fields/incidentField/Profiles.hpp"
 
 

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -1,0 +1,83 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+#include "picongpu/fields/incidentField/Profiles.hpp"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace detail
+            {
+                /** Get ZMin incident field source type
+                 *
+                 * The resulting field source is set as ::type.
+                 * Implementation for 3d returns ZMin from incidentField.param.
+                 *
+                 * @tparam T_is3d if the simulation is 3d or not
+                 */
+                template<bool T_is3d = true>
+                struct GetZMin
+                {
+                    using type = ZMin;
+                };
+
+                //! Get None incident field source type as ZMin in the non-3d case
+                template<>
+                struct GetZMin<false>
+                {
+                    using type = None;
+                };
+
+                /** Get ZMax incident field source type
+                 *
+                 * The resulting field source is set as ::type.
+                 * Implementation for 3d returns ZMax from incidentField.param.
+                 *
+                 * @tparam T_is3d is the simulation 3d
+                 */
+                template<bool T_is3d = true>
+                struct GetZMax
+                {
+                    using type = ZMax;
+                };
+
+                //! Get None incident field source type as ZMax in the non-3d case
+                template<>
+                struct GetZMax<false>
+                {
+                    using type = None;
+                };
+
+                //! ZMin incident field type alias adjusted for dimensionality
+                using ZMin = GetZMin<simDim == 3>::type;
+
+                //! ZMax incident field type alias adjusted for dimensionality
+                using ZMax = GetZMax<simDim == 3>::type;
+
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -52,11 +52,12 @@ namespace picongpu
 
                 /** Calculate incident field E_inc(r, t) for a source
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  * @return incident field value in internal units
                  */
-                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
@@ -82,11 +83,12 @@ namespace picongpu
 
                 /** Calculate incident field B_inc(r, t) for a source
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  * @return incident field value in internal units
                  */
-                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
@@ -120,7 +122,7 @@ namespace picongpu
             constexpr uint32_t GAP_FROM_ABSORBER[3][2] = {
                 {0, 0}, // x direction [negative, positive]
                 {0, 0}, // y direction [negative, positive]
-                {0, 0}  // z direction [negative, positive]
+                {0, 0} // z direction [negative, positive]
             };
 
         } // namespace incidentField

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -1,0 +1,128 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file incidentField.param
+ *
+ * Load incident field parameters
+ */
+
+#pragma once
+
+#include "picongpu/fields/incidentField/Profiles.def"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            /** Functor to set values of incident E field
+             */
+            class FunctorIncidentE
+            {
+            public:
+                /* We use this to calculate your SI input back to our unit system */
+                PMACC_ALIGN(m_unitField, const float3_64);
+
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                {
+                }
+
+                /** Calculate incident field E_inc(r, t) for a source
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 * @return incident field value in internal units
+                 */
+                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                {
+                    auto const fieldSI = float3_X(0.0_X, 0.0_X, 0.0_X);
+                    return fieldSI / precisionCast<float_X>(m_unitField);
+                }
+            };
+
+            /** Functor to set values of incident B field
+             */
+            class FunctorIncidentB
+            {
+            public:
+                /* We use this to calculate your SI input back to our unit system */
+                PMACC_ALIGN(m_unitField, const float3_64);
+
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                {
+                }
+
+                /** Calculate incident field B_inc(r, t) for a source
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 * @return incident field value in internal units
+                 */
+                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                {
+                    auto const fieldSI = float3_X(0.0_X, 0.0_X, 0.0_X);
+                    return fieldSI / precisionCast<float_X>(m_unitField);
+                }
+            };
+
+            /** Source of incident E and B fields.
+             *
+             * Each source type combines functors for incident field E and B, which must be consistent to each other.
+             */
+            using MySource = Source<FunctorIncidentE, FunctorIncidentB>;
+
+            /**@{*/
+            /** Incident field source types along each boundary, these 6 types (or aliases) are required.
+             *
+             * Each type has to be either Source<> or None.
+             */
+            using XMin = None;
+            using XMax = None;
+            using YMin = None;
+            using YMax = None;
+            using ZMin = None;
+            using ZMax = None;
+            /**@}*/
+
+            /** Gap of the Huygence surface from absorber
+             *
+             * The gap is in cells, counted from the corrresponding boundary in the normal direction pointing inwards.
+             * It is similar to specifying absorber cells, just this layer is further inside.
+             */
+            constexpr uint32_t GAP_FROM_ABSORBER[3][2] = {
+                {0, 0}, // x direction [negative, positive]
+                {0, 0}, // y direction [negative, positive]
+                {0, 0}  // z direction [negative, positive]
+            };
+
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/examples/IncidentField/cmakeFlags
+++ b/share/picongpu/examples/IncidentField/cmakeFlags
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch, Sergei Bastrakov
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+# Test 3d and 2d
+flags[0]=""
+flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_DIMENSION=DIM2'"
+
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
@@ -1,0 +1,77 @@
+# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="0:10:00"
+
+TBG_devices_x=1
+TBG_devices_y=1
+TBG_devices_z=1
+
+TBG_numCells=128
+TBG_gridSize="!TBG_numCells !TBG_numCells !TBG_numCells"
+TBG_steps="1000"
+
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+# png image output (rough electron density and laser preview)
+TBG_png="--e_png.period 100                     \
+           --e_png.axis yx --e_png.slicePoint 0.5 \
+           --e_png.folder png"
+
+
+# file I/O with openPMD-HDF5
+TBG_openPMD="--openPMD.period 100   \
+             --openPMD.file simData \
+             --openPMD.ext h5"
+
+TBG_plugins="--fields_energy.period 10 !TBG_png"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
@@ -46,7 +46,7 @@ TBG_steps="1000"
 #################################
 
 # png image output (rough electron density and laser preview)
-TBG_png="--e_png.period 100                     \
+TBG_png="--e_png.period 20                     \
            --e_png.axis yx --e_png.slicePoint 0.5 \
            --e_png.folder png"
 

--- a/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
@@ -1,0 +1,80 @@
+# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="0:10:00"
+
+TBG_devices_x=2
+TBG_devices_y=2
+TBG_devices_z=1
+
+# Num cells needs to be changed together with the laser center
+TBG_numCells=128
+TBG_gridSize="!TBG_numCells !TBG_numCells !TBG_numCells"
+TBG_steps="600"
+
+TBG_periodic="--periodic 0 0 1"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+# png image output (rough electron density and laser preview)
+TBG_png="--e_png.period 10                     \
+           --e_png.axis yx --e_png.slicePoint 0.5 \
+           --e_png.folder png"
+
+
+# file I/O with openPMD-HDF5
+TBG_openPMD="--openPMD.period 100   \
+             --openPMD.file simData \
+             --openPMD.ext h5"
+
+TBG_plugins="--fields_energy.period 10 !TBG_png"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
@@ -48,7 +48,7 @@ TBG_periodic="--periodic 0 0 1"
 #################################
 
 # png image output (rough electron density and laser preview)
-TBG_png="--e_png.period 10                     \
+TBG_png="--e_png.period 20                     \
            --e_png.axis yx --e_png.slicePoint 0.5 \
            --e_png.folder png"
 

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/dimension.param
@@ -1,0 +1,31 @@
+/* Copyright 2014-2021 Axel Huebl, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef PARAM_DIMENSION
+#    define PARAM_DIMENSION DIM3
+#endif
+
+#define SIMDIM PARAM_DIMENSION
+
+namespace picongpu
+{
+    constexpr uint32_t simDim = SIMDIM;
+} // namespace picongpu

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/fieldSolver.param
@@ -1,0 +1,64 @@
+/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the field solver.
+ *
+ * Select the numerical Maxwell solver (e.g. Yee's method).
+ *
+ * \attention
+ * Currently, the laser initialization in PIConGPU is implemented to work with the standard Yee solver.
+ * Using a solver of higher order will result in a slightly increased laser amplitude and energy than expected.
+ *
+ */
+
+#pragma once
+
+#include "picongpu/fields/MaxwellSolver/Solvers.def"
+
+#include <boost/preprocessor/punctuation/comma.hpp>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        /** FieldSolver
+         *
+         * Field Solver Selection (note <> for some solvers):
+         *  - Yee<> : Standard Yee solver approximating derivatives with respect to time and
+         * space by second order finite differences.
+         *  - YeePML<>: Standard Yee solver using Perfectly Matched Layer Absorbing Boundary
+         * Conditions (PML)
+         *  - Lehe<>: Num. Cherenkov free field solver in a chosen direction
+         *  - LehePML<>: Num. Cherenkov free field solver in a chosen direction
+         *               using Perfectly Matched Layer Absorbing Boundary Conditions (PML)
+         *  - ArbitraryOrderFDTD<4>: Solver using 4 neighbors to each direction to approximate
+         * *spatial* derivatives by finite differences. The number of neighbors can be changed from 4 to any positive,
+         * integer number. The order of the solver will be twice the number of neighbors in each direction. Yee's
+         * method is a special case of this using one neighbor to each direction.
+         *  - ArbitraryOrderFDTDPML<4>: ArbitraryOrderFDTD solver using Perfectly Matched Layer
+         *                              Absorbing Boundary Conditions (PML)
+         *  - None: disable the vacuum update of E and B
+         */
+        using Solver = maxwellSolver::YeePML<>;
+
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
@@ -1,0 +1,105 @@
+/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** This setup is based on section 7.11.1 of
+         *  A. Taflove, S.C. Hagness. Computational Electrodynamics
+         *  The Finite-Difference Time-Domain Method. 3rd Edition.
+         *  The difference is we consider both 2D and 3D cases,
+         *  and grid size is increased due to our absorber being part of
+         *  the simulation area, not located outside of it as in the book.
+         */
+
+        constexpr float_64 CELL_SIZE_SI = 1.0e-3; // 1 mm
+
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = CELL_SIZE_SI;
+        /** equals Y
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Duration of one timestep is just below the CFL limit
+         *  unit: seconds */
+        constexpr float_64 CFL_RATIO = 0.999;
+        constexpr float_64 SQRT_3 = 1.73205080757;
+        constexpr float_64 DELTA_T_SI = CFL_RATIO * CELL_SIZE_SI / (SPEED_OF_LIGHT_SI * SQRT_3);
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneous, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+
+    } // namespace SI
+
+    //! Define the size of the absorbing zone (in cells) for both exponential
+    //! absorber and PML, a compile-time parameter
+#ifndef PARAM_ABSORBER_SIZE
+#    define PARAM_ABSORBER_SIZE 8
+#endif
+    constexpr uint32_t ABSORBER_SIZE = PARAM_ABSORBER_SIZE;
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
+        {ABSORBER_SIZE, ABSORBER_SIZE}, /*x direction [negative,positive]*/
+        {ABSORBER_SIZE, ABSORBER_SIZE}, /*y direction [negative,positive]*/
+        {ABSORBER_SIZE, ABSORBER_SIZE} /*z direction [negative,positive]*/
+    }; // unit: number of cells
+
+    //! Define the strength of the exponential absorber only
+    constexpr float_X ABSORBER_STRENGTH_VALUE = 1.0e-3;
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
+        {ABSORBER_STRENGTH_VALUE, ABSORBER_STRENGTH_VALUE}, /*x direction [negative,positive]*/
+        {ABSORBER_STRENGTH_VALUE, ABSORBER_STRENGTH_VALUE}, /*y direction [negative,positive]*/
+        {ABSORBER_STRENGTH_VALUE, ABSORBER_STRENGTH_VALUE} /*z direction [negative,positive]*/
+    }; // unit: none
+
+    /** When to move the co-moving window.
+     *  An initial pseudo particle, flying with the speed of light,
+     *  is fired at the begin of the simulation.
+     *  When it reaches movePoint % of the absolute(*) simulation area,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
+     *            when you use the co-moving window
+     *  0.75 means only 75% of simulation area is used for real simulation
+     *
+     * Warning: this variable is deprecated, but currently still required for
+     * building purposes. Please keep the variable here. In case a moving window
+     * is enabled in your .cfg file, please set the move point using the
+     * 'windowMovePoint' parameter in that file, its default value is movePoint.
+     */
+    constexpr float_64 movePoint = 0.90;
+
+} // namespace picongpu

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -1,0 +1,235 @@
+/* Copyright 2020-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file incidentField.param
+ *
+ * Load incident field parameters
+ */
+
+#pragma once
+
+#include "picongpu/fields/incidentField/Profiles.def"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            class FunctorBase
+            {
+            public:
+                // Constants for pulse generation
+                static constexpr float_64 TIME_PERIOD_SI = 20 * SI::DELTA_T_SI;
+                static constexpr float_64 WAVE_LENGTH_SI = 2.0 * PI * TIME_PERIOD_SI * SI::SPEED_OF_LIGHT_SI;
+                static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+                    * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
+                static constexpr float_64 A0 = 8.0;
+                static constexpr float_64 AMPLITUDE_SI = A0 * UNITCONV_A0_to_Amplitude_SI;
+                static constexpr uint32_t DURATION_STEPS = 300;
+                /// These need to be changed together with grid size
+                static constexpr uint32_t CENTER_X_CELLS = 80;
+                static constexpr uint32_t WIDTH_X_CELLS = 40;
+                static constexpr uint32_t CENTER_Y_CELLS = 40;
+                static constexpr uint32_t WIDTH_Y_CELLS = 20;
+
+                HDINLINE float_X getTimeComponentSI(const float_X currentStep) const
+                {
+                    auto const durationStepsMiddle = DURATION_STEPS / 2;
+                    auto const normalizedDuration = (currentStep - durationStepsMiddle) / durationStepsMiddle;
+                    auto const timeSI = currentStep * SI::DELTA_T_SI;
+                    const float_X sinArg = precisionCast<float_X>(timeSI / TIME_PERIOD_SI * 2.0 * PI);
+                    return AMPLITUDE_SI * math::exp(-normalizedDuration * normalizedDuration) * math::sin(sinArg);
+                }
+
+                HDINLINE float_X getTransversalXComponentSI(const floatD_X& cellIdx) const
+                {
+                    auto const normalizedX = (cellIdx[0] - CENTER_X_CELLS) / WIDTH_X_CELLS;
+                    return math::exp(-normalizedX * normalizedX);
+                }
+
+                HDINLINE float_X getTransversalYComponentSI(const floatD_X& cellIdx) const
+                {
+                    auto const normalizedY = (cellIdx[1] - CENTER_Y_CELLS) / WIDTH_Y_CELLS;
+                    return math::exp(-normalizedY * normalizedY);
+                }
+            };
+
+            /** Functor to set values of incident E field
+             */
+            class FunctorXMinIncidentE : public FunctorBase
+            {
+            public:
+                /* We use this to calculate your SI input back to our unit system */
+                PMACC_ALIGN(m_unitField, const float3_64);
+
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorXMinIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                {
+                }
+
+                /** Calculate incident field E_inc(r, t) for a source
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 */
+                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                {
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(cellIdx);
+                    auto const fieldSI = float3_X(0.0_X, valueSI, 0.0_X);
+                    return fieldSI / precisionCast<float_X>(m_unitField);
+                }
+            };
+
+            /** Functor to set values of incident B field
+             */
+            class FunctorXMinIncidentB : public FunctorBase
+            {
+            public:
+                /* We use this to calculate your SI input back to our unit system */
+                PMACC_ALIGN(m_unitField, const float3_64);
+
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorXMinIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                {
+                }
+
+                /** Calculate incident field B_inc(r, t) for a source
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 */
+                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                {
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(cellIdx);
+                    auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
+                    return fieldSI / precisionCast<float_X>(m_unitField);
+                }
+            };
+
+            /** Functor to set values of incident E field
+             */
+            class FunctorYMaxIncidentE : public FunctorBase
+            {
+            public:
+                /* We use this to calculate your SI input back to our unit system */
+                PMACC_ALIGN(m_unitField, const float3_64);
+
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorYMaxIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                {
+                }
+
+                /** Calculate incident field E_inc(r, t) for a source
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 */
+                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                {
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(cellIdx);
+                    auto const fieldSI = float3_X(valueSI, 0.0_X, 0.0_X);
+                    return fieldSI / precisionCast<float_X>(m_unitField);
+                }
+            };
+
+            /** Functor to set values of incident B field
+             */
+            class FunctorYMaxIncidentB : public FunctorBase
+            {
+            public:
+                /* We use this to calculate your SI input back to our unit system */
+                PMACC_ALIGN(m_unitField, const float3_64);
+
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE FunctorYMaxIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                {
+                }
+
+                /** Calculate incident field B_inc(r, t) for a source
+                 *
+                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 */
+                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                {
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(cellIdx);
+                    auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
+                    return fieldSI / precisionCast<float_X>(m_unitField);
+                }
+            };
+
+            /** Source of incident E and B fields.
+             *
+             * Each source type combines functors for incident field E and B, which must be consistent to each other.
+             */
+            using MyXMinSource = Source<FunctorXMinIncidentE, FunctorXMinIncidentB>;
+
+            /** Another source of incident E and B fields.
+             *
+             * Each source type combines functors for incident field E and B, which must be consistent to each other.
+             */
+            using MyYMaxSource = Source<FunctorYMaxIncidentE, FunctorYMaxIncidentB>;
+
+            /**@{*/
+            /** Incident field source types along each boundary, these 6 types (or aliases) are required.
+             *
+             * Each type has to be either Source<> or None.
+             *
+             * Here we generate a plane wave from the X min border.
+             */
+            using XMin = MyXMinSource;
+            using XMax = None;
+            using YMin = None;
+            using YMax = MyYMaxSource;
+            using ZMin = None;
+            using ZMax = None;
+            /**@}*/
+
+            /** Gap of the Huygence surface from absorber
+             *
+             * The gap is in cells, counted from the corrresponding boundary in the normal direction pointing inwards.
+             * It is similar to specifying absorber cells, just this layer is further inside.
+             */
+            constexpr uint32_t GAP_FROM_ABSORBER[3][2] = {
+                {0, 0}, // x direction [negative, positive]
+                {0, 0}, // y direction [negative, positive]
+                {0, 0} // z direction [negative, positive]
+            };
+
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -59,15 +59,15 @@ namespace picongpu
                     return AMPLITUDE_SI * math::exp(-normalizedDuration * normalizedDuration) * math::sin(sinArg);
                 }
 
-                HDINLINE float_X getTransversalXComponentSI(const floatD_X& cellIdx) const
+                HDINLINE float_X getTransversalXComponentSI(const floatD_X& totalCellIdx) const
                 {
-                    auto const normalizedX = (cellIdx[0] - CENTER_X_CELLS) / WIDTH_X_CELLS;
+                    auto const normalizedX = (totalCellIdx[0] - CENTER_X_CELLS) / WIDTH_X_CELLS;
                     return math::exp(-normalizedX * normalizedX);
                 }
 
-                HDINLINE float_X getTransversalYComponentSI(const floatD_X& cellIdx) const
+                HDINLINE float_X getTransversalYComponentSI(const floatD_X& totalCellIdx) const
                 {
-                    auto const normalizedY = (cellIdx[1] - CENTER_Y_CELLS) / WIDTH_Y_CELLS;
+                    auto const normalizedY = (totalCellIdx[1] - CENTER_Y_CELLS) / WIDTH_Y_CELLS;
                     return math::exp(-normalizedY * normalizedY);
                 }
             };
@@ -91,12 +91,13 @@ namespace picongpu
 
                 /** Calculate incident field E_inc(r, t) for a source
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(cellIdx);
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(totalCellIdx);
                     auto const fieldSI = float3_X(0.0_X, valueSI, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -121,12 +122,13 @@ namespace picongpu
 
                 /** Calculate incident field B_inc(r, t) for a source
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(cellIdx);
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(totalCellIdx);
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -151,12 +153,13 @@ namespace picongpu
 
                 /** Calculate incident field E_inc(r, t) for a source
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(cellIdx);
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(totalCellIdx);
                     auto const fieldSI = float3_X(valueSI, 0.0_X, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -181,12 +184,13 @@ namespace picongpu
 
                 /** Calculate incident field B_inc(r, t) for a source
                  *
-                 * @param cellIdx cell index in the global domain, note that it is fractional
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
                  * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& cellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(cellIdx);
+                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(totalCellIdx);
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/pml.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/pml.param
@@ -1,0 +1,147 @@
+/* Copyright 2019-2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the perfectly matched layer (PML).
+ *
+ * To enable PML use YeePML, LehePML or ArbitraryOrderFDTDPML field solver.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            namespace Pml
+            {
+                /* The parameters in this file are only used if field solver is YeePML or LehePML.
+                 * The original paper on this approach is J.A. Roden, S.D. Gedney.
+                 * Convolution PML (CPML): An efficient FDTD implementation of the CFS - PML
+                 * for arbitrary media. Microwave and optical technology letters. 27 (5),
+                 * 334-339 (2000).
+                 * https://doi.org/10.1002/1098-2760(20001205)27:5%3C334::AID-MOP14%3E3.0.CO;2-A
+                 * Our implementation based on a more detailed description in section 7.9 of
+                 * the book A. Taflove, S.C. Hagness. Computational Electrodynamics.
+                 * The Finite-Difference Time-Domain Method. Third Edition. Artech house,
+                 * Boston (2005), referred to as [Taflove, Hagness].
+                 */
+                constexpr uint32_t THICKNESS = 8;
+
+                /** Thickness of the absorbing layer, in number of cells
+                 *
+                 * PML is located inside the global simulation area, near the outer borders.
+                 * Setting size to 0 results in disabling absorption at the corresponding
+                 * boundary. Normally thickness is between 6 and 16 cells, with larger
+                 * values providing less reflections.
+                 * 8 cells should be good enough for most simulations. There are no
+                 * requirements on thickness being a multiple of the supercell size.
+                 * It is only required that PML is small enough to fit near-boundary local
+                 * domains at all time steps.
+                 * Unit: number of cells.
+                 */
+                constexpr uint32_t NUM_CELLS[3][2] = {
+                    {THICKNESS, THICKNESS}, // x direction [negative, positive]
+                    {THICKNESS, THICKNESS}, // y direction [negative, positive]
+                    {THICKNESS, THICKNESS} // z direction [negative, positive]
+                };
+
+                /** Order of polynomial grading for artificial electric conductivity and
+                 *  stretching coefficient
+                 *
+                 * The conductivity (sigma) is polynomially scaling from 0 at the internal
+                 * border of PML to the maximum value (defined below) at the external
+                 * border. The stretching coefficient (kappa) scales from 1 to the
+                 * corresponding maximum value (defined below) with the same polynomial.
+                 * The grading is given in [Taflove, Hagness], eq. (7.60a, b), with
+                 * the order denoted 'm'.
+                 * Must be >= 0. Normally between 3 and 4, not required to be integer.
+                 * Unitless.
+                 */
+                constexpr float_64 SIGMA_KAPPA_GRADING_ORDER = 4.0;
+
+                // [Taflove, Hagness], eq. (7.66)
+                constexpr float_64 SIGMA_OPT_SI[3]
+                    = {0.8 * (SIGMA_KAPPA_GRADING_ORDER + 1.0) / (SI::Z0_SI * SI::CELL_WIDTH_SI),
+                       0.8 * (SIGMA_KAPPA_GRADING_ORDER + 1.0) / (SI::Z0_SI * SI::CELL_HEIGHT_SI),
+                       0.8 * (SIGMA_KAPPA_GRADING_ORDER + 1.0) / (SI::Z0_SI * SI::CELL_DEPTH_SI)};
+
+                // Muptiplier to express SIGMA_MAX_SI with SIGMA_OPT_SI
+                constexpr float_64 SIGMA_OPT_MULTIPLIER = 1.0;
+
+                /** Max value of artificial electric conductivity in PML
+                 *
+                 * Components correspond to directions: element 0 corresponds to absorption
+                 * along x direction, 1 = y, 2 = z. Grading is described in comments for
+                 * SIGMA_KAPPA_GRADING_ORDER.
+                 * Too small values lead to significant reflections from the external
+                 * border, too large - to reflections due to discretization errors.
+                 * Artificial magnetic permeability will be chosen to perfectly match this.
+                 * Must be >= 0. Normally between 0.7 * SIGMA_OPT_SI and 1.1 * SIGMA_OPT_SI.
+                 * Unit: siemens / m.
+                 */
+                constexpr float_64 SIGMA_MAX_SI[3]
+                    = {SIGMA_OPT_SI[0] * SIGMA_OPT_MULTIPLIER,
+                       SIGMA_OPT_SI[1] * SIGMA_OPT_MULTIPLIER,
+                       SIGMA_OPT_SI[2] * SIGMA_OPT_MULTIPLIER};
+
+                /** Max value of coordinate stretching coefficient in PML
+                 *
+                 * Components correspond to directions: element 0 corresponds to absorption
+                 * along x direction, 1 = y, 2 = z. Grading is described in comments for
+                 * SIGMA_KAPPA_GRADING_ORDER.
+                 * Must be >= 1. For relatively homogeneous domains 1.0 is a reasonable value.
+                 * Highly elongated domains can have better absorption with values between
+                 * 7.0 and 20.0, for example, see section 7.11.2 in [Taflove, Hagness].
+                 * Unitless.
+                 */
+                constexpr float_64 KAPPA_MAX[3] = {1.0, 1.0, 1.0};
+
+                /** Order of polynomial grading for complex frequency shift
+                 *
+                 * The complex frequency shift (alpha) is polynomially downscaling from the
+                 * maximum value (defined below) at the internal border of PML to 0 at the
+                 * external border. The grading is given in [Taflove, Hagness], eq. (7.79),
+                 * with the order denoted 'm_a'.
+                 * Must be >= 0. Normally values are around 1.0.
+                 * Unitless.
+                 */
+                constexpr float_64 ALPHA_GRADING_ORDER = 1.0;
+
+                /** Complex frequency shift in PML
+                 *
+                 * Components correspond to directions: element 0 corresponds to absorption
+                 * along x direction, 1 = y, 2 = z. Setting it to 0 will make PML behave
+                 * as uniaxial PML. Setting it to a positive value helps to attenuate
+                 * evanescent modes, but can degrade absorption of propagating modes, as
+                 * described in section 7.7 and 7.11.3 in [Taflove, Hagness].
+                 * Must be >= 0. Normally values are 0 or between 0.15 and 0.3.
+                 * Unit: siemens / m.
+                 */
+
+                constexpr float_64 ALPHA_MAX_SI[3] = {0.2, 0.2, 0.2};
+
+            } // namespace Pml
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/png.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/png.param
@@ -1,0 +1,83 @@
+/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <cmath>
+
+namespace picongpu
+{
+    /*scale image before write to file, only scale if value is not 1.0
+     */
+    constexpr float_64 scale_image = 1.0;
+
+    /*if true image is scaled if cellsize is not quadratic, else no scale*/
+    constexpr bool scale_to_cellsize = true;
+
+    constexpr bool white_box_per_GPU = false;
+
+    namespace visPreview
+    {
+        // normalize EM fields to typical laser or plasma quantities
+        //-1: Auto:    enable adaptive scaling for each output
+        // 1: Laser:   typical fields calculated out of the laser amplitude
+        // 2: Drift:   [outdated]
+        // 3: PlWave:  typical fields calculated out of the plasma freq.,
+        //             assuming the wave moves approx. with c
+        // 4: Thermal: typical fields calculated out of the electron temperature
+        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
+        //             regime causes a bubble with radius of approx. the laser's
+        //             beam waist (use for bubble fields)
+#define EM_FIELD_SCALE_CHANNEL1 -1
+#define EM_FIELD_SCALE_CHANNEL2 -1
+#define EM_FIELD_SCALE_CHANNEL3 -1
+
+        // multiply highest undisturbed particle density with factor
+        constexpr float_X preParticleDens_opacity = 0.25_X;
+        constexpr float_X preChannel1_opacity = 1.0_X;
+        constexpr float_X preChannel2_opacity = 1.0_X;
+        constexpr float_X preChannel3_opacity = 1.0_X;
+
+        // specify color scales for each channel
+        namespace preParticleDensCol = colorScales::red;
+        namespace preChannel1Col = colorScales::blue;
+        namespace preChannel2Col = colorScales::green;
+        namespace preChannel3Col = colorScales::none;
+
+        /* png preview settings for each channel */
+        DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
+        {
+            // YMax source
+            return field_E.x() * field_E.x();
+        }
+
+        DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
+        {
+            // XMin source
+            return field_E.y() * field_E.y();
+        }
+
+        DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
+        {
+            return 0.0_X;
+        }
+    } // namespace visPreview
+} // namespace picongpu


### PR DESCRIPTION
This PR (draft so far) adds a new way of generating incoming lasers. It uses the total field / scatter field formulation and takes user-set values for values of E and B. Those values are provided as a pair of functors in a new `incidentField.param` file.

Implementation is based on the review paper M. Potter, J.-P. Berenger. A Review of the Total Field/Scattered Field Technique for the FDTD Method. FERMAT, Volume 19, Article 1, 2017. And the Taflove book explaining more or less same with more details.

Differences vs. the standard PIConGPU laser:

- Requires explicit expressions for E and B, not just E.
- Uses soft source, not hard source. When applicable, should be easier to use: a user just provides actual field values, also no need to know the workarounds of the laser implementation
- Not hard-set to YMin boundary, can be applied at any boundary (or boundaries). Moreover, can actually be applied at any any axis-aligned boundary box inside simulation (and absorber) area.
- No need to disable absorber while the laser is generated.

Differences vs. field background:

- Is propagated normally, as part of the field solver
- Only calculated at boundary, not everywhere, so should be much faster for complex lasers.

Limitations of the current PR, are not planned to be fixed within it (but in follow ups):

- Only supports standard Yee and YeePML, no Lehe or higher-order. To be fair, other two laser generators also only work for this case. This scheme can actually be extended for other solvers.
- For now only free functors, no preset profiles for Gaussian etc. Those will be added later, the internal implementation doesn't need details so that should be rather straightforward as long as the free functor version works.

I also added a small example illustrating the usage. Attaching a gif made of png output. It shows two lasers: green is from XMin border, blue is from YMax border (standard laser is YMin border in this naming schema).

![IncidentField](https://user-images.githubusercontent.com/6825656/115287811-fc765080-a150-11eb-807f-d429bcf41679.gif)

Resolves #3159.