### PR TITLE
Compatibility check for laser and field solver

### DIFF
--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -87,6 +87,12 @@ namespace picongpu
         /** Laser init in a single xz plane */
         struct LaserPhysics
         {
+            //! Return if a laser is enabled for this simulation (None laser counts as not enabled)
+            static bool isEnabled()
+            {
+                return laserProfiles::Selected::INIT_TIME > 0.0_X;
+            }
+
             void operator()(uint32_t currentStep) const
             {
                 /* The laser can be initialized in the plane of the first cell or

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -109,7 +109,7 @@ namespace picongpu
                         auto& exponentialImpl = absorberImpl->asExponentialImpl();
                         exponentialImpl.run(currentStep, fieldE->getDeviceDataBox());
                     }
-                    if(laserProfiles::Selected::INIT_TIME > 0.0_X)
+                    if(LaserPhysics::isEnabled())
                         LaserPhysics{}(currentStep);
 
                     // Incident field solver update does not use exchanged E, so does not have to wait for it

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -28,6 +28,7 @@
 #include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/FDTD/FDTD.def"
 #include "picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel"
+#include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/absorber/pml/Pml.hpp"
 #include "picongpu/fields/cellType/Yee.hpp"
@@ -58,6 +59,7 @@ namespace picongpu
                 FDTD(MappingDesc const cellDescription) : cellDescription(cellDescription)
                 {
                     CFLChecker<FDTD>{}();
+                    LaserChecker<FDTD>{}();
                     DataConnector& dc = Environment<>::get().DataConnector();
                     fieldE = dc.get<FieldE>(FieldE::getName(), true);
                     fieldB = dc.get<FieldB>(FieldB::getName(), true);

--- a/include/picongpu/fields/MaxwellSolver/LaserChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/LaserChecker.hpp
@@ -1,0 +1,53 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Functor to check the laser compatibility to the given field solver
+             *
+             * Performs a run-time check and prints a warning if failed.
+             *
+             * @tparam T_FieldSolver field solver type
+             * @tparam T_Defer technical parameter to defer evaluation;
+             *                 is needed for specializations with non-template solver classes
+             */
+            template<typename T_FieldSolver, typename T_Defer = void>
+            struct LaserChecker
+            {
+                /** Check the laser compatibility, prints a warning when failed.
+                 *
+                 * The default implementation assumes the solver is compatible to any enabled laser.
+                 */
+                void operator()() const
+                {
+                }
+            };
+
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
@@ -22,6 +22,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/fields/LaserPhysics.hpp"
+#include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp"
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.def"
 
@@ -29,6 +31,33 @@
 
 #include <cstdint>
 
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Specialization of the laser compatibility checker for for the Lehe solver
+             *
+             * @tparam T_CherenkovFreeDir the direction (axis) which should be free of cherenkov radiation
+             */
+            template<uint32_t T_cherenkovFreeDir>
+            struct LaserChecker<Lehe<T_cherenkovFreeDir>>
+            {
+                //! This solver is not compatible to any enabled laser
+                void operator()() const
+                {
+                    if(LaserPhysics::isEnabled())
+                        log<picLog::PHYSICS>(
+                            "Warning: chosen field solver is not compatible to laser\n"
+                            "   The generated laser will be less accurate.\n"
+                            "   For an accurate generation, either use field background or switch to Yee solver");
+                }
+            };
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu
 
 namespace pmacc
 {

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
+#include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/None/None.def"
 #include "picongpu/fields/cellType/Yee.hpp"
 #include "picongpu/traits/GetMargin.hpp"
@@ -47,6 +48,7 @@ namespace picongpu
                 {
                     // Note: the default CFL checker is sufficient, thus it is not specialized for None
                     CFLChecker<None>{}();
+                    LaserChecker<None>{}();
                 }
 
                 void update_beforeCurrent(uint32_t)


### PR DESCRIPTION
If they are not compatible, a warning will be printed. Currently only the classic `Yee` solver is compatible to lasers.

The fix was triggered by #3726. Now such a usage would yield a warning.