### PR TITLE
Isaac plugin vector field vis compatility and benchmarking

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -288,6 +288,8 @@ TBG_restartLoop="--checkpoint.restart.loop 5000"
 #   By default the ISAAC Plugin tries to reconnect if the sever is not available
 #   at start or the servers crashes. This can be deactivated with this option
 #     --isaac.reconnect false
+#   Enable and write benchmark results into the given file.
+#     --isaac.timingsFilename benchRsults.txt
 TBG_isaac="--isaac.period 1 --isaac.name !TBG_jobName --isaac.url <server_url>"
 TBG_isaac_quality="--isaac.quality 90"
 TBG_isaac_resolution="--isaac.width 1024 --isaac.height 768"

--- a/docs/source/usage/plugins/isaac.rst
+++ b/docs/source/usage/plugins/isaac.rst
@@ -13,24 +13,28 @@ The plugin is available as soon as the :ref:`ISAAC library <install-dependencies
 .cfg file
 ^^^^^^^^^
 
-=========================== =========================================================================
-Command line option          Description
-=========================== =========================================================================
-``--isaac.period N``        Sets up, that every *N* th timestep an image will be rendered.
-                            This parameter can be changed later with the controlling client.
-``--isaac.name NAME``       Sets the *NAME* of the simulation, which is shown at the client.
-``--isaac.url URL``         *URL* of the required and running isaac server.
-                            Host names and IPs are supported.
-``--isaac.port PORT``       *PORT* of the isaac server.
-                            The default value is ``2458`` (for the in-situ plugins), but may be needed to be changed for tunneling reasons or if more than one server shall run on the very same hardware.
-``--isaac.width WIDTH``     Setups the *WIDTH* and *HEIGHT* of the created image(s).
-``--isaac.height HEIGHT``   Default is ``1024x768``.
-``--isaac.direct_pause``    If activated ISAAC will pause directly after the simulation started.
-                            Useful for presentations or if you don't want to miss the beginning of the simulation.
-``--isaac.quality QUALITY`` Sets the *QUALITY* of the images, which are compressed right after creation.
-                            Values between ``1`` and ``100`` are possible.
-                            The default is ``90``, but ``70`` does also still produce decent results.
-=========================== =========================================================================
+================================= ============================================================================
+Command line option               Description
+================================= ============================================================================
+``--isaac.period N``              Sets up, that every *N* th timestep an image will be rendered.
+                                  This parameter can be changed later with the controlling client.
+``--isaac.name NAME``             Sets the *NAME* of the simulation, which is shown at the client.
+``--isaac.url URL``               *URL* of the required and running isaac server.
+                                  Host names and IPs are supported.
+``--isaac.port PORT``             *PORT* of the isaac server.
+                                  The default value is ``2458`` (for the in-situ plugins), but may be needed
+                                  to be changed for tunneling reasons or if more than one server shall run on
+                                  the very same hardware.
+``--isaac.width WIDTH``           Setups the *WIDTH* and *HEIGHT* of the created image(s).
+``--isaac.height HEIGHT``         Default is ``1024x768``.
+``--isaac.direct_pause``          If activated ISAAC will pause directly after the simulation started.
+                                  Useful for presentations or if you don't want to miss the beginning of
+                                  the simulation.
+``--isaac.quality QUALITY``       Sets the *QUALITY* of the images, which are compressed right after creation.
+                                  Values between ``1`` and ``100`` are possible.
+                                  The default is ``90``, but ``70`` does also still produce decent results.
+``--isaac.timingsFilename NAME``  Enable and write benchmark results into the given file.
+================================= ============================================================================
 
 The most important settings for ISAAC are ``--isaac.period``, ``--isaac.name`` and ``--isaac.url``.
 A possible addition for your submission ``tbg`` file could be ``--isaac.period 1 --isaac.name !TBG_jobName --isaac.url YOUR_SERVER``, where the tbg variables ``!TBG_jobName`` is used as name and ``YOUR_SERVER`` needs to be set up by yourself.

--- a/include/picongpu/param/isaac.param
+++ b/include/picongpu/param/isaac.param
@@ -39,10 +39,14 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+
 namespace picongpu
 {
     namespace isaacP
     {
+        namespace deriveField = particles::particleToGrid;
+
         /** Intermediate list of native particle species of PIConGPU which shall be
          *  visualized. */
         using Particle_Seq = VectorAllSpecies;

--- a/include/picongpu/param/isaac.param
+++ b/include/picongpu/param/isaac.param
@@ -68,6 +68,10 @@ namespace picongpu
          *  the join of Native_Seq and Density_Seq. */
         using Fields_Seq = MakeSeq_t<Native_Seq, Density_Seq>;
 
+        /** Compile time sequence of all fields which shall be visualized. Basically
+         *  the join of Native_Seq and Density_Seq. */
+        using VectorFields_Seq = Native_Seq;
+
 
     } // namespace isaacP
 } // namespace picongpu

--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -19,7 +19,8 @@ sed -i 's/inline/GLM_FUNC_DECL/g' $GLM_ROOT/glm/gtc/type_ptr.inl
 cd $CI_PROJECT_DIR
 git clone https://github.com/ComputationalRadiationPhysics/isaac.git
 cd isaac
-git checkout 822f3c240a3bbdf3962984f4fc43f2ea7e75f2eb
+# issac version with bew LIC kernel https://github.com/ComputationalRadiationPhysics/isaac/pull/143
+git checkout 773330664ac77e43870576de29e1121b3b67a898
 mkdir build_isaac
 cd build_isaac
 cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/isaac.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/isaac.param
@@ -39,10 +39,14 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+
 namespace picongpu
 {
     namespace isaacP
     {
+        namespace deriveField = particles::particleToGrid;
+
         /** Intermediate list of native particle species of PIConGPU which shall be
          *  visualized. */
         using Particle_Seq = MakeSeq_t<>;
@@ -53,11 +57,24 @@ namespace picongpu
 
         /** Intermediate list of particle species, from which density fields
          *  shall be created at runtime to visualize them. */
-        using Density_Seq = MakeSeq_t<>;
+        using Density_Seq = deriveField::CreateEligible_t<Particle_Seq, deriveField::derivedAttributes::Density>;
+        /** Intermediate list of filtered particle species, from which density fields
+         *  shall be created at runtime to visualize them.
+         *
+         *  You can create such densities from filtered particles by passing a particle
+         *  filter as the third template argument (`filter::All` by default). Don't forget
+         *  to add your filtered densities to the `Fields_Seq` below.
+         *  */
+        //  using Density_Seq_Filtered = deriveField::CreateEligible_t<Particle_Seq,
+        //      deriveField::derivedAttributes::Density, filter::All>;
 
         /** Compile time sequence of all fields which shall be visualized. Basically
          *  the join of Native_Seq and Density_Seq. */
         using Fields_Seq = MakeSeq_t<>;
+
+        /** Compile time sequence of all fields which shall be visualized. Basically
+         *  the join of Native_Seq and Density_Seq. */
+        using VectorFields_Seq = MakeSeq_t<>;
 
 
     } // namespace isaacP

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/isaac.param
@@ -39,18 +39,42 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+
 namespace picongpu
 {
     namespace isaacP
     {
+        namespace deriveField = particles::particleToGrid;
+
         /** Intermediate list of native particle species of PIConGPU which shall be
          *  visualized. */
         using Particle_Seq = MakeSeq_t<>;
 
+        /** Intermediate list of native fields of PIConGPU which shall be
+         *  visualized. */
+        using Native_Seq = MakeSeq_t<>;
+
+        /** Intermediate list of particle species, from which density fields
+         *  shall be created at runtime to visualize them. */
+        using Density_Seq = deriveField::CreateEligible_t<Particle_Seq, deriveField::derivedAttributes::Density>;
+        /** Intermediate list of filtered particle species, from which density fields
+         *  shall be created at runtime to visualize them.
+         *
+         *  You can create such densities from filtered particles by passing a particle
+         *  filter as the third template argument (`filter::All` by default). Don't forget
+         *  to add your filtered densities to the `Fields_Seq` below.
+         *  */
+        //  using Density_Seq_Filtered = deriveField::CreateEligible_t<Particle_Seq,
+        //      deriveField::derivedAttributes::Density, filter::All>;
 
         /** Compile time sequence of all fields which shall be visualized. Basically
          *  the join of Native_Seq and Density_Seq. */
         using Fields_Seq = MakeSeq_t<>;
+
+        /** Compile time sequence of all fields which shall be visualized. Basically
+         *  the join of Native_Seq and Density_Seq. */
+        using VectorFields_Seq = MakeSeq_t<>;
 
 
     } // namespace isaacP

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/isaac.param
@@ -39,18 +39,42 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+
 namespace picongpu
 {
     namespace isaacP
     {
+        namespace deriveField = particles::particleToGrid;
+
         /** Intermediate list of native particle species of PIConGPU which shall be
          *  visualized. */
         using Particle_Seq = MakeSeq_t<>;
 
+        /** Intermediate list of native fields of PIConGPU which shall be
+         *  visualized. */
+        using Native_Seq = MakeSeq_t<>;
+
+        /** Intermediate list of particle species, from which density fields
+         *  shall be created at runtime to visualize them. */
+        using Density_Seq = deriveField::CreateEligible_t<Particle_Seq, deriveField::derivedAttributes::Density>;
+        /** Intermediate list of filtered particle species, from which density fields
+         *  shall be created at runtime to visualize them.
+         *
+         *  You can create such densities from filtered particles by passing a particle
+         *  filter as the third template argument (`filter::All` by default). Don't forget
+         *  to add your filtered densities to the `Fields_Seq` below.
+         *  */
+        //  using Density_Seq_Filtered = deriveField::CreateEligible_t<Particle_Seq,
+        //      deriveField::derivedAttributes::Density, filter::All>;
 
         /** Compile time sequence of all fields which shall be visualized. Basically
          *  the join of Native_Seq and Density_Seq. */
         using Fields_Seq = MakeSeq_t<>;
+
+        /** Compile time sequence of all fields which shall be visualized. Basically
+         *  the join of Native_Seq and Density_Seq. */
+        using VectorFields_Seq = MakeSeq_t<>;
 
 
     } // namespace isaacP

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/isaac.param
@@ -39,18 +39,42 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
+
 namespace picongpu
 {
     namespace isaacP
     {
+        namespace deriveField = particles::particleToGrid;
+
         /** Intermediate list of native particle species of PIConGPU which shall be
          *  visualized. */
         using Particle_Seq = MakeSeq_t<>;
 
+        /** Intermediate list of native fields of PIConGPU which shall be
+         *  visualized. */
+        using Native_Seq = MakeSeq_t<>;
+
+        /** Intermediate list of particle species, from which density fields
+         *  shall be created at runtime to visualize them. */
+        using Density_Seq = deriveField::CreateEligible_t<Particle_Seq, deriveField::derivedAttributes::Density>;
+        /** Intermediate list of filtered particle species, from which density fields
+         *  shall be created at runtime to visualize them.
+         *
+         *  You can create such densities from filtered particles by passing a particle
+         *  filter as the third template argument (`filter::All` by default). Don't forget
+         *  to add your filtered densities to the `Fields_Seq` below.
+         *  */
+        //  using Density_Seq_Filtered = deriveField::CreateEligible_t<Particle_Seq,
+        //      deriveField::derivedAttributes::Density, filter::All>;
 
         /** Compile time sequence of all fields which shall be visualized. Basically
          *  the join of Native_Seq and Density_Seq. */
         using Fields_Seq = MakeSeq_t<>;
+
+        /** Compile time sequence of all fields which shall be visualized. Basically
+         *  the join of Native_Seq and Density_Seq. */
+        using VectorFields_Seq = MakeSeq_t<>;
 
 
     } // namespace isaacP


### PR DESCRIPTION
- Added compatibility to the isaac vector field visualization and usage of vector field sources
- Benchmarking code example, can be enabled in .cfg files with the parameter `--isaac.timingsFilename [PATH/FILENAME.csv]`


Known issues:
- Moving window creates artifacts (for LIC visualization) at front GPUs as the seeding positions for the vector field visualization are stationary

- [x] Requires the picongpu PR https://github.com/ComputationalRadiationPhysics/picongpu/pull/3718 to be merged
- [x] Requires the isaac PR https://github.com/ComputationalRadiationPhysics/isaac/pull/143 to be merged

