### PR TITLE
refactor field update functor

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -197,7 +197,7 @@ namespace picongpu
                 void updateBHalf(uint32_t const currentStep, bool const updatePsiB)
                 {
                     constexpr auto numWorkers = getNumWorkers();
-                    using Kernel = fdtd::KernelUpdateB<numWorkers, BlockDescription<CurlE>>;
+                    using Kernel = fdtd::KernelUpdateField<numWorkers>;
                     AreaMapper<T_Area> mapper{cellDescription};
 
                     // The ugly transition from run-time to compile-time polymorphism is contained here
@@ -233,7 +233,7 @@ namespace picongpu
                 void updateE(uint32_t currentStep)
                 {
                     constexpr auto numWorkers = getNumWorkers();
-                    using Kernel = fdtd::KernelUpdateE<numWorkers, BlockDescription<CurlB>>;
+                    using Kernel = fdtd::KernelUpdateField<numWorkers>;
                     auto mapper = AreaMapper<T_Area>{cellDescription};
 
                     // The ugly transition from run-time to compile-time polymorphism is contained here

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
+#include <pmacc/dimensions/SuperCellDescription.hpp>
 #include <pmacc/lockstep.hpp>
 #include <pmacc/mappings/threads/ThreadCollective.hpp>
 #include <pmacc/math/operation.hpp>
@@ -47,6 +48,11 @@ namespace picongpu
                 class UpdateEFunctor
                 {
                 public:
+                    //! Stencil requirements for lower margins
+                    using LowerMargin = typename traits::GetLowerMargin<T_CurlB>::type;
+                    //! Stencil requirements for upper margins
+                    using UpperMargin = typename traits::GetUpperMargin<T_CurlB>::type;
+
                     /** Update electric field at the given position
                      *
                      * @tparam T_LocalBBox local magnetic field box type
@@ -72,6 +78,7 @@ namespace picongpu
                     }
 
                 private:
+                    // keep curl as member to support stateful types
                     T_CurlB const curl = T_CurlB{};
                 };
 
@@ -84,6 +91,11 @@ namespace picongpu
                 class UpdateBHalfFunctor
                 {
                 public:
+                    //! Stencil requirements for lower margins
+                    using LowerMargin = typename traits::GetLowerMargin<T_CurlE>::type;
+                    //! Stencil requirements for upper margins
+                    using UpperMargin = typename traits::GetUpperMargin<T_CurlE>::type;
+
                     /** Update magnetic field at the given position
                      *
                      * @tparam T_LocalEBox local electric field box type
@@ -108,130 +120,79 @@ namespace picongpu
                     }
 
                 private:
+                    // keep curl as member to support stateful types
                     T_CurlE const curl = T_CurlE{};
                 };
 
-                /** Kernel to update the electric field
+                /** Kernel to update each cell
                  *
                  * @tparam T_numWorkers number of workers
-                 * @tparam T_BlockDescription field (electric and magnetic) domain description
                  */
-                template<uint32_t T_numWorkers, typename T_BlockDescription>
-                struct KernelUpdateE
+                template<uint32_t T_numWorkers>
+                struct KernelUpdateField
                 {
                     /** Update the electric field using the given functor
                      *
                      * @tparam T_Acc alpaka accelerator type
                      * @tparam T_Mapping mapper functor type
-                     * @tparam T_UpdateFunctor update functor type
-                     * @tparam T_BBox pmacc::DataBox, magnetic field box type
-                     * @tparam T_EBox pmacc::DataBox, electric field box type
+                     * @tparam T_StencilFunctor stencil functor type to update a cell
+                     * @tparam T_SrcBox pmacc::DataBox, source field box type
+                     * @tparam T_DestBox pmacc::DataBox, electric field box type
                      *
                      * @param acc alpaka accelerator
                      * @param mapper functor to map a block to a supercell
-                     * @param updateFunctor update functor
-                     * @param fieldB magnetic field iterator
-                     * @param fieldE electric field iterator
+                     * @param stencilFunctor stencil functor
+                     * @param srcField source field iterator (is not allowed to be an alias of destField data)
+                     * @param destField destination field iterator
                      */
                     template<
                         typename T_Acc,
                         typename T_Mapping,
-                        typename T_UpdateFunctor,
-                        typename T_BBox,
-                        typename T_EBox>
+                        typename T_StencilFunctor,
+                        typename T_SrcBox,
+                        typename T_DestBox>
                     DINLINE void operator()(
                         T_Acc const& acc,
                         T_Mapping const mapper,
-                        T_UpdateFunctor updateFunctor,
-                        T_BBox const fieldB,
-                        T_EBox fieldE) const
+                        T_StencilFunctor stencilFunctor,
+                        T_SrcBox const srcField,
+                        T_DestBox destField) const
                     {
-                        /* Each block processes grid values in a supercell,
+                        /* Each block processes all cells of a supercell,
                          * the index includes guards, same as all indices in this kernel
                          */
-                        auto const blockBeginIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)))
+                        auto const superCellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)))
                             * MappingDesc::SuperCellSize::toRT();
 
