### PR TITLE
Extend TBG_macros and help string for changing field absorber

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -91,8 +91,9 @@ TBG_gridDist="--gridDist '64{2}' '64,32{2},64'"
 TBG_periodic="--periodic 1 0 1"
 
 
-# Set absorber type of absorbing boundaries
-# Supported values: exponential, pml (default)
+# Set absorber type of absorbing boundaries.
+# Supported values: exponential, pml (default).
+# When changing absorber type, one should normally adjust NUM_CELLS in fieldAbsorber.param
 TBG_absorber="--fieldAbsorber pml"
 
 # Enables moving window (sliding) in your simulation

--- a/include/picongpu/simulation/stage/FieldAbsorber.hpp
+++ b/include/picongpu/simulation/stage/FieldAbsorber.hpp
@@ -54,7 +54,7 @@ namespace picongpu
                         po::value<std::string>(&kindName),
                         std::string(
                             "Field absorber kind [exponential, pml] default: " + kindName
-                            + "Other parameters are set in fieldAbsorber.param")
+                            + ".\nWhen changing absorber, adjust parameters in fieldAbsorber.param")
                             .c_str());
                 }
 


### PR DESCRIPTION
Readthedocs already had recommendations on absorber thickness for both kinds. This PR extends `TBG_macros` and the help string with recommendation to adjust `fieldAbsorber.param` when changing absober kind.