### PR TITLE
fix observation direction precision to float_X

### DIFF
--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -75,6 +75,9 @@ namespace picongpu
                  */
                 HDINLINE vector_64 observation_direction(const int observation_id_extern)
                 {
+                    /* float type used in radiation direction calculations */
+                    using float_obs = picongpu::float_X;
+
                     /* generate two indices from single block index */
                     /** split distance of given index
                      * pseudo-code:
@@ -117,12 +120,12 @@ namespace picongpu
                     const picongpu::float_64 phi(my_index_phi * delta_angle_phi - angle_phi_start);
 
                     /* helper functions for efficient trigonometric calculations */
-                    picongpu::float_X sinPhi;
-                    picongpu::float_X cosPhi;
-                    picongpu::float_X sinTheta;
-                    picongpu::float_X cosTheta;
-                    pmacc::math::sincos(precisionCast<picongpu::float_X>(phi), sinPhi, cosPhi);
-                    pmacc::math::sincos(precisionCast<picongpu::float_X>(theta), sinTheta, cosTheta);
+                    float_obs sinPhi;
+                    float_obs cosPhi;
+                    float_obs sinTheta;
+                    float_obs cosTheta;
+                    pmacc::math::sincos(precisionCast<float_obs>(phi), sinPhi, cosPhi);
+                    pmacc::math::sincos(precisionCast<float_obs>(theta), sinTheta, cosTheta);
                     /** compute observation unit vector */
                     return vector_64(sinTheta * cosPhi, cosTheta, sinTheta * sinPhi);
                 }

--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -117,12 +117,12 @@ namespace picongpu
                     const picongpu::float_64 phi(my_index_phi * delta_angle_phi - angle_phi_start);
 
                     /* helper functions for efficient trigonometric calculations */
-                    picongpu::float_32 sinPhi;
-                    picongpu::float_32 cosPhi;
-                    picongpu::float_32 sinTheta;
-                    picongpu::float_32 cosTheta;
-                    pmacc::math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
-                    pmacc::math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+                    picongpu::float_X sinPhi;
+                    picongpu::float_X cosPhi;
+                    picongpu::float_X sinTheta;
+                    picongpu::float_X cosTheta;
+                    pmacc::math::sincos(precisionCast<picongpu::float_X>(phi), sinPhi, cosPhi);
+                    pmacc::math::sincos(precisionCast<picongpu::float_X>(theta), sinTheta, cosTheta);
                     /** compute observation unit vector */
                     return vector_64(sinTheta * cosPhi, cosTheta, sinTheta * sinPhi);
                 }

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
@@ -52,6 +52,9 @@ namespace picongpu
                      *  energy of the electrons.
                      */
 
+                    /* float type used in radiation direction calculations */
+                    using float_obs = picongpu::float_X;
+
                     /* in this case only one id is needed: an index for theta */
                     const int my_theta_id = observation_id_extern;
 
@@ -68,9 +71,9 @@ namespace picongpu
                     /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
                     /* compute observation unit vector */
-                    picongpu::float_X sinTheta;
-                    picongpu::float_X cosTheta;
-                    pmacc::math::sincos(precisionCast<picongpu::float_X>(theta), sinTheta, cosTheta);
+                    float_obs sinTheta;
+                    float_obs cosTheta;
+                    pmacc::math::sincos(precisionCast<float_obs>(theta), sinTheta, cosTheta);
                     return vector_64(sinTheta, cosTheta, 0.0);
                 }
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
@@ -68,9 +68,9 @@ namespace picongpu
                     /* + picongpu::PI -> turn observation direction 180 degrees towards -y */
 
                     /* compute observation unit vector */
-                    picongpu::float_32 sinTheta;
-                    picongpu::float_32 cosTheta;
-                    pmacc::math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+                    picongpu::float_X sinTheta;
+                    picongpu::float_X cosTheta;
+                    pmacc::math::sincos(precisionCast<picongpu::float_X>(theta), sinTheta, cosTheta);
                     return vector_64(sinTheta, cosTheta, 0.0);
                 }
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
@@ -68,12 +68,12 @@ namespace picongpu
                     const picongpu::float_64 phi(my_index_phi * delta_angle);
 
                     /* compute unit vector */
-                    picongpu::float_32 sinPhi;
-                    picongpu::float_32 cosPhi;
-                    picongpu::float_32 sinTheta;
-                    picongpu::float_32 cosTheta;
-                    pmacc::math::sincos(precisionCast<picongpu::float_32>(phi), sinPhi, cosPhi);
-                    pmacc::math::sincos(precisionCast<picongpu::float_32>(theta), sinTheta, cosTheta);
+                    picongpu::float_X sinPhi;
+                    picongpu::float_X cosPhi;
+                    picongpu::float_X sinTheta;
+                    picongpu::float_X cosTheta;
+                    pmacc::math::sincos(precisionCast<picongpu::float_X>(phi), sinPhi, cosPhi);
+                    pmacc::math::sincos(precisionCast<picongpu::float_X>(theta), sinTheta, cosTheta);
                     return vector_64(sinTheta * cosPhi, sinTheta * sinPhi, cosTheta);
                 }
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
@@ -50,6 +50,9 @@ namespace picongpu
                      *  (+1,0,0) ; (0,+1,0) ; (0,0,-1)
                      */
 
+                    /* float type used in radiation direction calculations */
+                    using float_obs = picongpu::float_X;
+
                     /* generate two indices from single block index */
                     constexpr int N_angle_split = 16; /* index split distance */
                     /* get column index for computing angle theta: */
@@ -68,12 +71,12 @@ namespace picongpu
                     const picongpu::float_64 phi(my_index_phi * delta_angle);
 
                     /* compute unit vector */
-                    picongpu::float_X sinPhi;
-                    picongpu::float_X cosPhi;
-                    picongpu::float_X sinTheta;
-                    picongpu::float_X cosTheta;
-                    pmacc::math::sincos(precisionCast<picongpu::float_X>(phi), sinPhi, cosPhi);
-                    pmacc::math::sincos(precisionCast<picongpu::float_X>(theta), sinTheta, cosTheta);
+                    float_obs sinPhi;
+                    float_obs cosPhi;
+                    float_obs sinTheta;
+                    float_obs cosTheta;
+                    pmacc::math::sincos(precisionCast<float_obs>(phi), sinPhi, cosPhi);
+                    pmacc::math::sincos(precisionCast<float_obs>(theta), sinTheta, cosTheta);
                     return vector_64(sinTheta * cosPhi, sinTheta * sinPhi, cosTheta);
                 }
 


### PR DESCRIPTION
In case of ultra high gamma particles, the precision of the observation direction needs to be increased since the radiation cone decreases with ~1/gamma. `float_32` are not precise enough for particles above gamma>800. 
This fix removed the hard coded `float_32` implementation of the observation direction calculation and sets it to `float_X`. Thus it can be adjusted by setting PIConGPU's precision. This will coast a bit of performance, but can currently not be handled otherwise. 