-                        // Cache B values for the block
                         constexpr auto numWorkers = T_numWorkers;
                         auto const workerIdx = cupla::threadIdx(acc).x;
-                        pmacc::math::operation::Assign assign;
-                        auto fieldBBlock = fieldB.shift(blockBeginIdx);
-                        ThreadCollective<T_BlockDescription, numWorkers> collectiveCacheB(workerIdx);
-                        auto cachedB = CachedBox::create<0u, typename T_BBox::ValueType>(acc, T_BlockDescription());
-                        collectiveCacheB(acc, assign, cachedB, fieldBBlock);
-                        cupla::__syncthreads(acc);
-                        constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                        lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)([&](uint32_t const linearIdx) {
-                            auto const idxInSuperCell
-                                = DataSpaceOperations<simDim>::template map<SuperCellSize>(linearIdx);
-                            auto const gridIdx = blockBeginIdx + idxInSuperCell;
-                            updateFunctor(gridIdx, cachedB.shift(idxInSuperCell), fieldE.shift(gridIdx));
-                        });
-                    }
-                };
 
-                /** Kernel to update the magnetic field
-                 *
-                 * @tparam T_numWorkers number of workers
-                 * @tparam T_BlockDescription field (electric and magnetic) domain description
-                 */
-                template<uint32_t T_numWorkers, typename T_BlockDescription>
-                struct KernelUpdateB
-                {
-                    /** Update the magnetic field using the given functor
-                     *
-                     * @tparam T_Acc alpaka accelerator type
-                     * @tparam T_Mapping mapper functor type
-                     * @tparam T_UpdateFunctor update functor type
-                     * @tparam T_EBox pmacc::DataBox electric field box type
-                     * @tparam T_BBox pmacc::DataBox magnetic field box type
-                     *
-                     * @param acc alpaka accelerator
-                     * @param mapper functor to map a block to a supercell
-                     * @param updateFunctor update functor
-                     * @param fieldE electric field iterator
-                     * @param fieldB magnetic field iterator
-                     */
-                    template<
-                        typename T_Acc,
-                        typename T_Mapping,
-                        typename T_UpdateFunctor,
-                        typename T_EBox,
-                        typename T_BBox>
-                    DINLINE void operator()(
-                        T_Acc const& acc,
-                        T_Mapping const mapper,
-                        T_UpdateFunctor updateFunctor,
-                        T_EBox const fieldE,
-                        T_BBox fieldB) const
-                    {
-                        /* Each block processes grid values in a supercell,
-                         * the index includes guards, same as all indices in this kernel
+                        // Description of the area and guards where the stencil is performed.
+                        using StencilCfg = pmacc::SuperCellDescription<
+                            SuperCellSize,
+                            typename traits::GetLowerMargin<T_StencilFunctor>::type,
+                            typename traits::GetUpperMargin<T_StencilFunctor>::type>;
+                        /* Cache source field values of the supercell including guard cells to perform the stencil
+                         * functor
                          */
-                        auto const blockBeginIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)))
-                            * MappingDesc::SuperCellSize::toRT();
-
-                        // Cache E values for the block
-                        constexpr auto numWorkers = T_numWorkers;
-                        auto const workerIdx = cupla::threadIdx(acc).x;
                         pmacc::math::operation::Assign assign;
