### PR TITLE
Optimize radiation plugin math

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -1,5 +1,5 @@
 /* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
- *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
+ *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -132,7 +132,7 @@ namespace picongpu
                     PMACC_SMEM(acc, real_amplitude_s, memory::Array<vector_64, blockSize>);
 
                     // retarded time
-                    PMACC_SMEM(acc, t_ret_s, memory::Array<picongpu::float_64, blockSize>);
+                    PMACC_SMEM(acc, t_ret_s, memory::Array<picongpu::float_X, blockSize>);
 
                     // storage for macro particle weighting needed if
                     // the coherent and incoherent radiation of a single
@@ -318,7 +318,7 @@ namespace picongpu
                                                 * particle_charge * picongpu::float_64(DELTA_T);
 
                                             // retarded time stored in shared memory
-                                            t_ret_s[saveParticleAt] = amplitude3.get_t_ret(look);
+                                            t_ret_s[saveParticleAt] = static_cast<float_X>(amplitude3.get_t_ret(look));
 
                                             lowpass_s[saveParticleAt] = NyquistLowPass(look, particle);
 
@@ -359,16 +359,20 @@ namespace picongpu
                                 Amplitude amplitude = Amplitude::zero();
 
                                 // compute frequency "omega" using for-loop-index "o"
-                                picongpu::float_64 const omega = freqFkt(o);
+                                picongpu::float_X const omega = static_cast<float_X>(freqFkt(o));
 
-                                // create a form factor object
-                                radFormFactor::radFormFactor const myRadFormFactor{};
+                                // create a form factor functor
+                                radFormFactor::radFormFactor const myRadFormFactor{omega, look};
 
                                 /* Particle loop: thread runs through loaded particle data
                                  *
                                  * Summation of Jackson radiation formula integrand
                                  * over all electrons for fixed, thread-specific
                                  * frequency
+                                 *
+                                 * This is the hot loop of this kernel, taking ~95% of its time.
+                                 * So performance-wise the rest of this kernel does not significantly contribute.
+                                 * On the contrary, few operations done inside the loop matter a lot.
                                  */
                                 for(int j = 0; j < counter_s; ++j)
                                 {
@@ -381,7 +385,7 @@ namespace picongpu
 
                                         // calulate the form factor's' influences to the real amplitude
                                         vector_64 const weighted_real_amp = real_amplitude_s[j]
-                                            * precisionCast<float_64>(myRadFormFactor(radWeighting_s[j], omega, look));
+                                            * precisionCast<float_64>(myRadFormFactor(radWeighting_s[j]));
 
                                         /* complex amplitude increment for j-th particle
                                          * It is local to the loop and can be single precision

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -379,25 +379,12 @@ namespace picongpu
                                     // check Nyquist-limit for each particle "j" and each frequency "omega"
                                     if(lowpass_s[j].check(omega))
                                     {
-                                        /****************************************************
-                                         **** Here happens the true physical calculation ****
-                                         ****************************************************/
-
-                                        // calulate the form factor's' influences to the real amplitude
-                                        vector_64 const weighted_real_amp = real_amplitude_s[j]
-                                            * precisionCast<float_64>(myRadFormFactor(radWeighting_s[j]));
-
-                                        /* complex amplitude increment for j-th particle
-                                         * It is local to the loop and can be single precision
-                                         */
-                                        Amplitude amplitude_add(weighted_real_amp, t_ret_s[j] * omega);
-
-                                        // add this single amplitude those previously considered
-                                        amplitude += amplitude_add;
-
-                                    } // END: check Nyquist-limit for each particle "j" and each frequency "omega"
-
-                                } // END: Particle loop
+                                        // Here happens the true physical calculation
+                                        float_X const formFactorValue = myRadFormFactor(radWeighting_s[j]);
+                                        float_X const phase = t_ret_s[j] * omega;
+                                        amplitude.addContribution(real_amplitude_s[j], phase, formFactorValue);
+                                    }
+                                }
 
                                 /* the radiation contribution of the following is added to global memory:
                                  *     - valid particles of last super cell

--- a/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
+++ b/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -19,9 +19,11 @@
 
 #pragma once
 
-#include "VectorTypes.hpp"
-#include "calc_amplitude.hpp"
-#include "particle.hpp"
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/plugins/radiation/VectorTypes.hpp"
+#include "picongpu/plugins/radiation/calc_amplitude.hpp"
+#include "picongpu/plugins/radiation/particle.hpp"
 
 
 namespace picongpu
@@ -30,37 +32,36 @@ namespace picongpu
     {
         namespace radiation
         {
+            //! Low pass filter on frequencies, the threshold depends on the Nyquist frequency
             class NyquistLowPass : public One_minus_beta_times_n
             {
             public:
-                /**
-                 * calculates \f$omega_{Nyquist}\f$ for particle in a direction \f$n\f$
+                /** Calculates the filter threshold, only frequencies below it pass
+                 *
+                 * The threshold is equal to \f$omega_{Nyquist} * NyquistFactor\f$ for particle in a direction \f$n\f$
                  * \f$omega_{Nyquist} = (\pi - \epsilon )/(\delta t * (1 - \vec(\beta) * \vec(n)))\f$
-                 * so that all Amplitudes for higher frequencies can be ignored
+                 * so that all Amplitudes for higher frequencies can be ignored.
+                 * The Nyquist factor value is set in radiation.param.
                  **/
                 HDINLINE NyquistLowPass(const vector_64& n, const Particle& particle)
