### PR TITLE
Remove --openPMD.compression parameter

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -150,7 +150,6 @@ TBG_ranksPerDevice="--numRanksPerDevice 2"
 #--<species>_radiation.end     Time step to stop calculating the radiation
 #--<species>_radiation.radPerGPU     If flag is set, each GPU stores its own spectra without summing the entire simulation area
 #--<species>_radiation.folderRadPerGPU     Folder where the GPU specific spectras are stored
-#--<species>_radiation.compression    If flag is set, the hdf5 output will be compressed.
 #--<species>_radiation.numJobs     Number of independent jobs used for the radiation calculation.
 TBG_radiation="--<species>_radiation.period 1 --<species>_radiation.dump 2 --<species>_radiation.totalRadiation \
                --<species>_radiation.lastRadiation --<species>_radiation.start 2800 --<species>_radiation.end 3000"
@@ -172,7 +171,6 @@ TBG_transRad="--<species>_transRad.period 1000"
 #--<species>_xrayScattering.n_qy    Number of scattering vectors needed to be calculated in qy direction.
 #--<species>_xrayScattering.file    Output file name. Default is `<species>_xrayScatteringOutput`.
 #--<species>_xrayScattering.ext    `openPMD` filename extension. This controls the backend picked by the `openPMD` API. Default is `bp` for adios backend.
-#--<species>_xrayScattering.compression    Backend-specific `openPMD` compression method (e.g.) zlib.
 #--<species>_xrayScattering.memoryLayout    Possible values: `mirror` and `split`. Output can be mirrored on all Host+Device pairs or uniformly split, in chunks, over all nodes.
 TBG_<species>_xrayScattering="--<species>_xrayScattering.period 1 --e_xrayScattering.outputPeriod 10 \
                     --e_xrayScattering.n_qx 512 --e_xrayScattering.n_qy 512 \
@@ -245,9 +243,6 @@ TBG_openPMD="--openPMD.period 100   \
 # * JSON-formatted configuration string
 # Further information on both is retrieved from the official documentation
 # https://openpmd-api.readthedocs.io
-# Notice that specifying compression settings via --openPMD.compression
-# is considered legacy and backend-specific settings via the JSON string are
-# preferred if available for a backend.
 
 # Create a checkpoint that is restartable every --checkpoint.period steps
 #   http://git.io/PToFYg

--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -113,7 +113,6 @@ PIConGPU command line option          description
 ===================================== ====================================================================================================================================================
 ``--openPMD.period``                  Period after which simulation data should be stored on disk.
 ``--openPMD.source``                  Select data sources and filters to dump. Default is ``species_all,fields_all``, which dumps all fields and particle species.
-``--openPMD.compression``             Legacy parameter to set data transform compression method to be used for ADIOS1 backend until it implements setting compression from JSON config.
 ``--openPMD.file``                    Relative or absolute openPMD file prefix for simulation data. If relative, files are stored under ``simOutput``. 
 ``--openPMD.ext``                     openPMD filename extension (this controls thebackend picked by the openPMD API).
 ``--openPMD.infix``                   openPMD filename infix (use to pick file- or group-based layout in openPMD). Set to NULL to keep empty (e.g. to pick group-based iteration layout).

--- a/docs/source/usage/plugins/xrayScattering.rst
+++ b/docs/source/usage/plugins/xrayScattering.rst
@@ -108,8 +108,6 @@ Command line option                          Description
 
 ``--<species>_xrayScattering.ext``           `openPMD` filename extension. This controls the backend picked by the `openPMD` API. Default is `bp` for adios backend.
 
-``--<species>_xrayScattering.compression``   Backend-specific `openPMD` compression method (e.g.) zlib.
-
 ``--<species>_xrayScattering.memoryLayout``  Possible values: `mirror` and `split`. Output can be mirrored on all Host+Device pairs or uniformly split, in chunks, over all nodes.
                                              Use split when the output array is too big to store the complete computed q-space on one device.
                                              For small output grids the `mirror` setting could turn out to be more efficient.

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -97,13 +97,7 @@ namespace picongpu
                 }
 
                 std::string datasetName = series.meshesPath() + baseName + "_" + group + "/" + dataset;
