### PR TITLE
fix hemera tpl files

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -105,6 +105,6 @@ export OMPI_MCA_io=^ompio
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \
-    !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \
+    !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -115,5 +115,5 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -113,5 +113,5 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -115,6 +115,6 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
-    !TBG_author !TBG_programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+    !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -174,8 +174,8 @@ else
 fi
 
 if [ $? -eq 0 ] ; then
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
-    $stepSetup !TBG_author $programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+    $stepSetup !TBG_author $programParams
 fi
 
 if [ $nextStep -lt $finalStep ]

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -115,5 +115,5 @@ fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -175,8 +175,8 @@ else
 fi
 
 if [ $? -eq 0 ] ; then
-  $(!TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
-    $stepSetup !TBG_author $programParams)
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+    $stepSetup !TBG_author $programParams
 fi
 
 if [ $nextStep -lt $finalStep ]


### PR DESCRIPTION
With #3633 got broken. The signal forward script must be called with `source` and not via `$(...)`.

@ComputationalRadiationPhysics/picongpu-developers Everyone how used the dev branch on hemera from last week should update to the latest version as soon as this PR is merged.