### PR TITLE
Clarify naming and comments for pmacc kernel mapping types

### DIFF
--- a/include/pmacc/mappings/kernel/AreaMapping.hpp
+++ b/include/pmacc/mappings/kernel/AreaMapping.hpp
@@ -24,31 +24,16 @@
 
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/mappings/kernel/AreaMappingMethods.hpp"
+#include "pmacc/mappings/kernel/MapperConcept.hpp"
 #include "pmacc/types.hpp"
 
 #include <cstdint>
 
 namespace pmacc
 {
-    /** Mapping between block indices and supercells in the given area for alpaka kernels
+    /** Mapping from block indices to supercells in the given area for alpaka kernels
      *
-     * The mapping covers the case of supercell-level parallelism between alpaka blocks.
-     * The supercells can be processed concurrently in any order.
-     *
-     * This class makes a 1:1 mapping between supercells in the area and alpaka blocks.
-     * A kernel must be launched with exactly getGridDim() blocks.
-     * Each block must process a single supercell with index getSuperCellIndex(blockIndex).
-     * Implementation is optimized for the standard areas in AreaType.
-     *
-     * In-block parallelism is independent of this mapping and is done by a kernel.
-     * Naturally, this parallelism should also define block size, again independent of this mapping.
-     *
-     * This pattern is used in most kernels in particle-mesh codes.
-     * Two most common parallel patterns are:
-     *    - for particle or particle-grid operations:
-     *      alpaka block per supercell with this mapping, thread-level parallelism between particles of a frame
-     *    - for grid operations:
-     *      alpaka block per supercell with this mapping, thread-level parallelism between cells of a supercell
+     * Adheres to the MapperConcept.
      *
      * @tparam T_area area, a value from type::AreaType or a sum of such values
      * @tparam T_MappingDescription mapping description type
@@ -93,33 +78,13 @@ namespace pmacc
          */
         HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
-            return AreaMappingMethods<areaType, DIM>::getBlockIndex(*this, this->getGridSuperCells(), blockIdx);
+            return AreaMappingMethods<areaType, DIM>::getSuperCellIndex(*this, this->getGridSuperCells(), blockIdx);
         }
-    };
-
-    /** Concept for area mapper factory
-     *
-     * Defines interface for implementations of such factories.
-     * (A user-provided implementation is needed for user-defined areas.)
-     */
-    class AreaMapperFactoryConcept
-    {
-    public:
-        /** Construct an area mapper object
-         *
-         * @tparam T_MappingDescription mapping description type
-         *
-         * @param mappingDescription mapping description
-         *
-         * @return an object adhering to the AreaMapping concept
-         */
-        template<typename T_MappingDescription>
-        HINLINE auto operator()(T_MappingDescription mappingDescription) const;
     };
 
     /** Construct an area mapper instance for the given standard area and description
      *
-     * Adheres to the AreaMapperFactoryConcept.
+     * Adheres to the MapperFactoryConcept.
      *
      * @tparam T_area area, a value from type::AreaType or a sum of such values
      */

--- a/include/pmacc/mappings/kernel/AreaMappingMethods.hpp
+++ b/include/pmacc/mappings/kernel/AreaMappingMethods.hpp
@@ -49,7 +49,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM> getBlockIndex(
+        HDINLINE static DataSpace<DIM> getSuperCellIndex(
             const Base&,
             const DataSpace<DIM>&,
             const DataSpace<DIM>& _blockIdx)
@@ -72,7 +72,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM> getBlockIndex(
+        HDINLINE static DataSpace<DIM> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM>& gBlocks,
             const DataSpace<DIM>& _blockIdx)
@@ -96,7 +96,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM> getBlockIndex(
+        HDINLINE static DataSpace<DIM> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM>& gBlocks,
             const DataSpace<DIM>& _blockIdx)
@@ -128,7 +128,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM2> getBlockIndex(
+        HDINLINE static DataSpace<DIM2> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM2>& gBlocks,
             const DataSpace<DIM2>& _blockIdx)
@@ -174,7 +174,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM2> getBlockIndex(
+        HDINLINE static DataSpace<DIM2> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM2>& gBlocks,
             const DataSpace<DIM2>& _blockIdx)
@@ -183,7 +183,7 @@ namespace pmacc
             const DataSpace<DIM2> sizeWithoutGuard(gBlocks - 2 * base.getGuardingSuperCells());
 
             // use result of the shrinked domain and skip guarding supercells
-            return AreaMappingMethods<GUARD, DIM2>{}.getBlockIndex(base, sizeWithoutGuard, _blockIdx)
+            return AreaMappingMethods<GUARD, DIM2>{}.getSuperCellIndex(base, sizeWithoutGuard, _blockIdx)
                 + base.getGuardingSuperCells();
         }
     };
