### PR TITLE
Cori DGX: Module purge

### DIFF
--- a/etc/picongpu/cori-nersc/a100_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/a100_picongpu.profile.example
@@ -21,6 +21,7 @@ export RESERVATION=""
 
 # General modules #############################################################
 #
+module purge
 module load dgx
 module swap PrgEnv-intel PrgEnv-gnu
 module load cuda openmpi


### PR DESCRIPTION
Missing in #3694 and recommended by docs.
(Not part of the Cori Cray system software env.)