### PR TITLE
Use span-based storeChunk API in openPMD plugin (more memory efficient in ADIOS2)

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -20,6 +20,8 @@
 
 #include "openPMD/openPMD.hpp"
 
+#include <utility> // std::declval
+
 #if OPENPMDAPI_VERSION_GE(0, 13, 0)
 // Streaming API is available, use it
 #    define WRITE_ITERATIONS writeIterations()
@@ -65,11 +67,86 @@ namespace picongpu
                     ds.options = std::move(options);
                 }
             };
+
+            template<typename ValueType, typename = ::openPMD::RecordComponent, typename = void>
+            struct openPMDSpan
+            {
+                std::shared_ptr<ValueType> m_buffer;
+                ValueType* currentBuffer() const
+                {
+                    return m_buffer.get();
+                }
+
+                template<typename Functor>
+                openPMDSpan(
+                    ::openPMD::RecordComponent& rc,
+                    ::openPMD::Offset offset,
+                    ::openPMD::Extent extent,
+                    Functor&& createBaseBuffer)
+                {
+                    using extent_t = ::openPMD::Extent::value_type;
+                    extent_t scalarExtent = 1;
+                    for(auto val : extent)
+                    {
+                        scalarExtent *= val;
+                    }
+                    m_buffer = std::forward<Functor>(createBaseBuffer)(scalarExtent);
+                    rc.storeChunk(m_buffer, std::move(offset), std::move(extent));
+                }
+            };
+
+            template<typename ValueType, typename RecordComponent>
+            struct openPMDSpan<
+                ValueType,
+                RecordComponent,
+                // check for existence of span-based storeChunk API
+                void_t<decltype(std::declval<RecordComponent>().template storeChunk<ValueType>(
+                    std::declval<::openPMD::Offset>(),
+                    std::declval<::openPMD::Extent>()))>>
+            {
+                // We cannot use ::openPMD::DynamicMemoryView directly since that is non-dependent lookup
+                // so, use a dependent type
+                using DynamicMemoryView = decltype(std::declval<RecordComponent>().template storeChunk<ValueType>(
+                    std::declval<::openPMD::Offset>(),
+                    std::declval<::openPMD::Extent>()));
+                DynamicMemoryView m_buffer;
+                ValueType* currentBuffer()
+                {
+                    return m_buffer.currentBuffer().data();
+                }
+
+                template<typename Functor>
+                openPMDSpan(
+                    ::openPMD::RecordComponent& rc,
+                    ::openPMD::Offset offset,
+                    ::openPMD::Extent extent,
+                    Functor&& createBaseBuffer)
+                    : m_buffer{rc.storeChunk<ValueType>(
+                        std::move(offset),
+                        std::move(extent),
+                        std::forward<Functor>(createBaseBuffer))}
+                {
+                }
+            };
         } // namespace detail
 
         void setDatasetOptions(::openPMD::Dataset& ds, std::string options)
         {
             detail::SetDatasetOptions<>::run(ds, std::move(options));
+        }
+
+        template<typename ValueType, typename Functor>
+        auto storeChunkSpan(
+            ::openPMD::RecordComponent& rc,
+            ::openPMD::Offset offset,
+            ::openPMD::Extent extent,
+            Functor&& createBaseBuffer) -> detail::openPMDSpan<ValueType>
+        {
+            return detail::openPMDSpan<ValueType>(
+                rc,
+                std::move(offset),
+                std::move(extent),
+                std::forward<Functor>(createBaseBuffer));
         }
     } // namespace openPMD
 } // namespace picongpu

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1030,7 +1030,8 @@ Please pick either of the following:
 
                     // ask openPMD to create a buffer for us
                     // in some backends (ADIOS2), this allows avoiding memcopies
