### PR TITLE
Update of spack installation guide

### DIFF
--- a/docs/source/install/instructions/spack.rst
+++ b/docs/source/install/instructions/spack.rst
@@ -32,6 +32,8 @@ First `install spack <http://spack.readthedocs.io/en/latest/getting_started.html
 
    # add the PIConGPU repository
    git clone https://github.com/ComputationalRadiationPhysics/spack-repo.git $HOME/src/spack-repo
+   
+   # add the new repo to spack
    spack repo add $HOME/src/spack-repo
 
 .. note::


### PR DESCRIPTION
Minor change of description for more clarity. Seperated the addition of the downloaded repo to the spack installation into a seperate step.