### PR TITLE
Fix inaccurate supercell loop stop condition in the radiation kernel

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -171,7 +171,7 @@ namespace picongpu
                     /* go over all super cells on GPU with a stride depending on number of temporary results
                      * but ignore all guarding supercells
                      */
-                    for(int super_cell_index = jobIdx; super_cell_index <= numSuperCells; super_cell_index += numJobs)
+                    for(int super_cell_index = jobIdx; super_cell_index < numSuperCells; super_cell_index += numJobs)
                     {
                         // select SuperCell and add one sided guard again
                         DataSpace<simDim> const superCell


### PR DESCRIPTION
It was a logical mistake.
However, with guards present it resulted in only an extra empty iteration. So does not need backporting.

But found during the hackathon.