### PR TITLE
Record probe data with all pusher Pusher

### DIFF
--- a/docs/source/usage/workflows/probeParticles.rst
+++ b/docs/source/usage/workflows/probeParticles.rst
@@ -16,7 +16,7 @@ Self-consistently interacting particles are usually called :ref:`tracer particle
 Workflow
 """"""""
 
-* ``speciesDefinition.param``: create a species specifically for probes and add ``probeE`` and ``probeB`` attributes to it for storing interpolated fields
+* ``speciesDefinition.param``: create a stationary probe species, add ``probeE`` and ``probeB`` attributes to it for storing interpolated fields
 
 .. code-block:: cpp
 
@@ -93,7 +93,7 @@ and add it to ``VectorAllSpecies``:
        >
    >;
 
-* ``fileOutput.param``: make sure the the tracer particles are part of ``FileOutputParticles``
+* ``fileOutput.param``: make sure the the probe particles are part of ``FileOutputParticles``
 
 .. code-block:: cpp
 
@@ -114,3 +114,4 @@ Known Limitations
 .. warning::
 
    If the probe particles are dumped in the file output, the instantaneous fields they recorded will be one time step behind the last field update (since our runOneStep pushed the particles first and then calls the field solver).
+   Adding the attributes ``probeE`` or ``probeB`` to a species will increase the particle memory footprint only for the corresponding species by ``3 * sizeof(float_X)`` byte per attribute and particle.

--- a/docs/source/usage/workflows/tracerParticles.rst
+++ b/docs/source/usage/workflows/tracerParticles.rst
@@ -8,13 +8,46 @@ Tracer Particles
 Tracer particles are like :ref:`probe particles <usage-workflows-probeParticles>`, but interact self-consistenly with the simulation.
 They are usually used to visualize *representative* particle trajectories of a larger distribution.
 
+In PIConGPU each species can be a tracer particle species, which allows tracking fields along the particle trajectory.
+
 Workflow
 """"""""
 
-* ``speciesDefinition.param``: create a species specifically for tracer particles
+* ``speciesDefinition.param``:
 
-  * add the particle attribute ``particleId`` to your species' ``Particles< ... >`` class (third argument, ``T_Attributes``)
-  * optional: add ``fieldE`` and ``fieldB`` attributes to the species to store fields as in :ref:`probes <usage-workflows-probeParticles>` 
+Add the particle attribute ``particleId`` to your species to give each particle a unique id.
+The id is optional and only required if the particle should be tracked over time.
+Adding ``probeE`` creates a tracer species stores the interpolated electric field seen by the tracer particle.
+
+  .. code-block:: cpp
+
+      using ParticleFlagsTracerElectrons = MakeSeq_t<
+          particlePusher< particles::pusher::Boris >,
+          shape< UsedParticleShape >,
+          interpolation< UsedField2Particle >,
+          currentSolver::EmZ<UsedParticleCurrentSolver>
+      >;
+
+      using TracerElectron = Particles<
+          PMACC_CSTRING( "e_tracer" ),
+          ParticleFlagsTracerElectrons,
+          MakeSeq_t<
+              position< position_pic >,
+              momentum,
+              weighting,
+              particleId,
+              probeE
+          >
+      >;
+
+and add it to ``VectorAllSpecies``:
+
+.. code-block:: cpp
+
+   using VectorAllSpecies = MakeSeq_t<
+       TracerElectron,
+       // ...
+   >;
 
 * create tracer particles by either
 
@@ -22,7 +55,14 @@ Workflow
   * ``speciesInitialization.param``: assigning the target (electron) species of an ion's ionization routine to the tracer species or
   * ``speciesInitialization.param``: moving some particles of an already initialized species to the tracer species (upcoming)
 
-* ``fileOutput.param``: output the tracer particles
+* ``fileOutput.param``: make sure the the tracer particles are part of ``FileOutputParticles``
+
+.. code-block:: cpp
+
+   // either all via VectorAllSpecies or just select
+   using FileOutputParticles = MakeSeq_t< TracerElectron >;
+
+The electron tracer species is equivalent to normal electrons, the initial density distribution can be configured in :ref:`speciesInitialization.param <usage-params-core>`.
 
 Known Limitations
 """""""""""""""""

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -73,10 +73,16 @@ namespace picongpu
     //! Voronoi cell of the macro particle
     value_identifier(int16_t, voronoiCellId, -1);
 
-    //! interpolated electric field with respect to particle shape
+    /** interpolated electric field with respect to particle shape
+     *
+     * Attribute can be added to any species.
+     */
     value_identifier(float3_X, probeE, float3_X::create(0.));
 
-    //! interpolated electric field with respect to particle shape
+    /** interpolated magnetic field with respect to particle shape
+     *
+     * Attribute can be added to any species.
+     */
     value_identifier(float3_X, probeB, float3_X::create(0.));
 
     /** masking a particle for radiation

--- a/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
@@ -25,6 +25,8 @@
 #include "picongpu/traits/attribute/GetCharge.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
 
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 namespace picongpu
 {
@@ -70,6 +72,15 @@ namespace picongpu
 
                 // normalize input SI values to
                 const float3_X eField(UnitlessParam::AMPLITUDEx, UnitlessParam::AMPLITUDEy, UnitlessParam::AMPLITUDEz);
+                const auto bField = functorBField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 /* ToDo: Refactor to ensure a smooth and slow increase of eField with time
                  * which may help to reduce radiation due to acceleration, if present.

--- a/include/picongpu/particles/pusher/particlePusherAxel.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAxel.hpp
@@ -25,6 +25,8 @@
 #include "picongpu/traits/attribute/GetCharge.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
 
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 // That is a sum over two out of 3 coordinates, as described in the script
 // above. (See Ref.!)
@@ -82,8 +84,17 @@ namespace picongpu
                 using MomType = momentum::type;
                 MomType mom = particle[momentum_];
 
-                auto bField = functorBField(pos);
-                auto eField = functorEField(pos);
+                const auto bField = functorBField(pos);
+                const auto eField = functorEField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 Gamma gammaCalc;
                 Velocity velocityCalc;

--- a/include/picongpu/particles/pusher/particlePusherBoris.hpp
+++ b/include/picongpu/particles/pusher/particlePusherBoris.hpp
@@ -24,6 +24,8 @@
 #include "picongpu/traits/attribute/GetCharge.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
 
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 namespace picongpu
 {
@@ -53,8 +55,16 @@ namespace picongpu
                 using MomType = momentum::type;
                 MomType const mom = particle[momentum_];
 
-                auto bField = functorBField(pos);
-                auto eField = functorEField(pos);
+                const auto bField = functorBField(pos);
+                const auto eField = functorEField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 const float_X QoM = charge / mass;
 

--- a/include/picongpu/particles/pusher/particlePusherFree.hpp
+++ b/include/picongpu/particles/pusher/particlePusherFree.hpp
@@ -24,6 +24,8 @@
 
 #include "picongpu/traits/attribute/GetMass.hpp"
 
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 namespace picongpu
 {
@@ -51,6 +53,17 @@ namespace picongpu
 
                 using MomType = momentum::type;
                 MomType const mom = particle[momentum_];
+
+                const auto bField = functorBField(pos);
+                const auto eField = functorEField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 Velocity velocity;
                 const MomType vel = velocity(mom, mass);

--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -24,6 +24,8 @@
 #include "picongpu/traits/attribute/GetCharge.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
 
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 namespace picongpu
 {
@@ -69,8 +71,16 @@ namespace picongpu
                 using MomType = momentum::type;
                 MomType const mom = particle[momentum_];
 
-                auto bField = functorBField(pos);
-                auto eField = functorEField(pos);
+                const auto bField = functorBField(pos);
+                const auto eField = functorEField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 float_X const deltaT = DELTA_T;
 

--- a/include/picongpu/particles/pusher/particlePusherPhoton.hpp
+++ b/include/picongpu/particles/pusher/particlePusherPhoton.hpp
@@ -22,6 +22,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 namespace picongpu
 {
@@ -46,6 +48,17 @@ namespace picongpu
             {
                 using MomType = momentum::type;
                 MomType const mom = particle[momentum_];
+
+                const auto bField = functorBField(pos);
+                const auto eField = functorEField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 const float_X mom_abs = math::abs(mom);
                 const MomType vel = mom * (SPEED_OF_LIGHT / mom_abs);

--- a/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -27,7 +27,8 @@
 
 #include <pmacc/math/RungeKutta.hpp>
 #include <pmacc/math/Vector.hpp>
-
+#include <pmacc/meta/InvokeIf.hpp>
+#include <pmacc/traits/HasIdentifier.hpp>
 
 namespace picongpu
 {
@@ -73,6 +74,17 @@ namespace picongpu
                 using TypeWeighting = weighting::type;
 
                 TypeMomentum mom = particle[momentum_];
+
+                const auto bField = functorBField(pos);
+                const auto eField = functorEField(pos);
+
+                // update probe field if particle contains required attributes
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeB>::type::value>(
+                    [&bField](auto&& par) { par[probeB_] = bField; },
+                    particle);
+                pmacc::meta::invokeIf<pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value>(
+                    [&eField](auto&& par) { par[probeE_] = eField; },
+                    particle);
 
                 const float_X deltaT = DELTA_T;
                 const uint32_t dimMomentum = GetNComponents<TypeMomentum>::value;

--- a/include/pmacc/meta/InvokeIf.hpp
+++ b/include/pmacc/meta/InvokeIf.hpp
@@ -1,0 +1,124 @@
+/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <utility>
+
+namespace pmacc
+{
+    namespace meta
+    {
+        namespace detail
+        {
+            /** Conditional functor execution
+             *
+             * @tparam T_condition condition for executing a functor
+             */
+            template<bool T_condition>
+            struct IfElse;
+
+            /** Specialization if condition is true
+             *
+             * Execute trueFunctor passed to operator()
+             */
+            template<>
+            struct IfElse<true>
+            {
+                template<typename T_ConditionTrueFunctor, typename T_ConditionFalseFunctor, typename... T_Args>
+                HDINLINE void operator()(
+                    T_ConditionTrueFunctor&& trueFunctor,
+                    T_ConditionFalseFunctor&&,
+                    T_Args&&... args) const
+                {
+                    trueFunctor(std::forward<T_Args>(args)...);
+                }
+            };
+
+            /** Specialization if condition is false
+             *
+             * Execute falseFunctor passed to operator()
+             */
+            template<>
+            struct IfElse<false>
+            {
+                template<typename T_ConditionTrueFunctor, typename T_ConditionFalseFunctor, typename... T_Args>
+                HDINLINE void operator()(
+                    T_ConditionTrueFunctor&&,
+                    T_ConditionFalseFunctor&& falseFunctor,
+                    T_Args&&... args) const
+                {
+                    falseFunctor(std::forward<T_Args>(args)...);
+                }
+            };
+        } // namespace detail
+
+        /** Conditional functor invocation
+         *
+         * Evaluate and invoke a functor based on the conditional compile-time argument.
+         * The functor implementations must have valid C++ syntax but is only evaluated on invocation.
+         *
+         * @tparam T_condition invoke trueFunctor if the condition is true, else no operation is performed
+         * @tparam T_ConditionTrueFunctor functor type, the functor is only evaluated if T_condition is true
+         * @tparam T_Args types of the arguments forwarded to the trueFunctor
+         * @param trueFunctor functor instance which is called with the arguments args if T_condition is true
+         * @param args arguments forwarded to the functor
+         */
+        template<bool T_condition, typename T_ConditionTrueFunctor, typename... T_Args>
+        HDINLINE void invokeIf(T_ConditionTrueFunctor&& trueFunctor, T_Args&&... args)
+        {
+            detail::IfElse<T_condition>{}(
+                trueFunctor,
+                /* T_Args instead of auto for arguments is required to avoid a nvcc compiler bug shown when compiling
+                 * for A100. https://github.com/ComputationalRadiationPhysics/picongpu/pull/3714#issuecomment-914349936
+                 */
+                [](T_Args&&...) {},
+                std::forward<T_Args>(args)...);
+        }
+
+        /** Conditional functor invocation
+         *
+         * Evaluate and invoke a functor based on the conditional compile-time argument.
+         * The functor implementations must have valid C++ syntax but is only evaluated on invocation.
+         *
+         * @tparam T_condition invoke trueFunctor if the condition is true, else falseFunctor
+         * @tparam T_ConditionTrueFunctor functor type, the functor is only evaluated if T_condition is true
+         * @tparam T_ConditionFalseFunctor functor type, the functor is only evaluated if T_condition is false
+         * @tparam T_Args types of the arguments forwarded to the functor
+         * @param trueFunctor functor instance which is called with the arguments args if T_condition is true
+         * @param falseFunctor functor instance which is called with the arguments args if T_condition is false
+         * @param args arguments forwarded to the functor
+         */
+        template<
+            bool T_condition,
+            typename T_ConditionTrueFunctor,
+            typename T_ConditionFalseFunctor,
+            typename... T_Args>
+        HDINLINE void invokeIfElse(
+            T_ConditionTrueFunctor&& trueFunctor,
+            T_ConditionFalseFunctor&& falseFunctor,
+            T_Args&&... args)
+        {
+            detail::IfElse<T_condition>{}(trueFunctor, falseFunctor, std::forward<T_Args>(args)...);
+        }
+
+    } // namespace meta
+} // namespace pmacc


### PR DESCRIPTION
Add functionality to all pushers to record particle attribute probeB and probeE data.
PMacc: add meta function `executeIf` and `executeIfElse`.

All pushers record field data if a particle as the attribute `probeB` or `probeE`. 
There is no need anymore to add attributes, depending on which attributes are available to corresponding data will be recorded.

# Todo

 - [x] add doxygen to `executeIf` and `executeIfElse`
 - [x] update PIConGPU probe documentation
 - [x] rebase after #3715 is merged