### PR TITLE
spock-ornl: compile for MI100 architecture only

### DIFF
--- a/etc/picongpu/spock-ornl/caar_picongpu.profile.example
+++ b/etc/picongpu/spock-ornl/caar_picongpu.profile.example
@@ -68,7 +68,7 @@ export CMAKE_PREFIX_PATH=$Splash_DIR:$CMAKE_PREFIX_PATH
 #
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
-export PIC_BACKEND="hip"
+export PIC_BACKEND="hip:908"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin


### PR DESCRIPTION
Explicit compile for gfx908 only.

This will reduce the compile time because by default alpaka compiles for the HIP architecture 906 and 908.