### PR TITLE
CI: allow to interrupt job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ stages:
   artifacts:
     paths:
       - compile.yml
+  interruptible: true
 
 # pull request validation:
 #   - check PR destination
@@ -46,6 +47,7 @@ pull-request-validation:
     - source $CI_PROJECT_DIR/share/ci/check_cpp_code_style.sh
   tags:
     - x86_64
+  interruptible: true
 
 # generate reduced test matrix
 # required variables (space separated lists):

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -15,3 +15,4 @@
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
+  interruptible: true

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -17,6 +17,7 @@
   tags:
     - cuda
     - x86_64 
+  interruptible: true
 
 .base_clangCuda_cuda_9.2:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda92-clangpic:1.3

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -15,3 +15,4 @@
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
+  interruptible: true

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -28,3 +28,4 @@
   tags:
     - amd
     - rocm
+  interruptible: true

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -17,7 +17,8 @@
   tags:
     - cuda
     - x86_64 
-    
+  interruptible: true
+
 .base_nvcc_cuda_9.2:
   image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda92-gccpic:1.3
   extends: .base_nvcc


### PR DESCRIPTION
To reduce the CI load allow to interrupt the previous CI jobs if a branch is updated.

see: https://docs.gitlab.com/ee/ci/yaml/#interruptible