### PR TITLE
Make PML default field absorber

### DIFF
--- a/docs/source/usage/workflows/boundaryConditions.rst
+++ b/docs/source/usage/workflows/boundaryConditions.rst
@@ -36,7 +36,9 @@ The field absorber mechanism and user-controlled parameters depend on the field 
 It is controlled by command-line option ``--fieldAbsorber``.
 For all absorber kinds, the parameters are controlled by :ref:`fieldAbsorber.param <usage-params-core>`.
 
-For the exponential absorber (default), thickness of about 32 cells is recommended.
-For the Perfectly Matched Layer (PML) absorber, thickness of 8 to 12 cells is recommended.
+By default, the Perfectly Matched Layer (PML) absorber is used.
+For this absorber, thickness of 8 to 12 cells is recommended.
 Other absorber parameters can generally be used with default values.
 PML generally provides much better absorber qualities than the exponential damping absorber.
+
+For the exponential absorber, thickness of about 32 cells is recommended.

--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -103,10 +103,16 @@ namespace picongpu
             class Absorber
             {
             public:
-                //! Supported absorber kinds
+                /** Supported absorber kinds, same for all absorbing boundaries
+                 *
+                 * Exponential - exponential damping absorber.
+                 * None - all boundaries are periodic, no absorber.
+                 * Pml - perfectly matched layer absorber.
+                 */
                 enum class Kind
                 {
                     Exponential,
+                    None,
                     Pml
                 };
 

--- a/include/picongpu/fields/absorber/Absorber.tpp
+++ b/include/picongpu/fields/absorber/Absorber.tpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/absorber/exponential/Exponential.hpp"
+#include "picongpu/fields/absorber/none/None.hpp"
 #include "picongpu/fields/absorber/pml/Pml.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -44,6 +45,9 @@ namespace picongpu
                 {
                 case Kind::Exponential:
                     name = std::string{"exponential damping"};
+                    break;
+                case Kind::None:
+                    name = std::string{"none"};
                     break;
                 case Kind::Pml:
                     name = std::string{"convolutional PML"};
@@ -211,6 +215,8 @@ namespace picongpu
                 {
                 case Absorber::Kind::Exponential:
                     return std::make_unique<exponential::ExponentialImpl>(cellDescription);
+                case Absorber::Kind::None:
+                    return std::make_unique<none::NoneImpl>(cellDescription);
                 case Absorber::Kind::Pml:
                     return std::make_unique<pml::PmlImpl>(cellDescription);
                 default:

--- a/include/picongpu/fields/absorber/none/None.hpp
+++ b/include/picongpu/fields/absorber/none/None.hpp
@@ -1,0 +1,67 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/absorber/Absorber.hpp"
+
+#include <pmacc/Environment.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace absorber
+        {
+            namespace none
+            {
+                /** None field absorber implementation
+                 *
+                 * Does nothing, just checks that all boundaries are periodic.
+                 */
+                class NoneImpl : public AbsorberImpl
+                {
+                public:
+                    /** Create none absorber implementation instance
+                     *
+                     * @param cellDescription mapping for kernels
+                     */
+                    NoneImpl(MappingDesc const cellDescription) : AbsorberImpl(Absorber::Kind::None, cellDescription)
+                    {
+                        const DataSpace<DIM3> isPeriodicBoundary
+                            = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
+                        bool areAllBoundariesPeriodic = true;
+                        for(uint32_t axis = 0u; axis < simDim; axis++)
+                            if(!isPeriodicBoundary[axis])
+                                areAllBoundariesPeriodic = false;
+                        if(!areAllBoundariesPeriodic)
+                            throw std::runtime_error(
+                                "None absorber implementation instantiated, but some boundaries are not periodic");
+                    }
+                };
+
+            } // namespace none
+        } // namespace absorber
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/param/fieldAbsorber.param
+++ b/include/picongpu/param/fieldAbsorber.param
@@ -20,7 +20,7 @@
 /** @file
  *
  * Configure the field absorber parameters.
- * Field absorber type is set by command-line option --fieldAbsorber.kind.
+ * Field absorber type is set by command-line option --fieldAbsorber.
  */
 
 #pragma once
@@ -35,7 +35,7 @@ namespace picongpu
         namespace absorber
         {
             // This variable is not required, defined for convenience
-            constexpr uint32_t THICKNESS = 32;
+            constexpr uint32_t THICKNESS = 12;
 
             /** Thickness of the absorbing layer, in number of cells
              *

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldAbsorber.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldAbsorber.param
@@ -20,7 +20,7 @@
 /** @file
  *
  * Configure the field absorber parameters.
- * Field absorber type is set by command-line option --fieldAbsorber.kind.
+ * Field absorber type is set by command-line option --fieldAbsorber.
  */
 
 #pragma once

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/fieldAbsorber.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/fieldAbsorber.param
@@ -20,7 +20,7 @@
 /** @file
  *
  * Configure the field absorber parameters.
- * Field absorber type is set by command-line option --fieldAbsorber.kind.
+ * Field absorber type is set by command-line option --fieldAbsorber.
  */
 
 #pragma once
@@ -35,7 +35,7 @@ namespace picongpu
         namespace absorber
         {
             // This variable is not required, defined for convenience
-            constexpr uint32_t THICKNESS = 64;
+            constexpr uint32_t THICKNESS = 16;
 
             /** Thickness of the absorbing layer, in number of cells
              *


### PR DESCRIPTION
To enable the smooth transition, this PR also adds a new `None` absorber type and implementation that does nothing. It is not chooseable by a user directly, but is set when all boundaries are periodic. This is done for the following reasons, all valid only for the all-periodic case:

- compatibility with older checkpoints (otherwise PML would have tried to load its fields, although zero-sized, and that would not work)
- efficiency reasons: as @psychocoderHPC told me earlier, even writing a zero-sized field may take time
- also to lower confusion if someone looks in checkpoint and sees the PML fields

With this change, the setups with absorbing boundaries, default absorber, and particles present in the absorbing area may behave somewhat differently in this area besides just absorption. The reason is, the currents created in the area will behave differently than with the exponential absorber. I think neither the "new" nor the "old" behavior is more correct, since there ideally should not be currents in the absorbing area. If we observe this for some examples, I think we may switch back to exponential for those examples - now it is just a single line in `.cfg` files.

Edit: also the default absorber thickness in `fieldAbsorber.param` is changed to match the recommended range for PML.