### PR TITLE
Fix: RTD Docutils Build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,9 @@ breathe>=4.12.0,<4.15.0
 sphinxcontrib.programoutput
 sphinxcontrib-napoleon>=0.7
 pygments
+# docutils 0.17 breaks HTML tags & RTD theme
+# https://github.com/sphinx-doc/sphinx/issues/9001
+docutils==0.16
 # generate plots
 matplotlib
 scipy


### PR DESCRIPTION
The docutils 0.17+ release uses more semantic HTML5 tags, which the RTD theme does not (yet) know.

This breaks side bar, lists and other elements.

fix /vs. broken:
![Screenshot from 2021-07-18 22-37-56](https://user-images.githubusercontent.com/1353258/126108264-7eb18475-a43b-4422-b0f5-ba572c359c43.png) ![Screenshot from 2021-07-18 22-37-43](https://user-images.githubusercontent.com/1353258/126108268-0ff8e9cb-9677-498d-8739-bb77d9ab83b5.png)
