### PR TITLE
CI: use stages for downstream pipe

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
     - apt install -y python3-pip
     - pip3 install allpairspy
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - $CI_PROJECT_DIR/share/ci/generate_reduced_matrix.sh -n ${TEST_TUPLE_NUM_ELEM} > compile.yml
+    - $CI_PROJECT_DIR/share/ci/generate_reduced_matrix.sh -n ${TEST_TUPLE_NUM_ELEM} -j 15 > compile.yml
     - cat compile.yml
   artifacts:
     paths:


### PR DESCRIPTION
Group the downstream pipe into stages to reduce the load on the CI.
Additionally, this had the advantage that in case a job in the first stage is not passing the checks other stages will not be started, which keeps more CI resources free.

thx @SimeonEhrig for the hint that downstream pipes can have their own stages.

@SimeonEhrig said I should clean the python code, this will be a task for a follow-up PR.