### PR TITLE
CI: check for doxygen style

### DIFF
--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -51,13 +51,13 @@ namespace picongpu
         /** Does a 3D trilinear field-to-point interpolation for
          * arbitrary assignment function and arbitrary field_value types.
          *
-         * \tparam T_AssignmentFunction function for assignment
-         * \tparam T_begin lower margin for interpolation
-         * \tparam T_end upper margin for interpolation
+         * @tparam T_AssignmentFunction function for assignment
+         * @tparam T_begin lower margin for interpolation
+         * @tparam T_end upper margin for interpolation
          *
-         * \param cursor cursor pointing to the field
-         * \param pos position of the interpolation point
-         * \return sum over: field_value * assignment
+         * @param cursor cursor pointing to the field
+         * @param pos position of the interpolation point
+         * @return sum over: field_value * assignment
          *
          * interpolate on grid points in range [T_begin;T_end]
          */

--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -35,10 +35,10 @@ namespace picongpu
      * interpolate around a point from -AssignmentFunction::support/2 to
      * (AssignmentFunction::support+1)/2
      *
-     * \tparam GridShiftMethod functor which shift coordinate system that al value are
+     * @tparam GridShiftMethod functor which shift coordinate system that al value are
      * located on corner
-     * \tparam AssignmentFunction AssignmentFunction which is used for interpolation
-     * \tparam InterpolationMethod functor for interpolation method
+     * @tparam AssignmentFunction AssignmentFunction which is used for interpolation
+     * @tparam InterpolationMethod functor for interpolation method
      */
     template<class T_Shape, class InterpolationMethod>
     struct FieldToParticleInterpolation

--- a/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
@@ -35,10 +35,10 @@ namespace picongpu
      * interpolate around of a point from -AssignmentFunction::support/2 to
      * (AssignmentFunction::support+1)/2
      *
-     * \tparam GridShiftMethod functor which shift coordinate system that al value are
+     * @tparam GridShiftMethod functor which shift coordinate system that al value are
      * located on corner
-     * \tparam AssignmentFunction AssignmentFunction which is used for interpolation
-     * \tparam InterpolationMethod functor for interpolation method
+     * @tparam AssignmentFunction AssignmentFunction which is used for interpolation
+     * @tparam InterpolationMethod functor for interpolation method
      */
     template<class T_Shape, class InterpolationMethod>
     struct FieldToParticleInterpolationNative

--- a/include/picongpu/fields/Fields.def
+++ b/include/picongpu/fields/Fields.def
@@ -59,13 +59,13 @@ namespace picongpu
      */
     class FieldTmp;
 
-    /** Electric Field, \see FieldE.hpp */
+    /** Electric Field, @see FieldE.hpp */
     class FieldE;
 
-    /** Magnetic Field, \see FieldB.hpp */
+    /** Magnetic Field, @see FieldB.hpp */
     class FieldB;
 
-    /** Current Density j, \see FieldJ.hpp */
+    /** Current Density j, @see FieldJ.hpp */
     class FieldJ;
 
 } // namespace picongpu

--- a/include/picongpu/fields/background/cellwiseOperation.hpp
+++ b/include/picongpu/fields/background/cellwiseOperation.hpp
@@ -105,7 +105,7 @@ namespace picongpu
 
         /** Call a functor on each cell of a field
          *
-         * \tparam T_Area Where to compute on (CORE, BORDER, GUARD)
+         * @tparam T_Area Where to compute on (CORE, BORDER, GUARD)
          */
         template<uint32_t T_Area>
         class CellwiseOperation

--- a/include/picongpu/fields/background/templates/TWTS/BField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.hpp
@@ -93,21 +93,21 @@ namespace picongpu
 
                 /** Magnetic field of the TWTS laser
                  *
-                 * \param focus_y_SI the distance to the laser focus in y-direction [m]
-                 * \param wavelength_SI central wavelength [m]
-                 * \param pulselength_SI sigma of std. gauss for intensity (E^2),
+                 * @param focus_y_SI the distance to the laser focus in y-direction [m]
+                 * @param wavelength_SI central wavelength [m]
+                 * @param pulselength_SI sigma of std. gauss for intensity (E^2),
                  *  pulselength_SI = FWHM_of_Intensity / 2.35482 [seconds (sigma)]
-                 * \param w_x beam waist: distance from the axis where the pulse electric field
+                 * @param w_x beam waist: distance from the axis where the pulse electric field
                  *  decreases to its 1/e^2-th part at the focus position of the laser [m]
-                 * \param w_y \see w_x
-                 * \param phi interaction angle between TWTS laser propagation vector and
+                 * @param w_y @see w_x
+                 * @param phi interaction angle between TWTS laser propagation vector and
                  *  the y-axis [rad, default = 90.*(PI/180.)]
-                 * \param beta_0 propagation speed of overlap normalized to
+                 * @param beta_0 propagation speed of overlap normalized to
                  *  the speed of light [c, default = 1.0]
-                 * \param tdelay_user manual time delay if auto_tdelay is false
-                 * \param auto_tdelay calculate the time delay such that the TWTS pulse is not
+                 * @param tdelay_user manual time delay if auto_tdelay is false
+                 * @param auto_tdelay calculate the time delay such that the TWTS pulse is not
                  *  inside the simulation volume at simulation start timestep = 0 [default = true]
-                 * \param pol determines the TWTS laser polarization, which is either normal or parallel
+                 * @param pol determines the TWTS laser polarization, which is either normal or parallel
                  *  to the laser pulse front tilt plane [ default= LINEAR_X , LINEAR_YZ ]
                  */
                 HINLINE
