### PR TITLE
change wrong default

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -92,7 +92,7 @@ TBG_periodic="--periodic 1 0 1"
 
 
 # Set absorber type of absorbing boundaries
-# Supported values: exponential (default), pml
+# Supported values: exponential, pml (default)
 TBG_absorber="--fieldAbsorber pml"
 
 # Enables moving window (sliding) in your simulation


### PR DESCRIPTION
The pull request #3672 introduces PMLs as default absorber. This was not updated in the `TBG_macros.cfg`. This pull request adjusts the documentation accordingly. 