### PR TITLE
fix compile with icc

### DIFF
--- a/include/pmacc/static_assert.hpp
+++ b/include/pmacc/static_assert.hpp
@@ -46,7 +46,7 @@ namespace pmacc
  * @param pmacc_unique_id pre compiler unique id
  * @param pmacc_typeInfo a type that is shown in error message
  */
-#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA || BOOST_COMP_HIP
+#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA || BOOST_COMP_HIP || BOOST_COMP_INTEL
 /* device compile with clang: boost static assert can not be used
  * error is: calling a `__host__` function from `__device__`
  * Therefore C++11 `static_assert` is used


### PR DESCRIPTION
fix

```
include/pmacc/../pmacc/math/vector/Vector.hpp(181): error: variable in constexpr function does not have automatic storage duration
                  PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM3, dim == 3&& sizeof(Storage));
```

@jkelling Said to me a long time ago that there is an issue with ICC. I forgot about it and watched the issue during my tests again :-(