### PR TITLE
Radiation: Coalescence Write to Global

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -421,7 +421,7 @@ namespace picongpu
                     for(int resultIdx = 1; resultIdx < numJobs; ++resultIdx)
                         for(int ampIdx = 0; ampIdx < numAmp; ++ampIdx)
                         {
-                            dbox(DataSpace<2>(ampIdx, 0)) += dbox(DataSpace<2>(ampIdx, resultIdx));
+                            dbox(DataSpace<2>(0, ampIdx)) += dbox(DataSpace<2>(resultIdx, ampIdx));
                         }
                 }
 
@@ -1206,7 +1206,7 @@ namespace picongpu
 
                     // PIC-like kernel call of the radiation kernel
                     PMACC_KERNEL(KernelRadiationParticles<numWorkers>{})
-                    (DataSpace<2>(gridDim_rad, numJobs), DataSpace<2>(numWorkers, 1))(
+                    (DataSpace<2>(numJobs, gridDim_rad), DataSpace<2>(numWorkers, 1))(
                         /*Pointer to particles memory on the device*/
                         particles->getDeviceParticlesBox(),
 

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -146,7 +146,7 @@ namespace picongpu
                     PMACC_SMEM(acc, lowpass_s, memory::Array<NyquistLowPass, blockSize>);
 
 
-                    int const theta_idx = cupla::blockIdx(acc).x; // cupla::blockIdx(acc).x is used to determine theta
+                    int const theta_idx = cupla::blockIdx(acc).y; // cupla::blockIdx(acc).y is used to determine theta
 
                     // simulation time (needed for retarded time)
                     picongpu::float_64 const t(picongpu::float_64(currentStep) * picongpu::float_64(DELTA_T));
@@ -165,8 +165,8 @@ namespace picongpu
                     // get absolute number of relevant super cells
                     int const numSuperCells = superCellsCount.productOfComponents();
 
-                    int const numJobs = cupla::gridDim(acc).y;
-                    int const jobIdx = cupla::blockIdx(acc).y;
+                    int const numJobs = cupla::gridDim(acc).x;
+                    int const jobIdx = cupla::blockIdx(acc).x;
 
                     /* go over all super cells on GPU with a stride depending on number of temporary results
                      * but ignore all guarding supercells
@@ -400,7 +400,7 @@ namespace picongpu
                                  *     - from this (one) time step
                                  *     - omega_id = theta_idx * radiation_frequencies::N_omega + o
                                  */
-                                radiation(DataSpace<2>(theta_idx * radiation_frequencies::N_omega + o, jobIdx))
+                                radiation(DataSpace<2>(jobIdx, theta_idx * radiation_frequencies::N_omega + o))
                                     += amplitude;
 
                             } // end frequency loop


### PR DESCRIPTION
Fix a warning seen with Nsight Compute today. Since the `jobIdx` for splitting the `numJobs` is the slowest varying index, the order should be inverted.

Follow-up to #3354

Co-authored-by: @PrometheusPi & @sbastrakov