### PR TITLE
plugin radiation: fix warning

### DIFF
--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -44,9 +44,7 @@ namespace picongpu
 
                 // default constructor
 
-                HDINLINE cuda_vec()
-                {
-                }
+                HDINLINE cuda_vec() = default;
 
                 // constructor
 
@@ -56,6 +54,8 @@ namespace picongpu
                     this->y() = other.y();
                     this->z() = other.z();
                 }
+
+                HDINLINE cuda_vec(const cuda_vec& other) = default;
 
                 HDINLINE static cuda_vec<V, T> zero()
                 {
@@ -73,13 +73,7 @@ namespace picongpu
                     this->z() = (T) other.z();
                 }
 
-                HDINLINE cuda_vec<V, T>& operator=(const cuda_vec<V, T>& other)
-                {
-                    this->x() = other.x();
-                    this->y() = other.y();
-                    this->z() = other.z();
-                    return (*this);
-                }
+                HDINLINE cuda_vec& operator=(const cuda_vec& other) = default;
 
                 HDINLINE T& operator[](uint32_t dim)
                 {


### PR DESCRIPTION
```
picongpu/include/pmacc/../picongpu/plugins/radiation/particle.hpp: In constructor ‘picongpu::plugins::radiation::Particle::Particle(const vector_X&, const vector_X&, const vector_X&, picongpu::float_X)’:
picongpu/include/pmacc/../picongpu/plugins/radiation/particle.hpp:75:119: warning: implicitly-declared ‘constexpr picongpu::plugins::radiation::cuda_vec<pmacc::math::Vector<float, 3>, float>::cuda_vec(const picongpu::plugins::radiation::cuda_vec<pmacc::math::Vector<float, 3>, float>&)’ is deprecated [-Wdeprecated-copy]
   75 |                     const picongpu::float_X mass_set)
...
picongpu/plugins/radiation/vector.hpp:76:40: note: because ‘picongpu::plugins::radiation::cuda_vec<pmacc::math::Vector<float, 3>, float>’ has user-provided ‘picongpu::plugins::radiation::cuda_vec<V, T>& picongpu::plugins::radiation::cuda_vec<V, T>::operator=(const picongpu::plugins::radiation::cuda_vec<V, T>&) [with V = pmacc::math::Vector<float, 3>; T = float]’
   76 |                 HDINLINE cuda_vec<V, T>& operator=(const cuda_vec<V, T>& other)
```