### PR TITLE
Add simplified rad form factor

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -30,7 +30,7 @@ Variable                       Meaning
 ============================== ================================================================================
 
 Currently this allows to predict the emitted radiation from plasma if it can be described by classical means.
-Not considered are emissions from ionization, Compton scattering or any bremsstrahlung that originate from scattering on scales smaller than the PIC cell size. 
+Not considered are emissions from ionization, Compton scattering or any bremsstrahlung that originate from scattering on scales smaller than the PIC cell size.
 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
@@ -68,18 +68,18 @@ namespace                     Description
 
 All three options require variable definitions in the according namespaces as described below:
 
-For the **linear frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::linear_frequencies`` namespace. 
+For the **linear frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::linear_frequencies`` namespace.
 The number of total sample frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``.
 In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
 
-For the **logarithmic frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::log_frequencies`` namespace. 
-Equivalently to the linear case, three variables need to be defined: 
+For the **logarithmic frequency** scale all definitions need to be in the ``picongpu::plugins::radiation::log_frequencies`` namespace.
+Equivalently to the linear case, three variables need to be defined:
 The number of total sample frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``.
 In the sub-namespace ``SI``, a minimal frequency ``omega_min`` and a maximum frequency ``omega_max`` need to be defined as ``constexpr float_64``.
 
 For the **file-based frequency** definition,  all definitions need to be in the ``picongpu::plugins::radiation::frequencies_from_list`` namespace.
 The number of total frequencies ``N_omega`` need to be defined as ``constexpr unsigned int``  and the path to the file containing the frequency values in units of :math:`\mathrm{[s^{-1}]}` needs to be given as ``constexpr const char * listLocation = "/path/to/frequency_list";``.
-The frequency values in the file can be separated by newlines, spaces, tabs, or any other whitespace. The numbers should be given in such a way, that c++ standard ``std::ifstream`` can interpret the number e.g., as ``2.5344e+16``. 
+The frequency values in the file can be separated by newlines, spaces, tabs, or any other whitespace. The numbers should be given in such a way, that c++ standard ``std::ifstream`` can interpret the number e.g., as ``2.5344e+16``.
 
 .. note::
 
@@ -93,14 +93,14 @@ Observation directions
 The number of observation directions ``N_theta`` is defined in :ref:`radiation.param <usage-params-plugins>`, but the distribution of observation directions is given in :ref:`radiationObserver.param <usage-params-plugins>`)
 There, the function ``observation_direction`` defines the observation directions.
 
-This function returns the x,y and z component of a **unit vector** pointing in the observation direction. 
+This function returns the x,y and z component of a **unit vector** pointing in the observation direction.
 
 .. code:: cpp
 
    DINLINE vector_64
    observation_direction( int const observation_id_extern )
    {
-       /* use the scalar index const int observation_id_extern to compute an 
+       /* use the scalar index const int observation_id_extern to compute an
         * observation direction (x,y,y) */
        return vector_64( x , y , z );
    }
@@ -116,9 +116,9 @@ Nyquist limit
 
 A major limitation of discrete Fourier transform is the limited frequency resolution due to the discrete time steps of the temporal signal.
 (see `Nyquist-Shannon sampling theorem <https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem>`_)
-Due to the consideration of relativistic delays, the sampling of the emitted radiation is not equidistantly sampled. 
-The plugin has the option to ignore any frequency contributions that lies above the frequency resolution given by the Nyquist-Shannon sampling theorem. 
-Because performing this check costs computation time, it can be switched off. 
+Due to the consideration of relativistic delays, the sampling of the emitted radiation is not equidistantly sampled.
+The plugin has the option to ignore any frequency contributions that lies above the frequency resolution given by the Nyquist-Shannon sampling theorem.
+Because performing this check costs computation time, it can be switched off.
 This is done via a precompiler pragma:
 
 .. code:: cpp
@@ -138,8 +138,8 @@ Additionally, the maximally resolvable frequency compared to the Nyquist frequen
        const float NyquistFactor = 0.5;
    }
 
