### PR TITLE
Partially enable runtime kernel mapping

### DIFF
--- a/include/picongpu/fields/EMFieldBase.tpp
+++ b/include/picongpu/fields/EMFieldBase.tpp
@@ -32,7 +32,6 @@
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/SuperCellDescription.hpp>
 #include <pmacc/eventSystem/EventSystem.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/kernel/ExchangeMapping.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -260,7 +260,7 @@ namespace picongpu
         auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
         auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
 
-        AreaMapping<T_area, MappingDesc> mapper(cellDescription);
+        auto const mapper = makeAreaMapper<T_area>(cellDescription);
 
         constexpr uint32_t numWorkers
             = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -33,7 +33,6 @@
 #include <pmacc/fields/operations/AddExchangeToBorder.hpp>
 #include <pmacc/fields/operations/CopyGuardToExchange.hpp>
 #include <pmacc/fields/tasks/FieldFactory.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -35,6 +35,7 @@
 #include "picongpu/fields/incidentField/Solver.hpp"
 #include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/traits/GetStringProperties.hpp>
 
 #include <memory>
@@ -149,8 +150,6 @@ namespace picongpu
                     SuperCellSize,
                     typename traits::GetLowerMargin<T_Curl>::type,
                     typename traits::GetUpperMargin<T_Curl>::type>;
