### PR TITLE
Extend particles::Manipulate and the underlying implementation with area parameter

### DIFF
--- a/include/pmacc/particles/algorithm/CallForEach.hpp
+++ b/include/pmacc/particles/algorithm/CallForEach.hpp
@@ -26,6 +26,7 @@
 #include "pmacc/particles/algorithm/ForEach.hpp"
 #include "pmacc/particles/frame_types.hpp"
 
+#include <cstdint>
 #include <utility>
 
 namespace pmacc
@@ -34,14 +35,15 @@ namespace pmacc
     {
         namespace algorithm
         {
-            /** Functor to execute an operation on all particles
+            /** Functor to execute an operation on all particles of a species in the given area
              *
              * @tparam T_SpeciesOperator an operator to create the used species
              *                           with the species type as ::type
              * @tparam T_FunctorOperator an operator to create a particle functor
              *                           with the functor type as ::type
+             * @tparam T_area area to process particles in
              */
-            template<typename T_SpeciesOperator, typename T_FunctorOperator>
+            template<typename T_SpeciesOperator, typename T_FunctorOperator, uint32_t T_area>
             struct CallForEach
             {
                 /** Operate on the domain CORE and BORDER
@@ -59,7 +61,7 @@ namespace pmacc
                     DataConnector& dc = Environment<>::get().DataConnector();
                     auto species = dc.get<Species>(FrameType::getName(), true);
 
-                    forEach(*species, UnaryFunctor(currentStep));
+                    forEach<T_area>(*species, UnaryFunctor(currentStep));
                 }
             };
 

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -26,6 +26,7 @@
 #include "pmacc/mappings/kernel/AreaMapping.hpp"
 #include "pmacc/particles/frame_types.hpp"
 
+#include <cstdint>
 #include <utility>
 
 
@@ -116,7 +117,7 @@ namespace pmacc
                 } // namespace detail
             } // namespace acc
 
-            /** Run a unary functor for each particle of a species
+            /** Run a unary functor for each particle of a species in the given area
              *
              * @warning Does NOT fill gaps automatically! If the
              *          operation deactivates particles or creates "gaps" in any
@@ -125,6 +126,7 @@ namespace pmacc
              *
              * Operates on the domain CORE and BORDER
              *
+             * @tparam T_area area to process particles in
              * @tparam T_Species type of the species
              * @tparam T_Functor unary particle functor type which follows the interface of
              *                   pmacc::functor::Interface<F, 1u, void>
@@ -132,11 +134,11 @@ namespace pmacc
              * @param species species to operate on
              * @param functor operation which is applied to each particle of the species
              */
-            template<typename T_Species, typename T_Functor>
+            template<uint32_t T_area, typename T_Species, typename T_Functor>
             void forEach(T_Species&& species, T_Functor functor)
             {
                 using MappingDesc = decltype(species.getCellDescription());
-                AreaMapping<CORE + BORDER, MappingDesc> mapper(species.getCellDescription());
+                AreaMapping<T_area, MappingDesc> mapper(species.getCellDescription());
 
                 using SuperCellSize = typename MappingDesc::SuperCellSize;
 


### PR DESCRIPTION
By default it is `CORE + BORDER`, which was hard-set before.
Thus, no existing code needs to be changed, but more flexibility is added.

I think this change will become useful for implemeting other types of particle boundary conditions, like reflective or thermal, that require per-particle processing in kernel. Then we can use this extended version with `T_area = GUARD`. Based on discussions with @steindev 

Edit: for now PIConGPU operates with compile-time areas and area mappings. In principle it would of course be nice to allow run-time ones as well at some point, as that would add much flexibility to e.g. define an area for absorber region, or maybe apply particle boundary conditions at adjustable points.