### PR TITLE
Replace custom compile-time string creation by BOOST_METAPARSE_STRING

### DIFF
--- a/include/pmacc/boost_workaround.hpp
+++ b/include/pmacc/boost_workaround.hpp
@@ -45,4 +45,12 @@
  */
 #include <boost/optional/optional.hpp>
 
+#if defined(__clang__) && defined(__CUDACC__)
+// Boost.Config wrongly detects the BOOST_CUDA_VERSION with clang as CUDA compiler and disables variadic templates.
+// See: https://github.com/boostorg/config/issues/297
+// We also need to do this after including Boost.optional, so we do not retrigger the bug the above workaround fixes.
+#    undef BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#    undef BOOST_NO_VARIADIC_TEMPLATES
+#endif
+
 // clang-format on

--- a/include/pmacc/meta/String.hpp
+++ b/include/pmacc/meta/String.hpp
@@ -21,27 +21,15 @@
 
 #pragma once
 
-#include <boost/preprocessor/repetition/repeat_from_to.hpp>
+#include <boost/metaparse/string.hpp>
 
+#include <array>
+#include <string>
 
 namespace pmacc
 {
     namespace meta
     {
-        /** get character of an C-string
-         *
-         * @tparam T_len length of the string
-         *
-         * @param cstr input string
-         * @param idx index of the character
-         * @return if x < T_len character at index idx, else '0'
-         */
-        template<int T_len>
-        constexpr auto elem_at(char const (&cstr)[T_len], size_t const idx) -> char
-        {
-            return idx < T_len ? cstr[idx] : 0;
-        }
-
         /** compile time string
          *
          * The size of the instance is 1 byte.
@@ -59,13 +47,19 @@ namespace pmacc
             }
         };
 
+        namespace internal
+        {
+            template<typename T>
+            struct MakeString;
 
-#define PMACC_CHAR_AT_N(z, n, name) pmacc::meta::elem_at<sizeof(name)>(name, n),
+            template<char... T_c>
+            struct MakeString<boost::metaparse::string<T_c...>>
+            {
+                using type = String<T_c...>;
+            };
+        } // namespace internal
 
         /** create a compile time string type
-         *
-         * Support strings with up to 64 characters.
-         * Longer strings are cropped to 64 characters.
          *
          * usage example:
          * @code{.cpp}
@@ -75,23 +69,7 @@ namespace pmacc
          * using Electrons = PMACC_CSTRING( "electrons" );
          * @endcode
          */
-
-#define PMACC_CSTRING(str)                                                                                            \
-    /* // PMACC_CSTRING("example") is transformed in                                                                  \
-     * pmacc::meta::String<                                                                                           \
-     *     pmacc::meta::elem_at< sizeof("example") >( sizeof("example", 0 ),                                          \
-     *     pmacc::meta::elem_at< sizeof("example") >( sizeof("example", 1 ),                                          \
-     *     ...                                                                                                        \
-     *     pmacc::meta::elem_at< sizeof("example") >( sizeof("example", 63 ),                                         \
-     *     0                                                                                                          \
-     * >                                                                                                              \
-     */                                                                                                               \
-    pmacc::meta::String<BOOST_PP_REPEAT_FROM_TO(                                                                      \
-        0, /* support up to 64 charactres */                                                                          \
-        64,                                                                                                           \
-        PMACC_CHAR_AT_N,                                                                                              \
-        str) /* add a end zero because PMACC_CHAR_AT_N end with a comma */                                            \
-                        0>
+#define PMACC_CSTRING(str) typename ::pmacc::meta::internal::MakeString<BOOST_METAPARSE_STRING(str)>::type
 
     } // namespace meta
 } // namespace pmacc


### PR DESCRIPTION
This PR improves the readability of error messages during compilation by shrinking the template argument list of `pmacc::meta::String` to the necessary amount of characters. It uses `BOOST_METAPARSE_STRING` to convert a string literal into a char pack.

