### PR TITLE
Update plugin requirements in readthedocs

### DIFF
--- a/docs/source/usage/plugins/chargeConservation.rst
+++ b/docs/source/usage/plugins/chargeConservation.rst
@@ -53,5 +53,7 @@ The charge is normalized to ``UNIT_CHARGE`` (third column) which is the typical 
 There is a up 5% difference to a native hdf5 post-processing based implementation of the charge conversation check due to a different order of subtraction.
 And the zero-th time step (only numerical differences) might differ more then 5% relative due to the close to zero result. 
 
+Known Limitations
+^^^^^^^^^^^^^^^^^
 
-
+- this plugin is only available with the CUDA backend

--- a/docs/source/usage/plugins/countPerSupercell.rst
+++ b/docs/source/usage/plugins/countPerSupercell.rst
@@ -9,7 +9,7 @@ Only in case of constant particle weighting, where each macro particle describes
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <install-dependencies>` are compiled in.
+The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
 
 .cfg files
 ^^^^^^^^^^

--- a/docs/source/usage/plugins/intensity.rst
+++ b/docs/source/usage/plugins/intensity.rst
@@ -48,9 +48,15 @@ Both files have two header rows describing the data.
 
 The following odd rows give the time step and then describe the y-position of the slice at which the maximum electric field or integrated electric field is computed.
 The even rows give the time step again and then the data (maximum electric field or integrated electric field) at the positions given in the previews row.
- 
-Know Issues
-^^^^^^^^^^^
+
+Known Limitations
+^^^^^^^^^^^^^^^^^
+
+- this plugin is only available with the CUDA backend
+- this plugin is only available for 3D simulations
+
+Known Issues
+^^^^^^^^^^^^
 
 Currently, the output file is overwritten after restart.
 Additionally, this plugin does not work with non-regular domains, see `here <https://github.com/ComputationalRadiationPhysics/picongpu/blob/4a6d8ed0ea4a1bf54f55b4941461c6368df89b1c/src/picongpu/include/plugins/IntensityPlugin.hpp#L235>`_ .

--- a/docs/source/usage/plugins/particleCalorimeter.rst
+++ b/docs/source/usage/plugins/particleCalorimeter.rst
@@ -12,7 +12,7 @@ The calorimeter takes into account all existing particles as well as optionally 
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-The plugin is available as soon as the :ref:`libSplash and HDF5 libraries <install-dependencies>` are compiled in.
+The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
 
 .param file
 ^^^^^^^^^^^

--- a/docs/source/usage/plugins/positionsParticles.rst
+++ b/docs/source/usage/plugins/positionsParticles.rst
@@ -73,6 +73,11 @@ In order to extract e.g. the position from this line the following can be used:
 
    cat trajectory.dat | awk '{print $7}' | sed -e "s/{//g" | sed -e 's/}//g' | sed -e 's/,/\t/g' > position.dat
 
+Known Limitations
+^^^^^^^^^^^^^^^^^
+
+- this plugin is only available with the CUDA backend
+
 Known Issues
 ^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/sliceFieldPrinter.rst
+++ b/docs/source/usage/plugins/sliceFieldPrinter.rst
@@ -74,6 +74,10 @@ Each entry is of the format ``{1.1e-1,2.2e-2,3.3e.3}`` giving each value of the 
 In order to read this data format, there is a python module in ``lib/python/picongpu/plugins/sliceFieldReader.py``.
 The function ``readFieldSlices`` needs a data file (file or filename) with data from the plugin and returns the data as numpy-array of size ``(N_y, N_x, 3)``
 
+Known Limitations
+^^^^^^^^^^^^^^^^^
+
+- this plugin is only available with the CUDA backend
 
 Known Issues
 ^^^^^^^^^^^^

--- a/docs/source/usage/plugins/sumCurrents.rst
+++ b/docs/source/usage/plugins/sumCurrents.rst
@@ -54,6 +54,11 @@ In order to extract only the total current information from the output stored in
 
 The plugin data is then stored in ``totalCurrent.dat``.
 
+Known Limitations
+^^^^^^^^^^^^^^^^^
+
+- this plugin is only available with the CUDA backend
+
 Known Issues
 ^^^^^^^^^^^^
 

--- a/docs/source/usage/plugins/xrayScattering.rst
+++ b/docs/source/usage/plugins/xrayScattering.rst
@@ -38,6 +38,12 @@ The volume integral is realized by a discrete sum over the simulation cells and 
 .. note::
     This calculation is based on the kinematic model of scattering. Multiple scattering CAN NOT be handled in this model.
 
+External Dependencies
+^^^^^^^^^^^^^^^^^^^^^
+
+The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
+
+
 .param file
 ^^^^^^^^^^^
 


### PR DESCRIPTION
This concerns external dependencies and backends. Some things were not documented, some things outdated (like libSplash dependency which is now openPMD).