-                    : omegaNyquist((PI - 0.01) / (DELTA_T * One_minus_beta_times_n()(n, particle)))
                 {
+                    auto const omegaNyquist = (PI - 0.01) / (DELTA_T * One_minus_beta_times_n()(n, particle));
+                    threshold = static_cast<float_X>(omegaNyquist * radiationNyquist::NyquistFactor);
                 }
 
-                /**
-                 * default constructor - needed for allocating shared memory on GPU (Radiation.hpp kernel)
-                 **/
-                HDINLINE NyquistLowPass(void)
-                {
-                }
+                //! Default constructor - needed for allocating shared memory on GPU (Radiation.kernel)
+                HDINLINE NyquistLowPass() = default;
 
-
-                /**
-                 * checks if frequency omega is below Nyquist frequency
-                 **/
-                HDINLINE bool check(const float_32 omega)
+                //! Checks if frequency omega is below the threshold
+                HDINLINE bool check(const float_X omega) const
                 {
-                    return omega < omegaNyquist * radiationNyquist::NyquistFactor;
+                    return omega < threshold;
                 }
 
             private:
-                float_32 omegaNyquist; // Nyquist frequency for a particle (at a certain time step) for one direction
+                // Nyquist frequency for a particle (at a certain time step) for one direction multiplied by the
+                // Nyquist factor
+                float_X threshold;
             };
 
         } // namespace radiation

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -29,42 +29,90 @@ namespace picongpu
     {
         namespace radiation
         {
+            /** Base radiation form factor functor
+             *
+             * Each functor instance is used for fixed frequency and observation direction
+             *
+             * This class serves to define the interface requirements for radiation form factor implementations.
+             * So if roughly defines a "concept", does not have to be inherited.
+             *
+             * Most implementations would precompute normalized coherent amplification for the given frequency and
+             * observation direction in the constructor. It will be then used by operator() called in the hot loop of
+             * the radiation kernel.
+             */
+            struct RadFormFactorConcept
+            {
+                /** Create a functor for the given frequency and observation direction, is required
+                 *
+                 * @param omega frequency
+                 * @param observerUnitVec unit vector of observation direction
+                 */
+                HDINLINE RadFormFactorConcept(const float_X omega, vector_64 const& observerUnitVec);
+
+                /** Calculate form factor value \f$ \sqrt( | \mathcal{F} |^2 ) \f$
+                 *
+                 * @param N macro particle weighting
+                 */
+                HDINLINE float_X operator()(const float_X N) const;
+            };
+
             namespace radFormFactor_baseShape_3D
             {
                 /** general form factor class of discrete charge distribution of PIC particle shape of order
                  * T_shapeOrder
                  *
+                 * Adheres to the RadFormFactorConcept concept
+                 *
                  * @tparam T_shapeOrder order of charge distribution shape in PIC code used for radiation form factor
                  */
-
                 template<uint32_t T_shapeOrder>
                 struct radFormFactor
                 {
+                    /** Construct the form factor functor for the given frequency and observation direction
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : normalizedCoherentAmplification(getNormalizedCoherentAmplification(omega, observerUnitVec))
+                    {
+                    }
+
                     /** Form Factor for T_shapeOrder-order particle shape charge distribution of N discrete electrons:
                      * \f[ | \mathcal{F} |^2 = N + (N*N - N) * (sinc^2(n_x * L_x * \omega) * sinc^2(n_y * L_y * \omega)
                      * * sinc^2(n_z * L_z * \omega))^T_shapeOrder \f]
                      *
                      * with observation direction (unit vector) \f$ \vec{n} = (n_x, n_y, n_z) \f$
                      * and with:
-                     * @param N     = weighting
-                     * @param omega = frequency
-                     * @param L_d   = the size of the CIC-particle / cell in dimension d
                      *
                      * @param N = macro particle weighting
                      * @param omega = frequency at which to calculate the  form factor
-                     * @param observer_unit_vec = observation direction
+                     *
                      * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 ) \f$
                      */
-                    HDINLINE float_X
-                    operator()(const float_X N, const float_X omega, vector_X const& observer_unit_vec) const
+                    HDINLINE float_X operator()(const float_X N) const
                     {
-                        float_X sincValue = float_X(1.0);
+                        return math::sqrt(N + (N * N - N) * normalizedCoherentAmplification);
+                    }
+
+                private:
+                    //! Precomputed value of normalized coherent amplification for the given frequency
+                    float_X const normalizedCoherentAmplification;
+
+                    /** Calculate normalized coherent amplification for the given frequency and observation direction
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE float_X
+                    getNormalizedCoherentAmplification(const float_X omega, vector_64 const& observerUnitVec) const
+                    {
+                        // here we combine sinc^2(..) with (...)^T_shapeOrder to ...^(2 * T_shapeOrder)
+                        float_X sincValue = 1.0_X;
                         for(uint32_t d = 0; d < DIM3; ++d)
                             sincValue *= pmacc::math::sinc(
-                                observer_unit_vec[d] * cellSize[d] / (SPEED_OF_LIGHT * float_X(2.0)) * omega);
-
-                        // here we combine sinc^2(..) with (...)^T_shapeOrder to ...^(2 * T_shapeOrder)
-                        return math::sqrt(N + (N * N - N) * util::pow(sincValue, 2 * T_shapeOrder));
+                                observerUnitVec[d] * cellSize[d] / (SPEED_OF_LIGHT * 2.0_X) * omega);
+                        return util::pow(sincValue, 2 * T_shapeOrder);
                     }
                 };
             } // namespace radFormFactor_baseShape_3D
@@ -72,115 +120,180 @@ namespace picongpu
 
             namespace radFormFactor_CIC_3D
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor<1>
                 {
+                    /** Construct the form factor functor for the given frequency and observation direction
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : radFormFactor_baseShape_3D::radFormFactor<1>(omega, observerUnitVec)
+                    {
+                    }
                 };
             } // namespace radFormFactor_CIC_3D
 
             namespace radFormFactor_TSC_3D
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor<2>
                 {
+                    /** Construct the form factor functor for the given frequency and observation direction
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : radFormFactor_baseShape_3D::radFormFactor<2>(omega, observerUnitVec)
+                    {
+                    }
                 };
             } // namespace radFormFactor_TSC_3D
 
             namespace radFormFactor_PCS_3D
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor<3>
                 {
+                    /** Construct the form factor functor for the given frequency and observation direction
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : radFormFactor_baseShape_3D::radFormFactor<3>(omega, observerUnitVec)
+                    {
+                    }
                 };
             } // namespace radFormFactor_PCS_3D
 
 
             namespace radFormFactor_CIC_1Dy
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor
                 {
+                    /** Construct the form factor functor for the given frequency
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction,
+                     *                        not used for this form factor but requried by RadFormFactorConcept
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const&)
+                        : normalizedCoherentAmplification(
+                            util::square(pmacc::math::sinc(CELL_HEIGHT / (SPEED_OF_LIGHT * 2.0_X) * omega)))
+                    {
+                    }
+
                     /** Form Factor for 1-d CIC charge distribution iy y of N discrete electrons:
                      * \f[ | \mathcal{F} |^2 = N + (N*N - N) * sinc^2(n_y * L_y * \omega) \f]
                      *
                      * with observation direction (unit vector) \f$ \vec{n} = (n_x, n_y, n_z) \f$
                      * and with:
-                     * @param N     = weighting
-                     * @param omega = frequency
-                     * @param L_d   = the size of the CIC-particle / cell in dimension d
                      *
-                     * @param N = macro particle weighting
-                     * @param omega = frequency at which to calculate the  form factor
-                     * @param observer_unit_vec = observation direction
+                     * @param N macro particle weighting
+                     *
                      * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 ) \f$
                      */
-                    HDINLINE float_X
-                    operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+                    HDINLINE float_X operator()(const float_X N) const
                     {
-                        return math::sqrt(
-                            N
-                            + (N * N - N)
-                                * util::square(
-                                    pmacc::math::sinc(CELL_HEIGHT / (SPEED_OF_LIGHT * float_X(2.0)) * omega)));
+                        return math::sqrt(N + (N * N - N) * normalizedCoherentAmplification);
                     }
+
+                private:
+                    //! Precomputed value of normalized coherent amplification for the given frequency
+                    float_X const normalizedCoherentAmplification;
                 };
             } // namespace radFormFactor_CIC_1Dy
 
 
             namespace radFormFactor_Gauss_spherical
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor
                 {
+                    /** Construct the form factor functor for the given frequency
+                     *
+                     * Currently a fixed sigma of DELTA_T * c is used to describe the distribution - might become a
+                     * parameter.
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction,
+                     *                        not used for this form factor but requried by RadFormFactorConcept
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const&)
+                        : normalizedCoherentAmplification(
+                            util::square(math::exp(-0.5_X * util::square(omega * 0.5_X * DELTA_T))))
+                    {
+                    }
+
                     /** Form Factor for point-symmetric Gauss-shaped charge distribution of N discrete electrons:
                      * \f[ <rho(r)> = N*q_e* 1/sqrt(2*pi*sigma^2) * exp(-0.5 * r^2/sigma^2) \f]
                      * with sigma = 0.5*c/delta_t (0.5 because sigma is defined around center)
                      *
-                     * @param N = macro particle weighting
-                     * @param omega = frequency at which to calculate the  form factor
-                     * @param observer_unit_vec = observation direction
+                     * @param N macro particle weighting
+                     *
                      * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 ) \f$
                      */
-                    HDINLINE float_X
-                    operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+                    HDINLINE float_X operator()(const float_X N) const
                     {
-                        /* currently a fixed sigma of DELTA_T * c is used to describe the distribution - might become a
-                         * parameter */
-                        return math::sqrt(
-                            N
-                            + (N * N - N)
-                                * util::square(
-                                    math::exp(float_X(-0.5) * util::square(omega * float_X(0.5) * DELTA_T))));
+                        return math::sqrt(N + (N * N - N) * normalizedCoherentAmplification);
                     }
+
+                private:
+                    //! Precomputed value of normalized coherent amplification for the given frequency
+                    float_X const normalizedCoherentAmplification;
                 };
             } // namespace radFormFactor_Gauss_spherical
 
 
             namespace radFormFactor_Gauss_cell
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor
                 {
+                    /** Construct the form factor functor for the given frequency and observation direction
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : normalizedCoherentAmplification(getNormalizedCoherentAmplification(omega, observerUnitVec))
+                    {
+                    }
+
                     /** Form Factor for per-dimension Gauss-shaped charge distribution of N discrete electrons:
                      * \f[ <rho(r)> = N*q_e* product[d={x,y,z}](1/sqrt(2*pi*sigma_d^2) * exp(-0.5 * d^2/sigma_d^2)) \f]
                      * with sigma_d = 0.5*cell_width_d*n_d
                      *
-                     * @param N = macro particle weighting
-                     * @param omega = frequency at which to calculate the  form factor
-                     * @param observer_unit_vec = observation direction
+                     * @param N macro particle weighting
+                     *
                      * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 ) \f$
                      */
-                    HDINLINE float_X
-                    operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+                    HDINLINE float_X operator()(const float_X N) const
                     {
-                        return math::sqrt(
-                            N
-                            + (N * N - N)
-                                * util::square(math::exp(
-                                    float_X(-0.5)
-                                    * (util::square(
-                                           observer_unit_vec.x() * CELL_WIDTH / (SPEED_OF_LIGHT * float_X(2.0))
-                                           * omega)
-                                       + util::square(
-                                           observer_unit_vec.y() * CELL_HEIGHT / (SPEED_OF_LIGHT * float_X(2.0))
-                                           * omega)
-                                       + util::square(
-                                           observer_unit_vec.z() * CELL_DEPTH / (SPEED_OF_LIGHT * float_X(2.0))
-                                           * omega)))));
+                        return math::sqrt(N + (N * N - N) * normalizedCoherentAmplification);
+                    }
+
+                private:
+                    //! Precomputed value of normalized coherent amplification for the given frequency
+                    float_X const normalizedCoherentAmplification;
+
+                    /** Calculate normalized coherent amplification for the given frequency
+                     *
+                     * @param omega frequency
+                     * @param observerUnitVec unit vector of observation direction
+                     */
+                    HDINLINE float_X
+                    getNormalizedCoherentAmplification(const float_X omega, vector_64 const& observerUnitVec)
+                    {
+                        return util::square(math::exp(
+                            -0.5_X
+                            * (util::square(observerUnitVec.x() * CELL_WIDTH / (SPEED_OF_LIGHT * 2.0_X) * omega)
+                               + util::square(observerUnitVec.y() * CELL_HEIGHT / (SPEED_OF_LIGHT * 2.0_X) * omega)
+                               + util::square(observerUnitVec.z() * CELL_DEPTH / (SPEED_OF_LIGHT * 2.0_X) * omega))));
                     }
                 };
             } // namespace radFormFactor_Gauss_cell