@@ -208,7 +208,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM3> getBlockIndex(
+        HDINLINE static DataSpace<DIM3> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM3>& gBlocks,
             const DataSpace<DIM3>& _blockIdx)
@@ -276,7 +276,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM3> getBlockIndex(
+        HDINLINE static DataSpace<DIM3> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM3>& gBlocks,
             const DataSpace<DIM3>& _blockIdx)
@@ -285,7 +285,7 @@ namespace pmacc
             const DataSpace<DIM3> sizeWithoutGuard(gBlocks - 2 * base.getGuardingSuperCells());
 
             // use result of the shrinked domain and skip guarding supercells
-            return AreaMappingMethods<GUARD, DIM3>{}.getBlockIndex(base, sizeWithoutGuard, _blockIdx)
+            return AreaMappingMethods<GUARD, DIM3>{}.getSuperCellIndex(base, sizeWithoutGuard, _blockIdx)
                 + base.getGuardingSuperCells();
         }
     };

--- a/include/pmacc/mappings/kernel/BorderMapping.hpp
+++ b/include/pmacc/mappings/kernel/BorderMapping.hpp
@@ -24,13 +24,17 @@
 
 #include "pmacc/assert.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/mappings/kernel/MapperConcept.hpp"
 #include "pmacc/types.hpp"
 
 #include <stdexcept>
 
 namespace pmacc
 {
-    /**
+    /** Mapping from block indices to supercells in the given border for alpaka kernels
+     *
+     * Adheres to the MapperConcept.
+     *
      * This maps onto the border to 1 exchange direction (e.g. TOP, BOTTOM, TOP + LEFT, ...)
      * Choosing multiple directions defines an intersection [1] in mathematical set theory.
      * The area is basically the same as the surrounding guard region but on the border.
@@ -83,10 +87,11 @@ namespace pmacc
             return m_direction;
         }
 
-        /**
-         * Generate grid dimension information for kernel calls
+        /** Generate grid dimension information for alpaka kernel calls
          *
-         * @return size of the grid
+         * A kernel using this mapping must use exacly the returned number of blocks
+         *
+         * @return number of blocks in a grid
          */
         HINLINE DimDataSpace getGridDim() const
         {
@@ -103,15 +108,14 @@ namespace pmacc
             return result;
         }
 
-        /**
-         * Returns index of current logical block
+        /** Return index of a supercell to be processed by the given alpaka block
          *
-         * @param realSuperCellIdx current SuperCell index (block index)
-         * @return mapped SuperCell index
+         * @param blockIdx alpaka block index
+         * @return mapped SuperCell index including guards
          */
-        HDINLINE DimDataSpace getSuperCellIndex(const DimDataSpace& realSuperCellIdx) const
+        HDINLINE DimDataSpace getSuperCellIndex(const DimDataSpace& blockIdx) const
         {
-            DimDataSpace result = realSuperCellIdx;
+            DimDataSpace result = blockIdx;
 
             const DimDataSpace directions = Mask::getRelativeDirections<Dim>(m_direction);
 

--- a/include/pmacc/mappings/kernel/ExchangeMapping.hpp
+++ b/include/pmacc/mappings/kernel/ExchangeMapping.hpp
@@ -24,20 +24,24 @@
 
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/mappings/kernel/ExchangeMappingMethods.hpp"
+#include "pmacc/mappings/kernel/MapperConcept.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc
 {
-    template<uint32_t areaType, class baseClass>
-    class ExchangeMapping;
-
-    /**
+    /** Mapping from block indices to supercells in the given exchange area for alpaka kernels
+     *
+     * Adheres to the MapperConcept.
+     *
      * Allows mapping thread/block indices to a specific region in a DataSpace
      * defined by a valid ExchangeType combination.
      *
      * @tparam areaType are to map to
      * @tparam baseClass base class for mapping, should be MappingDescription
      */
+    template<uint32_t areaType, class baseClass>
+    class ExchangeMapping;
+
     template<uint32_t areaType, template<unsigned, class> class baseClass, unsigned DIM, class SuperCellSize_>
     class ExchangeMapping<areaType, baseClass<DIM, SuperCellSize_>> : public baseClass<DIM, SuperCellSize_>
     {
@@ -73,25 +77,25 @@ namespace pmacc
             return exchangeType;
         }
 
-        /**
-         * Generate grid dimension information for kernel calls
+        /** Generate grid dimension information for alpaka kernel calls
          *
-         * @return size of the grid
+         * A kernel using this mapping must use exacly the returned number of blocks
+         *
+         * @return number of blocks in a grid
          */
         HINLINE DataSpace<DIM> getGridDim() const
         {
             return ExchangeMappingMethods<areaType, DIM>::getGridDim(*this, exchangeType);
         }
 
-        /**
-         * Returns index of current logical block
+        /** Return index of a supercell to be processed by the given alpaka block
          *
-         * @param realSuperCellIdx current SuperCell index (block index)
-         * @return mapped SuperCell index
+         * @param blockIdx alpaka block index
+         * @return mapped SuperCell index including guards
          */
-        HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& realSuperCellIdx) const
+        HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
-            return ExchangeMappingMethods<areaType, DIM>::getBlockIndex(*this, realSuperCellIdx, exchangeType);
+            return ExchangeMappingMethods<areaType, DIM>::getSuperCellIndex(*this, blockIdx, exchangeType);
         }
     };
 

