### PR TITLE
Fix CFL conditions

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.hpp
@@ -23,11 +23,48 @@
 
 #include "picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.def"
 #include "picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Derivative.hpp"
+#include "picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Weights.hpp"
+#include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/differentiation/Curl.hpp"
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Specialization of the CFL condition checker for the arbitrary-order FDTD
+             *
+             * @tparam T_neighbors number of neighbors used to calculate the derivatives
+             */
+            template<uint32_t T_neighbors>
+            struct CFLChecker<ArbitraryOrderFDTD<T_neighbors>>
+            {
+                //! Check the CFL condition, throws when failed
+                void operator()() const
+                {
+                    // The equations are given at https://picongpu.readthedocs.io/en/latest/models/AOFDTD.html
+                    auto weights = aoFDTD::AOFDTDWeights<T_neighbors>{};
+                    auto additionalFactor = 0.0_X;
+                    for(uint32_t i = 0u; i < T_neighbors; i++)
+                    {
+                        auto const term = (i % 2) ? -weights[i] : weights[i];
+                        additionalFactor += term;
+                    }
+                    if(SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM * additionalFactor
+                           * additionalFactor
+                       > 1.0_X)
+                        throw std::runtime_error(
+                            "Courant-Friedrichs-Lewy condition check failed, check your grid.param file");
+                }
+            };
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu
 
 namespace pmacc
 {

--- a/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
@@ -1,0 +1,59 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Functor to check the Courant-Friedrichs-Lewy-Condition for the given field solver
+             *
+             * Performs either a compile-time check or a run-time check and throws if failed.
+             *
+             * @tparam T_FieldSolver field solver type
+             */
+            template<typename T_FieldSolver>
+            struct CFLChecker
+            {
+                /** Check the CFL condition, doesn't compile when failed
+                 *
+                 * The default implementation checks the basic explicit PIC assumption c * dt <= min(dx, dy, dz).
+                 * Note that generally FDTD-type field solvers have a more strict condition, and have to provide a
+                 * specialization.
+                 */
+                void operator()() const
+                {
+                    // T_FieldSolver is added to defer evaluation
+                    PMACC_CASSERT_MSG(
+                        Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
+                        (SPEED_OF_LIGHT * DELTA_T / CELL_WIDTH <= 1.0)
+                            && (SPEED_OF_LIGHT * DELTA_T / CELL_HEIGHT <= 1.0)
+                            && (SPEED_OF_LIGHT * DELTA_T / CELL_DEPTH <= 1.0) && sizeof(T_FieldSolver*) != 0);
+                }
+            };
+
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.def
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.def
@@ -69,8 +69,8 @@ namespace picongpu
             template<uint32_t T_cherenkovFreeDir = lehe::CherenkovFreeDirection_Y>
             using Lehe = ::picongpu::fields::maxwellSolver::Yee<lehe::CurlE<T_cherenkovFreeDir>>;
 
-            /* We need no definition of margins, because the Yee solver uses its curl
-             * classes to define margins
+            /* We need no definition of margins, because the Yee solver uses its curl classes to define margins.
+             * The default CFL checker is sufficient, thus it is not specialized for Lehe
              */
 
         } // namespace maxwellSolver

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -45,6 +45,7 @@ namespace picongpu
 
                 None(MappingDesc)
                 {
+                    // Note: the default CFL checker is sufficient, thus it is not specialized for None
                     CFLChecker<None>{}();
                 }
 

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/None/None.def"
 #include "picongpu/fields/cellType/Yee.hpp"
 #include "picongpu/traits/GetMargin.hpp"
@@ -34,34 +35,7 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
-            namespace none
-            {
-                /** Check Yee grid and time conditions
-                 *
-                 * This is a workaround that the condition check is only
-                 * triggered if the current used solver is `NoSolver`
-                 */
-                template<typename T_UsedSolver, typename T_Dummy = void>
-                struct ConditionCheck
-                {
-                };
-
-                template<typename T_Dummy>
-                struct ConditionCheck<None, T_Dummy>
-                {
-                    /* Courant-Friedrichs-Levy-Condition for Yee Field Solver:
-                     *
-                     * A workaround is to add a template dependency to the expression.
-                     * `sizeof(ANY_TYPE*) != 0` is always true and defers the evaluation.
-                     */
-                    PMACC_CASSERT_MSG(
-                        Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
-                        (SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM) <= 1.0
-                            && sizeof(T_Dummy*) != 0);
-                };
-            } // namespace none
-
-            class None : private none::ConditionCheck<None>
+            class None
             {
             private:
                 typedef MappingDesc::SuperCellSize SuperCellSize;
@@ -71,6 +45,7 @@ namespace picongpu
 
                 None(MappingDesc)
                 {
+                    CFLChecker<None>{}();
                 }
 
                 void update_beforeCurrent(uint32_t)

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -278,25 +278,18 @@ namespace picongpu
                 std::unique_ptr<fields::absorber::AbsorberImpl> absorberImpl;
             };
 