-                        auto fieldEBlock = fieldE.shift(blockBeginIdx);
-                        ThreadCollective<T_BlockDescription, numWorkers> collectiveCacheE(workerIdx);
-                        auto cachedE = CachedBox::create<0u, typename T_EBox::ValueType>(acc, T_BlockDescription());
-                        collectiveCacheE(acc, assign, cachedE, fieldEBlock);
+                        auto srcFieldBlock = srcField.shift(superCellIdx);
+                        ThreadCollective<StencilCfg, numWorkers> collectiveCacheB(workerIdx);
+                        auto cachedSrcField = CachedBox::create<0u, typename T_SrcBox::ValueType>(acc, StencilCfg{});
+                        collectiveCacheB(acc, assign, cachedSrcField, srcFieldBlock);
+
                         cupla::__syncthreads(acc);
 
                         constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                        // Execute the stencil functor for each cell in the supercell.
                         lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)([&](uint32_t const linearIdx) {
                             auto const idxInSuperCell
                                 = DataSpaceOperations<simDim>::template map<SuperCellSize>(linearIdx);
-                            auto const gridIdx = blockBeginIdx + idxInSuperCell;
-                            updateFunctor(gridIdx, cachedE.shift(idxInSuperCell), fieldB.shift(gridIdx));
+                            auto const gridIdx = superCellIdx + idxInSuperCell;
+                            stencilFunctor(gridIdx, cachedSrcField.shift(idxInSuperCell), destField.shift(gridIdx));
                         });
                     }
                 };
-
             } // namespace fdtd
         } // namespace maxwellSolver
     } // namespace fields

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
@@ -21,6 +21,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/fields/MaxwellSolver/Yee/StencilFunctor.hpp"
+
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
 #include <pmacc/dimensions/SuperCellDescription.hpp>
 #include <pmacc/lockstep.hpp>
@@ -39,20 +41,15 @@ namespace picongpu
         {
             namespace fdtd
             {
-                /** Functor to update electric field by a time step using standard FDTD with the given curl
+                /** Stencil functor to update electric field by a time step using FDTD with the given curl
                  *
                  * @tparam T_CurlB curl functor type to be applied to magnetic field,
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlB>
-                class UpdateEFunctor
+                class UpdateEFunctor : public yee::StencilFunctor<T_CurlB>
                 {
                 public:
-                    //! Stencil requirements for lower margins
-                    using LowerMargin = typename traits::GetLowerMargin<T_CurlB>::type;
-                    //! Stencil requirements for upper margins
-                    using UpperMargin = typename traits::GetUpperMargin<T_CurlB>::type;
-
                     /** Update electric field at the given position
                      *
                      * @tparam T_LocalBBox local magnetic field box type
@@ -76,26 +73,19 @@ namespace picongpu
                         constexpr auto dt = DELTA_T;
                         localE() += curl(localB) * c2 * dt;
                     }
-
-                private:
                     // keep curl as member to support stateful types
                     T_CurlB const curl = T_CurlB{};
                 };
 
-                /** Functor to update magnetic field by half a time step using standard FDTD with the given curl
+                /** Stencil functor to update magnetic field by a half time step using FDTD with the given curl
                  *
                  * @tparam T_CurlE curl functor type to be applied to electric field,
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlE>
-                class UpdateBHalfFunctor
+                class UpdateBHalfFunctor : public yee::StencilFunctor<T_CurlE>
                 {
                 public:
-                    //! Stencil requirements for lower margins
-                    using LowerMargin = typename traits::GetLowerMargin<T_CurlE>::type;
-                    //! Stencil requirements for upper margins
-                    using UpperMargin = typename traits::GetUpperMargin<T_CurlE>::type;
-
                     /** Update magnetic field at the given position
                      *
                      * @tparam T_LocalEBox local electric field box type
@@ -118,8 +108,6 @@ namespace picongpu
                         constexpr auto halfDt = 0.5_X * DELTA_T;
                         localB() -= curl(localE) * halfDt;
                     }
-
-                private:
                     // keep curl as member to support stateful types
                     T_CurlE const curl = T_CurlE{};
                 };
@@ -131,13 +119,14 @@ namespace picongpu
                 template<uint32_t T_numWorkers>
                 struct KernelUpdateField
                 {
-                    /** Update the electric field using the given functor
+                    /** Update the yee field using the given functor
                      *
                      * @tparam T_Acc alpaka accelerator type
                      * @tparam T_Mapping mapper functor type
-                     * @tparam T_StencilFunctor stencil functor type to update a cell
+                     * @tparam T_StencilFunctor stencil functor type to update a cell,
+                     *         adheres the StencilFunctor concept
                      * @tparam T_SrcBox pmacc::DataBox, source field box type
-                     * @tparam T_DestBox pmacc::DataBox, electric field box type
+                     * @tparam T_DestBox pmacc::DataBox, destination field box type
                      *
                      * @param acc alpaka accelerator
                      * @param mapper functor to map a block to a supercell
@@ -161,7 +150,7 @@ namespace picongpu
                         /* Each block processes all cells of a supercell,
                          * the index includes guards, same as all indices in this kernel
                          */
-                        auto const superCellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)))
+                        auto const beginCellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)))
                             * MappingDesc::SuperCellSize::toRT();
 
                         constexpr auto numWorkers = T_numWorkers;