-                    auto span = mrc.storeChunk<float_X>(
+                    auto span = storeChunkSpan<float_X>(
+                        mrc,
                         asStandardVector(fieldsOffsetDims),
                         asStandardVector(fieldsSizeDims),
                         [&fieldBuffer](size_t size) {

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -117,21 +117,21 @@ namespace picongpu
                     ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer(); // can be moved up?
                     // ask openPMD to create a buffer for us
                     // in some backends (ADIOS2), this allows avoiding memcopies
-                    auto span = recordComponent
-                                    .storeChunk<ComponentType>(
-                                        ::openPMD::Offset{globalOffset},
-                                        ::openPMD::Extent{elements},
-                                        [&storeBfr](size_t size) {
-                                            // if there is no special backend support for creating buffers,
-                                            // reuse the storeBfr
-                                            if(!storeBfr && size > 0)
-                                            {
-                                                storeBfr = std::shared_ptr<ComponentType>{
-                                                    new ComponentType[size],
-                                                    [](ComponentType* ptr) { delete[] ptr; }};
-                                            }
-                                            return storeBfr;
-                                        })
+                    auto span = storeChunkSpan<ComponentType>(
+                                    recordComponent,
+                                    ::openPMD::Offset{globalOffset},
+                                    ::openPMD::Extent{elements},
+                                    [&storeBfr](size_t size) {
+                                        // if there is no special backend support for creating buffers,
+                                        // reuse the storeBfr
+                                        if(!storeBfr && size > 0)
+                                        {
+                                            storeBfr = std::shared_ptr<ComponentType>{
+                                                new ComponentType[size],
+                                                [](ComponentType* ptr) { delete[] ptr; }};
+                                        }
+                                        return storeBfr;
+                                    })
                                     .currentBuffer();
 
 /* copy strided data from source to temporary buffer */

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -86,27 +86,13 @@ namespace picongpu
                 log<picLog::INPUT_OUTPUT>("openPMD:  (begin) write species attribute: %1%") % Identifier::getName();
 
                 std::shared_ptr<ComponentType> storeBfr;
-                if(elements > 0)
-                    storeBfr = std::shared_ptr<ComponentType>{new ComponentType[elements], [](ComponentType* ptr) {
-                                                                  delete[] ptr;
-                                                              }};
 
                 for(uint32_t d = 0; d < components; d++)
                 {
                     ::openPMD::RecordComponent recordComponent
                         = components > 1 ? record[name_lookup[d]] : record[::openPMD::MeshRecordComponent::SCALAR];
+
                     std::string datasetName = components > 1 ? baseName + "/" + name_lookup[d] : baseName;
-
-                    ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer(); // can be moved up?
-                    auto storePtr = storeBfr.get();
-
-/* copy strided data from source to temporary buffer */
-#pragma omp parallel for simd
-                    for(size_t i = 0; i < elements; ++i)
-                    {
-                        storePtr[i] = reinterpret_cast<ComponentType*>(dataPtr)[d + i * components];
-                    }
-
                     params->initDataset<DIM1>(
                         recordComponent,
                         openPMDType,
@@ -114,13 +100,47 @@ namespace picongpu
                         true,
                         params->compressionMethod,
                         datasetName);
-                    if(storeBfr)
-                        recordComponent.storeChunk(storeBfr, {globalOffset}, {elements});
 
                     if(unit.size() >= (d + 1))
                     {
                         recordComponent.setUnitSI(unit[d]);
                     }
+
+                    if(elements == 0)
+                    {
+                        // technically not necessary if we write no dataset,
+                        // but let's keep things uniform
+                        params->openPMDSeries->flush();
+                        continue;
+                    }
+
+                    ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer(); // can be moved up?
+                    // ask openPMD to create a buffer for us
+                    // in some backends (ADIOS2), this allows avoiding memcopies
+                    auto span = recordComponent
+                                    .storeChunk<ComponentType>(
+                                        ::openPMD::Offset{globalOffset},
+                                        ::openPMD::Extent{elements},
+                                        [&storeBfr](size_t size) {
+                                            // if there is no special backend support for creating buffers,
+                                            // reuse the storeBfr
+                                            if(!storeBfr && size > 0)
+                                            {
+                                                storeBfr = std::shared_ptr<ComponentType>{
+                                                    new ComponentType[size],
+                                                    [](ComponentType* ptr) { delete[] ptr; }};
+                                            }
+                                            return storeBfr;
+                                        })
+                                    .currentBuffer();
+
+/* copy strided data from source to temporary buffer */
+#pragma omp parallel for simd
+                    for(size_t i = 0; i < elements; ++i)
+                    {
+                        span[i] = reinterpret_cast<ComponentType*>(dataPtr)[d + i * components];
+                    }
+
                     params->openPMDSeries->flush();
                 }
 


### PR DESCRIPTION
For measurements see [this comment](https://github.com/openPMD/openPMD-api/pull/901#issuecomment-784193402) on the same PR in the openPMD API.

Rationale: The openPMD plugin writes its field data to [an intermediate buffer](https://github.com/ComputationalRadiationPhysics/picongpu/blob/6aa3290a771388303e8a545582a85842729c458d/include/picongpu/plugins/openPMD/openPMDWriter.def#L101) before storing. The same holds for [particle data](https://github.com/ComputationalRadiationPhysics/picongpu/blob/6aa3290a771388303e8a545582a85842729c458d/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp#L90). 
On the other hand, ADIOS2 internally serializes all of the given data into one large buffer before actually performing IO.
This means that the openPMD plugin + ADIOS2 redundantly stages all data twice before writing. The recently-added span-based storeChunk API in openPMD allows users to write directly into the ADIOS2 serialization buffer, while automatically handling a fallback-solution for the other backends. This saves needless allocations and memcopies in ADIOS2 and retains the same performance in HDF5.

The last commit adds compatibility with previous openPMD versions.

TODO
- [ ] Testing