Example error before this change (typo in `pmacc::Frame`):
```
/mnt/c/dev/picongpu/include/picongpu/../pmacc/particles/memory/frames/Frame.hpp:74:47: error: no type named 'asdf' in 'pmacc::ParticleDescription<pmacc::meta::String<'e', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<pmacc::localCellIdx, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>'
        typedef typename ParticleDescription::asdf Name;
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/mnt/c/dev/picongpu/include/picongpu/../pmacc/particles/memory/buffers/ParticlesBuffer.hpp:132:39: note: in instantiation of template class 'pmacc::Frame<pmacc::ParticlesBuffer<pmacc::ParticleDescription<pmacc::meta::String<'e', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, picongpu::DeviceHeap, 3>::OperatorCreatePairStaticArray<1>, pmacc::ParticleDescription<pmacc::meta::String<'e', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<pmacc::localCellIdx, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>>' requested here
            SizeOfOneBorderElement = (sizeof(FrameTypeBorder) + sizeof(BorderFrameIndex))
                                      ^
/mnt/c/dev/picongpu/include/picongpu/../pmacc/particles/ParticlesBase.hpp:61:26: note: in instantiation of template class 'pmacc::ParticlesBuffer<pmacc::ParticleDescription<pmacc::meta::String<'e', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, picongpu::DeviceHeap, 3>' requested here
        typedef typename BufferType::FrameType FrameType;
```
After this change:
```
/mnt/c/dev/picongpu/include/picongpu/../pmacc/particles/memory/frames/Frame.hpp:74:47: error: no type named 'asdf' in 'pmacc::ParticleDescription<pmacc::meta::String<'e'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<pmacc::localCellIdx, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>'
        typedef typename ParticleDescription::asdf Name;
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/mnt/c/dev/picongpu/include/picongpu/../pmacc/particles/memory/buffers/ParticlesBuffer.hpp:132:39: note: in instantiation of template class 'pmacc::Frame<pmacc::ParticlesBuffer<pmacc::ParticleDescription<pmacc::meta::String<'e'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, picongpu::DeviceHeap, 3>::OperatorCreatePairStaticArray<1>, pmacc::ParticleDescription<pmacc::meta::String<'e'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<pmacc::localCellIdx, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>>' requested here
            SizeOfOneBorderElement = (sizeof(FrameTypeBorder) + sizeof(BorderFrameIndex))
                                      ^
/mnt/c/dev/picongpu/include/picongpu/../pmacc/particles/ParticlesBase.hpp:61:26: note: in instantiation of template class 'pmacc::ParticlesBuffer<pmacc::ParticleDescription<pmacc::meta::String<'e'>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic>, boost::mpl::vector0<>, 0>, 0>, 0>, boost::mpl::v_item<picongpu::chargeRatio<picongpu::ChargeRatioElectrons>, boost::mpl::v_item<picongpu::massRatio<picongpu::MassRatioElectrons>, boost::mpl::v_item<picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::PQS>>, boost::mpl::v_item<picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::PQS, picongpu::AssignedTrilinearInterpolation>>, boost::mpl::v_item<picongpu::shape<picongpu::particles::shapes::PQS>, boost::mpl::v_item<picongpu::particlePusher<picongpu::particles::pusher::Boris>, boost::mpl::vector0<>, 0>, 0>, 0>, 0>, 0>, 0>, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, picongpu::particles::boundary::CallPluginsAndDeleteParticles>>, pmacc::math::CT::Vector<mpl_::integral_c<int, 8>, mpl_::integral_c<int, 8>, mpl_::integral_c<int, 4>>, picongpu::DeviceHeap, 3>' requested here
        typedef typename BufferType::FrameType FrameType;
```
Notice the reduction of `pmacc::meta::String<'e', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00', '\x00'>` to `pmacc::meta::String<'e'>` in the error messages.

This PR also contains a fix for #3796.