### PR TITLE
Update summit profile

### DIFF
--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -18,23 +18,22 @@ export proj=<yourProject>
 #export EDITOR="nano"
 
 # basic environment ###########################################################
-module load gcc/8.1.1
+module load gcc/6.4.0  e4s/21.02  spectrum-mpi/10.3.1.2-20200121
 
 export CC=$(which gcc)
 export CXX=$(which g++)
 
 # required tools and libs
-module load git
-module load cmake/3.18.2
-module load cuda/10.1.243
+module load git/2.29.0
+module load cmake/3.20.2
+module load cuda/10.2.89
 module load boost/1.66.0
 
 # plugins (optional) ##########################################################
-module load ums
-module load ums-aph114
-module load hdf5/1.10.4
-module load adios/1.13.1-py2 c-blosc zfp/0.5.5 sz lz4
-module load openpmd-api/0.12.0
+module load hdf5/1.10.7
+module load c-blosc/1.21.0 zfp/0.5.5 sz/2.1.11.1 lz4/1.9.3
+module load adios2/2.7.1
+module load openpmd-api/0.13.2
 
 # optionally download libSplash and compile it yourself from
 #   https://github.com/ComputationalRadiationPhysics/libSplash/
@@ -45,7 +44,7 @@ module load openpmd-api/0.12.0
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$T3PIO_ROOT/lib
 
 module load zlib/1.2.11
-module load libpng/1.6.34 freetype/2.9.1
+module load libpng/1.6.37 freetype/2.9.1
 # optionally install pngwriter yourself:
 #   https://github.com/pngwriter/pngwriter#install
 # export PNGwriter_ROOT=<your pngwriter install directory>  # e.g., ${HOME}/sw/pngwriter


### PR DESCRIPTION
Use latest openpmd-api/0.13.2 and adios2/2.7.1 module.
To do so, first, gcc module has to be downgraded due to module incompatibilities of gcc/9.3.0 with other required modules.
Second, adios1 can not be used anymore as it is incompatible with e4s module (which is on the other hand required for adios2 and openpmd-api).
But adios1 is deprecated anyway.

LaserWakefield example compiles and runs with these changes on summit.