### PR TITLE
fix signal handling

### DIFF
--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -104,6 +104,17 @@ namespace pmacc
             return topology;
         }
 
+        /*! MPI communicator for signal handling
+         *
+         * @attention Do not use this communicator to transfer simulation data.
+         *
+         * @return communicator used transfer signal information only
+         */
+        MPI_Comm getMPISignalComm() const
+        {
+            return commSignal;
+        }
+
         MPI_Info getMPIInfo() const
         {
             return MPI_INFO_NULL;
@@ -150,6 +161,8 @@ namespace pmacc
 
             /*create new communicator based on cartesian coordinates*/
             MPI_CHECK(MPI_Cart_create(computing_comm, DIM, dims, periods, 0, &topology));
+            // create communicator for signal handling
+            MPI_CHECK(MPI_Comm_dup(topology, &commSignal));
 
             // 3. update Host rank
             updateHostRank();
@@ -435,6 +448,8 @@ namespace pmacc
         DataSpace<DIM3> periodic;
         //! MPI communicator (currently MPI_COMM_WORLD)
         MPI_Comm topology;
+        //! Communicator to handle signals
+        MPI_Comm commSignal;
         //! array for exchangetype-to-rank conversion @see ExchangeTypeToRank
         int ranks[27];
         //! size of pmacc [cx,cy,cz]

--- a/include/pmacc/eventSystem/Manager.hpp
+++ b/include/pmacc/eventSystem/Manager.hpp
@@ -58,6 +58,17 @@ namespace pmacc
          */
         void waitForFinished(id_t taskId);
 
+        /** Blocks until func is ready.
+         *
+         * The functor is executed until it returns true. After each functor executing PMaccs event system is executed.
+         *
+         * @tparam T_Functor Type of the functor.
+         * @param func Functor to execute. signature: `bool func()`
+         *             The functor is not allowed to execute MPI collectives or any other blocking function.
+         */
+        template<typename T_Functor>
+        void waitFor(T_Functor&& func);
+
         /**
          * blocks until all tasks in the manager are finished
          */

--- a/include/pmacc/eventSystem/Manager.tpp
+++ b/include/pmacc/eventSystem/Manager.tpp
@@ -163,6 +163,15 @@ namespace pmacc
         }
     }
 
+    template<typename T_Functor>
+    void Manager::waitFor(T_Functor&& func)
+    {
+        while(!func())
+        {
+            this->execute();
+        }
+    }
+
     inline void Manager::waitForAllTasks()
     {
         while(tasks.size() != 0 || passiveTasks.size() != 0)


### PR DESCRIPTION
With #3633 we introduced signal handling.
@Anton-Le observed deadlocks when using signaling. 
The reason for the deadlocks was that PMacc used MPI collective blocking operations to handle signals, together with blocking operations in PIConGPU plugins or other simulation phases this can result in deadlocks.

This PR provided two interface extensions for PMacc to be able to handle signals correctly.
  - add method `pmacc::Manager::waitFor(T_Functor&&)` to wait for a user given functor.
  - extend interface with `pmacc::CommunucatorMPI::getMPISignalComm()` 
 
Additionally, the signal processing in `pmacc::SimulationHelper` is updated to avoid that the event system is blocked and signals are allowed to be handled even if MPI ranks of the simulation are in different time steps.