### PR TITLE
Fix warning: Attribute /date cannot be overwritten (openPMD plugin)

### DIFF
--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -139,8 +139,12 @@ namespace picongpu
                     softwareVersion << "-" << PICONGPU_VERSION_LABEL;
                 series.setSoftware(software, softwareVersion.str());
 
-                const std::string date = helper::getDateString("%F %T %z");
-                series.setDate(date);
+                // don't write this if a previous run already wrote it
+                if(!series.containsAttribute("date"))
+                {
+                    const std::string date = helper::getDateString("%F %T %z");
+                    series.setDate(date);
+                }
 
                 ::openPMD::Container<::openPMD::Mesh>& meshes = iteration.meshes;
 


### PR DESCRIPTION
Background: Using steps in openPMD/ADIOS2 with BP files is currently experimental and will stay so for a while (likely until we switch to an entirely new ADIOS2 schema). Until then, we should try to get PIConGPU to work in combination with steps without spamming warnings to stderr.

To fix the warning about attributes from previous steps not being modifiable, write the `date` attribute only once. (The other attributes are not affected since openPMD compares the attributes against those already specified, and does not write them anew if nothing changes)

I've already tested this and verified that the warnings do no longer occur.

This also fixes some low-key unspecified behavior: The `date` attribute is global in openPMD. If you specify it time after time again, there is no guarantee which instance you get. With this fix, you get the timestamp of the first iteration written with the plugin, i.e. simulation start time.