### PR TITLE
Refactor common field absorber implementation

### DIFF
--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -126,11 +126,12 @@ namespace picongpu
                     constexpr bool isLaserDisabled = laserProfiles::Selected::Unitless::INIT_TIME == 0.0_X;
                     constexpr bool isLaserInitInFirstCell = laserProfiles::Selected::Unitless::initPlaneY == 0;
                     // X + 1 is a workaround to avoid warning: pointless comparison of unsigned integer with zero
-                    constexpr bool isInitPlaneYOutsideOfAbsorber
-                        = laserProfiles::Selected::Unitless::initPlaneY + 1 > absorber::numCells[1][0] + 1;
-                    PMACC_CASSERT_MSG(
-                        __initPlaneY_needs_to_be_greater_than_the_top_absorber_cells_or_zero,
-                        isLaserDisabled || isLaserInitInFirstCell || isInitPlaneYOutsideOfAbsorber);
+                    auto& absorber = absorber::Absorber::get();
+                    bool isInitPlaneYOutsideOfAbsorber
+                        = laserProfiles::Selected::Unitless::initPlaneY + 1 > absorber.getGlobalThickness()(1, 0) + 1;
+                    PMACC_VERIFY_MSG(
+                        isLaserDisabled || isLaserInitInFirstCell || isInitPlaneYOutsideOfAbsorber,
+                        "laser initPlaneY needs to be greater than the top absorber cells or zero");
 
                     /* Calculate how many neighbors to the left we have
                      * to initialize the laser in the E-Field

--- a/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
+++ b/include/picongpu/fields/MaxwellSolver/YeePML/YeePML.hpp
@@ -241,9 +241,10 @@ namespace picongpu
                         Thickness getGlobalThickness() const
                         {
                             Thickness globalThickness;
+                            auto& absorber = absorber::Absorber::get();
                             for(uint32_t axis = 0u; axis < simDim; axis++)
                                 for(auto direction = 0; direction < 2; direction++)
-                                    globalThickness(axis, direction) = absorber::getGlobalThickness()(axis, direction);
+                                    globalThickness(axis, direction) = absorber.getGlobalThickness()(axis, direction);
                             return globalThickness;
                         }
 

--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -21,11 +21,9 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include <pmacc/Environment.hpp>
 #include <pmacc/traits/GetStringProperties.hpp>
 
 #include <cstdint>
-#include <sstream>
 #include <string>
 
 
@@ -33,132 +31,8 @@ namespace picongpu
 {
     namespace fields
     {
-        namespace maxwellSolver
-        {
-            /** Forward declaration to avoid mutual including with YeePML.hpp
-             *
-             * @tparam T_CurlE functor to compute curl of E
-             * @tparam T_CurlB functor to compute curl of B
-             */
-            template<typename T_CurlE, typename T_CurlB>
-            class YeePML;
-
-        } // namespace maxwellSolver
-
         namespace absorber
         {
-            //! Forward declaration to avoid mutual including with ExponentialDamping.hpp
-            class ExponentialDamping;
-
-            namespace detail
-            {
-                /** Get string properties of the absorber
-                 *
-                 * @param name absorber name
-                 */
-                HINLINE pmacc::traits::StringProperty getStringProperties(std::string const& name);
-
-                /** Absorber wrapper
-                 *
-                 * Provides unified interface for the absorber information:
-                 * size along the 6 boundaries and getStringProperties() implementation.
-                 * Currently does not provide the computational part, only description.
-                 *
-                 * The general version uses exponential absorber settings since this is the
-                 * default absorber.
-                 *
-                 * @tparam T_FieldSolver field solver
-                 */
-                template<typename T_FieldSolver>
-                struct Absorber
-                {
-                    //! Number of absorber cells along the min x boundary
-                    static constexpr uint32_t xNegativeNumCells = ABSORBER_CELLS[0][0];
-
-                    //! Number of absorber cells along the max x boundary
-                    static constexpr uint32_t xPositiveNumCells = ABSORBER_CELLS[0][1];
-
-                    //! Number of absorber cells along the min y boundary
-                    static constexpr uint32_t yNegativeNumCells = ABSORBER_CELLS[1][0];
-
-                    //! Number of absorber cells along the max y boundary
-                    static constexpr uint32_t yPositiveNumCells = ABSORBER_CELLS[1][1];
-
-                    //! Number of absorber cells along the min z boundary
-                    static constexpr uint32_t zNegativeNumCells = ABSORBER_CELLS[2][0];
-
-                    //! Number of cells along the max z boundary
-                    static constexpr uint32_t zPositiveNumCells = ABSORBER_CELLS[2][1];
-
-                    //! Get string properties of the absorber
-                    static pmacc::traits::StringProperty getStringProperties()
-                    {
-                        return detail::getStringProperties("exponential damping");
-                    }
-                };
-
-                namespace pml = maxwellSolver::Pml;
-
-                /** Absorber wrapper
-                 *
-                 * Specialization for PML, works for both YeePML and LehePML
-                 *
-                 * @tparam T_CurlE curl E for YeePML
-                 * @tparam T_CurlB curl B for YeePML
-                 */
-                template<typename T_CurlE, typename T_CurlB>
-                struct Absorber<maxwellSolver::YeePML<T_CurlE, T_CurlB>>
-                {
-                    //! Number of absorber cells along the min x boundary
-                    static constexpr uint32_t xNegativeNumCells = pml::NUM_CELLS[0][0];
-
-                    //! Number of absorber cells along the max x boundary
-                    static constexpr uint32_t xPositiveNumCells = pml::NUM_CELLS[0][1];
-
-                    //! Number of absorber cells along the min y boundary
-                    static constexpr uint32_t yNegativeNumCells = pml::NUM_CELLS[1][0];
-
-                    //! Number of absorber cells along the max y boundary
-                    static constexpr uint32_t yPositiveNumCells = pml::NUM_CELLS[1][1];
-
-                    //! Number of absorber cells along the min z boundary
-                    static constexpr uint32_t zNegativeNumCells = pml::NUM_CELLS[2][0];
-
-                    //! Number of absorber cells along the max z boundary
-                    static constexpr uint32_t zPositiveNumCells = pml::NUM_CELLS[2][1];
-
-                    //! Get string properties of the absorber
-                    static pmacc::traits::StringProperty getStringProperties()
-                    {
-                        return detail::getStringProperties("convolutional PML");
-                    }
-                };
-
-            } // namespace detail
-
-            /** Absorber description implementing getStringProperties()
-             *
-             * To be used for writing absorber meta information, does not provide
-             * interface for running the absorber
-             */
-            using Absorber = detail::Absorber<Solver>;
-
-            /** Number of absorber cells along each boundary
-             *
-             * Stores the global absorber thickness in case the absorbing boundary
-             * conditions are used along each boundary. Note that in case of periodic
-             * boundaries the corresponding values will be ignored.
-             *
-             * Is uniform for both PML and exponential damping absorbers.
-             * First index: 0 = x, 1 = y, 2 = z.
-             * Second index: 0 = negative (min coordinate), 1 = positive (max coordinate).
-             * Not for ODR-use.
-             */
-            constexpr uint32_t numCells[3][2]
-                = {{Absorber::xNegativeNumCells, Absorber::xPositiveNumCells},
-                   {Absorber::yNegativeNumCells, Absorber::yPositiveNumCells},
-                   {Absorber::zNegativeNumCells, Absorber::zPositiveNumCells}};
-
             //! Thickness of the absorbing layer
             class Thickness
             {
@@ -202,122 +76,61 @@ namespace picongpu
                 uint32_t numCells[3][2];
             };
 
-            /** Get absorber thickness in number of cells for the global domain
+            /** Singleton for field absorber
              *
-             * This function takes into account which boundaries are periodic and
-             * absorbing.
+             * Provides run-time utilities to get thickness and string properties.
+             * Does not yet provide absorption itself.
              */
-            inline Thickness getGlobalThickness()
+            class Absorber
             {
-                Thickness thickness;
-                for(uint32_t axis = 0u; axis < 3u; axis++)
-                    for(uint32_t direction = 0u; direction < 2u; direction++)
-                        thickness(axis, direction) = numCells[axis][direction];
-                const DataSpace<DIM3> isPeriodicBoundary
-                    = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
-                for(uint32_t axis = 0u; axis < 3u; axis++)
-                    if(isPeriodicBoundary[axis])
-                    {
-                        thickness(axis, 0) = 0u;
-                        thickness(axis, 1) = 0u;
-                    }
-                return thickness;
-            }
+            public:
+                //! Get absorber instance
+                static Absorber& get();
 
-            /** Get absorber thickness in number of cells for the current local domain
-             *
-             * This function takes into account the current domain decomposition and
-             * which boundaries are periodic and absorbing.
-             *
-             * Note that unlike getGlobalThickness() result which does not change
-             * throughout the simulation, the local thickness can change. Thus,
-             * the result of this function should not be reused on another time step,
-             * but rather the function called again.
-             */
-            inline Thickness getLocalThickness()
-            {
-                Thickness thickness = getGlobalThickness();
-                auto const numExchanges = NumberOfExchanges<simDim>::value;
-                auto const communicationMask = Environment<simDim>::get().GridController().getCommunicationMask();
-                for(uint32_t exchange = 1u; exchange < numExchanges; exchange++)
-                {
-                    /* Here we are only interested in the positive and negative
-                     * directions for x, y, z axes and not the "diagonal" ones.
-                     * So skip other directions except left, right, top, bottom,
-                     * back, front
-                     */
-                    if(FRONT % exchange != 0)
-                        continue;
+                /** Get absorber thickness in number of cells for the global domain
+                 *
+                 * This function takes into account which boundaries are periodic and absorbing.
+                 */
+                inline Thickness getGlobalThickness() const;
 
-                    // Transform exchange into a pair of axis and direction
-                    uint32_t axis = 0;
-                    if(exchange >= BOTTOM && exchange <= TOP)
-                        axis = 1;
-                    if(exchange >= BACK)
-                        axis = 2;
-                    uint32_t direction = exchange % 2;
+                /** Get absorber thickness in number of cells for the current local domain
+                 *
+                 * This function takes into account the current domain decomposition and
+                 * which boundaries are periodic and absorbing.
+                 *
+                 * Note that unlike getGlobalThickness() result which does not change
+                 * throughout the simulation, the local thickness can change.
+                 * Thus, the result of this function should not be reused on another time step,
+                 * but rather the function called again.
+                 */
+                inline Thickness getLocalThickness() const;
 
-                    // No absorber at the borders between two local domains
-                    bool hasNeighbour = communicationMask.isSet(exchange);
-                    if(hasNeighbour)
-                        thickness(axis, direction) = 0u;
-                }
-                return thickness;
-            }
+                //! Get string properties
+                static inline pmacc::traits::StringProperty getStringProperties();
 
-            namespace detail
-            {
-                // Implementation has to be after numCells is defined
-                pmacc::traits::StringProperty getStringProperties(std::string const& name)
-                {
-                    pmacc::traits::StringProperty propList;
-                    const DataSpace<DIM3> periodic
-                        = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
+            protected:
+                /** Number of absorber cells along each boundary
+                 *
+                 * Stores the global absorber thickness along each boundary.
+                 * Note that in case of periodic
+                 * boundaries the corresponding values will be ignored.
+                 *
+                 * Is uniform for both PML and exponential damping absorbers.
+                 * First index: 0 = x, 1 = y, 2 = z.
+                 * Second index: 0 = negative (min coordinate), 1 = positive (max coordinate).
+                 */
+                uint32_t numCells[3][2];
 
-                    for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
-                    {
-                        // for each planar direction: left right top bottom back front
-                        if(FRONT % i == 0)
-                        {
-                            const std::string directionName = ExchangeTypeNames()[i];
-                            const DataSpace<DIM3> relDir = Mask::getRelativeDirections<DIM3>(i);
+                //! Name for string properties
+                std::string name;
 
-                            bool isPeriodic = false;
-                            uint32_t axis = 0; // x(0) y(1) z(2)
-                            uint32_t axisDir = 0; // negative (0), positive (1)
-                            for(uint32_t d = 0; d < simDim; d++)
-                            {
-                                if(relDir[d] * periodic[d] != 0)
-                                    isPeriodic = true;
-                                if(relDir[d] != 0)
-                                    axis = d;
-                            }
-                            if(relDir[axis] > 0)
-                                axisDir = 1;
-
-                            std::string boundaryName = "open"; // absorbing boundary
-                            if(isPeriodic)
-                                boundaryName = "periodic";
-
-                            if(boundaryName == "open")
-                            {
-                                std::ostringstream boundaryParam;
-                                boundaryParam << name + " over " << numCells[axis][axisDir] << " cells";
-                                propList[directionName]["param"] = boundaryParam.str();
-                            }
-                            else
-                            {
-                                propList[directionName]["param"] = "none";
-                            }
-
-                            propList[directionName]["name"] = boundaryName;
-                        }
-                    }
-                    return propList;
-                }
-
-            } // namespace detail
+                Absorber() = default;
+                Absorber(Absorber const&) = delete;
+                ~Absorber() = default;
+            };
 
         } // namespace absorber
     } // namespace fields
 } // namespace picongpu
