### PR TITLE
CI: compile on x86 runners 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,11 @@
 stages:
   - validate
   - generate
-  - compile
+  - test_picongpu
+  - test_pmacc
+
+variables:
+  CONTAINER_TAG: "1.3"
 
 .base_generate-reduced-matrix:
   stage: generate
@@ -51,21 +55,36 @@ pull-request-validation:
 
 # generate reduced test matrix
 # required variables (space separated lists):
-#   PIC_INPUTS - path to examples relative to share/picongpu
+#   PIC_INPUTS - Path to examples relative to share/picongpu.
+#                If input is 'pmacc' the folder will be ignored and tests for pmacc will be generated.
 #                e.g.
 #                    "examples" starts one gitlab job per directory in `examples/*`
 #                    "examples/" compile all directories in `examples/*` within one gitlab job
 #                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
-generate-reduced-matrix:
+picongpu-generate-reduced-matrix:
   variables:
     PIC_INPUTS: "examples tests benchmarks"
     TEST_TUPLE_NUM_ELEM: 1
   extends: ".base_generate-reduced-matrix"
 
-compile-reduced-matrix:
-  stage: compile
+picongpu-compile-reduced-matrix:
+  stage: test_picongpu
   trigger:
     include:
       - artifact: compile.yml
-        job: generate-reduced-matrix
+        job: picongpu-generate-reduced-matrix
+    strategy: depend
+
+pmacc-generate-reduced-matrix:
+  variables:
+    PIC_INPUTS: "pmacc"
+    TEST_TUPLE_NUM_ELEM: 1
+  extends: ".base_generate-reduced-matrix"
+
+pmacc-compile-reduced-matrix:
+  stage: test_pmacc
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: pmacc-generate-reduced-matrix
     strategy: depend

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -2,7 +2,7 @@
 #   [clang++-X] : X = {4.0, 5.0, 6.0, 7, 8, 9, 10, 11}
 
 .base_clang:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-clang-pic:1.3
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-clang-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   script:
@@ -10,9 +10,15 @@
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
-    - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
-    - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
+    - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
   interruptible: true
+
+
+.base_clang_compile:
+  extends: .base_clang
+
+.base_clang_run:
+  extends: .base_clang

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -13,6 +13,7 @@
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
+    - cpuonly
     - x86_64
   interruptible: true
 

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -3,6 +3,7 @@
 # cuda9.2Clang is not supporting clang-7
 
 .base_cuda_clang:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda${CUDA_CONTAINER_VERSION}-clangpic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_CUDA_COMPILER=clang -DCMAKE_CXX_FLAGS=--no-cuda-version-check"
@@ -12,33 +13,16 @@
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
-    - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
-    - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
-  tags:
-    - cuda
-    - x86_64 
+    - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   interruptible: true
 
-.base_clangCuda_cuda_9.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda92-clangpic:1.3
+.base_clangCuda_cuda_compile:
   extends: .base_cuda_clang
-  
-.base_clangCuda_cuda_10.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda100-clangpic:1.3
-  extends: .base_cuda_clang
+  tags:
+    - x86_64
 
-.base_clangCuda_cuda_10.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda101-clangpic:1.3
+.base_clangCuda_cuda_run:
   extends: .base_cuda_clang
-
-.base_clangCuda_cuda_11.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda110-clangpic:1.3
-  extends: .base_cuda_clang
-
-.base_clangCuda_cuda_11.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda111-clangpic:1.3
-  extends: .base_cuda_clang
-
-.base_clangCuda_cuda_11.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda112-clangpic:1.3
-  extends: .base_cuda_clang
+  tags:
+    - cuda
+    - x86_64

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -19,6 +19,7 @@
 .base_clangCuda_cuda_compile:
   extends: .base_cuda_clang
   tags:
+    - cpuonly
     - x86_64
 
 .base_clangCuda_cuda_run:

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -2,7 +2,7 @@
 #   [g++-X] : X = {5, 6, 7, 8, 9 ,10}
 
 .base_gcc:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-gcc-pic:1.3
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-gcc-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   script:
@@ -10,9 +10,14 @@
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
-    - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
-    - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
+    - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
     - x86_64
   interruptible: true
