### PR TITLE
Add iteration start pipeline

### DIFF
--- a/docs/source/usage/param/core.rst
+++ b/docs/source/usage/param/core.rst
@@ -27,6 +27,14 @@ components.param
    :path: include/picongpu/param/components.param
    :no-link:
 
+iterationStart.param
+^^^^^^^^^^^^^^^^^^^^
+
+.. doxygenfile:: iterationStart.param
+   :project: PIConGPU
+   :path: include/picongpu/param/iterationStart.param
+   :no-link:
+
 fieldSolver.param
 ^^^^^^^^^^^^^^^^^
 

--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -56,6 +56,7 @@
 #include "picongpu/param/species.param"
 #include "picongpu/param/speciesDefinition.param"
 #include "picongpu/param/speciesInitialization.param"
+#include "picongpu/param/iterationStart.param"
 #include "picongpu/param/collision.param"
 #include "picongpu/param/laser.param"
 #include "picongpu/param/fieldSolver.param"

--- a/include/picongpu/param/iterationStart.param
+++ b/include/picongpu/param/iterationStart.param
@@ -1,0 +1,41 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Specify a sequence of functors to be called at start of each time iteration.
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+    /** IterationStartPipeline defines the functors called at each iteration start
+     *
+     * The functors will be called in the given order.
+     *
+     * The functors must be default-constructible and take the current time iteration as the only parameter.
+     * These are the same requirements as for functors in particles::InitPipeline.
+     */
+    using IterationStartPipeline = bmpl::vector<>;
+
+} // namespace picongpu

