### PR TITLE
pmacc::ConstVector: Add omp declare target around Name

### DIFF
--- a/include/pmacc/math/ConstVector.hpp
+++ b/include/pmacc/math/ConstVector.hpp
@@ -130,7 +130,10 @@
         namespace PMACC_JOIN(pmacc_static_const_vector_host, id)                                                      \
         {                                                                                                             \
             /* create const instance on host*/                                                                        \
+            PMACC_PRAGMA_OMP_TARGET_BEGIN_DECLARE                                                                     \
             constexpr PMACC_JOIN(Name, _t) Name;                                                                      \
+            PMACC_PRAGMA_OMP_TARGET_END_DECLARE                                                                       \
+            PMACC_PRAGMA_OACC_DECLARE_ARRAY(Name, 1)                                                                  \
         } /* namespace pmacc_static_const_vector_host + id  */                                                        \
     } /* namespace pmacc_static_const_storage + id */
 


### PR DESCRIPTION
Because an instance of this consexpr variabe is required  at runtime, it needs to be explicitly mapped to be compliant OpenMP.

This is a fix for the OpenMP target support already present in `ConstVector`. It also includes the same mapping for OpenACC, which may be requires by the OpenACC standart at the moment.