+
+.base_gcc_compile:
+  extends: .base_gcc
+
+.base_gcc_run:
+  extends: .base_gcc

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -13,6 +13,7 @@
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:
+    - cpuonly
     - x86_64
   interruptible: true
 

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -3,7 +3,7 @@
 # clang compiler is located under /opt/rocm/llvm/bin
 
 .base_hipcc:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-rocm4.2-pic:1.3
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-rocm${HIP_CONTAINER_VERSION}-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_HIP_ARCH=900 -DCMAKE_MODULE_PATH=/opt/rocm/hip/cmake"
@@ -23,9 +23,17 @@
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
-    - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
-    - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
+    - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
+  interruptible: true
+
+
+.base_hipcc_compile:
+  extends: .base_hipcc
+  tags:
+    - x86_64
+
+.base_hipcc_run:
+  extends: .base_hipcc
   tags:
     - amd
     - rocm
-  interruptible: true

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -30,6 +30,7 @@
 .base_hipcc_compile:
   extends: .base_hipcc
   tags:
+    - cpuonly
     - x86_64
 
 .base_hipcc_run:

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -19,6 +19,7 @@
 .base_nvcc_cuda_compile:
   extends: .base_nvcc
   tags:
+    - cpuonly
     - x86_64
 
 .base_nvcc_cuda_run:

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -2,6 +2,7 @@
 #   [g++-X] : X = {5, 6, 7, 8, 9, 10}
 
 .base_nvcc:
+  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda${CUDA_CONTAINER_VERSION}-gccpic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
   before_script:
@@ -12,37 +13,16 @@
     - apt install -y curl libjpeg-dev
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
-    - $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
-    - $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
-  tags:
-    - cuda
-    - x86_64 
+    - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   interruptible: true
 
-.base_nvcc_cuda_9.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda92-gccpic:1.3
+.base_nvcc_cuda_compile:
   extends: .base_nvcc
+  tags:
+    - x86_64
 
-.base_nvcc_cuda_10.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda100-gccpic:1.3
+.base_nvcc_cuda_run:
   extends: .base_nvcc
-  
-.base_nvcc_cuda_10.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda101-gccpic:1.3
-  extends: .base_nvcc
-
-.base_nvcc_cuda_10.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda102-gccpic:1.3
-  extends: .base_nvcc
-
-.base_nvcc_cuda_11.0:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda110-gccpic:1.3
-  extends: .base_nvcc
-
-.base_nvcc_cuda_11.1:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda111-gccpic:1.3
-  extends: .base_nvcc
-
-.base_nvcc_cuda_11.2:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-cuda112-gccpic:1.3
-  extends: .base_nvcc
+  tags:
+    - cuda
+    - x86_64

--- a/share/ci/generate_reduced_matrix.sh
+++ b/share/ci/generate_reduced_matrix.sh
@@ -28,15 +28,21 @@ if [ "$has_label" == "0" ] ; then
 fi
 
 folders=()
-for CASE in ${PIC_INPUTS}; do
-  if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] || [  "$CASE" == "benchmarks"  ] ; then
-      all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
-  else
-      all_cases=$(find $CASE -maxdepth 0 -type d)
-  fi
-  for test_case_folder in $all_cases ; do
-      folders+=($test_case_folder)
+if [ "$PIC_INPUTS" == "pmacc" ] ; then
+  # create test cases for PMacc
+  echo "pmacc" | tr " " "\n" | n_wise_generator.py $@ --limit_boost_version
+else
+  # create test cases for PIConGPU
+  for CASE in ${PIC_INPUTS}; do
+    if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] || [  "$CASE" == "benchmarks"  ] ; then
+        all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
+    else
+        all_cases=$(find $CASE -maxdepth 0 -type d)
+    fi
+    for test_case_folder in $all_cases ; do
+        folders+=($test_case_folder)
+    done
   done
-done
 
-echo "${folders[@]}" | tr " " "\n" | n_wise_generator.py $@
+  echo "${folders[@]}" | tr " " "\n" | n_wise_generator.py $@
+fi

--- a/share/ci/run_tests.sh
+++ b/share/ci/run_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if [ "$1" == "pmacc" ] ; then
+  $CI_PROJECT_DIR/share/ci/run_pmacc_tests.sh
+else
+  $CI_PROJECT_DIR/share/ci/run_picongpu_tests.sh
+fi


### PR DESCRIPTION
Separate PMacc and PIConGPU jobs. PIConGPU is currently not executed on GPU therefore we can run the compile tests on CPU CI runner and only perform PMacc tests on the accelerator-specific runners. This is reducing the CI load and should result in result in faster CI response times.

To reduce the load PMacc is only testing each second boost version. The newest boost version is always included.

Update the CI base job descriptions to simplify switching to a new container tag or cuda/hip version.

The time to pass the CI is reduced from over 200 min to less than 100 min.

- [x] merge after #3761 (included in this PR)