--- a/include/pmacc/mappings/kernel/ExchangeMappingMethods.hpp
+++ b/include/pmacc/mappings/kernel/ExchangeMappingMethods.hpp
@@ -46,7 +46,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM> getBlockIndex(
+        HDINLINE static DataSpace<DIM> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM>& _blockIdx,
             uint32_t exchangeType)
@@ -79,7 +79,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM> getBlockIndex(
+        HDINLINE static DataSpace<DIM> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM>& _blockIdx,
             uint32_t exchangeType)
@@ -126,7 +126,7 @@ namespace pmacc
         }
 
         template<class Base>
-        HDINLINE static DataSpace<DIM> getBlockIndex(
+        HDINLINE static DataSpace<DIM> getSuperCellIndex(
             const Base& base,
             const DataSpace<DIM>& _blockIdx,
             uint32_t exchangeType)

--- a/include/pmacc/mappings/kernel/MapperConcept.hpp
+++ b/include/pmacc/mappings/kernel/MapperConcept.hpp
@@ -1,0 +1,114 @@
+/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <pmacc/types.hpp>
+
+
+namespace pmacc
+{
+    /** Concept for mapper from block indices to supercells in the given area for alpaka kernels
+     *
+     * The mapping covers the case of supercell-level parallelism between alpaka blocks.
+     * The supercells can be processed concurrently in any order.
+     * This class is not used directly, but defines a concept for such mappers.
+     *
+     * Mapper provides a 1:1 mapping from supercells in the area to alpaka blocks.
+     * (Since it is 1:1, the mapping is invertible, but only this direction is provided.)
+     * Dimensionality of the area indices and block indices is the same.
+     * A kernel must be launched with exactly getGridDim() blocks.
+     * Each block must process a single supercell with index getSuperCellIndex(blockIndex).
+     * Implementation is optimized for the standard areas in AreaType.
+     *
+     * In-block parallelism is independent of this mapping and is done by a kernel.
+     * Naturally, this parallelism should also define block size, again independent of this mapping.
+     *
+     * This pattern is used in most kernels in particle-mesh codes.
+     * Two most common parallel patterns are:
+     *    - for particle or particle-grid operations:
+     *      alpaka block per supercell with this mapping, thread-level parallelism between particles of a frame
+     *    - for grid operations:
+     *      alpaka block per supercell with this mapping, thread-level parallelism between cells of a supercell
+     *
+     * @tparam T_areaType parameter describing area to be mapped (depends on mapper type)
+     * @tparam T_MappingDescription mapping description type, base class for MapperConcept
+     * @tparam T_dim dimensionality of area and block indices
+     * @tparam T_SupercellSize compile-time supercell size
+     */
+    template<
+        uint32_t T_areaType,
+        template<unsigned, typename>
+        typename T_MappingDescription,
+        unsigned T_dim,
+        typename T_SupercellSize>
+    class MapperConcept : public T_MappingDescription<T_dim, T_SupercellSize>
+    {
+        //! Base class
+        using BaseClass = T_MappingDescription<T_dim, T_SupercellSize>;
+
+        //! Compile-time super cell size
+        using SuperCellSize = typename BaseClass::SuperCellSize;
+
+        /** Create a mapper instance
+         *
+         * @param base base class instance
+         */
+        HINLINE MapperConcept(T_MappingDescription<T_dim, T_SupercellSize> base);
+
+        /** Generate grid dimension information for alpaka kernel calls
+         *
+         * A kernel using this mapping must use exacly the returned number of blocks
+         *
+         * @return number of blocks in a grid
+         */
+        HINLINE DataSpace<T_dim> getGridDim() const;
+
+        /** Return index of a supercell to be processed by the given alpaka block
+         *
+         * @param blockIdx alpaka block index
+         * @return mapped SuperCell index including guards
+         */
+        HDINLINE DataSpace<T_dim> getSuperCellIndex(const DataSpace<T_dim>& blockIdx) const;
+    };
+
+    /** Concept for mapper factory
+     *
+     * Defines interface for implementations of such factories.
+     * (A user-provided implementation is needed for user-defined areas.)
+     */
+    class MapperFactoryConcept
+    {
+    public:
+        /** Construct an mapper object using the given base class instance
+         *
+         * @tparam T_MappingDescription mapping description type
+         *
+         * @param mappingDescription mapping description
+         *
+         * @return an object adhering to the MapperConcept, inheriting T_MappingDescription
+         */
+        template<typename T_MappingDescription>
+        HINLINE auto operator()(T_MappingDescription mappingDescription) const;
+    };
+
+} // namespace pmacc

--- a/include/pmacc/mappings/kernel/StrideMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapping.hpp
@@ -24,11 +24,22 @@
 
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
+#include "pmacc/mappings/kernel/MapperConcept.hpp"
 #include "pmacc/mappings/kernel/StrideMappingMethods.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc
 {
+    /** Mapping from block indices to supercells in the given strided area for alpaka kernels
+     *
+     * Adheres to the MapperConcept.
+     *
+     * The mapped area is an intersection of T_area and an integer lattice with given stride in all directions
+     *
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     * @tparam stride stride value
+     * @tparam baseClass mapping description type
+     */
     template<uint32_t areaType, uint32_t stride, class baseClass>
     class StrideMapping;
 
@@ -58,25 +69,25 @@ namespace pmacc
         {
         }
 
-        /**
-         * Generate grid dimension information for kernel calls
+        /** Generate grid dimension information for alpaka kernel calls
          *
-         * @return size of the grid
+         * A kernel using this mapping must use exacly the returned number of blocks
+         *
+         * @return number of blocks in a grid
          */
         HINLINE DataSpace<DIM> getGridDim() const
         {
             return (StrideMappingMethods<areaType, DIM>::getGridDim(*this) - offset + (int) Stride - 1) / (int) Stride;
         }
 
-        /**
-         * Returns index of current logical block
+        /** Return index of a supercell to be processed by the given alpaka block
          *
-         * @param realSuperCellIdx current SuperCell index (block index)
-         * @return mapped SuperCell index
+         * @param blockIdx alpaka block index
+         * @return mapped SuperCell index including guards
          */
-        HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& realSuperCellIdx) const
+        HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
-            const DataSpace<DIM> blockId((realSuperCellIdx * (int) Stride) + offset);
+            const DataSpace<DIM> blockId((blockIdx * (int) Stride) + offset);
             return StrideMappingMethods<areaType, DIM>::shift(*this, blockId);
         }
 


### PR DESCRIPTION
Fix mixing up of block and supercell indexing in the naming.
Move the `MapperConcept` and `MapperFactoryConcept` to a new file.
Link in the comments all mapping templates to the `MapperConcept` and the only (so far) existing factory to the factory concept.