-This allows to make a save margin to the hard limit of the Nyquist frequency. 
-By using ``NyquistFactor = 0.5`` for periodic boundary conditions, particles that jump from one border to another and back can still be considered. 
+This allows to make a save margin to the hard limit of the Nyquist frequency.
+By using ``NyquistFactor = 0.5`` for periodic boundary conditions, particles that jump from one border to another and back can still be considered.
 
 
 Form factor
@@ -158,25 +158,26 @@ A shape can be selected by choosing one of the available namespaces:
    namespace radFormFactor = radFormFactor_CIC_3D;
 
 
-==================================== ===================================================================================================================
-Namespace                            Description
-==================================== ===================================================================================================================
-``radFormFactor_CIC_3D``             3D Cloud-In-Cell shape
-``radFormFactor_TSC_3D``             3D Triangular shaped density cloud
-``radFormFactor_PCS_3D``             3D Quadratic spline density shape (Piecewise Cubic Spline assignment function)
-``radFormFactor_CIC_1Dy``            Cloud-In-Cell shape in y-direction, dot like in the other directions
-``radFormFactor_Gauss_spherical``    symmetric Gauss charge distribution
-``radFormFactor_Gauss_cell``         Gauss charge distribution according to cell size
-``radFormFactor_incoherent``         forces a completely incoherent emission by scaling the macro particle charge with the square root of the weighting
-``radFormFactor_coherent``           forces a completely coherent emission by scaling the macro particle charge with the weighting
-==================================== ===================================================================================================================
+========================================== ===================================================================================================================
+Namespace                                  Description
+========================================== ===================================================================================================================
+``radFormFactor_CIC_3D``                   3D Cloud-In-Cell shape
+``radFormFactor_TSC_3D``                   3D Triangular shaped density cloud
+``radFormFactor_PCS_3D``                   3D Quadratic spline density shape (Piecewise Cubic Spline assignment function)
+``radFormFactor_CIC_1Dy``                  Cloud-In-Cell shape in y-direction, dot like in the other directions
+``radFormFactor_Gauss_spherical``          symmetric Gauss charge distribution
+``radFormFactor_Gauss_spherical_simple``   symmetric Gauss charge distribution
+``radFormFactor_Gauss_cell``               Gauss charge distribution according to cell size
+``radFormFactor_incoherent``               forces a completely incoherent emission by scaling the macro particle charge with the square root of the weighting
+``radFormFactor_coherent``                 forces a completely coherent emission by scaling the macro particle charge with the weighting
+========================================== ===================================================================================================================
 
 
 Reducing the particle sample
 """"""""""""""""""""""""""""
 
 In order to save computation time, only a random subset of all macro particles can be used to compute the emitted radiation.
-In order to do that, the radiating particle species needs the attribute ``radiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.  
+In order to do that, the radiating particle species needs the attribute ``radiationMask`` (which is initialized as ``false``) which further needs to be manipulated, to set to true for specific (random) particles.
 
 
 .. note::
@@ -208,7 +209,7 @@ Using a filter functor as:
     >;
 
 (see Bunch or Kelvin Helmholtz example for details)
-sets the flag to true is a particle fulfills the gamma condition.  
+sets the flag to true is a particle fulfills the gamma condition.
 
 .. note::
 
@@ -252,7 +253,7 @@ There are several different window function available:
    namespace radWindowFunctionGauss { }
 
    namespace radWindowFunction = radWindowFunctionTriangle;
- 
+
 By setting ``radWindowFunction`` a specific window function is selected.
 
 More details can be found in [Pausch2019]_.
@@ -260,7 +261,7 @@ More details can be found in [Pausch2019]_.
 .cfg file
 ^^^^^^^^^
 
-For a specific (charged) species ``<species>`` e.g. ``e``, the radiation can be computed by the following commands.  
+For a specific (charged) species ``<species>`` e.g. ``e``, the radiation can be computed by the following commands.
 
 ========================================= ==============================================================================================================================
 Command line option                       Description
@@ -322,7 +323,7 @@ Command line flag                        Output description
                                          The spectral intensity is stored in the units :math:`\mathrm{[Js]}`.
 ``--<species>_radiation.lastRadiation``  has the same format as the output of *totalRadiation*.
                                          The spectral intensity is only summed over the last radiation ``dump`` period.
-``--<species>_radiation.radPerGPU``      Same output as *totalRadiation* but only summed over each GPU. 
+``--<species>_radiation.radPerGPU``      Same output as *totalRadiation* but only summed over each GPU.
                                          Because each GPU specifies a spatial region, the origin of radiation signatures can be distinguished.
 *radiationHDF5*                          In the folder  ``radiationHDF5``, hdf5 files for each radiation dump and species are stored.
                                          These are complex amplitudes in units used by *PIConGPU*.
@@ -333,7 +334,7 @@ Command line flag                        Output description
 Text-based output
 """""""""""""""""
 
