### PR TITLE
Remove compile-time movePoint from grid.param

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -110,6 +110,8 @@ TBG_movingWindow="-m"
 # Defines when to start sliding the window.
 # The window starts sliding at the time required to pass the distance of
 # windowMovePoint * (global window size in y) when moving with the speed of light
+# Note: beware, there is one "hidden" row of gpus at the y-front, so e.g. when the window is enabled
+# and this variable is set to 0.75, only 75% of simulation area is used for real simulation
 TBG_windowMovePoint="--windowMovePoint 0.9"
 
 

--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -49,23 +49,6 @@ namespace picongpu
         {
             using pmacc::log;
             using Level = PIConGPUVerbose::PHYSICS;
-
-            /* Moving window: a new run-time parameter 'windowMovePoint' to replace
-             * compile-time 'movePoint' variable
-             */
-            bool isMovingWindowEnabled = !vm["moving"].empty();
-            if(isMovingWindowEnabled)
-            {
-                bool isWindowMovePointSet = !vm["windowMovePoint"].defaulted();
-                if(!isWindowMovePointSet)
-                    log<Level>("Warning: Compile-time variable 'movePoint' in grid.param "
-                               "is deprecated. It is currently still required for "
-                               "building purposes. Please keep the variable in your "
-                               "grid.param, but for future compatibility set this value "
-                               "using the 'windowMovePoint' parameter in your .cfg file. "
-                               "The value of movePoint is the default for windowMovePoint, "
-                               "setting the latter explicitly will override this.");
-            }
         }
 
     } // anonymous namespace

--- a/include/picongpu/param/grid.param
+++ b/include/picongpu/param/grid.param
@@ -62,22 +62,4 @@ namespace picongpu
         constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.9;
-
 } // namespace picongpu

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -158,10 +158,7 @@ namespace picongpu
                  "periodic dimensions")
                 ("moving,m", po::value<bool>(&slidingWindow)->zero_tokens(),
                  "enable sliding/moving window")
-                /* For now we still use the compile-time movePoint variable to set
-                 * the default value and provide backward compatibility
-                 */
-                ("windowMovePoint", po::value<float_64>(&windowMovePoint)->default_value(movePoint),
+                ("windowMovePoint", po::value<float_64>(&windowMovePoint)->default_value(0.9),
                  "ratio of the global window size in y which defines when to start sliding the window. "
                  "The window starts sliding at the time required to pass the distance of"
                  "windowMovePoint * (global window size in y) when moving with the speed of light")

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/grid.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/grid.param
@@ -73,17 +73,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/grid.param
@@ -66,22 +66,4 @@ namespace picongpu
          *  unit: seconds */
         constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / SPEED_OF_LIGHT_SI / SQRT_OF_2 / EPS_CFL;
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/Bunch/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/grid.param
@@ -73,22 +73,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/grid.param
@@ -86,22 +86,4 @@ namespace picongpu
          */
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/grid.param
@@ -64,22 +64,4 @@ namespace picongpu
         constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / (1.415 * SPEED_OF_LIGHT_SI);
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.9;
-
 } // namespace picongpu

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
@@ -64,22 +64,4 @@ namespace picongpu
          */
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
@@ -77,22 +77,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/grid.param
@@ -73,22 +73,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/grid.param
@@ -78,22 +78,4 @@ namespace picongpu
          */
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/grid.param
@@ -73,22 +73,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/grid.param
@@ -73,17 +73,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/grid.param
@@ -85,22 +85,4 @@ namespace picongpu
          */
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/grid.param
@@ -73,22 +73,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/grid.param
@@ -70,22 +70,4 @@ namespace picongpu
         constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.9;
-
 } // namespace picongpu

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/grid.param
@@ -67,22 +67,4 @@ namespace picongpu
         constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.9;
-
 } // namespace picongpu

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/grid.param
@@ -64,22 +64,4 @@ namespace picongpu
         constexpr float_64 DELTA_T_SI = CELL_WIDTH_SI / (1.734 * SPEED_OF_LIGHT_SI);
 
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.9;
-
 } // namespace picongpu

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/grid.param
@@ -74,22 +74,4 @@ namespace picongpu
          * in fields with perfect symmetry in Z.
          */
     } // namespace SI
-
-    /** When to move the co-moving window.
-     *  An initial pseudo particle, flying with the speed of light,
-     *  is fired at the begin of the simulation.
-     *  When it reaches movePoint % of the absolute(*) simulation area,
-     *  the co-moving window starts to move with the speed of light.
-     *
-     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
-     *            when you use the co-moving window
-     *  0.75 means only 75% of simulation area is used for real simulation
-     *
-     * Warning: this variable is deprecated, but currently still required for
-     * building purposes. Please keep the variable here. In case a moving window
-     * is enabled in your .cfg file, please set the move point using the
-     * 'windowMovePoint' parameter in that file, its default value is movePoint.
-     */
-    constexpr float_64 movePoint = 0.90;
-
 } // namespace picongpu


### PR DESCRIPTION
We already had a runtime parameter for it, now it is the only way to set it.
Update all `grid.param` files.