-                params.initDataset<simDim>(
-                    mrc,
-                    openPMDScalarType,
-                    std::move(globalDomainSize),
-                    true,
-                    params.compressionMethod,
-                    datasetName);
+                params.initDataset<simDim>(mrc, openPMDScalarType, std::move(globalDomainSize), datasetName);
 
                 return std::make_tuple(
                     std::move(mrc),

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -82,7 +82,6 @@ namespace picongpu
             bool isCheckpoint;
 
             MPI_Comm communicator; /* MPI communicator for openPMD API */
-            std::string compressionMethod; /* openPMD data transform compression method */
             std::string fileName; /* Name of the openPMDSeries, excluding the extension */
             std::string fileExtension; /* Extension of the file name */
             std::string fileInfix;
@@ -120,8 +119,6 @@ namespace picongpu
              * Series
              * @param datatype Variable type
              * @param globalDimensions Dataset global dimensions
-             * @param compression Enable compression data transform
-             * @param compressionMethod String denoting the data transform to use
              * @return The input recordComponent
              */
             template<unsigned DIM>
@@ -129,8 +126,6 @@ namespace picongpu
                 ::openPMD::RecordComponent& recordComponent,
                 ::openPMD::Datatype datatype,
                 pmacc::math::UInt64<DIM> const& globalDimensions,
-                bool compression,
-                std::string const& compressionMethod,
                 std::string const& datasetName);
         };
     } // namespace openPMD

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -105,17 +105,11 @@ namespace picongpu
             ::openPMD::RecordComponent& recordComponent,
             ::openPMD::Datatype datatype,
             pmacc::math::UInt64<DIM> const& globalDimensions,
-            bool compression,
-            std::string const& compressionMethod,
             std::string const& datasetName)
         {
             std::vector<uint64_t> v = asStandardVector(globalDimensions);
             ::openPMD::Dataset dataset{datatype, std::move(v)};
             setDatasetOptions(dataset, jsonMatcher->get(datasetName));
-            if(compression && compressionMethod != "none")
-            {
-                dataset.compression = compressionMethod;
-            }
             recordComponent.resetDataset(std::move(dataset));
             return recordComponent;
         }
@@ -239,13 +233,6 @@ Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                    "respectively.",
                    "doubleBuffer"};
 