-The text-based output of ``lastRadiation`` and ``totalRadiation`` contains the intensity values in SI-units :math:`\mathrm{[Js]}`. Intensity values for different frequencies are separated by spaces, while newlines separate values for different observation directions. 
+The text-based output of ``lastRadiation`` and ``totalRadiation`` contains the intensity values in SI-units :math:`\mathrm{[Js]}`. Intensity values for different frequencies are separated by spaces, while newlines separate values for different observation directions.
 
 
 In order to read and plot the text-based radiation data, a python script as follows could be used:
@@ -409,8 +410,8 @@ Dataset  Description                                           Dimensions
 
    Please be aware, that despite the fact, that the SI-unit of each amplitude entry is :math:`\mathrm{[\sqrt{Js}]}`, the stored ``unitSI`` attribute returns :math:`\mathrm{[Js]}`.
    This inconsistency will be fixed in the future.
-   Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units. 
-   
+   Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units.
+
 
 **DetectorDirection (Group):**
 
@@ -431,14 +432,14 @@ Dataset    Description                                             Dimensions
 ========== ======================================================= ===============================
 
 
-Please be aware that all datasets in the hdf5 output are given in the PIConGPU-intrinsic unit system. In order to convert, for example, the frequencies :math:`\omega` to SI-units one has to multiply with the dataset-attribute `unitSI`. 
+Please be aware that all datasets in the hdf5 output are given in the PIConGPU-intrinsic unit system. In order to convert, for example, the frequencies :math:`\omega` to SI-units one has to multiply with the dataset-attribute `unitSI`.
 
 .. code:: python
 
    import h5py
    f = h5py.File("e_radAmplitudes_2800_0_0_0.h5", "r")
    omega_handler = f['/data/2800/DetectorMesh/DetectorFrequency/omega']
-   omega = omega_handler[0, :, 0] * omega_handler.attrs['unitSI'] 
+   omega = omega_handler[0, :, 0] * omega_handler.attrs['unitSI']
    f.close()
 
 In order to extract the radiation data from the HDF5 datasets, PIConGPU provides a python module to read the data and obtain the result in SI-units. An example python script is given below:
@@ -446,7 +447,7 @@ In order to extract the radiation data from the HDF5 datasets, PIConGPU provides
 .. code:: python
 
     import numpy as np
-    import matplotlib.pyplot as plt 
+    import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
 
     from picongpu.plugins.data import RadiationData
@@ -461,7 +462,7 @@ In order to extract the radiation data from the HDF5 datasets, PIConGPU provides
 
     vec_n = radData.get_vector_n()
     gamma = 5.0
-    theta_norm = np.arctan(vec_n[:, 0]/vec_n[:, 1]) * gamma 
+    theta_norm = np.arctan(vec_n[:, 0]/vec_n[:, 1]) * gamma
 
     # get spectrum over observation angle
     spectrum = radData.get_Spectra()
@@ -505,7 +506,7 @@ Method                       Description
 
 .. note::
 
-   Modules for visualizing radiation data and a widget interface to explore the data interactively will be developed in the future. 
+   Modules for visualizing radiation data and a widget interface to explore the data interactively will be developed in the future.
 
 Analyzing tools
 ^^^^^^^^^^^^^^^
@@ -527,7 +528,7 @@ Tool                           Description
 Known Issues
 ^^^^^^^^^^^^
 
-The plugin supports multiple radiation species but spectra (frequencies and observation directions) are the same for all species. 
+The plugin supports multiple radiation species but spectra (frequencies and observation directions) are the same for all species.
 
 
 References

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -410,7 +410,7 @@ Dataset  Description                                           Dimensions
 
    Please be aware, that despite the fact, that the SI-unit of each amplitude entry is :math:`\mathrm{[\sqrt{Js}]}`, the stored ``unitSI`` attribute returns :math:`\mathrm{[Js]}`.
    This inconsistency will be fixed in the future.
