### PR TITLE
Fix crash in output after moving window stopped

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -351,8 +351,11 @@ namespace picongpu
                 using usedFilters = bmpl::vector<typename GetPositionFilter<simDim>::type>;
                 using MyParticleFilter = typename FilterFactory<usedFilters>::FilterType;
                 MyParticleFilter filter;
-                /* activate filter pipeline if moving window is activated */
-                filter.setStatus(MovingWindow::getInstance().isSlidingWindowActive(params->currentStep));
+                /* activate filter pipeline if moving window is used in the sumulation.
+                 * Note that it is intentionally activated even when the window is not moving currently,
+                 * as we still have to apply the position filter in this case
+                 */
+                filter.setStatus(MovingWindow::getInstance().isEnabled());
                 filter.setWindowPosition(params->localWindowToDomainOffset, params->window.localDimensions.size);
 
                 using RunParameters_T = StrategyRunParameters<


### PR DESCRIPTION
The issue was in the condition of position filter activation.
Fixes #3742.

The same bug was probably present in other output backends (when we had those) and got copypasted here.