### PR TITLE
switch to new 'chdir' SLURM command

### DIFF
--- a/etc/picongpu/taurus-tud/k80.tpl
+++ b/etc/picongpu/taurus-tud/k80.tpl
@@ -33,7 +33,7 @@
 #SBATCH --gres=gpu:!TBG_gpusPerNode
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress
-#SBATCH --workdir=!TBG_dstPath
+#SBATCH --chdir=!TBG_dstPath
 
 #SBATCH -o stdout
 #SBATCH -e stderr


### PR DESCRIPTION
This pull request fixes the first part of #3722 that was introduced with #3181. 
It changes the outdated `--workdir` command to `--chdir`. 