### PR TITLE
Cori: Add DGX (A100) Profile

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -180,6 +180,12 @@ Queue: regular (Intel Xeon Phi - Knights Landing)
 .. literalinclude:: profiles/cori-nersc/knl_picongpu.profile.example
    :language: bash
 
+Queue: dgx (DGX - A100)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/cori-nersc/a100_picongpu.profile.example
+   :language: bash
+
 Draco (MPCDF)
 -------------
 

--- a/etc/picongpu/cori-nersc/a100.tpl
+++ b/etc/picongpu/cori-nersc/a100.tpl
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Copyright 2021 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for Cori's SLURM batch system
+
+#SBATCH -p !TBG_queue
+#SBATCH -q shared
+#SBATCH --gpus=!TBG_tasks
+#SBATCH --constraint="dgx"
+#S BATCH --reservation="..."
+#SBATCH --time=!TBG_wallTime
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --cpus-per-task=!TBG_coresPerAcc
+#SBATCH --mem=!TBG_memPerNode
+#SBATCH --chdir=!TBG_dstPath
+
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --account=!TBG_nameProject
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="dgx"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=8
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+
+# number of cores to block per A100 - per node, we got 2 Epyc CPUs with each
+# 64 physical cores and use them w/o HT
+.TBG_coresPerAcc=16
+
+# host memory per gpu
+.TBG_memPerGPU="$((1010000 / $TBG_numHostedGPUPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+# note: no need to source profile as environment is cloned from submit environment
+# source !TBG_profile
+echo "profile cloned at submit time: !TBG_profile"
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+  # Run CUDA memtest to check GPU's health
+  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+fi
+
+export OMP_NUM_THREADS=!TBG_coresPerAcc
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun --cpu_bind=cores                 \
+       !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+fi

--- a/etc/picongpu/cori-nersc/a100.tpl
+++ b/etc/picongpu/cori-nersc/a100.tpl
@@ -25,7 +25,7 @@
 #SBATCH -q shared
 #SBATCH --gpus=!TBG_tasks
 #SBATCH --constraint="dgx"
-#S BATCH --reservation="..."
+#!TBG_slurmReservation
 #SBATCH --time=!TBG_wallTime
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
@@ -52,6 +52,8 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_nameProject=${proj:-""}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+.TBG_slurmReservation=`if [ -z "$RESERVATION" ] ; then echo -n ""; else echo -n "SBATCH --reservation=!RESERVATION"; fi`
 
 # number of available/hosted GPUs per node in the system
 .TBG_numHostedGPUPerNode=8

--- a/etc/picongpu/cori-nersc/a100_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/a100_picongpu.profile.example
@@ -12,6 +12,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 # Project Information ######################################## (edit this line)
 #   - project account for computing time
 export proj="<yourProject>"
+# Project reservation (can be empty if no reservation exists)
+export RESERVATION=""
 
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
@@ -59,15 +61,46 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/cori-nersc/a100.tpl"
 
-# allocate an interactive shell for one hour
+if [ -z "$RESERVATION" ] ; then
+  SLURM_RESERVATION=""
+else
+  SLURM_RESERVATION="--reservation=$RESERVATION"
+fi
+
+# allocate an interactive node for one hour to execute a mpi parallel application
 #   getNode 2  # allocates two interactive A100 GPUs (default: 1)
 function getNode() {
     if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+    echo "             use 'srun -n 1 --pty bash' for launching a interactive shell for compiling."
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node 8 --gpus 8 --cpus-per-task=16 -A $proj -C dgx -q shared $SLURM_RESERVATION
+}
+
+# allocate an interactive device for one hour to execute a mpi parallel application
+#   getDevice 2  # allocates two interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
         numGPUs=1
     else
