### PR TITLE
Fix a warning in MapperConcept

### DIFF
--- a/include/pmacc/mappings/kernel/MapperConcept.hpp
+++ b/include/pmacc/mappings/kernel/MapperConcept.hpp
@@ -58,7 +58,7 @@ namespace pmacc
     template<
         uint32_t T_areaType,
         template<unsigned, typename>
-        typename T_MappingDescription,
+        class T_MappingDescription,
         unsigned T_dim,
         typename T_SupercellSize>
     class MapperConcept : public T_MappingDescription<T_dim, T_SupercellSize>


### PR DESCRIPTION
Was accidentally introduced by me recently, was using C++17 syntax.