@@ -126,55 +126,55 @@ namespace picongpu
 
                 /** Specify your background field B(r,t) here
                  *
-                 * \param cellIdx The total cell id counted from the start at t=0
-                 * \param currentStep The current time step */
+                 * @param cellIdx The total cell id counted from the start at t=0
+                 * @param currentStep The current time step */
                 HDINLINE float3_X operator()(const DataSpace<simDim>& cellIdx, const uint32_t currentStep) const;
 
                 /** Calculate the By(r,t) field, when electric field vector (Ex,0,0)
                  *  is normal to the pulse-front-tilt plane (y,z)
                  *
-                 * \param pos Spatial position of the target field.
-                 * \param time Absolute time (SI, including all offsets and transformations)
+                 * @param pos Spatial position of the target field.
+                 * @param time Absolute time (SI, including all offsets and transformations)
                  *  for calculating the field */
                 HDINLINE float_T calcTWTSBy(const float3_64& pos, const float_64 time) const;
 
                 /** Calculate the Bz(r,t) field, when electric field vector (Ex,0,0)
                  *  is normal to the pulse-front-tilt plane (y,z)
                  *
-                 * \param pos Spatial position of the target field.
-                 * \param time Absolute time (SI, including all offsets and transformations)
+                 * @param pos Spatial position of the target field.
+                 * @param time Absolute time (SI, including all offsets and transformations)
                  *  for calculating the field */
                 HDINLINE float_T calcTWTSBz_Ex(const float3_64& pos, const float_64 time) const;
 
                 /** Calculate the By(r,t) field, when electric field vector (0,Ey,0)
                  *  lies within the pulse-front-tilt plane (y,z)
                  *
-                 * \param pos Spatial position of the target field.
-                 * \param time Absolute time (SI, including all offsets and transformations)
+                 * @param pos Spatial position of the target field.
+                 * @param time Absolute time (SI, including all offsets and transformations)
                  *  for calculating the field */
                 HDINLINE float_T calcTWTSBx(const float3_64& pos, const float_64 time) const;
 
                 /** Calculate the Bz(r,t) field here (electric field vector (0,Ey,0)
                  *  lies within the pulse-front-tilt plane (y,z)
                  *
-                 * \param pos Spatial position of the target field.
-                 * \param time Absolute time (SI, including all offsets and transformations)
+                 * @param pos Spatial position of the target field.
+                 * @param time Absolute time (SI, including all offsets and transformations)
                  *  for calculating the field */
                 HDINLINE float_T calcTWTSBz_Ey(const float3_64& pos, const float_64 time) const;
 
                 /** Calculate the B-field vector of the TWTS laser in SI units.
-                 * \tparam T_dim Specializes for the simulation dimension
-                 * \param cellIdx The total cell id counted from the start at timestep 0
-                 * \return B-field vector of the rotated TWTS field in SI units */
+                 * @tparam T_dim Specializes for the simulation dimension
+                 * @param cellIdx The total cell id counted from the start at timestep 0
+                 * @return B-field vector of the rotated TWTS field in SI units */
                 template<unsigned T_dim>
                 HDINLINE float3_X getTWTSBfield_Normalized(
                     const pmacc::math::Vector<floatD_64, detail::numComponents>& eFieldPositions_SI,
                     const float_64 time) const;
 
                 /** Calculate the B-field vector of the "in-plane" polarized TWTS laser in SI units.
-                 * \tparam T_dim Specializes for the simulation dimension
-                 * \param cellIdx The total cell id counted from the start at timestep 0
-                 * \return B-field vector of the rotated TWTS field in SI units */
+                 * @tparam T_dim Specializes for the simulation dimension
+                 * @param cellIdx The total cell id counted from the start at timestep 0
+                 * @return B-field vector of the rotated TWTS field in SI units */
                 template<unsigned T_dim>
                 HDINLINE float3_X getTWTSBfield_Normalized_Ey(
                     const pmacc::math::Vector<floatD_64, detail::numComponents>& eFieldPositions_SI,

--- a/include/picongpu/fields/background/templates/TWTS/BField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.tpp
@@ -288,8 +288,8 @@ namespace picongpu
 
             /** Calculate the By(r,t) field here
              *
-             * \param pos Spatial position of the target field.
-             * \param time Absolute time (SI, including all offsets and transformations)
+             * @param pos Spatial position of the target field.
+             * @param time Absolute time (SI, including all offsets and transformations)
              *             for calculating the field */
             HDINLINE BField::float_T BField::calcTWTSBy(const float3_64& pos, const float_64 time) const
             {
@@ -439,8 +439,8 @@ namespace picongpu
 
             /** Calculate the Bz(r,t) field
              *
-             * \param pos Spatial position of the target field.
-             * \param time Absolute time (SI, including all offsets and transformations)
+             * @param pos Spatial position of the target field.
+             * @param time Absolute time (SI, including all offsets and transformations)
              *             for calculating the field */
             HDINLINE BField::float_T BField::calcTWTSBz_Ex(const float3_64& pos, const float_64 time) const
             {
@@ -551,8 +551,8 @@ namespace picongpu
 
             /** Calculate the Bx(r,t) field
              *
-             * \param pos Spatial position of the target field.
-             * \param time Absolute time (SI, including all offsets and transformations)
+             * @param pos Spatial position of the target field.
+             * @param time Absolute time (SI, including all offsets and transformations)
              *             for calculating the field */
             HDINLINE BField::float_T BField::calcTWTSBx(const float3_64& pos, const float_64 time) const
             {
@@ -564,8 +564,8 @@ namespace picongpu
 
             /** Calculate the Bz(r,t) field
              *
-             * \param pos Spatial position of the target field.
-             * \param time Absolute time (SI, including all offsets and transformations)
+             * @param pos Spatial position of the target field.
+             * @param time Absolute time (SI, including all offsets and transformations)
              *             for calculating the field */
             HDINLINE BField::float_T BField::calcTWTSBz_Ey(const float3_64& pos, const float_64 time) const
             {

--- a/include/picongpu/fields/background/templates/TWTS/EField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.hpp
@@ -92,21 +92,21 @@ namespace picongpu
 
                 /** Electric field of the TWTS laser
                  *
-                 * \param focus_y_SI the distance to the laser focus in y-direction [m]
-                 * \param wavelength_SI central wavelength [m]
-                 * \param pulselength_SI sigma of std. gauss for intensity (E^2),
+                 * @param focus_y_SI the distance to the laser focus in y-direction [m]
+                 * @param wavelength_SI central wavelength [m]
+                 * @param pulselength_SI sigma of std. gauss for intensity (E^2),
                  *  pulselength_SI = FWHM_of_Intensity / 2.35482 [seconds (sigma)]
-                 * \param w_x beam waist: distance from the axis where the pulse electric field
+                 * @param w_x beam waist: distance from the axis where the pulse electric field
                  *  decreases to its 1/e^2-th part at the focus position of the laser [m]
-                 * \param w_y \see w_x
-                 * \param phi interaction angle between TWTS laser propagation vector and
+                 * @param w_y @see w_x
+                 * @param phi interaction angle between TWTS laser propagation vector and
                  *  the y-axis [rad, default = 90.*(PI/180.)]
-                 * \param beta_0 propagation speed of overlap normalized to
+                 * @param beta_0 propagation speed of overlap normalized to
                  *  the speed of light [c, default = 1.0]
-                 * \param tdelay_user manual time delay if auto_tdelay is false
-                 * \param auto_tdelay calculate the time delay such that the TWTS pulse is not
+                 * @param tdelay_user manual time delay if auto_tdelay is false
+                 * @param auto_tdelay calculate the time delay such that the TWTS pulse is not
                  *  inside the simulation volume at simulation start timestep = 0 [default = true]
-                 * \param pol dtermines the TWTS laser polarization, which is either normal or parallel
+                 * @param pol dtermines the TWTS laser polarization, which is either normal or parallel
                  *  to the laser pulse front tilt plane [ default= LINEAR_X , LINEAR_YZ ]
                  */
                 HINLINE
@@ -124,41 +124,41 @@ namespace picongpu
 
                 /** Specify your background field E(r,t) here
                  *
-                 * \param cellIdx The total cell id counted from the start at timestep 0.
-                 * \param currentStep The current time step
-                 * \return float3_X with field normalized to amplitude in range [-1.:1.]
+                 * @param cellIdx The total cell id counted from the start at timestep 0.
+                 * @param currentStep The current time step
+                 * @return float3_X with field normalized to amplitude in range [-1.:1.]
                  */
                 HDINLINE float3_X operator()(const DataSpace<simDim>& cellIdx, const uint32_t currentStep) const;
 
                 /** Calculate the Ex(r,t) field here (electric field vector normal to pulse-front-tilt plane)
                  *
-                 * \param pos Spatial position of the target field
-                 * \param time Absolute time (SI, including all offsets and transformations)
+                 * @param pos Spatial position of the target field
+                 * @param time Absolute time (SI, including all offsets and transformations)
                  *  for calculating the field
-                 * \return Ex-field component of the non-rotated TWTS field in SI units */
+                 * @return Ex-field component of the non-rotated TWTS field in SI units */
                 HDINLINE float_T calcTWTSEx(const float3_64& pos, const float_64 time) const;
 
                 /** Calculate the Ey(r,t) field here (electric field vector in pulse-front-tilt plane)
                  *
-                 * \param pos Spatial position of the target field
-                 * \param time Absolute time (SI, including all offsets and transformations)
+                 * @param pos Spatial position of the target field
+                 * @param time Absolute time (SI, including all offsets and transformations)
                  *  for calculating the field
-                 * \return Ex-field component of the non-rotated TWTS field in SI units */
+                 * @return Ex-field component of the non-rotated TWTS field in SI units */
                 HDINLINE float_T calcTWTSEy(const float3_64& pos, const float_64 time) const;
 
                 /** Calculate the E-field vector of the TWTS laser in SI units.
-                 * \tparam T_dim Specializes for the simulation dimension
-                 * \param cellIdx The total cell id counted from the start at timestep 0
-                 * \return Efield vector of the rotated TWTS field in SI units */
+                 * @tparam T_dim Specializes for the simulation dimension
+                 * @param cellIdx The total cell id counted from the start at timestep 0
+                 * @return Efield vector of the rotated TWTS field in SI units */
                 template<unsigned T_dim>
                 HDINLINE float3_X getTWTSEfield_Normalized(
                     const pmacc::math::Vector<floatD_64, detail::numComponents>& eFieldPositions_SI,
                     const float_64 time) const;
 
                 /** Calculate the E-field vector of the "in-plane polarized" TWTS laser in SI units.
-                 * \tparam T_dim Specializes for the simulation dimension
-                 * \param cellIdx The total cell id counted from the start at timestep 0
-                 * \return Efield vector of the rotated TWTS field in SI units */
+                 * @tparam T_dim Specializes for the simulation dimension
+                 * @param cellIdx The total cell id counted from the start at timestep 0
+                 * @return Efield vector of the rotated TWTS field in SI units */
                 template<unsigned T_dim>
                 HDINLINE float3_X getTWTSEfield_Normalized_Ey(
                     const pmacc::math::Vector<floatD_64, detail::numComponents>& eFieldPositions_SI,

--- a/include/picongpu/fields/background/templates/TWTS/EField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.tpp
@@ -199,8 +199,8 @@ namespace picongpu
 
             /** Calculate the Ex(r,t) field here
              *
-             * \param pos Spatial position of the target field.
-             * \param time Absolute time (SI, including all offsets and transformations) for calculating
+             * @param pos Spatial position of the target field.
+             * @param time Absolute time (SI, including all offsets and transformations) for calculating
              *             the field */
             HDINLINE EField::float_T EField::calcTWTSEx(const float3_64& pos, const float_64 time) const
             {
@@ -334,8 +334,8 @@ namespace picongpu
 
             /** Calculate the Ey(r,t) field here
              *
-             * \param pos Spatial position of the target field.
-             * \param time Absolute time (SI, including all offsets and transformations) for calculating
+             * @param pos Spatial position of the target field.
+             * @param time Absolute time (SI, including all offsets and transformations) for calculating
              *             the field */
             HDINLINE EField::float_T EField::calcTWTSEy(const float3_64& pos, const float_64 time) const
             {

--- a/include/picongpu/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
@@ -39,19 +39,19 @@ namespace picongpu
                 public:
                     /** Obtain the SI time delay that later enters the Ex(r, t), By(r, t) and Bz(r, t)
                      *  calculations as t.
-                     * \tparam T_dim Specializes for the simulation dimension
-                     *  \param auto_tdelay calculate the time delay such that the TWTS pulse is not
+                     * @tparam T_dim Specializes for the simulation dimension
+                     *  @param auto_tdelay calculate the time delay such that the TWTS pulse is not
                      *                     inside the simulation volume at simulation start
                      *                     timestep = 0 [default = true]
-                     *  \param tdelay_user_SI manual time delay if auto_tdelay is false
-                     *  \param halfSimSize center of simulation volume in number of cells
-                     *  \param pulselength_SI sigma of std. gauss for intensity (E^2)
-                     *  \param focus_y_SI the distance to the laser focus in y-direction [m]
-                     *  \param phi interaction angle between TWTS laser propagation vector and
+                     *  @param tdelay_user_SI manual time delay if auto_tdelay is false
+                     *  @param halfSimSize center of simulation volume in number of cells
+                     *  @param pulselength_SI sigma of std. gauss for intensity (E^2)
+                     *  @param focus_y_SI the distance to the laser focus in y-direction [m]
+                     *  @param phi interaction angle between TWTS laser propagation vector and
                      *             the y-axis [rad, default = 90.*(PI / 180.)]
-                     *  \param beta_0 propagation speed of overlap normalized
+                     *  @param beta_0 propagation speed of overlap normalized
                      *                to the speed of light [c, default = 1.0]
-                     *  \return time delay in SI units */
+                     *  @return time delay in SI units */
                     HDINLINE float_64 operator()(
                         const bool auto_tdelay,
                         const float_64 tdelay_user_SI,

--- a/include/picongpu/fields/background/templates/TWTS/getFieldPositions_SI.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/getFieldPositions_SI.tpp
@@ -37,7 +37,7 @@ namespace picongpu
             {
                 /** Calculate the SI position vectors that later enter the Ex(r, t), By(r, t)
                  *  and Bz(r ,t) calculations as r.
-                 *  \param cellIdx The total cell id counted from the start at timestep 0. */
+                 *  @param cellIdx The total cell id counted from the start at timestep 0. */
                 HDINLINE pmacc::math::Vector<floatD_64, numComponents> getFieldPositions_SI(
                     const DataSpace<simDim>& cellIdx,
                     const DataSpace<simDim>& halfSimSize,

--- a/include/picongpu/fields/cellType/Centered.hpp
+++ b/include/picongpu/fields/cellType/Centered.hpp
@@ -89,8 +89,8 @@ namespace picongpu
         template<>
         struct FieldPosition<fields::cellType::Centered, FieldJ, DIM2>
         {
-            /** \tparam float2_X position of the component in the cell
-             *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+            /** @tparam float2_X position of the component in the cell
+             *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector2D3V = const ::pmacc::math::Vector<float2_X, DIM3>;
             /// boost::result_of hints
@@ -122,8 +122,8 @@ namespace picongpu
         template<>
         struct FieldPosition<fields::cellType::Centered, FieldJ, DIM3>
         {
-            /** \tparam float2_X position of the component in the cell
-             *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+            /** @tparam float2_X position of the component in the cell
+             *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector3D3V = const ::pmacc::math::Vector<float3_X, DIM3>;
             /// boost::result_of hints

--- a/include/picongpu/fields/cellType/Yee.hpp
+++ b/include/picongpu/fields/cellType/Yee.hpp
@@ -47,8 +47,8 @@ namespace picongpu
         template<>
         struct FieldPosition<fields::cellType::Yee, FieldE, DIM2>
         {
-            /** \tparam float2_X position of the component in the cell
-             *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+            /** @tparam float2_X position of the component in the cell
+             *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector2D3V = const ::pmacc::math::Vector<float2_X, DIM3>;
             /// boost::result_of hints
@@ -80,8 +80,8 @@ namespace picongpu
         template<>
         struct FieldPosition<fields::cellType::Yee, FieldE, DIM3>
         {
-            /** \tparam float2_X position of the component in the cell
-             *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+            /** @tparam float2_X position of the component in the cell
+             *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector3D3V = const ::pmacc::math::Vector<float3_X, DIM3>;
 
@@ -114,8 +114,8 @@ namespace picongpu
         template<>
         struct FieldPosition<fields::cellType::Yee, FieldB, DIM2>
         {
-            /** \tparam float2_X position of the component in the cell
-             *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+            /** @tparam float2_X position of the component in the cell
+             *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector2D3V = const ::pmacc::math::Vector<float2_X, DIM3>;
             /// boost::result_of hints
@@ -147,8 +147,8 @@ namespace picongpu
         template<>
         struct FieldPosition<fields::cellType::Yee, FieldB, DIM3>
         {
-            /** \tparam float2_X position of the component in the cell
-             *  \tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
+            /** @tparam float2_X position of the component in the cell
+             *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector3D3V = const ::pmacc::math::Vector<float3_X, DIM3>;
 

--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -104,9 +104,9 @@ namespace picongpu
 
                 /** deposites current in z-direction
                  *
-                 * \param cursorJ cursor pointing at the current density field of the particle's cell
-                 * \param line trajectory of the virtual particle
-                 * \param currentSurfaceDensity surface density
+                 * @param cursorJ cursor pointing at the current density field of the particle's cell
+                 * @param line trajectory of the virtual particle
+                 * @param currentSurfaceDensity surface density
                  */
                 template<typename CursorJ, typename T_Line, typename T_Acc>
                 DINLINE void cptCurrent1D(
@@ -175,9 +175,9 @@ namespace picongpu
 
                 /** deposites current in x-direction
                  *
-                 * \param cursorJ cursor pointing at the current density field of the particle's cell
-                 * \param line trajectory of the virtual particle
-                 * \param currentSurfaceDensity surface density
+                 * @param cursorJ cursor pointing at the current density field of the particle's cell
+                 * @param line trajectory of the virtual particle
+                 * @param currentSurfaceDensity surface density
                  */
                 template<typename CursorJ, typename T_Line, typename T_Acc>
                 DINLINE void cptCurrent1D(
@@ -213,9 +213,9 @@ namespace picongpu
 
                 /** deposites current in z-direction
                  *
-                 * \param cursorJ cursor pointing at the current density field of the particle's cell
-                 * \param line trajectory of the virtual particle
-                 * \param currentSurfaceDensityZ surface density in z direction
+                 * @param cursorJ cursor pointing at the current density field of the particle's cell
+                 * @param line trajectory of the virtual particle
+                 * @param currentSurfaceDensityZ surface density in z direction
                  */
                 template<typename CursorJ, typename T_Line, typename T_Acc>
                 DINLINE void cptCurrentZ(

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -129,11 +129,11 @@ namespace picongpu
             /**
              * deposites current in z-direction
              *
-             * \param leaveCell vector with information if the particle is leaving the cell
+             * @param leaveCell vector with information if the particle is leaving the cell
              *         (for each direction, 0 means stays in cell and 1 means leaves cell)
-             * \param cursorJ cursor pointing at the current density field of the particle's cell
-             * \param line trajectory of the particle from to last to the current time step
-             * \param cellEdgeLength length of edge of the cell in z-direction
+             * @param cursorJ cursor pointing at the current density field of the particle's cell
+             * @param line trajectory of the particle from to last to the current time step
+             * @param cellEdgeLength length of edge of the cell in z-direction
              */
             template<typename CursorJ, typename T_Acc>
             DINLINE void cptCurrent1D(

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -128,11 +128,11 @@ namespace picongpu
 
             /**
              * deposites current in z-direction
-             * \param leaveCell vector with information if the particle is leaving the cell
+             * @param leaveCell vector with information if the particle is leaving the cell
              *         (for each direction, 0 means stays in cell and 1 means leaves cell)
-             * \param cursorJ cursor pointing at the current density field of the particle's cell
-             * \param line trajectory of the particle from to last to the current time step
-             * \param cellEdgeLength length of edge of the cell in z-direction
+             * @param cursorJ cursor pointing at the current density field of the particle's cell
+             * @param line trajectory of the particle from to last to the current time step
+             * @param cellEdgeLength length of edge of the cell in z-direction
              *
              * @{
              */

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -109,9 +109,9 @@ namespace picongpu
 
             /**
              * deposites current in z-direction
-             * \param cursorJ cursor pointing at the current density field of the particle's cell
-             * \param line trajectory of the particle from to last to the current time step
-             * \param cellEdgeLength length of edge of the cell in z-direction
+             * @param cursorJ cursor pointing at the current density field of the particle's cell
+             * @param line trajectory of the particle from to last to the current time step
+             * @param cellEdgeLength length of edge of the cell in z-direction
              */
             template<typename CursorJ, typename T_Acc>
             DINLINE void cptCurrent1D(

--- a/include/picongpu/initialization/ParserGridDistribution.hpp
+++ b/include/picongpu/initialization/ParserGridDistribution.hpp
@@ -54,8 +54,8 @@ namespace picongpu
 
         /** Get local Size of this dimension
          *
-         *  \param[in] devicePos as unsigned integer in the range [0, n-1] for this dimension
-         *  \return uint32_t with local number of cells
+         *  @param[in] devicePos as unsigned integer in the range [0, n-1] for this dimension
+         *  @return uint32_t with local number of cells
          */
         uint32_t getLocalSize(uint32_t const devicePos) const;
 
@@ -64,7 +64,7 @@ namespace picongpu
          * Check that the number of subdomains in a dimension, after we
          * expanded all regexes, matches the number of devices for it.
          *
-         * \param[in] numDevices number of devices for this dimension
+         * @param[in] numDevices number of devices for this dimension
          */
         void verifyDevices(uint32_t const numDevices) const;
 
@@ -77,8 +77,8 @@ namespace picongpu
          * to a vector of SubdomainPair with extent number (a,b,c,d,e,f) and
          * counts (1,1,n,m,e,f)
          *
-         * \param[in] s as string in the form a,b{n}
-         * \return std::vector<SubdomainPair> with 2x uint32_t (extent, count)
+         * @param[in] s as string in the form a,b{n}
+         * @return std::vector<SubdomainPair> with 2x uint32_t (extent, count)
          */
         value_type parse(std::string const s) const;
     };

--- a/include/picongpu/param/fieldBackground.param
+++ b/include/picongpu/param/fieldBackground.param
@@ -42,8 +42,8 @@ namespace picongpu
 
         /** Specify your background field E(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t = 0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t = 0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(const DataSpace<simDim>& cellIdx, const uint32_t currentStep) const
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
@@ -74,8 +74,8 @@ namespace picongpu
 
         /** Specify your background field B(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t=0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(const DataSpace<simDim>& cellIdx, const uint32_t currentStep) const
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */
@@ -106,8 +106,8 @@ namespace picongpu
 
         /** Specify your background field J(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t=0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(const DataSpace<simDim>& cellIdx, const uint32_t currentStep) const
         {
             /* example: periodicity of 20 microns ( = 2.0e-5 m) */

--- a/include/picongpu/param/particleCalorimeter.param
+++ b/include/picongpu/param/particleCalorimeter.param
@@ -29,11 +29,11 @@ namespace picongpu
          *
          * Useful for fine tuning the spatial calorimeter resolution.
          *
-         * \param yaw -maxYaw...maxYaw
-         * \param pitch -maxPitch...maxPitch
-         * \param maxYaw maximum value of angle yaw
-         * \param maxPitch maximum value of angle pitch
-         * \return Two values within [-1,1]
+         * @param yaw -maxYaw...maxYaw
+         * @param pitch -maxPitch...maxPitch
+         * @param maxYaw maximum value of angle yaw
+         * @param maxPitch maximum value of angle pitch
+         * @return Two values within [-1,1]
          */
         HDINLINE float2_X
         mapYawPitchToNormedRange(const float_X yaw, const float_X pitch, const float_X maxYaw, const float_X maxPitch)

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -268,7 +268,7 @@ namespace picongpu
 
         /** Call an ionization method upon an ion species
          *
-         * \tparam T_SpeciesType type or name as boost::mpl::string of particle species that is going to be ionized
+         * @tparam T_SpeciesType type or name as boost::mpl::string of particle species that is going to be ionized
          * with ionization scheme T_SelectIonizer
          */
         template<typename T_SpeciesType, typename T_SelectIonizer>
@@ -286,10 +286,10 @@ namespace picongpu
 
             /** Functor implementation
              *
-             * \tparam T_CellDescription contains the number of blocks and blocksize
+             * @tparam T_CellDescription contains the number of blocks and blocksize
              *                           that is later passed to the kernel
-             * \param cellDesc logical block information like dimension and cell sizes
-             * \param currentStep The current time step
+             * @param cellDesc logical block information like dimension and cell sizes
+             * @param currentStep The current time step
              */
             template<typename T_CellDescription>
             HINLINE void operator()(T_CellDescription cellDesc, const uint32_t currentStep) const
@@ -316,7 +316,7 @@ namespace picongpu
          *
          * Tests if species can be ionized and calls the kernels to do that
          *
-         * \tparam T_SpeciesType type or name as boost::mpl::string of particle species that is checked for ionization
+         * @tparam T_SpeciesType type or name as boost::mpl::string of particle species that is checked for ionization
          */
         template<typename T_SpeciesType>
         struct CallIonization
@@ -329,10 +329,10 @@ namespace picongpu
 
             /** Functor implementation
              *
-             * \tparam T_CellDescription contains the number of blocks and blocksize
+             * @tparam T_CellDescription contains the number of blocks and blocksize
              *                           that is later passed to the kernel
-             * \param cellDesc logical block information like dimension and cell sizes
-             * \param currentStep The current time step
+             * @param cellDesc logical block information like dimension and cell sizes
+             * @param currentStep The current time step
              */
             template<typename T_CellDescription>
             HINLINE void operator()(T_CellDescription cellDesc, const uint32_t currentStep) const
@@ -374,10 +374,10 @@ namespace picongpu
 
             /** Functor implementation
              *
-             * \tparam T_CellDescription contains the number of blocks and blocksize
+             * @tparam T_CellDescription contains the number of blocks and blocksize
              *                           that is later passed to the kernel
-             * \param cellDesc logical block information like dimension and cell sizes
-             * \param currentStep the current time step
+             * @param cellDesc logical block information like dimension and cell sizes
+             * @param currentStep the current time step
              */
             template<typename T_CellDescription, typename ScaledSpectrumMap>
             HINLINE void operator()(
@@ -428,11 +428,11 @@ namespace picongpu
 
             /** Functor implementation
              *
-             * \tparam T_CellDescription contains the number of blocks and blocksize
+             * @tparam T_CellDescription contains the number of blocks and blocksize
              *                           that is later passed to the kernel
-             * \param cellDesc logical block information like dimension and cell sizes
-             * \param currentStep The current time step
-             * \param synchrotronFunctions synchrotron functions wrapper object
+             * @param cellDesc logical block information like dimension and cell sizes
+             * @param currentStep The current time step
+             * @param synchrotronFunctions synchrotron functions wrapper object
              */
             template<typename T_CellDescription>
             HINLINE void operator()(

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -215,7 +215,7 @@ namespace picongpu
 
                         /** we now initialize all attributes of the new particle to their default values
                          *   some attributes, such as the position, localCellIdx, weighting or the
-                         *   multiMask (\see AttrToIgnore) of the particle will be set individually
+                         *   multiMask (@see AttrToIgnore) of the particle will be set individually
                          *   in the following lines since they are already known at this point.
                          */
                         {

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -52,8 +52,8 @@ namespace picongpu
              * The photon emission angle is taken from the Lorentz-boosted dipole radiation formula,
              * see e.g. Jackson, chap. 15.2
              *
-             * \tparam T_ElectronSpecies
-             * \tparam T_PhotonSpecies
+             * @tparam T_ElectronSpecies
+             * @tparam T_PhotonSpecies
              */
             template<typename T_IonSpecies, typename T_ElectronSpecies, typename T_PhotonSpecies>
             struct Bremsstrahlung
@@ -166,8 +166,8 @@ namespace picongpu
                  *
                  * Called once for each single particle creation.
                  *
-                 * \tparam Electron type of electron which creates the photon
-                 * \tparam Photon type of photon that is created
+                 * @tparam Electron type of electron which creates the photon
+                 * @tparam Photon type of photon that is created
                  */
                 template<typename Electron, typename Photon, typename T_Acc>
                 DINLINE void operator()(const T_Acc& acc, Electron& electron, Photon& photon);

--- a/include/picongpu/particles/creation/creation.hpp
+++ b/include/picongpu/particles/creation/creation.hpp
@@ -42,7 +42,7 @@ namespace picongpu
              * @param cellDesc mapping description
              *
              * `particleCreator` must define: `init()`, `numNewParticles()` and `operator()()`
-             * \see `PhotonCreator.hpp` for a further description.
+             * @see `PhotonCreator.hpp` for a further description.
              */
             template<
                 typename T_SourceSpecies,

--- a/include/picongpu/particles/ionization/None/AlgorithmNone.hpp
+++ b/include/picongpu/particles/ionization/None/AlgorithmNone.hpp
@@ -43,13 +43,13 @@ namespace picongpu
             {
                 /** Functor implementation
                  *
-                 * \tparam EType type of electric field
-                 * \tparam BType type of magnetic field
-                 * \tparam ParticleType type of particle to be ionized
+                 * @tparam EType type of electric field
+                 * @tparam BType type of magnetic field
+                 * @tparam ParticleType type of particle to be ionized
                  *
-                 * \param bField magnetic field value at t=0
-                 * \param eField electric field value at t=0
-                 * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+                 * @param bField magnetic field value at t=0
+                 * @param eField electric field value at t=0
+                 * @param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
                  */
                 template<typename EType, typename BType, typename ParticleType>
                 HDINLINE void operator()(const BType bField, const EType eField, ParticleType& parentIon)

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def
@@ -29,11 +29,11 @@ namespace picongpu
         {
             /** Thomas-Fermi impact ionization model
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_SrcSpecies particle species that is ionized
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_SrcSpecies particle species that is ionized
              *         default is boost::mpl placeholder because specialization
              *         cannot be known in list of particle species' flags
-             *         \see speciesDefinition.param
+             *         @see speciesDefinition.param
              */
             template<typename T_IonizationAlgorithm, typename T_DestSpecies, typename T_SrcSpecies = bmpl::_1>
             struct ThomasFermi_Impl;
@@ -57,12 +57,12 @@ namespace picongpu
              * \url http://www.sciencedirect.com/science/article/pii/S0065219908601451
              * doi:10.1016/S0065-2199(08)60145-1
              *
-             * \tparam T_DestSpecies electron species to be created
+             * @tparam T_DestSpecies electron species to be created
              *
              * wrapper class,
              * needed because the SrcSpecies cannot be known during the
              * first specialization of the ionization model in the particle definition
-             * \see speciesDefinition.param
+             * @see speciesDefinition.param
              */
             template<typename T_DestSpecies>
             struct ThomasFermi

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -278,10 +278,10 @@ namespace picongpu
                  *
                  * Ionization model specific particle creation
                  *
-                 * \tparam T_parentIon type of ion species that is being ionized
-                 * \tparam T_childElectron type of electron species that is created
-                 * \param parentIon ion instance that is ionized
-                 * \param childElectron electron instance that is created
+                 * @tparam T_parentIon type of ion species that is being ionized
+                 * @tparam T_childElectron type of electron species that is created
+                 * @param parentIon ion instance that is ionized
+                 * @param childElectron electron instance that is created
                  */
                 template<typename T_parentIon, typename T_childElectron, typename T_Acc>
                 DINLINE void operator()(T_Acc const& acc, T_parentIon& parentIon, T_childElectron& childElectron)

--- a/include/picongpu/particles/ionization/byField/ADK/ADK.def
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK.def
@@ -31,12 +31,12 @@ namespace picongpu
         {
             /** Ammosov-Delone-Krainov tunneling model
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
-             * \tparam T_SrcSpecies ion species to be ionized
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_SrcSpecies ion species to be ionized
              *         default is boost::mpl placeholder because specialization
              *         cannot be known in list of particle species' flags
-             *         \see speciesDefinition.param
+             *         @see speciesDefinition.param
              */
             template<
                 typename T_IonizationAlgorithm,
@@ -59,7 +59,7 @@ namespace picongpu
              * wrapper class,
              * needed because the SrcSpecies cannot be known during the
              * first specialization of the ionization model in the particle definition
-             * \see speciesDefinition.param
+             * @see speciesDefinition.param
              */
             template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
             struct ADKLinPol
@@ -85,7 +85,7 @@ namespace picongpu
              * wrapper class,
              * needed because the SrcSpecies cannot be known during the
              * first specialization of the ionization model in the particle definition
-             * \see speciesDefinition.param
+             * @see speciesDefinition.param
              */
             template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
             struct ADKCircPol

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -56,9 +56,9 @@ namespace picongpu
              * \brief Ammosov-Delone-Krainov
              *        Tunneling ionization for hydrogenlike atoms
              *
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
-             * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
              */
             template<
                 typename T_IonizationAlgorithm,
@@ -182,8 +182,8 @@ namespace picongpu
 
                 /** Determine number of new macro electrons due to ionization
                  *
-                 * \param ionFrame reference to frame of the to-be-ionized particles
-                 * \param localIdx local (linear) index in super cell / frame
+                 * @param ionFrame reference to frame of the to-be-ionized particles
+                 * @param localIdx local (linear) index in super cell / frame
                  */
                 template<typename T_Acc>
                 DINLINE uint32_t numNewParticles(const T_Acc& acc, FrameType& ionFrame, int localIdx)
@@ -226,10 +226,10 @@ namespace picongpu
                  *
                  * Ionization model specific particle creation
                  *
-                 * \tparam T_parentIon type of ion species that is being ionized
-                 * \tparam T_childElectron type of electron species that is created
-                 * \param parentIon ion instance that is ionized
-                 * \param childElectron electron instance that is created
+                 * @tparam T_parentIon type of ion species that is being ionized
+                 * @tparam T_childElectron type of electron species that is created
+                 * @param parentIon ion instance that is ionized
+                 * @param childElectron electron instance that is created
                  */
                 template<typename T_parentIon, typename T_childElectron, typename T_Acc>
                 DINLINE void operator()(const T_Acc& acc, T_parentIon& parentIon, T_childElectron& childElectron)

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -52,22 +52,22 @@ namespace picongpu
              *
              * for either linear or circular laser polarization
              *
-             * \tparam T_linPol boolean value that is true for lin. pol. and false for circ. pol.
+             * @tparam T_linPol boolean value that is true for lin. pol. and false for circ. pol.
              */
             template<bool T_linPol>
             struct AlgorithmADK
             {
                 /** Functor implementation
-                 * \tparam EType type of electric field
-                 * \tparam BType type of magnetic field
-                 * \tparam ParticleType type of particle to be ionized
+                 * @tparam EType type of electric field
+                 * @tparam BType type of magnetic field
+                 * @tparam ParticleType type of particle to be ionized
                  *
-                 * \param bField magnetic field value at t=0
-                 * \param eField electric field value at t=0
-                 * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
-                 * \param randNr random number, equally distributed in range [0.:1.0]
+                 * @param bField magnetic field value at t=0
+                 * @param eField electric field value at t=0
+                 * @param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+                 * @param randNr random number, equally distributed in range [0.:1.0]
                  *
-                 * \return ionization energy and number of new macro electrons to be created
+                 * @return ionization energy and number of new macro electrons to be created
                  */
                 template<typename EType, typename BType, typename ParticleType>
                 HDINLINE IonizerReturn

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -47,15 +47,15 @@ namespace picongpu
             {
                 /** Functor implementation
                  *
-                 * \tparam EType type of electric field
-                 * \tparam ParticleType type of particle to be ionized
+                 * @tparam EType type of electric field
+                 * @tparam ParticleType type of particle to be ionized
                  *
-                 * \param eField electric field value at t=0
-                 * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+                 * @param eField electric field value at t=0
+                 * @param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
                  *
                  * and "t" being with respect to the current time step (on step/half a step backward/-""-forward)
                  *
-                 * \return ionization energy and number of new macro electrons to be created
+                 * @return ionization energy and number of new macro electrons to be created
                  * (current implementation supports only 0 or 1 per execution)
                  */
                 template<typename EType, typename ParticleType>

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -48,15 +48,15 @@ namespace picongpu
             {
                 /** Functor implementation
                  *
-                 * \tparam EType type of electric field
-                 * \tparam ParticleType type of particle to be ionized
+                 * @tparam EType type of electric field
+                 * @tparam ParticleType type of particle to be ionized
                  *
-                 * \param eField electric field value at t=0
-                 * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+                 * @param eField electric field value at t=0
+                 * @param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
                  *
                  * and "t" being with respect to the current time step (on step/half a step backward/-""-forward)
                  *
-                 * \return ionization energy and number of new macro electrons to be created
+                 * @return ionization energy and number of new macro electrons to be created
                  * (current implementation supports only 0 or 1 per execution)
                  */
                 template<typename EType, typename ParticleType>

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -47,15 +47,15 @@ namespace picongpu
             {
                 /** Functor implementation
                  *
-                 * \tparam EType type of electric field
-                 * \tparam ParticleType type of particle to be ionized
+                 * @tparam EType type of electric field
+                 * @tparam ParticleType type of particle to be ionized
                  *
-                 * \param eField electric field value at t=0
-                 * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+                 * @param eField electric field value at t=0
+                 * @param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
                  *
                  * and "t" being with respect to the current time step (on step/half a step backward/-""-forward)
                  *
-                 * \return ionization energy and number of new macro electrons to be created
+                 * @return ionization energy and number of new macro electrons to be created
                  * (current implementation supports only 0 or 1 per execution)
                  */
                 template<typename EType, typename ParticleType>

--- a/include/picongpu/particles/ionization/byField/BSI/BSI.def
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI.def
@@ -31,12 +31,12 @@ namespace picongpu
         {
             /** Barrier Suppression Ionization - Implementation
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
-             * \tparam T_SrcSpecies particle species that is ionized
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_SrcSpecies particle species that is ionized
              *         default is boost::mpl placeholder because specialization
              *         cannot be known in list of particle species' flags
-             *         \see speciesDefinition.param
+             *         @see speciesDefinition.param
              */
             template<
                 typename T_IonizationAlgorithm,
@@ -60,13 +60,13 @@ namespace picongpu
              *   `proton number - number of inner shell electrons`.
              * - This model neglects the Stark upshift of ionization energies.
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              *
              * wrapper class,
              * needed because the SrcSpecies cannot be known during the
              * first specialization of the ionization model in the particle definition
-             * \see speciesDefinition.param
+             * @see speciesDefinition.param
              */
             template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
             struct BSI
@@ -83,8 +83,8 @@ namespace picongpu
              *   effective atomic numbers for each filled electron shell @see ionizer.param
              * - unvalidated and still in development
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              */
             template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
             struct BSIEffectiveZ
@@ -102,8 +102,8 @@ namespace picongpu
              *   hydrogenlike ions originally
              * - \todo needs to be extrapolated to arbitrary ions
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              */
             template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
             struct BSIStarkShifted

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -53,9 +53,9 @@ namespace picongpu
              *
              * \brief Barrier Suppression Ionization - Implementation
              *
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
-             * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
              */
             template<
                 typename T_IonizationAlgorithm,
@@ -170,8 +170,8 @@ namespace picongpu
 
                 /** Determine number of new macro electrons due to ionization
                  *
-                 * \param ionFrame reference to frame of the to-be-ionized particles
-                 * \param localIdx local (linear) index in super cell / frame
+                 * @param ionFrame reference to frame of the to-be-ionized particles
+                 * @param localIdx local (linear) index in super cell / frame
                  */
                 template<typename T_Acc>
                 DINLINE uint32_t numNewParticles(T_Acc const& acc, FrameType& ionFrame, int localIdx)
@@ -211,10 +211,10 @@ namespace picongpu
                  *
                  * Ionization model specific particle creation
                  *
-                 * \tparam T_parentIon type of ion species that is being ionized
-                 * \tparam T_childElectron type of electron species that is created
-                 * \param parentIon ion instance that is ionized
-                 * \param childElectron electron instance that is created
+                 * @tparam T_parentIon type of ion species that is being ionized
+                 * @tparam T_childElectron type of electron species that is created
+                 * @param parentIon ion instance that is ionized
+                 * @param childElectron electron instance that is created
                  */
                 template<typename T_parentIon, typename T_childElectron, typename T_Acc>
                 DINLINE void operator()(T_Acc const& acc, T_parentIon& parentIon, T_childElectron& childElectron)

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
@@ -43,10 +43,10 @@ namespace picongpu
              *            Modeling field ionization in an energy conserving form and resulting nonstandard fluid
              * dynamcis, Physics of Plasmas 5, 4466 (1998) https://doi.org/10.1063/1.873184
              *
-             * \tparam T_Acc alpaka accelerator type
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
-             * \tparam T_Dim dimension of simulation
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_Dim dimension of simulation
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              */
             template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim, typename T_IonizationCurrent>
             struct IonizationCurrent;

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
@@ -37,9 +37,9 @@ namespace picongpu
             /**@{*/
             /** Implementation of actual ionization current
              *
-             * \tparam T_Acc alpaka accelerator type
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
-             * \tparam T_Dim dimension of simulation
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_Dim dimension of simulation
              */
             template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim>
             struct IonizationCurrent<T_Acc, T_DestSpecies, T_Dim, current::EnergyConservation>
@@ -48,7 +48,7 @@ namespace picongpu
 
                 /** Ionization current routine
                  *
-                 * \tparam T_JBox type of current density data box
+                 * @tparam T_JBox type of current density data box
                  */
                 template<typename T_JBox>
                 HDINLINE void operator()(

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
@@ -32,7 +32,7 @@ namespace picongpu
         {
             /** defining traits for current assignment
              *
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
              */
             template<typename T_DestSpecies>
             struct JIonizationAssignmentParent
@@ -48,9 +48,9 @@ namespace picongpu
             /**@{*/
             /** implementation of current assignment
              *
-             * \tparam T_Acc alpaka accelerator type
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
-             * \tparam T_Dim dimension of simulation
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_Dim dimension of simulation
              */
             template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim>
             struct JIonizationAssignment;
@@ -63,7 +63,7 @@ namespace picongpu
             {
                 /** functor for  assigning current to databox
                  *
-                 * \tparam T_JBox type of current density data box
+                 * @tparam T_JBox type of current density data box
                  */
                 template<typename T_JBox>
                 HDINLINE void operator()(

--- a/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -50,16 +50,16 @@ namespace picongpu
             struct AlgorithmKeldysh
             {
                 /** Functor implementation
-                 * \tparam EType type of electric field
-                 * \tparam BType type of magnetic field
-                 * \tparam ParticleType type of particle to be ionized
+                 * @tparam EType type of electric field
+                 * @tparam BType type of magnetic field
+                 * @tparam ParticleType type of particle to be ionized
                  *
-                 * \param bField magnetic field value at t=0
-                 * \param eField electric field value at t=0
-                 * \param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
-                 * \param randNr random number, equally distributed in range [0.:1.0]
+                 * @param bField magnetic field value at t=0
+                 * @param eField electric field value at t=0
+                 * @param parentIon particle instance to be ionized with position at t=0 and momentum at t=-1/2
+                 * @param randNr random number, equally distributed in range [0.:1.0]
                  *
-                 * \return ionization energy and number of new macro electrons to be created
+                 * @return ionization energy and number of new macro electrons to be created
                  */
                 template<typename EType, typename BType, typename ParticleType>
                 HDINLINE IonizerReturn

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
@@ -31,12 +31,12 @@ namespace picongpu
         {
             /** Keldysh model
              *
-             * \tparam T_DestSpecies electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
-             * \tparam T_SrcSpecies ion species to be ionized
+             * @tparam T_DestSpecies electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_SrcSpecies ion species to be ionized
              *         default is boost::mpl placeholder because specialization
              *         cannot be known in list of particle species' flags
-             *         \see speciesDefinition.param
+             *         @see speciesDefinition.param
              */
             template<
                 typename T_IonizationAlgorithm,
@@ -62,7 +62,7 @@ namespace picongpu
              * wrapper class,
              * needed because the SrcSpecies cannot be known during the
              * first specialization of the ionization model in the particle definition
-             * \see speciesDefinition.param
+             * @see speciesDefinition.param
              */
             template<typename T_DestSpecies, typename T_IonizationCurrent = current::None>
             struct Keldysh

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -56,9 +56,9 @@ namespace picongpu
              * \brief Ammosov-Delone-Krainov
              *        Tunneling ionization for hydrogenlike atoms
              *
-             * \tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
-             * \tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
-             * \tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
+             * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
+             * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
+             * @tparam T_SrcSpecies type or name as boost::mpl::string of the particle species that is ionized
              */
             template<
                 typename T_IonizationAlgorithm,
@@ -182,8 +182,8 @@ namespace picongpu
 
                 /** Determine number of new macro electrons due to ionization
                  *
-                 * \param ionFrame reference to frame of the to-be-ionized particles
-                 * \param localIdx local (linear) index in super cell / frame
+                 * @param ionFrame reference to frame of the to-be-ionized particles
+                 * @param localIdx local (linear) index in super cell / frame
                  */
                 template<typename T_Acc>
                 DINLINE uint32_t numNewParticles(T_Acc const& acc, FrameType& ionFrame, int localIdx)
@@ -226,10 +226,10 @@ namespace picongpu
                  *
                  * Ionization model specific particle creation
                  *
-                 * \tparam T_parentIon type of ion species that is being ionized
-                 * \tparam T_childElectron type of electron species that is created
-                 * \param parentIon ion instance that is ionized
-                 * \param childElectron electron instance that is created
+                 * @tparam T_parentIon type of ion species that is being ionized
+                 * @tparam T_childElectron type of electron species that is created
+                 * @param parentIon ion instance that is ionized
+                 * @param childElectron electron instance that is created
                  */
                 template<typename T_parentIon, typename T_childElectron, typename T_Acc>
                 DINLINE void operator()(T_Acc const& acc, T_parentIon& parentIon, T_childElectron& childElectron)

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -80,10 +80,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.def
@@ -76,10 +76,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Density.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Density.def
@@ -71,10 +71,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.def
@@ -80,10 +80,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -82,10 +82,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -77,10 +77,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def
@@ -73,10 +73,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -96,10 +96,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def
@@ -84,10 +84,10 @@ namespace picongpu
                      * This method is called on a per-thread basis (each thread of a block
                      * handles a particle of a frame).
                      *
-                     * \tparam T_Particle particle in the frame
-                     * \param particle particle in the frame
+                     * @tparam T_Particle particle in the frame
+                     * @param particle particle in the frame
                      *
-                     * \return new attribute for the particle (type \see T_AttributeType)
+                     * @return new attribute for the particle (type @see T_AttributeType)
                      */
                     template<class T_Particle>
                     DINLINE float_X operator()(T_Particle& particle) const;

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -80,7 +80,7 @@ namespace picongpu
                 struct ChargeAssignmentOnSupport : public detail::CIC
                 {
                     /** form factor of this particle shape.
-                     * \param x has to be within [-support/2, support/2]
+                     * @param x has to be within [-support/2, support/2]
                      */
                     HDINLINE float_X operator()(float_X const x)
                     {

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -83,7 +83,7 @@ namespace picongpu
                 struct ChargeAssignmentOnSupport : public detail::Counter
                 {
                     /** form factor of this particle shape.
-                     * \param x has to be within [0, 1)
+                     * @param x has to be within [0, 1)
                      */
                     HDINLINE float_X operator()(float_X const x)
                     {

--- a/include/picongpu/particles/shapes/NGP.hpp
+++ b/include/picongpu/particles/shapes/NGP.hpp
@@ -74,7 +74,7 @@ namespace picongpu
                 struct ChargeAssignmentOnSupport : public detail::NGP
                 {
                     /** form factor of this particle shape.
-                     * \param x has to be within [-support/2, support/2)
+                     * @param x has to be within [-support/2, support/2)
                      */
                     HDINLINE float_X operator()(float_X const)
                     {

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -105,7 +105,7 @@ namespace picongpu
                 struct ChargeAssignmentOnSupport : public detail::TSC
                 {
                     /** form factor of this particle shape.
-                     * \param x has to be within [-support/2, support/2]
+                     * @param x has to be within [-support/2, support/2]
                      */
                     HDINLINE float_X operator()(float_X const x)
                     {

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.def
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.def
@@ -35,8 +35,8 @@ namespace picongpu
              *
              * This functor is called by the general particle creation module.
              *
-             * \tparam T_ElectronSpecies
-             * \tparam T_PhotonSpecies
+             * @tparam T_ElectronSpecies
+             * @tparam T_PhotonSpecies
              */
             template<typename T_ElectronSpecies, typename T_PhotonSpecies>
             struct PhotonCreator;

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -63,8 +63,8 @@ namespace picongpu
              *
              * This functor is called by the general particle creation module.
              *
-             * \tparam T_ElectronSpecies
-             * \tparam T_PhotonSpecies
+             * @tparam T_ElectronSpecies
+             * @tparam T_PhotonSpecies
              */
             template<typename T_ElectronSpecies, typename T_PhotonSpecies>
             struct PhotonCreator
@@ -330,8 +330,8 @@ namespace picongpu
                  *
                  * Called once for each single particle creation.
                  *
-                 * \tparam Electron type of electron which creates the photon
-                 * \tparam Photon type of photon that is created
+                 * @tparam Electron type of electron which creates the photon
+                 * @tparam Photon type of photon that is created
                  */
                 template<typename Electron, typename Photon, typename T_Acc>
                 DINLINE void operator()(const T_Acc& acc, Electron& electron, Photon& photon) const

--- a/include/picongpu/particles/traits/MacroWeighted.hpp
+++ b/include/picongpu/particles/traits/MacroWeighted.hpp
@@ -38,13 +38,13 @@ namespace picongpu
          *
          * This trait defines for each attribute if it needs to be scaled with the
          * weighting. *How* the scaling with weighting is applied can be seen in
-         * \see WeightingPower
-         *   \see http://www.openPMD.org
-         *   \see http://dx.doi.org/10.5281/zenodo.33624
-         *   \see https://git.io/vwlWa
+         * @see WeightingPower
+         *   @see http://www.openPMD.org
+         *   @see http://dx.doi.org/10.5281/zenodo.33624
+         *   @see https://git.io/vwlWa
          *
-         * \tparam T_Identifier any picongpu identifier
-         * \return \p bool ::get() as static public method
+         * @tparam T_Identifier any picongpu identifier
+         * @return \p bool ::get() as static public method
          *
          */
         template<typename T_Identifier>

--- a/include/picongpu/particles/traits/WeightingPower.hpp
+++ b/include/picongpu/particles/traits/WeightingPower.hpp
@@ -31,17 +31,17 @@ namespace picongpu
          *
          * Depending on the implementation of an attribute, it might be sometimes
          * useful to return a quantity regarding one of the underlying real
-         * particles (\see MacroWeighted).
+         * particles (@see MacroWeighted).
          *
          * This trait defines how each attribute needs to be scaled with the
          * weighting (linear, quadratic, ...) to convert between "real" and "macro"
          * particle attributes.
-         *   \see http://www.openPMD.org
-         *   \see http://dx.doi.org/10.5281/zenodo.33624
-         *   \see https://git.io/vwlWa
+         *   @see http://www.openPMD.org
+         *   @see http://dx.doi.org/10.5281/zenodo.33624
+         *   @see https://git.io/vwlWa
          *
-         * \tparam T_Identifier any picongpu identifier
-         * \return \p float_64 ::get() as static public method
+         * @tparam T_Identifier any picongpu identifier
+         * @return \p float_64 ::get() as static public method
          *
          */
         template<typename T_Identifier>

--- a/include/picongpu/plugins/PhaseSpace/AxisDescription.hpp
+++ b/include/picongpu/plugins/PhaseSpace/AxisDescription.hpp
@@ -30,9 +30,9 @@ namespace picongpu
      */
     struct AxisDescription
     {
-        /** px, py or pz: \see element_momentum*/
+        /** px, py or pz: @see element_momentum*/
         uint32_t momentum;
-        /** x, y or z: \see element_coordinate */
+        /** x, y or z: @see element_coordinate */
         uint32_t space;
 
         /** short hand enums */

--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
@@ -50,15 +50,15 @@ namespace picongpu
     public:
         /** Dump the PhaseSpace host Buffer
          *
-         * \tparam Type the HBuffers element type
-         * \tparam int the HBuffers dimension
-         * \param hBuffer const reference to the hBuffer, including guard cells in spatial dimension
-         * \param axis_element plot to create: e.g. py, x from momentum/spatial-coordinate
-         * \param unit sim unit of the buffer
-         * \param strSpecies unique short hand name of the species
-         * \param filenameSuffix infix + extension part of openPMD filename
-         * \param currentStep current time step
-         * \param mpiComm communicator of the participating ranks
+         * @tparam Type the HBuffers element type
+         * @tparam int the HBuffers dimension
+         * @param hBuffer const reference to the hBuffer, including guard cells in spatial dimension
+         * @param axis_element plot to create: e.g. py, x from momentum/spatial-coordinate
+         * @param unit sim unit of the buffer
+         * @param strSpecies unique short hand name of the species
+         * @param filenameSuffix infix + extension part of openPMD filename
+         * @param currentStep current time step
+         * @param mpiComm communicator of the participating ranks
          */
         template<typename T_Type, int T_bufDim>
         void operator()(

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -287,7 +287,7 @@ namespace picongpu
          *   During the kernels we calculate with a typical single/real
          *   momentum range. Now for the dump the meta information of units
          *   on the p-axis should be scaled to represent single/real particles.
-         *   \see PhaseSpaceMulti::pluginLoad( )
+         *   @see PhaseSpaceMulti::pluginLoad( )
          */
         float_64 const pRange_unit = UNIT_MASS * UNIT_SPEED;
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -38,7 +38,7 @@ namespace picongpu
 
     /** Atomic Add Functor
      *
-     * \tparam Type of the values to perform a atomicAdd on
+     * @tparam Type of the values to perform a atomicAdd on
      */
     template<typename Type>
     struct FunctorAtomicAdd
@@ -59,9 +59,9 @@ namespace picongpu
      * add the particle to the shared memory buffer for that phase
      * space snippet the super cell contributes to.
      *
-     * \tparam r_dir spatial direction of the phase space (0,1,2) \see AxisDescription
-     * \tparam num_pbins number of bins in momentum space \see PhaseSpace.hpp
-     * \tparam SuperCellSize how many cells form a super cell \see memory.param
+     * @tparam r_dir spatial direction of the phase space (0,1,2) @see AxisDescription
+     * @tparam num_pbins number of bins in momentum space @see PhaseSpace.hpp
+     * @tparam SuperCellSize how many cells form a super cell @see memory.param
      */
     template<uint32_t r_dir, uint32_t num_pbins, typename SuperCellSize>
     struct FunctorParticle
@@ -70,11 +70,11 @@ namespace picongpu
 
         /** Functor implementation
          *
-         * \param frame current frame for this block
-         * \param particleID id of the particle in the current frame
-         * \param curDBufferOriginInBlock section of the phase space, shifted to the start of the block
-         * \param el_p coordinate of the momentum \see PhaseSpace::axis_element \see AxisDescription
-         * \param axis_p_range range of the momentum coordinate \see PhaseSpace::axis_p_range
+         * @param frame current frame for this block
+         * @param particleID id of the particle in the current frame
+         * @param curDBufferOriginInBlock section of the phase space, shifted to the start of the block
+         * @param el_p coordinate of the momentum @see PhaseSpace::axis_element @see AxisDescription
+         * @param axis_p_range range of the momentum coordinate @see PhaseSpace::axis_p_range
          */
         template<typename FramePtr, typename float_PS, typename Pitch, typename T_Acc>
         DINLINE void operator()(
@@ -124,12 +124,12 @@ namespace picongpu
      * Afterwards all blocks reduce their data to a combined gpu-local (spatial)
      * snippet of the phase space in global memory.
      *
-     * \tparam Species the particle species to create the phase space for
-     * \tparam T_filter type of the particle filter
-     * \tparam SuperCellSize how many cells form a super cell \see memory.param
-     * \tparam float_PS type for each bin in the phase space
-     * \tparam num_pbins number of bins in momentum space \see PhaseSpace.hpp
-     * \tparam r_dir spatial direction of the phase space (0,1,2) \see AxisDescription
+     * @tparam Species the particle species to create the phase space for
+     * @tparam T_filter type of the particle filter
+     * @tparam SuperCellSize how many cells form a super cell @see memory.param
+     * @tparam float_PS type for each bin in the phase space
+     * @tparam num_pbins number of bins in momentum space @see PhaseSpace.hpp
+     * @tparam r_dir spatial direction of the phase space (0,1,2) @see AxisDescription
      */
     template<
         typename Species,
@@ -153,11 +153,11 @@ namespace picongpu
 
         /** Constructor to transfer params to device
          *
-         * \param pb ParticleBox for a species
-         * \param parFilter filter functor to select particles
-         * \param cur cursor to start of the local phase space in global memory
-         * \param p_dir direction of the 2D phase space in momentum \see AxisDescription
-         * \param p_range range of the momentum axis \see PhaseSpace::axis_p_range
+         * @param pb ParticleBox for a species
+         * @param parFilter filter functor to select particles
+         * @param cur cursor to start of the local phase space in global memory
+         * @param p_dir direction of the 2D phase space in momentum @see AxisDescription
+         * @param p_range range of the momentum axis @see PhaseSpace::axis_p_range
          */
         HDINLINE
         FunctorBlock(
@@ -176,9 +176,9 @@ namespace picongpu
 
         /** Called for the first cell of each block #-of-cells-in-block times
          *
-         * \param indexBlockOffset cell index in global memory, describes where
+         * @param indexBlockOffset cell index in global memory, describes where
          *                         the current block starts
-         *                         \see cuSTL/algorithm/kernel/Foreach.hpp
+         *                         @see cuSTL/algorithm/kernel/Foreach.hpp
          */
         template<typename T_Acc>
         DINLINE void operator()(const T_Acc& acc, const pmacc::math::Int<simDim>& indexBlockOffset)

--- a/include/picongpu/plugins/adios/NDScalars.hpp
+++ b/include/picongpu/plugins/adios/NDScalars.hpp
@@ -147,7 +147,7 @@ namespace picongpu
                 uint64_t count[varInfo->ndim];
                 for(int d = 0; d < varInfo->ndim; ++d)
                 {
-                    /* \see adios_define_var: z,y,x in C-order */
+                    /* @see adios_define_var: z,y,x in C-order */
                     start[d] = gridPos.revert()[d];
                     count[d] = 1;
                 }

--- a/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/adios/restart/RestartFieldLoader.hpp
@@ -151,7 +151,7 @@ namespace picongpu
                     uint64_t count[varInfo->ndim];
                     for(int d = 0; d < varInfo->ndim; ++d)
                     {
-                        /* \see adios_define_var: z,y,x in C-order */
+                        /* @see adios_define_var: z,y,x in C-order */
                         start[d] = domain_offset.revert()[d];
                         count[d] = local_domain_size.revert()[d];
                     }

--- a/include/picongpu/plugins/common/stringHelpers.cpp
+++ b/include/picongpu/plugins/common/stringHelpers.cpp
@@ -26,8 +26,8 @@ namespace picongpu
     {
         /** Return the current date as string
          *
-         * \param format, \see http://www.cplusplus.com/reference/ctime/strftime/
-         * \return std::string with formatted date
+         * @param format, @see http://www.cplusplus.com/reference/ctime/strftime/
+         * @return std::string with formatted date
          */
         std::string getDateString(std::string format)
         {

--- a/include/picongpu/plugins/common/stringHelpers.hpp
+++ b/include/picongpu/plugins/common/stringHelpers.hpp
@@ -34,8 +34,8 @@ namespace picongpu
     {
         /** Return the current date as string
          *
-         * \param format, \see http://www.cplusplus.com/reference/ctime/strftime/
-         * \return std::string with formatted date
+         * @param format, @see http://www.cplusplus.com/reference/ctime/strftime/
+         * @return std::string with formatted date
          */
         std::string getDateString(std::string format);
 

--- a/include/picongpu/plugins/common/txtFileHandling.hpp
+++ b/include/picongpu/plugins/common/txtFileHandling.hpp
@@ -33,15 +33,15 @@ namespace picongpu
     /** Restore a txt file from the checkpoint dir
      *
      * Restores a txt file from the checkpoint dir and starts appending to it.
-     * Opened files in \see outFile are closed and a valid handle is opened again
+     * Opened files in @see outFile are closed and a valid handle is opened again
      * if a restart file is found. Otherwise new output file stays untouched.
      *
-     * \param outFile std::ofstream file handle to regular file that shall be restored
-     * \param filename the file's name
-     * \param restartStep the file's version in time to restore
-     * \param restartDirectory path to the checkpoint directory
+     * @param outFile std::ofstream file handle to regular file that shall be restored
+     * @param filename the file's name
+     * @param restartStep the file's version in time to restore
+     * @param restartDirectory path to the checkpoint directory
      *
-     * \return operation was successful or not
+     * @return operation was successful or not
      */
     HINLINE bool restoreTxtFile(
         std::ofstream& outFile,
@@ -88,10 +88,10 @@ namespace picongpu
      *
      * The file is flushed, copied to the checkpoint dir with extension fileName.step
      *
-     * \param outFile std::ofstream file handle to regular file that shall be checkpointed
-     * \param filename the file's name
-     * \param currentStep the current time step
-     * \param checkpointDirectory path to the checkpoint directory
+     * @param outFile std::ofstream file handle to regular file that shall be checkpointed
+     * @param filename the file's name
+     * @param currentStep the current time step
+     * @param checkpointDirectory path to the checkpoint directory
      */
     HINLINE void checkpointTxtFile(
         std::ofstream& outFile,

--- a/include/picongpu/plugins/multi/ISlave.hpp
+++ b/include/picongpu/plugins/multi/ISlave.hpp
@@ -61,8 +61,8 @@ namespace picongpu
                  * The order in which the plugins are called is undefined, so this means
                  * read-only access to the particles.
                  *
-                 * \param speciesName name of the particle species
-                 * \param direction the direction the particles are leaving the simulation
+                 * @param speciesName name of the particle species
+                 * @param direction the direction the particles are leaving the simulation
                  */
                 virtual void onParticleLeave(const std::string& speciesName, const int32_t direction)
                 {

--- a/include/picongpu/plugins/multi/Master.hpp
+++ b/include/picongpu/plugins/multi/Master.hpp
@@ -95,8 +95,8 @@ namespace picongpu
                  *
                  * Called each timestep if particles are leaving the global simulation volume.
                  *
-                 * \param speciesName name of the particle species
-                 * \param direction the direction the particles are leaving the simulation
+                 * @param speciesName name of the particle species
+                 * @param direction the direction the particles are leaving the simulation
                  */
                 void onParticleLeave(const std::string& speciesName, const int32_t direction)
                 {

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -67,7 +67,7 @@ namespace picongpu
     // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
     //             regime causes a bubble with radius of approx. the laser's
     //             beam waist (use for bubble fields)
-    ///  \return float3_X( tyBField, tyEField, tyCurrent )
+    ///  @return float3_X( tyBField, tyEField, tyCurrent )
 
     template<int T>
     struct typicalFields

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.hpp
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.hpp
@@ -48,7 +48,7 @@ namespace picongpu
              * Voronoi particle merging algorithm for PIC codes.
              * Computer Physics Communications, 202, 165-174.
              *
-             * \tparam T_ParticlesType particle species
+             * @tparam T_ParticlesType particle species
              */
             template<
                 class T_ParticlesType,

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -38,7 +38,7 @@ namespace picongpu
              * Voronoi particle merging algorithm for PIC codes.
              * Computer Physics Communications, 202, 165-174.
              *
-             * \tparam T_ParticlesBox container of the particle species
+             * @tparam T_ParticlesBox container of the particle species
              */
             template<class T_ParticlesBox>
             struct ParticleMergerKernel

--- a/include/picongpu/simulation/control/MovingWindow.hpp
+++ b/include/picongpu/simulation/control/MovingWindow.hpp
@@ -366,7 +366,7 @@ namespace picongpu
             const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
 
             /* Without moving window, the selected window spans the whole global domain.
-             * \see https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions
+             * @see https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions
              *
              * The window's global offset is therefore zero inside the global domain.
              * The window's global and local size are equal to the SubGrid quantities.

--- a/include/picongpu/traits/GetDataBoxType.hpp
+++ b/include/picongpu/traits/GetDataBoxType.hpp
@@ -26,8 +26,8 @@ namespace picongpu
     {
         /** Get data box type of a buffer
          *
-         * \tparam T_Type type from which you need the DataBoxType
-         * \treturn ::type
+         * @tparam T_Type type from which you need the DataBoxType
+         * @treturn ::type
          */
         template<typename T_Type>
         struct GetDataBoxType;

--- a/include/picongpu/traits/PICToAdios.hpp
+++ b/include/picongpu/traits/PICToAdios.hpp
@@ -27,8 +27,8 @@ namespace picongpu
     {
         /** Convert a PIConGPU Type to an Adios data type
          *
-         * \tparam T_Type Typename in PIConGPU
-         * \return \p ::type as public typedef of an Adios type
+         * @tparam T_Type Typename in PIConGPU
+         * @return \p ::type as public typedef of an Adios type
          */
         template<typename T_Type>
         struct PICToAdios;

--- a/include/picongpu/traits/PICToSplash.hpp
+++ b/include/picongpu/traits/PICToSplash.hpp
@@ -27,8 +27,8 @@ namespace picongpu
     {
         /** Convert a PIConGPU Type to a Splash CollectionType
          *
-         * \tparam T_Type Typename in PIConGPU
-         * \return \p ::type as public typedef of a Splash CollectionType
+         * @tparam T_Type Typename in PIConGPU
+         * @return \p ::type as public typedef of a Splash CollectionType
          */
         template<typename T_Type>
         struct PICToSplash;

--- a/include/picongpu/traits/SIBaseUnits.hpp
+++ b/include/picongpu/traits/SIBaseUnits.hpp
@@ -25,7 +25,7 @@ namespace picongpu
     {
         /* openPMD uses the powers of the 7 SI base measures to describe
          * the unit of a record
-         * \see http://git.io/vROmP */
+         * @see http://git.io/vROmP */
         constexpr uint32_t NUnitDimension = 7;
 
         // pre-C++11 "scoped enumerator" work-around

--- a/include/picongpu/traits/SplashToPIC.hpp
+++ b/include/picongpu/traits/SplashToPIC.hpp
@@ -27,8 +27,8 @@ namespace picongpu
     {
         /** Convert a Splash CollectionType to a PIConGPU Type
          *
-         * \tparam T_SplashType Splash CollectionType
-         * \return \p ::type as public typedef
+         * @tparam T_SplashType Splash CollectionType
+         * @return \p ::type as public typedef
          */
         template<typename T_SplashType>
         struct SplashToPIC;

--- a/include/picongpu/traits/Unit.hpp
+++ b/include/picongpu/traits/Unit.hpp
@@ -27,12 +27,12 @@ namespace picongpu
     {
         /** Get unit of a date that is represented by an identifier
          *
-         * \tparam T_Identifier any PIConGPU identifier
-         * \return \p std::vector<float_64> ::get() as static public method
+         * @tparam T_Identifier any PIConGPU identifier
+         * @return \p std::vector<float_64> ::get() as static public method
          *
          * Unitless identifies, see \UnitDimension, can still be scaled by a
          * factor. If they are not scaled, implement the unit as 1.0;
-         * \see unitless/speciesAttributes.unitless
+         * @see unitless/speciesAttributes.unitless
          */
         template<typename T_Identifier>
         struct Unit;

--- a/include/picongpu/traits/UnitDimension.hpp
+++ b/include/picongpu/traits/UnitDimension.hpp
@@ -30,13 +30,13 @@ namespace picongpu
          * Definition must follow the openPMD `unitDimension` definition:
          * length L, mass M, time T, electric current I, thermodynamic temperature
          * theta, amount of substance N, luminous intensity J
-         *   \see http://www.openPMD.org
-         *   \see http://dx.doi.org/10.5281/zenodo.33624
+         *   @see http://www.openPMD.org
+         *   @see http://dx.doi.org/10.5281/zenodo.33624
          * Must return a vector of size() == 7, for unitless attributes all
          * elements are zero.
          *
-         * \tparam T_Identifier any picongpu identifier
-         * \return \p std::vector<float_64> ::get() as static public method
+         * @tparam T_Identifier any picongpu identifier
+         * @return \p std::vector<float_64> ::get() as static public method
          *
          */
         template<typename T_Identifier>

--- a/include/picongpu/traits/attribute/GetCharge.hpp
+++ b/include/picongpu/traits/attribute/GetCharge.hpp
@@ -42,7 +42,7 @@ namespace picongpu
                  * use attribute `boundElectrons` and the proton number from
                  * flag `atomicNumbers` to calculate the charge
                  *
-                 * \tparam T_HasBoundElectrons boolean that describes if species allows multiple charge states
+                 * @tparam T_HasBoundElectrons boolean that describes if species allows multiple charge states
                  * due to bound electrons
                  */
                 template<bool T_HasBoundElectrons>
@@ -50,9 +50,9 @@ namespace picongpu
                 {
                     /** Functor implementation
                      *
-                     * \tparam T_Particle particle type
-                     * \param weighting the particle's weighting
-                     * \param particle particle reference
+                     * @tparam T_Particle particle type
+                     * @param weighting the particle's weighting
+                     * @param particle particle reference
                      */
                     template<typename T_Particle>
                     HDINLINE float_X operator()(const float_X weighting, const T_Particle& particle)
@@ -79,9 +79,9 @@ namespace picongpu
                 {
                     /** Functor implementation
                      *
-                     * \tparam T_Particle particle type
-                     * \param weighting the particle's weighting
-                     * \param particle particle reference
+                     * @tparam T_Particle particle type
+                     * @param weighting the particle's weighting
+                     * @param particle particle reference
                      */
                     template<typename T_Particle>
                     HDINLINE float_X operator()(const float_X weighting, const T_Particle&)

--- a/include/picongpu/traits/attribute/GetChargeState.hpp
+++ b/include/picongpu/traits/attribute/GetChargeState.hpp
@@ -46,7 +46,7 @@ namespace picongpu
                 {
                     /** Functor implementation
                      *
-                     * \return chargeState = number of electrons in neutral atom - number of currently bound electrons
+                     * @return chargeState = number of electrons in neutral atom - number of currently bound electrons
                      */
                     template<typename T_Particle>
                     HDINLINE float_X operator()(const T_Particle& particle)

--- a/include/picongpu/unitless/speciesAttributes.unitless
+++ b/include/picongpu/unitless/speciesAttributes.unitless
@@ -32,25 +32,25 @@
 /** \file speciesAttributes.unitless
  *
  * This file describes the particle attributes defined in
- * \see speciesAttributes.param of a particle species.
+ * @see speciesAttributes.param of a particle species.
  * Each particle attribute needs to implement the following traits
  *   - `Unit`
  *      - conversion between PIConGPU units and SI
- *      - \see traits/Unit.hpp
- *      - \see https://git.io/vriio
+ *      - @see traits/Unit.hpp
+ *      - @see https://git.io/vriio
  *   - `UnitDimension`
  *      - powers of the seven SI base units
- *      - \see traits/UnitDimension.hpp
- *      - \see https://git.io/vriio
+ *      - @see traits/UnitDimension.hpp
+ *      - @see https://git.io/vriio
  *   - `MacroWeighted`
  *      - attribute is weighted to a macro-particle?
- *      - \see particles/traits/MacroWeighted.hpp
- *      - \see https://git.io/vwlWa
+ *      - @see particles/traits/MacroWeighted.hpp
+ *      - @see https://git.io/vwlWa
  *   - `WeightingPower`
  *      - attribute is different for macro and real particles?
  *        describe how it scales with the weighting
- *      - \see particles/traits/WeightingPower.hpp
- *      - \see https://git.io/vwlWa
+ *      - @see particles/traits/WeightingPower.hpp
+ *      - @see https://git.io/vwlWa
  */
 namespace picongpu
 {

--- a/include/pmacc/communication/AsyncCommunication.hpp
+++ b/include/pmacc/communication/AsyncCommunication.hpp
@@ -32,8 +32,8 @@ namespace pmacc
         struct Bool2Type;
 
         /**
-         * Implementations of \see AsyncCommunication should specialize this,
-         * but it is not intended to be called directly. Use \see AsyncCommunication
+         * Implementations of @see AsyncCommunication should specialize this,
+         * but it is not intended to be called directly. Use @see AsyncCommunication
          *
          * The 2nd template parameter can be used to check for conditions on
          * templated implementations. E.g.:
@@ -57,7 +57,7 @@ namespace pmacc
          * derived classes but want to use the possibly more derived type
          *
          * For different T_Data types you can either specialize this or the more
-         * generic \see AsyncCommunicationImpl
+         * generic @see AsyncCommunicationImpl
          */
         template<typename T_Data>
         struct AsyncCommunication : public AsyncCommunicationImpl<T_Data>

--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -340,7 +340,7 @@ namespace pmacc
             }
         }
 
-        /*! update coordinates \see getCoordinates
+        /*! update coordinates @see getCoordinates
          */
         void updateCoordinates()
         {
@@ -435,11 +435,11 @@ namespace pmacc
         DataSpace<DIM3> periodic;
         //! MPI communicator (currently MPI_COMM_WORLD)
         MPI_Comm topology;
-        //! array for exchangetype-to-rank conversion \see ExchangeTypeToRank
+        //! array for exchangetype-to-rank conversion @see ExchangeTypeToRank
         int ranks[27];
         //! size of pmacc [cx,cy,cz]
         int dims[3];
-        //! \see getCommunicationMask
+        //! @see getCommunicationMask
         Mask communicationMask;
         //! rank of this process local to its host (node)
         int hostRank;

--- a/include/pmacc/communication/ICommunicator.hpp
+++ b/include/pmacc/communication/ICommunicator.hpp
@@ -57,11 +57,11 @@ namespace pmacc
 
         /*! starts sending via MPI (non-blocking)
          *
-         * \param[in] ex                direction to send (enum ExchangeType)
-         * \param[in] send_data         pointer to data; should have at least send_data_count bytes
-         * \param[in] send_data_count   message size in bytes to sent
-         * \param[in] tag               user-defined tag; only message with the same tag can be exchanged (i.e.
-         * startSend and startReceive must use the same tag) \returns an request for testing if this operation has
+         * @param[in] ex                direction to send (enum ExchangeType)
+         * @param[in] send_data         pointer to data; should have at least send_data_count bytes
+         * @param[in] send_data_count   message size in bytes to sent
+         * @param[in] tag               user-defined tag; only message with the same tag can be exchanged (i.e.
+         * startSend and startReceive must use the same tag) @returns an request for testing if this operation has
          * already finished
          */
         virtual MPI_Request* startSend(uint32_t ex, const char* send_data, size_t send_data_count, uint32_t tag) = 0;
@@ -70,11 +70,11 @@ namespace pmacc
          *
          * If recv_data_max is less then send_data_count (on other host) multiple startReceive are needed!
          *
-         * \param[in] ex                direction to send (enum ExchangeType)
-         * \param[in] recv_data         pointer to data; should have at least recv_data_max bytes
-         * \param[in] recv_data_max     maximum message size in bytes to receive
-         * \param[in] tag               user-defined tag; only message with the same tag can be exchanged (i.e.
-         * startSend and startReceive must use the same tag) \returns an request for testing if this operation has
+         * @param[in] ex                direction to send (enum ExchangeType)
+         * @param[in] recv_data         pointer to data; should have at least recv_data_max bytes
+         * @param[in] recv_data_max     maximum message size in bytes to receive
+         * @param[in] tag               user-defined tag; only message with the same tag can be exchanged (i.e.
+         * startSend and startReceive must use the same tag) @returns an request for testing if this operation has
          * already finished
          */
         virtual MPI_Request* startReceive(uint32_t ex, char* recv_data, size_t recv_data_max, uint32_t tag) = 0;
@@ -83,7 +83,7 @@ namespace pmacc
 
         /*! Return which of the three directions are periodic
          *
-         * \return for each direction a false (0) or true(1) value
+         * @return for each direction a false (0) or true(1) value
          */
         virtual DataSpace<DIM3> getPeriodic() const = 0;
     };

--- a/include/pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp
@@ -64,7 +64,7 @@ namespace pmacc
 
             /** Foreach algorithm that is executed by one cupla thread block
              *
-             * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
+             * @tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
              *
              * BlockDim could also be obtained from cupla itself at runtime but
              * it is faster to know it at compile-time.
@@ -82,9 +82,9 @@ namespace pmacc
 
                 /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
                  *
-                 * \param zone compile-time zone object, see zone::CT::SphericZone. (e.g. ContainerType::Zone())
-                 * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
-                 * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
+                 * @param zone compile-time zone object, see zone::CT::SphericZone. (e.g. ContainerType::Zone())
+                 * @param cursorN cursor for the N-th data source (e.g. containerObj.origin())
+                 * @param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
                  * _2)
                  *
                  * The functor or lambdaFun is called for each cell within the zone.

--- a/include/pmacc/cuSTL/algorithm/host/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/host/Foreach.hpp
@@ -109,9 +109,9 @@ namespace pmacc
             {
                 /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
                  *
-                 * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
-                 * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
-                 * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
+                 * @param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
+                 * @param cursorN cursor for the N-th data source (e.g. containerObj.origin())
+                 * @param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
                  * _2)
                  *
                  * The functor or lambdaFun is called for each cell within the zone.

--- a/include/pmacc/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/Foreach.hpp
@@ -68,7 +68,7 @@ namespace pmacc
 
             /** Foreach algorithm that calls a cupla kernel
              *
-             * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
+             * @tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
              *
              * blockDim has to fit into the computing volume.
              * E.g. (8,8,4) fits into (256, 256, 256)
@@ -78,9 +78,9 @@ namespace pmacc
             {
                 /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
                  *
-                 * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
-                 * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
-                 * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
+                 * @param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
+                 * @param cursorN cursor for the N-th data source (e.g. containerObj.origin())
+                 * @param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
                  * _2)
                  *
                  * The functor or lambdaFun is called for each cell within the zone.

--- a/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -100,17 +100,17 @@ namespace pmacc
              * shifts them to the top left (front) corner cell of their corresponding cupla block.
              * So if BlockDim is 4x4x4 it shifts 64 cursors to (0,0,0), 64 to (4,0,0), 64 to (8,0,0), ...
              *
-             * \tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
-             * \tparam ThreadBlock ignored
+             * @tparam BlockDim 3D compile-time vector (pmacc::math::CT::Int) of the size of the cupla blockDim.
+             * @tparam ThreadBlock ignored
              */
             template<typename BlockDim, typename ThreadBlock = BlockDim>
             struct ForeachBlock
             {
                 /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
                  *
-                 * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
-                 * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
-                 * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
+                 * @param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
+                 * @param cursorN cursor for the N-th data source (e.g. containerObj.origin())
+                 * @param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g. _1 =
                  * _2)
                  *
                  * It is called like functor(*cursor0(cellId), ..., *cursorN(cellId))

--- a/include/pmacc/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/Reduce.hpp
@@ -37,11 +37,11 @@ namespace pmacc
              */
             struct Reduce
             {
-                /* \param srcCursor Cursor located at the origin of the area of reduce
-                 * \param p_zone Zone of cells spanning the area of reduce
-                 * \param functor Functor with two arguments which returns the result of the reduce operation.
+                /* @param srcCursor Cursor located at the origin of the area of reduce
+                 * @param p_zone Zone of cells spanning the area of reduce
+                 * @param functor Functor with two arguments which returns the result of the reduce operation.
                  *
-                 * \tparam T_Operation reduce operation type from pmacc::operation::*
+                 * @tparam T_Operation reduce operation type from pmacc::operation::*
                  */
                 template<typename SrcCursor, typename Zone, typename T_Operation>
                 typename SrcCursor::ValueType operator()(

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -37,9 +37,9 @@ namespace pmacc
                 namespace mpl = boost::mpl;
 
                 /** The SphericMapper maps from cupla blockIdx and/or threadIdx to the cell index
-                 * \tparam dim dimension
-                 * \tparam BlockSize compile-time vector of the cupla block size (optional)
-                 * \tparam dummy neccesary to implement the optional BlockSize parameter
+                 * @tparam dim dimension
+                 * @tparam BlockSize compile-time vector of the cupla block size (optional)
+                 * @tparam dummy neccesary to implement the optional BlockSize parameter
                  *
                  * If BlockSize is given the cupla variable blockDim is not used which is faster.
                  */

--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -162,7 +162,7 @@ namespace pmacc
                 {
                     math::Size_t<DIM3> _blockDim;
 
-                    /* \param _blockDim size of the cupla blockDim.
+                    /* @param _blockDim size of the cupla blockDim.
                      *
                      * blockDim has to fit into the computing volume.
                      * E.g. (8,8,4) fits into (256, 256, 256)
@@ -176,9 +176,9 @@ namespace pmacc
 
                     /* operator()(zone, cursor0, cursor1, ..., cursorN-1, functor or lambdaFun)
                      *
-                     * \param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
-                     * \param cursorN cursor for the N-th data source (e.g. containerObj.origin())
-                     * \param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g.
+                     * @param zone Accepts currently only a zone::SphericZone object (e.g. containerObj.zone())
+                     * @param cursorN cursor for the N-th data source (e.g. containerObj.origin())
+                     * @param functor or lambdaFun either a functor with N arguments or a N-ary lambda function (e.g.
                      * _1 = _2)
                      *
                      * The functor or lambdaFun is called for each cell within the zone.

--- a/include/pmacc/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Reduce.hpp
@@ -36,7 +36,7 @@ namespace pmacc
         {
             /** Reduce algorithm for mpi
              *
-             * \tparam dim dimension of the mpi node volume which has to be reduced.
+             * @tparam dim dimension of the mpi node volume which has to be reduced.
              *
              * This algorithm reduces node-wise. For each node you pass a data container as source
              * and another container of the same size as destination. The result is stored in
@@ -57,8 +57,8 @@ namespace pmacc
             public:
                 /** constructor
                  *
-                 * \param zone The zone specifies which mpi-nodes participate in the reduce operation.
-                 * \param setThisAsRoot Set this node explicitly as root. May only be true for one node.
+                 * @param zone The zone specifies which mpi-nodes participate in the reduce operation.
+                 * @param setThisAsRoot Set this node explicitly as root. May only be true for one node.
                  *
                  * if setThisAsRoot is not set mpi chooses the root node.
                  *
@@ -68,9 +68,9 @@ namespace pmacc
 
                 /* execute the algorithm
                  *
-                 * \param dest destination container
-                 * \param src source container
-                 * \param ExprOrFunctor functor with two arguments which returns the result of the reduce operation.
+                 * @param dest destination container
+                 * @param src source container
+                 * @param ExprOrFunctor functor with two arguments which returns the result of the reduce operation.
                  *
                  * Since only the functor's type is given, the functor must have a standart constructor.
                  *

--- a/include/pmacc/cuSTL/container/CartBuffer.hpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.hpp
@@ -51,11 +51,11 @@ namespace pmacc
          * Is designed to be an RAII class, but does not fully obey the RAII rules (see copy-ctor).
          * The way memory gets allocated, copied and assigned is
          * fully controlled by three policy classes.
-         * \tparam Type type of a single value
-         * \tparam T_dim dimension of the container
-         * \tparam Allocator allocates and releases memory
-         * \tparam Copier copies one memory buffer to another
-         * \tparam Assigner assigns a value to every datum of a memory buffer
+         * @tparam Type type of a single value
+         * @tparam T_dim dimension of the container
+         * @tparam Allocator allocates and releases memory
+         * @tparam Copier copies one memory buffer to another
+         * @tparam Assigner assigns a value to every datum of a memory buffer
          *
          * Assigner policy has to support `apply2`: Assigner<Dim, CartBuffer>
          *
@@ -106,9 +106,9 @@ namespace pmacc
             HDINLINE CartBuffer& operator=(CartBuffer&& rhs);
 
             /* get a view. Views represent a clipped area of the container.
-             * \param a Top left corner of the view, inside the view.
+             * @param a Top left corner of the view, inside the view.
              * Negative values are remapped, e.g. Int<2>(-1,-2) == Int<2>(width-1, height-2)
-             * \param b Bottom right corner of the view, outside the view.
+             * @param b Bottom right corner of the view, outside the view.
              * Values are remapped, so that Int<2>(0,0) == Int<2>(width, height)
              */
             HDINLINE View<CartBuffer> view(
@@ -120,7 +120,7 @@ namespace pmacc
             /* get a safe cursor at the container's origin cell */
             HDINLINE cursor::SafeCursor<cursor::BufferCursor<Type, T_dim>> originSafe() const;
             /* get a component-twisted cursor at the container's origin cell
-             * \param axes x-axis -> axes[0], y-axis -> axes[1], ...
+             * @param axes x-axis -> axes[0], y-axis -> axes[1], ...
              * */
             HDINLINE cursor::Cursor<cursor::PointerAccessor<Type>, cursor::CartNavigator<T_dim>, char*>
             originCustomAxes(const math::UInt32<T_dim>& axes) const;

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -44,8 +44,8 @@ namespace pmacc
     {
         /** typedef version of a CartBuffer for a GPU.
          * Additional feature: Able to copy data from a HostBuffer
-         * \tparam Type type of a single datum
-         * \tparam T_dim Dimension of the container
+         * @tparam Type type of a single datum
+         * @tparam T_dim Dimension of the container
          */
         template<typename Type, int T_dim>
         class DeviceBuffer
@@ -75,9 +75,9 @@ namespace pmacc
 
             /* constructors
              *
-             * \param _size size of the container
+             * @param _size size of the container
              *
-             * \param x,y,z convenient wrapper
+             * @param x,y,z convenient wrapper
              *
              */
             HDINLINE DeviceBuffer(const math::Size_t<T_dim>& size) : Base(size)

--- a/include/pmacc/cuSTL/container/HostBuffer.hpp
+++ b/include/pmacc/cuSTL/container/HostBuffer.hpp
@@ -43,8 +43,8 @@ namespace pmacc
     {
         /** typedef version of a CartBuffer for a CPU.
          * Additional feature: Able to copy data from a DeviceBuffer
-         * \tparam Type type of a single datum
-         * \tparam T_dim Dimension of the container
+         * @tparam Type type of a single datum
+         * @tparam T_dim Dimension of the container
          */
         template<typename Type, int T_dim>
         class HostBuffer
@@ -73,9 +73,9 @@ namespace pmacc
 
             /* constructors
              *
-             * \param _size size of the container
+             * @param _size size of the container
              *
-             * \param x,y,z convenient wrapper
+             * @param x,y,z convenient wrapper
              *
              */
             HINLINE HostBuffer(const math::Size_t<T_dim>& size) : Base(size)

--- a/include/pmacc/cuSTL/container/PNGBuffer.hpp
+++ b/include/pmacc/cuSTL/container/PNGBuffer.hpp
@@ -83,8 +83,8 @@ namespace pmacc
             typedef cursor::Cursor<PNGBuffer::Accessor, cursor::MultiIndexNavigator<2>, math::Int<2>> Cursor;
 
             /* constructor
-             * \param x width of png image
-             * \param y height of png image
+             * @param x width of png image
+             * @param y height of png image
              * \name name of png file
              */
             PNGBuffer(int x, int y, const std::string& name) : png(x, y, 0.0, name.data()), size(x, y)

--- a/include/pmacc/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/include/pmacc/cuSTL/container/compile-time/CartBuffer.hpp
@@ -36,7 +36,7 @@ namespace pmacc
         namespace CT
         {
             /** compile-time version of container::CartBuffer
-             * \tparam _Size compile-time vector specifying the size of the container
+             * @tparam _Size compile-time vector specifying the size of the container
              */
             template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
             class CartBuffer

--- a/include/pmacc/cuSTL/container/compile-time/SharedBuffer.hpp
+++ b/include/pmacc/cuSTL/container/compile-time/SharedBuffer.hpp
@@ -32,7 +32,7 @@ namespace pmacc
         namespace CT
         {
             /* typedef version of container::CT::CartBuffer for shared mem on a GPU inside a cupla kernel.
-             * \param uid If two containers in one kernel have the same Type and Size,
+             * @param uid If two containers in one kernel have the same Type and Size,
              * uid has to be different. This is due to a nvcc bug.
              */
             template<typename Type, typename Size, int uid = 0>

--- a/include/pmacc/cuSTL/container/view/View.hpp
+++ b/include/pmacc/cuSTL/container/view/View.hpp
@@ -31,7 +31,7 @@ namespace pmacc
          * Views don't take care of reference counters. So if the corresponding
          * container dies, all views become invalid.
          * Usual way to contruct a view goes with container.view(...);
-         * \tparam Buffer Corresponding container type
+         * @tparam Buffer Corresponding container type
          */
         template<typename Buffer>
         struct View : public Buffer

--- a/include/pmacc/cuSTL/cursor/BufferCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/BufferCursor.hpp
@@ -37,14 +37,14 @@ namespace pmacc
          *
          * BufferCursor does access and jumping on a cartesian memory buffer.
          *
-         * \tparam T_Type type of a single datum
-         * \tparam T_dim dimension of the memory buffer
+         * @tparam T_Type type of a single datum
+         * @tparam T_dim dimension of the memory buffer
          */
         template<typename T_Type, int T_dim>
         struct BufferCursor : public Cursor<PointerAccessor<T_Type>, BufferNavigator<T_dim>, T_Type*>
         {
-            /* \param pointer data pointer
-             * \param pitch pitch of the memory buffer
+            /* @param pointer data pointer
+             * @param pitch pitch of the memory buffer
              * pitch is a Size_t vector with one dimension less than dim
              * pitch[0] is the distance in bytes to the incremented y-coordinate
              * pitch[1] is the distance in bytes to the incremented z-coordiante

--- a/include/pmacc/cuSTL/cursor/Cursor.hpp
+++ b/include/pmacc/cuSTL/cursor/Cursor.hpp
@@ -37,11 +37,11 @@ namespace pmacc
     {
         /** A cursor is used to access a single datum and to jump to another one.
          * It is always located at a certain datum. Think of a generalized iterator.
-         * \tparam _Accessor Policy functor class that is called inside operator*().
+         * @tparam _Accessor Policy functor class that is called inside operator*().
          * It typically returns a reference to the current selected datum.
-         * \tparam _Navigator Policy functor class that is called inside operator()().
+         * @tparam _Navigator Policy functor class that is called inside operator()().
          * It jumps to another datum.
-         * \tparam _Marker Runtime data that is used by the accessor and the navigator.
+         * @tparam _Marker Runtime data that is used by the accessor and the navigator.
          * This is typically a data pointer.
          */
         template<typename _Accessor, typename _Navigator, typename _Marker>
@@ -71,7 +71,7 @@ namespace pmacc
             }
 
             /** access
-             * \return Accessor's return type.
+             * @return Accessor's return type.
              * Typically a reference to the current selected single datum.
              */
             HDINLINE
@@ -92,9 +92,9 @@ namespace pmacc
             }
 
             /** jumping
-             * \param jump Specifies a jump relative to the current selected datum.
+             * @param jump Specifies a jump relative to the current selected datum.
              * This is usually a int vector but may be any type that navigator accepts.
-             * \return A new cursor, which has jumped according to the jump param.
+             * @return A new cursor, which has jumped according to the jump param.
              */
             template<typename Jump>
             HDINLINE This operator()(const Jump& jump) const

--- a/include/pmacc/cuSTL/cursor/FunctorCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/FunctorCursor.hpp
@@ -36,8 +36,8 @@ namespace pmacc
          * On each access of the new cursor the result of the nested cursor access
          * is filtered through a user-defined functor.
          *
-         * \param cursor Cursor to be wrapped
-         * \param functor User functor acting as a filter.
+         * @param cursor Cursor to be wrapped
+         * @param functor User functor acting as a filter.
          */
         template<typename TCursor, typename Functor>
         HDINLINE Cursor<

--- a/include/pmacc/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/MultiIndexCursor.hpp
@@ -32,9 +32,9 @@ namespace pmacc
     {
         /** construct a cursor where accessing means getting the current position
          * in terms of an 2D, 3D, ... index. Usefull to obtain for example the current cell index.
-         * \tparam dim Dimension of the index (say: int-vector)
-         * \param idx Initial index value
-         * \return cursor with the behavior mentioned above
+         * @tparam dim Dimension of the index (say: int-vector)
+         * @param idx Initial index value
+         * @return cursor with the behavior mentioned above
          */
         template<int dim>
         HDINLINE cursor::Cursor<cursor::MarkerAccessor<math::Int<dim>>, MultiIndexNavigator<dim>, math::Int<dim>>

--- a/include/pmacc/cuSTL/cursor/NestedCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/NestedCursor.hpp
@@ -31,8 +31,8 @@ namespace pmacc
     {
         /** wraps a cursor into a new cursor in a way that accessing on the new cursor
          * means getting the nested cursor and jumping means jumping on the nested cursor.
-         * \param cursor Cursor to be wrapped
-         * \return A new cursor which wraps the given cursor
+         * @param cursor Cursor to be wrapped
+         * @return A new cursor which wraps the given cursor
          */
         template<typename TCursor>
         HDINLINE Cursor<MarkerAccessor<TCursor>, CursorNavigator, TCursor> make_NestedCursor(const TCursor& cursor)

--- a/include/pmacc/cuSTL/cursor/SafeCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/SafeCursor.hpp
@@ -46,9 +46,9 @@ namespace pmacc
 
         public:
             /**
-             * \param cursor Base cursor
-             * \param lowerExtent Top left corner of valid range, inside the range.
-             * \param upperExtent Bottom right corner of valid range, inside the range.
+             * @param cursor Base cursor
+             * @param lowerExtent Top left corner of valid range, inside the range.
+             * @param upperExtent Bottom right corner of valid range, inside the range.
              */
             HDINLINE SafeCursor(
                 const Cursor& cursor,

--- a/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
@@ -33,7 +33,7 @@ namespace pmacc
     {
         /** Performs a 1D, 2D or 3D, linear interpolation on access.
          *
-         * \tparam T_Cursor input data
+         * @tparam T_Cursor input data
          */
         template<typename T_Cursor, int dim = cursor::traits::dim<T_Cursor>::value>
         struct LinearInterpAccessor;

--- a/include/pmacc/cuSTL/cursor/tools/LinearInterp.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/LinearInterp.hpp
@@ -37,7 +37,7 @@ namespace pmacc
         {
             /** Return a cursor that does 1D, 2D or 3D, linear interpolation on input data.
              *
-             * \tparam T_PositionComp integral type of the weighting factor
+             * @tparam T_PositionComp integral type of the weighting factor
              */
             template<typename T_PositionComp = float>
             struct LinearInterp

--- a/include/pmacc/cuSTL/cursor/tools/twistAxes.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/twistAxes.hpp
@@ -38,7 +38,7 @@ namespace pmacc
              * the components of the passed int-vector are reordered according to the Axes
              * parameter and then passed to the nested cursor.
              *
-             * \tparam Axes compile-time vector (pmacc::math::CT::Int) that descripes the mapping.
+             * @tparam Axes compile-time vector (pmacc::math::CT::Int) that descripes the mapping.
              * x-axis -> Axes::at<0>, y-axis -> Axes::at<1>, ...
              */
             template<typename Axes, typename TCursor>

--- a/include/pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
@@ -36,9 +36,9 @@ namespace pmacc
             {
                 /** result for TwistVectorFieldAxes
                  *
-                 * \tparam T_NavigatorPerm permutation vector for navigator
-                 * \tparam T_AccessorPerm permutation vector for the accessor
-                 * \tparam T_Cursor cursor to permute
+                 * @tparam T_NavigatorPerm permutation vector for navigator
+                 * @tparam T_AccessorPerm permutation vector for the accessor
+                 * @tparam T_Cursor cursor to permute
                  */
                 template<typename T_NavigatorPerm, typename T_AccessorPerm, typename T_Cursor>
                 struct TwistVectorFieldAxes
@@ -61,7 +61,7 @@ namespace pmacc
              *
              * e.g.: new_cur = twistVectorFieldAxes<math::CT::Int<1,2,0> >(cur); // x -> y, y -> z, z -> x
              *
-             * \tparam T_Permutation compile-time vector (pmacc::math::CT::Int) that describes the mapping.
+             * @tparam T_Permutation compile-time vector (pmacc::math::CT::Int) that describes the mapping.
              * x-axis -> T_Permutation::at<0>, y-axis -> T_Permutation::at<1>, ...
              *
              */
@@ -79,10 +79,10 @@ namespace pmacc
              *
              * use same permutation for accessor and navigator
              *
-             * \tparam T_Permutation permutation vector
-             * \tparam T_Cursor permutation vector
-             * \param cursor cursor to permute
-             * \param permutation cursor to permute
+             * @tparam T_Permutation permutation vector
+             * @tparam T_Cursor permutation vector
+             * @param cursor cursor to permute
+             * @param permutation cursor to permute
              */
             template<typename T_Cursor, typename T_Permutation>
             HDINLINE typename result_of::TwistVectorFieldAxes<T_Permutation, T_Permutation, T_Cursor>::type
@@ -98,9 +98,9 @@ namespace pmacc
              *
              * different dimensions for the accessor and navigator permutation vector are allowed
              *
-             * \param cursor cursor to permute
-             * \param navigatorPermutation compile time permutation vector for the navigator
-             * \param accessorPermutation compile time permutation vector for the accessor
+             * @param cursor cursor to permute
+             * @param navigatorPermutation compile time permutation vector for the navigator
+             * @param accessorPermutation compile time permutation vector for the accessor
              */
             template<typename T_Cursor, typename T_NavigatorPerm, typename T_AccessorPerm>
             HDINLINE typename result_of::TwistVectorFieldAxes<T_NavigatorPerm, T_AccessorPerm, T_Cursor>::type

--- a/include/pmacc/cuSTL/zone/SphericZone.hpp
+++ b/include/pmacc/cuSTL/zone/SphericZone.hpp
@@ -39,7 +39,7 @@ namespace pmacc
 
         /* spheric (no holes), cartesian zone
          *
-         * \tparam T_dim dimension of the zone
+         * @tparam T_dim dimension of the zone
          *
          * This is a zone which is simply described by a size and a offset.
          *

--- a/include/pmacc/cuSTL/zone/compile-time/SphericZone.hpp
+++ b/include/pmacc/cuSTL/zone/compile-time/SphericZone.hpp
@@ -31,8 +31,8 @@ namespace pmacc
         {
             /* spheric (no holes), cartesian, compile-time zone
              *
-             * \tparam _Size compile-time vector (pmacc::math::CT::Size_t) of the zone's size.
-             * \tparam _Offset compile-time vector (pmacc::math::CT::Size_t) of the zone's offset. default is a zero
+             * @tparam _Size compile-time vector (pmacc::math::CT::Size_t) of the zone's size.
+             * @tparam _Offset compile-time vector (pmacc::math::CT::Size_t) of the zone's offset. default is a zero
              * vector.
              *
              * This is a zone which is simply described by a size and a offset.

--- a/include/pmacc/math/VectorOperations.hpp
+++ b/include/pmacc/math/VectorOperations.hpp
@@ -32,7 +32,7 @@ namespace pmacc
          *
          *  The size of the space to map the index to must be know at compile time
          *
-         * \tparam T_Dim dimension of the position to map to
+         * @tparam T_Dim dimension of the position to map to
          */
         template<uint32_t T_Dim>
         struct MapToPos;
@@ -42,10 +42,10 @@ namespace pmacc
         {
             /** Functor
              *
-             *  \tparam T_ctVec math::CT::vector type like \see math::CT::Int
-             *  \param math::CT::vector with spatial size to map the index to
-             *  \param linearIndex linear index to be mapped
-             *  \return runtime math::vector of dimension T_Dim
+             *  @tparam T_ctVec math::CT::vector type like @see math::CT::Int
+             *  @param math::CT::vector with spatial size to map the index to
+             *  @param linearIndex linear index to be mapped
+             *  @return runtime math::vector of dimension T_Dim
              */
             template<typename T_ctVec>
             DINLINE typename T_ctVec::RT_type operator()(T_ctVec, const int linearIndex)

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -63,10 +63,10 @@ namespace pmacc
          * a new navigator which merely consists of the old navigator plus a twisting navigator.
          * This new navigator does not use any real memory.
          *
-         * \tparam T_Axes Mapped indices
-         * \tparam T_Vector type of vector to be twisted
-         * \param vector vector to be twisted
-         * \return reference of the input vector with twisted axes.
+         * @tparam T_Axes Mapped indices
+         * @tparam T_Vector type of vector to be twisted
+         * @param vector vector to be twisted
+         * @return reference of the input vector with twisted axes.
          */
         template<typename T_Axes, typename T_Vector>
         HDINLINE typename result_of::TwistComponents<T_Axes, T_Vector>::type twistComponents(T_Vector& vector)

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -148,7 +148,7 @@ namespace pmacc
                  *
                  *  Creates the corresponding runtime vector object.
                  *
-                 *  \return RT_type runtime vector with same value type
+                 *  @return RT_type runtime vector with same value type
                  */
                 static HDINLINE RT_type toRT()
                 {

--- a/include/pmacc/math/vector/navigator/StackedNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/StackedNavigator.hpp
@@ -29,8 +29,8 @@ namespace pmacc
     {
         /* Sticks two navigators together resulting in a new navigator.
          *
-         * \tparam NaviA first navigator to be called
-         * \tparam NaviB second navigator to be called
+         * @tparam NaviA first navigator to be called
+         * @tparam NaviB second navigator to be called
          */
         template<typename NaviA, typename NaviB>
         struct StackedNavigator

--- a/include/pmacc/memory/dataTypes/Mask.hpp
+++ b/include/pmacc/memory/dataTypes/Mask.hpp
@@ -246,7 +246,7 @@ namespace pmacc
 
     protected:
         /**
-         * mask which is a combination of the type \see ExchangeType
+         * mask which is a combination of the type @see ExchangeType
          */
         uint32_t bitMask;
     };

--- a/include/pmacc/meta/ForEach.hpp
+++ b/include/pmacc/meta/ForEach.hpp
@@ -40,9 +40,9 @@ namespace pmacc
         {
             /** call the functor were itBegin points to
              *
-             *  \tparam itBegin iterator to an element in a mpl sequence
-             *  \tparam itEnd iterator to the end of a mpl sequence
-             *  \tparam isEnd true if itBegin == itEnd, else false
+             *  @tparam itBegin iterator to an element in a mpl sequence
+             *  @tparam itEnd iterator to the end of a mpl sequence
+             *  @tparam isEnd true if itBegin == itEnd, else false
              */
             template<typename itBegin, typename itEnd, bool isEnd = boost::is_same<itBegin, itEnd>::value>
             struct CallFunctorOfIterator
@@ -89,12 +89,12 @@ namespace pmacc
 
         /** Compile-Time for each for Boost::MPL Type Lists
          *
-         *  \tparam T_MPLSeq A mpl sequence that can be accessed by mpl::begin, mpl::end, mpl::next
-         *  \tparam T_Functor An unary lambda functor with a HDINLINE void operator()(...) method
+         *  @tparam T_MPLSeq A mpl sequence that can be accessed by mpl::begin, mpl::end, mpl::next
+         *  @tparam T_Functor An unary lambda functor with a HDINLINE void operator()(...) method
          *          _1 is substituted by Accessor's result using boost::mpl::apply with elements from T_MPLSeq.
          *          The maximum number of parameters for the operator() is limited by
          *          PMACC_MAX_FUNCTOR_OPERATOR_PARAMS
-         *  \tparam T_Accessor An unary lambda operation
+         *  @tparam T_Accessor An unary lambda operation
          *
          * Example:
          *      MPLSeq = boost::mpl::vector<int,float>

--- a/include/pmacc/meta/GetKeyFromAlias.hpp
+++ b/include/pmacc/meta/GetKeyFromAlias.hpp
@@ -36,9 +36,9 @@ namespace pmacc
     /**
      * Returns the key type from an alias
      *
-     * \tparam T_MPLSeq Sequence of keys to search
-     * \tparam T_Key Key or alias of a key in the sequence
-     * \tparam T_KeyNotFoundPolicy Binary meta-function that is called like (T_MPLSeq, T_Key)
+     * @tparam T_MPLSeq Sequence of keys to search
+     * @tparam T_Key Key or alias of a key in the sequence
+     * @tparam T_KeyNotFoundPolicy Binary meta-function that is called like (T_MPLSeq, T_Key)
      *         when T_Key is not found in the sequence. Default is to return bmpl::void_
      */
     template<typename T_MPLSeq, typename T_Key, typename T_KeyNotFoundPolicy = errorHandlerPolicies::ReturnType<>>

--- a/include/pmacc/meta/accessors/First.hpp
+++ b/include/pmacc/meta/accessors/First.hpp
@@ -32,7 +32,7 @@ namespace pmacc
         {
             /** Get first type of the given type
              *
-             * \tparam T type from which we return the first held type
+             * @tparam T type from which we return the first held type
              *
              * T must have defined ::first
              */

--- a/include/pmacc/meta/accessors/Identity.hpp
+++ b/include/pmacc/meta/accessors/Identity.hpp
@@ -34,7 +34,7 @@ namespace pmacc
         {
             /** Get the type of a given type without changes
              *
-             * \tparam T in type
+             * @tparam T in type
              *
              */
             template<typename T = bmpl::_1>

--- a/include/pmacc/meta/accessors/Second.hpp
+++ b/include/pmacc/meta/accessors/Second.hpp
@@ -32,7 +32,7 @@ namespace pmacc
         {
             /** Get second type of the given type
              *
-             * \tparam T type from which we return the second held type
+             * @tparam T type from which we return the second held type
              *
              * T must have defined ::second
              */

--- a/include/pmacc/mpi/SeedPerRank.hpp
+++ b/include/pmacc/mpi/SeedPerRank.hpp
@@ -36,7 +36,7 @@ namespace pmacc
          * This functor derives a unique seed for each MPI rank (or GPU) from
          * a given global seed in a deterministic manner.
          *
-         * \tparam T_DIM Dimensionality of the simulation (1-3 D)
+         * @tparam T_DIM Dimensionality of the simulation (1-3 D)
          */
         template<unsigned T_DIM>
         struct SeedPerRank
@@ -48,10 +48,10 @@ namespace pmacc
              * it is furthermore guaranteed that this number does not collide
              * with an other seed.
              *
-             * \param localSeed Initial seed to vary two identical simulations
+             * @param localSeed Initial seed to vary two identical simulations
              *                  can have been xor'ed with e.g. a unique species id
              *                  to get an unique seed per species
-             * \return uint32_t seed
+             * @return uint32_t seed
              */
             uint32_t operator()(uint32_t localSeed)
             {

--- a/include/pmacc/particles/boostExtension/InheritGenerators.hpp
+++ b/include/pmacc/particles/boostExtension/InheritGenerators.hpp
@@ -83,7 +83,7 @@ namespace pmacc
 
 
     /** Create a data structure which inherit linearly
-     * \tparam vec_ boost mpl vector with classes
+     * @tparam vec_ boost mpl vector with classes
      *
      * class A<pmacc::NullFrame>;
      * LinearInherit<mpl::vector<A<>,B> >::type return

--- a/include/pmacc/particles/policies/ExchangeParticles.hpp
+++ b/include/pmacc/particles/policies/ExchangeParticles.hpp
@@ -31,7 +31,7 @@ namespace pmacc
         namespace policies
         {
             /**
-             * Policy for \see HandleGuardRegion that moves particles from guard cells to exchange buffers
+             * Policy for @see HandleGuardRegion that moves particles from guard cells to exchange buffers
              * and sends those to the correct neighbors
              */
             struct ExchangeParticles

--- a/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
+++ b/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
@@ -61,8 +61,8 @@ namespace pmacc
              * boost::static_assert(boost::is_same<PhotonsSpecies, PIC_Photons>::value);
              * \endcode
              *
-             * \tparam T_SpeciesType particle species
-             * \tparam T_Alias alias
+             * @tparam T_SpeciesType particle species
+             * @tparam T_Alias alias
              */
             template<typename T_SpeciesType, typename T_Alias>
             struct ResolveAliasFromSpecies;

--- a/include/pmacc/pluginSystem/IPlugin.hpp
+++ b/include/pmacc/pluginSystem/IPlugin.hpp
@@ -120,8 +120,8 @@ namespace pmacc
          * The order in which the plugins are called is undefined, so this means
          * read-only access to the particles.
          *
-         * \param speciesName name of the particle species
-         * \param direction the direction the particles are leaving the simulation
+         * @param speciesName name of the particle species
+         * @param direction the direction the particles are leaving the simulation
          */
         virtual void onParticleLeave(const std::string& /*speciesName*/, const int32_t /*direction*/)
         {

--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -51,7 +51,7 @@ namespace pmacc
         /** Register a plugin for loading/unloading and notifications
          *
          * Plugins are loaded in the order they are registered and unloaded in reverse order.
-         * To trigger plugin notifications, call \see setNotificationPeriod after
+         * To trigger plugin notifications, call @see setNotificationPeriod after
          * registration.
          *
          * @param plugin plugin to register
@@ -186,7 +186,7 @@ namespace pmacc
         /**
          * Get a vector of pointers of all registered plugin instances of a given type.
          *
-         * \tparam Plugin type of plugin
+         * @tparam Plugin type of plugin
          * @return vector of plugin pointers
          */
         template<typename Plugin>

--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -61,7 +61,7 @@ namespace pmacc
             /**
              * Initializes this instance
              *
-             * \param cellIdx index into the underlying RNG provider
+             * @param cellIdx index into the underlying RNG provider
              */
             HDINLINE void init(const RNGSpace& cellIdx)
             {

--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -34,8 +34,8 @@ namespace pmacc
         /**
          * Provider of a per cell random number generator
          *
-         * \tparam T_dim Number of dimensions of the grid
-         * \tparam T_RNGMethod Method to use for random number generation
+         * @tparam T_dim Number of dimensions of the grid
+         * @tparam T_RNGMethod Method to use for random number generation
          */
         template<uint32_t T_dim, class T_RNGMethod>
         class RNGProvider : public ISimulationData

--- a/include/pmacc/random/Random.hpp
+++ b/include/pmacc/random/Random.hpp
@@ -58,7 +58,7 @@ namespace pmacc
             /**
              * Initializes this instance
              *
-             * \param cellIdx index into the underlying RNG Provider
+             * @param cellIdx index into the underlying RNG Provider
              */
             template<typename T_Offset>
             HDINLINE void init(const T_Offset& cellIdx)

--- a/include/pmacc/simulationControl/SimulationDescription.hpp
+++ b/include/pmacc/simulationControl/SimulationDescription.hpp
@@ -81,7 +81,7 @@ namespace pmacc
 
             /** Returns the current time step of the simulation
              *
-             * \return uint32_t current time step
+             * @return uint32_t current time step
              */
             uint32_t getCurrentStep()
             {

--- a/include/pmacc/static_assert.hpp
+++ b/include/pmacc/static_assert.hpp
@@ -79,7 +79,7 @@ namespace pmacc
  */
 #define PMACC_STATIC_ASSERT(pmacc_cond) PMACC_STATIC_ASSERT_MSG(pmacc_cond, STATIC_ASSERTION_FAILURE, )
 
-/*! static assert wrapper which is easier to use than \see PMACC_STATIC_ASSERT_MSG
+/*! static assert wrapper which is easier to use than @see PMACC_STATIC_ASSERT_MSG
  * @param pmacc_msg A message which is shown if the condition is false. Msg must a valid c++ variable name (etc.
  * _only_human_make_mistakes)
  * @param pmacc_typeInfo a type that is shown in error message
@@ -88,7 +88,7 @@ namespace pmacc
 #define PMACC_CASSERT_MSG_TYPE(pmacc_msg, pmacc_typeInfo, ...)                                                        \
     PMACC_STATIC_ASSERT_MSG((__VA_ARGS__), pmacc_msg, pmacc_typeInfo)
 
-/*! static assert wrapper which is easier to use than \see PMACC_STATIC_ASSERT_MSG
+/*! static assert wrapper which is easier to use than @see PMACC_STATIC_ASSERT_MSG
  * @param pmacc_msg A message which is shown if the condition is false. Msg must a valid c++ variable name (etc.
  * _only_human_make_mistakes)
  * @param ... A condition which return true or false.

--- a/include/pmacc/traits/GetComponentsType.hpp
+++ b/include/pmacc/traits/GetComponentsType.hpp
@@ -29,8 +29,8 @@ namespace pmacc
     {
         /** Get component type of an object
          *
-         * \tparam T_Type any type
-         * \return \p ::type get result type
+         * @tparam T_Type any type
+         * @return \p ::type get result type
          *            If T_Type is fundamental c++ type, the identity is returned
          *
          * Attention: do not defines this trait for structs with different attributes inside

--- a/include/pmacc/traits/GetInitializedInstance.hpp
+++ b/include/pmacc/traits/GetInitializedInstance.hpp
@@ -33,7 +33,7 @@ namespace pmacc
          * The main reason to use this is for templated types where it's unknown
          * if they are fundamental or vector-like.
          *
-         * \tparam T_Type type of object
+         * @tparam T_Type type of object
          */
         template<typename T_Type>
         struct GetInitializedInstance

--- a/include/pmacc/traits/GetNComponents.hpp
+++ b/include/pmacc/traits/GetNComponents.hpp
@@ -29,8 +29,8 @@ namespace pmacc
     {
         /** C
          *
-         * \tparam T_Type any type
-         * \return \p ::value as public with number of components (uint32_t)
+         * @tparam T_Type any type
+         * @return \p ::value as public with number of components (uint32_t)
          */
         template<typename T_Type, bool T_IsFundamental = boost::is_fundamental<T_Type>::value>
         struct GetNComponents

--- a/include/pmacc/traits/GetStringProperties.hpp
+++ b/include/pmacc/traits/GetStringProperties.hpp
@@ -53,8 +53,8 @@ namespace pmacc
              *
              * creates a property with one key value
              *
-             * \param key name of the key
-             * \param propertyValue value of the property
+             * @param key name of the key
+             * @param propertyValue value of the property
              */
             StringProperty(const std::string& key, const std::string& propertyValue) : value(propertyValue)
             {
@@ -63,8 +63,8 @@ namespace pmacc
 
             /** overwrite the value from a property
              *
-             * \param propertyValue new value
-             * \return the property itself
+             * @param propertyValue new value
+             * @return the property itself
              */
             StringProperty& operator=(const std::string& propertyValue)
             {
@@ -89,8 +89,8 @@ namespace pmacc
          * specialize this struct including the static method `StringProperty get()`
          * to define a property for an object without the method `getStringProperties()`
          *
-         * \tparam T_Type any type
-         * \return \p T_Type::getStringProperties() if trait `GetStringProperties<>` is not specialized
+         * @tparam T_Type any type
+         * @return \p T_Type::getStringProperties() if trait `GetStringProperties<>` is not specialized
          */
         template<typename T_Type>
         struct StringProperties
@@ -121,8 +121,8 @@ namespace pmacc
          *
          * same as `GetStringProperties<>` but accepts an instance instead a type
          *
-         * \param an instance that shall be queried
-         * \return StringProperty of the given instance
+         * @param an instance that shall be queried
+         * @return StringProperty of the given instance
          */
         template<typename T_Type>
         HINLINE StringProperty getStringProperties(const T_Type&)

--- a/include/pmacc/traits/NumberOfExchanges.hpp
+++ b/include/pmacc/traits/NumberOfExchanges.hpp
@@ -29,8 +29,8 @@ namespace pmacc
     {
         /** Get number of possible exchanges
          *
-         * \tparam T_dim dimension of the simulation
-         * \return \p ::value number of possible exchanges
+         * @tparam T_dim dimension of the simulation
+         * @return \p ::value number of possible exchanges
          *              (is number neighbors + myself)
          */
         template<uint32_t T_dim>

--- a/share/ci/check_cpp_code_style.sh
+++ b/share/ci/check_cpp_code_style.sh
@@ -56,3 +56,17 @@ test/hasExtLibIncludeBrackets share/picongpu/examples cupla
 test/hasExtLibIncludeBrackets share/picongpu/examples splash
 test/hasExtLibIncludeBrackets share/picongpu/examples mallocMC
 test/hasExtLibIncludeBrackets share/pmacc/examples pmacc
+
+#############################################################################
+# Disallow doxygen with \                                                   #
+#############################################################################
+test/hasWrongDoxygenStyle include param
+test/hasWrongDoxygenStyle include tparam
+test/hasWrongDoxygenStyle include see
+test/hasWrongDoxygenStyle include return
+test/hasWrongDoxygenStyle include treturn
+test/hasWrongDoxygenStyle share param
+test/hasWrongDoxygenStyle share tparam
+test/hasWrongDoxygenStyle share see
+test/hasWrongDoxygenStyle share return
+test/hasWrongDoxygenStyle share treturn

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
@@ -41,8 +41,8 @@ namespace picongpu
 
         /** Specify your background field E(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t = 0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t = 0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(
             const DataSpace<simDim>& /*cellIdx*/,
             const uint32_t /*currentStep*/
@@ -68,8 +68,8 @@ namespace picongpu
 
         /** Specify your background field B(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t=0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(
             const DataSpace<simDim>& /*cellIdx*/,
             const uint32_t /*currentStep*/
@@ -118,8 +118,8 @@ namespace picongpu
 
         /** Specify your background field J(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step
+         * @param cellIdx The total cell id counted from the start at t=0
+         * @param currentStep The current time step
          */
         HDINLINE float3_X operator()(const DataSpace<simDim>& cellIdx, const uint32_t currentStep) const
         {

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
@@ -39,8 +39,8 @@ namespace picongpu
 
         /** Specify your background field E(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t = 0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t = 0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(
             const DataSpace<simDim>& /*cellIdx*/,
             const uint32_t /*currentStep*/
@@ -66,8 +66,8 @@ namespace picongpu
 
         /** Specify your background field B(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t=0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(
             const DataSpace<simDim>& /*cellIdx*/,
             const uint32_t /*currentStep*/
@@ -93,8 +93,8 @@ namespace picongpu
 
         /** Specify your background field J(r,t) here
          *
-         * \param cellIdx The total cell id counted from the start at t=0
-         * \param currentStep The current time step */
+         * @param cellIdx The total cell id counted from the start at t=0
+         * @param currentStep The current time step */
         HDINLINE float3_X operator()(
             const DataSpace<simDim>& /*cellIdx*/,
             const uint32_t /*currentStep*/

--- a/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -47,12 +47,12 @@ namespace gol
         typedef Evolution<MappingDesc> Evolutiontype;
 
         Space gridSize;
-        /* holds rule mask derived from 23/3 input, \see Evolution.hpp */
+        /* holds rule mask derived from 23/3 input, @see Evolution.hpp */
         Evolutiontype evo;
         GatherSlice gather;
 
         /* for storing black (dead) and white (alive) data for gol */
-        Buffer* buff1; /* Buffer(\see types.h) for swapping between old and new world */
+        Buffer* buff1; /* Buffer(@see types.h) for swapping between old and new world */
         Buffer* buff2; /* like evolve(buff2 &, const buff1) would work internally */
         uint32_t steps;
 

--- a/test/hasWrongDoxygenStyle
+++ b/test/hasWrongDoxygenStyle
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2021 Axel Huebl, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# search recursive inside the `$1` folder if a file is using the
+# wrong include brackets "..." instead of <...> to include external library files
+#
+# @param $1 path to the folder
+# @param $2 prefix of the extern library e.g pmacc, boost
+# @result 0 if no files are found, else 1
+
+folderName=$1
+keyword=$2
+
+ok=0
+files=()
+
+pattern="\.def$|\.h$|\.cpp$|\.cu$|\.hpp$|\.tpp$|\.kernel$|\.loader$|"\
+"\.param$|\.unitless$"
+
+for i in $(find $folderName \
+    -not -path "./.git/*" \
+    -type f | \
+    grep -P "${pattern}")
+do
+    grep -q "\\\\${keyword}" $i
+    if [ $? -eq 0 ]
+    then
+        files+=($i)
+        echo "$i uses \\${keyword} instead of @$keyword"
+        ok=1
+    fi
+done
+
+if [ $ok -ne 0 ]
+then
+    echo ""
+    echo "SUMMARY"
+    echo "-------"
+    echo "Run the following command(s) on the above files to update your style:"
+    echo ""
+    for i in ${files[@]}
+    do
+        echo "sed -i 's/\\\\${keyword}/@${keyword}/g' $i"
+    done
+fi
+
+exit $ok


### PR DESCRIPTION
Add tool to check the `@` is used for doxygen (for the most important commands) to fulfill our code style.

Update wrong code style in the first commit. The second commit contains the new test.