### PR TITLE
SPEC bechmark: add new configurations

### DIFF
--- a/share/picongpu/benchmarks/SPEC/cmakeFlags
+++ b/share/picongpu/benchmarks/SPEC/cmakeFlags
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2021 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+
+flags[0]=""
+flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision32Bit;-DPARAM_PARTICLESHAPE=TSC'"
+flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_PRECISION=precision64Bit;-DPARAM_PARTICLESHAPE=TSC'"
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/memory.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/memory.param
@@ -79,7 +79,7 @@ namespace picongpu
         // memory used for a direction
         static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 4 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 1 * 1024 * 1024; // 1 MiB
-        static constexpr uint32_t BYTES_EXCHANGE_Z = 6 * 1024 * 1024; // 6 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 8 * 1024 * 1024; // 8 MiB
         static constexpr uint32_t BYTES_EDGES = 512 * 1024; // 512 kiB
         static constexpr uint32_t BYTES_CORNER = 256 * 1024; // 256 kiB
 

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/precision.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/precision.param
@@ -1,0 +1,59 @@
+/* Copyright 2013-2021 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define the precision of typically used floating point types in the
+ * simulation.
+ *
+ * PIConGPU normalizes input automatically, allowing to use single-precision by
+ * default for the core algorithms. Note that implementations of various
+ * algorithms (usually plugins or non-core components) might still decide to
+ * hard-code a different (mixed) precision for some critical operations.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+/*! Select a precision for the simulation data
+ *  - precision32Bit : use 32Bit floating point numbers
+ *                     [significant digits 7 to 8]
+ *  - precision64Bit : use 64Bit floating point numbers
+ *                     [significant digits 15 to 16]
+ */
+#ifndef PARAM_PRECISION
+#    define PARAM_PRECISION precision32Bit
+#endif
+    namespace precisionPIConGPU = PARAM_PRECISION;
+
+    /*! Select a precision special operations (can be different from simulation precision)
+     *  - precisionPIConGPU : use precision which is selected on top (precisionPIConGPU)
+     *  - precision32Bit    : use 32Bit floating point numbers
+     *  - precision64Bit    : use 64Bit floating point numbers
+     */
+    namespace precisionSqrt = precisionPIConGPU;
+    namespace precisionExp = precisionPIConGPU;
+    namespace precisionTrigonometric = precisionPIConGPU;
+
+
+} // namespace picongpu
+
+#include "picongpu/unitless/precision.unitless"

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
@@ -43,6 +43,9 @@
 #include "picongpu/particles/flylite/NonLTE.def"
 #include "picongpu/fields/currentDeposition/Solver.def"
 
+#ifndef PARAM_PARTICLESHAPE
+#    define PARAM_PARTICLESHAPE PQS
+#endif
 
 namespace picongpu
 {
@@ -55,7 +58,7 @@ namespace picongpu
      *  - particles::shapes::PQS : Assignment function is a piecewise cubic spline
      *  - particles::shapes::PCS : Assignment function is a piecewise quartic spline
      */
-    using UsedParticleShape = particles::shapes::PQS;
+    using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
 
     /** select interpolation method to be used for interpolation of grid-based field values to particle positions
      */


### PR DESCRIPTION
Add two additional configurations to compile for
  - 32bit and TSC particle shape
  - 64bit and TSC particle shape

The particle exchange buffer memory is increased from 6MiB to 8MiB to avoid that we need to send particles within one simulation step twice.

The default case will not compile for 64bit because of the limited shared memory.
At all the selection should help in the CAAR project to validate the performance of 32bit and 64bit runs.