### PR TITLE
fix getting unitSI for amplitude

### DIFF
--- a/lib/python/picongpu/plugins/data/radiation.py
+++ b/lib/python/picongpu/plugins/data/radiation.py
@@ -54,7 +54,7 @@ class RadiationData:
         self.h5_Az_Im = detectorAmplitude["z_Im"]
 
         # conversion factor for spectra from PIC units to SI units
-        self.convert_to_SI = detectorAmplitude.attrs['unitSI']
+        self.convert_to_SI = detectorAmplitude["x_Re"].attrs['unitSI']
 
     def get_timestep(self):
         """Returns simulation timestep of the hdf5 data."""


### PR DESCRIPTION
This pull request fixes a design error in the python module to load the hdf5 radiation data that will break using the module with the upcoming  transfer from libSpalsh to openPMD-api #3566. 
The `unitSI` attribute currently exists for both the group and the data, thus it dies not break existing code