### PR TITLE
Rename picongpu::particles::CallFunctor to pmacc::functor::Call 

### DIFF
--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -46,22 +46,6 @@ namespace picongpu
 {
     namespace particles
     {
-        /** call a functor
-         *
-         * @tparam T_Functor unary lambda functor, must be default-constructible and
-         *         operator() must take the current time step as the only parameter
-         */
-        template<typename T_Functor = bmpl::_1>
-        struct CallFunctor
-        {
-            using Functor = T_Functor;
-
-            HINLINE void operator()(const uint32_t currentStep)
-            {
-                Functor()(currentStep);
-            }
-        };
-
         /** Create particle distribution from a normalized density profile
          *
          * Create particles inside a species. The created particles are macroscopically

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -58,6 +58,7 @@
 #include <pmacc/assert.hpp>
 #include <pmacc/dimensions/GridLayout.hpp>
 #include <pmacc/eventSystem/EventSystem.hpp>
+#include <pmacc/functor/Call.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/mappings/simulation/SubGrid.hpp>
@@ -494,7 +495,7 @@ namespace picongpu
                 else
                 {
                     initialiserController->init();
-                    meta::ForEach<particles::InitPipeline, particles::CallFunctor<bmpl::_1>> initSpecies;
+                    meta::ForEach<particles::InitPipeline, pmacc::functor::Call<bmpl::_1>> initSpecies;
                     initSpecies(step);
                     particles::debyeLength::check(*cellDescription);
                 }
@@ -588,7 +589,7 @@ namespace picongpu
                 log<picLog::SIMULATION_STATE>("slide in step %1%") % currentStep;
                 resetAll(currentStep);
                 initialiserController->slide(currentStep);
-                meta::ForEach<particles::InitPipeline, particles::CallFunctor<bmpl::_1>> initSpecies;
+                meta::ForEach<particles::InitPipeline, pmacc::functor::Call<bmpl::_1>> initSpecies;
                 initSpecies(currentStep);
             }
         }

--- a/include/picongpu/simulation/stage/IterationStart.hpp
+++ b/include/picongpu/simulation/stage/IterationStart.hpp
@@ -21,7 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/particles/InitFunctors.hpp"
+#include <pmacc/functor/Call.hpp>
 
 #include <cstdint>
 
@@ -44,7 +44,7 @@ namespace picongpu
                  */
                 void operator()(uint32_t const step) const
                 {
-                    meta::ForEach<IterationStartPipeline, particles::CallFunctor<bmpl::_1>> callFunctors;
+                    meta::ForEach<IterationStartPipeline, pmacc::functor::Call<bmpl::_1>> callFunctors;
                     callFunctors(step);
                 }
             };

--- a/include/pmacc/functor/Call.hpp
+++ b/include/pmacc/functor/Call.hpp
@@ -1,0 +1,57 @@
+/* Copyright 2014-2021 Rene Widera, Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/types.hpp"
+
+#include <boost/mpl/placeholders.hpp>
+
+#include <cstdint>
+
+
+namespace pmacc
+{
+    namespace functor
+    {
+        /** Wrapper functor to call a functor of the given type
+         *
+         * @tparam T_Functor stateless unary functor type, must be default-constructible and
+         *         operator() must take the current time step as the only parameter
+         */
+        template<typename T_Functor = bmpl::_1>
+        struct Call
+        {
+            //! Functor type
+            using Functor = T_Functor;
+
+            /** Instantiate and call the functor
+             *
+             * @param currentStep current time iteration
+             */
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                Functor()(currentStep);
+            }
+        };
+
+    } // namespace functor
+} // namespace pmacc

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -36,21 +36,6 @@ namespace pmacc
     {
         namespace acc
         {
-            namespace detail
-            {
-                /** Helper class to compare void with void
-                 *
-                 * std::is_same does not allow to use void as type. By wrapping the type before
-                 * comparing, we can workaround this limitation.
-                 *
-                 * @tparam T_Type type to be wrapped
-                 */
-                template<typename T_Type>
-                struct VoidWrapper
-                {
-                };
-            } // namespace detail
-
             /** functor interface used on the accelerator side
              *
              * The user functor of the type T_UserFunctor must contain
@@ -104,8 +89,7 @@ namespace pmacc
                     // compare user functor return type with the interface requirements
                     PMACC_CASSERT_MSG(
                         __wrong_user_functor_return_type,
-                        std::is_same<detail::VoidWrapper<UserFunctorReturnType>, detail::VoidWrapper<T_ReturnType>>::
-                            value);
+                        std::is_same<UserFunctorReturnType, T_ReturnType>::value);
                     return (*static_cast<UserFunctor*>(this))(acc, args...);
                 }
             };


### PR DESCRIPTION
Also move the file accordingly. The change was suggested [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/3607#discussion_r619392750).

The second commit is unrelated refactoring, that I noticed along the way. I assume that is some old workaround, as I never heard of this `std::is_same<void, void>` issue.