+
+#include "picongpu/fields/absorber/Absorber.tpp"

--- a/include/picongpu/fields/absorber/Absorber.tpp
+++ b/include/picongpu/fields/absorber/Absorber.tpp
@@ -1,0 +1,164 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/absorber/Absorber.hpp"
+#include "picongpu/fields/absorber/ExponentialDamping.hpp"
+#include "picongpu/fields/absorber/Pml.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/traits/IsBaseTemplateOf.hpp>
+
+#include <sstream>
+#include <type_traits>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Forward declaration to avoid mutual including with YeePML.hpp
+             *
+             * @tparam T_CurlE functor to compute curl of E
+             * @tparam T_CurlB functor to compute curl of B
+             */
+            template<typename T_CurlE, typename T_CurlB>
+            class YeePML;
+
+        } // namespace maxwellSolver
+
+        namespace absorber
+        {
+            // This implementation has to go to a .tpp file as it requires definitions of Pml and ExponentialDamping
+            Absorber& Absorber::get()
+            {
+                // This is currently a static type, until absorbers go full runtime
+                constexpr bool isPmlSolver
+                    = pmacc::traits::IsBaseTemplateOf_t<maxwellSolver::YeePML, fields::Solver>::value;
+                using Implementation = std::conditional_t<isPmlSolver, Pml, ExponentialDamping>;
+                static Implementation instance;
+                return instance;
+            }
+
+            Thickness Absorber::getGlobalThickness() const
+            {
+                Thickness thickness;
+                for(uint32_t axis = 0u; axis < 3u; axis++)
+                    for(uint32_t direction = 0u; direction < 2u; direction++)
+                        thickness(axis, direction) = numCells[axis][direction];
+                const DataSpace<DIM3> isPeriodicBoundary
+                    = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
+                for(uint32_t axis = 0u; axis < 3u; axis++)
+                    if(isPeriodicBoundary[axis])
+                    {
+                        thickness(axis, 0) = 0u;
+                        thickness(axis, 1) = 0u;
+                    }
+                return thickness;
+            }
+
+            Thickness Absorber::getLocalThickness() const
+            {
+                Thickness thickness = getGlobalThickness();
+                auto const numExchanges = NumberOfExchanges<simDim>::value;
+                auto const communicationMask = Environment<simDim>::get().GridController().getCommunicationMask();
+                for(uint32_t exchange = 1u; exchange < numExchanges; exchange++)
+                {
+                    /* Here we are only interested in the positive and negative
+                     * directions for x, y, z axes and not the "diagonal" ones.
+                     * So skip other directions except left, right, top, bottom,
+                     * back, front
+                     */
+                    if(FRONT % exchange != 0)
+                        continue;
+
+                    // Transform exchange into a pair of axis and direction
+                    uint32_t axis = 0;
+                    if(exchange >= BOTTOM && exchange <= TOP)
+                        axis = 1;
+                    if(exchange >= BACK)
+                        axis = 2;
+                    uint32_t direction = exchange % 2;
+
+                    // No absorber at the borders between two local domains
+                    bool hasNeighbour = communicationMask.isSet(exchange);
+                    if(hasNeighbour)
+                        thickness(axis, direction) = 0u;
+                }
+                return thickness;
+            }
+
+            pmacc::traits::StringProperty Absorber::getStringProperties()
+            {
+                auto& absorber = get();
+                auto const thickness = absorber.getGlobalThickness();
+                pmacc::traits::StringProperty propList;
+                const DataSpace<DIM3> periodic
+                    = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
+
+                for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
+                {
+                    // for each planar direction: left right top bottom back front
+                    if(FRONT % i == 0)
+                    {
+                        const std::string directionName = ExchangeTypeNames()[i];
+                        const DataSpace<DIM3> relDir = Mask::getRelativeDirections<DIM3>(i);
+
+                        bool isPeriodic = false;
+                        uint32_t axis = 0; // x(0) y(1) z(2)
+                        uint32_t axisDir = 0; // negative (0), positive (1)
+                        for(uint32_t d = 0; d < simDim; d++)
+                        {
+                            if(relDir[d] * periodic[d] != 0)
+                                isPeriodic = true;
+                            if(relDir[d] != 0)
+                                axis = d;
+                        }
+                        if(relDir[axis] > 0)
+                            axisDir = 1;
+
+                        std::string boundaryName = "open"; // absorbing boundary
+                        if(isPeriodic)
+                            boundaryName = "periodic";
+
+                        if(boundaryName == "open")
+                        {
+                            std::ostringstream boundaryParam;
+                            boundaryParam << absorber.name + " over " << thickness(axis, axisDir) << " cells";
+                            propList[directionName]["param"] = boundaryParam.str();
+                        }
+                        else
+                        {
+                            propList[directionName]["param"] = "none";
+                        }
+
+                        propList[directionName]["name"] = boundaryName;
+                    }
+                }
+                return propList;
+            }
+
+        } // namespace absorber
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/absorber/Pml.hpp
+++ b/include/picongpu/fields/absorber/Pml.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/absorber/Absorber.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace absorber
+        {
+            /** Perfectly matched layer field absorber
+             *
+             * Does not yet provide absorption itself.
+             * However this class is required, as thickness is set when it is instantiated.
+             */
+            class Pml : public Absorber
+            {
+            public:
+                //! Create PML absorber instance
+                Pml()
+                {
+                    // Copy thickness from pml.param
+                    for(uint32_t axis = 0u; axis < 3u; axis++)
+                        for(uint32_t direction = 0u; direction < 2u; direction++)
+                            numCells[axis][direction] = maxwellSolver::Pml::NUM_CELLS[axis][direction];
+                    name = "convolutional PML";
+                }
+            };
+
+        } // namespace absorber
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/plugins/adios/WriteMeta.hpp
+++ b/include/picongpu/plugins/adios/WriteMeta.hpp
@@ -258,7 +258,8 @@ namespace picongpu
                  *    3D: z-lower, z-upper, y-lower, y-upper, x-lower, x-upper
                  *    2D: y-lower, y-upper, x-lower, x-upper
                  */
