### PR TITLE
 openPMD plugin: do not use JSON configurations when restarting #3674 

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -143,8 +143,15 @@ namespace picongpu
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 __getTransactionEvent().waitForFinished();
-                openPMDSeries
-                    = std::make_unique<::openPMD::Series>(fullName, at, communicator, jsonMatcher->getDefault());
+                openPMDSeries = std::make_unique<::openPMD::Series>(
+                    fullName,
+                    at,
+                    communicator,
+                    /*
+                     * The openPMD plugin only supports configuring writing routines via JSON.
+                     * Reading routines get an empty JSON set.
+                     */
+                    at == ::openPMD::Access::READ_ONLY ? "{}" : jsonMatcher->getDefault());
                 if(openPMDSeries->backend() == "MPI_ADIOS1")
                 {
                     throw std::runtime_error(R"END(


### PR DESCRIPTION
It is currently impossible to specify different plugin parameters for checkpointing and restarting. ADIOS2 reading routines do apparently read the `InitialBufferSize` parameter even when opened in read-only mode. See screenshot below: Memory profile when reading 16 iterations, one time not specifying the `InitialBufferSize`, one time specifying it.
![Bildschirmfoto vom 2021-07-09 11-11-05](https://user-images.githubusercontent.com/14241876/125057020-16b53000-e0a9-11eb-9115-668671a850d5.png)


Since there is currently no useful configuration to use for reading routines when restarting, just don't use JSON configurations at all when reading.
