### PR TITLE
Add a factory and a factory function for pmacc::StrideMapping

### DIFF
--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -170,7 +170,7 @@ namespace picongpu
             typename FrameSolver::UpperMargin>
             BlockArea;
 
-        StrideMapping<AREA, 3, MappingDesc> mapper(cellDescription);
+        auto mapper = makeStrideAreaMapper<AREA, 3>(cellDescription);
         typename ParticlesClass::ParticlesBoxType pBox = parClass.getDeviceParticlesBox();
         FieldTmp::DataBoxType tmpBox = this->fieldTmp->getDeviceBuffer().getDataBox();
         FrameSolver solver;

--- a/include/picongpu/fields/currentDeposition/Deposit.hpp
+++ b/include/picongpu/fields/currentDeposition/Deposit.hpp
@@ -79,11 +79,8 @@ namespace picongpu
                  */
                 constexpr uint32_t skipSuperCells
                     = (MaxMargin::value + SuperCellMinSize::value - 1u) / SuperCellMinSize::value;
-                StrideMapping<
-                    T_area,
-                    skipSuperCells + 1u, // stride 1u means each supercell is used
-                    MappingDesc>
-                    mapper(cellDescription);
+                // stride 1u means each supercell is used
+                auto mapper = makeStrideAreaMapper<T_area, skipSuperCells + 1u>(cellDescription);
 
                 do
                 {

--- a/include/pmacc/mappings/kernel/StrideMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *
@@ -30,14 +30,14 @@
 
 namespace pmacc
 {
-    /** Mapping from block indices to supercells in the given strided area for alpaka kernels
+    /** Strided mapping from block indices to supercells in the given area for alpaka kernels
      *
      * Adheres to the MapperConcept.
      *
      * The mapped area is an intersection of T_area and an integer lattice with given stride in all directions
      *
      * @tparam T_area area, a value from type::AreaType or a sum of such values
-     * @tparam stride stride value
+     * @tparam stride stride value, same for all directions
      * @tparam baseClass mapping description type
      */
     template<uint32_t areaType, uint32_t stride, class baseClass>
@@ -117,5 +117,44 @@ namespace pmacc
     private:
         PMACC_ALIGN(offset, DataSpace<DIM>);
     };
+
+    /** Construct a strided area mapper instance for the given standard area, stride, and description
+     *
+     * Adheres to the MapperFactoryConcept.
+     *
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     * @tparam stride stride value, same for all directions
+     */
+    template<uint32_t T_area, uint32_t T_stride>
+    struct StrideAreaMapperFactory
+    {
+        /** Construct a strided area mapper object
+         *
+         * @tparam T_MappingDescription mapping description type
+         *
+         * @param mappingDescription mapping description
+         *
+         * @return an object adhering to the StridedMapping concept
+         */
+        template<typename T_MappingDescription>
+        HINLINE auto operator()(T_MappingDescription mappingDescription) const
+        {
+            return StrideMapping<T_area, T_stride, T_MappingDescription>{mappingDescription};
+        }
+    };
+
+    /** Construct a strided area mapper instance for the given area, stride, and description
+     *
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     * @tparam stride stride value, same for all directions
+     * @tparam T_MappingDescription mapping description type
+     *
+     * @param mappingDescription mapping description
+     */
+    template<uint32_t T_area, uint32_t T_stride, typename T_MappingDescription>
+    HINLINE auto makeStrideAreaMapper(T_MappingDescription mappingDescription)
+    {
+        return StrideAreaMapperFactory<T_area, T_stride>{}(mappingDescription);
+    }
 
 } // namespace pmacc

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -104,7 +104,7 @@ namespace pmacc
         template<uint32_t AREA>
         void shiftParticles()
         {
-            StrideMapping<AREA, 3, MappingDesc> mapper(this->cellDescription);
+            auto mapper = makeStrideAreaMapper<AREA, 3>(this->cellDescription);
             ParticlesBoxType pBox = particlesBuffer->getDeviceParticleBox();
             auto const numSupercellsWithGuards = particlesBuffer->getSuperCellsCount();
 


### PR DESCRIPTION
I called the new factory / factory function with `area` explicitly, as it is more descriptive and also I plan to add a new stride mapping for intervals introduced by #3783. This will be useful for particle absorber optimizations after #3776 is merged.

The second commit parametrizes the `shiftParticles()` with an area factory. It is in the same fashion as `picongpu::particles::manipulate()`. We will need this one, again, for particle absorbers.