-   Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units.
+   Until this inconsistency is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units.
 
 
 **DetectorDirection (Group):**

--- a/include/picongpu/param/radiation.param
+++ b/include/picongpu/param/radiation.param
@@ -114,6 +114,7 @@ namespace picongpu
              *  - radFormFactor_PCS_3D ... PCS charge distribution
              *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
              *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+             *  - radFormFactor_Gauss_spherical_simple ... as above but faster
              *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
              *  - radFormFactor_incoherent ... only incoherent radiation
              *  - radFormFactor_coherent ... only coherent radiation
@@ -131,6 +132,9 @@ namespace picongpu
             {
             }
             namespace radFormFactor_Gauss_spherical
+            {
+            }
+            namespace radFormFactor_Gauss_spherical_simple
             {
             }
             namespace radFormFactor_Gauss_cell

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -142,10 +142,7 @@ namespace picongpu
                         /* currently a fixed sigma of DELTA_T * c is used to describe the distribution - might become a
                          * parameter */
                         return math::sqrt(
-                            N
-                            + (N * N - N)
-                                * util::square(
-                                    math::exp(float_X(-0.5) * util::square(omega * float_X(0.5) * DELTA_T))));
+                            N + (N * N - N) * math::exp(float_X(-1.0) * util::square(omega * float_X(0.5) * DELTA_T)));
                     }
                 };
             } // namespace radFormFactor_Gauss_spherical

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -170,7 +170,7 @@ namespace picongpu
                         /* currently a fixed sigma of DELTA_T * c is used to describe the distribution - might become a
                          * parameter */
                         // optimized paramter for exponent beta=16 (see picongpu PR #3696 for details):
-                        const float_X alpha = 0.0172169f;
+                        constexpr float_X alpha = 0.0172169_X;
                         const float_X baseValue_toThePower16 = util::square(util::square(
                             util::square(util::square(1.0 / (alpha * DELTA_T * DELTA_T * omega * omega + 1.0)))));
                         return math::sqrt(N + (N * N - N) * baseValue_toThePower16);

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -151,6 +151,36 @@ namespace picongpu
             } // namespace radFormFactor_Gauss_spherical
 
 