-                GetStringProperties<fields::absorber::Absorber> fieldBoundaryProp;
+                auto& absorber = fields::absorber::Absorber::get();
+                auto fieldBoundaryProp = absorber.getStringProperties();
                 std::list<std::string> listFieldBoundary;
                 std::list<std::string> listFieldBoundaryParam;
                 for(uint32_t i = NumberOfExchanges<simDim>::value - 1; i > 0; --i)

--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -20,7 +20,7 @@
 #pragma once
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/absorber/ExponentialDamping.hpp"
+#include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/currentInterpolation/CurrentInterpolation.hpp"
 #include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/stringHelpers.hpp"
@@ -159,7 +159,8 @@ namespace picongpu
                      *    3D: z-lower, z-upper, y-lower, y-upper, x-lower, x-upper
                      *    2D: y-lower, y-upper, x-lower, x-upper
                      */
-                    GetStringProperties<fields::absorber::Absorber> fieldBoundaryProp;
+                    auto& absorber = fields::absorber::Absorber::get();
+                    auto fieldBoundaryProp = absorber.getStringProperties();
                     std::vector<std::string> listFieldBoundary;
                     std::vector<std::string> listFieldBoundaryParam;
                     auto n = NumberOfExchanges<simDim>::value;

--- a/include/picongpu/simulation/control/DomainAdjuster.hpp
+++ b/include/picongpu/simulation/control/DomainAdjuster.hpp
@@ -223,16 +223,18 @@ namespace picongpu
             bool const isBoundaryDevice = (m_mpiPosition[dim] == 0 || m_mpiPosition[dim] == m_numDevices[dim] - 1);
             if(isAbsorberEnabled && isBoundaryDevice)
             {
+                auto const& absorber = fields::absorber::Absorber::get();
+                auto const absorberThickness = absorber.getGlobalThickness();
                 size_t boundary = m_mpiPosition[dim] == 0u ? 0u : 1u;
-                int maxAbsorberCells = fields::absorber::numCells[dim][boundary];
+                int maxAbsorberCells = absorberThickness(dim, boundary);
 
                 if(m_movingWindowEnabled && dim == 1u)
                 {
                     /* since the device changes their position during the simulation
                      * the negative and positive absorber cells must fit into the domain
                      */
-                    maxAbsorberCells = static_cast<int>(
-                        std::max(fields::absorber::numCells[dim][0], fields::absorber::numCells[dim][1]));
+                    maxAbsorberCells
+                        = static_cast<int>(std::max(absorberThickness(dim, 0), absorberThickness(dim, 1)));
                 }
 
                 if(m_localDomainSize[dim] < maxAbsorberCells)


### PR DESCRIPTION
Move more responsibility into `fields::absorber::Absorber`.
Now more things are handled run-time.
This is to prepare the following transition to run-time absorber setting and unification of PML and non-PML field solvers.
User interface is unchanged yet.