### PR TITLE
pmacc ExchangeTypeToRank changed from protected to public

### DIFF
--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -271,6 +271,13 @@ namespace pmacc
             return result;
         }
 
+        /*! converts an exchangeType (e.g. RIGHT) to an MPI-rank
+         */
+        int ExchangeTypeToRank(uint32_t type)
+        {
+            return ranks[type];
+        }
+
 
     protected:
         /* Set the first found non charactor or number to 0 (nullptr)
@@ -432,13 +439,6 @@ namespace pmacc
 
                 // std::cout << "rank: " << rank << " " << i << " : " << ranks[i] << std::endl;
             }
-        }
-
-        /*! converts an exchangeType (e.g. RIGHT) to an MPI-rank
-         */
-        int ExchangeTypeToRank(uint32_t type)
-        {
-            return ranks[type];
         }
 
     private:


### PR DESCRIPTION
Changed visibilit of pmacc function `ExchangeTypeToRank` from protected to public.
This change is needed for later features in the `IsaacPlugin.hpp`.