+            namespace radFormFactor_Gauss_spherical_simple
+            {
+                struct radFormFactor
+                {
+                    /** Form Factor for point-symmetric Gauss-shaped charge distribution of N discrete electrons:
+                     * \f[ <rho(r)> = N*q_e* 1/sqrt(2*pi*sigma^2) * exp(-0.5 * r^2/sigma^2) \f]
+                     * with sigma = 0.5*c/delta_t (0.5 because sigma is defined around center)
+                     * simplified to avoid calling too often special functions to:
+                     * sqrt( N + (N^2 - N) * F(omega) )
+                     * F(omega) = ( exp(-0.5 * (x/2.0 * delta_t)^2) )^2 ~ 1/(0.03*(delta_t)^2 * x^2 + 1)^12
+                     *
+                     * @param N = macro particle weighting
+                     * @param omega = frequency at which to calculate the  form factor
+                     * @param observer_unit_vec = observation direction
+                     * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 ) \f$
+                     */
+                    HDINLINE float_X
+                    operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+                    {
+                        /* currently a fixed sigma of DELTA_T * c is used to describe the distribution - might become a
+                         * parameter */
+                        const float_X baseValue_toThePower4
+                            = util::square(util::square(1.0 / (0.025 * DELTA_T * DELTA_T * omega * omega + 1.0)));
+                        return math::sqrt(
+                            N + (N * N - N) * baseValue_toThePower4 * baseValue_toThePower4 * baseValue_toThePower4);
+                    }
+                };
+            } // namespace radFormFactor_Gauss_spherical_simple
+
+
             namespace radFormFactor_Gauss_cell
             {
                 struct radFormFactor

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -157,7 +157,7 @@ namespace picongpu
                      * with sigma = 0.5*c/delta_t (0.5 because sigma is defined around center)
                      * simplified to avoid calling too often special functions to:
                      * sqrt( N + (N^2 - N) * F(omega) )
-                     * F(omega) = ( exp(-0.5 * (x/2.0 * delta_t)^2) )^2 ~ 1/(0.03*(delta_t)^2 * x^2 + 1)^12
+                     * F(omega) = ( exp(-0.5 * (x/2.0 * delta_t)^2) )^2 ~ 1/(alpha*(delta_t)^2 * x^2 + 1)^beta
                      *
                      * @param N = macro particle weighting
                      * @param omega = frequency at which to calculate the  form factor
@@ -169,10 +169,11 @@ namespace picongpu
                     {
                         /* currently a fixed sigma of DELTA_T * c is used to describe the distribution - might become a
                          * parameter */
-                        const float_X baseValue_toThePower4
-                            = util::square(util::square(1.0 / (0.025 * DELTA_T * DELTA_T * omega * omega + 1.0)));
-                        return math::sqrt(
-                            N + (N * N - N) * baseValue_toThePower4 * baseValue_toThePower4 * baseValue_toThePower4);
+                        // optimized paramter for exponent beta=16 (see picongpu PR #3696 for details):
+                        const float_X alpha = 0.0172169f;
+                        const float_X baseValue_toThePower16 = util::square(util::square(
+                            util::square(util::square(1.0 / (alpha * DELTA_T * DELTA_T * omega * omega + 1.0)))));
+                        return math::sqrt(N + (N * N - N) * baseValue_toThePower16);
                     }
                 };
             } // namespace radFormFactor_Gauss_spherical_simple

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiation.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiation.param
@@ -100,6 +100,7 @@ namespace picongpu
              *  - radFormFactor_PCS_3D ... PCS charge distribution
              *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
              *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+             *  - radFormFactor_Gauss_spherical_simple ... as above but faster
              *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
              *  - radFormFactor_incoherent ... only incoherent radiation
              *  - radFormFactor_coherent ... only coherent radiation
@@ -117,6 +118,9 @@ namespace picongpu
             {
             }
             namespace radFormFactor_Gauss_spherical
+            {
+            }
+            namespace radFormFactor_Gauss_spherical_simple
             {
             }
             namespace radFormFactor_Gauss_cell

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -88,6 +88,7 @@ namespace picongpu
              *  - radFormFactor_PCS_3D ... PCS charge distribution
              *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
              *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+             *  - radFormFactor_Gauss_spherical_simple ... as above but faster
              *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
              *  - radFormFactor_incoherent ... only incoherent radiation
              *  - radFormFactor_coherent ... only coherent radiation
@@ -105,6 +106,9 @@ namespace picongpu
             {
             }
             namespace radFormFactor_Gauss_spherical
+            {
+            }
+            namespace radFormFactor_Gauss_spherical_simple
             {
             }
             namespace radFormFactor_Gauss_cell

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -91,6 +91,7 @@ namespace picongpu
              *  - radFormFactor_PCS_3D ... PCS charge distribution
              *  - radFormFactor_CIC_1Dy ... only CIC charge distribution in y
              *  - radFormFactor_Gauss_spherical ... symmetric Gauss charge distribution
+             *  - radFormFactor_Gauss_spherical_simple ... as above but faster
              *  - radFormFactor_Gauss_cell ... Gauss charge distribution according to cell size
              *  - radFormFactor_incoherent ... only incoherent radiation
              *  - radFormFactor_coherent ... only coherent radiation
@@ -108,6 +109,9 @@ namespace picongpu
             {
             }
             namespace radFormFactor_Gauss_spherical
+            {
+            }
+            namespace radFormFactor_Gauss_spherical_simple
             {
             }
             namespace radFormFactor_Gauss_cell


### PR DESCRIPTION
This pull request adds another form factor which is emulates the `radFormFactor_Gauss_spherical` but avoids calling the `math::exp` function. 

The simplification does not perfectly match the original function but is good enough for any practical application. 
For reference, the adjustment looks as follows:
![grafik](https://user-images.githubusercontent.com/5121158/126165987-f6cec969-aa8e-4d43-9c22-2a9061f85fa4.png)