-                template<uint32_t T_Area>
-                using AreaMapper = pmacc::AreaMapping<T_Area, MappingDesc>;
 
                 /** Propagate B values in the given area by the first half of a time step
                  *
@@ -200,7 +199,7 @@ namespace picongpu
                 {
                     constexpr auto numWorkers = getNumWorkers();
                     using Kernel = fdtd::KernelUpdateField<numWorkers>;
-                    AreaMapper<T_Area> mapper{cellDescription};
+                    auto const mapper = pmacc::makeAreaMapper<T_Area>(cellDescription);
 
                     // The ugly transition from run-time to compile-time polymorphism is contained here
                     auto& absorber = absorber::Absorber::get();
@@ -236,7 +235,7 @@ namespace picongpu
                 {
                     constexpr auto numWorkers = getNumWorkers();
                     using Kernel = fdtd::KernelUpdateField<numWorkers>;
-                    auto mapper = AreaMapper<T_Area>{cellDescription};
+                    auto const mapper = pmacc::makeAreaMapper<T_Area>(cellDescription);
 
                     // The ugly transition from run-time to compile-time polymorphism is contained here
                     auto& absorber = absorber::Absorber::get();

--- a/include/picongpu/fields/absorber/pml/Pml.hpp
+++ b/include/picongpu/fields/absorber/pml/Pml.hpp
@@ -26,6 +26,8 @@
 #include "picongpu/fields/absorber/pml/Parameters.hpp"
 #include "picongpu/fields/absorber/pml/Pml.kernel"
 
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+
 #include <cstdint>
 #include <string>
 
@@ -78,7 +80,7 @@ namespace picongpu
                     template<typename T_CurlB, uint32_t T_Area>
                     UpdateEFunctor<T_CurlB> getUpdateEFunctor(uint32_t const currentStep)
                     {
-                        AreaMapper<T_Area> mapper{cellDescription};
+                        auto const mapper = makeAreaMapper<T_Area>(cellDescription);
                         return UpdateEFunctor<T_CurlB>{
                             psiE->getDeviceOuterLayerBox(),
                             getLocalParameters(mapper, currentStep)};
@@ -98,7 +100,7 @@ namespace picongpu
                         uint32_t const currentStep,
                         bool const updatePsiB)
                     {
-                        AreaMapper<T_Area> mapper{cellDescription};
+                        auto const mapper = makeAreaMapper<T_Area>(cellDescription);
                         return UpdateBHalfFunctor<T_CurlE>{
                             psiB->getDeviceOuterLayerBox(),
                             getLocalParameters(mapper, currentStep),
@@ -119,13 +121,9 @@ namespace picongpu
                         }
                     }
 
-                    //! Helper area mapper type
-                    template<uint32_t T_Area>
-                    using AreaMapper = pmacc::AreaMapping<T_Area, MappingDesc>;
-
                     //! Get parameters for the local domain
-                    template<uint32_t T_Area>
-                    LocalParameters getLocalParameters(AreaMapper<T_Area>& mapper, uint32_t const currentStep) const
+                    template<typename T_Mapper>
+                    LocalParameters getLocalParameters(T_Mapper mapper, uint32_t const currentStep) const
                     {
                         Thickness localThickness = getLocalThickness(currentStep);
                         checkLocalThickness(localThickness);

--- a/include/picongpu/fields/background/cellwiseOperation.hpp
+++ b/include/picongpu/fields/background/cellwiseOperation.hpp
@@ -25,6 +25,7 @@
 
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/lockstep.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 #include <pmacc/mappings/simulation/SubGrid.hpp>
 #include <pmacc/traits/GetNumWorkers.hpp>
@@ -138,7 +139,7 @@ namespace picongpu
                 constexpr uint32_t numWorkers
                     = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
-                AreaMapping<T_Area, MappingDesc> mapper(m_cellDescription);
+                auto const mapper = makeAreaMapper<T_Area>(m_cellDescription);
 
                 PMACC_KERNEL(KernelCellwiseOperation<numWorkers>{})
                 (mapper.getGridDim(),

--- a/include/picongpu/fields/currentDeposition/Deposit.hpp
+++ b/include/picongpu/fields/currentDeposition/Deposit.hpp
@@ -115,7 +115,7 @@ namespace picongpu
                 T_JBox const& jBox,
                 T_ParticleBox const& parBox) const
             {
-                AreaMapping<T_area, MappingDesc> mapper(cellDescription);
+                auto const mapper = makeAreaMapper<T_area>(cellDescription);
 
                 PMACC_KERNEL(depositionKernel)(mapper.getGridDim(), T_numWorkers)(jBox, parBox, frameSolver, mapper);
             }

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -28,6 +28,7 @@
 #include "picongpu/fields/incidentField/Solver.kernel"
 #include "picongpu/fields/incidentField/Traits.hpp"
 
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Vector.hpp>
 
 #include <cstdint>
@@ -159,7 +160,7 @@ namespace picongpu
                         pmacc::math::CT::volume<PlaneSizeInSuperCells>::type::value>::value;
 
                     // Shift by guard size to go to the in-kernel coordinate system
-                    pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper{parameters.cellDescription};
+                    auto const mapper = pmacc::makeAreaMapper<CORE + BORDER>(parameters.cellDescription);
                     auto numGuardCells = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
                     auto beginGridIdx = beginLocalUserIdx + numGuardCells;
                     auto endGridIdx = endLocalUserIdx + numGuardCells;

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -342,7 +342,7 @@ namespace picongpu
 
         using BlockArea = SuperCellDescription<typename MappingDesc::SuperCellSize, LowerMargin, UpperMargin>;
 
-        AreaMapping<CORE + BORDER, picongpu::MappingDesc> mapper(this->cellDescription);
+        auto const mapper = makeAreaMapper<CORE + BORDER>(this->cellDescription);
 
         constexpr uint32_t numWorkers
             = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
@@ -377,7 +377,7 @@ namespace picongpu
         constexpr uint32_t numWorkers
             = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
-        AreaMapping<CORE + BORDER, picongpu::MappingDesc> mapper(this->cellDescription);
+        auto const mapper = makeAreaMapper<CORE + BORDER>(this->cellDescription);
         PMACC_KERNEL(KernelFillGridWithParticles<numWorkers, Particles>{})
         (mapper.getGridDim(), numWorkers)(
             densityFunctor,
@@ -403,7 +403,7 @@ namespace picongpu
     {
         log<picLog::SIMULATION_STATE>("clone species %1%") % FrameType::getName();
 
-        AreaMapping<CORE + BORDER, picongpu::MappingDesc> mapper(this->cellDescription);
+        auto const mapper = makeAreaMapper<CORE + BORDER>(this->cellDescription);
 
         constexpr uint32_t numWorkers
             = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;

--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/particles/collision/detail/cellDensity.hpp"
 
 #include <pmacc/lockstep.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
@@ -335,7 +336,7 @@ namespace picongpu
                     auto species1 = dc.get<Species1>(FrameType1::getName(), true);
 
                     // Use mapping information from the first species:
-                    AreaMapping<CORE + BORDER, picongpu::MappingDesc> mapper(species0->getCellDescription());
+                    auto const mapper = makeAreaMapper<CORE + BORDER>(species0->getCellDescription());
 
                     constexpr uint32_t numWorkers
                         = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/particles/collision/detail/cellDensity.hpp"
 
 #include <pmacc/lockstep.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/random/RNGProvider.hpp>
 #include <pmacc/random/distributions/Uniform.hpp>
@@ -215,7 +216,7 @@ namespace picongpu
                     DataConnector& dc = Environment<>::get().DataConnector();
                     auto species = dc.get<Species>(FrameType::getName(), true);
 
-                    AreaMapping<CORE + BORDER, picongpu::MappingDesc> mapper(species->getCellDescription());
+                    auto const mapper = makeAreaMapper<CORE + BORDER>(species->getCellDescription());
 
                     constexpr uint32_t numWorkers
                         = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -28,7 +28,6 @@
 
 #include <pmacc/kernel/atomic.hpp>
 #include <pmacc/lockstep.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/math/vector/Int.hpp>
 #include <pmacc/memory/Array.hpp>

--- a/include/picongpu/particles/debyeLength/Estimate.hpp
+++ b/include/picongpu/particles/debyeLength/Estimate.hpp
@@ -25,6 +25,7 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/buffers/HostDeviceBuffer.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
@@ -53,7 +54,7 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
                 auto& electrons = *(dc.get<T_ElectronSpecies>(Frame::getName(), true));
 
-                pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(cellDescription);
+                auto const mapper = pmacc::makeAreaMapper<CORE + BORDER>(cellDescription);
                 constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
                     pmacc::math::CT::volume<MappingDesc::SuperCellSize>::type::value>::value;
 

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -24,7 +24,6 @@
 #include "picongpu/traits/frame/GetMass.hpp"
 
 #include <pmacc/lockstep.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 
 #include <cstdint>
 

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
@@ -26,6 +26,7 @@
 
 // pmacc
 #include <pmacc/Environment.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/meta/ForEach.hpp>
 #include <pmacc/static_assert.hpp>
 
@@ -76,7 +77,7 @@ namespace picongpu
                                 speciesTmp->getParticlesBuffer().getSuperCellsLayout().getDataSpace()
                                     * SuperCellSize::toRT(),
                                 GuardSize::toRT());
-                            AreaMapping<CORE + BORDER, MappingDesc> mapper(cellDescription);
+                            auto const mapper = makeAreaMapper<CORE + BORDER>(cellDescription);
 
                             // add energy histogram on top of existing data
                             constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -28,7 +28,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/lockstep/Worker.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -32,7 +32,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/lockstep/Worker.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -35,7 +35,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/lockstep/Worker.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -32,7 +32,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/lockstep/Worker.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -34,7 +34,6 @@
 #include <pmacc/algorithms/math/defines/dot.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -455,7 +455,7 @@ namespace picongpu
             constexpr uint32_t numWorkers
                 = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
-            AreaMapping<AREA, MappingDesc> mapper(*m_cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 
             auto kernel = PMACC_KERNEL(KernelBinEnergyParticles<numWorkers>{})(
                 mapper.getGridDim(),

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -26,7 +26,6 @@
 #include "picongpu/plugins/ISimulationPlugin.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
 #include <pmacc/mpi/reduceMethods/Reduce.hpp>

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -514,7 +514,7 @@ namespace picongpu
             constexpr uint32_t numWorkers
                 = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
-            AreaMapping<AREA, MappingDesc> mapper(*m_cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 
             auto kernel = PMACC_KERNEL(KernelCalcEmittance<numWorkers>{})(mapper.getGridDim(), numWorkers);
 

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -384,7 +384,7 @@ namespace picongpu
             constexpr uint32_t numWorkers
                 = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
-            AreaMapping<AREA, MappingDesc> mapper(*m_cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 
             auto kernel = PMACC_KERNEL(KernelEnergyParticles<numWorkers>{})(mapper.getGridDim(), numWorkers);
             auto binaryKernel = std::bind(

--- a/include/picongpu/plugins/IntensityPlugin.hpp
+++ b/include/picongpu/plugins/IntensityPlugin.hpp
@@ -27,7 +27,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/SuperCellDescription.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/memory/Array.hpp>
 #include <pmacc/memory/boxes/CachedBox.hpp>

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -256,7 +256,7 @@ namespace picongpu
             gParticle->getDeviceBuffer().setValue(positionParticleTmp);
             auto block = SuperCellSize::toRT();
 
-            AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(*cellDescription);
             PMACC_KERNEL(KernelPositionsParticles{})
             (mapper.getGridDim(),
              block)(particles->getDeviceParticlesBox(), gParticle->getDeviceBuffer().getBasePointer(), mapper);

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -27,6 +27,7 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
 
 #include <iostream>
@@ -175,7 +176,7 @@ namespace picongpu
             sumcurrents->getDeviceBuffer().setValue(float3_X::create(0.0));
             auto block = MappingDesc::SuperCellSize::toRT();
 
-            AreaMapping<CORE + BORDER, MappingDesc> mapper(*cellDescription);
+            auto const mapper = makeAreaMapper<CORE + BORDER>(*cellDescription);
             PMACC_KERNEL(KernelSumCurrents{})
             (mapper.getGridDim(),
              block)(fieldJ->getDeviceDataBox(), sumcurrents->getDeviceBuffer().getBasePointer(), mapper);

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -215,7 +215,7 @@ namespace picongpu
 
             /*############ count particles #######################################*/
             typedef MappingDesc::SuperCellSize SuperCellSize;