-            /** Specialization of the CFL condition checker for the Yee solver
-             *
-             * @tparam T_CurlE functor to compute curl of E
-             * @tparam T_CurlB functor to compute curl of B
-             */
-            template<typename T_CurlE, typename T_CurlB>
-            struct CFLChecker<Yee<T_CurlE, T_CurlB>>
+            //! Specialization of the CFL condition checker for the classic Yee solver
+            template<>
+            struct CFLChecker<Yee<>>
             {
-                /** Check the CFL condition, doesn't compile when failed
-                 *
-                 * @warning currently always checks for the basic Yee solver
-                 */
+                //! Check the CFL condition, doesn't compile when failed
                 void operator()() const
                 {
                     // Yee<T_CurlE, T_CurlB> is added to defer evaluation
                     PMACC_CASSERT_MSG(
                         Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
                         (SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM) <= 1.0
-                            && sizeof(Yee<T_CurlE, T_CurlB>*) != 0);
+                            && sizeof(Yee<>*) != 0);
                 }
             };
 

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/fields/LaserPhysics.hpp"
+#include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/Yee/Yee.kernel"
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/absorber/pml/Pml.hpp"
@@ -63,6 +64,7 @@ namespace picongpu
 
                 Yee(MappingDesc const cellDescription) : cellDescription(cellDescription)
                 {
+                    CFLChecker<Yee>{}();
                     DataConnector& dc = Environment<>::get().DataConnector();
                     fieldE = dc.get<FieldE>(FieldE::getName(), true);
                     fieldB = dc.get<FieldB>(FieldB::getName(), true);
@@ -237,16 +239,6 @@ namespace picongpu
                 template<uint32_t T_Area>
                 void updateE(uint32_t currentStep)
                 {
-                    /* Courant-Friedrichs-Levy-Condition for Yee Field Solver:
-                     *
-                     * A workaround is to add a template dependency to the expression.
-                     * `sizeof(ANY_TYPE*) != 0` is always true and defers the evaluation.
-                     */
-                    PMACC_CASSERT_MSG(
-                        Courant_Friedrichs_Levy_condition_failure____check_your_grid_param_file,
-                        (SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM) <= 1.0
-                            && sizeof(T_CurlE*) != 0);
-
                     constexpr auto numWorkers = getNumWorkers();
                     using Kernel = yee::KernelUpdateE<numWorkers, BlockDescription<CurlB>>;
                     auto mapper = AreaMapper<T_Area>{cellDescription};
@@ -284,6 +276,28 @@ namespace picongpu
 
                 // Absorber implementation
                 std::unique_ptr<fields::absorber::AbsorberImpl> absorberImpl;
+            };
+
+            /** Specialization of the CFL condition checker for the Yee solver
+             *
+             * @tparam T_CurlE functor to compute curl of E
+             * @tparam T_CurlB functor to compute curl of B
+             */
+            template<typename T_CurlE, typename T_CurlB>
+            struct CFLChecker<Yee<T_CurlE, T_CurlB>>
+            {
+                /** Check the CFL condition, doesn't compile when failed
+                 *
+                 * @warning currently always checks for the basic Yee solver
+                 */
+                void operator()() const
+                {
+                    // Yee<T_CurlE, T_CurlB> is added to defer evaluation
+                    PMACC_CASSERT_MSG(
+                        Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
+                        (SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM) <= 1.0
+                            && sizeof(Yee<T_CurlE, T_CurlB>*) != 0);
+                }
             };
 
         } // namespace maxwellSolver
@@ -336,5 +350,4 @@ namespace picongpu
         };
 
     } // namespace traits
-
 } // namespace picongpu


### PR DESCRIPTION
For a very long time, CFL checks were wrong for each solver but the standard `Yee`. This PR fixes it for all other solvers:

- `None`
- `Lehe` (thanks @psychocoderHPC for pointing it out recently)
- arbitrary order #3581

I also added a new functor to check those, to provide easier specialization, and fixed a typo in Lewy.
The basic check is what we rely on in current deposition: a particle can't move by more than one cell size in one time step. For `None` and `Lehe` that is enough, Yee and arbitrary-order FDTD pose more strict conditions in their specializations.

Note: it is probably possible to make the arbitrary-order check compile-time as well. However, the `Weights` class there claims to be constexpr, but making a `constexpr` object of it doesn't work. @steindev could you comment on that?