### PR TITLE
spock-ornl: fix compile warning

### DIFF
--- a/etc/picongpu/spock-ornl/caar_picongpu.profile.example
+++ b/etc/picongpu/spock-ornl/caar_picongpu.profile.example
@@ -79,7 +79,8 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export CMAKE_MODULE_PATH=$HIP_PATH/cmake:$CMAKE_MODULE_PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_ROOT/lib
 export CMAKE_PREFIX_PATH=$BOOST_ROOT:$CMAKE_PREFIX_PATH
-export HIPCC_COMPILE_FLAGS_APPEND="$HIPCC_COMPILE_FLAGS_APPEND -I${MPICH_DIR}/include -L${MPICH_DIR}/lib -lmpi -L/opt/cray/pe/mpich/8.1.4/gtl/lib -lmpi_gtl_hsa"
+export HIPCC_COMPILE_FLAGS_APPEND="$HIPCC_COMPILE_FLAGS_APPEND -I${MPICH_DIR}/include"
+export HIPCC_LINK_FLAGS_APPEND="$HIPCC_LINK_FLAGS_APPEND -L${MPICH_DIR}/lib -lmpi -L/opt/cray/pe/mpich/8.1.4/gtl/lib -lmpi_gtl_hsa"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)


### PR DESCRIPTION
Fix warnings:

```
clang-12: warning: argument unused during compilation: '-L/opt/cray/pe/mpich/8.1.4/gtl/lib' [-Wunused-command-line-argument]
clang-12: warning: argument unused during compilation: '-L/opt/cray/pe/mpich/8.1.4/ofi/gnu/9.1/lib' [-Wunused-command-line-argument]
clang-12: warning: argument unused during compilation: '-L/opt/cray/pe/mpich/8.1.4/gtl/lib' [-Wunused-command-line-argument]
clang-12: warning: -lmpi: 'linker' input unused [-Wunused-command-line-argument]
clang-12: warning: -lmpi_gtl_hsa: 'linker' input unused [-Wunused-command-line-argument]
```