### PR TITLE
set current solver EmZ as default

### DIFF
--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
 
 /** particle pusher configuration
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
@@ -82,7 +82,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
 #ifndef PARAM_CURRENTSOLVER
-#    define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>
+#    define PARAM_CURRENTSOLVER EmZ<UsedParticleShape>
 #endif
     using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
 


### PR DESCRIPTION
Use EmZ as the default current solver.

We discussed in the PIConGPU developer meeting to set EmZ as the default current solver.
There are no known issues with EmZ and the user should not realize any difference except that the simulation should run faster.