@@ -176,10 +165,10 @@ namespace picongpu
                          * functor
                          */
                         pmacc::math::operation::Assign assign;
-                        auto srcFieldBlock = srcField.shift(superCellIdx);
-                        ThreadCollective<StencilCfg, numWorkers> collectiveCacheB(workerIdx);
+                        auto srcFieldBlock = srcField.shift(beginCellIdx);
+                        ThreadCollective<StencilCfg, numWorkers> cacheStencilArea(workerIdx);
                         auto cachedSrcField = CachedBox::create<0u, typename T_SrcBox::ValueType>(acc, StencilCfg{});
-                        collectiveCacheB(acc, assign, cachedSrcField, srcFieldBlock);
+                        cacheStencilArea(acc, assign, cachedSrcField, srcFieldBlock);
 
                         cupla::__syncthreads(acc);
 
@@ -188,7 +177,7 @@ namespace picongpu
                         lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)([&](uint32_t const linearIdx) {
                             auto const idxInSuperCell
                                 = DataSpaceOperations<simDim>::template map<SuperCellSize>(linearIdx);
-                            auto const gridIdx = superCellIdx + idxInSuperCell;
+                            auto const gridIdx = beginCellIdx + idxInSuperCell;
                             stencilFunctor(gridIdx, cachedSrcField.shift(idxInSuperCell), destField.shift(gridIdx));
                         });
                     }

--- a/include/picongpu/fields/MaxwellSolver/Yee/StencilFunctor.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/StencilFunctor.hpp
@@ -1,0 +1,75 @@
+/* Copyright 2021 Rene Widera, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            namespace yee
+            {
+                /** Base stencil functor to update fields inside the kernel
+                 *
+                 * This class serves to define the interface requirements for stencil functor implementations.
+                 * So if roughly defines a "concept".
+                 *
+                 * @tparam T_Curl curl functor type to be applied to update the destination field,
+                 *                 adheres to the Curl concept
+                 */
+                template<typename T_Curl>
+                struct StencilFunctor
+                {
+                public:
+                    //! Stencil requirements for lower margins
+                    using LowerMargin = typename traits::GetLowerMargin<T_Curl>::type;
+                    //! Stencil requirements for upper margins
+                    using UpperMargin = typename traits::GetUpperMargin<T_Curl>::type;
+
+                    /** Update field at the given position
+                     *
+                     * @tparam T_SrcBox source box type
+                     * @tparam T_DestBox destination box type
+                     *
+                     * @param gridIndex index of the updated field element, with guards
+                     * @param srcBoc source box shifted to position gridIndex,
+                     *               note that it is the box, not the value
+                     * @param destBox destination box shifted to position gridIndex,
+                     *               note that it is the box, not the value
+                     *
+                     * @return update the value pointed to by localE
+                     */
+                    template<typename T_SrcBox, typename T_DestBox>
+                    DINLINE void operator()(
+                        pmacc::DataSpace<simDim> const& gridIndex,
+                        T_SrcBox const srcBoc,
+                        T_DestBox destBox);
+                };
+
+            } // namespace yee
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/fields/MaxwellSolver/Yee/StencilFunctor.hpp"
 #include "picongpu/fields/absorber/pml/Parameters.hpp"
 
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
@@ -228,13 +229,13 @@ namespace picongpu
                     }
                 } // namespace detail
 
