### PR TITLE
Add checkpointing of internal RNG states

### DIFF
--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2021 Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -104,11 +104,17 @@ namespace pmacc
             SimulationDataId getUniqueId() override;
             void synchronize() override;
 
+            //! Synchronize device data with host data
+            void syncToDevice();
+
             /**
              * Return a reference to the buffer containing the states
              * Note: This buffer might be empty
              */
             Buffer& getStateBuffer();
+
+            //! Get size of the internal buffer
+            HINLINE Space getSize() const;
 
         private:
             /**

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2021 Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -112,6 +112,12 @@ namespace pmacc
         }
 
         template<uint32_t T_dim, class T_RNGMethod>
+        typename RNGProvider<T_dim, T_RNGMethod>::Space RNGProvider<T_dim, T_RNGMethod>::getSize() const
+        {
+            return m_size;
+        }
+
+        template<uint32_t T_dim, class T_RNGMethod>
         typename RNGProvider<T_dim, T_RNGMethod>::DataBoxType RNGProvider<T_dim, T_RNGMethod>::getDeviceDataBox()
         {
             return buffer->getDeviceBuffer().getDataBox();
@@ -135,6 +141,12 @@ namespace pmacc
         void RNGProvider<T_dim, T_RNGMethod>::synchronize()
         {
             buffer->deviceToHost();
+        }
+
+        template<uint32_t T_dim, class T_RNGMethod>
+        void RNGProvider<T_dim, T_RNGMethod>::syncToDevice()
+        {
+            buffer->hostToDevice();
         }
 
     } // namespace random


### PR DESCRIPTION
Previously they were re-initialized after loading thus potentially causing differences.
In case the states can't be loaded, the old scheme is used.
Thus, for old checkpoints there is no change in behavior.

Current status: compiles ~~but not checked yet~~ and works.