### PR TITLE
refactor `lockstep::ForEach`

### DIFF
--- a/include/pmacc/lockstep/Config.hpp
+++ b/include/pmacc/lockstep/Config.hpp
@@ -45,9 +45,9 @@ namespace pmacc
             /** SIMD width */
             static constexpr uint32_t simdSize = T_simdSize;
 
-            /** number of collective iterations needed to address all indices */
-            static constexpr uint32_t numCollIter
-                = (domainSize + simdSize * numWorkers - 1u) / (simdSize * numWorkers);
+            /** maximum number of indices a worker must process if the domain is equally distributed over all worker */
+            static constexpr uint32_t maxIndicesPerWorker
+                = ((domainSize + simdSize * numWorkers - 1u) / (simdSize * numWorkers)) * simdSize;
         };
     } // namespace lockstep
 } // namespace pmacc

--- a/include/pmacc/lockstep/Variable.hpp
+++ b/include/pmacc/lockstep/Variable.hpp
@@ -49,15 +49,14 @@ namespace pmacc
          */
         template<typename T_Type, typename T_Config>
         struct Variable
-            : protected memory::Array<T_Type, T_Config::numCollIter * T_Config::simdSize>
+            : protected memory::Array<T_Type, T_Config::maxIndicesPerWorker>
             , T_Config
         {
             using T_Config::domainSize;
-            using T_Config::numCollIter;
             using T_Config::numWorkers;
             using T_Config::simdSize;
 
-            using BaseArray = memory::Array<T_Type, T_Config::numCollIter * T_Config::simdSize>;
+            using BaseArray = memory::Array<T_Type, T_Config::maxIndicesPerWorker>;
 
             /** default constructor
              *


### PR DESCRIPTION
Split the forEach compile-time loop into peel and reminder part.
This is slightly better for CPU compiler and is more human-readable compared to the original implementation.
Add two helper types to derive if a functor is callable with or without Idx as an argument. 
This was suggested by @sbastrakov in #3616.