-            AreaMapping<AREA, MappingDesc> mapper(*cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(*cellDescription);
 
             PMACC_KERNEL(CountMakroParticle{})
             (mapper.getGridDim(), SuperCellSize::toRT())(

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -132,7 +132,7 @@ namespace picongpu
                     % name;
 
                 int particlesProcessed = 0;
-                AreaMapping<CORE + BORDER, MappingDesc> mapper(*(rp.params.cellDescription));
+                auto const mapper = makeAreaMapper<CORE + BORDER>(*(rp.params.cellDescription));
 
                 pmacc::particles::operations::ConcatListOfFrames<simDim> concatListOfFrames(mapper.getGridDim());
 
@@ -207,7 +207,7 @@ namespace picongpu
                 log<picLog::INPUT_OUTPUT>("openPMD:  ( end ) get mapped memory device pointer: %1%") % name;
 
                 GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
-                AreaMapping<CORE + BORDER, MappingDesc> mapper(*(rp.params.cellDescription));
+                auto const mapper = makeAreaMapper<CORE + BORDER>(*(rp.params.cellDescription));
 
                 constexpr uint32_t numWorkers
                     = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -27,7 +27,6 @@
 #include "picongpu/plugins/output/WriteSpeciesCommon.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/meta/conversion/MakeSeq.hpp>
 #include <pmacc/meta/conversion/RemoveFromSeq.hpp>
 #include <pmacc/particles/ParticleDescription.hpp>

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -24,7 +24,6 @@
 #include "picongpu/plugins/ISimulationPlugin.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/meta/conversion/MakeSeq.hpp>
 #include <pmacc/meta/conversion/RemoveFromSeq.hpp>
 #include <pmacc/traits/Resolve.hpp>

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -37,6 +37,7 @@
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/kernel/atomic.hpp>
 #include <pmacc/lockstep.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/math/Vector.hpp>
@@ -707,7 +708,7 @@ namespace picongpu
 
             PMACC_ASSERT(cellDescription != nullptr);
 
-            AreaMapping<CORE + BORDER, MappingDesc> mapper(*cellDescription);
+            auto const mapper = makeAreaMapper<CORE + BORDER>(*cellDescription);
 
             // create image fields
             PMACC_KERNEL(KernelPaintFields<numWorkers>{})

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -585,7 +585,7 @@ namespace picongpu
             DataConnector& dc = Environment<>::get().DataConnector();
             auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
 
-            AreaMapping<CORE + BORDER, MappingDesc> const mapper(*this->m_cellDescription);
+            auto const mapper = makeAreaMapper<CORE + BORDER>(*this->m_cellDescription);
             auto const grid = mapper.getGridDim();
 
             constexpr uint32_t numWorkers

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -35,7 +35,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
 #include <pmacc/mpi/reduceMethods/Reduce.hpp>

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -38,7 +38,6 @@
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/kernel/atomic.hpp>
 #include <pmacc/lockstep.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/memory/Array.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -34,7 +34,6 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Complex.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -30,7 +30,6 @@
 
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/kernel/atomic.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 
 #include <cstdlib>
 #include <fstream>

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -38,7 +38,6 @@
 #include <pmacc/assert.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
 #include <pmacc/mpi/reduceMethods/Reduce.hpp>

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.kernel
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.kernel
@@ -25,7 +25,6 @@
 
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/lockstep.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
 
 #include <cstdio>
 

--- a/include/pmacc/mappings/kernel/AreaMapping.hpp
+++ b/include/pmacc/mappings/kernel/AreaMapping.hpp
@@ -26,6 +26,8 @@
 #include "pmacc/mappings/kernel/AreaMappingMethods.hpp"
 #include "pmacc/types.hpp"
 
+#include <cstdint>
+
 namespace pmacc
 {
     /** Mapping between block indices and supercells in the given area for alpaka kernels
@@ -48,10 +50,10 @@ namespace pmacc
      *    - for grid operations:
      *      alpaka block per supercell with this mapping, thread-level parallelism between cells of a supercell
      *
-     * @tparam areaType area, a value from type::AreaType or a sum of such values
-     * @tparam baseClass mapping description type
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     * @tparam T_MappingDescription mapping description type
      */
-    template<uint32_t areaType, class baseClass>
+    template<uint32_t T_area, typename T_MappingDescription>
     class AreaMapping;
 
     template<uint32_t areaType, template<unsigned, class> class baseClass, unsigned DIM, class SuperCellSize_>
@@ -94,5 +96,18 @@ namespace pmacc
             return AreaMappingMethods<areaType, DIM>::getBlockIndex(*this, this->getGridSuperCells(), blockIdx);
         }
     };
+
+    /** Construct an area mapping instance for the given area and description
+     *
+     * Currently always returns AreaMapping, but in principle could return a compatible type.
+     *
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     * @tparam T_MappingDescription mapping description type
+     */
+    template<uint32_t T_area, typename T_MappingDescription>
+    HINLINE auto makeAreaMapper(T_MappingDescription mappingDescription)
+    {
+        return AreaMapping<T_area, T_MappingDescription>{mappingDescription};
+    }
 
 } // namespace pmacc

