### PR TITLE
fix compile: debye length

### DIFF
--- a/include/picongpu/particles/debyeLength/Estimate.hpp
+++ b/include/picongpu/particles/debyeLength/Estimate.hpp
@@ -70,7 +70,6 @@ namespace picongpu
 
                 // Copy is asynchronous, need to wait for it to finish
                 __getTransactionEvent().waitForFinished();
-                dc.releaseData(Frame::getName());
                 return hostBox(0);
             }
 


### PR DESCRIPTION
With #3582 the `DataConnector` method `releaseData()` was removed.


Bug was introduced with #3446