@@ -188,17 +301,27 @@ namespace picongpu
 
             namespace radFormFactor_incoherent
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor
                 {
+                    /** Construct the form factor functor for the given frequency
+                     *
+                     * @param omega frequency
+                     *              not used for this form factor but requried by RadFormFactorConcept
+                     * @param observerUnitVec unit vector of observation direction,
+                     *                        not used for this form factor but requried by RadFormFactorConcept
+                     */
+                    HDINLINE radFormFactor(const float_X, vector_64 const&)
+                    {
+                    }
+
                     /** Form Factor for an incoherent charge distribution:
                      *
-                     * @param N = macro particle weighting
-                     * @param omega = frequency at which to calculate the  form factor
-                     * @param observer_unit_vec = observation direction
+                     * @param N macro particle weighting
+                     *
                      * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 == \sqrt(weighting) \f$
                      */
-                    HDINLINE float_X
-                    operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+                    HDINLINE float_X operator()(const float_X N) const
                     {
                         return math::sqrt(N);
                     }
@@ -208,17 +331,27 @@ namespace picongpu
 
             namespace radFormFactor_coherent
             {
+                //! Adheres to the RadFormFactorConcept concept
                 struct radFormFactor
                 {
+                    /** Construct the form factor functor for the given frequency
+                     *
+                     * @param omega frequency
+                     *              not used for this form factor but requried by RadFormFactorConcept
+                     * @param observerUnitVec unit vector of observation direction,
+                     *                        not used for this form factor but requried by RadFormFactorConcept
+                     */
+                    HDINLINE radFormFactor(const float_X, vector_64 const&)
+                    {
+                    }
+
                     /** Form Factor for a coherent charge distribution:
                      *
                      * @param N = macro particle weighting
-                     * @param omega = frequency at which to calculate the  form factor
-                     * @param observer_unit_vec = observation direction
+                     *
                      * @return the Form Factor: \f$ \sqrt( | \mathcal{F} |^2 == \sqrt(weighting) \f$
                      */
-                    HDINLINE float_X
-                    operator()(const float_X N, const float_X omega, const vector_X observer_unit_vec) const
+                    HDINLINE float_X operator()(const float_X N) const
                     {
                         return N;
                     }

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -292,14 +292,16 @@ namespace picongpu
 
                                 // create a form factor object for physical correct coherence effects within
                                 // macro-particles
-                                macroParticleFormFactor::radFormFactor const macroParticleFormFactor{};
+                                float_X const omega = freqFkt(o);
+                                macroParticleFormFactor::radFormFactor const macroParticleFormFactor{
+                                    omega,
+                                    precisionCast<float_64>(look)};
 
                                 for(int j = 0; j < counter_s; ++j)
                                 {
-                                    float_X const omega = freqFkt(o);
                                     complex_X const formfactor
                                         = transitionRadiation::calcFormFactor(omega, formfactorExponent_s[j])
-                                        * macroParticleFormFactor(radWeighting_s[j], omega, look);
+                                        * macroParticleFormFactor(radWeighting_s[j]);
 
                                     itrSum += radWeighting_s[j]
                                         * (energyPerp_s[j] * energyPerp_s[j] + energyPara_s[j] * energyPara_s[j]);


### PR DESCRIPTION
This PR is based on the work we did last week during the NERSC hackathon. It is basically a nice way to implement [these changes](https://github.com/sbastrakov/picongpu/tree/topic-hackathonRadiationOptimization).

These changes should not be reducing accuracy. The results are not bitwise-identical due to reordering, but should not be consistently less accurate. Moving to all-float calculation would be of course faster, but that may be a significant loss of accuracy that should be studied before getting applied.

From what we observed at the hackathon, on the benchmark setup #3683 the commits 1 and 2 together (well, almost all must be 2) gave 1.11 x speedup of the radiation kernel. Note that these also make the previously proposed #3696 obsolete. Commit 3 gave further 1.19 x speedup.

Another thing we saw at the hackathon, not covered in this PR, is giving sufficient number of blocks to utilize the whole GPU at as much occupancy as possible, with properly choosing the `--numJobs` parameter.

@PrometheusPi checked the original hacky version and found it to work. This should produce the same results, but I didn't test it yet, as I do not have a ready setup. @PrometheusPi could you try it out?

**For reviewers**: I think it is easier to review commit-by-commit.
