### PR TITLE
Fix wrong helpline for current interpolation kinds

### DIFF
--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -61,7 +61,7 @@ namespace picongpu
                     desc.add_options()(
                         "currentInterpolation",
                         po::value<std::string>(&kindName),
-                        (std::string("Current interpolation kind [None, Binomial] default: " + kindName).c_str()));
+                        std::string("Current interpolation kind [none, binomial] default: " + kindName).c_str());
                 }
 
                 /** Initialize the current interpolation stage


### PR DESCRIPTION
That was a slight mistake when this feature was introduced. The bracket change is unrelated, they were just redundant there.