--- a/include/pmacc/mappings/kernel/AreaMapping.hpp
+++ b/include/pmacc/mappings/kernel/AreaMapping.hpp
@@ -89,7 +89,7 @@ namespace pmacc
         /** Return index of a supercell to be processed by the given alpaka block
          *
          * @param blockIdx alpaka block index
-         * @return mapped SuperCell index
+         * @return mapped SuperCell index including guards
          */
         HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
@@ -97,17 +97,61 @@ namespace pmacc
         }
     };
 
-    /** Construct an area mapping instance for the given area and description
+    /** Concept for area mapper factory
      *
-     * Currently always returns AreaMapping, but in principle could return a compatible type.
+     * Defines interface for implementations of such factories.
+     * (A user-provided implementation is needed for user-defined areas.)
+     */
+    class AreaMapperFactoryConcept
+    {
+    public:
+        /** Construct an area mapper object
+         *
+         * @tparam T_MappingDescription mapping description type
+         *
+         * @param mappingDescription mapping description
+         *
+         * @return an object adhering to the AreaMapping concept
+         */
+        template<typename T_MappingDescription>
+        HINLINE auto operator()(T_MappingDescription mappingDescription) const;
+    };
+
+    /** Construct an area mapper instance for the given standard area and description
+     *
+     * Adheres to the AreaMapperFactoryConcept.
+     *
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     */
+    template<uint32_t T_area>
+    struct AreaMapperFactory
+    {
+        /** Construct an area mapper object
+         *
+         * @tparam T_MappingDescription mapping description type
+         *
+         * @param mappingDescription mapping description
+         *
+         * @return an object adhering to the AreaMapping concept
+         */
+        template<typename T_MappingDescription>
+        HINLINE auto operator()(T_MappingDescription mappingDescription) const
+        {
+            return AreaMapping<T_area, T_MappingDescription>{mappingDescription};
+        }
+    };
+
+    /** Construct an area mapper instance for the given area and description
      *
      * @tparam T_area area, a value from type::AreaType or a sum of such values
      * @tparam T_MappingDescription mapping description type
+     *
+     * @param mappingDescription mapping description
      */
     template<uint32_t T_area, typename T_MappingDescription>
     HINLINE auto makeAreaMapper(T_MappingDescription mappingDescription)
     {
-        return AreaMapping<T_area, T_MappingDescription>{mappingDescription};
+        return AreaMapperFactory<T_area>{}(mappingDescription);
     }
 
 } // namespace pmacc

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -125,7 +125,7 @@ namespace pmacc
         template<uint32_t AREA>
         void fillGaps()
         {
-            AreaMapping<AREA, MappingDesc> mapper(this->cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(this->cellDescription);
 
             constexpr uint32_t numWorkers
                 = traits::GetNumWorkers<math::CT::volume<typename FrameType::SuperCellSize>::type::value>::value;

--- a/include/pmacc/particles/ParticlesBase.tpp
+++ b/include/pmacc/particles/ParticlesBase.tpp
@@ -24,6 +24,7 @@
 #include "pmacc/Environment.hpp"
 #include "pmacc/eventSystem/EventSystem.hpp"
 #include "pmacc/fields/SimulationFieldHelper.hpp"
+#include "pmacc/mappings/kernel/AreaMapping.hpp"
 #include "pmacc/mappings/kernel/ExchangeMapping.hpp"
 #include "pmacc/particles/memory/boxes/ParticlesBox.hpp"
 #include "pmacc/particles/memory/buffers/ParticlesBuffer.hpp"
@@ -48,7 +49,7 @@ namespace pmacc
     template<uint32_t T_area>
     void ParticlesBase<T_ParticleDescription, MappingDesc, T_DeviceHeap>::deleteParticlesInArea()
     {
-        AreaMapping<T_area, MappingDesc> mapper(this->cellDescription);
+        auto const mapper = makeAreaMapper<T_area>(this->cellDescription);
 
         constexpr uint32_t numWorkers
             = traits::GetNumWorkers<math::CT::volume<typename FrameType::SuperCellSize>::type::value>::value;

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl, Rene Widera
+/* Copyright 2017-2021 Axel Huebl, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -119,33 +119,57 @@ namespace pmacc
 
             /** Run a unary functor for each particle of a species in the given area
              *
+             * Has a version for a fixed area, and for a user-provided mapper factory.
+             * They differ only in how the area is defined.
+             *
              * @warning Does NOT fill gaps automatically! If the
              *          operation deactivates particles or creates "gaps" in any
              *          other way, CallFillAllGaps needs to be called for the
              *          species manually afterwards!
              *
-             * Operates on the domain CORE and BORDER
-             *
-             * @tparam T_area area to process particles in
              * @tparam T_Species type of the species
              * @tparam T_Functor unary particle functor type which follows the interface of
              *                   pmacc::functor::Interface<F, 1u, void>
              *
              * @param species species to operate on
              * @param functor operation which is applied to each particle of the species
+             *
+             * @{
              */
-            template<uint32_t T_area, typename T_Species, typename T_Functor>
-            void forEach(T_Species&& species, T_Functor functor)
+
+            /** Version for a custom area mapper factory
+             *
+             * @tparam T_AreaMapperFactory factory type to construct an area mapper that defines the area to process,
+             *                             adheres to the AreaMapperFactory concept
+             *
+             * @param areaMapperFactory factory to construct an area mapper,
+             *                          the area is defined by the constructed mapper object
+             */
+            template<typename T_Species, typename T_Functor, typename T_AreaMapperFactory>
+            HINLINE void forEach(T_Species&& species, T_Functor functor, T_AreaMapperFactory const& areaMapperFactory)
             {
                 using MappingDesc = decltype(species.getCellDescription());
                 using SuperCellSize = typename MappingDesc::SuperCellSize;
                 constexpr uint32_t numWorkers
                     = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
-                auto const mapper = makeAreaMapper<T_area>(species.getCellDescription());
+                auto const mapper = areaMapperFactory(species.getCellDescription());
                 PMACC_KERNEL(acc::detail::ForEachParticle<numWorkers>{})
                 (mapper.getGridDim(), numWorkers)(std::move(functor), mapper, species.getDeviceParticlesBox());
             }
+
+            /** Version for a fixed area
+             *
+             * @tparam T_area area to process particles in
+             */
+            template<uint32_t T_area, typename T_Species, typename T_Functor>
+            HINLINE void forEach(T_Species&& species, T_Functor functor)
+            {
+                auto const areaMapperFactory = AreaMapperFactory<T_area>{};
+                forEach(species, functor, areaMapperFactory);
+            }
+
+            /** @} */
 
         } // namespace algorithm
     } // namespace particles

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -138,13 +138,11 @@ namespace pmacc
             void forEach(T_Species&& species, T_Functor functor)
             {
                 using MappingDesc = decltype(species.getCellDescription());
-                AreaMapping<T_area, MappingDesc> mapper(species.getCellDescription());
-
                 using SuperCellSize = typename MappingDesc::SuperCellSize;
-
                 constexpr uint32_t numWorkers
                     = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
 
+                auto const mapper = makeAreaMapper<T_area>(species.getCellDescription());
                 PMACC_KERNEL(acc::detail::ForEachParticle<numWorkers>{})
                 (mapper.getGridDim(), numWorkers)(std::move(functor), mapper, species.getDeviceParticlesBox());
             }

--- a/include/pmacc/particles/operations/CountParticles.hpp
+++ b/include/pmacc/particles/operations/CountParticles.hpp
@@ -159,7 +159,7 @@ namespace pmacc
         {
             GridBuffer<uint64_cu, DIM1> counter(DataSpace<DIM1>(1));
 
-            AreaMapping<AREA, CellDesc> mapper(cellDescription);
+            auto const mapper = makeAreaMapper<AREA>(cellDescription);
             constexpr uint32_t numWorkers
                 = traits::GetNumWorkers<math::CT::volume<typename CellDesc::SuperCellSize>::type::value>::value;
 


### PR DESCRIPTION
Traditionally PIConGPU kernels relied on compile-time defined areas `CORE`, `BORDER`, `GUARD` and combinations of those. Which is great for performance and not so great to express some operations. This PR makes a step towards allowing custom areas and mappings between alpaka thread blocks and supercells. It also adds documentation of existing use patterns, part of this will go to readthedocs as well in a follow up PR.

Currently the change affects some infrastructure to enable this in principle. The immediate effect is only on `pmacc::particles::algorithm::forEach` and its callees, mostly `picongpu::particles::Manipulate`. The default behavior is unchanged, including performance-wise. For now we dont have an existing use case for particles (but may need it for future boundary conditions). For fields there is a use case for absorbers, I will try it soon.