-            plugins::multi::Option<std::string> compression
-                = {"compression",
-                   "Backend-specific openPMD compression method, e.g., zlib (see "
-                   "`adios_config -m` for help). Legacy parameter until compression"
-                   " can be fully configured via JSON in the openPMD API.",
-                   "none"};
-
             /** defines if the plugin must register itself to the PMacc plugin
              * system
              *
@@ -300,7 +287,6 @@ Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{})
             {
-                compression.registerHelp(desc, masterPrefix + prefix);
                 fileName.registerHelp(desc, masterPrefix + prefix);
                 fileNameExtension.registerHelp(desc, masterPrefix + prefix);
                 fileNameInfix.registerHelp(desc, masterPrefix + prefix);
@@ -637,8 +623,6 @@ Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     mrc,
                     ::openPMD::determineDatatype<ReinterpretedType>(),
                     fieldsGlobalSizeDims,
-                    true,
-                    params->compressionMethod,
                     datasetName);
 
                 // define record component level attributes
@@ -744,8 +728,6 @@ Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 , outputDirectory("openPMD")
                 , lastSpeciesSyncStep(pmacc::traits::limits::Max<uint32_t>::value)
             {
-                mThreadParams.compressionMethod = m_help->compression.get(id);
-
                 GridController<simDim>& gc = Environment<simDim>::get().GridController();
                 /* It is important that we never change the mpi_pos after this point
                  * because we get problems with the restart.
@@ -1157,13 +1139,7 @@ Make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         ? params->openPMDSeries->meshesPath() + name + "/" + name_lookup_tpl[d]
                         : params->openPMDSeries->meshesPath() + name;
 
-                    params->initDataset<simDim>(
-                        mrc,
-                        openPMDType,
-                        fieldsGlobalSizeDims,
-                        true,
-                        params->compressionMethod,
-                        datasetName);
+                    params->initDataset<simDim>(mrc, openPMDType, fieldsGlobalSizeDims, datasetName);
 
                     // define record component level attributes
                     mrc.setPosition(inCellPosition.at(d));

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -93,13 +93,7 @@ namespace picongpu
                         = components > 1 ? record[name_lookup[d]] : record[::openPMD::MeshRecordComponent::SCALAR];
 
                     std::string datasetName = components > 1 ? baseName + "/" + name_lookup[d] : baseName;
-                    params->initDataset<DIM1>(
-                        recordComponent,
-                        openPMDType,
-                        {globalElements},
-                        true,
-                        params->compressionMethod,
-                        datasetName);
+                    params->initDataset<DIM1>(recordComponent, openPMDType, {globalElements}, datasetName);
 
                     if(unit.size() >= (d + 1))
                     {

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -109,7 +109,6 @@ namespace picongpu
                 std::string pluginPrefix;
                 std::string fileName;
                 std::string fileExtension;
-                std::string compressionMethod;
                 std::string outputPeriod_s;
                 std::string memoryLayout;
                 //! Plugin functioning mode
@@ -202,10 +201,6 @@ namespace picongpu
                         po::value<std::string>(&fileExtension)->default_value("bp"),
                         "openPMD filename extension (this controls the backend "
                         "picked by the openPMD API)")(
-                        (pluginPrefix + ".compression").c_str(),
-                        po::value<std::string>(&compressionMethod)->default_value(""),
-                        "Backend-specific openPMD compression method, e.g., zlib "
-                        "(see `adios_config2 -m` for help)")(
                         (pluginPrefix + ".memoryLayout").c_str(),
                         po::value<std::string>(&memoryLayout)->default_value("mirror"),
                         "Possible values: 'mirror' and 'distribute'"
@@ -334,7 +329,6 @@ namespace picongpu
                             fileExtension,
                             "xrayScatteringOutput",
                             outputLayout,
-                            compressionMethod,
                             precisionCast<uint64_t>(numVectors),
                             q_step,
                             amplitudeUnit,

--- a/include/picongpu/plugins/xrayScattering/XrayScatteringWriter.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScatteringWriter.hpp
@@ -93,7 +93,6 @@ namespace picongpu
                 //! MPI Communicator for the parallel data write
                 MPI_Comm mpiCommunicator;
                 std::string const fileName, fileExtension, dir;
-                std::string const compressionMethod;
                 //! Functioning mode
                 OutputMemoryLayout outputMemoryLayout;
                 //! Output dimensions
@@ -113,7 +112,6 @@ namespace picongpu
                  * @param fileExtension File extension, specifies the API backend.
                  * @param dir Where to save the output file.
                  * @param outputMemoryLayout  Functioning mode.
-                 * @param compressionMethod
                  * @param globalExtent Output dimensions.
                  */
                 HINLINE XrayScatteringWriter(
@@ -121,7 +119,6 @@ namespace picongpu
                     std::string const fileExtension,
                     std::string const dir,
                     OutputMemoryLayout outputMemoryLayout,
-                    std::string const compressionMethod,
                     pmacc::math::UInt64<DIM2> const globalExtent,
                     float2_X const gridSpacing,
                     float_64 const unit,
@@ -130,7 +127,6 @@ namespace picongpu
                     , dir(dir)
                     , fileExtension(fileExtension)
                     , outputMemoryLayout(outputMemoryLayout)
-                    , compressionMethod(compressionMethod)
                     , globalExtent(globalExtent)
                     , gridSpacing(gridSpacing)
                     , unit(unit)
@@ -255,15 +251,6 @@ namespace picongpu
 
                     std::vector<uint64_t> shape = asStandardVector<DIM2>(globalExtent);
                     ::openPMD::Dataset dataset{datatype, std::move(shape)};
-
-                    if(isADIOS1())
-                    {
-                        dataset.transform = compressionMethod;
-                    }
-                    else
-                    {
-                        dataset.compression = compressionMethod;
-                    }
                     mrc.resetDataset(std::move(dataset));
                     mrc.setUnitSI(unit);
                     return mrc;


### PR DESCRIPTION
This parameter was for legacy-style selection of compression in openPMD
which is implemented only in ADIOS1. The openPMD plugin does not support
ADIOS1, so this is inaccessible functionality.
The legacy-style compression support will likely be removed in openPMD,
compression should be configured in a backend-specific style via JSON.