### PR TITLE
device oversubscription

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -113,6 +113,9 @@ TBG_currentInterpolation="--currentInterpolation binomial"
 # Duplicate E and B field storage inside field background to improve performance at cost of additional memory
 TBG_fieldBackground="--fieldBackground.duplicateFields"
 
+# Allow two MPI ranks to use one compute device.
+TBG_ranksPerDevice="--numRanksPerDevice 2"
+
 ################################################################################
 ## Placeholder for multi data plugins:
 ##

--- a/docs/source/expert/deviceOversubscription.rst
+++ b/docs/source/expert/deviceOversubscription.rst
@@ -1,0 +1,49 @@
+.. _expert-deviceOversubscription:
+
+Device Oversubscription
+=======================
+
+.. moduleauthor:: René Widera
+
+By default the strategy to execute PIConGPU is that one MPI rank is using a single device e.g. a GPU.
+In some situation it could be beneficial to use multiple MPI ranks per device to get a better load balancing
+or better overlap communications with computation.
+
+Usage
+-----
+
+Follow :ref:`the description to pass command line parameter to PIConGPU <usage-cfg>`.
+PIConGPU provides the command line parameter ``--numRanksPerDevice`` or short ``-r`` to allow sharing a compute device
+between multiple MPI ranks.
+If you change the default value ``1`` to ``2`` PIConGPU is supporting two MPI processes per device.
+
+.. note::
+    Using device oversubscription will limit the maximal memory footprint per PIConGPU MPI rank on the device too
+    ``<total available memory on device>/<number of ranks per device>``.
+
+NVIDIA
+------
+
+Compute Mode
+^^^^^^^^^^^^
+
+On NVIDIA GPUs there are different point which can influence the oversubscription of a device/GPU.
+`NVIDIA Compute Mode  <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-modes>`_
+must be ```Default`` to allow multiple processes to use a single GPU.
+If you use device oversubscription with NVIDIA GPUs the kernel executed from different processes will be serialized by the driver,
+this is mostly describing the performance of PIConGPU because the device is under utilized.
+
+Multi-Process Service (MPS)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you use `NVIDIA MPS <https://docs.nvidia.com/deploy/mps/index.html>`_ and split one device into ``4`` you need to use
+``--numRanksPerDevice 4`` for PIConGPU even if MPS is providing you with ``4`` virtual gpus.
+MPS can be used to workaround the kernel serialization when using multiple processes per GPU.
+
+CPU
+---
+
+If you :ref:`compiled PIConGPU with a CPU accelerator <usage-basics-configure>` e.g. `omp2b`, `serial`, `tbb`, or `threads`
+device oversubscribing will have no effect.
+For CPU accelerators PIConGPU is not using a pre allocated device memory heap therefore you can freely choose the number
+of MPI ranks per CPU.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,16 @@ Post-Processing
    postprocessing/openPMD
    postprocessing/paraview
 
+*****************
+Usage for Experts
+*****************
+.. toctree::
+   :caption: EXPERTs
+   :maxdepth: 1
+   :hidden:
+
+   expert/deviceOversubscription
+
 ***********
 Development
 ***********

--- a/include/pmacc/device/MemoryInfo.hpp
+++ b/include/pmacc/device/MemoryInfo.hpp
@@ -26,6 +26,8 @@
 
 #include <cstring> // memset
 
+#include <mpi.h>
+
 namespace pmacc
 {
     namespace device
@@ -43,7 +45,7 @@ namespace pmacc
              * @param free amount of free memory in bytes. can be nullptr
              * @param total total amount of memory in bytes. can be nullptr. (nullptr by default)
              */
-            void getMemoryInfo(size_t* free, size_t* total = nullptr)
+            void getMemoryInfo(size_t* free, size_t* total = nullptr) const
             {
                 size_t freeInternal = 0;
                 size_t totalInternal = 0;
@@ -70,28 +72,53 @@ namespace pmacc
                 }
             }
 
-            /** Returns true if the memory pool is shared by host and device */
-            bool isSharedMemoryPool()
+            /** Check if the memory pool is shared by host and device.
+             *
+             * @attention This method is using MPI collectives and must be called from all MPI processes collectively.
+             *
+             *  @param numRanksPerDevice number of ranks using one device
+             *  @param mpiComm MPI communicator
+             *
+             *  @return true if the device memory is shared with the host else false
+             */
+            bool isSharedMemoryPool(uint32_t const numRanksPerDevice, MPI_Comm mpiComm) const
             {
+                alpaka::ignore_unused(mpiComm);
 #if(PMACC_CUDA_ENABLED != 1 && ALPAKA_ACC_GPU_HIP_ENABLED != 1)
+                alpaka::ignore_unused(numRanksPerDevice);
                 return true;
 #else
+                if(numRanksPerDevice >= 2u)
+                    MPI_CHECK(MPI_Barrier(mpiComm));
+
                 size_t freeInternal = 0;
                 size_t freeAtStart = 0;
 
                 getMemoryInfo(&freeAtStart);
 
-                /* alloc 90%, since allocating 100% is a bit risky on a SoC-like device */
-                size_t allocSth = size_t(0.9 * double(freeAtStart));
+                if(numRanksPerDevice >= 2u)
+                    MPI_CHECK(MPI_Barrier(mpiComm));
+
+                /* Do not allocate 100% is a bit risky on a SoC-like device */
+                double const fractionOfMemory = 0.9 / static_cast<double>(numRanksPerDevice);
+                size_t allocSth = static_cast<size_t>(fractionOfMemory * static_cast<double>(freeAtStart));
                 uint8_t* c = new uint8_t[allocSth];
                 memset(c, 0, allocSth);
 
+                if(numRanksPerDevice >= 2u)
+                    MPI_CHECK(MPI_Barrier(mpiComm));
+
                 getMemoryInfo(&freeInternal);
+
+                if(numRanksPerDevice >= 2u)
+                    MPI_CHECK(MPI_Barrier(mpiComm));
+
                 delete[] c;
 
                 /* if we allocated 90% of available mem, we should have "lost" more
                  * than 50% of memory, even with fluctuations from the OS */
-                if(double(freeInternal) / double(freeAtStart) < 0.5)
+                double const thresholdFraction = 0.5 / static_cast<double>(numRanksPerDevice);
+                if(static_cast<double>(freeInternal) / static_cast<double>(freeAtStart) < thresholdFraction)
                     return true;
 
                 return false;


### PR DESCRIPTION
- Add option `--numRanksPerDevice` and `-r` to allow multiple MPI ranks to
use a device together.
- Documentation:
  - add section `EXPERT`
  - describe the usage of the new option
- change interface of `isSharedMemoryPool()` 