### PR TITLE
ISAAC fix for particle vis and vector field vis in moving window simulation

### DIFF
--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -19,8 +19,9 @@ sed -i 's/inline/GLM_FUNC_DECL/g' $GLM_ROOT/glm/gtc/type_ptr.inl
 cd $CI_PROJECT_DIR
 git clone https://github.com/ComputationalRadiationPhysics/isaac.git
 cd isaac
-# issac version with bew LIC kernel https://github.com/ComputationalRadiationPhysics/isaac/pull/143
-git checkout 773330664ac77e43870576de29e1121b3b67a898
+# ISAAC version with new LIC kernel https://github.com/ComputationalRadiationPhysics/isaac/pull/143
+# and moving window fix https://github.com/ComputationalRadiationPhysics/isaac/pull/148
+git checkout b8c66ba851e9dfcc48e7bc1ab677828e3adbd22f
 mkdir build_isaac
 cd build_isaac
 cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT


### PR DESCRIPTION
Fixes moving window issues https://github.com/ComputationalRadiationPhysics/isaac/issues/146#issue-968862927 and https://github.com/ComputationalRadiationPhysics/isaac/issues/145#issue-968860368 by keeping the local volume sizes constant and only adjust the local volume position. 
Clipping to the global volume is done by ISAAC with the ISAAC PR https://github.com/ComputationalRadiationPhysics/isaac/pull/148#issue-716605360, which is required.

Update CI to use ISAAC dev branch continuing: https://github.com/ComputationalRadiationPhysics/isaac/pull/148#issue-716605360