--- a/include/picongpu/param/speciesInitialization.param
+++ b/include/picongpu/param/speciesInitialization.param
@@ -37,7 +37,8 @@ namespace picongpu
     {
         /** InitPipeline defines in which order species are initialized
          *
-         * the functors are called in order (from first to last functor)
+         * the functors are called in order (from first to last functor).
+         * The functors must be default-constructible and take the current time iteration as the only parameter.
          */
         using InitPipeline = bmpl::vector<>;
 

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -48,10 +48,8 @@ namespace picongpu
     {
         /** call a functor
          *
-         * @tparam T_Functor unary lambda functor
-         *                   operator() must take two params
-         *                      - first: storage tuple
-         *                      - second: current time step
+         * @tparam T_Functor unary lambda functor, must be default-constructible and
+         *         operator() must take the current time step as the only parameter
          */
         template<typename T_Functor = bmpl::_1>
         struct CallFunctor

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -47,6 +47,7 @@
 #include "picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp"
 #include "picongpu/simulation/stage/CurrentReset.hpp"
 #include "picongpu/simulation/stage/FieldBackground.hpp"
+#include "picongpu/simulation/stage/IterationStart.hpp"
 #include "picongpu/simulation/stage/MomentumBackup.hpp"
 #include "picongpu/simulation/stage/ParticleIonization.hpp"
 #include "picongpu/simulation/stage/ParticlePush.hpp"
@@ -521,6 +522,7 @@ namespace picongpu
         {
             using namespace simulation::stage;
 
+            IterationStart{}(currentStep);
             MomentumBackup{}(currentStep);
             CurrentReset{}(currentStep);
             Collision{deviceHeap}(currentStep);

--- a/include/picongpu/simulation/stage/IterationStart.hpp
+++ b/include/picongpu/simulation/stage/IterationStart.hpp
@@ -1,0 +1,54 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace simulation
+    {
+        namespace stage
+        {
+            /** Functor for the very first stage of the PIC loop
+             *
+             * Calls functors defined in iterationStart.param
+             */
+            struct IterationStart
+            {
+                /** Call all iteration start functors
+                 *
+                 * @param step index of time iteration
+                 */
+                void operator()(uint32_t const step) const
+                {
+                    meta::ForEach<IterationStartPipeline, particles::CallFunctor<bmpl::_1>> callFunctors;
+                    callFunctors(step);
+                }
+            };
+
+        } // namespace stage
+    } // namespace simulation
+} // namespace picongpu

--- a/share/picongpu/tests/compileIterationStart/README.rst
+++ b/share/picongpu/tests/compileIterationStart/README.rst
@@ -1,0 +1,4 @@
+Compile Test for Iteration Start Pipeline
+=========================================
+
+This test compiles a non-empty iteration start pipeline.

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/iterationStart.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/iterationStart.param
@@ -1,0 +1,81 @@
+/* Copyright 2013-2021 Rene Widera, Richard Pausch, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Specify a sequence of functors to be called at start of each time iteration.
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+    //! Functor to move a source particle to the destination species if it has a high gamma value
+    struct MoveIfHighGammaFunctor
+    {
+        /** Process a pair of particles.
+         *
+         * Move a source particle to a destination particle if the source particle has high gamma value.
+         *
+         * @tparam T_DestParticle destination particle type
+         * @tparam T_SrcParticle source particle type
+         *
+         * @param particleDest destination particle
+         * @param particleSrc source particle
+         */
+        template<typename T_DestParticle, typename T_SrcParticle>
+        HDINLINE void operator()(T_DestParticle& particleDest, T_SrcParticle& particleSrc)
+        {
+            auto const gamma = picongpu::gamma<float_X>(
+                particleSrc[picongpu::momentum_],
+                picongpu::traits::attribute::getMass(particleSrc[picongpu::weighting_], particleSrc));
+            constexpr float_X thresholdGamma = 3.0_X;
+            if(gamma >= thresholdGamma)
+            {
+                pmacc::particles::operations::assign(particleDest, particleSrc);
+                particleSrc[picongpu::multiMask_] = 0;
+            }
+            else
+                particleDest[picongpu::multiMask_] = 0;
+        }
+    };
+
+
+    //! Manipulator to move a source particle to the destination species if it has a high gamma value
+    using MoveIfHighGamma = particles::manipulators::generic::Free<MoveIfHighGammaFunctor>;
+
+    /** IterationStartPipeline defines the functors called at each iteration start
+     *
+     * The functors will be called in the given order.
+     *
+     * The functors must be default-constructible and take the current time iteration as the only parameter.
+     * These are the same requirements as for functors in particles::InitPipeline.
+     *
+     * At each iteration start move high gamma electron particles from PIC_Electrons species to PIC_HighGammaElectrons.
+     * Since some particles of PIC_Electrons may be removed, the following FillAllGaps is needed
+     * (for PIC_HighGammaElectrons it is done as part of ManipulateDerive<>).
+     */
+    using IterationStartPipeline = bmpl::vector<
+        particles::ManipulateDerive<MoveIfHighGamma, PIC_Electrons, PIC_HighGammaElectrons>,
+        particles::FillAllGaps<PIC_Electrons>>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/particle.param
@@ -1,0 +1,85 @@
+/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/filter/filter.def"
+#include "picongpu/particles/manipulators/manipulators.def"
+#include "picongpu/particles/startPosition/functors.def"
+
+#include <pmacc/math/operation.hpp>
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace startPosition
+        {
+            struct QuietParam25ppc
+            {
+                /** Count of particles per cell per direction at initial state
+                 *  unit: none
+                 */
+                using numParticlesPerDimension = typename mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type;
+            };
+            using Quiet25ppc = QuietImpl<QuietParam25ppc>;
+
+        } // namespace startPosition
+
+        /** a particle with a weighting below MIN_WEIGHTING will not
+         *      be created / will be deleted
+         *  unit: none
+         */
+        constexpr float_X MIN_WEIGHTING = 10.0;
+
+        /** During unit normalization, we assume this is a typical
+         *  number of particles per cell for normalization of weighted
+         *  particle attributes.
+         */
+        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL
+            = mCT::volume<startPosition::QuietParam25ppc::numParticlesPerDimension>::type::value;
+
+        namespace manipulators
+        {
+            CONST_VECTOR(float_X, 3, DriftParamPositive_direction, 1.0, 0.0, 0.0);
+            struct DriftParamPositive
+            {
+                /** Initial particle drift velocity for electrons and ions
+                 *  Examples:
+                 *    - No drift is equal to 1.0
+                 *  unit: none
+                 */
+                static constexpr float_64 gamma = 1.021;
+                const DriftParamPositive_direction_t direction;
+            };
+            using AssignXDriftPositive = unary::Drift<DriftParamPositive, pmacc::math::operation::Assign>;
+
+            struct TemperatureParam
+            {
+                /* Initial temperature
+                 *  unit: keV
+                 */
+                static constexpr float_64 temperature = 0.0005;
+            };
+            using AddTemperature = unary::Temperature<TemperatureParam>;
+
+        } // namespace manipulators
+    } // namespace particles
+} // namespace picongpu

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,73 @@
+/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/meta/String.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+
+namespace picongpu
+{
+    /*########################### define particle attributes #####################*/
+
+    /** describe attributes of a particle*/
+    using DefaultParticleAttributes = MakeSeq_t<position<position_pic>, momentum, weighting, probeE, probeB>;
+
+    /*########################### end particle attributes ########################*/
+
+    /*########################### define species #################################*/
+
+    /*--------------------------- electrons --------------------------------------*/
+
+    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    value_identifier(float_X, MassRatioElectrons, 1.0);
+    value_identifier(float_X, ChargeRatioElectrons, 1.0);
+
+    using ParticleFlagsElectrons = MakeSeq_t<
+        particlePusher<UsedParticlePusher>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        current<UsedParticleCurrentSolver>,
+        massRatio<MassRatioElectrons>,
+        chargeRatio<ChargeRatioElectrons>>;
+
+    /* define species electrons */
+    using PIC_Electrons = Particles<PMACC_CSTRING("e"), ParticleFlagsElectrons, DefaultParticleAttributes>;
+
+    /* define species electrons */
+    using PIC_HighGammaElectrons = Particles<PMACC_CSTRING("h"), ParticleFlagsElectrons, DefaultParticleAttributes>;
+
+    /*########################### end species ####################################*/
+
+    /** All known particle species of the simulation
+     *
+     * List all defined particle species from above in this list
+     * to make them available to the PIC algorithm.
+     */
+    using VectorAllSpecies = MakeSeq_t<PIC_Electrons, PIC_HighGammaElectrons>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesInitialization.param
@@ -1,0 +1,47 @@
+/* Copyright 2015-2021 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Initialize particles inside particle species. This is the final step in
+ * setting up particles (defined in `speciesDefinition.param`) via density
+ * profiles (defined in `density.param`). One can then further derive particles
+ * from one species to another and manipulate attributes with "manipulators"
+ * and "filters" (defined in `particle.param` and `particleFilters.param`).
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        /** InitPipeline define in which order species are initialized
+         *
+         * the functors are called in order (from first to last functor)
+         */
+        using InitPipeline = bmpl::vector<
+            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet25ppc, PIC_Electrons>,
+            Manipulate<manipulators::AddTemperature, PIC_Electrons>>;
+
+    } // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
Allow specifying a sequence of functors to be called at start of each time step. So this is similar to `InitPipeline`, but called repeatedly and not once. It is set in a new input file `iterationStart.param`. The pipeline is empty by default. The way of setting and requirements for functors are exactly the same as in `InitPipeline`, updated comments there as well. (Also note that `InitPipeline` could actually be whatever functors and doesn't have to deal with particles, even though the namespace and comments suggest it)

Note that if we didn't have awkward include order stuff, the whole PIC loop could have been put there externally in theory. Actually, almost all simulation stages already have the same interface as functors in the pipeline. So in far (well, or depends on prioritization) future maybe we could even do that.

Add a new compile test to test and demonstrate a potential use, but with no immediate physically meaningful simulation, hence it's a compile test and not an example.