### PR TITLE
Fix domain adjuster for absorber in case there is a single domain along a direction

### DIFF
--- a/include/picongpu/simulation/control/DomainAdjuster.hpp
+++ b/include/picongpu/simulation/control/DomainAdjuster.hpp
@@ -237,6 +237,10 @@ namespace picongpu
                         = static_cast<int>(std::max(absorberThickness(dim, 0), absorberThickness(dim, 1)));
                 }
 
+                // If this is the only device along the direction, both absorbers must fit
+                if(m_numDevices[dim] == 1)
+                    maxAbsorberCells = absorberThickness(dim, 0) + absorberThickness(dim, 1);
+
                 if(m_localDomainSize[dim] < maxAbsorberCells)
                 {
                     int const sCellSize = SuperCellSize::toRT()[dim];
@@ -246,11 +250,7 @@ namespace picongpu
 
                 if(validLocalSize != m_localDomainSize[dim])
                 {
-                    showMessage(
-                        dim,
-                        "Local grid size must be greater or equal than the largest absorber.",
-                        m_localDomainSize[dim],
-                        validLocalSize);
+                    showMessage(dim, "Local grid size must fir the absorber.", m_localDomainSize[dim], validLocalSize);
 
                     m_localDomainSize[dim] = validLocalSize;
                 }


### PR DESCRIPTION
In this case, both sides of absorber must fit, not just one side.
Fixes #3757.