### PR TITLE
Ensure variances are >= 0

### DIFF
--- a/include/picongpu/particles/debyeLength/Check.hpp
+++ b/include/picongpu/particles/debyeLength/Check.hpp
@@ -154,7 +154,7 @@ namespace picongpu
                                 "%1% (%2% %3%) supercells had local Debye length estimate not resolved"
                                 " by a single cell")
                                 % estimate.numFailingSupercells % ratioFailingSupercells % "%";
-                            log<picLog::PHYSICS>("Estimated weighted average temperature %1% KeV and corresponding "
+                            log<picLog::PHYSICS>("Estimated weighted average temperature %1% keV and corresponding "
                                                  "Debye length %2% m.\n"
                                                  "   The grid has %3% cells per average Debye length")
                                 % temperatureKeV % debyeLengthSI % cellsPerDebyeLength;

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -47,7 +47,7 @@ namespace picongpu
                 //! Total macroparticle weighting
                 float_64 sumWeighting = 0.0;
 
-                //! Total weighted sum of estimated temperatures in KeV, the sum of weights is sumWeighting
+                //! Total weighted sum of estimated temperatures in keV, the sum of weights is sumWeighting
                 float_64 sumTemperatureKeV = 0.0;
 
                 //! Total weighted sum of estimated Debye length in PIC units, the sum of weights is sumWeighting

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -169,7 +169,9 @@ namespace picongpu
                     onlyMaster([&]() {
                         auto const mean = supercellSumMomentum / supercellSumWeighting;
                         // Use a simple variance estimator, the fact it is biased should not matter here
-                        auto const variance = supercellSumMomentumSquared / supercellSumWeighting - mean * mean;
+                        auto const variance = pmacc::math::max(
+                            float3_64::create(0.0),
+                            supercellSumMomentumSquared / supercellSumWeighting - mean * mean);
                         check(acc, electronBox, supercellIdx, supercellSumWeighting, variance, estimateBox);
                     });
                 }


### PR DESCRIPTION
In `Estimate.kernel`, if the temperature drops to zero (particles are initialized with zero momentum variance), floating point math makes the variances become small, but sometimes negative inaccurate output.

This patch adds a `max` in `Estimate.kernel` to keep the variances from becoming negative.

```diff
< PIConGPUVerbose PHYSICS(1) | 0 (0 %) supercells had local Debye length estimate not resolved by a single cell
< PIConGPUVerbose PHYSICS(1) | Estimated weighted average temperature -7.58771e-11 KeV and corresponding Debye length -nan m.
<    The grid has -nan cells per average Debye length
---
> PIConGPUVerbose PHYSICS(1) | 1536 (100 %) supercells had local Debye length estimate not resolved by a single cell
> PIConGPUVerbose PHYSICS(1) | Estimated weighted average temperature 0 keV and corresponding Debye length 0 m.
>    The grid has 0 cells per average Debye length
```

Are there other places where variance are calculated which may deserve the same treatment?