### PR TITLE
Make the CFL check deferred (again)

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
@@ -33,8 +33,10 @@ namespace picongpu
              * Performs either a compile-time check or a run-time check and throws if failed.
              *
              * @tparam T_FieldSolver field solver type
+             * @tparam T_Defer technical parameter to defer evaluation;
+             *                 is needed for specializations with non-template solver classes
              */
-            template<typename T_FieldSolver>
+            template<typename T_FieldSolver, typename T_Defer = void>
             struct CFLChecker
             {
                 /** Check the CFL condition, doesn't compile when failed
@@ -45,12 +47,14 @@ namespace picongpu
                  */
                 void operator()() const
                 {
-                    // T_FieldSolver is added to defer evaluation
+                    /* Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
+                     * (in this case, could have depended on T_FieldSolver as well)
+                     */
                     PMACC_CASSERT_MSG(
                         Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
                         (SPEED_OF_LIGHT * DELTA_T / CELL_WIDTH <= 1.0)
                             && (SPEED_OF_LIGHT * DELTA_T / CELL_HEIGHT <= 1.0)
-                            && (SPEED_OF_LIGHT * DELTA_T / CELL_DEPTH <= 1.0) && sizeof(T_FieldSolver*) != 0);
+                            && (SPEED_OF_LIGHT * DELTA_T / CELL_DEPTH <= 1.0) && sizeof(T_Defer*) != 0);
                 }
             };
 

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -34,18 +34,21 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
-            //! Specialization of the CFL condition checker for the classic Yee solver
-            template<>
-            struct CFLChecker<Yee>
+            /** Specialization of the CFL condition checker for the classic Yee solver
+             *
+             * @tparam T_Defer technical parameter to defer evaluation
+             */
+            template<typename T_Defer>
+            struct CFLChecker<Yee, T_Defer>
             {
                 //! Check the CFL condition, doesn't compile when failed
                 void operator()() const
                 {
-                    // Yee<T_CurlE, T_CurlB> is added to defer evaluation
+                    // Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
                     PMACC_CASSERT_MSG(
                         Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
                         (SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM) <= 1.0
-                            && sizeof(Yee*) != 0);
+                            && sizeof(T_Defer*) != 0);
                 }
             };
 


### PR DESCRIPTION
During the work on #3641 I didn't notice that at some point the check was no longer deferred for the classic Yee solver. This results in the check being done for al setups, which is incorrect. Add dependance on template parameters to make it deferred again.

[On another thing discussed on VC](https://github.com/ComputationalRadiationPhysics/picongpu/pull/3641#issuecomment-862327513), for Lehe solver the default checks seems fine (and checking it lead to discovering this bug).

- [x] Rebase after #3643 is merged. There is no logical dependency, but same lines were changed.