### PR TITLE
Free memory in collisions when using HIP

### DIFF
--- a/include/picongpu/particles/collision/detail/ListEntry.hpp
+++ b/include/picongpu/particles/collision/detail/ListEntry.hpp
@@ -105,7 +105,7 @@ namespace picongpu
                     {
                         if(ptrToIndicies != nullptr)
                         {
-#if(PMACC_CUDA_ENABLED == 1)
+#if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
                             deviceHeapHandle.free(acc, (void*) ptrToIndicies);
                             ptrToIndicies = nullptr;
 #else


### PR DESCRIPTION
This doesn't solve the freezing issue that's happening on cuda devices but I noticed that we request memory via `deviceHeapHandle` for both cuda and hip but we free it only for cuda. This makes the two `#if` macros guarding `deviceHeapHandle` calls identical.