### PR TITLE
Fix drift manipulator in SingleParticle Example

### DIFF
--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/particle.param
@@ -55,7 +55,7 @@ namespace picongpu
                 static constexpr float_64 gamma = 1.1547; // beta: 0.5
                 const DriftParam_direction_t direction;
             };
-            using AssignYDrift = unary::Drift<DriftParam, pmacc::math::operation::Assign>;
+            using AssignXDrift = unary::Drift<DriftParam, pmacc::math::operation::Assign>;
 
         } // namespace manipulators
 

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
@@ -41,7 +41,7 @@ namespace picongpu
          */
         using InitPipeline = bmpl::vector<
             CreateDensity<densityProfiles::FreeFormula, startPosition::OnePosition, PIC_Electrons>,
-            Manipulate<manipulators::AssignYDrift, PIC_Electrons>>;
+            Manipulate<manipulators::AssignXDrift, PIC_Electrons>>;
 
     } // namespace particles
 } // namespace picongpu


### PR DESCRIPTION
Name suggested y-drift, but it is x-drift