-                /** Functor to update electric field by a time step using FDTD with the given curl and PML
+                /** Stencil functor to update electric field by a time step using FDTD with the given curl and PML
                  *
                  * @tparam T_CurlB curl functor type to be applied to magnetic field,
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlB>
-                class UpdateEFunctor
+                class UpdateEFunctor : public maxwellSolver::yee::StencilFunctor<T_CurlB>
                 {
                 public:
                     /** Create a functor instance on the host side
@@ -318,23 +319,18 @@ namespace picongpu
                     FieldBox fieldPsiE;
                     LocalParameters const parameters;
                     // keep curl as member to support stateful types
-                    T_CurlB const curl;
+                    T_CurlB const curl = T_CurlB{};
                 };
 
-                /** Functor to update magnetic field by half a time step using FDTD with the given curl and PML
+                /** Stencil functor to update magnetic field by half a time step using FDTD with the given curl and PML
                  *
                  * @tparam T_CurlE curl functor type to be applied to electric field,
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlE>
-                class UpdateBHalfFunctor
+                class UpdateBHalfFunctor : public maxwellSolver::yee::StencilFunctor<T_CurlE>
                 {
                 public:
-                    //! Stencil requirements for lower margins
-                    using LowerMargin = typename traits::GetLowerMargin<T_CurlE>::type;
-                    //! Stencil requirements for upper margins
-                    using UpperMargin = typename traits::GetUpperMargin<T_CurlE>::type;
-
                     /** Create a functor instance on the host side
                      *
                      * @param fieldPsiE PML convolutional electric field iterator
@@ -428,7 +424,7 @@ namespace picongpu
                     LocalParameters const parameters;
                     bool const updatePsiB;
                     // keep curl as member to support stateful types
-                    T_CurlE const curl;
+                    T_CurlE const curl = T_CurlE{};
                 };
 
             } // namespace pml

--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -317,6 +317,7 @@ namespace picongpu
                 private:
                     FieldBox fieldPsiE;
                     LocalParameters const parameters;
+                    // keep curl as member to support stateful types
                     T_CurlB const curl;
                 };
 
@@ -329,6 +330,11 @@ namespace picongpu
                 class UpdateBHalfFunctor
                 {
                 public:
+                    //! Stencil requirements for lower margins
+                    using LowerMargin = typename traits::GetLowerMargin<T_CurlE>::type;
+                    //! Stencil requirements for upper margins
+                    using UpperMargin = typename traits::GetUpperMargin<T_CurlE>::type;
+
                     /** Create a functor instance on the host side
                      *
                      * @param fieldPsiE PML convolutional electric field iterator
@@ -421,6 +427,7 @@ namespace picongpu
                     FieldBox fieldPsiB;
                     LocalParameters const parameters;
                     bool const updatePsiB;
+                    // keep curl as member to support stateful types
                     T_CurlE const curl;
                 };
 


### PR DESCRIPTION
This PR refactors the field update, this removes the requirements that the update kernel required stencil information on the host side we only need within the kernel.
The new update kernel could be removed by a simple `ForEach` kernel with support of cached fields/Boxes but since we do not have it in pmacc or PIConGPU the explicit implementation is required.

- Make the stencil functor for field update more descriptive.
  - The functor is providing the required stencil width information.
- Remove the duplicated implementation of `KernelUpdateE` and `KernelUpdateB`


- [x] rebase against #3644  (therefore I stopped the CI by hand)
- [x] (Sergei) I think it will cause merge conflicts with #3643 (not hard to fix, just won't auto-merge)