-        numGPUs=$1
+        if [ "$1" -gt 8 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
     fi
-    srun --time=1:00:00 --nodes=1 --ntasks-per-node $numGPUs --gpus $numGPUs --cpus-per-task=8 -A $proj -C dgx -q shared --pty bash
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+    echo "             use 'srun -n 1 --pty bash' for launching a interactive shell for compiling."
+    salloc --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gpus=$numGPUs --mem=$((1010000 / 8) * $numGPUs) -A $proj -C dgx -q shared $SLURM_RESERVATION
+}
+
+# allocate an interactive shell for compilation (without gpus)
+function getShell() {
+    srun --time=1:00:00 --nodes=1 --ntasks 1 --cpus-per-task=16 -A $proj -C dgx -q shared $SLURM_RESERVATION --pty bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/cori-nersc/a100_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/a100_picongpu.profile.example
@@ -1,0 +1,79 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Project Information ######################################## (edit this line)
+#   - project account for computing time
+export proj="<yourProject>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# General modules #############################################################
+#
+module load dgx
+module swap PrgEnv-intel PrgEnv-gnu
+module load cuda openmpi
+module load cmake/3.18.2
+module load boost/1.70.0
+
+# Other Software ##############################################################
+#
+module load png/1.6.34
+module load zlib/1.2.11
+
+export ADIOS2_ROOT=/global/cfs/cdirs/ntrain/dgx/openmpi/adios-2.7.1
+export HDF5_ROOT=/global/cfs/cdirs/ntrain/dgx/openmpi/hdf5-1.10.7
+export openPMD_ROOT=/global/cfs/cdirs/ntrain/dgx/openmpi/openPMD-api-0.13.4
+export PNGwriter_ROOT=/global/cfs/cdirs/ntrain/dgx/pngwriter-0.7.0-25-g0c30be5
+
+# Environment #################################################################
+#
+export CC="$(which gcc)"
+export CXX="$(which g++)"
+export CUDACXX=$(which nvcc)
+export CUDAHOSTCXX=$(which g++)
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:80"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$HDF5_ROOT/lib:$openPMD_ROOT/lib64:$PNGwriter_ROOT/lib64:$LD_LIBRARY_PATH
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "defq" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/cori-nersc/a100.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates two interactive A100 GPUs (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        numGPUs=$1
+    fi
+    srun --time=1:00:00 --nodes=1 --ntasks-per-node $numGPUs --gpus $numGPUs --cpus-per-task=8 -A $proj -C dgx -q shared --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi


### PR DESCRIPTION
Add documentation to compile & run on Cori's A100 GPUs.

Preparation: load profile once and build (HDF5,) ADIOS2, openPMD-api & PNGwriter:
```bash
. ~/a100_picongpu.profile
export SW_DIR=/global/cfs/cdirs/ntrain/dgx  # only Axel can write here, use $HOME/sw in doubt

# potentially good idea: get a node via:
getNode 8

mkdir src
cd src

curl -Lo hdf5-1.10.7.tar.gz https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.7/src/hdf5-1.10.7.tar.gz
tar -xzf hdf5-1.10.7.tar.gz
cd hdf5-1.10.7
./configure --enable-parallel --enable-shared --prefix $SW_DIR/openmpi/hdf5-1.10.7 CC=mpicc CXX=mpic++
make -j 16
make install
cd ..

git clone https://github.com/ornladios/ADIOS2.git adios2
cd adios2
git checkout v2.7.1
cmake -S . -B build -DADIOS2_USE_Fortran=OFF -DCMAKE_INSTALL_PREFIX=$SW_DIR/openmpi/adios-2.7.1
cmake --build build -j 16
cmake --build build --target install
cd ..

git clone https://github.com/openPMD/openPMD-api.git
cd openPMD-api
git checkout 0.13.4
cmake -S . -B build -DopenPMD_USE_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=$SW_DIR/openmpi/openPMD-api-0.13.4
cmake --build build -j 16
cmake --build build --target install
cd ..

git clone https://github.com/pngwriter/pngwriter.git
cd pngwriter
git checkout dev
cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$SW_DIR/pngwriter-0.7.0-25-g0c30be5
cmake --build build -j 16
cmake --build build --target install
cd ..
```