### PR TITLE
OpenPMD plugin: fix attribute charge/mass

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -260,6 +260,7 @@ namespace picongpu
 
             void setParticleAttributes(
                 ::openPMD::ParticleSpecies& record,
+                uint64_t const globalNumParticles,
                 AbstractJsonMatcher& matcher,
                 std::string const& basename)
             {
@@ -286,7 +287,7 @@ namespace picongpu
 
                 // const records stuff
                 ::openPMD::Datatype dataType = ::openPMD::Datatype::DOUBLE;
-                ::openPMD::Extent extent = {0};
+                ::openPMD::Extent extent = {globalNumParticles};
                 ::openPMD::Dataset dataSet = ::openPMD::Dataset(dataType, extent);
 
                 // mass
@@ -503,6 +504,7 @@ namespace picongpu
                     /* openPMD ED-PIC: additional attributes */
                     setParticleAttributes(
                         particleSpecies,
+                        globalNumParticles,
                         *params->jsonMatcher,
                         series.particlesPath() + speciesGroup);
                     params->openPMDSeries->flush();


### PR DESCRIPTION
fix: https://github.com/ComputationalRadiationPhysics/picongpu/pull/3389#discussion_r663311000

The extent for the OpenPMD attribute charge and mass requires the number of particles in the simulation even if they are constant/equal for all particles.