### PR TITLE
change how QuietImpl positions reduced number of particles

### DIFF
--- a/include/picongpu/particles/startPosition/QuietImpl.hpp
+++ b/include/picongpu/particles/startPosition/QuietImpl.hpp
@@ -115,9 +115,9 @@ namespace picongpu
                     }
 
                 private:
+                    PMACC_ALIGN(m_numParDirection, DataSpace<simDim>);
                     float_X m_weighting;
                     uint32_t m_currentMacroParticles;
-                    PMACC_ALIGN(m_numParDirection, DataSpace<simDim>);
                 };
 
             } // namespace acc


### PR DESCRIPTION
This changes how the `QuietImpl` `startPosition` functor positions particles when the number of created macro particles has to be reduced to satisfy `weighting >= MIN_WEGHTING` . The new code matches the previous calculation in `numMacroParticles`.

Now the number of particle rows / layers is reduced along the direction  with the highest amount of rows / layers until the condition is fulfilled. This is how the `numMacroParticles` was calculated before but this adjusted particle spacing was ignored in the operator body.