### PR TITLE
Extend doc section on particle filter workflows

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -26,6 +26,7 @@ One can e.g. disable the output of particles by setting:
    using FileOutputParticles = MakeSeq_t< >;
 
 Particle filters used for output plugins, including this one, are defined in :ref:`particleFilters.param <usage-params-core>`.
+Also see :ref:`common patterns of defining particle filters <usage-workflows-particleFilters>`.
 
 .cfg file
 ^^^^^^^^^

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -76,7 +76,7 @@ A particle only stores its relative position inside the cell.
 Thus, with a simple filter like one shown above, it is not possible to get global position of a particle.
 However, there are helper wrapper filters that provide such information in addition to the particle data.
 
-For a special case of slicing along one axis there is a simple existing filter that only needs to be parametrized:
+For a special case of slicing along one axis this is a simple existing filter that only needs to be parametrized:
 
 .. code:: cpp
 
@@ -143,7 +143,7 @@ For a more general case of filtering based on cell index (possibly combined with
                    T_Particle const & particle
                )
                {
-                   /* Here totalCellOffset is cell index of the particle in the total coordinate system.
+                   /* Here totalCellOffset is the cell index of the particle in the total coordinate system.
                     * So we can define conditions based on both cell index and other particle data.
                     */
                    return (totalCellOffset.x() >= 10) && (particle[momentum_].x() < 0.0_X);

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -3,7 +3,7 @@
 Particle Filters
 ----------------
 
-.. sectionauthor:: Axel Huebl
+.. sectionauthor:: Axel Huebl, Sergei Bastrakov
 
 A common task in both modeling, initializing and in situ processing (output) is the selection of particles of a particle species by attributes.
 PIConGPU implements such selections as *particle filters*.
@@ -60,10 +60,108 @@ and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
 
 .. code:: cpp
 
-   using AllParticleFilters = MakeSeq_t<
-       All,
-       ParticlesForwardPinhole
-   >;
+       using AllParticleFilters = MakeSeq_t<
+           All,
+           ParticlesForwardPinhole
+       >;
+
+   } // namespace filter
+   } // namespace particles
+   } // namespace picongpu
+
+Filtering Based on Global Position
+""""""""""""""""""""""""""""""""""
+
+A particle only stores its relative position inside the cell.
+Thus, with a simple filter like one shown above, it is not possible to get global position of a particle.
+However, there are helper wrapper filters that provide such information in addition to the particle data.
+
+For a special case of slicing along one axis there is a simple existing filter that only needs to be parametrized:
+
+.. code:: cpp
+
+   namespace picongpu
+   {
+   namespace particles
+   {
+   namespace filter
+   {
+       namespace detail
+       {
+           //! Parameters to be used with RelativeGlobalDomainPosition, change the values inside
+           struct SliceParam
+           {
+               // Lower bound in relative coordinates: global domain is [0.0, 1.0]
+               static constexpr float_X lowerBound = 0.55_X;
+
+               // Upper bound in relative coordinates
+               static constexpr float_X upperBound = 0.6_X;
+
+               // Axis: x = 0; y= 1; z = 2
+               static constexpr uint32_t dimension = 0;
+
+               // Text name of the filter, will be used in .cfg file
+               static constexpr char const* name = "slice";
+           };
+
+           //! Use the existing RelativeGlobalDomainPosition filter with our parameters
+           using Slice = RelativeGlobalDomainPosition<SliceParam>;
+       }
+
+and add ``detail::Slice`` to the ``AllParticleFilters`` list:
+
+.. code:: cpp
+
+       using AllParticleFilters = MakeSeq_t<
+           All,
+           detail::Slice
+       >;
+
+   } // namespace filter
+   } // namespace particles
+   } // namespace picongpu
+
+For a more general case of filtering based on cell index (possibly combined with other particle properties) use the following pattern:
+
+.. code:: cpp
+
+   namespace picongpu
+   {
+   namespace particles
+   {
+   namespace filter
+   {
+       namespace detail
+       {
+           struct AreaFilter
+           {
+               static constexpr char const* name = "areaFilter";
+
+               template<typename T_Particle>
+               HDINLINE bool operator()(
+                   DataSpace<simDim> const totalCellOffset,
+                   T_Particle const & particle
+               )
+               {
+                   /* Here totalCellOffset is cell index of the particle in the total coordinate system.
+                    * So we can define conditions based on both cell index and other particle data.
+                    */
+                   return (totalCellOffset.x() >= 10) && (particle[momentum_].x() < 0.0_X);
+                }
+            };
+
+            //! Wrap AreaFilter so that it fits the general filter interface
+            using Area = generic::FreeTotalCellOffset<AreaFilter>;
+       }
+
+and add ``detail::Area`` to the ``AllParticleFilters`` list:
+
+.. code:: cpp
+
+       using AllParticleFilters = MakeSeq_t<
+           All,
+           detail::Area
+       >;
 
    } // namespace filter
    } // namespace particles


### PR DESCRIPTION
I think this was rather unclear for users: #3666 , #3774 , #3780 . This PR at least clarifies the common use case of needing particle global position.

And may help do other `particle + some custom data` cases by example. Of course, there an issue is that in case there is no pre-existing wrapper, a user has to do it themselves. Which is mostly a copy-paste of existing wrappers, but not very intuitive.