### PR TITLE
CI: fix clang-format and ROCm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ pull-request-validation:
     - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
     - echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" | tee -a /etc/apt/sources.list
     - apt update
-    - apt install -y clang-format-11
+    - DEBIAN_FRONTEND=noninteractive apt install -y clang-format-11
     # Check C++ code style
     - source $CI_PROJECT_DIR/share/ci/check_cpp_code_style.sh
   tags:

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -17,7 +17,9 @@
     - ln -s /opt/rocm/llvm/bin/clang++ /opt/rocm/llvm/bin/clang++-12
     - rocm-smi
     - hipcc --version
-    - apt update
+    # AMD container keys are outdated and must be updated
+    - wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+    - apt -y update
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -241,6 +241,10 @@ for i in range(rounds):
             print("    BOOST_VERSION: '" + boost_version + "'")
             print("    CXX_VERSION: '" + compiler + "'")
             print("  before_script:")
+            if backend == "hip":
+                print("    - wget -q -O - "
+                      "https://repo.radeon.com/rocm/rocm.gpg.key | "
+                      "sudo apt-key add -")
             print("    - apt-get update -qq")
             print("    - apt-get install -y -qq libopenmpi-dev "
                   "openmpi-bin openssh-server")


### PR DESCRIPTION
fix #3713

- avoids that apt-get waits for user interaction. (fix clang-format)
- fix outdated ROCm keys