### PR TITLE
Add option for hemera low (gpu) partitions

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -24,7 +24,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!TBG_queue
+#SBATCH --account=!TBG_account
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName
@@ -44,7 +44,8 @@
 
 
 ## calculations will be performed by tbg ##
-.TBG_queue="fwkt_v100"
+.TBG_queue=${TBG_partition:-"fwkt_v100"}
+.TBG_account=`if [ $TBG_partition == "casus_low" ] ; then echo "low"; else echo "fwkt_v100"; fi`
 
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -57,6 +57,8 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - "fwkt_v100" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/fwkt_v100.tpl"
+# use fwkt_v100 for regular queue and casus_low for low priority queue
+export TBG_partition="fwkt_v100"
 
 # allocate an interactive shell for one hour
 #   getNode 2  # allocates two interactive nodes (default: 1)

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -22,6 +22,7 @@
 # PIConGPU batch script for hemera's SLURM batch system
 
 #SBATCH --partition=!TBG_queue
+#SBATCH --account=!TBG_account
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName
@@ -41,7 +42,8 @@
 
 
 ## calculations will be performed by tbg ##
-.TBG_queue="gpu"
+.TBG_queue=${TBG_partition:-"gpu"}
+.TBG_account=`if [ $TBG_partition == "gpu_low" ] ; then echo "low"; else echo "default"; fi`
 
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -57,6 +57,9 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - "gpu" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/gpu.tpl"
+# use gpu for regular queue and gpu_low for low priority queue
+export TBG_partition="gpu"
+
 
 # allocate an interactive shell for one hour
 #   getNode 2  # allocates two interactive nodes (default: 1)

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -24,7 +24,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!TBG_queue
+#SBATCH --account=!TBG_account
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName
@@ -44,7 +44,8 @@
 
 
 ## calculations will be performed by tbg ##
-.TBG_queue="k20"
+.TBG_queue=${TBG_partition:-"k20"}
+.TBG_account=`if [ $TBG_partition == "k20_low" ] ; then echo "low"; else echo "k20"; fi`
 
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -57,6 +57,9 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - "k20" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/k20.tpl"
+# use k20 for regular queue and k20_low for low priority queue
+export TBG_partition="k20"
+
 
 # allocate an interactive shell for one hour
 #   getNode 2  # allocates two interactive nodes (default: 1)

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -21,7 +21,8 @@
 
 
 ## calculation are done by tbg ##
-.TBG_queue="k20"
+.TBG_queue=${TBG_partition:-"k20"}
+.TBG_account=`if [ $TBG_partition == "k20_low" ] ; then echo "low"; else echo "k20"; fi`
 
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
@@ -55,7 +56,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!TBG_queue
+#SBATCH --account=!TBG_account
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -24,7 +24,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!TBG_queue
+#SBATCH --account=!TBG_account
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName
@@ -44,7 +44,8 @@
 
 
 ## calculations will be performed by tbg ##
-.TBG_queue="k80"
+.TBG_queue=${TBG_partition:-"k80"}
+.TBG_account=`if [ $TBG_partition == "k80_low" ] ; then echo "low"; else echo "k80"; fi`
 
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -57,6 +57,9 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 #   - "k80" queue
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/k80.tpl"
+# use k80 for regular queue and k80_low for low priority queue
+export TBG_partition="k80"
+
 
 # allocate an interactive shell for one hour
 #   getNode 2  # allocates two interactive nodes (default: 1)

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -21,7 +21,8 @@
 
 
 ## calculation are done by tbg ##
-.TBG_queue="k80"
+TBG_queue=${TBG_partition:-"k80"}
+.TBG_account=`if [ $TBG_partition == "k80_low" ] ; then echo "low"; else echo "k80"; fi`
 
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
@@ -55,7 +56,7 @@
 
 #SBATCH --partition=!TBG_queue
 # necessary to set the account also to the queue name because otherwise access is not allowed at the moment
-#SBATCH --account=!TBG_queue
+#SBATCH --account=!TBG_account
 #SBATCH --time=!TBG_wallTime
 # Sets batch job's name
 #SBATCH --job-name=!TBG_jobName


### PR DESCRIPTION
This pull request adds the option to use the respective low partition instead of the regular (gpu) partition for `k20`, `k80`, `gpu` and `fwkt_v100`. 

**check:**
- [x] verify that `--account default` works for `gpu` partition
- [x] test all partitions 