### PR TITLE
Fix outdated exception message for openPMD plugin with ADIOS1

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -156,12 +156,10 @@ namespace picongpu
                 {
                     throw std::runtime_error(R"END(
 Using ADIOS1 through PIConGPU's openPMD plugin is not supported.
-Please pick either of the following:
-* Use the ADIOS plugin.
-* Use the openPMD plugin with another backend, such as ADIOS2.
-  If the openPMD API has been compiled with support for ADIOS2, the openPMD API
-  will automatically prefer using ADIOS2 over ADIOS1.
-  Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
+Please use the openPMD plugin with another backend, such as ADIOS2.
+If the openPMD API has been compiled with support for ADIOS2, the openPMD API
+will automatically prefer using ADIOS2 over ADIOS1.
+Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 )END");
                 }
                 if(at == ::openPMD::Access::CREATE)


### PR DESCRIPTION
The check itself and the fact exception is thrown are fine.
Just the old message referred to the ADIOS1 plugin, which no longer exists.