### PR TITLE
Fix FromOpenPMD density and make it account for axisLabels attribute

### DIFF
--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -263,6 +263,8 @@ namespace picongpu
             /** Offset in the file in cells: each value is density at (total cell index - offset)
              *
              * This offset is in (x, y, z) coordinates.
+             * Positive offset means the file values "start" from index == offset in the total coordinates.
+             * Negative offset is also supported.
              */
             (PMACC_C_VECTOR_DIM(int, simDim, offset, 0, 0, 0))
 

--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -1,5 +1,5 @@
 /* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Richard Pausch
+ *                     Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -223,28 +223,47 @@ namespace picongpu
         /* definition of sphere profile with flanks */
         using SphereFlanks = SphereFlanksImpl<SphereFlanksParam>;
 
-        /** Density values taken from a file
+        /** Density values taken from an openPMD file
          *
-         * The file follows the openPMD standard.
-         * The density values are written as a dataset of type float_X.
-         * Each value defines density in the cell with the corresponding total coordinate minus the given offset.
-         * When the functor is instantiated, it will load the part matching the current domain position.
-         * If the file dataset is not large enough, it will be padded with the given defaultDensity value.
+         * The density values must be a scalar dataset of type float_X, type mismatch would cause errors.
+         * This implementation would ignore all openPMD metadata but axisLabels.
+         * Each value in the dataset defines density in the cell with the corresponding total coordinate minus the
+         * given offset. When the functor is instantiated, it will load the part matching the current domain position.
+         * Density in points not present in the file would be set to the given default density.
          * Dimensionality of the file indexing must match the simulation dimensionality.
          * Density values are in BASE_DENSITY_SI units.
          */
         PMACC_STRUCT(
             FromOpenPMDParam,
-            //! Name for the openPMD file
+            /** Path to the openPMD input file
+             *
+             * File-based iteration format is also supported, with the usual openPMD API naming scheme.
+             *
+             * It is recommended to use a full path to make it independent of how PIConGPU is launched.
+             * Relative paths require consistency to the current directory when PIConGPU is started.
+             * With tbg and the standard .tpl files, relative to the resulting simOutput directory.
+             */
             (PMACC_C_STRING(filename, "density.h5"))
 
-            //! Name of the dataset inside the file
-            (PMACC_C_STRING(datasetName, "density"))
+            /** Name of the openPMD dataset inside the file
+             *
+             * By default, this dataset indexing is assumed to be in (x, y, z) coordinates.
+             * This can be changed by setting openPMD attribute "axisLabels" of the correponding dataset.
+             * For example, PIConGPU output uses z-y-x via this attribute, and that automatically works.
+             * Note that only C dataOrder is supported.
+             *
+             * @warning it is only the dataset itself, a simple text name and not something like
+             * "/[directories]/density/[iteration]/fields/e_density".
+             */
+            (PMACC_C_STRING(datasetName, "e_density"))
 
             //! Iteration inside the file (only file, not related to the current simulation time iteration)
             (PMACC_C_VALUE(uint32_t, iteration, 0))
 
-            //! Offset in the file in cells: each value is density at (total cell index - offset)
+            /** Offset in the file in cells: each value is density at (total cell index - offset)
+             *
+             * This offset is in (x, y, z) coordinates.
+             */
             (PMACC_C_VECTOR_DIM(int, simDim, offset, 0, 0, 0))
 
             //! Default value to be used for cells with no corresponding file value

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -111,7 +111,7 @@ namespace picongpu
                 auto const& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 bool readFromFile = true;
                 // All indices are in PIConGPU x-y-z coordinates, unless explicitly stated otherwise
-                // Where the fieldBuffer data is starting from (no guards)
+                // Where the fieldBuffer data is starting from (no guards), so inside the local domain
                 auto localDataBoxStart = pmacc::DataSpace<simDim>::create(0);
                 // Start and extend of the file for the local domain
                 auto chunkOffset = ::openPMD::Offset(simDim, 0);
@@ -119,8 +119,8 @@ namespace picongpu
                 for(uint32_t d = 0; d < simDim; ++d)
                 {
                     localDataBoxStart[d] = std::max(ParamClass::offset[d] - totalLocalDomainOffset[d], 0);
-                    chunkOffset[d] = std::max(-localDataBoxStart[d], 0);
-                    // Here we take care, as chunkExtent is unsigned type
+                    chunkOffset[d] = std::max(totalLocalDomainOffset[d] - ParamClass::offset[d], 0);
+                    // Here we take care, as chunkExtent is unsigned
                     int32_t extent = std::min(
                         static_cast<int32_t>(localDomain.size[d] - localDataBoxStart[d]),
                         static_cast<int32_t>(datasetExtent[d] - chunkOffset[d]));


### PR DESCRIPTION
The original implementation was technically correct, as it worked as documented, so I did not add the bug label. But it was not easy to use in the common case of using output of the previous simulation as input. Now all Cartesian axis orders should be supported properly. Also extend the comments to the parameters.

Edit: the preceeding paragraph concerns only the axis part.
There was also a bug with reading incorrect parts of the file when having multiple MPI ranks. This is unrelated to axes, but also fixed in this PR.

This PR includes the comment improvements from #3684, I will close that one.

Resolves #3685.