### PR TITLE
Fix kernelName in kernelEvents.hpp

### DIFF
--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -155,7 +155,7 @@ namespace pmacc
                 CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash before kernel call ") + kernelInfo);
 
                 pmacc::TaskKernel* taskKernel
-                    = pmacc::Environment<>::get().Factory().createTaskKernel(typeid(kernelName).name());
+                    = pmacc::Environment<>::get().Factory().createTaskKernel(kernelName);
 
                 DataSpace<traits::GetNComponents<T_VectorGrid>::value> gridExtent(m_gridExtent);
 

--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -154,8 +154,7 @@ namespace pmacc
 
                 CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash before kernel call ") + kernelInfo);
 
-                pmacc::TaskKernel* taskKernel
-                    = pmacc::Environment<>::get().Factory().createTaskKernel(kernelName);
+                pmacc::TaskKernel* taskKernel = pmacc::Environment<>::get().Factory().createTaskKernel(kernelName);
 
                 DataSpace<traits::GetNComponents<T_VectorGrid>::value> gridExtent(m_gridExtent);
 


### PR DESCRIPTION
We were basically doing `typeid(typeid(kernelFucntor.name()).name()`. That's one `typeid().name()` too much. This is why `DEBUG_EVENTS` was printing `TaskKernel NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE` for all slow kernel events.