### PR TITLE
Fix TWTS implementations

### DIFF
--- a/include/picongpu/fields/background/templates/TWTS/BField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.hpp
@@ -69,7 +69,13 @@ namespace picongpu
                 PMACC_ALIGN(w_x_SI, const float_64);
                 /* line focus width of TWTS pulse [meter] */
                 PMACC_ALIGN(w_y_SI, const float_64);
-                /* interaction angle between TWTS laser propagation vector and the y-axis [rad] */
+                /** TWTS interaction angle
+                 *  Enclosed by the laser propagation direction and the y-axis.
+                 *  For a positive value of the interaction angle, the laser propagation direction
+                 *  points along the y-axis and against the z-axis.
+                 *  That is, for phi = 90 degree the laser propagates in the -z direction.
+                 * [rad]
+                 */
                 PMACC_ALIGN(phi, const float_X);
                 /* Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
                 PMACC_ALIGN(phiPositive, float_X);

--- a/include/picongpu/fields/background/templates/TWTS/BField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.tpp
@@ -542,8 +542,9 @@ namespace picongpu
                 const complex_T helpVar7 = cspeed * om0 * tauG * tauG
                     - complex_T(0, 1) * y * cosPhi / cosPhi2 / cosPhi2 * tanPhi2
                     - complex_T(0, 2) * z * tanPhi2 * tanPhi2;
-                const complex_T result = (complex_T(0, 2) * math::exp(helpVar6) * tauG * tanPhi2
-                                          * (cspeed * t - z + y * tanPhi2) * math::sqrt((om0 * rho0) / helpVar3))
+                const complex_T result = float_T(phiPositive)
+                    * (complex_T(0, 2) * math::exp(helpVar6) * tauG * tanPhi2 * (cspeed * t - z + y * tanPhi2)
+                       * math::sqrt((om0 * rho0) / helpVar3))
                     / math::pow(helpVar7, float_T(1.5));
 
                 return result.get_real() / UNIT_SPEED;
@@ -698,7 +699,7 @@ namespace picongpu
                                                - complex_T(0, 2) * z * tanPhi2 * tanPhi2))
                     / rho0;
 
-                const complex_T result = float_T(-1.0)
+                const complex_T result = float_T(phiPositive) * float_T(-1.0)
                     * (cspeed * math::exp(helpVar3) * k * tauG * x * math::pow(helpVar2, float_T(-1.5))
                        / math::sqrt(helpVar4));
 

--- a/include/picongpu/fields/background/templates/TWTS/EField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.hpp
@@ -68,7 +68,13 @@ namespace picongpu
                 PMACC_ALIGN(w_x_SI, const float_64);
                 /* line focus width of TWTS pulse [meter] */
                 PMACC_ALIGN(w_y_SI, const float_64);
-                /* interaction angle between TWTS laser propagation vector and the y-axis [rad] */
+                /** TWTS interaction angle
+                 *  Enclosed by the laser propagation direction and the y-axis.
+                 *  For a positive value of the interaction angle, the laser propagation direction
+                 *  points along the y-axis and against the z-axis.
+                 *  That is, for phi = 90 degree the laser propagates in the -z direction.
+                 * [rad]
+                 */
                 PMACC_ALIGN(phi, const float_X);
                 /* Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
                 PMACC_ALIGN(phiPositive, float_X);

--- a/include/picongpu/fields/background/templates/twtsfast/BField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.hpp
@@ -67,7 +67,13 @@ namespace picongpu
                 PMACC_ALIGN(pulselength_SI, float_64 const);
                 /** line focus height of TWTS pulse [meter] */
                 PMACC_ALIGN(w_x_SI, float_64 const);
-                /** interaction angle between TWTS laser propagation vector and the y-axis [rad] */
+                /** TWTS interaction angle
+                 *  Enclosed by the laser propagation direction and the y-axis.
+                 *  For a positive value of the interaction angle, the laser propagation direction
+                 *  points along the y-axis and against the z-axis.
+                 *  That is, for phi = 90 degree the laser propagates in the -z direction.
+                 * [rad]
+                 */
                 PMACC_ALIGN(phi, float_X const);
                 /** Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
                 PMACC_ALIGN(phiPositive, float_X);

--- a/include/picongpu/fields/background/templates/twtsfast/BField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.tpp
@@ -748,7 +748,7 @@ namespace picongpu
                     * (cspeed * om0 * tauG2 - complex_T(0, 8) * y * tanPI2_phi * cscPhi * cscPhi * sinPhi2_4
                        - complex_T(0, 2) * z * tanPhi2_2);
 
-                const complex_T result = float_T(-1.0)
+                const complex_T result = float_T(phiPositive) * float_T(-1.0)
                     * (cspeed * math::exp(helpVar3) * k * tauG * x * rho0
                        * math::pow(float_T(1.0) / helpVar2, float_T(1.5)))
                     / math::sqrt(helpVar4);

--- a/include/picongpu/fields/background/templates/twtsfast/EField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.hpp
@@ -66,7 +66,13 @@ namespace picongpu
                 PMACC_ALIGN(pulselength_SI, float_64 const);
                 /** line focus height of TWTS pulse [meter] */
                 PMACC_ALIGN(w_x_SI, float_64 const);
-                /** interaction angle between TWTS laser propagation vector and the y-axis [rad] */
+                /** TWTS interaction angle
+                 *  Enclosed by the laser propagation direction and the y-axis.
+                 *  For a positive value of the interaction angle, the laser propagation direction
+                 *  points along the y-axis and against the z-axis.
+                 *  That is, for phi = 90 degree the laser propagates in the -z direction.
+                 * [rad]
+                 */
                 PMACC_ALIGN(phi, float_X const);
                 /** Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
                 PMACC_ALIGN(phiPositive, float_X);


### PR DESCRIPTION
Bugs discovered during testing of TWEAC for Frontier.
* Add missing `phiPositive` in `BField::calcTWTSBz_Ey` of `twtsfast`.
* Add missing `phiPositive` in `BField::calcTWTSBz_Ey` and `BField::calcTWTSBz_Ex` of TWTS.
* Clarify documentation of the interaction angle

Comparing plasma dynamics before and after the fixes are applied to `TWTS` and `twtsfast`.
![twts-impl-comparison_yz-pol](https://user-images.githubusercontent.com/26382442/127300682-085945e0-5a72-4003-9ca5-4141c4d7065e.png)
![PIConGPU-TWTS_phiPositive-fix-comparison](https://user-images.githubusercontent.com/26382442/127300720-3081bdf8-b48d-4f2b-b642-09cb91f6aa17.png)

We expect symmetric behavior of plasma electrons as it is only apparent with the fixes.