### PR TITLE
Enable support for custom particle boundaries

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -91,6 +91,13 @@ TBG_gridDist="--gridDist '64{2}' '64,32{2},64'"
 TBG_periodic="--periodic 1 0 1"
 
 
+# Specifies boundary kinds for given species with a particle pusher, 'e' in the example.
+# The axis order matches --periodic.
+# Default: what is set by --periodic.
+# Currently only values that are same as default are supported, so this option can't change the behavior yet.
+TBG_boundaries="--e_boundary periodic absorbing periodic"
+
+
 # Set absorber type of absorbing boundaries.
 # Supported values: exponential, pml (default).
 # When changing absorber type, one should normally adjust NUM_CELLS in fieldAbsorber.param

--- a/docs/source/usage/workflows/boundaryConditions.rst
+++ b/docs/source/usage/workflows/boundaryConditions.rst
@@ -14,6 +14,10 @@ Particles
 """""""""
 
 For particles, the boundaries always match the global simulation area border.
+By default, boundary kinds match the value of ``--periodic``.
+For species with a particle pusher, it can be overridden with option `<prefix>_boundary <x> <y> <z>`.
+However, currently we do not support options that do not match the default value.
+
 The treatment of particles crossing a boundary is controlled by the ``boundaryCondition`` flag in :ref:`speciesDefinition.param <usage-params-core>`.
 Its default value provides the conventional treatment: particles crossing an absorbing boundary are deleted, particles crossing a periodic boundary are transferred to the other side of the global simulation area.
 The behavior for both boundary kinds can be customized per species by changing the flag to a user-defined type.

--- a/docs/source/usage/workflows/boundaryConditions.rst
+++ b/docs/source/usage/workflows/boundaryConditions.rst
@@ -18,9 +18,9 @@ By default, boundary kinds match the value of ``--periodic``.
 For species with a particle pusher, it can be overridden with option `<prefix>_boundary <x> <y> <z>`.
 However, currently we do not support options that do not match the default value.
 
-The treatment of particles crossing a boundary is controlled by the ``boundaryCondition`` flag in :ref:`speciesDefinition.param <usage-params-core>`.
-Its default value provides the conventional treatment: particles crossing an absorbing boundary are deleted, particles crossing a periodic boundary are transferred to the other side of the global simulation area.
-The behavior for both boundary kinds can be customized per species by changing the flag to a user-defined type.
+The internal treatment of particles crossing a boundary is controlled by the ``boundaryCondition`` flag in :ref:`speciesDefinition.param <usage-params-core>`.
+However, this option is for expert users and generally should not be modified.
+To set physical boundary conditions, use the command-line option described above.
 
 Fields
 """"""

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -218,14 +218,14 @@ namespace picongpu
      */
     alias(exchangeMemCfg);
 
-    /** alias to specify the boundary condition for particles
+    /** alias to specify the internal pmacc boundary treatment for particles
+     *
+     * It controls the internal behavior and intented for special cases only.
+     * To set physical boundary conditions for a species, instead use <species>_boundary command-line option.
      *
      * The default behavior if this alias is not given to a species is that the
-     * particles which leave the global simulation box where deleted.
+     * particles which leave the global simulation box are deleted.
      * This also notifies all plugins that can handle leaving particles.
-     *
-     * Note: alias `boundaryCondition` will be ignored if the runtime parameter
-     * `--periodic` is set.
      */
     alias(boundaryCondition);
 

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Marco Garten, Alexander Grund
+ *                     Marco Garten, Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -23,6 +23,7 @@
 #include "picongpu/fields/Fields.def"
 #include "picongpu/fields/Fields.hpp"
 #include "picongpu/particles/boundary/CallPluginsAndDeleteParticles.hpp"
+#include "picongpu/particles/boundary/Kind.hpp"
 #include "picongpu/particles/manipulators/manipulators.def"
 
 #include <pmacc/HandleGuardRegion.hpp>
@@ -40,6 +41,7 @@
 #include <boost/mpl/contains.hpp>
 #include <boost/mpl/if.hpp>
 
+#include <array>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -150,36 +152,52 @@ namespace picongpu
 
         void syncToDevice() override;
 
+        /** Get boundary kinds for the species.
+         *
+         * For each side, both boundaries have the same kind.
+         *
+         * This method is static as it is used by static getStringProperties().
+         */
+        static std::array<particles::boundary::Kind, simDim> boundaryKind()
+        {
+            using namespace particles::boundary;
+            static std::array<particles::boundary::Kind, simDim> kinds;
+            const DataSpace<DIM3> periodic
+                = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
+            for(uint32_t d = 0; d < simDim; d++)
+                kinds[d] = (periodic[d] ? Kind::Periodic : Kind::Absorbing);
+            return kinds;
+        }
+
         static pmacc::traits::StringProperty getStringProperties()
         {
             pmacc::traits::StringProperty propList;
-            const DataSpace<DIM3> periodic
-                = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
 
             for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
             {
                 // for each planar direction: left right top bottom back front
                 if(FRONT % i == 0)
                 {
-                    const std::string directionName = ExchangeTypeNames()[i];
                     const DataSpace<DIM3> relDir = Mask::getRelativeDirections<DIM3>(i);
+                    uint32_t axis = 0; // x(0) y(1) z(2)
+                    for(uint32_t d = 0; d < simDim; d++)
+                        if(relDir[d] != 0)
+                            axis = d;
 
-                    const bool isPeriodic = (relDir * periodic) != DataSpace<DIM3>::create(0);
-
-                    std::string boundaryName = "absorbing";
-                    if(isPeriodic)
-                        boundaryName = "periodic";
-
-                    if(boundaryName == "absorbing")
+                    const std::string directionName = ExchangeTypeNames()[i];
+                    propList[directionName]["param"] = std::string("none");
+                    switch(boundaryKind()[axis])
                     {
+                    case particles::boundary::Kind::Periodic:
+                        propList[directionName]["name"] = "periodic";
+                        break;
+                    case particles::boundary::Kind::Absorbing:
+                        propList[directionName]["name"] = "absorbing";
                         propList[directionName]["param"] = std::string("without field correction");
+                        break;
+                    default:
+                        propList[directionName]["name"] = "unknown";
                     }
-                    else
-                    {
-                        propList[directionName]["param"] = std::string("none");
-                    }
-
-                    propList[directionName]["name"] = boundaryName;
                 }
             }
             return propList;

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -155,17 +155,13 @@ namespace picongpu
         /** Get boundary kinds for the species.
          *
          * For each side, both boundaries have the same kind.
+         * Must not be modified outside of the ParticleBoundaries simulation stage.
          *
          * This method is static as it is used by static getStringProperties().
          */
-        static std::array<particles::boundary::Kind, simDim> boundaryKind()
+        static std::array<particles::boundary::Kind, simDim>& boundaryKind()
         {
-            using namespace particles::boundary;
-            static std::array<particles::boundary::Kind, simDim> kinds;
-            const DataSpace<DIM3> periodic
-                = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
-            for(uint32_t d = 0; d < simDim; d++)
-                kinds[d] = (periodic[d] ? Kind::Periodic : Kind::Absorbing);
+            static std::array<particles::boundary::Kind, simDim> kinds = getDefaultBoundaryKind();
             return kinds;
         }
 
@@ -218,6 +214,18 @@ namespace picongpu
 
         FieldE* fieldE;
         FieldB* fieldB;
+
+        //! Get default boundary kinds for the species matching the communicator topology.
+        static std::array<particles::boundary::Kind, simDim> getDefaultBoundaryKind()
+        {
+            using namespace particles::boundary;
+            std::array<particles::boundary::Kind, simDim> result;
+            const DataSpace<DIM3> periodic
+                = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
+            for(uint32_t d = 0; d < simDim; d++)
+                result[d] = (periodic[d] ? Kind::Periodic : Kind::Absorbing);
+            return result;
+        }
     };
 
     namespace traits

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -27,6 +27,7 @@
 #include "picongpu/particles/Particles.hpp"
 #include "picongpu/particles/Particles.kernel"
 #include "picongpu/particles/ParticlesInit.kernel"
+#include "picongpu/particles/boundary/Apply.hpp"
 #include "picongpu/particles/pusher/Traits.hpp"
 #include "picongpu/particles/traits/GetExchangeMemCfg.hpp"
 #include "picongpu/particles/traits/GetMarginPusher.hpp"
@@ -310,6 +311,8 @@ namespace picongpu
         using ParticlePush = typename pmacc::traits::Resolve<PusherAlias>::type;
         // Because of composite pushers, we have to defer using the launcher
         PushLauncher<ParticlePush>{}(*this, currentStep);
+
+        particles::boundary::apply(*this, currentStep);
     }
 
     /** Do the particle push stage using the given pusher

--- a/include/picongpu/particles/boundary/Apply.hpp
+++ b/include/picongpu/particles/boundary/Apply.hpp
@@ -1,0 +1,125 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/boundary/Kind.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/traits/NumberOfExchanges.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace boundary
+        {
+            /** Functor to apply the given boundary kind to particle species
+             *
+             * This functor operates on the near-boundary area where the boundary conditions are active.
+             * Currently, this is always a part of the GUARD area of the currently outer domains (wrt periodicity).
+             * The functor would only be called for the relevant exchang types of such domains.
+             * If there are particles left in this area after this functor ran, they will be removed later.
+             *
+             * So for standard Absorbing boundaries in GUARD the functor does not need to do anything.
+             * For Periodic boundaries, there are no outer domains and so again no need to do anything here.
+             *
+             * Thus, the general implementation doing nothing is already suited for Absorbing and Periodic.
+             * However, it probably needs to be specialized for other boundary types or other Absorbing zones.
+             * In this case, the implementation must ensure particles are moved to correct supercells afterwards.
+             * In the general case, by calling shiftParticles() at the end.
+             *
+             * @param T_kind boundary kind
+             */
+            template<Kind T_kind>
+            struct Apply
+            {
+                /** Apply boundary conditions along the given outer boundary
+                 *
+                 * @tparam T_Species particle species type
+                 *
+                 * @param species particle species
+                 * @param exchangeType exchange describing the active boundary
+                 * @param currentStep current time iteration
+                 */
+                template<typename T_Species>
+                void operator()(T_Species& species, uint32_t exchangeType, uint32_t currentStep)
+                {
+                }
+            };
+
+            /** Apply boundary conditions to the given species
+             *
+             * @tparam T_Species particle species type
+             *
+             * @param species particle species
+             * @param currentStep current time iteration
+             */
+            template<typename T_Species>
+            inline void apply(T_Species&& species, uint32_t currentStep)
+            {
+                auto boundaryKind = species.boundaryKind();
+                auto const numExchanges = NumberOfExchanges<simDim>::value;
+                auto const communicationMask = Environment<simDim>::get().GridController().getCommunicationMask();
+                for(uint32_t exchange = 1u; exchange < numExchanges; ++exchange)
+                {
+                    /* Here we are only interested in the positive and negative
+                     * directions for x, y, z axes and not the "diagonal" ones.
+                     * So skip other directions except left, right, top, bottom,
+                     * back, front
+                     */
+                    if(FRONT % exchange != 0)
+                        continue;
+
+                    // If this is not an outer boundary, also skip
+                    bool hasNeighbour = communicationMask.isSet(exchange);
+                    if(hasNeighbour)
+                        continue;
+
+                    // Transform exchange into axis
+                    uint32_t axis = 0;
+                    if(exchange >= BOTTOM && exchange <= TOP)
+                        axis = 1;
+                    if(exchange >= BACK)
+                        axis = 2;
+
+                    auto boundaryKind = species.boundaryKind()[axis];
+                    switch(boundaryKind)
+                    {
+                    case Kind::Periodic:
+                        Apply<Kind::Periodic>{}(species, exchange, currentStep);
+                        break;
+                    case Kind::Absorbing:
+                        Apply<Kind::Absorbing>{}(species, exchange, currentStep);
+                        break;
+                    default:
+                        throw std::runtime_error("Unsupported boundary kind when trying to apply particle boundary");
+                    }
+                }
+            }
+
+        } // namespace boundary
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/boundary/Kind.hpp
+++ b/include/picongpu/particles/boundary/Kind.hpp
@@ -1,0 +1,38 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace boundary
+        {
+            //! Supported particle boundary kinds
+            enum class Kind
+            {
+                Periodic,
+                Absorbing
+            };
+
+        } // namespace boundary
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -50,6 +50,7 @@
 #include "picongpu/simulation/stage/FieldBackground.hpp"
 #include "picongpu/simulation/stage/IterationStart.hpp"
 #include "picongpu/simulation/stage/MomentumBackup.hpp"
+#include "picongpu/simulation/stage/ParticleBoundaries.hpp"
 #include "picongpu/simulation/stage/ParticleIonization.hpp"
 #include "picongpu/simulation/stage/ParticlePush.hpp"
 #include "picongpu/simulation/stage/PopulationKinetics.hpp"
@@ -136,6 +137,7 @@ namespace picongpu
             currentInterpolationAndAdditionToEMF.registerHelp(desc);
             fieldAbsorber.registerHelp(desc);
             fieldBackground.registerHelp(desc);
+            particleBoundaries.registerHelp(desc);
             // clang-format off
             desc.add_options()(
                 "versionOnce", po::value<bool>(&showVersionOnce)->zero_tokens(),
@@ -326,6 +328,9 @@ namespace picongpu
             // initialize field background stage,
             // this may include allocation of additional fields so has to be done before particles
             fieldBackground.init(*cellDescription);
+
+            // initialize particle boundaries
+            particleBoundaries.init();
 
             // Initialize random number generator and synchrotron functions, if there are synchrotron or bremsstrahlung
             // Photons
@@ -625,6 +630,10 @@ namespace picongpu
         // Field background stage, has to live always as it is used for registering options like a plugin.
         // Because of it, has a special init() method that has to be called during initialization of the simulation
         simulation::stage::FieldBackground fieldBackground;
+
+        // Particle boundaries stage, has to live always as it is used for registering options like a plugin.
+        // Because of it, has a special init() method that has to be called during initialization of the simulation
+        simulation::stage::ParticleBoundaries particleBoundaries;
 
 #if(PMACC_CUDA_ENABLED == 1)
         // creates lookup tables for the bremsstrahlung effect

--- a/include/picongpu/simulation/stage/ParticleBoundaries.hpp
+++ b/include/picongpu/simulation/stage/ParticleBoundaries.hpp
@@ -1,0 +1,164 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/meta/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/traits/NumberOfExchanges.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+
+namespace picongpu
+{
+    namespace simulation
+    {
+        namespace stage
+        {
+            namespace detail
+            {
+                /** Functor to set boundary kind for the given species via command-line parameters
+                 *
+                 * @tparam T_Species particle species type
+                 */
+                template<typename T_Species>
+                class ParticleBoundariesCommandLine
+                {
+                public:
+                    //! Create particle boundaries functor
+                    ParticleBoundariesCommandLine() : prefix(T_Species::FrameType::getName())
+                    {
+                    }
+
+                    /** Register command-line options
+                     *
+                     * Done as operator() to simplify invoking with pmacc::meta::ForEach
+                     */
+                    void operator()(po::options_description& desc)
+                    {
+                        auto example = std::string{"example: --" + prefix + "_boundary absorbing periodic"};
+                        if(simDim == 3)
+                            example += " periodic";
+                        desc.add_options()(
+                            (prefix + "_boundary").c_str(),
+                            po::value<std::vector<std::string>>(&(kindNames()))->multitoken(),
+                            std::string(
+                                "Boundary kinds for species '" + prefix
+                                + "' for each axis. "
+                                  "Supported values: default (matching --periodic values), periodic, absorbing"
+                                  "\n"
+                                + example)
+                                .c_str());
+                    }
+
+                    /** Set boundary kind of T_Species according to command-line options
+                     *
+                     * Done as operator() to simplify invoking with pmacc::meta::ForEach
+                     */
+                    void operator()()
+                    {
+                        for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
+                        {
+                            // for each planar direction: left right top bottom back front
+                            if(FRONT % i == 0)
+                            {
+                                const DataSpace<DIM3> relDir = Mask::getRelativeDirections<DIM3>(i);
+                                uint32_t axis = 0; // x(0) y(1) z(2)
+                                for(uint32_t d = 0; d < simDim; d++)
+                                    if(relDir[d] != 0)
+                                        axis = d;
+                                /* For now we do not support any type not matching --periodic values.
+                                 * So just check that the user-provided type matches the default one.
+                                 */
+                                auto const kindName = kindNames()[axis];
+                                bool isInvalidPeriodic
+                                    = ((kindName == "periodic")
+                                       && (T_Species::boundaryKind()[axis] != particles::boundary::Kind::Periodic));
+                                bool isInvalidAbsorbing
+                                    = ((kindName == "absorbing")
+                                       && (T_Species::boundaryKind()[axis] != particles::boundary::Kind::Absorbing));
+                                if(isInvalidPeriodic || isInvalidAbsorbing)
+                                {
+                                    throw std::runtime_error(
+                                        "Boundary kind for species '" + prefix + "' and axis " + std::to_string(axis)
+                                        + " is not compatible with --periodic value");
+                                }
+                            }
+                        }
+                    }
+
+                private:
+                    //! Names of boundary kinds for all axes
+                    static std::vector<std::string>& kindNames()
+                    {
+                        static auto names = std::vector<std::string>(simDim, "default");
+                        return names;
+                    }
+
+                    //! Prefix for the given species
+                    std::string prefix;
+                };
+
+            } // namespace detail
+
+            /** Functor for setting up particle boundaries for species with a pusher
+             *
+             * Allows overwriting default boundaries via command-line for those species.
+             * This stage does not apply boudaries by itself, but is needed to propagate command-line parameters
+             */
+            class ParticleBoundaries
+            {
+            public:
+                /** Register program options for particle boundaries
+                 *
+                 * @param desc program options following boost::program_options::options_description
+                 */
+                void registerHelp(po::options_description& desc)
+                {
+                    processSpecies(desc);
+                }
+
+                /** Initialize particle boundaries stage
+                 *
+                 * Sets boundary kind values for all affected species.
+                 */
+                void init()
+                {
+                    processSpecies();
+                }
+
+            private:
+                //! Only allow customization for species with pusher
+                using SpeciesWithPusher =
+                    typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, particlePusher<>>::type;
+                //! Functor to process all affected species
+                meta::ForEach<SpeciesWithPusher, detail::ParticleBoundariesCommandLine<bmpl::_1>> processSpecies;
+            };
+
+        } // namespace stage
+    } // namespace simulation
+} // namespace picongpu


### PR DESCRIPTION
By default, same boundaries as set in `--periodic` are used. In fact, this is the only supported combination so far as other boundaries are not yet implemented. So there are no actual features added immediately by this PR.

However, it does some preparatory work and interfaces it to the command-line parameters:

- command-line options are added and propagated to species
- hook to put other boundary conditions is added with explanations for requirements
- the calling code to detect active boundaries and only process those is implemented for the general case

**For review**: might make sense to review commit-by-commit, however up to you