### PR TITLE
use IUnary with filters in collisions and FieldTmp

### DIFF
--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -176,14 +176,14 @@ namespace picongpu
         FieldTmp::DataBoxType tmpBox = this->fieldTmp->getDeviceBuffer().getDataBox();
         FrameSolver solver;
         using ParticleFilter = typename Filter ::template apply<ParticlesClass>::type;
-        ParticleFilter particleFilter;
+        const uint32_t currentStep = Environment<>::get().SimulationDescription().getCurrentStep();
+        auto iFilter = particles::filter::IUnary<ParticleFilter>{currentStep};
         constexpr uint32_t numWorkers
             = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
-
         do
         {
             PMACC_KERNEL(KernelComputeSupercells<numWorkers, BlockArea>{})
-            (mapper.getGridDim(), numWorkers)(tmpBox, pBox, solver, particleFilter, mapper);
+            (mapper.getGridDim(), numWorkers)(tmpBox, pBox, solver, iFilter, mapper);
         } while(mapper.next());
     }
 

--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -353,8 +353,8 @@ namespace picongpu
                         RNGFactory::createHandle(),
                         CollisionFunctor(currentStep),
                         coulombLog,
-                        Filter0(),
-                        Filter1());
+                        particles::filter::IUnary<Filter0>{currentStep},
+                        particles::filter::IUnary<Filter1>{currentStep});
                 }
             };
 

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -231,7 +231,7 @@ namespace picongpu
                         RNGFactory::createHandle(),
                         CollisionFunctor(currentStep),
                         coulombLog,
-                        Filter());
+                        particles::filter::IUnary<Filter>{currentStep});
                 }
             };
 


### PR DESCRIPTION
Without this only particle filters with a default constructor would work. With `IUnary` filters with a `Filter(uint32_t currentStep)` constructor should work as well. 