### PR TITLE
clang-tidy modernize

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,26 @@
+Checks: '
+modernize-raw-string-literal,
+modernize-replace-disallow-copy-and-assign-macro,
+modernize-return-braced-init-list,
+modernize-unary-static-assert,
+modernize-use-auto,
+modernize-use-bool-literals,
+modernize-use-default-member-init,
+modernize-use-equals-default,
+modernize-use-equals-delete,
+modernize-use-nullptr,
+modernize-use-override,
+modernize-use-transparent-functors,
+modernize-use-using'
+CheckOptions:
+  - { key: modernize-use-auto.MinTypeNameLength, value: 0}
+  - { key: modernize-use-auto.RemoveStars, value: 0}
+  - { key: modernize-use-bool-literals.IgnoreMacros, value: 0}
+  - { key: modernize-use-default-member-init.UseAssignment, value: 0}
+  - { key: modernize-use-default-member-init.IgnoreMacros, value: 0}
+  - { key: modernize-use-equals-default.IgnoreMacros, value: 0}
+  - { key: modernize-use-equals-delete.IgnoreMacros, value: 0}
+  - { key: modernize-use-override.IgnoreDestructors, value: 0}
+  - { key: modernize-use-override.AllowOverrideAndFinal, value: 1}
+  - { key: modernize-use-transparent-functors.SafeMode, value: 1}
+  - { key: modernize-use-using.IgnoreMacros, value: 0}

--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -53,9 +53,7 @@ namespace picongpu
 
     } // anonymous namespace
 
-    ArgsParser::ArgsParser()
-    {
-    }
+    ArgsParser::ArgsParser() = default;
 
     ArgsParser::ArgsParser(ArgsParser&)
     {
@@ -100,7 +98,7 @@ namespace picongpu
                 "Config file(s)");
 
             // add all options from plugins
-            for(std::list<po::options_description>::iterator iter = options.begin(); iter != options.end(); ++iter)
+            for(auto iter = options.begin(); iter != options.end(); ++iter)
                 desc.add(*iter);
 
             // parse command line options and config file and store values in vm
@@ -112,8 +110,7 @@ namespace picongpu
             {
                 std::vector<std::string> conf_files = vm["config"].as<std::vector<std::string>>();
 
-                for(std::vector<std::string>::const_iterator iter = conf_files.begin(); iter != conf_files.end();
-                    ++iter)
+                for(auto iter = conf_files.begin(); iter != conf_files.end(); ++iter)
                 {
                     // log<picLog::SIMULATION_STATE > ("parsing config file '%1%'") % (*iter);
                     std::ifstream config_file_stream(iter->c_str());

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -148,7 +148,7 @@ unset(IN_SRC_POS)
 ################################################################################
 
 find_package(PMacc REQUIRED CONFIG PATHS "${PIConGPUapp_SOURCE_DIR}/../pmacc")
-include_directories(SYSTEM ${PMacc_INCLUDE_DIRS})
+include_directories(${PMacc_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${PMacc_LIBRARIES})
 add_definitions(${PMacc_DEFINITIONS})
 

--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -67,13 +67,13 @@ namespace picongpu
         {
             using type = typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type;
 
-            type result_z = type(0.0);
+            auto result_z = type(0.0);
             for(int z = T_begin; z <= T_end; ++z)
             {
-                type result_y = type(0.0);
+                auto result_y = type(0.0);
                 for(int y = T_begin; y <= T_end; ++y)
                 {
-                    type result_x = type(0.0);
+                    auto result_x = type(0.0);
                     for(int x = T_begin; x <= T_end; ++x)
                         /* a form factor is the "amount of particle" that is affected by this cell
                          * so we have to sum over: cell_value * form_factor

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -240,11 +240,10 @@ namespace picongpu
                 T_Mapping mapper) const
             {
                 /* Caching of fieldJ */
-                typedef SuperCellDescription<
+                using BlockArea = SuperCellDescription<
                     SuperCellSize,
                     typename T_CurrentInterpolationFunctor::LowerMargin,
-                    typename T_CurrentInterpolationFunctor::UpperMargin>
-                    BlockArea;
+                    typename T_CurrentInterpolationFunctor::UpperMargin>;
 
                 constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
                 constexpr uint32_t numWorkers = T_numWorkers;

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -226,17 +226,16 @@ namespace picongpu
     void FieldJ::computeCurrent(T_Species& species, uint32_t)
     {
         using FrameType = typename T_Species::FrameType;
-        typedef typename pmacc::traits::Resolve<typename GetFlagType<FrameType, current<>>::type>::type
-            ParticleCurrentSolver;
+        using ParticleCurrentSolver =
+            typename pmacc::traits::Resolve<typename GetFlagType<FrameType, current<>>::type>::type;
 
         using FrameSolver
             = currentSolver::ComputePerFrame<ParticleCurrentSolver, Velocity, MappingDesc::SuperCellSize>;
 
-        typedef SuperCellDescription<
+        using BlockArea = SuperCellDescription<
             typename MappingDesc::SuperCellSize,
             typename GetMargin<ParticleCurrentSolver>::LowerMargin,
-            typename GetMargin<ParticleCurrentSolver>::UpperMargin>
-            BlockArea;
+            typename GetMargin<ParticleCurrentSolver>::UpperMargin>;
 
         using Strategy = currentSolver::traits::GetStrategy_t<FrameSolver>;
 

--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -74,7 +74,7 @@ namespace picongpu
         HINLINE FieldTmp(MappingDesc const& cellDescription, uint32_t slotId);
 
         //! Destroy a field
-        virtual ~FieldTmp() = default;
+        ~FieldTmp() override = default;
 
         //! Get a reference to the host-device buffer for the field values
         HINLINE GridBuffer<ValueType, simDim>& getGridBuffer();

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -76,44 +76,44 @@ namespace picongpu
          */
         const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout().getDataSpaceWithoutGuarding();
 
-        typedef typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, interpolation<>>::type
-            VectorSpeciesWithInterpolation;
+        using VectorSpeciesWithInterpolation =
+            typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, interpolation<>>::type;
 
         /* ------------------ lower margin  ----------------------------------*/
-        typedef bmpl::accumulate<
+        using SpeciesLowerMargin = bmpl::accumulate<
             VectorSpeciesWithInterpolation,
             typename pmacc::math::CT::make_Int<simDim, 0>::type,
-            pmacc::math::CT::max<bmpl::_1, GetLowerMargin<GetInterpolation<bmpl::_2>>>>::type SpeciesLowerMargin;
+            pmacc::math::CT::max<bmpl::_1, GetLowerMargin<GetInterpolation<bmpl::_2>>>>::type;
 
-        typedef bmpl::accumulate<
+        using FieldTmpLowerMargin = bmpl::accumulate<
             FieldTmpSolvers,
             typename pmacc::math::CT::make_Int<simDim, 0>::type,
-            pmacc::math::CT::max<bmpl::_1, GetLowerMargin<bmpl::_2>>>::type FieldTmpLowerMargin;
+            pmacc::math::CT::max<bmpl::_1, GetLowerMargin<bmpl::_2>>>::type;
 
-        typedef pmacc::math::CT::max<SpeciesLowerMargin, FieldTmpLowerMargin>::type SpeciesFieldTmpLowerMargin;
+        using SpeciesFieldTmpLowerMargin = pmacc::math::CT::max<SpeciesLowerMargin, FieldTmpLowerMargin>::type;
 
         using FieldSolverLowerMargin = GetLowerMargin<fields::Solver>::type;
 
-        typedef pmacc::math::CT::max<SpeciesFieldTmpLowerMargin, FieldSolverLowerMargin>::type LowerMargin;
+        using LowerMargin = pmacc::math::CT::max<SpeciesFieldTmpLowerMargin, FieldSolverLowerMargin>::type;
 
 
         /* ------------------ upper margin  -----------------------------------*/
 
-        typedef bmpl::accumulate<
+        using SpeciesUpperMargin = bmpl::accumulate<
             VectorSpeciesWithInterpolation,
             typename pmacc::math::CT::make_Int<simDim, 0>::type,
-            pmacc::math::CT::max<bmpl::_1, GetUpperMargin<GetInterpolation<bmpl::_2>>>>::type SpeciesUpperMargin;
+            pmacc::math::CT::max<bmpl::_1, GetUpperMargin<GetInterpolation<bmpl::_2>>>>::type;
 
-        typedef bmpl::accumulate<
+        using FieldTmpUpperMargin = bmpl::accumulate<
             FieldTmpSolvers,
             typename pmacc::math::CT::make_Int<simDim, 0>::type,
-            pmacc::math::CT::max<bmpl::_1, GetUpperMargin<bmpl::_2>>>::type FieldTmpUpperMargin;
+            pmacc::math::CT::max<bmpl::_1, GetUpperMargin<bmpl::_2>>>::type;
 
-        typedef pmacc::math::CT::max<SpeciesUpperMargin, FieldTmpUpperMargin>::type SpeciesFieldTmpUpperMargin;
+        using SpeciesFieldTmpUpperMargin = pmacc::math::CT::max<SpeciesUpperMargin, FieldTmpUpperMargin>::type;
 
         using FieldSolverUpperMargin = GetUpperMargin<fields::Solver>::type;
 
-        typedef pmacc::math::CT::max<SpeciesFieldTmpUpperMargin, FieldSolverUpperMargin>::type UpperMargin;
+        using UpperMargin = pmacc::math::CT::max<SpeciesFieldTmpUpperMargin, FieldSolverUpperMargin>::type;
 
         const DataSpace<simDim> originGuard(LowerMargin().toRT());
         const DataSpace<simDim> endGuard(UpperMargin().toRT());
@@ -164,11 +164,10 @@ namespace picongpu
     template<uint32_t AREA, class FrameSolver, typename Filter, class ParticlesClass>
     void FieldTmp::computeValue(ParticlesClass& parClass, uint32_t)
     {
-        typedef SuperCellDescription<
+        using BlockArea = SuperCellDescription<
             typename MappingDesc::SuperCellSize,
             typename FrameSolver::LowerMargin,
-            typename FrameSolver::UpperMargin>
-            BlockArea;
+            typename FrameSolver::UpperMargin>;
 
         auto mapper = makeStrideAreaMapper<AREA, 3>(cellDescription);
         typename ParticlesClass::ParticlesBoxType pBox = parClass.getDeviceParticlesBox();

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -39,7 +39,7 @@ namespace picongpu
             class None
             {
             private:
-                typedef MappingDesc::SuperCellSize SuperCellSize;
+                using SuperCellSize = MappingDesc::SuperCellSize;
 
             public:
                 using CellType = cellType::Yee;

--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -201,7 +201,7 @@ namespace picongpu
                 AbsorberImpl(Kind kind, MappingDesc cellDescription);
 
                 //! Destructor
-                virtual ~AbsorberImpl() = default;
+                ~AbsorberImpl() override = default;
 
                 /** Interpret this as ExponentialImpl instance
                  *

--- a/include/picongpu/fields/absorber/pml/Field.hpp
+++ b/include/picongpu/fields/absorber/pml/Field.hpp
@@ -481,7 +481,7 @@ namespace pmacc
         template<>
         struct GetComponentsType<picongpu::fields::absorber::pml::NodeValues, false>
         {
-            typedef picongpu::float_X type;
+            using type = picongpu::float_X;
         };
 
         //! Node value traits for checkpointing

--- a/include/picongpu/fields/background/templates/TWTS/BField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.tpp
@@ -91,7 +91,7 @@ namespace picongpu
                 const pmacc::math::Vector<floatD_64, detail::numComponents>& bFieldPositions_SI,
                 const float_64 time) const
             {
-                typedef pmacc::math::Vector<float3_64, detail::numComponents> PosVecVec;
+                using PosVecVec = pmacc::math::Vector<float3_64, detail::numComponents>;
                 PosVecVec pos(PosVecVec::create(float3_64::create(0.0)));
 
                 for(uint32_t k = 0; k < detail::numComponents; ++k)
@@ -128,7 +128,7 @@ namespace picongpu
                 const pmacc::math::Vector<floatD_64, detail::numComponents>& bFieldPositions_SI,
                 const float_64 time) const
             {
-                typedef pmacc::math::Vector<float3_64, detail::numComponents> PosVecVec;
+                using PosVecVec = pmacc::math::Vector<float3_64, detail::numComponents>;
                 PosVecVec pos(PosVecVec::create(float3_64::create(0.0)));
 
                 for(uint32_t k = 0; k < detail::numComponents; ++k)
@@ -158,7 +158,7 @@ namespace picongpu
                 const pmacc::math::Vector<floatD_64, detail::numComponents>& bFieldPositions_SI,
                 const float_64 time) const
             {
-                typedef pmacc::math::Vector<float3_64, detail::numComponents> PosVecVec;
+                using PosVecVec = pmacc::math::Vector<float3_64, detail::numComponents>;
                 PosVecVec pos(PosVecVec::create(float3_64::create(0.0)));
 
                 for(uint32_t k = 0; k < detail::numComponents; ++k)
@@ -217,7 +217,7 @@ namespace picongpu
                 const pmacc::math::Vector<floatD_64, detail::numComponents>& bFieldPositions_SI,
                 const float_64 time) const
             {
-                typedef pmacc::math::Vector<float3_64, detail::numComponents> PosVecVec;
+                using PosVecVec = pmacc::math::Vector<float3_64, detail::numComponents>;
                 PosVecVec pos(PosVecVec::create(float3_64::create(0.0)));
 
                 for(uint32_t k = 0; k < detail::numComponents; ++k)
@@ -303,12 +303,12 @@ namespace picongpu
                 const float_64 UNIT_LENGTH = UNIT_TIME * UNIT_SPEED;
 
                 /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                const float_T beta0 = float_T(beta_0);
+                const auto beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                const float_T phiReal = float_T(math::abs(phi));
+                const auto phiReal = float_T(math::abs(phi));
                 const float_T alphaTilt
                     = math::atan2(float_T(1.0) - beta0 * math::cos(phiReal), beta0 * math::sin(phiReal));
                 /* Definition of the laser pulse front tilt angle for the laser field below.
@@ -328,25 +328,25 @@ namespace picongpu
                  * const float_T eta = float_T(PI/2) - (phiReal - alphaTilt);
                  */
 
-                const float_T cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-                const float_T om0 = float_T(2.0 * PI * cspeed / lambda0);
+                const auto cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                const auto lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                const auto om0 = float_T(2.0 * PI * cspeed / lambda0);
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                const float_T tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                const auto tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-                const float_T rho0 = float_T(PI * w0 * w0 / lambda0);
+                const auto w0 = float_T(w_x_SI / UNIT_LENGTH);
+                const auto rho0 = float_T(PI * w0 * w0 / lambda0);
                 /* wy is width of TWTS pulse */
-                const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-                const float_T k = float_T(2.0 * PI / lambda0);
+                const auto wy = float_T(w_y_SI / UNIT_LENGTH);
+                const auto k = float_T(2.0 * PI / lambda0);
                 /* If phi < 0 the entire pulse is rotated by 180 deg around the
                  * z-axis of the coordinate system without also changing
                  * the orientation of the resulting field vectors.
                  */
-                const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
-                const float_T z = float_T(pos.z() / UNIT_LENGTH);
-                const float_T t = float_T(time / UNIT_TIME);
+                const auto x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                const auto y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
+                const auto z = float_T(pos.z() / UNIT_LENGTH);
+                const auto t = float_T(time / UNIT_TIME);
 
                 /* Shortcuts for speeding up the field calculation. */
                 const float_T sinPhi = math::sin(phiT);
@@ -453,12 +453,12 @@ namespace picongpu
                 const float_64 UNIT_LENGTH = UNIT_TIME * UNIT_SPEED;
 
                 /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                const float_T beta0 = float_T(beta_0);
+                const auto beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                const float_T phiReal = float_T(math::abs(phi));
+                const auto phiReal = float_T(math::abs(phi));
                 const float_T alphaTilt
                     = math::atan2(float_T(1.0) - beta0 * math::cos(phiReal), beta0 * math::sin(phiReal));
 
@@ -479,25 +479,25 @@ namespace picongpu
                  * const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt);
                  */
 
-                const float_T cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-                const float_T om0 = float_T(2.0 * PI * cspeed / lambda0);
+                const auto cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                const auto lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                const auto om0 = float_T(2.0 * PI * cspeed / lambda0);
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                const float_T tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                const auto tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-                const float_T rho0 = float_T(PI * w0 * w0 / lambda0);
+                const auto w0 = float_T(w_x_SI / UNIT_LENGTH);
+                const auto rho0 = float_T(PI * w0 * w0 / lambda0);
                 /* wy is width of TWTS pulse */
-                const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-                const float_T k = float_T(2.0 * PI / lambda0);
+                const auto wy = float_T(w_y_SI / UNIT_LENGTH);
+                const auto k = float_T(2.0 * PI / lambda0);
                 /* If phi < 0 the entire pulse is rotated by 180 deg around the
                  * z-axis of the coordinate system without also changing
                  * the orientation of the resulting field vectors.
                  */
-                const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
-                const float_T z = float_T(pos.z() / UNIT_LENGTH);
-                const float_T t = float_T(time / UNIT_TIME);
+                const auto x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                const auto y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
+                const auto z = float_T(pos.z() / UNIT_LENGTH);
+                const auto t = float_T(time / UNIT_TIME);
 
                 /* Shortcuts for speeding up the field calculation. */
                 const float_T sinPhi = math::sin(phiT);
@@ -580,12 +580,12 @@ namespace picongpu
                 const float_64 UNIT_LENGTH = UNIT_TIME * UNIT_SPEED;
 
                 /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                const float_T beta0 = float_T(beta_0);
+                const auto beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                const float_T phiReal = float_T(math::abs(phi));
+                const auto phiReal = float_T(math::abs(phi));
                 const float_T alphaTilt
                     = math::atan2(float_T(1.0) - beta0 * math::cos(phiReal), beta0 * math::sin(phiReal));
                 /* Definition of the laser pulse front tilt angle for the laser field below.
@@ -605,25 +605,25 @@ namespace picongpu
                  * const float_T eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt);
                  */
 
-                const float_T cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-                const float_T om0 = float_T(2.0 * PI * cspeed / lambda0);
+                const auto cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                const auto lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                const auto om0 = float_T(2.0 * PI * cspeed / lambda0);
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                const float_T tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                const auto tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-                const float_T rho0 = float_T(PI * w0 * w0 / lambda0);
+                const auto w0 = float_T(w_x_SI / UNIT_LENGTH);
+                const auto rho0 = float_T(PI * w0 * w0 / lambda0);
                 /* wy is width of TWTS pulse */
-                const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-                const float_T k = float_T(2.0 * PI / lambda0);
+                const auto wy = float_T(w_y_SI / UNIT_LENGTH);
+                const auto k = float_T(2.0 * PI / lambda0);
                 /* If phi < 0 the entire pulse is rotated by 180 deg around the
                  * z-axis of the coordinate system without also changing
                  * the orientation of the resulting field vectors.
                  */
-                const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
-                const float_T z = float_T(pos.z() / UNIT_LENGTH);
-                const float_T t = float_T(time / UNIT_TIME);
+                const auto x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                const auto y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
+                const auto z = float_T(pos.z() / UNIT_LENGTH);
+                const auto t = float_T(time / UNIT_TIME);
 
                 /* Shortcuts for speeding up the field calculation. */
                 const float_T sinPhi = math::sin(phiT);

--- a/include/picongpu/fields/background/templates/TWTS/EField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.tpp
@@ -101,7 +101,7 @@ namespace picongpu
                 const pmacc::math::Vector<floatD_64, detail::numComponents>& eFieldPositions_SI,
                 const float_64 time) const
             {
-                typedef pmacc::math::Vector<float3_64, detail::numComponents> PosVecVec;
+                using PosVecVec = pmacc::math::Vector<float3_64, detail::numComponents>;
                 PosVecVec pos(PosVecVec::create(float3_64::create(0.0)));
 
                 for(uint32_t k = 0; k < detail::numComponents; ++k)
@@ -145,7 +145,7 @@ namespace picongpu
                 const pmacc::math::Vector<floatD_64, detail::numComponents>& eFieldPositions_SI,
                 const float_64 time) const
             {
-                typedef pmacc::math::Vector<float3_64, detail::numComponents> PosVecVec;
+                using PosVecVec = pmacc::math::Vector<float3_64, detail::numComponents>;
                 PosVecVec pos(PosVecVec::create(float3_64::create(0.0)));
 
                 /* The 2D output of getFieldPositions_SI only returns
@@ -214,12 +214,12 @@ namespace picongpu
                 const float_64 UNIT_LENGTH = UNIT_TIME * UNIT_SPEED;
 
                 /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                const float_T beta0 = float_T(beta_0);
+                const auto beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                const float_T phiReal = float_T(math::abs(phi));
+                const auto phiReal = float_T(math::abs(phi));
                 const float_T alphaTilt
                     = math::atan2(float_T(1.0) - beta0 * math::cos(phiReal), beta0 * math::sin(phiReal));
                 /* Definition of the laser pulse front tilt angle for the laser field below.
@@ -239,21 +239,21 @@ namespace picongpu
                  * const float_T eta = (PI / 2) - (phiReal - alphaTilt);
                  */
 
-                const float_T cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                const float_T lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
-                const float_T om0 = float_T(2.0 * PI * cspeed / lambda0);
+                const auto cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                const auto lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                const auto om0 = float_T(2.0 * PI * cspeed / lambda0);
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                const float_T tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                const auto tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                const float_T w0 = float_T(w_x_SI / UNIT_LENGTH);
-                const float_T rho0 = float_T(PI * w0 * w0 / lambda0);
+                const auto w0 = float_T(w_x_SI / UNIT_LENGTH);
+                const auto rho0 = float_T(PI * w0 * w0 / lambda0);
                 /* wy is width of TWTS pulse */
-                const float_T wy = float_T(w_y_SI / UNIT_LENGTH);
-                const float_T k = float_T(2.0 * PI / lambda0);
-                const float_T x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                const float_T y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
-                const float_T z = float_T(pos.z() / UNIT_LENGTH);
-                const float_T t = float_T(time / UNIT_TIME);
+                const auto wy = float_T(w_y_SI / UNIT_LENGTH);
+                const auto k = float_T(2.0 * PI / lambda0);
+                const auto x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                const auto y = float_T(phiPositive * pos.y() / UNIT_LENGTH);
+                const auto z = float_T(pos.z() / UNIT_LENGTH);
+                const auto t = float_T(time / UNIT_TIME);
 
                 /* Calculating shortcuts for speeding up field calculation */
                 const float_T sinPhi = math::sin(phiT);

--- a/include/picongpu/fields/background/templates/TWTS/RotateField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/RotateField.tpp
@@ -39,8 +39,8 @@ namespace picongpu
                 template<typename T_Type, typename T_AngleType>
                 struct RotateField<pmacc::math::Vector<T_Type, 3>, T_AngleType>
                 {
-                    typedef pmacc::math::Vector<T_Type, 3> result;
-                    typedef T_AngleType AngleType;
+                    using result = pmacc::math::Vector<T_Type, 3>;
+                    using AngleType = T_AngleType;
                     HDINLINE result operator()(const result& fieldPosVector, const AngleType phi) const
                     {
                         /*  Since, the laser propagation direction encloses an angle of phi with the
@@ -62,8 +62,8 @@ namespace picongpu
                 template<typename T_Type, typename T_AngleType>
                 struct RotateField<pmacc::math::Vector<T_Type, 2>, T_AngleType>
                 {
-                    typedef pmacc::math::Vector<T_Type, 2> result;
-                    typedef T_AngleType AngleType;
+                    using result = pmacc::math::Vector<T_Type, 2>;
+                    using AngleType = T_AngleType;
                     HDINLINE result operator()(const result& fieldPosVector, const AngleType phi) const
                     {
                         /*  Since, the laser propagation direction encloses an angle of phi with the

--- a/include/picongpu/fields/background/templates/twtsfast/BField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.tpp
@@ -318,12 +318,12 @@ namespace picongpu
                 using complex_64 = pmacc::math::Complex<float_64>;
 
                 /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                float_T const beta0 = float_T(beta_0);
+                auto const beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                float_T const phiReal = float_T(math::abs(phi));
+                auto const phiReal = float_T(math::abs(phi));
                 float_T sinPhiReal;
                 float_T cosPhiReal;
                 pmacc::math::sincos(phiReal, sinPhiReal, cosPhiReal);
@@ -345,15 +345,15 @@ namespace picongpu
                  * float_T const eta = float_T(PI/2) - (phiReal - alphaTilt);
                  */
 
-                float_T const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                float_T const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                auto const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                auto const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
                 float_T const om0 = float_T(2.0 * PI) * cspeed / lambda0;
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                float_T const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                auto const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                float_T const w0 = float_T(w_x_SI / UNIT_LENGTH);
-                float_T const rho0 = float_T(PI * w0 * w0 / lambda0);
-                float_T const k = float_T(2.0 * PI / lambda0);
+                auto const w0 = float_T(w_x_SI / UNIT_LENGTH);
+                auto const rho0 = float_T(PI * w0 * w0 / lambda0);
+                auto const k = float_T(2.0 * PI / lambda0);
 
                 /* In order to calculate in single-precision and in order to account for errors in
                  * the approximations far from the coordinate origin, we use the wavelength-periodicity and
@@ -370,14 +370,14 @@ namespace picongpu
                 float_64 const deltaY = wavelength_SI / tanFocalLine;
                 float_64 const deltaZ = -wavelength_SI;
                 float_64 const numberOfPeriods = math::floor(time / deltaT);
-                float_T const timeMod = float_T(time - numberOfPeriods * deltaT);
-                float_T const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
-                float_T const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
+                auto const timeMod = float_T(time - numberOfPeriods * deltaT);
+                auto const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
+                auto const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
 
-                float_T const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                float_T const y = float_T(phiPositive * yMod / UNIT_LENGTH);
-                float_T const z = float_T(zMod / UNIT_LENGTH);
-                float_T const t = float_T(timeMod / UNIT_TIME);
+                auto const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                auto const y = float_T(phiPositive * yMod / UNIT_LENGTH);
+                auto const z = float_T(zMod / UNIT_LENGTH);
+                auto const t = float_T(timeMod / UNIT_TIME);
 
                 /* Calculating shortcuts for speeding up field calculation */
                 float_T sinPhi;
@@ -464,12 +464,12 @@ namespace picongpu
                 using complex_T = pmacc::math::Complex<float_T>;
 
                 /* propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                float_T const beta0 = float_T(beta_0);
+                auto const beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                float_T const phiReal = float_T(math::abs(phi));
+                auto const phiReal = float_T(math::abs(phi));
                 float_T sinPhiReal;
                 float_T cosPhiReal;
                 pmacc::math::sincos(phiReal, sinPhiReal, cosPhiReal);
@@ -492,15 +492,15 @@ namespace picongpu
                  * float_T const eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt);
                  */
 
-                float_T const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                float_T const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                auto const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                auto const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
                 float_T const om0 = float_T(2.0 * PI) * cspeed / lambda0;
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                float_T const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                auto const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                float_T const w0 = float_T(w_x_SI / UNIT_LENGTH);
-                float_T const rho0 = float_T(PI * w0 * w0 / lambda0);
-                float_T const k = float_T(2.0 * PI / lambda0);
+                auto const w0 = float_T(w_x_SI / UNIT_LENGTH);
+                auto const rho0 = float_T(PI * w0 * w0 / lambda0);
+                auto const k = float_T(2.0 * PI / lambda0);
 
                 /* In order to calculate in single-precision and in order to account for errors in
                  * the approximations far from the coordinate origin, we use the wavelength-periodicity and
@@ -517,14 +517,14 @@ namespace picongpu
                 float_64 const deltaY = wavelength_SI / tanFocalLine;
                 float_64 const deltaZ = -wavelength_SI;
                 float_64 const numberOfPeriods = math::floor(time / deltaT);
-                float_T const timeMod = float_T(time - numberOfPeriods * deltaT);
-                float_T const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
-                float_T const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
+                auto const timeMod = float_T(time - numberOfPeriods * deltaT);
+                auto const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
+                auto const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
 
-                float_T const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                float_T const y = float_T(phiPositive * yMod / UNIT_LENGTH);
-                float_T const z = float_T(zMod / UNIT_LENGTH);
-                float_T const t = float_T(timeMod / UNIT_TIME);
+                auto const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                auto const y = float_T(phiPositive * yMod / UNIT_LENGTH);
+                auto const z = float_T(zMod / UNIT_LENGTH);
+                auto const t = float_T(timeMod / UNIT_TIME);
 
                 /* Calculating shortcuts for speeding up field calculation */
                 float_T sinPhi;
@@ -620,12 +620,12 @@ namespace picongpu
                 using complex_64 = pmacc::math::Complex<float_64>;
 
                 /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                float_T const beta0 = float_T(beta_0);
+                auto const beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                float_T const phiReal = float_T(math::abs(phi));
+                auto const phiReal = float_T(math::abs(phi));
                 float_T cosPhiReal;
                 float_T sinPhiReal;
                 pmacc::math::sincos(phiReal, sinPhiReal, cosPhiReal);
@@ -647,15 +647,15 @@ namespace picongpu
                  * float_T const eta = float_T(float_T(PI / 2)) - (phiReal - alphaTilt);
                  */
 
-                float_T const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                float_T const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                auto const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                auto const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
                 float_T const om0 = float_T(2.0 * PI) * cspeed / lambda0;
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                float_T const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                auto const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                float_T const w0 = float_T(w_x_SI / UNIT_LENGTH);
-                float_T const rho0 = float_T(PI * w0 * w0 / lambda0);
-                float_T const k = float_T(2.0 * PI / lambda0);
+                auto const w0 = float_T(w_x_SI / UNIT_LENGTH);
+                auto const rho0 = float_T(PI * w0 * w0 / lambda0);
+                auto const k = float_T(2.0 * PI / lambda0);
 
                 /* In order to calculate in single-precision and in order to account for errors in
                  * the approximations far from the coordinate origin, we use the wavelength-periodicity and
@@ -672,14 +672,14 @@ namespace picongpu
                 float_64 const deltaY = wavelength_SI / tanFocalLine;
                 float_64 const deltaZ = -wavelength_SI;
                 float_64 const numberOfPeriods = math::floor(time / deltaT);
-                float_T const timeMod = float_T(time - numberOfPeriods * deltaT);
-                float_T const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
-                float_T const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
+                auto const timeMod = float_T(time - numberOfPeriods * deltaT);
+                auto const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
+                auto const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
 
-                float_T const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                float_T const y = float_T(phiPositive * yMod / UNIT_LENGTH);
-                float_T const z = float_T(zMod / UNIT_LENGTH);
-                float_T const t = float_T(timeMod / UNIT_TIME);
+                auto const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                auto const y = float_T(phiPositive * yMod / UNIT_LENGTH);
+                auto const z = float_T(zMod / UNIT_LENGTH);
+                auto const t = float_T(timeMod / UNIT_TIME);
 
                 /* Shortcuts for speeding up the field calculation. */
                 float_T sinPhi;

--- a/include/picongpu/fields/background/templates/twtsfast/EField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.tpp
@@ -212,12 +212,12 @@ namespace picongpu
                 using complex_64 = pmacc::math::Complex<float_64>;
 
                 /* Propagation speed of overlap normalized to the speed of light [Default: beta0=1.0] */
-                float_T const beta0 = float_T(beta_0);
+                auto const beta0 = float_T(beta_0);
                 /* If phi < 0 the formulas below are not directly applicable.
                  * Instead phi is taken positive, but the entire pulse rotated by 180 deg around the
                  * z-axis of the coordinate system in this function.
                  */
-                float_T const phiReal = float_T(math::abs(phi));
+                auto const phiReal = float_T(math::abs(phi));
                 float_T sinPhiReal;
                 float_T cosPhiReal;
                 pmacc::math::sincos(phiReal, sinPhiReal, cosPhiReal);
@@ -239,15 +239,15 @@ namespace picongpu
                  * float_T const eta = (PI / 2) - (phiReal - alphaTilt);
                  */
 
-                float_T const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
-                float_T const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
+                auto const cspeed = float_T(SI::SPEED_OF_LIGHT_SI / UNIT_SPEED);
+                auto const lambda0 = float_T(wavelength_SI / UNIT_LENGTH);
                 float_T const om0 = float_T(2.0 * PI) * cspeed / lambda0;
                 /* factor 2  in tauG arises from definition convention in laser formula */
-                float_T const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
+                auto const tauG = float_T(pulselength_SI * 2.0 / UNIT_TIME);
                 /* w0 is wx here --> w0 could be replaced by wx */
-                float_T const w0 = float_T(w_x_SI / UNIT_LENGTH);
-                float_T const rho0 = float_T(PI * w0 * w0 / lambda0);
-                float_T const k = float_T(2.0 * PI / lambda0);
+                auto const w0 = float_T(w_x_SI / UNIT_LENGTH);
+                auto const rho0 = float_T(PI * w0 * w0 / lambda0);
+                auto const k = float_T(2.0 * PI / lambda0);
 
                 /* In order to calculate in single-precision and in order to account for errors in
                  * the approximations far from the coordinate origin, we use the wavelength-periodicity and
@@ -264,14 +264,14 @@ namespace picongpu
                 float_64 const deltaY = wavelength_SI / tanFocalLine;
                 float_64 const deltaZ = -wavelength_SI;
                 float_64 const numberOfPeriods = math::floor(time / deltaT);
-                float_T const timeMod = float_T(time - numberOfPeriods * deltaT);
-                float_T const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
-                float_T const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
+                auto const timeMod = float_T(time - numberOfPeriods * deltaT);
+                auto const yMod = float_T(pos.y() + numberOfPeriods * deltaY);
+                auto const zMod = float_T(pos.z() + numberOfPeriods * deltaZ);
 
-                float_T const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
-                float_T const y = float_T(phiPositive * yMod / UNIT_LENGTH);
-                float_T const z = float_T(zMod / UNIT_LENGTH);
-                float_T const t = float_T(timeMod / UNIT_TIME);
+                auto const x = float_T(phiPositive * pos.x() / UNIT_LENGTH);
+                auto const y = float_T(phiPositive * yMod / UNIT_LENGTH);
+                auto const z = float_T(zMod / UNIT_LENGTH);
+                auto const t = float_T(timeMod / UNIT_TIME);
 
                 /* Calculating shortcuts for speeding up field calculation */
                 float_T sinPhi;

--- a/include/picongpu/fields/cellType/Yee.hpp
+++ b/include/picongpu/fields/cellType/Yee.hpp
@@ -61,9 +61,7 @@ namespace picongpu
                 using type = VectorVector2D3V;
             };
 
-            HDINLINE FieldPosition()
-            {
-            }
+            HDINLINE FieldPosition() = default;
 
             HDINLINE VectorVector2D3V operator()() const
             {
@@ -95,9 +93,7 @@ namespace picongpu
                 using type = VectorVector3D3V;
             };
 
-            HDINLINE FieldPosition()
-            {
-            }
+            HDINLINE FieldPosition() = default;
 
             HDINLINE VectorVector3D3V operator()() const
             {
@@ -128,9 +124,7 @@ namespace picongpu
                 using type = VectorVector2D3V;
             };
 
-            HDINLINE FieldPosition()
-            {
-            }
+            HDINLINE FieldPosition() = default;
 
             HDINLINE VectorVector2D3V operator()() const
             {
@@ -162,9 +156,7 @@ namespace picongpu
                 using type = VectorVector3D3V;
             };
 
-            HDINLINE FieldPosition()
-            {
-            }
+            HDINLINE FieldPosition() = default;
 
             HDINLINE VectorVector3D3V operator()() const
             {
@@ -183,9 +175,7 @@ namespace picongpu
         struct FieldPosition<fields::cellType::Yee, FieldJ, T_simDim>
             : public FieldPosition<fields::cellType::Yee, FieldE, T_simDim>
         {
-            HDINLINE FieldPosition()
-            {
-            }
+            HDINLINE FieldPosition() = default;
         };
 
         /** position (floatD_X in case of T_simDim == simDim) in cell, wrapped in
@@ -208,9 +198,7 @@ namespace picongpu
                 using type = ReturnType;
             };
 
-            HDINLINE FieldPosition()
-            {
-            }
+            HDINLINE FieldPosition() = default;
 
             HDINLINE ReturnType operator()() const
             {

--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -134,7 +134,7 @@ namespace picongpu
                                 * (s0i * s0j + float_X(0.5) * (dsi * s0j + s0i * dsj)
                                    + (float_X(1.0) / float_X(3.0)) * dsj * dsi);
 
-                            float_X accumulated_J = float_X(0.0);
+                            auto accumulated_J = float_X(0.0);
                             for(int k = T_begin; k < T_end - 1; ++k)
                             {
                                 /* This is the implementation of the FORTRAN W(i,j,k,3)/ C style W(i,j,k,2) version
@@ -196,7 +196,7 @@ namespace picongpu
 
                         float_X tmp = -currentSurfaceDensity * (s0j + float_X(0.5) * dsj);
 
-                        float_X accumulated_J = float_X(0.0);
+                        auto accumulated_J = float_X(0.0);
                         for(int i = T_begin; i < T_end - 1; ++i)
                         {
                             /* This is the implementation of the FORTRAN W(i,j,k,1)/ C style W(i,j,k,0) version from

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -39,8 +39,8 @@ namespace picongpu
 
             static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
             static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-            typedef typename pmacc::math::CT::make_Int<simDim, currentLowerMargin>::type LowerMargin;
-            typedef typename pmacc::math::CT::make_Int<simDim, currentUpperMargin>::type UpperMargin;
+            using LowerMargin = typename pmacc::math::CT::make_Int<simDim, currentLowerMargin>::type;
+            using UpperMargin = typename pmacc::math::CT::make_Int<simDim, currentUpperMargin>::type;
 
             PMACC_CASSERT_MSG(
                 __EmZ_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
@@ -87,8 +87,8 @@ namespace picongpu
             using Solver = picongpu::currentSolver::Esirkepov<T_ParticleShape, T_Strategy, T_dim>;
 
         public:
-            typedef typename Solver::LowerMargin LowerMargin;
-            typedef typename Solver::UpperMargin UpperMargin;
+            using LowerMargin = typename Solver::LowerMargin;
+            using UpperMargin = typename Solver::UpperMargin;
         };
 
     } // namespace traits

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -44,8 +44,8 @@ namespace picongpu
 
             static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
             static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-            typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
-            typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
+            using LowerMargin = pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin>;
+            using UpperMargin = pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin>;
 
             PMACC_CASSERT_MSG(
                 __Esirkepov_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
@@ -180,7 +180,7 @@ namespace picongpu
                                     * (s0i * s0j + float_X(0.5) * (dsi * s0j + s0i * dsj)
                                        + (float_X(1.0) / float_X(3.0)) * dsj * dsi);
 
-                                float_X accumulated_J = float_X(0.0);
+                                auto accumulated_J = float_X(0.0);
 
                                 /* attention: inner loop has no upper bound `end + 1` because
                                  * the current for the point `end` is always zero,

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -51,8 +51,8 @@ namespace picongpu
 
             static constexpr int currentLowerMargin = supp / 2 + 1 - (supp + 1) % 2;
             static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-            typedef typename pmacc::math::CT::make_Int<DIM2, currentLowerMargin>::type LowerMargin;
-            typedef typename pmacc::math::CT::make_Int<DIM2, currentUpperMargin>::type UpperMargin;
+            using LowerMargin = typename pmacc::math::CT::make_Int<2U, currentLowerMargin>::type;
+            using UpperMargin = typename pmacc::math::CT::make_Int<2U, currentUpperMargin>::type;
 
             PMACC_CASSERT_MSG(
                 __Esirkepov2D_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
@@ -162,7 +162,7 @@ namespace picongpu
 
                         float_X tmp = -currentSurfaceDensity * (s0j + float_X(0.5) * dsj);
 
-                        float_X accumulated_J = float_X(0.0);
+                        auto accumulated_J = float_X(0.0);
                         /* attention: inner loop has no upper bound `end + 1` because
                          * the current for the point `end` is always zero,
                          * therefore we skip the calculation

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -51,8 +51,8 @@ namespace picongpu
 
             static constexpr int currentLowerMargin = supp / 2 + 1;
             static constexpr int currentUpperMargin = (supp + 1) / 2 + 1;
-            typedef pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin> LowerMargin;
-            typedef pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin> UpperMargin;
+            using LowerMargin = pmacc::math::CT::Int<currentLowerMargin, currentLowerMargin, currentLowerMargin>;
+            using UpperMargin = pmacc::math::CT::Int<currentUpperMargin, currentUpperMargin, currentUpperMargin>;
 
             PMACC_CASSERT_MSG(
                 __EsirkepovNative_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
@@ -132,7 +132,7 @@ namespace picongpu
                             + float_X(0.5) * S0(line, i, 1) * DS(line, j, 2)
                             + (float_X(1.0) / float_X(3.0)) * DS(line, i, 1) * DS(line, j, 2);
 
-                        float_X accumulated_J = float_X(0.0);
+                        auto accumulated_J = float_X(0.0);
                         for(int k = begin; k < end; ++k)
                         {
                             const float_X W = DS(line, k, 3) * tmp;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Line.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Line.hpp
@@ -38,9 +38,7 @@ namespace picongpu
             type m_pos0;
             type m_pos1;
 
-            DINLINE Line()
-            {
-            }
+            DINLINE Line() = default;
 
             DINLINE Line(const type& pos0, const type& pos1) : m_pos0(pos0), m_pos1(pos1)
             {

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -61,7 +61,7 @@ namespace picongpu
                     velocity.y() * deltaTime / cellSize.y(),
                     velocity.z() * deltaTime / cellSize.z());
 
-                const PosType oldPos = (PosType)(precisionCast<float_X>(pos) - deltaPos);
+                const auto oldPos = (PosType)(precisionCast<float_X>(pos) - deltaPos);
 
                 addCurrentSplitX(acc, oldPos, pos, charge, boxJ_par, deltaTime);
             }

--- a/include/picongpu/fields/laserProfiles/None.hpp
+++ b/include/picongpu/fields/laserProfiles/None.hpp
@@ -56,9 +56,7 @@ namespace picongpu
 
                     /** Device-Side Constructor
                      */
-                    HDINLINE None()
-                    {
-                    }
+                    HDINLINE None() = default;
 
                     /** device side manipulation for init plane (transversal)
                      *

--- a/include/picongpu/initialization/IInitPlugin.hpp
+++ b/include/picongpu/initialization/IInitPlugin.hpp
@@ -37,8 +37,6 @@ namespace picongpu
         virtual void init() = 0;
         virtual void printInformation() = 0;
 
-        virtual ~IInitPlugin()
-        {
-        }
+        ~IInitPlugin() override = default;
     };
 } // namespace picongpu

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -44,18 +44,14 @@ namespace picongpu
     class InitialiserController : public IInitPlugin
     {
     public:
-        InitialiserController() : cellDescription(nullptr)
-        {
-        }
+        InitialiserController() = default;
 
-        virtual ~InitialiserController()
-        {
-        }
+        ~InitialiserController() override = default;
 
         /**
          * Initialize simulation state at timestep 0
          */
-        virtual void init()
+        void init() override
         {
             // start simulation using default values
             log<picLog::SIMULATION_STATE>("Starting simulation from timestep 0");
@@ -70,7 +66,7 @@ namespace picongpu
         /**
          * Load persistent simulation state from \p restartStep
          */
-        virtual void restart(uint32_t restartStep, const std::string restartDirectory)
+        void restart(uint32_t restartStep, const std::string restartDirectory) override
         {
             // restart simulation by loading from persistent data
             // the simulation will start after restartStep
@@ -122,7 +118,7 @@ namespace picongpu
         /**
          * Print interesting initialization information
          */
-        virtual void printInformation()
+        void printInformation() override
         {
             if(Environment<simDim>::get().GridController().getGlobalRank() == 0)
             {
@@ -163,28 +159,28 @@ namespace picongpu
             }
         }
 
-        void notify(uint32_t)
+        void notify(uint32_t) override
         {
             // nothing to do here
         }
 
-        void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             // nothing to do here
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "Initializers";
         }
 
-        virtual void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             PMACC_ASSERT(cellDescription != nullptr);
             this->cellDescription = cellDescription;
         }
 
-        virtual void slide(uint32_t currentStep)
+        void slide(uint32_t currentStep) override
         {
             SimStartInitialiser simStartInitialiser;
             Environment<>::get().DataConnector().initialise(simStartInitialiser, currentStep);
@@ -193,7 +189,7 @@ namespace picongpu
 
     private:
         /*Descripe simulation area*/
-        MappingDesc* cellDescription;
+        MappingDesc* cellDescription{nullptr};
 
         bool restartSim;
         std::string restartFile;

--- a/include/picongpu/initialization/ParserGridDistribution.cpp
+++ b/include/picongpu/initialization/ParserGridDistribution.cpp
@@ -37,7 +37,7 @@ namespace picongpu
 
     uint32_t ParserGridDistribution::getOffset(uint32_t const devicePos, uint32_t const maxCells) const
     {
-        value_type::const_iterator iter = parsedInput.begin();
+        auto iter = parsedInput.begin();
         // go to last device of these n subdomains extent{n}
         uint32_t i = iter->count - 1u;
         uint32_t sum = 0u;
@@ -67,7 +67,7 @@ namespace picongpu
 
     uint32_t ParserGridDistribution::getLocalSize(uint32_t const devicePos) const
     {
-        value_type::const_iterator iter = parsedInput.begin();
+        auto iter = parsedInput.begin();
         // go to last device of these n subdomains extent{n}
         uint32_t i = iter->count - 1u;
 

--- a/include/picongpu/initialization/SimStartInitialiser.hpp
+++ b/include/picongpu/initialization/SimStartInitialiser.hpp
@@ -37,12 +37,10 @@ namespace picongpu
     class SimStartInitialiser : public AbstractInitialiser
     {
     public:
-        void init(ISimulationData& data, uint32_t currentStep)
+        void init(ISimulationData& data, uint32_t currentStep) override
         {
         }
 
-        virtual ~SimStartInitialiser()
-        {
-        }
+        virtual ~SimStartInitialiser() = default;
     };
 } // namespace picongpu

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -272,7 +272,7 @@ namespace picongpu
                 pushSpecies(currentStep, eventInt, updateEventList);
 
                 /* join all push events */
-                for(typename EventList::iterator iter = updateEventList.begin(); iter != updateEventList.end(); ++iter)
+                for(auto iter = updateEventList.begin(); iter != updateEventList.end(); ++iter)
                 {
                     pushEvent += *iter;
                 }
@@ -282,7 +282,7 @@ namespace picongpu
                 communicateSpecies(updateEventList, commEventList);
 
                 /* join all communication events */
-                for(typename EventList::iterator iter = commEventList.begin(); iter != commEventList.end(); ++iter)
+                for(auto iter = commEventList.begin(); iter != commEventList.end(); ++iter)
                 {
                     commEvent += *iter;
                 }

--- a/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
+++ b/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
@@ -313,8 +313,8 @@ namespace picongpu
                                 = precisionCast<float_COLL>(picongpu::traits::attribute::getCharge(
                                     particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE,
                                     par1));
-                            float_COLL const gamma0 = picongpu::gamma<float_COLL>(labMomentum0, mass0);
-                            float_COLL const gamma1 = picongpu::gamma<float_COLL>(labMomentum1, mass1);
+                            auto const gamma0 = picongpu::gamma<float_COLL>(labMomentum0, mass0);
+                            auto const gamma1 = picongpu::gamma<float_COLL>(labMomentum1, mass1);
 
                             // [Perez 2012] (1)
                             float3_COLL const comsVelocity
@@ -478,11 +478,11 @@ namespace picongpu
                         float_X const& coulombLog) const
                     {
                         using namespace picongpu::particles::collision::precision;
-                        return acc::RelativisticBinaryCollision(
+                        return {
                             math::pow(precisionCast<float_COLL>(density0), 2.0_COLL / 3.0_COLL),
                             math::pow(precisionCast<float_COLL>(density1), 2.0_COLL / 3.0_COLL),
                             potentialPartners,
-                            precisionCast<float_COLL>(coulombLog));
+                            precisionCast<float_COLL>(coulombLog)};
                     }
 
                     //! get the name of the functor

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -186,7 +186,7 @@ namespace picongpu
                             return static_cast<bool>(sourceFrame[linearIdx][multiMask_]);
                         });
                         forEachParticle([&](lockstep::Idx const idx) {
-                            bool const isParticle = static_cast<bool>(sourceFrame[idx][multiMask_]);
+                            auto const isParticle = static_cast<bool>(sourceFrame[idx][multiMask_]);
                             numNewParticlesCtx[idx] = 0u;
                             if(isParticle)
                                 /* ask the particle creator functor how many new particles to create. */

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -62,7 +62,7 @@ namespace picongpu
                     return float_X(0.0);
                 }
 
-                float_X exponent = float_X(0.0);
+                auto exponent = float_X(0.0);
                 if(globalCellPos.y() < gas_center_left)
                 {
                     exponent = math::abs((globalCellPos.y() - gas_center_left) / gas_sigma_left);

--- a/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
@@ -53,7 +53,7 @@ namespace picongpu
                 const float_X gas_y_max = ParamClass::gasYMax_SI / UNIT_LENGTH;
 
                 const floatD_X globalCellPos(precisionCast<float_X>(totalCellOffset) * cellSize.shrink<simDim>());
-                float_X density = float_X(0.0);
+                auto density = float_X(0.0);
 
                 if(globalCellPos.y() < vacuum_y)
                     return density;

--- a/include/picongpu/particles/flylite/NonLTE.hpp
+++ b/include/picongpu/particles/flylite/NonLTE.hpp
@@ -48,7 +48,7 @@ namespace picongpu
                 using ElectronsList = T_ElectronsList;
                 using PhotonsList = T_PhotonsList;
 
-                virtual void init(pmacc::DataSpace<simDim> const& gridSizeLocal, std::string const& ionSpeciesName);
+                void init(pmacc::DataSpace<simDim> const& gridSizeLocal, std::string const& ionSpeciesName) override;
 
                 /** Update atomic configurations
                  *

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.hpp
@@ -63,7 +63,7 @@ namespace picongpu
                         m_density = new GridBuffer<ValueType, simDim>(sizeLocal);
                     }
 
-                    ~LocalDensity()
+                    ~LocalDensity() override
                     {
                         __delete(m_density);
                     }

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.hpp
@@ -61,7 +61,7 @@ namespace picongpu
                         m_energyHistogram = new GridBuffer<EnergyHistogram, simDim>(histSizeLocal);
                     }
 
-                    ~LocalEnergyHistogram()
+                    ~LocalEnergyHistogram() override
                     {
                         __delete(m_energyHistogram);
                     }

--- a/include/picongpu/particles/flylite/helperFields/LocalRateMatrix.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalRateMatrix.hpp
@@ -64,7 +64,7 @@ namespace picongpu
                         m_rateMatrix = new GridBuffer<RateMatrix, simDim>(histSizeLocal);
                     }
 
-                    ~LocalRateMatrix()
+                    ~LocalRateMatrix() override
                     {
                         __delete(m_rateMatrix);
                     }

--- a/include/picongpu/particles/functor/User.hpp
+++ b/include/picongpu/particles/functor/User.hpp
@@ -64,7 +64,9 @@ namespace picongpu
                  * @param is used to enable/disable the constructor (do not pass any value to this parameter)
                  */
                 template<typename DeferFunctor = Functor>
-                HINLINE User(uint32_t, typename std::enable_if<std::is_constructible<DeferFunctor>::value>::type* = 0)
+                HINLINE User(
+                    uint32_t,
+                    typename std::enable_if<std::is_constructible<DeferFunctor>::value>::type* = nullptr)
                     : Functor()
                 {
                 }

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -112,7 +112,7 @@ namespace picongpu
                         }
 
                         /* simulation time step in atomic units */
-                        float_X const timeStepAU = float_X(DELTA_T / ATOMIC_UNIT_TIME);
+                        auto const timeStepAU = float_X(DELTA_T / ATOMIC_UNIT_TIME);
                         /* ionization probability
                          *
                          * probability = rate * time step

--- a/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -89,7 +89,7 @@ namespace picongpu
                             * math::sqrt(float_X(1.) / charExpArg) * math::exp(-float_X(2. / 3.) * charExpArg);
 
                         /* simulation time step in atomic units */
-                        const float_X timeStepAU = float_X(DELTA_T / ATOMIC_UNIT_TIME);
+                        const auto timeStepAU = float_X(DELTA_T / ATOMIC_UNIT_TIME);
                         /* ionization probability
                          *
                          * probability = rate * time step

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -66,9 +66,7 @@ namespace picongpu
                 using LowerMargin = typename pmacc::math::CT::make_Int<simDim, lowerMargin>::type;
                 using UpperMargin = typename pmacc::math::CT::make_Int<simDim, upperMargin>::type;
 
-                HDINLINE ComputeGridValuePerFrame()
-                {
-                }
+                HDINLINE ComputeGridValuePerFrame() = default;
 
                 /** return unit for this solver
                  *

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -114,7 +114,7 @@ namespace picongpu
                     template<typename DeferFunctor = Functor>
                     HINLINE Free(
                         uint32_t,
-                        typename std::enable_if<std::is_constructible<DeferFunctor>::value>::type* = 0)
+                        typename std::enable_if<std::is_constructible<DeferFunctor>::value>::type* = nullptr)
                         : Functor()
                     {
                     }

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -58,7 +58,7 @@ namespace picongpu
                      */
                     const float_X x_m = math::pow(x, float_X(1.0 / 3.0));
 
-                    const float_X cutOff = static_cast<float_X>(SYNC_FUNCS_CUTOFF);
+                    const auto cutOff = static_cast<float_X>(SYNC_FUNCS_CUTOFF);
 
                     if(x_m >= cutOff)
                         return float_X(0.0);

--- a/include/picongpu/particles/traits/GetDensityRatio.hpp
+++ b/include/picongpu/particles/traits/GetDensityRatio.hpp
@@ -48,11 +48,11 @@ namespace picongpu
         struct GetDensityRatio
         {
             using FrameType = typename T_Species::FrameType;
-            typedef typename HasFlag<FrameType, densityRatio<>>::type hasDensityRatio;
-            typedef typename pmacc::traits::Resolve<typename GetFlagType<FrameType, densityRatio<>>::type>::type
-                DensityRatioOfSpecies;
+            using hasDensityRatio = typename HasFlag<FrameType, densityRatio<>>::type;
+            using DensityRatioOfSpecies =
+                typename pmacc::traits::Resolve<typename GetFlagType<FrameType, densityRatio<>>::type>::type;
 
-            typedef typename bmpl::if_<hasDensityRatio, DensityRatioOfSpecies, detail::DefaultDensityRatio>::type type;
+            using type = typename bmpl::if_<hasDensityRatio, DensityRatioOfSpecies, detail::DefaultDensityRatio>::type;
         };
 
     } // namespace traits

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -220,6 +220,7 @@ namespace picongpu
              * @param id index of the plugin, range: [0;help->getNumPlugins())
              */
             std::shared_ptr<ISlave> create(std::shared_ptr<IHelp>& help, size_t const id, MappingDesc* cellDescription)
+                override
             {
                 return std::shared_ptr<ISlave>(new BinEnergyParticles<ParticlesType>(help, id, cellDescription));
             }
@@ -243,7 +244,7 @@ namespace picongpu
             ///! method used by plugin controller to get --help description
             void registerHelp(
                 boost::program_options::options_description& desc,
-                std::string const& masterPrefix = std::string{})
+                std::string const& masterPrefix = std::string{}) override
             {
                 meta::ForEach<EligibleFilters, plugins::misc::AppendName<bmpl::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
@@ -259,12 +260,12 @@ namespace picongpu
 
             void expandHelp(
                 boost::program_options::options_description& desc,
-                std::string const& masterPrefix = std::string{})
+                std::string const& masterPrefix = std::string{}) override
             {
             }
 
 
-            void validateOptions()
+            void validateOptions() override
             {
                 if(notifyPeriod.size() != filter.size())
                     throw std::runtime_error(
@@ -283,12 +284,12 @@ namespace picongpu
                 }
             }
 
-            size_t getNumPlugins() const
+            size_t getNumPlugins() const override
             {
                 return notifyPeriod.size();
             }
 
-            std::string getDescription() const
+            std::string getDescription() const override
             {
                 return description;
             }
@@ -298,7 +299,7 @@ namespace picongpu
                 return prefix;
             }
 
-            std::string getName() const
+            std::string getName() const override
             {
                 return name;
             }
@@ -378,7 +379,7 @@ namespace picongpu
             Environment<>::get().PluginConnector().setNotificationPeriod(this, m_help->notifyPeriod.get(id));
         }
 
-        virtual ~BinEnergyParticles()
+        ~BinEnergyParticles() override
         {
             if(writeToFile)
             {
@@ -393,12 +394,12 @@ namespace picongpu
             __deleteArray(binReduced);
         }
 
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             calBinEnergyParticles<CORE + BORDER>(currentStep);
         }
 
-        void restart(uint32_t restartStep, std::string const& restartDirectory)
+        void restart(uint32_t restartStep, std::string const& restartDirectory) override
         {
             if(!writeToFile)
                 return;
@@ -406,7 +407,7 @@ namespace picongpu
             writeToFile = restoreTxtFile(outFile, filename, restartStep, restartDirectory);
         }
 
-        void checkpoint(uint32_t currentStep, std::string const& checkpointDirectory)
+        void checkpoint(uint32_t currentStep, std::string const& checkpointDirectory) override
         {
             if(!writeToFile)
                 return;

--- a/include/picongpu/plugins/Checkpoint.hpp
+++ b/include/picongpu/plugins/Checkpoint.hpp
@@ -45,7 +45,7 @@ namespace picongpu
     class Checkpoint : public ISimulationPlugin
     {
     public:
-        Checkpoint() : checkpointFilename("checkpoint"), restartChunkSize(0u)
+        Checkpoint() : checkpointFilename("checkpoint")
         {
 #if(ENABLE_OPENPMD == 1)
             ioBackendsHelp["openPMD"] = std::shared_ptr<plugins::multi::IHelp>(openPMD::openPMDWriter::getHelp());
@@ -69,11 +69,9 @@ namespace picongpu
             Environment<>::get().PluginConnector().registerPlugin(this);
         }
 
-        virtual ~Checkpoint()
-        {
-        }
+        ~Checkpoint() override = default;
 
-        void pluginRegisterHelp(boost::program_options::options_description& desc)
+        void pluginRegisterHelp(boost::program_options::options_description& desc) override
         {
             namespace po = boost::program_options;
             if(ioBackendsHelp.empty())
@@ -109,21 +107,21 @@ namespace picongpu
                 backend.second->expandHelp(desc, "checkpoint.");
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "Checkpoint";
         }
 
-        void notify(uint32_t)
+        void notify(uint32_t) override
         {
         }
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             m_cellDescription = cellDescription;
         }
 
-        void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+        void checkpoint(uint32_t currentStep, const std::string checkpointDirectory) override
         {
             auto cBackend = ioBackends.find(checkpointBackendName);
             if(cBackend != ioBackends.end())
@@ -132,7 +130,7 @@ namespace picongpu
             }
         }
 
-        void restart(uint32_t restartStep, const std::string restartDirectory)
+        void restart(uint32_t restartStep, const std::string restartDirectory) override
         {
             auto rBackend = ioBackends.find(restartBackendName);
             if(rBackend != ioBackends.end())
@@ -142,7 +140,7 @@ namespace picongpu
         }
 
     private:
-        void pluginLoad()
+        void pluginLoad() override
         {
             for(auto& backendHelp : ioBackendsHelp)
             {
@@ -186,7 +184,7 @@ namespace picongpu
             }
         }
 
-        virtual void pluginUnload()
+        void pluginUnload() override
         {
             ioBackends.clear();
         }
@@ -208,7 +206,7 @@ namespace picongpu
          * Load particles in chunks avoid that the accelerator backend is
          * running out of frame memory.
          */
-        uint32_t restartChunkSize;
+        uint32_t restartChunkSize{0u};
 
         // can be "openPMD"
         std::map<std::string, std::shared_ptr<IIOBackend>> ioBackends;

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -45,9 +45,9 @@ namespace picongpu
     class CountParticles : public ISimulationPlugin
     {
     private:
-        typedef MappingDesc::SuperCellSize SuperCellSize;
+        using SuperCellSize = MappingDesc::SuperCellSize;
 
-        MappingDesc* cellDescription;
+        MappingDesc* cellDescription{nullptr};
         std::string notifyPeriod;
 
         std::string pluginName;
@@ -56,7 +56,7 @@ namespace picongpu
 
         std::ofstream outFile;
         /*only rank 0 create a file*/
-        bool writeToFile;
+        bool writeToFile{false};
 
         mpi::MPIReduce reduce;
 
@@ -65,22 +65,19 @@ namespace picongpu
             : pluginName("CountParticles: count macro particles of a species")
             , pluginPrefix(ParticlesType::FrameType::getName() + std::string("_macroParticlesCount"))
             , filename(pluginPrefix + ".dat")
-            , cellDescription(nullptr)
-            , writeToFile(false)
+
         {
             Environment<>::get().PluginConnector().registerPlugin(this);
         }
 
-        virtual ~CountParticles()
-        {
-        }
+        ~CountParticles() override = default;
 
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             countParticles<CORE + BORDER>(currentStep);
         }
 
-        void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             desc.add_options()(
                 (pluginPrefix + ".period").c_str(),
@@ -88,18 +85,18 @@ namespace picongpu
                 "enable plugin [for each n-th step]");
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return pluginName;
         }
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             this->cellDescription = cellDescription;
         }
 
     private:
-        void pluginLoad()
+        void pluginLoad() override
         {
             if(!notifyPeriod.empty())
             {
@@ -123,7 +120,7 @@ namespace picongpu
             }
         }
 
-        void pluginUnload()
+        void pluginUnload() override
         {
             if(!notifyPeriod.empty())
             {
@@ -138,7 +135,7 @@ namespace picongpu
             }
         }
 
-        void restart(uint32_t restartStep, const std::string restartDirectory)
+        void restart(uint32_t restartStep, const std::string restartDirectory) override
         {
             if(!writeToFile)
                 return;
@@ -146,7 +143,7 @@ namespace picongpu
             writeToFile = restoreTxtFile(outFile, filename, restartStep, restartDirectory);
         }
 
-        void checkpoint(uint32_t currentStep, const std::string checkpointDirectory)
+        void checkpoint(uint32_t currentStep, const std::string checkpointDirectory) override
         {
             if(!writeToFile)
                 return;

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -201,6 +201,7 @@ namespace picongpu
              * @param id index of the plugin, range: [0;help->getNumPlugins())
              */
             std::shared_ptr<ISlave> create(std::shared_ptr<IHelp>& help, size_t const id, MappingDesc* cellDescription)
+                override
             {
                 return std::shared_ptr<ISlave>(new EnergyParticles<ParticlesType>(help, id, cellDescription));
             }
@@ -223,7 +224,7 @@ namespace picongpu
             ///! method used by plugin controller to get --help description
             void registerHelp(
                 boost::program_options::options_description& desc,
-                std::string const& masterPrefix = std::string{})
+                std::string const& masterPrefix = std::string{}) override
             {
                 meta::ForEach<EligibleFilters, plugins::misc::AppendName<bmpl::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
@@ -236,12 +237,12 @@ namespace picongpu
 
             void expandHelp(
                 boost::program_options::options_description& desc,
-                std::string const& masterPrefix = std::string{})
+                std::string const& masterPrefix = std::string{}) override
             {
             }
 
 
-            void validateOptions()
+            void validateOptions() override
             {
                 if(notifyPeriod.size() != filter.size())
                     throw std::runtime_error(
@@ -257,12 +258,12 @@ namespace picongpu
                 }
             }
 
-            size_t getNumPlugins() const
+            size_t getNumPlugins() const override
             {
                 return notifyPeriod.size();
             }
 
-            std::string getDescription() const
+            std::string getDescription() const override
             {
                 return description;
             }
@@ -272,7 +273,7 @@ namespace picongpu
                 return prefix;
             }
 
-            std::string getName() const
+            std::string getName() const override
             {
                 return name;
             }
@@ -326,7 +327,7 @@ namespace picongpu
             Environment<>::get().PluginConnector().setNotificationPeriod(this, m_help->notifyPeriod.get(id));
         }
 
-        virtual ~EnergyParticles()
+        ~EnergyParticles() override
         {
             if(writeToFile)
             {
@@ -345,14 +346,14 @@ namespace picongpu
         /** this code is executed if the current time step is supposed to compute
          * the energy
          */
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             // call the method that calls the plugin kernel
             calculateEnergyParticles<CORE + BORDER>(currentStep);
         }
 
 
-        void restart(uint32_t restartStep, std::string const& restartDirectory)
+        void restart(uint32_t restartStep, std::string const& restartDirectory) override
         {
             if(!writeToFile)
                 return;
@@ -360,7 +361,7 @@ namespace picongpu
             writeToFile = restoreTxtFile(outFile, filename, restartStep, restartDirectory);
         }
 
-        void checkpoint(uint32_t currentStep, std::string const& checkpointDirectory)
+        void checkpoint(uint32_t currentStep, std::string const& checkpointDirectory) override
         {
             if(!writeToFile)
                 return;

--- a/include/picongpu/plugins/ILightweightPlugin.hpp
+++ b/include/picongpu/plugins/ILightweightPlugin.hpp
@@ -30,18 +30,16 @@ namespace picongpu
     class ILightweightPlugin : public ISimulationPlugin
     {
     public:
-        void restart(uint32_t, const std::string)
+        void restart(uint32_t, const std::string) override
         {
             // disable checkpoint/restart capabilities for lightweight plugins
         }
 
-        void checkpoint(uint32_t, const std::string)
+        void checkpoint(uint32_t, const std::string) override
         {
             // disable checkpoint/restart capabilities for lightweight plugins
         }
 
-        virtual ~ILightweightPlugin()
-        {
-        }
+        ~ILightweightPlugin() override = default;
     };
 } // namespace picongpu

--- a/include/picongpu/plugins/ISimulationPlugin.hpp
+++ b/include/picongpu/plugins/ISimulationPlugin.hpp
@@ -37,8 +37,6 @@ namespace picongpu
     public:
         virtual void setMappingDescription(MappingDesc* cellDescription) = 0;
 
-        virtual ~ISimulationPlugin()
-        {
-        }
+        ~ISimulationPlugin() override = default;
     };
 } // namespace picongpu

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -245,37 +245,35 @@ namespace picongpu
             init();
         }
 
-        virtual ~PluginController()
-        {
-        }
+        ~PluginController() override = default;
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             PMACC_ASSERT(cellDescription != nullptr);
 
-            for(std::list<ISimulationPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
             {
                 (*iter)->setMappingDescription(cellDescription);
             }
         }
 
-        virtual void pluginRegisterHelp(po::options_description&)
+        void pluginRegisterHelp(po::options_description&) override
         {
             // no help required at the moment
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "PluginController";
         }
 
-        void notify(uint32_t)
+        void notify(uint32_t) override
         {
         }
 
-        virtual void pluginUnload()
+        void pluginUnload() override
         {
-            for(std::list<ISimulationPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
             {
                 __delete(*iter);
             }

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -48,27 +48,25 @@ namespace picongpu
     class PngPlugin : public ILightweightPlugin
     {
     public:
-        typedef VisClass VisType;
-        typedef std::list<VisType*> VisPointerList;
+        using VisType = VisClass;
+        using VisPointerList = std::list<VisType*>;
 
         PngPlugin()
             : pluginName("PngPlugin: create png's of a species and fields")
             , pluginPrefix(VisType::FrameType::getName() + "_" + VisClass::CreatorType::getName())
-            , cellDescription(nullptr)
+
         {
             Environment<>::get().PluginConnector().registerPlugin(this);
         }
 
-        virtual ~PngPlugin()
-        {
-        }
+        ~PngPlugin() override = default;
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return pluginName;
         }
 
-        void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
 #if(PIC_ENABLE_PNG == 1)
             desc.add_options()(
@@ -89,14 +87,14 @@ namespace picongpu
 #endif
         }
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             this->cellDescription = cellDescription;
         }
 
 
     private:
-        void pluginLoad()
+        void pluginLoad() override
         {
             if(0 != notifyPeriod.size())
             {
@@ -139,7 +137,7 @@ namespace picongpu
                                     = !isSlidingWindowEnabled || (transpose.x() == 1 || transpose.y() == 1);
                                 if(isAllowed2DSlice && isAllowedMovingWindowSlice)
                                 {
-                                    VisType* tmp = new VisType(
+                                    auto* tmp = new VisType(
                                         pluginName,
                                         pngCreator,
                                         period,
@@ -175,16 +173,16 @@ namespace picongpu
             }
         }
 
-        void pluginUnload()
+        void pluginUnload() override
         {
-            for(typename VisPointerList::iterator iter = visIO.begin(); iter != visIO.end(); ++iter)
+            for(auto iter = visIO.begin(); iter != visIO.end(); ++iter)
             {
                 __delete(*iter);
             }
             visIO.clear();
         }
 
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             // nothing to do here
         }
@@ -224,7 +222,7 @@ namespace picongpu
         std::vector<std::string> axis;
         VisPointerList visIO;
 
-        MappingDesc* cellDescription;
+        MappingDesc* cellDescription{nullptr};
     };
 
     namespace particles

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -61,7 +61,7 @@ namespace picongpu
     class ResourceLog : public ILightweightPlugin
     {
     private:
-        MappingDesc* cellDescription;
+        MappingDesc* cellDescription{nullptr};
         ResourceMonitor<simDim> resourceMonitor;
 
         // programm options
@@ -74,17 +74,17 @@ namespace picongpu
         std::map<std::string, bool> propertyMap;
 
     public:
-        ResourceLog() : cellDescription(NULL)
+        ResourceLog()
         {
             Environment<>::get().PluginConnector().registerPlugin(this);
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "ResourceLog";
         }
 
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             std::map<std::string, size_t> valueMap;
 
@@ -143,7 +143,7 @@ namespace picongpu
             }
         }
 
-        void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             /* register command line parameters for your plugin */
             desc.add_options()(
@@ -164,7 +164,7 @@ namespace picongpu
                 "Output format of log (pp for pretty print) [json, jsonpp, xml, xmlpp]");
         }
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             this->cellDescription = cellDescription;
         }
@@ -172,7 +172,7 @@ namespace picongpu
     private:
         std::string notifyPeriod;
 
-        void pluginLoad()
+        void pluginLoad() override
         {
             if(!notifyPeriod.empty())
             {
@@ -203,7 +203,7 @@ namespace picongpu
                 // Prepare file for output stream
                 if(streamType == "file")
                 {
-                    size_t rank = static_cast<size_t>(Environment<simDim>::get().GridController().getGlobalRank());
+                    auto rank = static_cast<size_t>(Environment<simDim>::get().GridController().getGlobalRank());
                     std::stringstream ss;
                     ss << outputFilePrefix << rank;
                     boost::filesystem::path resourceLogPath(ss.str());
@@ -213,7 +213,7 @@ namespace picongpu
             }
         }
 
-        void pluginUnload()
+        void pluginUnload() override
         {
             if(fileBuf.is_open())
             {

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -84,22 +84,20 @@ namespace picongpu
     class SumCurrents : public ILightweightPlugin
     {
     private:
-        MappingDesc* cellDescription;
+        MappingDesc* cellDescription{nullptr};
         std::string notifyPeriod;
 
         GridBuffer<float3_X, DIM1>* sumcurrents;
 
     public:
-        SumCurrents() : cellDescription(nullptr)
+        SumCurrents()
         {
             Environment<>::get().PluginConnector().registerPlugin(this);
         }
 
-        virtual ~SumCurrents()
-        {
-        }
+        ~SumCurrents() override = default;
 
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             const int rank = Environment<simDim>::get().GridController().getGlobalRank();
             const float3_X gCurrent = getSumCurrents();
@@ -131,7 +129,7 @@ namespace picongpu
                           << "] " << realCurrent_SI << " Abs:" << math::abs(realCurrent_SI) << std::endl;
         }
 
-        void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             desc.add_options()(
                 "sumcurr.period",
@@ -139,18 +137,18 @@ namespace picongpu
                 "enable plugin [for each n-th step]");
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "SumCurrents";
         }
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             this->cellDescription = cellDescription;
         }
 
     private:
-        void pluginLoad()
+        void pluginLoad() override
         {
             if(!notifyPeriod.empty())
             {
@@ -160,7 +158,7 @@ namespace picongpu
             }
         }
 
-        void pluginUnload()
+        void pluginUnload() override
         {
             if(!notifyPeriod.empty())
             {

--- a/include/picongpu/plugins/multi/Master.hpp
+++ b/include/picongpu/plugins/multi/Master.hpp
@@ -61,22 +61,20 @@ namespace picongpu
                     Environment<>::get().PluginConnector().registerPlugin(this);
                 }
 
-                virtual ~Master()
-                {
-                }
+                ~Master() override = default;
 
-                std::string pluginGetName() const
+                std::string pluginGetName() const override
                 {
                     // the PMacc plugin system needs a short description instead of the plugin name
                     return slaveHelp->getName() + ": " + slaveHelp->getDescription();
                 }
 
-                void pluginRegisterHelp(boost::program_options::options_description& desc)
+                void pluginRegisterHelp(boost::program_options::options_description& desc) override
                 {
                     slaveHelp->registerHelp(desc);
                 }
 
-                void setMappingDescription(MappingDesc* cellDescription)
+                void setMappingDescription(MappingDesc* cellDescription) override
                 {
                     m_cellDescription = cellDescription;
                 }
@@ -85,7 +83,7 @@ namespace picongpu
                  *
                  * Trigger the method restart() for all slave instances.
                  */
-                void restart(uint32_t restartStep, std::string const restartDirectory)
+                void restart(uint32_t restartStep, std::string const restartDirectory) override
                 {
                     for(auto& slave : slaveList)
                         slave->restart(restartStep, restartDirectory);
@@ -98,7 +96,7 @@ namespace picongpu
                  * @param speciesName name of the particle species
                  * @param direction the direction the particles are leaving the simulation
                  */
-                void onParticleLeave(const std::string& speciesName, const int32_t direction)
+                void onParticleLeave(const std::string& speciesName, const int32_t direction) override
                 {
                     for(auto& slave : slaveList)
                         slave->onParticleLeave(speciesName, direction);
@@ -108,14 +106,14 @@ namespace picongpu
                  *
                  * Trigger the method checkpoint() for all slave instances.
                  */
-                void checkpoint(uint32_t currentStep, std::string const checkpointDirectory)
+                void checkpoint(uint32_t currentStep, std::string const checkpointDirectory) override
                 {
                     for(auto& slave : slaveList)
                         slave->checkpoint(currentStep, checkpointDirectory);
                 }
 
             private:
-                void pluginLoad()
+                void pluginLoad() override
                 {
                     size_t const numSlaves = slaveHelp->getNumPlugins();
                     if(numSlaves > 0u)
@@ -126,12 +124,12 @@ namespace picongpu
                     }
                 }
 
-                void pluginUnload()
+                void pluginUnload() override
                 {
                     slaveList.clear();
                 }
 
-                void notify(uint32_t currentStep)
+                void notify(uint32_t currentStep) override
                 {
                     // nothing to do here
                 }

--- a/include/picongpu/plugins/multi/Option.hpp
+++ b/include/picongpu/plugins/multi/Option.hpp
@@ -69,7 +69,7 @@ namespace picongpu
                 Option(std::string const& name, std::string const& description)
                     : m_name(name)
                     , m_description(description)
-                    , m_hasDefaultValue(false)
+
                 {
                 }
 

--- a/include/picongpu/plugins/output/GatherSlice.hpp
+++ b/include/picongpu/plugins/output/GatherSlice.hpp
@@ -39,14 +39,8 @@ namespace picongpu
 
     struct GatherSlice
     {
-        GatherSlice()
-            : mpiRank(-1)
-            , numRanks(0)
-            , filteredData(nullptr)
-            , comm(MPI_COMM_NULL)
-            , fullData(nullptr)
-            , masterRank(0)
-            , isMPICommInitialized(false)
+        GatherSlice() : comm(MPI_COMM_NULL)
+
         {
         }
 
@@ -128,7 +122,7 @@ namespace picongpu
             MessageHeader* fakeHeader = MessageHeader::create();
             *fakeHeader = header;
 
-            char* recvHeader = new char[MessageHeader::bytes * numRanks];
+            auto* recvHeader = new char[MessageHeader::bytes * numRanks];
 
             if(fullData == nullptr && mpiRank == masterRank)
                 fullData = (char*) new ValueType[header.sim.size.productOfComponents()];
@@ -151,7 +145,7 @@ namespace picongpu
             int offset = 0;
             for(int i = 0; i < numRanks; ++i)
             {
-                MessageHeader* head = (MessageHeader*) (recvHeader + MessageHeader::bytes * i);
+                auto* head = (MessageHeader*) (recvHeader + MessageHeader::bytes * i);
                 counts[i] = head->node.maxSize.productOfComponents() * sizeof(ValueType);
                 displs[i] = offset;
                 offset += counts[i];
@@ -188,7 +182,7 @@ namespace picongpu
 
                 for(int i = 0; i < numRanks; ++i)
                 {
-                    MessageHeader* head = (MessageHeader*) (recvHeader + MessageHeader::bytes * i);
+                    auto* head = (MessageHeader*) (recvHeader + MessageHeader::bytes * i);
 
                     log<picLog::DOMAINS>("part image with offset %1%byte=%2%elements | size %3%  | offset %4%")
                         % displs[i] % (displs[i] / sizeof(ValueType)) % head->node.maxSize.toString()
@@ -248,13 +242,13 @@ namespace picongpu
             isMPICommInitialized = false;
         }
 
-        char* filteredData;
-        char* fullData;
+        char* filteredData{nullptr};
+        char* fullData{nullptr};
         MPI_Comm comm;
-        int mpiRank;
-        int numRanks;
-        int masterRank;
-        bool isMPICommInitialized;
+        int mpiRank{-1};
+        int numRanks{0};
+        int masterRank{0};
+        bool isMPICommInitialized{false};
     };
 
 } // namespace picongpu

--- a/include/picongpu/plugins/output/IIOBackend.hpp
+++ b/include/picongpu/plugins/output/IIOBackend.hpp
@@ -31,13 +31,9 @@ namespace picongpu
     class IIOBackend : public plugins::multi::ISlave
     {
     public:
-        IIOBackend()
-        {
-        }
+        IIOBackend() = default;
 
-        virtual ~IIOBackend()
-        {
-        }
+        ~IIOBackend() override = default;
 
         //! create a checkpoint
         virtual void dumpCheckpoint(

--- a/include/picongpu/plugins/output/header/DataHeader.hpp
+++ b/include/picongpu/plugins/output/header/DataHeader.hpp
@@ -24,11 +24,9 @@ namespace picongpu
 {
     struct DataHeader
     {
-        uint32_t byte;
+        uint32_t byte{0};
 
-        DataHeader() : byte(0)
-        {
-        }
+        DataHeader() = default;
 
         void writeToConsole(std::ostream& ocons) const
         {

--- a/include/picongpu/plugins/output/header/MessageHeader.hpp
+++ b/include/picongpu/plugins/output/header/MessageHeader.hpp
@@ -170,7 +170,7 @@ namespace picongpu
          *
          * it is only allowed to create Message header with @see create()
          */
-        MessageHeader();
+        MessageHeader() = delete;
     };
 
 } // namespace picongpu

--- a/include/picongpu/plugins/output/header/NodeHeader.hpp
+++ b/include/picongpu/plugins/output/header/NodeHeader.hpp
@@ -30,7 +30,7 @@ namespace picongpu
 {
     struct NodeHeader
     {
-        typedef pmacc::DataSpace<DIM2> Size2D;
+        using Size2D = pmacc::DataSpace<2U>;
 
         Size2D maxSize;
         Size2D size;

--- a/include/picongpu/plugins/output/header/SimHeader.hpp
+++ b/include/picongpu/plugins/output/header/SimHeader.hpp
@@ -30,17 +30,17 @@ namespace picongpu
 {
     struct SimHeader
     {
-        typedef pmacc::DataSpace<DIM2> Size2D;
+        using Size2D = pmacc::DataSpace<2U>;
 
         Size2D size;
         Size2D nodes;
         Size2D simOffsetToNull;
-        uint32_t step;
+        uint32_t step{0};
         picongpu::float_32 scale[2];
         picongpu::float_32 cellSizeArr[2];
 
 
-        SimHeader() : step(0)
+        SimHeader()
         {
             scale[0] = 1.f;
             scale[1] = 1.f;

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -612,7 +612,7 @@ namespace picongpu
     class Visualisation : public ILightweightPlugin
     {
     private:
-        typedef MappingDesc::SuperCellSize SuperCellSize;
+        using SuperCellSize = MappingDesc::SuperCellSize;
 
 
     public:
@@ -647,7 +647,7 @@ namespace picongpu
             Environment<>::get().PluginConnector().setNotificationPeriod(this, m_notifyPeriod);
         }
 
-        virtual ~Visualisation()
+        ~Visualisation() override
         {
             /* wait that shared buffers can destroyed */
             m_output.join();
@@ -658,12 +658,12 @@ namespace picongpu
             }
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "Visualisation";
         }
 
-        void notify(uint32_t currentStep)
+        void notify(uint32_t currentStep) override
         {
             PMACC_ASSERT(cellDescription != nullptr);
             const DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
@@ -680,7 +680,7 @@ namespace picongpu
             createImage(currentStep, window);
         }
 
-        void setMappingDescription(MappingDesc* cellDescription)
+        void setMappingDescription(MappingDesc* cellDescription) override
         {
             PMACC_ASSERT(cellDescription != nullptr);
             this->cellDescription = cellDescription;
@@ -727,7 +727,7 @@ namespace picongpu
             int elements = img->getGridLayout().getDataSpace().productOfComponents();
 
             // Add one dimension access to 2d DataBox
-            typedef DataBoxDim1Access<typename GridBuffer<float3_X, DIM2>::DataBoxType> D1Box;
+            using D1Box = DataBoxDim1Access<typename GridBuffer<float3_X, 2U>::DataBoxType>;
             D1Box d1access(img->getDeviceBuffer().getDataBox(), img->getGridLayout().getDataSpace());
 
 #if(EM_FIELD_SCALE_CHANNEL1 == -1 || EM_FIELD_SCALE_CHANNEL2 == -1 || EM_FIELD_SCALE_CHANNEL3 == -1)
@@ -832,7 +832,7 @@ namespace picongpu
             }
         }
 
-        void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             // nothing to do here
         }

--- a/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -33,9 +33,7 @@ namespace picongpu
                 class FreqFunctor
                 {
                 public:
-                    FreqFunctor(void)
-                    {
-                    }
+                    FreqFunctor(void) = default;
 
                     HDINLINE float_X operator()(const int ID)
                     {
@@ -52,9 +50,7 @@ namespace picongpu
                 class InitFreqFunctor
                 {
                 public:
-                    InitFreqFunctor(void)
-                    {
-                    }
+                    InitFreqFunctor(void) = default;
 
                     HINLINE void Init(const std::string path)
                     {
@@ -63,7 +59,7 @@ namespace picongpu
 
                     HINLINE FreqFunctor getFunctor(void)
                     {
-                        return FreqFunctor();
+                        return {};
                     }
                 };
 

--- a/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -38,11 +38,9 @@ namespace picongpu
                 class FreqFunctor
                 {
                 public:
-                    typedef GridBuffer<float_X, DIM1>::DataBoxType DBoxType;
+                    using DBoxType = GridBuffer<float_X, 1U>::DataBoxType;
 
-                    FreqFunctor(void)
-                    {
-                    }
+                    FreqFunctor(void) = default;
 
                     template<typename T>
                     FreqFunctor(T frequencies_handed)
@@ -70,16 +68,14 @@ namespace picongpu
                 class InitFreqFunctor
                 {
                 public:
-                    InitFreqFunctor(void)
-                    {
-                    }
+                    InitFreqFunctor(void) = default;
 
                     ~InitFreqFunctor(void)
                     {
                         __delete(frequencyBuffer);
                     }
 
-                    typedef GridBuffer<picongpu::float_X, DIM1>::DataBoxType DBoxType;
+                    using DBoxType = GridBuffer<picongpu::float_X, 1U>::DataBoxType;
 
                     HINLINE void Init(const std::string path)
                     {
@@ -120,7 +116,7 @@ namespace picongpu
 
                     FreqFunctor getFunctor(void)
                     {
-                        return FreqFunctor(frequencyBuffer);
+                        return {frequencyBuffer};
                     }
 
                 private:

--- a/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -58,9 +58,7 @@ namespace picongpu
                 class InitFreqFunctor
                 {
                 public:
-                    InitFreqFunctor(void)
-                    {
-                    }
+                    InitFreqFunctor(void) = default;
 
                     HINLINE void Init(const std::string path)
                     {
@@ -69,7 +67,7 @@ namespace picongpu
 
                     HINLINE FreqFunctor getFunctor(void)
                     {
-                        return FreqFunctor();
+                        return {};
                     }
                 };
 

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -129,9 +129,7 @@ namespace picongpu
                     Environment<>::get().PluginConnector().registerPlugin(this);
                 }
 
-                virtual ~TransitionRadiation()
-                {
-                }
+                ~TransitionRadiation() override = default;
 
                 /** Plugin management
                  *
@@ -142,7 +140,7 @@ namespace picongpu
                  *
                  * @param currentStep current step of simulation
                  */
-                void notify(uint32_t currentStep)
+                void notify(uint32_t currentStep) override
                 {
                     log<radLog::SIMULATION_STATE>("Transition Radition (%1%): calculate time step %2% ") % speciesName
                         % currentStep;
@@ -166,7 +164,7 @@ namespace picongpu
                  *
                  * @param desc boost::program_options description
                  */
-                void pluginRegisterHelp(po::options_description& desc)
+                void pluginRegisterHelp(po::options_description& desc) override
                 {
                     desc.add_options()(
                         (pluginPrefix + ".period").c_str(),
@@ -178,7 +176,7 @@ namespace picongpu
                  *
                  * @return name of plugin
                  */
-                std::string pluginGetName() const
+                std::string pluginGetName() const override
                 {
                     return pluginName;
                 }
@@ -187,7 +185,7 @@ namespace picongpu
                  *
                  * @param cellDescription
                  */
-                void setMappingDescription(MappingDesc* cellDescription)
+                void setMappingDescription(MappingDesc* cellDescription) override
                 {
                     this->cellDescription = cellDescription;
                 }
@@ -223,7 +221,7 @@ namespace picongpu
                  * transition radiation calculation and create a folder for transition
                  * radiation storage.
                  */
-                void pluginLoad()
+                void pluginLoad() override
                 {
                     if(!notifyPeriod.empty())
                     {
@@ -280,7 +278,7 @@ namespace picongpu
                 }
 
                 //! Implementation of base class function. Deletes buffers andf arrays.
-                void pluginUnload()
+                void pluginUnload() override
                 {
                     if(!notifyPeriod.empty())
                     {

--- a/include/picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp
@@ -33,9 +33,7 @@ namespace picongpu
                 class FreqFunctor
                 {
                 public:
-                    FreqFunctor(void)
-                    {
-                    }
+                    FreqFunctor(void) = default;
 
                     HDINLINE float_X operator()(const int ID)
                     {
@@ -51,9 +49,7 @@ namespace picongpu
                 class InitFreqFunctor
                 {
                 public:
-                    InitFreqFunctor(void)
-                    {
-                    }
+                    InitFreqFunctor(void) = default;
 
                     HINLINE void Init(const std::string path)
                     {
@@ -62,7 +58,7 @@ namespace picongpu
 
                     HINLINE FreqFunctor getFunctor(void)
                     {
-                        return FreqFunctor();
+                        return {};
                     }
                 }; // InitFreqFunctor
 

--- a/include/picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp
@@ -38,11 +38,9 @@ namespace picongpu
                 class FreqFunctor
                 {
                 public:
-                    typedef GridBuffer<float_X, DIM1>::DataBoxType DBoxType;
+                    using DBoxType = GridBuffer<float_X, 1U>::DataBoxType;
 
-                    FreqFunctor(void)
-                    {
-                    }
+                    FreqFunctor(void) = default;
 
                     template<typename T>
                     FreqFunctor(T frequencies_handed)
@@ -70,16 +68,14 @@ namespace picongpu
                 class InitFreqFunctor
                 {
                 public:
-                    InitFreqFunctor(void)
-                    {
-                    }
+                    InitFreqFunctor(void) = default;
 
                     ~InitFreqFunctor(void)
                     {
                         __delete(frequencyBuffer);
                     }
 
-                    typedef GridBuffer<picongpu::float_X, DIM1>::DataBoxType DBoxType;
+                    using DBoxType = GridBuffer<picongpu::float_X, 1U>::DataBoxType;
 
                     HINLINE void Init(const std::string path)
                     {
@@ -121,7 +117,7 @@ namespace picongpu
 
                     FreqFunctor getFunctor(void)
                     {
-                        return FreqFunctor(frequencyBuffer);
+                        return {frequencyBuffer};
                     }
 
                 private:

--- a/include/picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp
@@ -58,9 +58,7 @@ namespace picongpu
                 class InitFreqFunctor
                 {
                 public:
-                    InitFreqFunctor(void)
-                    {
-                    }
+                    InitFreqFunctor(void) = default;
 
                     HINLINE void Init(const std::string path)
                     {
@@ -69,7 +67,7 @@ namespace picongpu
 
                     HINLINE FreqFunctor getFunctor(void)
                     {
-                        return FreqFunctor();
+                        return {};
                     }
                 }; // InitFreqFunctor
 

--- a/include/picongpu/simulation/control/DomainAdjuster.hpp
+++ b/include/picongpu/simulation/control/DomainAdjuster.hpp
@@ -138,7 +138,7 @@ namespace picongpu
 
             // gather local sizes in the direction we are checking
             std::vector<uint64_t> allLocalSizes(numMpiRanks);
-            uint64_t lSize = static_cast<uint64_t>(m_localDomainSize[dim]);
+            auto lSize = static_cast<uint64_t>(m_localDomainSize[dim]);
             MPI_CHECK(MPI_Allgather(
                 &lSize,
                 1,
@@ -320,7 +320,7 @@ namespace picongpu
             }
             else
             {
-                uint64_t localDomainSize = static_cast<uint64_t>(m_localDomainSize[dim]);
+                auto localDomainSize = static_cast<uint64_t>(m_localDomainSize[dim]);
                 pmacc::mpi::MPIReduce mpiReduce;
                 mpiReduce(
                     pmacc::math::operation::Add(),

--- a/include/picongpu/simulation/control/ISimulationStarter.hpp
+++ b/include/picongpu/simulation/control/ISimulationStarter.hpp
@@ -34,9 +34,7 @@ namespace picongpu
     class ISimulationStarter : public IPlugin
     {
     public:
-        virtual ~ISimulationStarter()
-        {
-        }
+        ~ISimulationStarter() override = default;
         /**Pars progarm parameters
          *             *
          * @param argc number of arguments in argv
@@ -51,12 +49,12 @@ namespace picongpu
          */
         virtual void start() = 0;
 
-        virtual void restart(uint32_t, const std::string)
+        void restart(uint32_t, const std::string) override
         {
             // nothing to do here
         }
 
-        virtual void checkpoint(uint32_t, const std::string)
+        void checkpoint(uint32_t, const std::string) override
         {
             // nothing to do here
         }

--- a/include/picongpu/simulation/control/MovingWindow.hpp
+++ b/include/picongpu/simulation/control/MovingWindow.hpp
@@ -38,7 +38,7 @@ namespace picongpu
     private:
         MovingWindow() = default;
 
-        MovingWindow(MovingWindow& cc);
+        MovingWindow(MovingWindow& cc) = delete;
 
         void getCurrentSlideInfo(uint32_t currentStep, bool* doSlide, float_64* offsetFirstGPU)
         {
@@ -60,7 +60,7 @@ namespace picongpu
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
 
                 /* speed of the moving window */
-                const float_64 windowMovingSpeed = float_64(SPEED_OF_LIGHT);
+                const auto windowMovingSpeed = float_64(SPEED_OF_LIGHT);
 
                 /* defines in which direction the window moves
                  *
@@ -81,7 +81,7 @@ namespace picongpu
                 const uint32_t gpuNumberOfCellsInMoveDirection = subGrid.getLocalDomain().size[moveDirection];
 
                 /* unit PIConGPU length */
-                const float_64 cellSizeInMoveDirection = float_64(cellSize[moveDirection]);
+                const auto cellSizeInMoveDirection = float_64(cellSize[moveDirection]);
 
                 const float_64 deltaWayPerStep = (windowMovingSpeed * float_64(DELTA_T));
 
@@ -251,7 +251,7 @@ namespace picongpu
         void setEndSlideOnStep(int32_t step)
         {
             // maybe we have a underflow in the cast, this is fine because it results in a very large number
-            const uint32_t maxSlideStep = static_cast<uint32_t>(step);
+            const auto maxSlideStep = static_cast<uint32_t>(step);
             if(maxSlideStep < lastSlideStep)
                 throw std::runtime_error("It is not allowed to stop the moving window in the past.");
 

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -121,17 +121,10 @@ namespace picongpu
          * Constructor
          */
         Simulation()
-            : myFieldSolver(nullptr)
-            , cellDescription(nullptr)
-            , initialiserController(nullptr)
-            , slidingWindow(false)
-            , windowMovePoint(0.0)
-            , endSlidingOnStep(-1)
-            , showVersionOnce(false)
-        {
-        }
 
-        virtual void pluginRegisterHelp(po::options_description& desc)
+            = default;
+
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             SimulationHelper<simDim>::pluginRegisterHelp(desc);
             currentInterpolationAndAdditionToEMF.registerHelp(desc);
@@ -172,12 +165,12 @@ namespace picongpu
             // clang-format on
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "PIConGPU";
         }
 
-        virtual void pluginLoad()
+        void pluginLoad() override
         {
             // fill periodic with 0
             while(periodic.size() < 3)
@@ -289,7 +282,7 @@ namespace picongpu
             }
         }
 
-        virtual void pluginUnload()
+        void pluginUnload() override
         {
             DataConnector& dc = Environment<>::get().DataConnector();
 
@@ -307,11 +300,11 @@ namespace picongpu
             __delete(cellDescription);
         }
 
-        void notify(uint32_t)
+        void notify(uint32_t) override
         {
         }
 
-        virtual void init()
+        void init() override
         {
             // This has to be called before initFields()
             currentInterpolationAndAdditionToEMF.init();
@@ -449,7 +442,7 @@ namespace picongpu
 #endif
         }
 
-        virtual uint32_t fillSimulation()
+        uint32_t fillSimulation() override
         {
             /* assume start (restart in initialiserController might change that) */
             uint32_t step = 0;
@@ -537,7 +530,7 @@ namespace picongpu
          *
          * @param currentStep iteration number of the current step
          */
-        virtual void runOneStep(uint32_t currentStep)
+        void runOneStep(uint32_t currentStep) override
         {
             using namespace simulation::stage;
 
@@ -562,7 +555,7 @@ namespace picongpu
             myFieldSolver->update_afterCurrent(currentStep);
         }
 
-        virtual void movingWindowCheck(uint32_t currentStep)
+        void movingWindowCheck(uint32_t currentStep) override
         {
             if(MovingWindow::getInstance().slideInCurrentStep(currentStep))
             {
@@ -591,7 +584,7 @@ namespace picongpu
             }
         }
 
-        virtual void resetAll(uint32_t currentStep)
+        void resetAll(uint32_t currentStep) override
         {
             resetFields(currentStep);
             meta::ForEach<VectorAllSpecies, particles::CallReset<bmpl::_1>> resetParticles;
@@ -626,7 +619,7 @@ namespace picongpu
     protected:
         std::shared_ptr<DeviceHeap> deviceHeap;
 
-        fields::Solver* myFieldSolver;
+        fields::Solver* myFieldSolver{nullptr};
         simulation::stage::CurrentInterpolationAndAdditionToEMF currentInterpolationAndAdditionToEMF;
 
         // Field absorber stage, has to live always as it is used for registering options like a plugin.
@@ -653,9 +646,9 @@ namespace picongpu
 
         // output classes
 
-        IInitPlugin* initialiserController;
+        IInitPlugin* initialiserController{nullptr};
 
-        MappingDesc* cellDescription;
+        MappingDesc* cellDescription{nullptr};
 
         // layout parameter
         std::vector<uint32_t> devices;
@@ -666,10 +659,10 @@ namespace picongpu
 
         std::vector<std::string> gridDistribution;
 
-        bool slidingWindow;
-        int32_t endSlidingOnStep;
-        float_64 windowMovePoint;
-        bool showVersionOnce;
+        bool slidingWindow{false};
+        int32_t endSlidingOnStep{-1};
+        float_64 windowMovePoint{0.0};
+        bool showVersionOnce{false};
         bool autoAdjustGrid = true;
         uint32_t numRanksPerDevice = 1u;
 

--- a/include/picongpu/simulation/control/SimulationStarter.hpp
+++ b/include/picongpu/simulation/control/SimulationStarter.hpp
@@ -49,10 +49,10 @@ namespace picongpu
         PluginClass* pluginClass;
 
 
-        MappingDesc* mappingDesc;
+        MappingDesc* mappingDesc{nullptr};
 
     public:
-        SimulationStarter() : mappingDesc(nullptr)
+        SimulationStarter()
         {
             simulationClass = new SimulationClass();
             initClass = new InitClass();
@@ -60,19 +60,19 @@ namespace picongpu
             pluginClass = new PluginClass();
         }
 
-        virtual ~SimulationStarter()
+        ~SimulationStarter() override
         {
             __delete(initClass);
             __delete(pluginClass);
             __delete(simulationClass);
         }
 
-        virtual std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "PIConGPU simulation starter";
         }
 
-        virtual void start()
+        void start() override
         {
             PluginConnector& pluginConnector = Environment<>::get().PluginConnector();
             pluginConnector.loadPlugins();
@@ -81,15 +81,15 @@ namespace picongpu
             simulationClass->startSimulation();
         }
 
-        virtual void pluginRegisterHelp(po::options_description&)
+        void pluginRegisterHelp(po::options_description&) override
         {
         }
 
-        void notify(uint32_t)
+        void notify(uint32_t) override
         {
         }
 
-        ArgsParser::Status parseConfigs(int argc, char** argv)
+        ArgsParser::Status parseConfigs(int argc, char** argv) override
         {
             ArgsParser& ap = ArgsParser::getInstance();
             PluginConnector& pluginConnector = Environment<>::get().PluginConnector();
@@ -119,7 +119,7 @@ namespace picongpu
         }
 
     protected:
-        void pluginLoad()
+        void pluginLoad() override
         {
             simulationClass->load();
             mappingDesc = simulationClass->getMappingDescription();
@@ -127,7 +127,7 @@ namespace picongpu
             initClass->setMappingDescription(mappingDesc);
         }
 
-        void pluginUnload()
+        void pluginUnload() override
         {
             PluginConnector& pluginConnector = Environment<>::get().PluginConnector();
             pluginConnector.unloadPlugins();

--- a/include/picongpu/simulation_classTypes.hpp
+++ b/include/picongpu/simulation_classTypes.hpp
@@ -35,6 +35,6 @@ namespace picongpu
     using namespace pmacc;
 
     // short name for access verbose types of picongpu
-    typedef PIConGPUVerbose picLog;
+    using picLog = PIConGPUVerbose;
 
 } // namespace picongpu

--- a/include/picongpu/traits/attribute/GetCharge.hpp
+++ b/include/picongpu/traits/attribute/GetCharge.hpp
@@ -103,7 +103,7 @@ namespace picongpu
             HDINLINE float_X getCharge(const float_X weighting, const T_Particle& particle)
             {
                 using ParticleType = T_Particle;
-                typedef typename pmacc::traits::HasIdentifier<ParticleType, boundElectrons>::type hasBoundElectrons;
+                using hasBoundElectrons = typename pmacc::traits::HasIdentifier<ParticleType, boundElectrons>::type;
                 return detail::LoadBoundElectrons<hasBoundElectrons::value>()(weighting, particle);
             }
 

--- a/include/picongpu/traits/attribute/GetChargeState.hpp
+++ b/include/picongpu/traits/attribute/GetChargeState.hpp
@@ -98,7 +98,7 @@ namespace picongpu
             HDINLINE float_X getChargeState(const T_Particle& particle)
             {
                 using ParticleType = T_Particle;
-                typedef typename pmacc::traits::HasIdentifier<ParticleType, boundElectrons>::type hasBoundElectrons;
+                using hasBoundElectrons = typename pmacc::traits::HasIdentifier<ParticleType, boundElectrons>::type;
                 return detail::LoadChargeState<hasBoundElectrons::value>()(particle);
             }
 

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -57,24 +57,20 @@ namespace pmacc
             friend pmacc::Environment<DIM3>;
 
             EnvironmentContext()
-                : m_isMpiInitialized(false)
-                , m_isDeviceSelected(false)
-                , m_isSubGridDefined(false)
-                , m_isMpiDirectEnabled(false)
-            {
-            }
+
+                = default;
 
             /** initialization state of MPI */
-            bool m_isMpiInitialized;
+            bool m_isMpiInitialized{false};
 
             /** state if a computing device is selected */
-            bool m_isDeviceSelected;
+            bool m_isDeviceSelected{false};
 
             /** state if the SubGrid is defined */
-            bool m_isSubGridDefined;
+            bool m_isSubGridDefined{false};
 
             /** state shows if MPI direct is activated */
-            bool m_isMpiDirectEnabled;
+            bool m_isMpiDirectEnabled{false};
 
             /** get the singleton EnvironmentContext
              *
@@ -149,9 +145,7 @@ namespace pmacc
          */
         struct Environment
         {
-            Environment()
-            {
-            }
+            Environment() = default;
 
             /** cleanup the environment */
             void finalize()
@@ -400,13 +394,9 @@ namespace pmacc
         Environment& operator=(const Environment&) = delete;
 
     private:
-        Environment()
-        {
-        }
+        Environment() = default;
 
-        ~Environment()
-        {
-        }
+        ~Environment() = default;
     };
 
     namespace detail
@@ -416,7 +406,7 @@ namespace pmacc
             m_isMpiInitialized = true;
 
             // MPI_Init with NULL is allowed since MPI 2.0
-            MPI_CHECK(MPI_Init(NULL, NULL));
+            MPI_CHECK(MPI_Init(nullptr, nullptr));
         }
 
         void EnvironmentContext::finalize()

--- a/include/pmacc/HandleGuardRegion.hpp
+++ b/include/pmacc/HandleGuardRegion.hpp
@@ -41,8 +41,8 @@ namespace pmacc
     template<class T_HandleExchanged, class T_HandleNotExchanged>
     struct HandleGuardRegion
     {
-        typedef T_HandleExchanged HandleExchanged;
-        typedef T_HandleNotExchanged HandleNotExchanged;
+        using HandleExchanged = T_HandleExchanged;
+        using HandleNotExchanged = T_HandleNotExchanged;
     };
 
 } // namespace pmacc

--- a/include/pmacc/algorithms/GlobalReduce.hpp
+++ b/include/pmacc/algorithms/GlobalReduce.hpp
@@ -62,7 +62,7 @@ namespace pmacc
             template<class Functor, typename Src>
             typename traits::GetValueType<Src>::ValueType operator()(Functor func, Src src, uint32_t n)
             {
-                typedef typename traits::GetValueType<Src>::ValueType Type;
+                using Type = typename traits::GetValueType<Src>::ValueType;
 
                 Type localResult = reduce(func, src, n);
                 Type globalResult;

--- a/include/pmacc/algorithms/PromoteType.hpp
+++ b/include/pmacc/algorithms/PromoteType.hpp
@@ -31,14 +31,14 @@ namespace pmacc
             template<class T1, class T2>
             struct promoteType
             {
-                typedef T1 type;
+                using type = T1;
             };
 
             // special: promote float to double
             template<>
             struct promoteType<float, double>
             {
-                typedef double type;
+                using type = double;
             };
 
 

--- a/include/pmacc/algorithms/TypeCast.hpp
+++ b/include/pmacc/algorithms/TypeCast.hpp
@@ -30,7 +30,7 @@ namespace pmacc
             template<typename CastToType, typename Type>
             struct TypeCast
             {
-                typedef CastToType result;
+                using result = CastToType;
 
                 HDINLINE result operator()(const Type& value) const
                 {

--- a/include/pmacc/algorithms/math/defines/comparison.hpp
+++ b/include/pmacc/algorithms/math/defines/comparison.hpp
@@ -36,7 +36,7 @@ namespace pmacc
         template<typename T>
         struct Max<T, T>
         {
-            typedef T result;
+            using result = T;
 
             HDINLINE T operator()(T value1, T value2)
             {
@@ -47,7 +47,7 @@ namespace pmacc
         template<typename T>
         struct Min<T, T>
         {
-            typedef T result;
+            using result = T;
 
             HDINLINE T operator()(T value1, T value2)
             {

--- a/include/pmacc/algorithms/math/doubleMath/abs.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/abs.tpp
@@ -34,7 +34,7 @@ namespace pmacc
         template<>
         struct Abs2<double>
         {
-            typedef double result;
+            using result = double;
 
             HDINLINE double operator()(const double& value)
             {

--- a/include/pmacc/algorithms/math/doubleMath/comparison.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/comparison.tpp
@@ -33,7 +33,7 @@ namespace pmacc
         template<>
         struct Min<double, double>
         {
-            typedef double result;
+            using result = double;
 
             HDINLINE double operator()(double value1, double value2)
             {
@@ -44,7 +44,7 @@ namespace pmacc
         template<>
         struct Max<double, double>
         {
-            typedef double result;
+            using result = double;
 
             HDINLINE double operator()(double value1, double value2)
             {

--- a/include/pmacc/algorithms/math/doubleMath/exp.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/exp.tpp
@@ -34,7 +34,7 @@ namespace pmacc
         template<>
         struct Log10<double>
         {
-            typedef double result;
+            using result = double;
 
             HDINLINE double operator()(const double& value)
             {

--- a/include/pmacc/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/floatingPoint.tpp
@@ -35,7 +35,7 @@ namespace pmacc
         template<>
         struct Float2int_ru<double>
         {
-            typedef int result;
+            using result = int;
 
             HDINLINE result operator()(double value)
             {
@@ -50,7 +50,7 @@ namespace pmacc
         template<>
         struct Float2int_rd<double>
         {
-            typedef int result;
+            using result = int;
 
             HDINLINE result operator()(double value)
             {
@@ -65,7 +65,7 @@ namespace pmacc
         template<>
         struct Float2int_rn<double>
         {
-            typedef int result;
+            using result = int;
 
             HDINLINE result operator()(double value)
             {
@@ -76,7 +76,7 @@ namespace pmacc
                     return -(*this)(-value);
                 double intPart;
                 double fracPart = std::modf(value, &intPart);
-                result res = static_cast<int>(intPart);
+                auto res = static_cast<int>(intPart);
                 /* epsilon in the following code is used to consider values
                  * "very close" to x.5 also as x.5
                  */

--- a/include/pmacc/algorithms/math/doubleMath/modf.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/modf.tpp
@@ -32,7 +32,7 @@ namespace pmacc
         template<>
         struct Modf<double>
         {
-            typedef double result;
+            using result = double;
 
             HDINLINE double operator()(double value, double* intpart)
             {

--- a/include/pmacc/algorithms/math/doubleMath/trigo.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/trigo.tpp
@@ -34,7 +34,7 @@ namespace pmacc
         template<>
         struct SinCos<double, double, double>
         {
-            typedef void result;
+            using result = void;
 
             HDINLINE void operator()(double arg, double& sinValue, double& cosValue)
             {
@@ -51,7 +51,7 @@ namespace pmacc
         template<>
         struct Sinc<double>
         {
-            typedef double result;
+            using result = double;
 
             HDINLINE double operator()(const double& value)
             {

--- a/include/pmacc/algorithms/math/floatMath/abs.tpp
+++ b/include/pmacc/algorithms/math/floatMath/abs.tpp
@@ -33,7 +33,7 @@ namespace pmacc
         template<>
         struct Abs2<float>
         {
-            typedef float result;
+            using result = float;
 
             HDINLINE float operator()(const float& value)
             {

--- a/include/pmacc/algorithms/math/floatMath/comparison.tpp
+++ b/include/pmacc/algorithms/math/floatMath/comparison.tpp
@@ -33,7 +33,7 @@ namespace pmacc
         template<>
         struct Min<float, float>
         {
-            typedef float result;
+            using result = float;
 
             HDINLINE float operator()(float value1, float value2)
             {
@@ -44,7 +44,7 @@ namespace pmacc
         template<>
         struct Max<float, float>
         {
-            typedef float result;
+            using result = float;
 
             HDINLINE float operator()(float value1, float value2)
             {

--- a/include/pmacc/algorithms/math/floatMath/exp.tpp
+++ b/include/pmacc/algorithms/math/floatMath/exp.tpp
@@ -34,7 +34,7 @@ namespace pmacc
         template<>
         struct Log10<float>
         {
-            typedef float result;
+            using result = float;
 
             HDINLINE float operator()(const float& value)
             {

--- a/include/pmacc/algorithms/math/floatMath/floatingPoint.tpp
+++ b/include/pmacc/algorithms/math/floatMath/floatingPoint.tpp
@@ -35,7 +35,7 @@ namespace pmacc
         template<>
         struct Float2int_ru<float>
         {
-            typedef int result;
+            using result = int;
 
             HDINLINE result operator()(float value)
             {
@@ -50,7 +50,7 @@ namespace pmacc
         template<>
         struct Float2int_rd<float>
         {
-            typedef int result;
+            using result = int;
 
             HDINLINE result operator()(float value)
             {
@@ -65,7 +65,7 @@ namespace pmacc
         template<>
         struct Float2int_rn<float>
         {
-            typedef int result;
+            using result = int;
 
             HDINLINE result operator()(float value)
             {
@@ -76,7 +76,7 @@ namespace pmacc
                     return -(*this)(-value);
                 float intPart;
                 float fracPart = std::modf(value, &intPart);
-                result res = static_cast<int>(intPart);
+                auto res = static_cast<int>(intPart);
                 /* epsilon in the following code is used to consider values
                  * "very close" to x.5 also as x.5
                  */

--- a/include/pmacc/algorithms/math/floatMath/modf.tpp
+++ b/include/pmacc/algorithms/math/floatMath/modf.tpp
@@ -32,7 +32,7 @@ namespace pmacc
         template<>
         struct Modf<float>
         {
-            typedef float result;
+            using result = float;
 
             HDINLINE float operator()(float value, float* intpart)
             {

--- a/include/pmacc/algorithms/math/floatMath/trigo.tpp
+++ b/include/pmacc/algorithms/math/floatMath/trigo.tpp
@@ -35,7 +35,7 @@ namespace pmacc
         template<>
         struct SinCos<float, float, float>
         {
-            typedef void result;
+            using result = void;
 
             HDINLINE void operator()(float arg, float& sinValue, float& cosValue)
             {
@@ -51,7 +51,7 @@ namespace pmacc
         template<>
         struct Sinc<float>
         {
-            typedef float result;
+            using result = float;
 
             HDINLINE float operator()(const float& value)
             {

--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -76,7 +76,7 @@ namespace pmacc
     public:
         /*! ctor
          */
-        CommunicatorMPI() : hostRank(0)
+        CommunicatorMPI()
         {
             // MPI_Init(nullptr, nullptr);
         }
@@ -85,11 +85,9 @@ namespace pmacc
          *
          * calls MPI_Finalize
          */
-        virtual ~CommunicatorMPI()
-        {
-        }
+        virtual ~CommunicatorMPI() = default;
 
-        virtual int getRank()
+        int getRank() override
         {
             return mpiRank;
         }
@@ -120,7 +118,7 @@ namespace pmacc
             return MPI_INFO_NULL;
         }
 
-        DataSpace<DIM3> getPeriodic() const
+        DataSpace<DIM3> getPeriodic() const override
         {
             return this->periodic;
         }
@@ -183,7 +181,7 @@ namespace pmacc
 
         // description in ICommunicator
 
-        virtual const Mask& getCommunicationMask() const
+        const Mask& getCommunicationMask() const override
         {
             return communicationMask;
         }
@@ -200,9 +198,9 @@ namespace pmacc
 
         // description in ICommunicator
 
-        MPI_Request* startSend(uint32_t ex, const char* send_data, size_t send_data_count, uint32_t tag)
+        MPI_Request* startSend(uint32_t ex, const char* send_data, size_t send_data_count, uint32_t tag) override
         {
-            MPI_Request* request = new MPI_Request;
+            auto* request = new MPI_Request;
 
             MPI_CHECK(MPI_Isend(
                 (void*) send_data,
@@ -218,9 +216,9 @@ namespace pmacc
 
         // description in ICommunicator
 
-        MPI_Request* startReceive(uint32_t ex, char* recv_data, size_t recv_data_max, uint32_t tag)
+        MPI_Request* startReceive(uint32_t ex, char* recv_data, size_t recv_data_max, uint32_t tag) override
         {
-            MPI_Request* request = new MPI_Request;
+            auto* request = new MPI_Request;
 
             MPI_CHECK(MPI_Irecv(
                 recv_data,
@@ -236,7 +234,7 @@ namespace pmacc
 
         // description in ICommunicator
 
-        bool slide()
+        bool slide() override
         {
             // we can only slide in y direction right now
             if(DIM < DIM2)
@@ -252,7 +250,7 @@ namespace pmacc
             return coordinates[1] == dims[1] - 1;
         }
 
-        bool setStateAfterSlides(size_t numSlides)
+        bool setStateAfterSlides(size_t numSlides) override
         {
             // nothing happens
             if(numSlides == 0)
@@ -457,7 +455,7 @@ namespace pmacc
         //! @see getCommunicationMask
         Mask communicationMask;
         //! rank of this process local to its host (node)
-        int hostRank;
+        int hostRank{0};
         //! offset for sliding window
         int yoffset;
 

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -200,9 +200,9 @@ namespace pmacc
                         const math::Int<2>& _blockIdx,
                         const math::Int<2>& _threadIdx) const
                     {
-                        return math::Int<2>(
+                        return {
                             _blockIdx.x() * _blockDim.x() + _threadIdx.x(),
-                            _blockIdx.y() * _blockDim.y() + _threadIdx.y());
+                            _blockIdx.y() * _blockDim.y() + _threadIdx.y()};
                     }
 
                     template<typename T_Acc>
@@ -240,10 +240,10 @@ namespace pmacc
                         const math::Int<3>& _blockIdx,
                         const math::Int<3>& _threadIdx) const
                     {
-                        return math::Int<3>(
+                        return {
                             _blockIdx.x() * _blockDim.x() + _threadIdx.x(),
                             _blockIdx.y() * _blockDim.y() + _threadIdx.y(),
-                            _blockIdx.z() * _blockDim.z() + _threadIdx.z());
+                            _blockIdx.z() * _blockDim.z() + _threadIdx.z()};
                     }
 
                     template<typename T_Acc>

--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -62,19 +62,19 @@ namespace pmacc
                 template<>
                 struct MaxCudaBlockDim<DIM1>
                 {
-                    typedef math::CT::Size_t<1024, 1, 1> type;
+                    using type = math::CT::Size_t<1024, 1, 1>;
                 };
 
                 template<>
                 struct MaxCudaBlockDim<DIM2>
                 {
-                    typedef math::CT::Size_t<32, 32, 1> type;
+                    using type = math::CT::Size_t<32, 32, 1>;
                 };
 
                 template<>
                 struct MaxCudaBlockDim<DIM3>
                 {
-                    typedef math::CT::Size_t<8, 8, 8> type;
+                    using type = math::CT::Size_t<8, 8, 8>;
                 };
 
                 /** Check if MaxCudaBlockDim holds the cupla specification limits

--- a/include/pmacc/cuSTL/algorithm/mpi/Gather.tpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Gather.tpp
@@ -58,7 +58,7 @@ namespace pmacc
                 {
                     math::Size_t<0> operator()(const math::Size_t<DIM1>&)
                     {
-                        return math::Size_t<0>();
+                        return {};
                     }
                 };
 
@@ -162,7 +162,7 @@ namespace pmacc
             {
                 using namespace math;
 
-                int numRanks = static_cast<int>(gather.positions.size());
+                auto numRanks = static_cast<int>(gather.positions.size());
 
                 // calculate sizes per axis in destination buffer
                 std::vector<size_t> sizesPerAxis[memDim];
@@ -174,7 +174,7 @@ namespace pmacc
                     Int<memDim> posInMem = pos.template shrink<memDim>(dir + 1);
                     for(int axis = 0; axis < memDim; axis++)
                     {
-                        size_t posOnAxis = static_cast<size_t>(posInMem[axis]);
+                        auto posOnAxis = static_cast<size_t>(posInMem[axis]);
                         if(posOnAxis >= sizesPerAxis[axis].size())
                             sizesPerAxis[axis].resize(posOnAxis + 1);
                         sizesPerAxis[axis][posOnAxis] = srcSizes[i][axis];
@@ -235,8 +235,8 @@ namespace pmacc
 
                 if(!this->m_participate)
                     return;
-                typedef container::CartBuffer<Type, memDim, T_Alloc, T_Copy, T_Assign> DestBuffer;
-                typedef container::CartBuffer<Type, memDim, T_Alloc2, T_Copy2, T_Assign2> SrcBuffer;
+                using DestBuffer = container::CartBuffer<Type, memDim, T_Alloc, T_Copy, T_Assign>;
+                using SrcBuffer = container::CartBuffer<Type, memDim, T_Alloc2, T_Copy2, T_Assign2>;
                 PMACC_CASSERT_MSG(
                     Can_Only_Gather_Host_Memory,
                     boost::is_same<typename DestBuffer::memoryTag, allocator::tag::host>::value

--- a/include/pmacc/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Reduce.tpp
@@ -43,7 +43,7 @@ namespace pmacc
 
                 auto& con = Environment<dim>::get().GridController();
 
-                typedef std::pair<Int<dim>, bool> PosFlag;
+                using PosFlag = std::pair<Int<dim>, bool>;
                 PosFlag posFlag;
                 posFlag.first = con.getPosition();
                 posFlag.second = setThisAsRoot;
@@ -142,8 +142,8 @@ namespace pmacc
                     static void callback(void* invec, void* inoutvec, int* len, MPI_Datatype*)
                     {
                         Functor functor;
-                        type* inoutvec_t = (type*) inoutvec;
-                        type* invec_t = (type*) invec;
+                        auto* inoutvec_t = (type*) inoutvec;
+                        auto* invec_t = (type*) invec;
 
                         int size = (*len) / sizeof(type);
                         for(int i = 0; i < size; i++)

--- a/include/pmacc/cuSTL/container/CartBuffer.hpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.hpp
@@ -72,23 +72,21 @@ namespace pmacc
               bmpl::apply<Assigner, bmpl::int_<T_dim>, CartBuffer<Type, T_dim, Allocator, Copier, Assigner>>::type
         {
         public:
-            typedef Type type;
+            using type = Type;
             static constexpr int dim = T_dim;
-            typedef cursor::BufferCursor<Type, T_dim> Cursor;
-            typedef typename Allocator::tag memoryTag;
-            typedef math::Size_t<T_dim> SizeType;
-            typedef math::Size_t<T_dim - 1> PitchType;
+            using Cursor = cursor::BufferCursor<Type, T_dim>;
+            using memoryTag = typename Allocator::tag;
+            using SizeType = math::Size_t<T_dim>;
+            using PitchType = math::Size_t<T_dim - 1>;
 
         public:
             Type* dataPointer;
-            int* refCount;
+            int* refCount{nullptr};
             SizeType _size;
             PitchType pitch;
             HDINLINE void init();
             HDINLINE void exit();
-            HDINLINE CartBuffer() : refCount(nullptr)
-            {
-            }
+            HDINLINE CartBuffer() = default;
 
         public:
             HDINLINE CartBuffer(const math::Size_t<T_dim>& size);

--- a/include/pmacc/cuSTL/container/CartBuffer.tpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.tpp
@@ -51,7 +51,7 @@ namespace pmacc
 
                 HDINLINE math::Size_t<0u> operator()(const math::Size_t<1u>&)
                 {
-                    return math::Size_t<0u>();
+                    return {};
                 }
             };
             template<>
@@ -65,7 +65,7 @@ namespace pmacc
 
                 HDINLINE math::Size_t<1> operator()(const math::Size_t<2>& size)
                 {
-                    return math::Size_t<1>(size.x());
+                    return {size.x()};
                 }
             };
             template<>
@@ -74,14 +74,14 @@ namespace pmacc
                 template<typename TCursor>
                 HDINLINE math::Size_t<2> operator()(const TCursor& cursor)
                 {
-                    return math::Size_t<2>(
+                    return {
                         (size_t)((char*) cursor(0, 1, 0).getMarker() - (char*) cursor.getMarker()),
-                        (size_t)((char*) cursor(0, 0, 1).getMarker() - (char*) cursor.getMarker()));
+                        (size_t)((char*) cursor(0, 0, 1).getMarker() - (char*) cursor.getMarker())};
                 }
 
                 HDINLINE math::Size_t<2> operator()(const math::Size_t<3>& size)
                 {
-                    return math::Size_t<2>(size.x(), size.x() * size.y());
+                    return {size.x(), size.x() * size.y()};
                 }
             };
 
@@ -111,14 +111,14 @@ namespace pmacc
 
         template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
         HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(const math::Size_t<T_dim>& _size)
-            : refCount(nullptr)
+
         {
             this->_size = _size;
             init();
         }
 
         template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
-        HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(size_t x) : refCount(nullptr)
+        HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(size_t x)
         {
             this->_size = math::Size_t<1>(x);
             init();
@@ -126,7 +126,7 @@ namespace pmacc
 
         template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
         HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(size_t x, size_t y)
-            : refCount(nullptr)
+
         {
             this->_size = math::Size_t<2>(x, y);
             init();
@@ -134,7 +134,7 @@ namespace pmacc
 
         template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
         HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(size_t x, size_t y, size_t z)
-            : refCount(nullptr)
+
         {
             this->_size = math::Size_t<3>(x, y, z);
             init();
@@ -143,7 +143,7 @@ namespace pmacc
         template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
         HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(
             const CartBuffer<Type, T_dim, Allocator, Copier, Assigner>& other)
-            : refCount(nullptr)
+
         {
             this->dataPointer = other.dataPointer;
             this->refCount = other.refCount;
@@ -155,7 +155,7 @@ namespace pmacc
         template<typename Type, int T_dim, typename Allocator, typename Copier, typename Assigner>
         HDINLINE CartBuffer<Type, T_dim, Allocator, Copier, Assigner>::CartBuffer(
             CartBuffer<Type, T_dim, Allocator, Copier, Assigner>&& other)
-            : refCount(nullptr)
+
         {
             this->dataPointer = other.dataPointer;
             this->refCount = other.refCount;
@@ -195,7 +195,7 @@ namespace pmacc
             this->dataPointer = nullptr;
 #ifndef __CUDA_ARCH__
             delete this->refCount;
-            this->refCount = 0;
+            this->refCount = nullptr;
 #endif
         }
 

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -57,21 +57,18 @@ namespace pmacc
                   assigner::DeviceMemAssigner<>>
         {
         private:
-            typedef CartBuffer<
+            using Base = CartBuffer<
                 Type,
                 T_dim,
                 allocator::DeviceMemAllocator<Type, T_dim>,
                 copier::D2DCopier<T_dim>,
-                assigner::DeviceMemAssigner<>>
-                Base;
+                assigner::DeviceMemAssigner<>>;
 
         protected:
-            HDINLINE DeviceBuffer()
-            {
-            }
+            HDINLINE DeviceBuffer() = default;
 
         public:
-            typedef typename Base::PitchType PitchType;
+            using PitchType = typename Base::PitchType;
 
             /* constructors
              *

--- a/include/pmacc/cuSTL/container/HostBuffer.hpp
+++ b/include/pmacc/cuSTL/container/HostBuffer.hpp
@@ -64,9 +64,7 @@ namespace pmacc
                 assigner::HostMemAssigner<>>;
 
         protected:
-            HostBuffer()
-            {
-            }
+            HostBuffer() = default;
 
         public:
             using PitchType = typename Base::PitchType;

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -33,10 +33,10 @@ namespace pmacc
         template<typename Type, int T_dim>
         struct DeviceMemAllocator
         {
-            typedef Type type;
+            using type = Type;
             static constexpr int dim = T_dim;
-            typedef cursor::BufferCursor<type, dim> Cursor;
-            typedef allocator::tag::device tag;
+            using Cursor = cursor::BufferCursor<type, dim>;
+            using tag = allocator::tag::device;
 
             HDINLINE
             static cursor::BufferCursor<type, T_dim> allocate(const math::Size_t<T_dim>& size);
@@ -47,10 +47,10 @@ namespace pmacc
         template<typename Type>
         struct DeviceMemAllocator<Type, 1>
         {
-            typedef Type type;
+            using type = Type;
             static constexpr int dim = 1;
-            typedef cursor::BufferCursor<type, 1> Cursor;
-            typedef allocator::tag::device tag;
+            using Cursor = cursor::BufferCursor<type, 1>;
+            using tag = allocator::tag::device;
 
             HDINLINE
             static cursor::BufferCursor<type, 1> allocate(const math::Size_t<1>& size);

--- a/include/pmacc/cuSTL/container/allocator/EmptyAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/EmptyAllocator.hpp
@@ -31,7 +31,7 @@ namespace pmacc
     {
         struct EmptyAllocator
         {
-            typedef allocator::tag::unspecified tag;
+            using tag = allocator::tag::unspecified;
 
             template<typename TCursor>
             HDINLINE static void deallocate(const TCursor&)

--- a/include/pmacc/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -35,10 +35,10 @@ namespace pmacc
         template<typename Type, int T_dim>
         struct HostMemAllocator
         {
-            typedef Type type;
+            using type = Type;
             static constexpr int dim = T_dim;
-            typedef cursor::BufferCursor<type, T_dim> Cursor;
-            typedef allocator::tag::host tag;
+            using Cursor = cursor::BufferCursor<type, T_dim>;
+            using tag = allocator::tag::host;
 
             HDINLINE
             static cursor::BufferCursor<type, T_dim> allocate(const math::Size_t<T_dim>& size);
@@ -49,10 +49,10 @@ namespace pmacc
         template<typename Type>
         struct HostMemAllocator<Type, 1>
         {
-            typedef Type type;
+            using type = Type;
             static constexpr int dim = 1;
-            typedef cursor::BufferCursor<type, 1> Cursor;
-            typedef allocator::tag::host tag;
+            using Cursor = cursor::BufferCursor<type, 1>;
+            using tag = allocator::tag::host;
 
             HDINLINE
             static cursor::BufferCursor<type, 1> allocate(const math::Size_t<1>& size);

--- a/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -47,13 +47,13 @@ namespace pmacc
         struct DeviceMemAssigner
         {
             static constexpr int dim = T_Dim::value;
-            typedef T_CartBuffer CartBuffer;
+            using CartBuffer = T_CartBuffer;
 
             template<typename Type>
             HINLINE void assign(const Type& value)
             {
                 // "Curiously recurring template pattern"
-                CartBuffer* buffer = static_cast<CartBuffer*>(this);
+                auto* buffer = static_cast<CartBuffer*>(this);
 
                 zone::SphericZone<dim> myZone(buffer->size());
                 cursor::BufferCursor<Type, dim> cursor(buffer->dataPointer, buffer->pitch);

--- a/include/pmacc/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/include/pmacc/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -41,13 +41,13 @@ namespace pmacc
         struct HostMemAssigner
         {
             static constexpr int dim = T_Dim::value;
-            typedef T_CartBuffer CartBuffer;
+            using CartBuffer = T_CartBuffer;
 
             template<typename Type>
             HINLINE void assign(const Type& value)
             {
                 // "Curiously recurring template pattern"
-                CartBuffer* buffer = static_cast<CartBuffer*>(this);
+                auto* buffer = static_cast<CartBuffer*>(this);
 
                 // get a host accelerator
                 auto hostDev = cupla::manager::Device<cupla::AccHost>::get().device();

--- a/include/pmacc/cuSTL/container/view/View.hpp
+++ b/include/pmacc/cuSTL/container/view/View.hpp
@@ -36,9 +36,7 @@ namespace pmacc
         template<typename Buffer>
         struct View : public Buffer
         {
-            HDINLINE View()
-            {
-            }
+            HDINLINE View() = default;
 
             template<typename TBuffer>
             HDINLINE View(const View<TBuffer>& other)

--- a/include/pmacc/cuSTL/cursor/Cursor.hpp
+++ b/include/pmacc/cuSTL/cursor/Cursor.hpp
@@ -50,13 +50,13 @@ namespace pmacc
             , _Navigator
         {
         public:
-            typedef typename _Accessor::type type;
+            using type = typename _Accessor::type;
             typedef typename std::remove_reference_t<type> ValueType;
-            typedef _Accessor Accessor;
-            typedef _Navigator Navigator;
-            typedef _Marker Marker;
-            typedef Cursor<Accessor, Navigator, Marker> This;
-            typedef This result_type;
+            using Accessor = _Accessor;
+            using Navigator = _Navigator;
+            using Marker = _Marker;
+            using This = Cursor<Accessor, Navigator, Marker>;
+            using result_type = This;
 
         protected:
             Marker marker;

--- a/include/pmacc/cuSTL/cursor/accessor/CursorAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/CursorAccessor.hpp
@@ -30,7 +30,7 @@ namespace pmacc
         template<typename TCursor>
         struct CursorAccessor
         {
-            typedef typename TCursor::type type;
+            using type = typename TCursor::type;
 
             HDINLINE type operator()(TCursor& cursor)
             {

--- a/include/pmacc/cuSTL/cursor/accessor/FunctorAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/FunctorAccessor.hpp
@@ -32,7 +32,7 @@ namespace pmacc
         {
             _Functor functor;
 
-            typedef typename ::pmacc::result_of::Functor<_Functor, ArgType>::type type;
+            using type = typename ::pmacc::result_of::Functor<_Functor, ArgType>::type;
 
             HDINLINE FunctorAccessor(const _Functor& functor) : functor(functor)
             {

--- a/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
@@ -41,8 +41,8 @@ namespace pmacc
         template<typename T_Cursor>
         struct LinearInterpAccessor<T_Cursor, DIM1>
         {
-            typedef T_Cursor Cursor;
-            typedef typename Cursor::ValueType type;
+            using Cursor = T_Cursor;
+            using type = typename Cursor::ValueType;
 
             Cursor cursor;
 
@@ -66,7 +66,7 @@ namespace pmacc
                 const math::Int<DIM1> idx1D(static_cast<int>(intPart[0]));
 
                 type result = pmacc::traits::GetInitializedInstance<type>()(0.0);
-                typedef typename T_Position::type PositionComp;
+                using PositionComp = typename T_Position::type;
                 for(int i = 0; i < 2; i++)
                 {
                     const PositionComp weighting1D = (i == 0 ? (PositionComp(1.0) - fracPart[0]) : fracPart[0]);
@@ -80,8 +80,8 @@ namespace pmacc
         template<typename T_Cursor>
         struct LinearInterpAccessor<T_Cursor, DIM2>
         {
-            typedef T_Cursor Cursor;
-            typedef typename T_Cursor::ValueType type;
+            using Cursor = T_Cursor;
+            using type = typename T_Cursor::ValueType;
 
             Cursor cursor;
 
@@ -106,7 +106,7 @@ namespace pmacc
                 const math::Int<DIM2> idx2D(static_cast<int>(intPart[0]), static_cast<int>(intPart[1]));
 
                 type result = pmacc::traits::GetInitializedInstance<type>()(0.0);
-                typedef typename T_Position::type PositionComp;
+                using PositionComp = typename T_Position::type;
                 for(int i = 0; i < 2; i++)
                 {
                     const PositionComp weighting1D = (i == 0 ? (PositionComp(1.0) - fracPart[0]) : fracPart[0]);
@@ -125,8 +125,8 @@ namespace pmacc
         template<typename T_Cursor>
         struct LinearInterpAccessor<T_Cursor, DIM3>
         {
-            typedef T_Cursor Cursor;
-            typedef typename T_Cursor::ValueType type;
+            using Cursor = T_Cursor;
+            using type = typename T_Cursor::ValueType;
 
             Cursor cursor;
 
@@ -155,7 +155,7 @@ namespace pmacc
                     static_cast<int>(intPart[2]));
 
                 type result = pmacc::traits::GetInitializedInstance<type>()(0.0);
-                typedef typename T_Position::type PositionComp;
+                using PositionComp = typename T_Position::type;
                 for(int i = 0; i < 2; i++)
                 {
                     const PositionComp weighting1D = (i == 0 ? (PositionComp(1.0) - fracPart[0]) : fracPart[0]);

--- a/include/pmacc/cuSTL/cursor/accessor/MarkerAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/MarkerAccessor.hpp
@@ -28,7 +28,7 @@ namespace pmacc
         template<typename Marker>
         struct MarkerAccessor
         {
-            typedef const Marker type;
+            using type = const Marker;
             /** returns the cursor's marker.
              *
              * Here a copy of marker is returned because the cursor object

--- a/include/pmacc/cuSTL/cursor/accessor/PointerAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/PointerAccessor.hpp
@@ -28,7 +28,7 @@ namespace pmacc
         template<typename Type>
         struct PointerAccessor
         {
-            typedef Type& type;
+            using type = Type&;
 
             /** Returns the dereferenced pointer of type 'Type'
              *

--- a/include/pmacc/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
@@ -31,7 +31,7 @@ namespace pmacc
         template<typename TCursor, typename Axes>
         struct TwistAxesAccessor
         {
-            typedef typename math::result_of::TwistComponents<Axes, typename TCursor::ValueType>::type type;
+            using type = typename math::result_of::TwistComponents<Axes, typename TCursor::ValueType>::type;
 
             /** Returns a reference to the result of '*cursor' (with twisted axes).
              *

--- a/include/pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -37,7 +37,7 @@ namespace pmacc
             class SafeCursor : public Cursor
             {
             private:
-                typedef SafeCursor<Cursor, LowerExtent, UpperExtent> This;
+                using This = SafeCursor<Cursor, LowerExtent, UpperExtent>;
                 static constexpr int dim = pmacc::cursor::traits::dim<Cursor>::value;
                 math::Int<dim> offset;
 

--- a/include/pmacc/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -37,7 +37,7 @@ namespace pmacc
         class BufferNavigator
         {
         public:
-            typedef tag::BufferNavigator tag;
+            using tag = tag::BufferNavigator;
             static constexpr int dim = T_dim;
 
         private:
@@ -52,7 +52,7 @@ namespace pmacc
             template<typename Data>
             HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
             {
-                char* result = (char*) data;
+                auto* result = (char*) data;
                 result += jump.x() * sizeof(typename std::remove_pointer_t<Data>);
                 for(int i = 1; i < dim; i++)
                     result += jump[i] * this->pitch[i - 1];
@@ -70,7 +70,7 @@ namespace pmacc
         class BufferNavigator<1>
         {
         public:
-            typedef tag::BufferNavigator tag;
+            using tag = tag::BufferNavigator;
             static constexpr int dim = 1;
 
         public:
@@ -82,7 +82,7 @@ namespace pmacc
             template<typename Data>
             HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
             {
-                char* result = (char*) data;
+                auto* result = (char*) data;
                 result += jump.x() * sizeof(typename std::remove_pointer_t<Data>);
                 return (Data) result;
             }

--- a/include/pmacc/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -34,7 +34,7 @@ namespace pmacc
         class CartNavigator
         {
         public:
-            typedef tag::CartNavigator tag;
+            using tag = tag::CartNavigator;
             static constexpr int dim = T_dim;
 
         private:
@@ -49,7 +49,7 @@ namespace pmacc
             template<typename Data>
             HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
             {
-                char* result = (char*) data;
+                auto* result = (char*) data;
                 result += pmacc::math::dot(jump, this->factor);
                 return (Data) result;
             }

--- a/include/pmacc/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -33,7 +33,7 @@ namespace pmacc
         template<int T_dim>
         struct MultiIndexNavigator
         {
-            typedef tag::MultiIndexNavigator tag;
+            using tag = tag::MultiIndexNavigator;
             static constexpr int dim = T_dim;
 
             template<typename MultiIndex>

--- a/include/pmacc/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -42,7 +42,7 @@ namespace pmacc
                 template<typename Data>
                 HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
                 {
-                    char* result = (char*) data;
+                    auto* result = (char*) data;
                     result += jump.x() * sizeof(typename std::remove_pointer_t<Data>);
                     return (Data) result;
                 }
@@ -56,7 +56,7 @@ namespace pmacc
                 template<typename Data>
                 HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
                 {
-                    char* result = (char*) data;
+                    auto* result = (char*) data;
                     result += jump.x() * sizeof(typename std::remove_pointer_t<Data>) + jump.y() * Pitch::x::value;
                     return (Data) result;
                 }
@@ -70,7 +70,7 @@ namespace pmacc
                 template<typename Data>
                 HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
                 {
-                    char* result = (char*) data;
+                    auto* result = (char*) data;
                     result += jump.x() * sizeof(typename std::remove_pointer_t<Data>) + jump.y() * Pitch::x::value
                         + jump.z() * Pitch::y::value;
                     return (Data) result;

--- a/include/pmacc/cuSTL/cursor/tools/LinearInterp.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/LinearInterp.hpp
@@ -64,11 +64,10 @@ namespace pmacc
         template<typename T_Cursor, typename T_PositionComp>
         struct Functor<cursor::tools::LinearInterp<T_PositionComp>, T_Cursor>
         {
-            typedef pmacc::cursor::Cursor<
+            using type = pmacc::cursor::Cursor<
                 cursor::LinearInterpAccessor<T_Cursor>,
                 cursor::PlusNavigator,
-                pmacc::math::Vector<T_PositionComp, pmacc::cursor::traits::dim<T_Cursor>::value>>
-                type;
+                pmacc::math::Vector<T_PositionComp, pmacc::cursor::traits::dim<T_Cursor>::value>>;
         };
 
     } // namespace result_of

--- a/include/pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
@@ -43,11 +43,10 @@ namespace pmacc
                 template<typename T_NavigatorPerm, typename T_AccessorPerm, typename T_Cursor>
                 struct TwistVectorFieldAxes
                 {
-                    typedef Cursor<
+                    using type = Cursor<
                         TwistAxesAccessor<T_Cursor, T_AccessorPerm>,
                         pmacc::cursor::CT::TwistAxesNavigator<T_NavigatorPerm>,
-                        T_Cursor>
-                        type;
+                        T_Cursor>;
                 };
 
             } // namespace result_of

--- a/include/pmacc/cuSTL/zone/SphericZone.hpp
+++ b/include/pmacc/cuSTL/zone/SphericZone.hpp
@@ -47,14 +47,12 @@ namespace pmacc
         template<int T_dim>
         struct SphericZone
         {
-            typedef tag::SphericZone tag;
+            using tag = tag::SphericZone;
             static constexpr int dim = T_dim;
             math::Size_t<dim> size;
             math::Int<dim> offset;
 
-            HDINLINE SphericZone()
-            {
-            }
+            HDINLINE SphericZone() = default;
             HDINLINE SphericZone(const math::Size_t<dim>& size) : size(size), offset(math::Int<dim>::create(0))
             {
             }

--- a/include/pmacc/cudaSpecs.hpp
+++ b/include/pmacc/cudaSpecs.hpp
@@ -39,7 +39,7 @@ namespace pmacc
         constexpr uint32_t maxNumThreadsPerBlock = 1024;
 
         /** maximum number of threads per axis of a block */
-        typedef math::CT::Size_t<1024, 1024, 64> MaxNumThreadsPerBlockDim;
+        using MaxNumThreadsPerBlockDim = math::CT::Size_t<1024, 1024, 64>;
 
     } // namespace cudaSpecs
 } // namespace pmacc

--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -191,7 +191,8 @@ namespace pmacc
 
         std::list<std::shared_ptr<ISimulationData>> datasets;
 
-        DataConnector(){};
+        DataConnector() = default;
+        ;
 
         virtual ~DataConnector()
         {

--- a/include/pmacc/dataManagement/ISimulationData.hpp
+++ b/include/pmacc/dataManagement/ISimulationData.hpp
@@ -26,7 +26,7 @@
 
 namespace pmacc
 {
-    typedef std::string SimulationDataId;
+    using SimulationDataId = std::string;
 
     /**
      * Interface for simulation data which should be registered at DataConnector
@@ -35,9 +35,7 @@ namespace pmacc
     class ISimulationData
     {
     public:
-        virtual ~ISimulationData()
-        {
-        }
+        virtual ~ISimulationData() = default;
         /**
          * Synchronizes simulation data, meaning accessing (host side) data
          * will return up-to-date values.

--- a/include/pmacc/debug/VerboseLog.hpp
+++ b/include/pmacc/debug/VerboseLog.hpp
@@ -64,7 +64,7 @@ namespace pmacc
     template<uint64_t lvl_, class membership_>
     struct LogLvl
     {
-        typedef membership_ Parent;
+        using Parent = membership_;
         static constexpr uint64_t lvl = lvl_;
 
         /* This operation is only allowed for LogLvl with the same Parent type.
@@ -83,7 +83,7 @@ namespace pmacc
         class VerboseLog
         {
         private:
-            typedef typename LogLevel::Parent LogParent;
+            using LogParent = typename LogLevel::Parent;
             static constexpr uint64_t logLvl = LogLevel::lvl;
 
         public:
@@ -93,7 +93,7 @@ namespace pmacc
 
             ~VerboseLog()
             {
-                typedef LogLvl<(logLvl & LogParent::log_level), LogParent> LogClass;
+                using LogClass = LogLvl<(logLvl & LogParent::log_level), LogParent>;
                 /* check if a bit in the mask is set
                  * If you get an linker error in the next two lines you have not used
                  * DEFINE_LOGLVL makro to define a named logLvl

--- a/include/pmacc/device/MemoryInfo.hpp
+++ b/include/pmacc/device/MemoryInfo.hpp
@@ -131,7 +131,7 @@ namespace pmacc
             }
 
         protected:
-            size_t reservedMem;
+            size_t reservedMem{0};
 
         private:
             friend struct detail::Environment;
@@ -142,9 +142,7 @@ namespace pmacc
                 return instance;
             }
 
-            MemoryInfo() : reservedMem(0)
-            {
-            }
+            MemoryInfo() = default;
         };
 
     } // namespace device

--- a/include/pmacc/device/Reduce.hpp
+++ b/include/pmacc/device/Reduce.hpp
@@ -82,7 +82,7 @@ namespace pmacc
 
                 if(threads > n)
                     threads = n;
-                Type* dest = (Type*) reduceBuffer->getDeviceBuffer().getBasePointer();
+                auto* dest = (Type*) reduceBuffer->getDeviceBuffer().getBasePointer();
 
                 uint32_t blocks = threads / 2 / blockcount;
                 if(blocks == 0)

--- a/include/pmacc/dimensions/DataSpace.tpp
+++ b/include/pmacc/dimensions/DataSpace.tpp
@@ -36,7 +36,7 @@ namespace pmacc
         template<unsigned DIM>
         struct GetComponentsType<DataSpace<DIM>, false>
         {
-            typedef typename DataSpace<DIM>::type type;
+            using type = typename DataSpace<DIM>::type;
         };
 
         /** Trait for float_X */
@@ -55,7 +55,7 @@ namespace pmacc
             template<unsigned T_Dim>
             struct TypeCast<int, pmacc::DataSpace<T_Dim>>
             {
-                typedef const pmacc::DataSpace<T_Dim>& result;
+                using result = const pmacc::DataSpace<T_Dim>&;
 
                 HDINLINE result operator()(const pmacc::DataSpace<T_Dim>& vector) const
                 {
@@ -66,7 +66,7 @@ namespace pmacc
             template<typename T_CastToType, unsigned T_Dim>
             struct TypeCast<T_CastToType, pmacc::DataSpace<T_Dim>>
             {
-                typedef ::pmacc::math::Vector<T_CastToType, T_Dim> result;
+                using result = ::pmacc::math::Vector<T_CastToType, T_Dim>;
 
                 HDINLINE result operator()(const pmacc::DataSpace<T_Dim>& vector) const
                 {

--- a/include/pmacc/dimensions/SuperCellDescription.hpp
+++ b/include/pmacc/dimensions/SuperCellDescription.hpp
@@ -47,13 +47,13 @@ namespace pmacc
         {
             Dim = T_SuperCellSize::dim
         };
-        typedef T_SuperCellSize SuperCellSize;
-        typedef T_OffsetOrigin OffsetOrigin;
-        typedef T_OffsetEnd OffsetEnd;
-        typedef SuperCellDescription<SuperCellSize, OffsetOrigin, OffsetEnd> Type;
+        using SuperCellSize = T_SuperCellSize;
+        using OffsetOrigin = T_OffsetOrigin;
+        using OffsetEnd = T_OffsetEnd;
+        using Type = SuperCellDescription<SuperCellSize, OffsetOrigin, OffsetEnd>;
 
-        typedef typename ct::add<OffsetOrigin, SuperCellSize>::type AddFirst;
-        typedef typename ct::add<AddFirst, OffsetEnd>::type FullSuperCellSize;
+        using AddFirst = typename ct::add<OffsetOrigin, SuperCellSize>::type;
+        using FullSuperCellSize = typename ct::add<AddFirst, OffsetEnd>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/Manager.hpp
+++ b/include/pmacc/eventSystem/Manager.hpp
@@ -39,12 +39,12 @@ namespace pmacc
     class Manager : public IEvent
     {
     public:
-        typedef std::map<id_t, ITask*> TaskMap;
-        typedef std::set<id_t> TaskSet;
+        using TaskMap = std::map<id_t, ITask*>;
+        using TaskSet = std::set<id_t>;
 
         bool execute(id_t taskToWait = 0);
 
-        void event(id_t eventId, EventType type, IEventData* data);
+        void event(id_t eventId, EventType type, IEventData* data) override;
 
 
         /*! Return a ITask pointer if ITask is not finished
@@ -96,7 +96,7 @@ namespace pmacc
 
         Manager(const Manager& cc);
 
-        virtual ~Manager();
+        ~Manager() override;
 
         static Manager& getInstance()
         {

--- a/include/pmacc/eventSystem/Manager.tpp
+++ b/include/pmacc/eventSystem/Manager.tpp
@@ -57,7 +57,7 @@ namespace pmacc
         }
 #endif
 
-        static TaskMap::iterator iter = tasks.begin();
+        static auto iter = tasks.begin();
 
         if(iter == tasks.end())
             iter = tasks.begin();
@@ -121,7 +121,7 @@ namespace pmacc
 
     inline ITask* Manager::getPassiveITaskIfNotFinished(id_t taskId) const
     {
-        TaskMap::const_iterator itPassive = passiveTasks.find(taskId);
+        auto itPassive = passiveTasks.find(taskId);
         if(itPassive != passiveTasks.end())
             return itPassive->second;
         return nullptr;
@@ -129,7 +129,7 @@ namespace pmacc
 
     inline ITask* Manager::getActiveITaskIfNotFinished(id_t taskId) const
     {
-        TaskMap::const_iterator it = tasks.find(taskId);
+        auto it = tasks.find(taskId);
         if(it != tasks.end())
             return it->second;
         return nullptr;
@@ -195,9 +195,7 @@ namespace pmacc
         passiveTasks[task->getId()] = task;
     }
 
-    inline Manager::Manager()
-    {
-    }
+    inline Manager::Manager() = default;
 
     inline Manager::Manager(const Manager&)
     {
@@ -206,7 +204,7 @@ namespace pmacc
 
     inline std::size_t Manager::getCount()
     {
-        for(TaskMap::iterator iter = tasks.begin(); iter != tasks.end(); ++iter)
+        for(auto iter = tasks.begin(); iter != tasks.end(); ++iter)
         {
             if(iter->second != nullptr)
             {

--- a/include/pmacc/eventSystem/events/CudaEvent.def
+++ b/include/pmacc/eventSystem/events/CudaEvent.def
@@ -42,15 +42,15 @@ namespace pmacc
          */
         cuplaStream_t stream;
         /** state if event is recorded */
-        bool isRecorded;
+        bool isRecorded{false};
         /** state if a recorded event is finished
          *
          * avoid cupla driver calls after `isFinished()` returns the first time true
          */
-        bool finished;
+        bool finished{true};
 
         /** number of CudaEventHandle's to the instance */
-        uint32_t refCounter;
+        uint32_t refCounter{0u};
 
 
     public:

--- a/include/pmacc/eventSystem/events/CudaEvent.hpp
+++ b/include/pmacc/eventSystem/events/CudaEvent.hpp
@@ -28,7 +28,7 @@
 
 namespace pmacc
 {
-    CudaEvent::CudaEvent() : isRecorded(false), finished(true), refCounter(0u)
+    CudaEvent::CudaEvent()
     {
         log(ggLog::CUDA_RT() + ggLog::EVENT(), "create event");
         CUDA_CHECK(cuplaEventCreateWithFlags(&event, cuplaEventDisableTiming));

--- a/include/pmacc/eventSystem/events/CudaEventHandle.hpp
+++ b/include/pmacc/eventSystem/events/CudaEventHandle.hpp
@@ -33,13 +33,11 @@ namespace pmacc
     {
     private:
         /** pointer to the CudaEvent */
-        CudaEvent* event;
+        CudaEvent* event{nullptr};
 
     public:
         /** create invalid handle  */
-        CudaEventHandle() : event(nullptr)
-        {
-        }
+        CudaEventHandle() = default;
 
         /** create a handle to a valid CudaEvent
          *
@@ -50,7 +48,7 @@ namespace pmacc
             event->registerHandle();
         }
 
-        CudaEventHandle(const CudaEventHandle& other) : event(nullptr)
+        CudaEventHandle(const CudaEventHandle& other)
         {
             /* register and release handle is done by the assign operator */
             *this = other;

--- a/include/pmacc/eventSystem/events/EventNotify.hpp
+++ b/include/pmacc/eventSystem/events/EventNotify.hpp
@@ -37,9 +37,7 @@ namespace pmacc
     class EventNotify
     {
     public:
-        virtual ~EventNotify()
-        {
-        }
+        virtual ~EventNotify() = default;
 
         /**
          * Registers an observer at this observable.

--- a/include/pmacc/eventSystem/events/EventNotify.tpp
+++ b/include/pmacc/eventSystem/events/EventNotify.tpp
@@ -32,7 +32,7 @@ namespace pmacc
 {
     inline void EventNotify::notify(id_t eventId, EventType type, IEventData* data)
     {
-        std::set<IEvent*>::iterator iter = observers.begin();
+        auto iter = observers.begin();
         for(; iter != observers.end(); iter++)
         {
             if(*iter != nullptr)

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -77,7 +77,7 @@ namespace pmacc
         {
             for(size_t i = 0u; i < count; i++)
             {
-                CudaEvent* nativeEvent = new CudaEvent();
+                auto* nativeEvent = new CudaEvent();
                 events.push_back(nativeEvent);
                 push(nativeEvent);
             }
@@ -102,9 +102,7 @@ namespace pmacc
         }
 
         /** Constructor */
-        EventPool() : isClosed(false)
-        {
-        }
+        EventPool() = default;
 
         /** Destructor
          *
@@ -132,6 +130,6 @@ namespace pmacc
          *
          * if true no events can be added to the pool
          */
-        bool isClosed;
+        bool isClosed{false};
     };
 } // namespace pmacc

--- a/include/pmacc/eventSystem/events/EventTask.hpp
+++ b/include/pmacc/eventSystem/events/EventTask.hpp
@@ -50,7 +50,8 @@ namespace pmacc
          */
         EventTask();
 
-        virtual ~EventTask(){};
+        virtual ~EventTask() = default;
+        ;
 
         /**
          * Returns the task id.
@@ -98,7 +99,7 @@ namespace pmacc
         std::string toString();
 
     private:
-        id_t taskId;
+        id_t taskId{0};
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/events/EventTask.tpp
+++ b/include/pmacc/eventSystem/events/EventTask.tpp
@@ -31,9 +31,7 @@ namespace pmacc
     {
     }
 
-    inline EventTask::EventTask() : taskId(0)
-    {
-    }
+    inline EventTask::EventTask() = default;
 
     inline std::string EventTask::toString()
     {
@@ -87,18 +85,13 @@ namespace pmacc
             return *this;
         }
 
-        TaskLogicalAnd* taskAnd = new TaskLogicalAnd(myTask, otherTask);
+        auto* taskAnd = new TaskLogicalAnd(myTask, otherTask);
         this->taskId = taskAnd->getId();
         manager.addPassiveTask(taskAnd);
 
         return *this;
     }
 
-    inline EventTask& EventTask::operator=(const EventTask& other)
-    {
-        // this is faster than a copy constructor
-        taskId = other.taskId;
-        return *this;
-    }
+    inline EventTask& EventTask::operator=(const EventTask& other) = default;
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/events/IEvent.hpp
+++ b/include/pmacc/eventSystem/events/IEvent.hpp
@@ -37,9 +37,7 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~IEvent()
-        {
-        }
+        virtual ~IEvent() = default;
 
         // IEventData *should* be small; using a pointer here will result in memory leaks...
         /**

--- a/include/pmacc/eventSystem/events/IEventData.hpp
+++ b/include/pmacc/eventSystem/events/IEventData.hpp
@@ -39,9 +39,7 @@ namespace pmacc
         {
         }
 
-        virtual ~IEventData()
-        {
-        }
+        virtual ~IEventData() = default;
 
         EventNotify* getEventNotify()
         {

--- a/include/pmacc/eventSystem/streams/EventStream.hpp
+++ b/include/pmacc/eventSystem/streams/EventStream.hpp
@@ -38,7 +38,7 @@ namespace pmacc
          * Constructor.
          * Creates the cuplaStream_t object.
          */
-        EventStream() : stream(nullptr)
+        EventStream()
         {
             CUDA_CHECK(cuplaStreamCreate(&stream));
         }
@@ -72,7 +72,7 @@ namespace pmacc
         }
 
     private:
-        cuplaStream_t stream;
+        cuplaStream_t stream{nullptr};
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/streams/StreamController.hpp
+++ b/include/pmacc/eventSystem/streams/StreamController.hpp
@@ -112,9 +112,7 @@ namespace pmacc
         /**
          * Constructor.
          */
-        StreamController() : isActivated(false), currentStreamIndex(0)
-        {
-        }
+        StreamController() = default;
 
         /**
          * Get instance of this class.
@@ -128,8 +126,8 @@ namespace pmacc
         }
 
         std::vector<EventStream*> streams;
-        size_t currentStreamIndex;
-        bool isActivated;
+        size_t currentStreamIndex{0};
+        bool isActivated{false};
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/Factory.hpp
+++ b/include/pmacc/eventSystem/tasks/Factory.hpp
@@ -181,9 +181,11 @@ namespace pmacc
     private:
         friend struct detail::Environment;
 
-        Factory(){};
+        Factory() = default;
+        ;
 
-        Factory(const Factory&){};
+        Factory(const Factory&) = default;
+        ;
 
         static Factory& getInstance()
         {

--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -53,7 +53,7 @@ namespace pmacc
         DeviceBuffer<TYPE, DIM>& dst,
         ITask* registeringTask)
     {
-        TaskCopyHostToDevice<TYPE, DIM>* task = new TaskCopyHostToDevice<TYPE, DIM>(src, dst);
+        auto* task = new TaskCopyHostToDevice<TYPE, DIM>(src, dst);
 
         return startTask(*task, registeringTask);
     }
@@ -70,7 +70,7 @@ namespace pmacc
         HostBuffer<TYPE, DIM>& dst,
         ITask* registeringTask)
     {
-        TaskCopyDeviceToHost<TYPE, DIM>* task = new TaskCopyDeviceToHost<TYPE, DIM>(src, dst);
+        auto* task = new TaskCopyDeviceToHost<TYPE, DIM>(src, dst);
 
         return startTask(*task, registeringTask);
     }
@@ -87,7 +87,7 @@ namespace pmacc
         DeviceBuffer<TYPE, DIM>& dst,
         ITask* registeringTask)
     {
-        TaskCopyDeviceToDevice<TYPE, DIM>* task = new TaskCopyDeviceToDevice<TYPE, DIM>(src, dst);
+        auto* task = new TaskCopyDeviceToDevice<TYPE, DIM>(src, dst);
 
         return startTask(*task, registeringTask);
     }
@@ -100,7 +100,7 @@ namespace pmacc
     template<class TYPE, unsigned DIM>
     inline EventTask Factory::createTaskReceive(Exchange<TYPE, DIM>& ex, ITask* registeringTask)
     {
-        TaskReceive<TYPE, DIM>* task = new TaskReceive<TYPE, DIM>(ex);
+        auto* task = new TaskReceive<TYPE, DIM>(ex);
 
         return startTask(*task, registeringTask);
     }
@@ -113,7 +113,7 @@ namespace pmacc
     template<class TYPE, unsigned DIM>
     inline EventTask Factory::createTaskSend(Exchange<TYPE, DIM>& ex, ITask* registeringTask)
     {
-        TaskSend<TYPE, DIM>* task = new TaskSend<TYPE, DIM>(ex);
+        auto* task = new TaskSend<TYPE, DIM>(ex);
 
         return startTask(*task, registeringTask);
     }
@@ -126,7 +126,7 @@ namespace pmacc
     template<class TYPE, unsigned DIM>
     inline EventTask Factory::createTaskSendMPI(Exchange<TYPE, DIM>* ex, ITask* registeringTask)
     {
-        TaskSendMPI<TYPE, DIM>* task = new TaskSendMPI<TYPE, DIM>(ex);
+        auto* task = new TaskSendMPI<TYPE, DIM>(ex);
 
         return startTask(*task, registeringTask);
     }
@@ -139,7 +139,7 @@ namespace pmacc
     template<class TYPE, unsigned DIM>
     inline EventTask Factory::createTaskReceiveMPI(Exchange<TYPE, DIM>* ex, ITask* registeringTask)
     {
-        TaskReceiveMPI<TYPE, DIM>* task = new TaskReceiveMPI<TYPE, DIM>(ex);
+        auto* task = new TaskReceiveMPI<TYPE, DIM>(ex);
 
         return startTask(*task, registeringTask);
     }
@@ -164,7 +164,7 @@ namespace pmacc
             isSmall = (sizeof(TYPE) <= 128)
         }; // if we use const variable the compiler create warnings
 
-        TaskSetValue<TYPE, DIM, isSmall>* task = new TaskSetValue<TYPE, DIM, isSmall>(dst, value);
+        auto* task = new TaskSetValue<TYPE, DIM, isSmall>(dst, value);
 
         return startTask(*task, registeringTask);
     }
@@ -181,7 +181,7 @@ namespace pmacc
         size_t size,
         ITask* registeringTask)
     {
-        TaskSetCurrentSizeOnDevice<TYPE, DIM>* task = new TaskSetCurrentSizeOnDevice<TYPE, DIM>(dst, size);
+        auto* task = new TaskSetCurrentSizeOnDevice<TYPE, DIM>(dst, size);
 
         return startTask(*task, registeringTask);
     }
@@ -196,7 +196,7 @@ namespace pmacc
         DeviceBuffer<TYPE, DIM>& buffer,
         ITask* registeringTask)
     {
-        TaskGetCurrentSizeFromDevice<TYPE, DIM>* task = new TaskGetCurrentSizeFromDevice<TYPE, DIM>(buffer);
+        auto* task = new TaskGetCurrentSizeFromDevice<TYPE, DIM>(buffer);
 
         return startTask(*task, registeringTask);
     }
@@ -209,7 +209,7 @@ namespace pmacc
      */
     inline TaskKernel* Factory::createTaskKernel(std::string kernelname, ITask* registeringTask)
     {
-        TaskKernel* task = new TaskKernel(kernelname);
+        auto* task = new TaskKernel(kernelname);
 
         if(registeringTask != nullptr)
             task->addObserver(registeringTask);

--- a/include/pmacc/eventSystem/tasks/ITask.hpp
+++ b/include/pmacc/eventSystem/tasks/ITask.hpp
@@ -52,7 +52,7 @@ namespace pmacc
         /**
          * constructor
          */
-        ITask() : myType(ITask::TASK_UNKNOWN)
+        ITask()
         {
             // task id 0 is reserved for invalid
             static id_t globalId = 1;
@@ -62,9 +62,7 @@ namespace pmacc
         }
 
 
-        virtual ~ITask()
-        {
-        }
+        ~ITask() override = default;
 
         /**
          * Executes this task.
@@ -125,7 +123,7 @@ namespace pmacc
         virtual bool executeIntern() = 0;
 
         id_t myId;
-        TaskType myType;
+        TaskType myType{ITask::TASK_UNKNOWN};
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/MPITask.hpp
+++ b/include/pmacc/eventSystem/tasks/MPITask.hpp
@@ -37,7 +37,7 @@ namespace pmacc
          * Constructor.
          * Starts a MPI operation on the transaction system.
          */
-        MPITask() : ITask(), finished(false)
+        MPITask() : ITask()
         {
             this->setTaskType(ITask::TASK_MPI);
         }
@@ -45,9 +45,7 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~MPITask()
-        {
-        }
+        ~MPITask() override = default;
 
     protected:
         /**
@@ -69,6 +67,6 @@ namespace pmacc
         }
 
     private:
-        bool finished;
+        bool finished{false};
     };
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/StreamTask.hpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.hpp
@@ -44,9 +44,7 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~StreamTask()
-        {
-        }
+        ~StreamTask() override = default;
 
         /**
          * Returns the cupla event associated with this task.
@@ -99,10 +97,10 @@ namespace pmacc
         inline void activate();
 
 
-        EventStream* stream;
+        EventStream* stream{nullptr};
         CudaEventHandle cuplaEvent;
-        bool hasCudaEventHandle;
-        bool alwaysFinished;
+        bool hasCudaEventHandle{false};
+        bool alwaysFinished{false};
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/StreamTask.tpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.tpp
@@ -29,7 +29,7 @@
 
 namespace pmacc
 {
-    inline StreamTask::StreamTask() : ITask(), stream(nullptr), hasCudaEventHandle(false), alwaysFinished(false)
+    inline StreamTask::StreamTask() : ITask()
     {
         this->setTaskType(ITask::TASK_DEVICE);
     }

--- a/include/pmacc/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -43,21 +43,21 @@ namespace pmacc
             this->destination = &dst;
         }
 
-        virtual ~TaskCopyDeviceToDeviceBase()
+        ~TaskCopyDeviceToDeviceBase() override
         {
             notify(this->myId, COPYDEVICE2DEVICE, nullptr);
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             return isFinished();
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        virtual void init()
+        void init() override
         {
             size_t current_size = source->getCurrentSize();
             destination->setCurrentSize(current_size);
@@ -70,7 +70,7 @@ namespace pmacc
             this->activate();
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskCopyDeviceToDevice";
         }
@@ -102,7 +102,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM1>& devCurrentSize)
+        void copy(DataSpace<DIM1>& devCurrentSize) override
         {
             CUDA_CHECK(cuplaMemcpyAsync(
                 this->destination->getPointer(),
@@ -123,7 +123,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM2>& devCurrentSize)
+        void copy(DataSpace<DIM2>& devCurrentSize) override
         {
             CUDA_CHECK(cuplaMemcpy2DAsync(
                 this->destination->getPointer(),
@@ -147,7 +147,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM3>& devCurrentSize)
+        void copy(DataSpace<DIM3>& devCurrentSize) override
         {
             cuplaMemcpy3DParms params;
             params.srcArray = nullptr;

--- a/include/pmacc/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -45,26 +45,26 @@ namespace pmacc
             this->device = &src;
         }
 
-        virtual ~TaskCopyDeviceToHostBase()
+        ~TaskCopyDeviceToHostBase() override
         {
             notify(this->myId, COPYDEVICE2HOST, nullptr);
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             return isFinished();
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskCopyDeviceToHost";
         }
 
-        virtual void init()
+        void init() override
         {
             size_t current_size = device->getCurrentSize();
             host->setCurrentSize(current_size);
@@ -103,7 +103,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM1>& devCurrentSize)
+        void copy(DataSpace<DIM1>& devCurrentSize) override
         {
             CUDA_CHECK(cuplaMemcpyAsync(
                 this->host->getBasePointer(),
@@ -124,7 +124,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM2>& devCurrentSize)
+        void copy(DataSpace<DIM2>& devCurrentSize) override
         {
             CUDA_CHECK(cuplaMemcpy2DAsync(
                 this->host->getBasePointer(),
@@ -148,7 +148,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM3>& devCurrentSize)
+        void copy(DataSpace<DIM3>& devCurrentSize) override
         {
             cuplaPitchedPtr hostPtr;
             hostPtr.pitch = this->host->getDataSpace()[0] * sizeof(TYPE);

--- a/include/pmacc/eventSystem/tasks/TaskCopyHostToDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyHostToDevice.hpp
@@ -44,21 +44,21 @@ namespace pmacc
             this->device = &dst;
         }
 
-        virtual ~TaskCopyHostToDeviceBase()
+        ~TaskCopyHostToDeviceBase() override
         {
             notify(this->myId, COPYHOST2DEVICE, nullptr);
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             return isFinished();
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        virtual void init()
+        void init() override
         {
             size_t current_size = host->getCurrentSize();
             DataSpace<DIM> hostCurrentSize = host->getCurrentDataSpace(current_size);
@@ -76,7 +76,7 @@ namespace pmacc
             this->activate();
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskCopyHostToDevice";
         }
@@ -109,7 +109,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM1>& hostCurrentSize)
+        void copy(DataSpace<DIM1>& hostCurrentSize) override
         {
             CUDA_CHECK(cuplaMemcpyAsync(
                 this->device->getPointer(), /*pointer include X offset*/
@@ -130,7 +130,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM2>& hostCurrentSize)
+        void copy(DataSpace<DIM2>& hostCurrentSize) override
         {
             CUDA_CHECK(cuplaMemcpy2DAsync(
                 this->device->getPointer(),
@@ -154,7 +154,7 @@ namespace pmacc
         }
 
     private:
-        virtual void copy(DataSpace<DIM3>& hostCurrentSize)
+        void copy(DataSpace<DIM3>& hostCurrentSize) override
         {
             cuplaPitchedPtr hostPtr;
             hostPtr.pitch = this->host->getDataSpace()[0] * sizeof(TYPE);

--- a/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -43,21 +43,21 @@ namespace pmacc
             this->buffer = &buffer;
         }
 
-        virtual ~TaskGetCurrentSizeFromDevice()
+        ~TaskGetCurrentSizeFromDevice() override
         {
             notify(this->myId, GETVALUE, nullptr);
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             return isFinished();
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        virtual void init()
+        void init() override
         {
             CUDA_CHECK(cuplaMemcpyAsync(
                 (void*) buffer->getCurrentSizeHostSidePointer(),
@@ -68,7 +68,7 @@ namespace pmacc
             this->activate();
         }
 
-        virtual std::string toString()
+        std::string toString() override
         {
             return "TaskGetCurrentSizeFromDevice";
         }

--- a/include/pmacc/eventSystem/tasks/TaskKernel.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskKernel.hpp
@@ -35,12 +35,12 @@ namespace pmacc
         {
         }
 
-        virtual ~TaskKernel()
+        ~TaskKernel() override
         {
             notify(this->myId, KERNEL, nullptr);
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             if(canBeChecked)
             {
@@ -49,18 +49,18 @@ namespace pmacc
             return false;
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
         HINLINE void activateChecks();
 
-        virtual std::string toString()
+        std::string toString() override
         {
             return std::string("TaskKernel ") + kernelName;
         }
 
-        virtual void init()
+        void init() override
         {
         }
 

--- a/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -47,16 +47,16 @@ namespace pmacc
         /*
          * destructor
          */
-        virtual ~TaskLogicalAnd()
+        ~TaskLogicalAnd() override
         {
             notify(this->myId, LOGICALAND, nullptr);
         }
 
-        void init()
+        void init() override
         {
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             /*  TaskLogicalAnd is finished if all subtasks are
              *  finished (removed) and there is no current work
@@ -64,7 +64,7 @@ namespace pmacc
             return (task1 == 0) && (task2 == 0);
         }
 
-        void event(id_t eventId, EventType, IEventData*)
+        void event(id_t eventId, EventType, IEventData*) override
         {
             if(task1 == eventId)
             {
@@ -109,7 +109,7 @@ namespace pmacc
             }
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return std::string("TaskLogicalAnd (") + EventTask(task1).toString() + std::string(" - ")
                 + EventTask(task2).toString() + std::string(" )");

--- a/include/pmacc/eventSystem/tasks/TaskReceive.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceive.hpp
@@ -40,7 +40,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             state = WaitForReceived;
             if(Environment<>::get().isMpiDirectEnabled())
@@ -53,7 +53,7 @@ namespace pmacc
             Environment<>::get().Factory().createTaskReceiveMPI(exchange, this);
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(state)
             {
@@ -129,19 +129,19 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskReceive()
+        ~TaskReceive() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
         }
 
-        void event(id_t, EventType type, IEventData* data)
+        void event(id_t, EventType type, IEventData* data) override
         {
             switch(type)
             {
             case RECVFINISHED:
                 if(data != nullptr)
                 {
-                    EventDataReceive* rdata = static_cast<EventDataReceive*>(data);
+                    auto* rdata = static_cast<EventDataReceive*>(data);
                     // std::cout<<" data rec "<<rdata->getReceivedCount()/sizeof(TYPE)<<std::endl;
                     newBufferSize = rdata->getReceivedCount() / sizeof(TYPE);
                     state = RunCopy;
@@ -157,7 +157,7 @@ namespace pmacc
             }
         }
 
-        std::string toString()
+        std::string toString() override
         {
             std::stringstream ss;
             ss << state;

--- a/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -43,7 +43,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             Buffer<TYPE, DIM>* dst = exchange->getCommunicationBuffer();
 
@@ -54,7 +54,7 @@ namespace pmacc
                 exchange->getCommunicationTag());
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             if(this->isFinished())
                 return true;
@@ -75,7 +75,7 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskReceiveMPI()
+        ~TaskReceiveMPI() override
         {
             //! \todo this make problems because we send bytes and not combined types
             int recv_data_count;
@@ -88,11 +88,11 @@ namespace pmacc
             __delete(edata);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return std::string("TaskReceiveMPI exchange type=") + std::to_string(exchange->getExchangeType());
         }

--- a/include/pmacc/eventSystem/tasks/TaskSend.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSend.hpp
@@ -39,7 +39,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             state = InitDone;
             if(exchange->hasDeviceDoubleBuffer())
@@ -79,7 +79,7 @@ namespace pmacc
             }
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(state)
             {
@@ -102,12 +102,12 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskSend()
+        ~TaskSend() override
         {
             notify(this->myId, SENDFINISHED, nullptr);
         }
 
-        void event(id_t, EventType type, IEventData*)
+        void event(id_t, EventType type, IEventData*) override
         {
             if(type == COPYDEVICE2HOST || type == COPYDEVICE2DEVICE)
             {
@@ -121,7 +121,7 @@ namespace pmacc
             }
         }
 
-        std::string toString()
+        std::string toString() override
         {
             std::stringstream ss;
             ss << state;

--- a/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
@@ -42,7 +42,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             Buffer<TYPE, DIM>* src = exchange->getCommunicationBuffer();
 
@@ -53,7 +53,7 @@ namespace pmacc
                 exchange->getCommunicationTag());
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             if(this->isFinished())
                 return true;
@@ -74,16 +74,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskSendMPI()
+        ~TaskSendMPI() override
         {
             notify(this->myId, SENDFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return std::string("TaskSendMPI exchange type=") + std::to_string(exchange->getExchangeType());
         }

--- a/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -52,26 +52,26 @@ namespace pmacc
             this->destination = &dst;
         }
 
-        virtual ~TaskSetCurrentSizeOnDevice()
+        ~TaskSetCurrentSizeOnDevice() override
         {
             notify(this->myId, SETVALUE, nullptr);
         }
 
-        virtual void init()
+        void init() override
         {
             setSize();
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             return isFinished();
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskSetCurrentSizeOnDevice";
         }

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -43,7 +43,7 @@ namespace pmacc
         template<typename T_Type, bool isPointer>
         struct Value
         {
-            typedef const T_Type type;
+            using type = const T_Type;
 
             HDINLINE type& operator()(type& v) const
             {
@@ -141,7 +141,7 @@ namespace pmacc
     class TaskSetValueBase : public StreamTask
     {
     public:
-        typedef T_ValueType ValueType;
+        using ValueType = T_ValueType;
         static constexpr uint32_t dim = T_dim;
 
         TaskSetValueBase(DeviceBuffer<ValueType, dim>& dst, const ValueType& value) : StreamTask(), value(value)
@@ -149,24 +149,24 @@ namespace pmacc
             this->destination = &dst;
         }
 
-        virtual ~TaskSetValueBase()
+        ~TaskSetValueBase() override
         {
             notify(this->myId, SETVALUE, nullptr);
         }
 
-        virtual void init() = 0;
+        void init() override = 0;
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             return isFinished();
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
     protected:
-        std::string toString()
+        std::string toString() override
         {
             return "TaskSetValue";
         }
@@ -181,7 +181,7 @@ namespace pmacc
     class TaskSetValue<T_ValueType, T_dim, true> : public TaskSetValueBase<T_ValueType, T_dim>
     {
     public:
-        typedef T_ValueType ValueType;
+        using ValueType = T_ValueType;
         static constexpr uint32_t dim = T_dim;
 
         TaskSetValue(DeviceBuffer<ValueType, dim>& dst, const ValueType& value)
@@ -189,11 +189,9 @@ namespace pmacc
         {
         }
 
-        virtual ~TaskSetValue()
-        {
-        }
+        ~TaskSetValue() override = default;
 
-        virtual void init()
+        void init() override
         {
             // number of elements in destination
             size_t const current_size = this->destination->getCurrentSize();
@@ -230,7 +228,7 @@ namespace pmacc
     class TaskSetValue<T_ValueType, T_dim, false> : public TaskSetValueBase<T_ValueType, T_dim>
     {
     public:
-        typedef T_ValueType ValueType;
+        using ValueType = T_ValueType;
         static constexpr uint32_t dim = T_dim;
 
         TaskSetValue(DeviceBuffer<ValueType, dim>& dst, const ValueType& value)
@@ -239,7 +237,7 @@ namespace pmacc
         {
         }
 
-        virtual ~TaskSetValue()
+        ~TaskSetValue() override
         {
             if(valuePointer_host != nullptr)
             {
@@ -248,7 +246,7 @@ namespace pmacc
             }
         }
 
-        void init()
+        void init() override
         {
             size_t current_size = this->destination->getCurrentSize();
             const DataSpace<dim> area_size(this->destination->getCurrentDataSpace(current_size));

--- a/include/pmacc/eventSystem/transactions/Transaction.tpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.tpp
@@ -74,7 +74,7 @@ namespace pmacc
                 /* `StreamTask` from previous task must be reused to guarantee
                  * that the dependency chain not brake
                  */
-                StreamTask* task = static_cast<StreamTask*>(baseTask);
+                auto* task = static_cast<StreamTask*>(baseTask);
                 return task->getEventStream();
             }
             baseEvent.waitForFinished();

--- a/include/pmacc/fields/SimulationFieldHelper.hpp
+++ b/include/pmacc/fields/SimulationFieldHelper.hpp
@@ -32,15 +32,13 @@ namespace pmacc
     class SimulationFieldHelper
     {
     public:
-        typedef CellDescription MappingDesc;
+        using MappingDesc = CellDescription;
 
         SimulationFieldHelper(CellDescription description) : cellDescription(description)
         {
         }
 
-        virtual ~SimulationFieldHelper()
-        {
-        }
+        virtual ~SimulationFieldHelper() = default;
 
         /**
          * Reset is as well used for init.

--- a/include/pmacc/fields/tasks/FieldFactory.hpp
+++ b/include/pmacc/fields/tasks/FieldFactory.hpp
@@ -75,9 +75,11 @@ namespace pmacc
         }
 
     private:
-        FieldFactory(){};
+        FieldFactory() = default;
+        ;
 
-        FieldFactory(const FieldFactory&){};
+        FieldFactory(const FieldFactory&) = default;
+        ;
     };
 
 } // namespace pmacc

--- a/include/pmacc/fields/tasks/FieldFactory.tpp
+++ b/include/pmacc/fields/tasks/FieldFactory.tpp
@@ -34,7 +34,7 @@ namespace pmacc
     template<class Field>
     inline EventTask FieldFactory::createTaskFieldReceiveAndInsert(Field& buffer, ITask* registeringTask)
     {
-        TaskFieldReceiveAndInsert<Field>* task = new TaskFieldReceiveAndInsert<Field>(buffer);
+        auto* task = new TaskFieldReceiveAndInsert<Field>(buffer);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }
@@ -45,8 +45,7 @@ namespace pmacc
         uint32_t exchange,
         ITask* registeringTask)
     {
-        TaskFieldReceiveAndInsertExchange<Field>* task
-            = new TaskFieldReceiveAndInsertExchange<Field>(buffer, exchange);
+        auto* task = new TaskFieldReceiveAndInsertExchange<Field>(buffer, exchange);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }
@@ -54,7 +53,7 @@ namespace pmacc
     template<class Field>
     inline EventTask FieldFactory::createTaskFieldSend(Field& buffer, ITask* registeringTask)
     {
-        TaskFieldSend<Field>* task = new TaskFieldSend<Field>(buffer);
+        auto* task = new TaskFieldSend<Field>(buffer);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }
@@ -65,7 +64,7 @@ namespace pmacc
         uint32_t exchange,
         ITask* registeringTask)
     {
-        TaskFieldSendExchange<Field>* task = new TaskFieldSendExchange<Field>(buffer, exchange);
+        auto* task = new TaskFieldSendExchange<Field>(buffer, exchange);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -42,7 +42,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             m_state = Init;
             EventTask serialEvent = __getTransactionEvent();
@@ -59,7 +59,7 @@ namespace pmacc
             m_state = WaitForReceived;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(m_state)
             {
@@ -102,16 +102,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskFieldReceiveAndInsert()
+        ~TaskFieldReceiveAndInsert() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskFieldReceiveAndInsert";
         }

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -42,14 +42,14 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             m_state = Init;
             initDependency = m_buffer.getGridBuffer().asyncReceive(initDependency, m_exchange);
             m_state = WaitForReceive;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(m_state)
             {
@@ -71,16 +71,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskFieldReceiveAndInsertExchange()
+        ~TaskFieldReceiveAndInsertExchange() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             std::ostringstream stateNumber;
             stateNumber << m_state;

--- a/include/pmacc/fields/tasks/TaskFieldSend.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSend.hpp
@@ -44,7 +44,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             m_state = Init;
             EventTask serialEvent = __getTransactionEvent();
@@ -61,7 +61,7 @@ namespace pmacc
             m_state = WaitForSend;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(m_state)
             {
@@ -76,16 +76,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskFieldSend()
+        ~TaskFieldSend() override
         {
             notify(this->myId, SENDFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskFieldSend";
         }

--- a/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
@@ -42,7 +42,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             m_state = Init;
             __startTransaction(m_initDependency);
@@ -51,7 +51,7 @@ namespace pmacc
             m_state = WaitForBash;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(m_state)
             {
@@ -86,16 +86,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskFieldSendExchange()
+        ~TaskFieldSendExchange() override
         {
             notify(this->myId, SENDFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskFieldSendExchange";
         }

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -121,7 +121,7 @@ namespace pmacc
             template<typename DeferFunctor = UserFunctor>
             HINLINE Interface(
                 uint32_t const currentStep,
-                typename std::enable_if<std::is_constructible<DeferFunctor, uint32_t>::value>::type* = 0)
+                typename std::enable_if<std::is_constructible<DeferFunctor, uint32_t>::value>::type* = nullptr)
                 : UserFunctor(currentStep)
             {
             }
@@ -138,7 +138,7 @@ namespace pmacc
             template<typename DeferFunctor = UserFunctor>
             HINLINE Interface(
                 uint32_t const currentStep,
-                typename std::enable_if<std::is_constructible<DeferFunctor>::value>::type* = 0)
+                typename std::enable_if<std::is_constructible<DeferFunctor>::value>::type* = nullptr)
                 : UserFunctor()
             {
                 boost::ignore_unused(currentStep);

--- a/include/pmacc/identifier/alias.hpp
+++ b/include/pmacc/identifier/alias.hpp
@@ -73,10 +73,10 @@ namespace pmacc
         struct Resolve<T_Object<T_AnyType, pmacc::pmacc_isAlias>>
         {
             /*solve recursive if alias is nested*/
-            typedef typename bmpl::if_<
+            using type = typename bmpl::if_<
                 std::is_same<T_AnyType, typename Resolve<T_AnyType>::type>,
                 T_AnyType,
-                typename Resolve<T_AnyType>::type>::type type;
+                typename Resolve<T_AnyType>::type>::type;
         };
 
     } // namespace traits

--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -48,6 +48,6 @@
  */
 #define value_identifier(in_type, name, in_default)                                                                   \
     identifier(                                                                                                       \
-        name, typedef in_type type; static HDINLINE type getValue() {                                                 \
+        name, using type = in_type; static HDINLINE type getValue() {                                                 \
             return in_default;                                                                                        \
         } static std::string getName() { return std::string(#name); })

--- a/include/pmacc/lockstep/Idx.hpp
+++ b/include/pmacc/lockstep/Idx.hpp
@@ -55,7 +55,7 @@ namespace pmacc
             }
 
             template<typename T_Type, typename T_Config>
-            friend class Variable;
+            friend struct Variable;
 
         private:
             /** N-th element the worker is processing */

--- a/include/pmacc/lockstep/Variable.hpp
+++ b/include/pmacc/lockstep/Variable.hpp
@@ -34,7 +34,7 @@ namespace pmacc
     namespace lockstep
     {
         template<typename T_Config>
-        struct ForEach;
+        class ForEach;
 
         /** Variable used by virtual worker
          *

--- a/include/pmacc/mappings/kernel/AreaMapping.hpp
+++ b/include/pmacc/mappings/kernel/AreaMapping.hpp
@@ -45,7 +45,7 @@ namespace pmacc
     class AreaMapping<areaType, baseClass<DIM, SuperCellSize_>> : public baseClass<DIM, SuperCellSize_>
     {
     public:
-        typedef baseClass<DIM, SuperCellSize_> BaseClass;
+        using BaseClass = baseClass<DIM, SuperCellSize_>;
 
         enum
         {
@@ -54,7 +54,7 @@ namespace pmacc
         };
 
 
-        typedef typename BaseClass::SuperCellSize SuperCellSize;
+        using SuperCellSize = typename BaseClass::SuperCellSize;
 
         HINLINE AreaMapping(BaseClass base) : BaseClass(base)
         {

--- a/include/pmacc/mappings/kernel/ExchangeMapping.hpp
+++ b/include/pmacc/mappings/kernel/ExchangeMapping.hpp
@@ -49,7 +49,7 @@ namespace pmacc
         uint32_t exchangeType;
 
     public:
-        typedef baseClass<DIM, SuperCellSize_> BaseClass;
+        using BaseClass = baseClass<DIM, SuperCellSize_>;
 
         enum
         {
@@ -57,7 +57,7 @@ namespace pmacc
         };
 
 
-        typedef typename BaseClass::SuperCellSize SuperCellSize;
+        using SuperCellSize = typename BaseClass::SuperCellSize;
 
         /**
          * Constructor.

--- a/include/pmacc/mappings/kernel/MappingDescription.hpp
+++ b/include/pmacc/mappings/kernel/MappingDescription.hpp
@@ -48,7 +48,7 @@ namespace pmacc
             Dim = DIM
         };
 
-        typedef SuperCellSize_ SuperCellSize;
+        using SuperCellSize = SuperCellSize_;
 
         /** constructor
          *

--- a/include/pmacc/mappings/kernel/StrideMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapping.hpp
@@ -53,7 +53,7 @@ namespace pmacc
     class StrideMapping<areaType, stride, baseClass<DIM, SuperCellSize_>> : public baseClass<DIM, SuperCellSize_>
     {
     public:
-        typedef baseClass<DIM, SuperCellSize_> BaseClass;
+        using BaseClass = baseClass<DIM, SuperCellSize_>;
 
         enum
         {
@@ -63,7 +63,7 @@ namespace pmacc
         };
 
 
-        typedef typename BaseClass::SuperCellSize SuperCellSize;
+        using SuperCellSize = typename BaseClass::SuperCellSize;
 
         HINLINE StrideMapping(BaseClass base) : BaseClass(base), offset()
         {

--- a/include/pmacc/mappings/simulation/EnvironmentController.hpp
+++ b/include/pmacc/mappings/simulation/EnvironmentController.hpp
@@ -62,9 +62,7 @@ namespace pmacc
 
         /*! Default constructor.
          */
-        EnvironmentController()
-        {
-        }
+        EnvironmentController() = default;
 
         static EnvironmentController& getInstance()
         {

--- a/include/pmacc/mappings/simulation/Filesystem.hpp
+++ b/include/pmacc/mappings/simulation/Filesystem.hpp
@@ -95,16 +95,12 @@ namespace pmacc
         /**
          * Constructor
          */
-        Filesystem()
-        {
-        }
+        Filesystem() = default;
 
         /**
          * Constructor
          */
-        Filesystem(const Filesystem& fs)
-        {
-        }
+        Filesystem(const Filesystem& fs) = default;
 
         /**
          * Returns the instance of the filesystem class.

--- a/include/pmacc/mappings/simulation/ResourceMonitor.tpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.tpp
@@ -54,9 +54,7 @@ namespace pmacc
     };
 
     template<unsigned T_DIM>
-    ResourceMonitor<T_DIM>::ResourceMonitor()
-    {
-    }
+    ResourceMonitor<T_DIM>::ResourceMonitor() = default;
 
     template<unsigned T_DIM>
     size_t ResourceMonitor<T_DIM>::getCellCount()
@@ -70,7 +68,7 @@ namespace pmacc
         T_MappingDesc& cellDescription,
         T_ParticleFilter& parFilter)
     {
-        typedef bmpl::integral_c<unsigned, T_DIM> dim;
+        using dim = bmpl::integral_c<unsigned int, T_DIM>;
         std::vector<size_t> particleCounts;
         meta::ForEach<T_Species, MyCountParticles<dim, bmpl::_1>> countParticles;
         countParticles(particleCounts, cellDescription, parFilter);

--- a/include/pmacc/mappings/simulation/SubGrid.hpp
+++ b/include/pmacc/mappings/simulation/SubGrid.hpp
@@ -38,7 +38,7 @@ namespace pmacc
     class SubGrid
     {
     public:
-        typedef DataSpace<DIM> Size;
+        using Size = DataSpace<DIM>;
 
         constexpr SubGrid& operator=(const SubGrid&) = default;
 
@@ -127,9 +127,7 @@ namespace pmacc
         /**
          * Constructor
          */
-        SubGrid()
-        {
-        }
+        SubGrid() = default;
 
         static SubGrid<DIM>& getInstance()
         {
@@ -137,9 +135,7 @@ namespace pmacc
             return instance;
         }
 
-        virtual ~SubGrid()
-        {
-        }
+        virtual ~SubGrid() = default;
 
         /**
          * Constructor

--- a/include/pmacc/math/MapTuple.hpp
+++ b/include/pmacc/math/MapTuple.hpp
@@ -45,14 +45,12 @@ namespace pmacc
         template<typename T_Pair>
         struct AlignedData
         {
-            typedef typename T_Pair::first Key;
-            typedef typename T_Pair::second ValueType;
+            using Key = typename T_Pair::first;
+            using ValueType = typename T_Pair::second;
 
             PMACC_ALIGN(value, ValueType);
 
-            HDINLINE AlignedData()
-            {
-            }
+            HDINLINE AlignedData() = default;
 
             HDINLINE AlignedData(const ValueType& value) : value(value)
             {
@@ -76,14 +74,12 @@ namespace pmacc
         template<typename T_Pair>
         struct NativeData
         {
-            typedef typename T_Pair::first Key;
-            typedef typename T_Pair::second ValueType;
+            using Key = typename T_Pair::first;
+            using ValueType = typename T_Pair::second;
 
             ValueType value;
 
-            HDINLINE NativeData()
-            {
-            }
+            HDINLINE NativeData() = default;
 
             HDINLINE NativeData(const ValueType& value) : value(value)
             {
@@ -103,9 +99,9 @@ namespace pmacc
         template<typename T_Map, template<typename> class T_PodType = NativeData>
         struct MapTuple : protected InheritLinearly<T_Map, T_PodType>
         {
-            typedef T_Map Map;
+            using Map = T_Map;
             static constexpr int dim = bmpl::size<Map>::type::value;
-            typedef InheritLinearly<T_Map, T_PodType> Base;
+            using Base = InheritLinearly<T_Map, T_PodType>;
 
             template<class>
             struct result;
@@ -113,13 +109,13 @@ namespace pmacc
             template<class T_F, class T_Key>
             struct result<T_F(T_Key)>
             {
-                typedef typename bmpl::at<Map, T_Key>::type& type;
+                using type = typename bmpl::at<Map, T_Key>::type&;
             };
 
             template<class T_F, class T_Key>
             struct result<const T_F(T_Key)>
             {
-                typedef const typename bmpl::at<Map, T_Key>::type& type;
+                using type = const typename bmpl::at<Map, T_Key>::type&;
             };
 
             /** access a datum with a key

--- a/include/pmacc/math/RungeKutta/RungeKutta4.hpp
+++ b/include/pmacc/math/RungeKutta/RungeKutta4.hpp
@@ -43,9 +43,9 @@ namespace pmacc
             operator()(const T_Functor diffEq, const T_Variable var, const T_Time time, const T_Time deltaTime)
             {
                 // use typenames instead of template types
-                typedef T_Functor FunctorType;
-                typedef T_Variable VariableType;
-                typedef T_Time TimeType;
+                using FunctorType = T_Functor;
+                using VariableType = T_Variable;
+                using TimeType = T_Time;
 
                 // calculate all 4 steps of the Runge Kutta 4th order
                 const VariableType k_1 = diffEq(time, var);

--- a/include/pmacc/math/complex/Complex.hpp
+++ b/include/pmacc/math/complex/Complex.hpp
@@ -32,7 +32,7 @@ namespace pmacc
         struct Complex
         {
         public:
-            typedef T_Type type;
+            using type = T_Type;
 
             // constructor (real, imaginary)
             HDINLINE Complex(T_Type real, T_Type imaginary = type(0.0)) : real(real), imaginary(imaginary)
@@ -50,9 +50,7 @@ namespace pmacc
             }
 
             // default constructor ( ! no initialization of data ! )
-            HDINLINE Complex(void)
-            {
-            }
+            HDINLINE Complex(void) = default;
 
             // Conversion from scalar (assignment)
             HDINLINE Complex& operator=(const T_Type& other)

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -58,7 +58,7 @@ namespace pmacc
         template<typename T_Type>
         struct Euler
         {
-            typedef typename ::pmacc::math::Complex<T_Type> result;
+            using result = typename ::pmacc::math::Complex<T_Type>;
 
             HDINLINE result operator()(const T_Type& magnitude, const T_Type& phase)
             {
@@ -86,8 +86,8 @@ namespace pmacc
         template<typename T_Type>
         struct Arg<::pmacc::math::Complex<T_Type>>
         {
-            typedef typename ::pmacc::math::Complex<T_Type>::type result;
-            typedef T_Type type;
+            using result = typename ::pmacc::math::Complex<T_Type>::type;
+            using type = T_Type;
 
             HDINLINE result operator()(const ::pmacc::math::Complex<T_Type>& other)
             {
@@ -111,7 +111,7 @@ namespace pmacc
         template<typename T_Type>
         struct Abs2<::pmacc::math::Complex<T_Type>>
         {
-            typedef typename ::pmacc::math::Complex<T_Type>::type result;
+            using result = typename ::pmacc::math::Complex<T_Type>::type;
 
             HDINLINE result operator()(const ::pmacc::math::Complex<T_Type>& other)
             {
@@ -253,7 +253,7 @@ namespace pmacc
             template<typename T_CastToType>
             struct TypeCast<T_CastToType, ::pmacc::math::Complex<T_CastToType>>
             {
-                typedef const ::pmacc::math::Complex<T_CastToType>& result;
+                using result = const ::pmacc::math::Complex<T_CastToType>&;
 
                 HDINLINE result operator()(const ::pmacc::math::Complex<T_CastToType>& complexNumber) const
                 {
@@ -264,7 +264,7 @@ namespace pmacc
             template<typename T_CastToType, typename T_OldType>
             struct TypeCast<T_CastToType, ::pmacc::math::Complex<T_OldType>>
             {
-                typedef ::pmacc::math::Complex<T_CastToType> result;
+                using result = ::pmacc::math::Complex<T_CastToType>;
 
                 HDINLINE result operator()(const ::pmacc::math::Complex<T_OldType>& complexNumber) const
                 {

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -314,7 +314,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_FLOAT, T_dim);
+                    return {MPI_FLOAT, T_dim};
                 }
             };
 
@@ -323,7 +323,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_FLOAT, T_dim * T_N);
+                    return {MPI_FLOAT, T_dim * T_N};
                 }
             };
 
@@ -332,7 +332,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_DOUBLE, T_dim);
+                    return {MPI_DOUBLE, T_dim};
                 }
             };
 
@@ -341,7 +341,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_DOUBLE, T_dim * T_N);
+                    return {MPI_DOUBLE, T_dim * T_N};
                 }
             };
 

--- a/include/pmacc/memory/boxes/DataBox.hpp
+++ b/include/pmacc/memory/boxes/DataBox.hpp
@@ -40,8 +40,8 @@ namespace pmacc
             {
                 Dim = DIM1
             };
-            typedef typename Base::ValueType ValueType;
-            typedef typename Base::RefValueType RefValueType;
+            using ValueType = typename Base::ValueType;
+            using RefValueType = typename Base::RefValueType;
 
             HDINLINE RefValueType operator()(const DataSpace<DIM1>& idx = DataSpace<DIM1>()) const
             {
@@ -70,8 +70,8 @@ namespace pmacc
             {
                 Dim = DIM2
             };
-            typedef typename Base::ValueType ValueType;
-            typedef typename Base::RefValueType RefValueType;
+            using ValueType = typename Base::ValueType;
+            using RefValueType = typename Base::RefValueType;
 
             HDINLINE RefValueType operator()(const DataSpace<DIM2>& idx = DataSpace<DIM2>()) const
             {
@@ -100,8 +100,8 @@ namespace pmacc
             {
                 Dim = DIM3
             };
-            typedef typename Base::ValueType ValueType;
-            typedef typename Base::RefValueType RefValueType;
+            using ValueType = typename Base::ValueType;
+            using RefValueType = typename Base::RefValueType;
 
             HDINLINE RefValueType operator()(const DataSpace<DIM3>& idx = DataSpace<DIM3>()) const
             {
@@ -129,9 +129,9 @@ namespace pmacc
     class DataBox : public private_Box::Box<Base::Dim, Base>
     {
     public:
-        typedef typename Base::ValueType ValueType;
-        typedef DataBox<Base> Type;
-        typedef typename Base::RefValueType RefValueType;
+        using ValueType = typename Base::ValueType;
+        using Type = DataBox<Base>;
+        using RefValueType = typename Base::RefValueType;
 
         HDINLINE DataBox(Base base) : private_Box::Box<Base::Dim, Base>(base)
         {

--- a/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
+++ b/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
@@ -32,12 +32,12 @@ namespace pmacc
     class DataBoxDim1Access : protected T_Base
     {
     public:
-        typedef T_Base Base;
+        using Base = T_Base;
         static constexpr uint32_t Dim = Base::Dim;
 
 
-        typedef typename Base::ValueType ValueType;
-        typedef typename Base::RefValueType RefValueType;
+        using ValueType = typename Base::ValueType;
+        using RefValueType = typename Base::RefValueType;
 
 
         HDINLINE RefValueType operator()(const pmacc::DataSpace<DIM1>& idx = pmacc::DataSpace<DIM1>()) const

--- a/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
@@ -38,13 +38,13 @@ namespace pmacc
     class DataBoxUnaryTransform : public T_Base
     {
     public:
-        typedef T_Base Base;
-        typedef typename Base::ValueType BaseValueType;
+        using Base = T_Base;
+        using BaseValueType = typename Base::ValueType;
 
-        typedef T_UnaryFunctor<BaseValueType> UnaryFunctor;
+        using UnaryFunctor = T_UnaryFunctor<BaseValueType>;
 
-        typedef typename UnaryFunctor::result ValueType;
-        typedef ValueType RefValueType;
+        using ValueType = typename UnaryFunctor::result;
+        using RefValueType = ValueType;
         static constexpr uint32_t Dim = Base::Dim;
 
         HDINLINE DataBoxUnaryTransform(const Base& base) : Base(base)

--- a/include/pmacc/memory/boxes/PitchedBox.hpp
+++ b/include/pmacc/memory/boxes/PitchedBox.hpp
@@ -39,9 +39,9 @@ namespace pmacc
         {
             Dim = DIM1
         };
-        typedef TYPE ValueType;
-        typedef ValueType& RefValueType;
-        typedef PitchedBox<TYPE, DIM1> ReducedType;
+        using ValueType = TYPE;
+        using RefValueType = ValueType&;
+        using ReducedType = PitchedBox<TYPE, 1U>;
 
         HDINLINE RefValueType operator[](const int idx)
         {
@@ -67,9 +67,7 @@ namespace pmacc
         }
 
         /*Object must init by copy a valid instance*/
-        HDINLINE PitchedBox()
-        {
-        }
+        HDINLINE PitchedBox() = default;
 
         /*!return the first value in the box (list)
          * @return first value
@@ -101,9 +99,9 @@ namespace pmacc
         {
             Dim = DIM2
         };
-        typedef TYPE ValueType;
-        typedef ValueType& RefValueType;
-        typedef PitchedBox<TYPE, DIM1> ReducedType;
+        using ValueType = TYPE;
+        using RefValueType = ValueType&;
+        using ReducedType = PitchedBox<TYPE, 1U>;
 
         HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM2>& offset, const DataSpace<DIM2>&, const size_t pitch)
             : pitch(pitch)
@@ -116,9 +114,7 @@ namespace pmacc
         }
 
         /*Object must init by copy a valid instance*/
-        HDINLINE PitchedBox()
-        {
-        }
+        HDINLINE PitchedBox() = default;
 
         HDINLINE ReducedType operator[](const int idx)
         {
@@ -166,9 +162,9 @@ namespace pmacc
         {
             Dim = DIM3
         };
-        typedef TYPE ValueType;
-        typedef ValueType& RefValueType;
-        typedef PitchedBox<TYPE, DIM2> ReducedType;
+        using ValueType = TYPE;
+        using RefValueType = ValueType&;
+        using ReducedType = PitchedBox<TYPE, 2U>;
 
         HDINLINE ReducedType operator[](const int idx)
         {
@@ -207,9 +203,7 @@ namespace pmacc
         }
 
         /*Object must init by copy a valid instance*/
-        HDINLINE PitchedBox()
-        {
-        }
+        HDINLINE PitchedBox() = default;
 
         /*!return the first value in the box (list)
          * @return first value

--- a/include/pmacc/memory/boxes/SharedBox.hpp
+++ b/include/pmacc/memory/boxes/SharedBox.hpp
@@ -51,11 +51,11 @@ namespace pmacc
         {
             Dim = DIM1
         };
-        typedef T_TYPE ValueType;
-        typedef ValueType& RefValueType;
-        typedef T_Vector Size;
-        typedef SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id> ReducedType;
-        typedef SharedBox<ValueType, T_Vector, T_id, DIM1> This;
+        using ValueType = T_TYPE;
+        using RefValueType = ValueType&;
+        using Size = T_Vector;
+        using ReducedType = SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id>;
+        using This = SharedBox<ValueType, T_Vector, T_id, 1U>;
 
         HDINLINE RefValueType operator[](const int idx)
         {
@@ -118,11 +118,11 @@ namespace pmacc
         {
             Dim = DIM2
         };
-        typedef T_TYPE ValueType;
-        typedef ValueType& RefValueType;
-        typedef T_Vector Size;
-        typedef SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id> ReducedType;
-        typedef SharedBox<ValueType, T_Vector, T_id, DIM2> This;
+        using ValueType = T_TYPE;
+        using RefValueType = ValueType&;
+        using Size = T_Vector;
+        using ReducedType = SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id>;
+        using This = SharedBox<ValueType, T_Vector, T_id, 2U>;
 
         HDINLINE SharedBox(ValueType* pointer = nullptr) : fixedPointer(pointer)
         {
@@ -189,11 +189,11 @@ namespace pmacc
         {
             Dim = DIM3
         };
-        typedef T_TYPE ValueType;
-        typedef ValueType& RefValueType;
-        typedef T_Vector Size;
-        typedef SharedBox<ValueType, math::CT::Int<Size::x::value, Size::y::value>, T_id> ReducedType;
-        typedef SharedBox<ValueType, T_Vector, T_id, DIM3> This;
+        using ValueType = T_TYPE;
+        using RefValueType = ValueType&;
+        using Size = T_Vector;
+        using ReducedType = SharedBox<ValueType, math::CT::Int<Size::x::value, Size::y::value>, T_id>;
+        using This = SharedBox<ValueType, T_Vector, T_id, 3U>;
 
         HDINLINE ReducedType operator[](const int idx)
         {

--- a/include/pmacc/memory/buffers/Buffer.hpp
+++ b/include/pmacc/memory/buffers/Buffer.hpp
@@ -42,7 +42,7 @@ namespace pmacc
     class Buffer
     {
     public:
-        typedef DataBox<PitchedBox<TYPE, DIM>> DataBoxType;
+        using DataBoxType = DataBox<PitchedBox<TYPE, DIM>>;
 
         /** constructor
          *
@@ -108,7 +108,7 @@ namespace pmacc
         virtual DataSpace<DIM> getCurrentDataSpace(size_t currentSize)
         {
             DataSpace<DIM> tmp;
-            int64_t current_size = static_cast<int64_t>(currentSize);
+            auto current_size = static_cast<int64_t>(currentSize);
 
             //!\todo: current size can be changed if it is a DeviceBuffer and current size is on device
             // call first get current size (but const not allow this)

--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -70,7 +70,8 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~DeviceBuffer(){};
+        ~DeviceBuffer() override = default;
+        ;
 
         HINLINE
         container::CartBuffer<
@@ -127,7 +128,7 @@ namespace pmacc
          *
          * @param size count of elements per dimension
          */
-        virtual void setCurrentSize(const size_t size) = 0;
+        void setCurrentSize(const size_t size) override = 0;
 
         /**
          * Returns the internal pitched cupla pointer.

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -41,7 +41,7 @@ namespace pmacc
     class DeviceBufferIntern : public DeviceBuffer<TYPE, DIM>
     {
     public:
-        typedef typename DeviceBuffer<TYPE, DIM>::DataBoxType DataBoxType;
+        using DataBoxType = typename DeviceBuffer<TYPE, DIM>::DataBoxType;
 
         /*! create device buffer
          * @param size extent for each dimension (in elements)
@@ -86,7 +86,7 @@ namespace pmacc
             this->data1D = false;
         }
 
-        virtual ~DeviceBufferIntern()
+        ~DeviceBufferIntern() override
         {
             __startOperation(ITask::TASK_DEVICE);
 
@@ -100,7 +100,7 @@ namespace pmacc
             }
         }
 
-        void reset(bool preserveData = true)
+        void reset(bool preserveData = true) override
         {
             this->setCurrentSize(Buffer<TYPE, DIM>::getDataSpace().productOfComponents());
 
@@ -115,14 +115,14 @@ namespace pmacc
             }
         }
 
-        DataBoxType getDataBox()
+        DataBoxType getDataBox() override
         {
             __startOperation(ITask::TASK_DEVICE);
             return DataBoxType(
                 PitchedBox<TYPE, DIM>((TYPE*) data.ptr, offset, this->getPhysicalMemorySize(), data.pitch));
         }
 
-        TYPE* getPointer()
+        TYPE* getPointer() override
         {
             __startOperation(ITask::TASK_DEVICE);
 
@@ -142,17 +142,17 @@ namespace pmacc
             }
         }
 
-        DataSpace<DIM> getOffset() const
+        DataSpace<DIM> getOffset() const override
         {
             return offset;
         }
 
-        bool hasCurrentSizeOnDevice() const
+        bool hasCurrentSizeOnDevice() const override
         {
             return sizeOnDevice;
         }
 
-        size_t* getCurrentSizeOnDevicePointer()
+        size_t* getCurrentSizeOnDevicePointer() override
         {
             __startOperation(ITask::TASK_DEVICE);
             if(!sizeOnDevice)
@@ -162,13 +162,13 @@ namespace pmacc
             return sizeOnDevicePtr;
         }
 
-        size_t* getCurrentSizeHostSidePointer()
+        size_t* getCurrentSizeHostSidePointer() override
         {
             __startOperation(ITask::TASK_HOST);
             return this->current_size;
         }
 
-        TYPE* getBasePointer()
+        TYPE* getBasePointer() override
         {
             __startOperation(ITask::TASK_DEVICE);
             return (TYPE*) data.ptr;
@@ -177,7 +177,7 @@ namespace pmacc
         /*! Get current size of any dimension
          * @return count of current elements per dimension
          */
-        virtual size_t getCurrentSize()
+        size_t getCurrentSize() override
         {
             if(sizeOnDevice)
             {
@@ -189,7 +189,7 @@ namespace pmacc
             return DeviceBuffer<TYPE, DIM>::getCurrentSize();
         }
 
-        virtual void setCurrentSize(const size_t size)
+        void setCurrentSize(const size_t size) override
         {
             Buffer<TYPE, DIM>::setCurrentSize(size);
 
@@ -199,30 +199,30 @@ namespace pmacc
             }
         }
 
-        void copyFrom(HostBuffer<TYPE, DIM>& other)
+        void copyFrom(HostBuffer<TYPE, DIM>& other) override
         {
             PMACC_ASSERT(this->isMyDataSpaceGreaterThan(other.getCurrentDataSpace()));
             Environment<>::get().Factory().createTaskCopyHostToDevice(other, *this);
         }
 
-        void copyFrom(DeviceBuffer<TYPE, DIM>& other)
+        void copyFrom(DeviceBuffer<TYPE, DIM>& other) override
         {
             PMACC_ASSERT(this->isMyDataSpaceGreaterThan(other.getCurrentDataSpace()));
             Environment<>::get().Factory().createTaskCopyDeviceToDevice(other, *this);
         }
 
-        const cuplaPitchedPtr getCudaPitched() const
+        const cuplaPitchedPtr getCudaPitched() const override
         {
             __startOperation(ITask::TASK_DEVICE);
             return data;
         }
 
-        size_t getPitch() const
+        size_t getPitch() const override
         {
             return data.pitch;
         }
 
-        virtual void setValue(const TYPE& value)
+        void setValue(const TYPE& value) override
         {
             Environment<>::get().Factory().createTaskSetValue(*this, value);
         };

--- a/include/pmacc/memory/buffers/GridBuffer.hpp
+++ b/include/pmacc/memory/buffers/GridBuffer.hpp
@@ -55,9 +55,7 @@ namespace pmacc
             }
 
         private:
-            UniquTag()
-            {
-            }
+            UniquTag() = default;
 
             /**
              * Constructor
@@ -85,10 +83,10 @@ namespace pmacc
     template<class TYPE, unsigned DIM, class BORDERTYPE = TYPE>
     class GridBuffer : public HostDeviceBuffer<TYPE, DIM>
     {
-        typedef HostDeviceBuffer<TYPE, DIM> Parent;
+        using Parent = HostDeviceBuffer<TYPE, DIM>;
 
     public:
-        typedef typename Parent::DataBoxType DataBoxType;
+        using DataBoxType = typename Parent::DataBoxType;
 
         /**
          * Constructor.
@@ -171,7 +169,7 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~GridBuffer()
+        ~GridBuffer() override
         {
             for(uint32_t i = 0; i < 27; ++i)
             {

--- a/include/pmacc/memory/buffers/HostBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostBuffer.hpp
@@ -95,7 +95,8 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~HostBuffer(){};
+        ~HostBuffer() override = default;
+        ;
 
         /**
          * Conversion to cuSTL HostBuffer.

--- a/include/pmacc/memory/buffers/HostBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/HostBufferIntern.hpp
@@ -38,7 +38,7 @@ namespace pmacc
     class HostBufferIntern : public HostBuffer<TYPE, DIM>
     {
     public:
-        typedef typename HostBuffer<TYPE, DIM>::DataBoxType DataBoxType;
+        using DataBoxType = typename HostBuffer<TYPE, DIM>::DataBoxType;
 
         /** constructor
          *
@@ -62,7 +62,7 @@ namespace pmacc
         /**
          * destructor
          */
-        virtual ~HostBufferIntern()
+        ~HostBufferIntern() override
         {
             __startOperation(ITask::TASK_HOST);
 
@@ -75,25 +75,25 @@ namespace pmacc
         /*! Get pointer of memory
          * @return pointer to memory
          */
-        TYPE* getBasePointer()
+        TYPE* getBasePointer() override
         {
             __startOperation(ITask::TASK_HOST);
             return pointer;
         }
 
-        TYPE* getPointer()
+        TYPE* getPointer() override
         {
             __startOperation(ITask::TASK_HOST);
             return pointer;
         }
 
-        void copyFrom(DeviceBuffer<TYPE, DIM>& other)
+        void copyFrom(DeviceBuffer<TYPE, DIM>& other) override
         {
             PMACC_ASSERT(this->isMyDataSpaceGreaterThan(other.getCurrentDataSpace()));
             Environment<>::get().Factory().createTaskCopyDeviceToHost(other, *this);
         }
 
-        void reset(bool preserveData = true)
+        void reset(bool preserveData = true) override
         {
             __startOperation(ITask::TASK_HOST);
             this->setCurrentSize(this->getDataSpace().productOfComponents());
@@ -119,12 +119,12 @@ namespace pmacc
             }
         }
 
-        void setValue(const TYPE& value)
+        void setValue(const TYPE& value) override
         {
             __startOperation(ITask::TASK_HOST);
-            int64_t current_size = static_cast<int64_t>(this->getCurrentSize());
+            auto current_size = static_cast<int64_t>(this->getCurrentSize());
             auto memBox = getDataBox();
-            typedef DataBoxDim1Access<DataBoxType> D1Box;
+            using D1Box = DataBoxDim1Access<DataBoxType>;
             D1Box d1Box(memBox, this->getDataSpace());
 #pragma omp parallel for
             for(int64_t i = 0; i < current_size; i++)
@@ -133,7 +133,7 @@ namespace pmacc
             }
         }
 
-        DataBoxType getDataBox()
+        DataBoxType getDataBox() override
         {
             __startOperation(ITask::TASK_HOST);
             return DataBoxType(PitchedBox<TYPE, DIM>(

--- a/include/pmacc/memory/buffers/HostDeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostDeviceBuffer.hpp
@@ -36,14 +36,14 @@ namespace pmacc
     template<typename T_Type, unsigned T_dim>
     class HostDeviceBuffer
     {
-        typedef HostBufferIntern<T_Type, T_dim> HostBufferType;
-        typedef DeviceBufferIntern<T_Type, T_dim> DeviceBufferType;
+        using HostBufferType = HostBufferIntern<T_Type, T_dim>;
+        using DeviceBufferType = DeviceBufferIntern<T_Type, T_dim>;
 
     public:
         using ValueType = T_Type;
-        typedef HostBuffer<T_Type, T_dim> HBuffer;
-        typedef DeviceBuffer<T_Type, T_dim> DBuffer;
-        typedef typename HostBufferType::DataBoxType DataBoxType;
+        using HBuffer = HostBuffer<T_Type, T_dim>;
+        using DBuffer = DeviceBuffer<T_Type, T_dim>;
+        using DataBoxType = typename HostBufferType::DataBoxType;
         PMACC_CASSERT_MSG(
             DataBoxTypes_must_match,
             std::is_same<DataBoxType, typename DeviceBufferType::DataBoxType>::value);

--- a/include/pmacc/memory/dataTypes/Mask.hpp
+++ b/include/pmacc/memory/dataTypes/Mask.hpp
@@ -40,9 +40,7 @@ namespace pmacc
          *
          * Sets this mask to 0 (nothing).
          */
-        Mask() : bitMask(0u)
-        {
-        }
+        Mask() = default;
 
         /**
          * Constructor.
@@ -69,9 +67,7 @@ namespace pmacc
         /**
          * Destructor.
          */
-        virtual ~Mask()
-        {
-        }
+        virtual ~Mask() = default;
 
         /**
          * Gives uint32_t value of this mask.
@@ -248,7 +244,7 @@ namespace pmacc
         /**
          * mask which is a combination of the type @see ExchangeType
          */
-        uint32_t bitMask;
+        uint32_t bitMask{0u};
     };
 
     /** special implementation for `DIM1`

--- a/include/pmacc/meta/AllCombinations.hpp
+++ b/include/pmacc/meta/AllCombinations.hpp
@@ -62,19 +62,19 @@ namespace pmacc
         template<typename T_MplSeq, typename T_TmpResult>
         struct AllCombinations<T_MplSeq, T_TmpResult, false>
         {
-            typedef T_MplSeq MplSeq;
-            typedef T_TmpResult TmpResult;
+            using MplSeq = T_MplSeq;
+            using TmpResult = T_TmpResult;
 
             static constexpr uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
-            typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1>>::type LastElement;
-            typedef bmpl::empty<LastElement> IsLastElementEmpty;
-            typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
-            typedef typename bmpl::pop_back<MplSeq>::type ShrinkedRangeVector;
+            using LastElement = typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1>>::type;
+            using IsLastElementEmpty = bmpl::empty<LastElement>;
+            using LastElementAsSequence = typename MakeSeq<LastElement>::type;
+            using ShrinkedRangeVector = typename bmpl::pop_back<MplSeq>::type;
 
             /* copy last given sequence to a mpl::vector to be sure that we can later on
              * call mpl::transform even if the input sequence is mpl::range_c
              */
-            typedef typename bmpl::copy<LastElementAsSequence, bmpl::back_inserter<bmpl::vector0<>>>::type TmpVector;
+            using TmpVector = typename bmpl::copy<LastElementAsSequence, bmpl::back_inserter<bmpl::vector0<>>>::type;
 
             /** Assign to each element in a sequence of CT::Vector(s) a type at a given
              *  component position
@@ -87,21 +87,21 @@ namespace pmacc
             template<typename T_ComponentPos, typename T_Element>
             struct AssignToAnyElementInVector
             {
-                typedef TmpResult InVector;
-                typedef T_Element Element;
+                using InVector = TmpResult;
+                using Element = T_Element;
 
-                typedef typename bmpl::
-                    transform<InVector, pmacc::math::CT::Assign<bmpl::_1, T_ComponentPos, Element>>::type type;
+                using type = typename bmpl::
+                    transform<InVector, pmacc::math::CT::Assign<bmpl::_1, T_ComponentPos, Element>>::type;
             };
 
-            typedef typename bmpl::transform<
+            using NestedSeq = typename bmpl::transform<
                 TmpVector,
-                AssignToAnyElementInVector<bmpl::integral_c<uint32_t, rangeVectorSize - 1>, bmpl::_1>>::type NestedSeq;
+                AssignToAnyElementInVector<bmpl::integral_c<uint32_t, rangeVectorSize - 1>, bmpl::_1>>::type;
 
-            typedef typename MakeSeqFromNestedSeq<NestedSeq>::type OneSeq;
+            using OneSeq = typename MakeSeqFromNestedSeq<NestedSeq>::type;
 
-            typedef typename detail::AllCombinations<ShrinkedRangeVector, OneSeq>::type ResultIfNotEmpty;
-            typedef typename bmpl::if_<IsLastElementEmpty, bmpl::vector0<>, ResultIfNotEmpty>::type type;
+            using ResultIfNotEmpty = typename detail::AllCombinations<ShrinkedRangeVector, OneSeq>::type;
+            using type = typename bmpl::if_<IsLastElementEmpty, bmpl::vector0<>, ResultIfNotEmpty>::type;
         };
 
         /** recursive end implementation
@@ -109,7 +109,7 @@ namespace pmacc
         template<typename T_MplSeq, typename T_TmpResult>
         struct AllCombinations<T_MplSeq, T_TmpResult, true>
         {
-            typedef T_TmpResult type;
+            using type = T_TmpResult;
         };
 
     } // namespace detail
@@ -141,30 +141,29 @@ namespace pmacc
     {
         /* if T_MplSeq is no sequence it is a single type, we put this type in
          * a sequence because all next algorithms can only work with sequences */
-        typedef typename MakeSeq<T_MplSeq>::type MplSeq;
+        using MplSeq = typename MakeSeq<T_MplSeq>::type;
 
         static constexpr uint32_t rangeVectorSize = bmpl::size<MplSeq>::value;
-        typedef typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1>>::type LastElement;
-        typedef bmpl::empty<LastElement> IsLastElementEmpty;
-        typedef typename MakeSeq<LastElement>::type LastElementAsSequence;
+        using LastElement = typename bmpl::at<MplSeq, bmpl::integral_c<uint32_t, rangeVectorSize - 1>>::type;
+        using IsLastElementEmpty = bmpl::empty<LastElement>;
+        using LastElementAsSequence = typename MakeSeq<LastElement>::type;
 
-        typedef typename bmpl::pop_back<MplSeq>::type ShrinkedRangeVector;
+        using ShrinkedRangeVector = typename bmpl::pop_back<MplSeq>::type;
         /* copy last given sequence to a mpl::vector to be sure that we can later on
          * call mpl::transform even if the input sequence is mpl::range_c
          */
-        typedef typename bmpl::copy<LastElementAsSequence, bmpl::back_inserter<bmpl::vector0<>>>::type TmpVector;
+        using TmpVector = typename bmpl::copy<LastElementAsSequence, bmpl::back_inserter<bmpl::vector0<>>>::type;
 
 
         /* transform all elements in the vector to math::CT::vector<> */
-        typedef math::CT::Vector<> EmptyVector;
-        typedef typename bmpl::transform<
+        using EmptyVector = math::CT::Vector<>;
+        using FirstList = typename bmpl::transform<
             TmpVector,
-            pmacc::math::CT::Assign<EmptyVector, bmpl::integral_c<uint32_t, rangeVectorSize - 1>, bmpl::_1>>::type
-            FirstList;
+            pmacc::math::CT::Assign<EmptyVector, bmpl::integral_c<uint32_t, rangeVectorSize - 1>, bmpl::_1>>::type;
 
         /* result type: MplSequence of N-tuples */
-        typedef typename detail::AllCombinations<ShrinkedRangeVector, FirstList>::type ResultIfNotEmpty;
-        typedef typename bmpl::if_<IsLastElementEmpty, bmpl::vector0<>, ResultIfNotEmpty>::type type;
+        using ResultIfNotEmpty = typename detail::AllCombinations<ShrinkedRangeVector, FirstList>::type;
+        using type = typename bmpl::if_<IsLastElementEmpty, bmpl::vector0<>, ResultIfNotEmpty>::type;
     };
 
 

--- a/include/pmacc/meta/ForEach.hpp
+++ b/include/pmacc/meta/ForEach.hpp
@@ -47,9 +47,9 @@ namespace pmacc
             template<typename itBegin, typename itEnd, bool isEnd = std::is_same<itBegin, itEnd>::value>
             struct CallFunctorOfIterator
             {
-                typedef typename boost::mpl::next<itBegin>::type nextIt;
-                typedef typename boost::mpl::deref<itBegin>::type Functor;
-                typedef CallFunctorOfIterator<nextIt, itEnd> NextCall;
+                using nextIt = typename boost::mpl::next<itBegin>::type;
+                using Functor = typename boost::mpl::deref<itBegin>::type;
+                using NextCall = CallFunctorOfIterator<nextIt, itEnd>;
 
                 PMACC_NO_NVCC_HDWARNING
                 template<typename... T_Types>
@@ -115,16 +115,16 @@ namespace pmacc
             {
             };
 
-            typedef typename bmpl::transform<T_MPLSeq, ReplacePlaceholder<bmpl::_1>>::type SolvedFunctors;
+            using SolvedFunctors = typename bmpl::transform<T_MPLSeq, ReplacePlaceholder<bmpl::_1>>::type;
 
-            typedef typename boost::mpl::begin<SolvedFunctors>::type begin;
-            typedef typename boost::mpl::end<SolvedFunctors>::type end;
+            using begin = typename boost::mpl::begin<SolvedFunctors>::type;
+            using end = typename boost::mpl::end<SolvedFunctors>::type;
 
 
-            typedef detail::CallFunctorOfIterator<begin, end> NextCall;
+            using NextCall = detail::CallFunctorOfIterator<begin, end>;
 
             /* this functor does nothing */
-            typedef detail::CallFunctorOfIterator<end, end> Functor;
+            using Functor = detail::CallFunctorOfIterator<end, end>;
 
             PMACC_NO_NVCC_HDWARNING
             template<typename... T_Types>

--- a/include/pmacc/meta/GetKeyFromAlias.hpp
+++ b/include/pmacc/meta/GetKeyFromAlias.hpp
@@ -46,26 +46,26 @@ namespace pmacc
     struct GetKeyFromAlias
     {
     private:
-        typedef T_KeyNotFoundPolicy KeyNotFoundPolicy;
+        using KeyNotFoundPolicy = T_KeyNotFoundPolicy;
         /*create a map where Key is a undeclared alias and value is real type*/
-        typedef typename SeqToMap<T_MPLSeq, TypeToAliasPair<bmpl::_1>>::type AliasMap;
+        using AliasMap = typename SeqToMap<T_MPLSeq, TypeToAliasPair<bmpl::_1>>::type;
         /*create a map where Key and value is real type*/
-        typedef typename SeqToMap<T_MPLSeq, TypeToPair<bmpl::_1>>::type KeyMap;
+        using KeyMap = typename SeqToMap<T_MPLSeq, TypeToPair<bmpl::_1>>::type;
         /*combine both maps*/
-        typedef bmpl::inserter<KeyMap, bmpl::insert<bmpl::_1, bmpl::_2>> Map_inserter;
-        typedef typename bmpl::copy<AliasMap, Map_inserter>::type FullMap;
+        using Map_inserter = bmpl::inserter<KeyMap, bmpl::insert<bmpl::_1, bmpl::_2>>;
+        using FullMap = typename bmpl::copy<AliasMap, Map_inserter>::type;
         /* search for given key,
          * - we get the real type if key found
          * - else we get boost::mpl::void_
          */
-        typedef typename bmpl::at<FullMap, T_Key>::type MapType;
+        using MapType = typename bmpl::at<FullMap, T_Key>::type;
 
     public:
         /* Check for KeyNotFound and calculate final type. (Uses lazy evaluation) */
-        typedef typename bmpl::if_<
+        using type = typename bmpl::if_<
             std::is_same<MapType, bmpl::void_>,
             bmpl::apply<KeyNotFoundPolicy, T_MPLSeq, T_Key>,
-            bmpl::identity<MapType>>::type::type type;
+            bmpl::identity<MapType>>::type::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/accessors/First.hpp
+++ b/include/pmacc/meta/accessors/First.hpp
@@ -39,7 +39,7 @@ namespace pmacc
             template<typename T>
             struct First
             {
-                typedef typename T::first type;
+                using type = typename T::first;
             };
 
         } // namespace accessors

--- a/include/pmacc/meta/accessors/Second.hpp
+++ b/include/pmacc/meta/accessors/Second.hpp
@@ -39,7 +39,7 @@ namespace pmacc
             template<typename T>
             struct Second
             {
-                typedef typename T::second type;
+                using type = typename T::second;
             };
 
         } // namespace accessors

--- a/include/pmacc/meta/conversion/JoinToSeq.hpp
+++ b/include/pmacc/meta/conversion/JoinToSeq.hpp
@@ -41,11 +41,11 @@ namespace pmacc
     struct JoinToSeq
     {
     private:
-        typedef typename ToSeq<T_1>::type Seq1;
-        typedef typename ToSeq<T_2>::type Seq2;
+        using Seq1 = typename ToSeq<T_1>::type;
+        using Seq2 = typename ToSeq<T_2>::type;
 
     public:
-        typedef typename bmpl::copy<Seq2, bmpl::back_inserter<Seq1>>::type type;
+        using type = typename bmpl::copy<Seq2, bmpl::back_inserter<Seq1>>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/MakeSeq.hpp
+++ b/include/pmacc/meta/conversion/MakeSeq.hpp
@@ -45,7 +45,7 @@ namespace pmacc
     template<typename... T_Args>
     struct MakeSeq
     {
-        typedef typename MakeSeqFromNestedSeq<bmpl::vector<T_Args...>>::type type;
+        using type = typename MakeSeqFromNestedSeq<bmpl::vector<T_Args...>>::type;
     };
 
     /** short hand definition for @see MakeSeq<> */

--- a/include/pmacc/meta/conversion/MakeSeqFromNestedSeq.hpp
+++ b/include/pmacc/meta/conversion/MakeSeqFromNestedSeq.hpp
@@ -41,10 +41,10 @@ namespace pmacc
     struct MakeSeqFromNestedSeq
     {
     private:
-        typedef typename ToSeq<T_In>::type Seq;
+        using Seq = typename ToSeq<T_In>::type;
 
     public:
-        typedef typename bmpl::fold<Seq, bmpl::vector0<>, JoinToSeq<bmpl::_1, bmpl::_2>>::type type;
+        using type = typename bmpl::fold<Seq, bmpl::vector0<>, JoinToSeq<bmpl::_1, bmpl::_2>>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/OperateOnSeq.hpp
+++ b/include/pmacc/meta/conversion/OperateOnSeq.hpp
@@ -50,9 +50,9 @@ namespace pmacc
         {
         };
 
-        typedef T_MPLSeq MPLSeq;
-        typedef bmpl::back_inserter<bmpl::vector<>> Inserter;
-        typedef typename bmpl::transform<MPLSeq, Op<bmpl::_1>, Inserter>::type type;
+        using MPLSeq = T_MPLSeq;
+        using Inserter = bmpl::back_inserter<bmpl::vector<>>;
+        using type = typename bmpl::transform<MPLSeq, Op<bmpl::_1>, Inserter>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/RemoveFromSeq.hpp
+++ b/include/pmacc/meta/conversion/RemoveFromSeq.hpp
@@ -41,10 +41,10 @@ namespace pmacc
         template<typename T_Value>
         struct hasId
         {
-            typedef bmpl::contains<T_MPLSeqObjectsToRemove, T_Value> type;
+            using type = bmpl::contains<T_MPLSeqObjectsToRemove, T_Value>;
         };
 
-        typedef typename bmpl::remove_if<T_MPLSeqSrc, hasId<bmpl::_>>::type type;
+        using type = typename bmpl::remove_if<T_MPLSeqSrc, hasId<bmpl::_>>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/ResolveAliases.hpp
+++ b/include/pmacc/meta/conversion/ResolveAliases.hpp
@@ -46,18 +46,18 @@ namespace pmacc
         typename T_AliasNotFoundPolicy = errorHandlerPolicies::ThrowValueNotFound>
     struct ResolveAliases
     {
-        typedef T_MPLSeq MPLSeq;
-        typedef T_MPLSeqLookup MPLSeqLookup;
-        typedef T_AliasNotFoundPolicy AliasNotFoundPolicy;
-        typedef bmpl::back_inserter<bmpl::vector<>> Inserter;
+        using MPLSeq = T_MPLSeq;
+        using MPLSeqLookup = T_MPLSeqLookup;
+        using AliasNotFoundPolicy = T_AliasNotFoundPolicy;
+        using Inserter = bmpl::back_inserter<bmpl::vector<>>;
 
         template<typename T_Identifier>
         struct GetKeyFromAliasAccessor
         {
-            typedef typename GetKeyFromAlias<MPLSeqLookup, T_Identifier, AliasNotFoundPolicy>::type type;
+            using type = typename GetKeyFromAlias<MPLSeqLookup, T_Identifier, AliasNotFoundPolicy>::type;
         };
 
-        typedef typename bmpl::transform<MPLSeq, GetKeyFromAliasAccessor<bmpl::_1>>::type type;
+        using type = typename bmpl::transform<MPLSeq, GetKeyFromAliasAccessor<bmpl::_1>>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/ResolveAndRemoveFromSeq.hpp
+++ b/include/pmacc/meta/conversion/ResolveAndRemoveFromSeq.hpp
@@ -36,11 +36,11 @@ namespace pmacc
     template<typename T_MPLSeqSrc, typename T_MPLSeqObjectsToRemove>
     struct ResolveAndRemoveFromSeq
     {
-        typedef T_MPLSeqSrc MPLSeqSrc;
-        typedef T_MPLSeqObjectsToRemove MPLSeqObjectsToRemove;
-        typedef typename ResolveAliases<MPLSeqObjectsToRemove, MPLSeqSrc, errorHandlerPolicies::ReturnValue>::type
-            ResolvedSeqWithObjectsToRemove;
-        typedef typename RemoveFromSeq<MPLSeqSrc, ResolvedSeqWithObjectsToRemove>::type type;
+        using MPLSeqSrc = T_MPLSeqSrc;
+        using MPLSeqObjectsToRemove = T_MPLSeqObjectsToRemove;
+        using ResolvedSeqWithObjectsToRemove =
+            typename ResolveAliases<MPLSeqObjectsToRemove, MPLSeqSrc, errorHandlerPolicies::ReturnValue>::type;
+        using type = typename RemoveFromSeq<MPLSeqSrc, ResolvedSeqWithObjectsToRemove>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/SeqToMap.hpp
+++ b/include/pmacc/meta/conversion/SeqToMap.hpp
@@ -50,9 +50,9 @@ namespace pmacc
         {
         };
 
-        typedef T_MPLSeq MPLSeq;
-        typedef bmpl::inserter<bmpl::map<>, bmpl::insert<bmpl::_1, bmpl::_2>> Map_inserter;
-        typedef typename bmpl::transform<MPLSeq, Op<bmpl::_1>, Map_inserter>::type type;
+        using MPLSeq = T_MPLSeq;
+        using Map_inserter = bmpl::inserter<bmpl::map<>, bmpl::insert<bmpl::_1, bmpl::_2>>;
+        using type = typename bmpl::transform<MPLSeq, Op<bmpl::_1>, Map_inserter>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/ToSeq.hpp
+++ b/include/pmacc/meta/conversion/ToSeq.hpp
@@ -37,7 +37,7 @@ namespace pmacc
     template<typename T_Type>
     struct ToSeq
     {
-        typedef typename bmpl::if_<bmpl::is_sequence<T_Type>, T_Type, bmpl::vector1<T_Type>>::type type;
+        using type = typename bmpl::if_<bmpl::is_sequence<T_Type>, T_Type, bmpl::vector1<T_Type>>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/TypeToAliasPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToAliasPair.hpp
@@ -40,14 +40,14 @@ namespace pmacc
     template<typename T_Type>
     struct TypeToAliasPair
     {
-        typedef typename TypeToPair<T_Type>::type type;
+        using type = typename TypeToPair<T_Type>::type;
     };
 
     /** specialisation if T_Type is a pmacc alias*/
     template<template<typename, typename> class T_Alias, typename T_Type>
     struct TypeToAliasPair<T_Alias<T_Type, pmacc::pmacc_isAlias>>
     {
-        typedef bmpl::pair<T_Alias<pmacc_void, pmacc::pmacc_isAlias>, T_Alias<T_Type, pmacc::pmacc_isAlias>> type;
+        using type = bmpl::pair<T_Alias<pmacc_void, pmacc::pmacc_isAlias>, T_Alias<T_Type, pmacc::pmacc_isAlias>>;
     };
 
 

--- a/include/pmacc/meta/conversion/TypeToPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToPair.hpp
@@ -35,7 +35,7 @@ namespace pmacc
     template<typename T_Type>
     struct TypeToPair
     {
-        typedef bmpl::pair<T_Type, T_Type> type;
+        using type = bmpl::pair<T_Type, T_Type>;
     };
 
 

--- a/include/pmacc/meta/conversion/TypeToPointerPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToPointerPair.hpp
@@ -36,7 +36,7 @@ namespace pmacc
     template<typename T_Type>
     struct TypeAsIdentifier
     {
-        typedef T_Type type;
+        using type = T_Type;
     };
 
     /** Unary functor to wrap any type with TypeAsIdentifier
@@ -46,7 +46,7 @@ namespace pmacc
     template<typename T_Type>
     struct MakeIdentifier
     {
-        typedef TypeAsIdentifier<T_Type> type;
+        using type = TypeAsIdentifier<T_Type>;
     };
 
     /** Pass through of an already existing Identifier
@@ -56,7 +56,7 @@ namespace pmacc
     template<typename T_Type>
     struct MakeIdentifier<TypeAsIdentifier<T_Type>>
     {
-        typedef TypeAsIdentifier<T_Type> type;
+        using type = TypeAsIdentifier<T_Type>;
     };
 
     /** create boost mpl pair <TypeAsIdentifier<Type>,PointerOfType>
@@ -67,8 +67,8 @@ namespace pmacc
     template<typename T_Type>
     struct TypeToPointerPair
     {
-        typedef T_Type* TypePtr;
-        typedef bmpl::pair<typename MakeIdentifier<T_Type>::type, TypePtr> type;
+        using TypePtr = T_Type*;
+        using type = bmpl::pair<typename MakeIdentifier<T_Type>::type, TypePtr>;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/errorHandlerPolicies/ReturnType.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ReturnType.hpp
@@ -36,7 +36,7 @@ namespace pmacc
             template<typename T_MPLSeq, typename T_Value>
             struct apply
             {
-                typedef T_ReturnType type;
+                using type = T_ReturnType;
             };
         };
 

--- a/include/pmacc/meta/errorHandlerPolicies/ReturnValue.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ReturnValue.hpp
@@ -35,7 +35,7 @@ namespace pmacc
             template<typename T_MPLSeq, typename T_Value>
             struct apply
             {
-                typedef T_Value type;
+                using type = T_Value;
             };
         };
 

--- a/include/pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp
@@ -45,7 +45,7 @@ namespace pmacc
                  * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
                  */
                 PMACC_CASSERT_MSG_TYPE(value_not_found_in_seq, T_Value, false && (sizeof(T_MPLSeq) != 0));
-                typedef bmpl::void_ type;
+                using type = bmpl::void_;
             };
         };
 

--- a/include/pmacc/mpi/GetMPI_StructAsArray.tpp
+++ b/include/pmacc/mpi/GetMPI_StructAsArray.tpp
@@ -34,7 +34,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_INT, 1);
+                    return {MPI_INT, 1};
                 }
             };
 
@@ -43,7 +43,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_UNSIGNED, 1);
+                    return {MPI_UNSIGNED, 1};
                 }
             };
 
@@ -52,7 +52,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_LONG, 1);
+                    return {MPI_LONG, 1};
                 }
             };
 
@@ -61,7 +61,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_UNSIGNED_LONG, 1);
+                    return {MPI_UNSIGNED_LONG, 1};
                 }
             };
 
@@ -70,7 +70,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_LONG_LONG, 1);
+                    return {MPI_LONG_LONG, 1};
                 }
             };
 
@@ -79,7 +79,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_UNSIGNED_LONG_LONG, 1);
+                    return {MPI_UNSIGNED_LONG_LONG, 1};
                 }
             };
 
@@ -88,7 +88,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_FLOAT, 1);
+                    return {MPI_FLOAT, 1};
                 }
             };
 
@@ -97,7 +97,7 @@ namespace pmacc
             {
                 MPI_StructAsArray operator()() const
                 {
-                    return MPI_StructAsArray(MPI_DOUBLE, 1);
+                    return {MPI_DOUBLE, 1};
                 }
             };
 

--- a/include/pmacc/mpi/MPIReduce.hpp
+++ b/include/pmacc/mpi/MPIReduce.hpp
@@ -38,7 +38,7 @@ namespace pmacc
         /** reduce data over selected mpi ranks */
         struct MPIReduce
         {
-            MPIReduce() : mpiRank(-1), numRanks(0), comm(MPI_COMM_NULL), isMPICommInitialized(false)
+            MPIReduce() : comm(MPI_COMM_NULL)
             {
             }
 
@@ -147,7 +147,7 @@ namespace pmacc
             {
                 if(!isMPICommInitialized)
                     participate(true);
-                typedef Type ValueType;
+                using ValueType = Type;
 
                 method(
                     func,
@@ -182,9 +182,9 @@ namespace pmacc
 
         private:
             MPI_Comm comm;
-            int mpiRank;
-            int numRanks;
-            bool isMPICommInitialized;
+            int mpiRank{-1};
+            int numRanks{0};
+            bool isMPICommInitialized{false};
         };
     } // namespace mpi
 } // namespace pmacc

--- a/include/pmacc/particles/ParticleDescription.hpp
+++ b/include/pmacc/particles/ParticleDescription.hpp
@@ -62,22 +62,21 @@ namespace pmacc
         typename T_FrameExtensionList = bmpl::vector0<>>
     struct ParticleDescription
     {
-        typedef T_Name Name;
-        typedef T_SuperCellSize SuperCellSize;
-        typedef typename ToSeq<T_ValueTypeSeq>::type ValueTypeSeq;
-        typedef typename ToSeq<T_Flags>::type FlagsList;
-        typedef T_HandleGuardRegion HandleGuardRegion;
-        typedef typename ToSeq<T_MethodsList>::type MethodsList;
-        typedef typename ToSeq<T_FrameExtensionList>::type FrameExtensionList;
-        typedef ParticleDescription<
+        using Name = T_Name;
+        using SuperCellSize = T_SuperCellSize;
+        using ValueTypeSeq = typename ToSeq<T_ValueTypeSeq>::type;
+        using FlagsList = typename ToSeq<T_Flags>::type;
+        using HandleGuardRegion = T_HandleGuardRegion;
+        using MethodsList = typename ToSeq<T_MethodsList>::type;
+        using FrameExtensionList = typename ToSeq<T_FrameExtensionList>::type;
+        using ThisType = ParticleDescription<
             Name,
             SuperCellSize,
             ValueTypeSeq,
             FlagsList,
             HandleGuardRegion,
             MethodsList,
-            FrameExtensionList>
-            ThisType;
+            FrameExtensionList>;
     };
 
 
@@ -90,16 +89,15 @@ namespace pmacc
     template<typename T_OldParticleDescription, typename T_NewValueTypeSeq>
     struct ReplaceValueTypeSeq
     {
-        typedef T_OldParticleDescription OldParticleDescription;
-        typedef ParticleDescription<
+        using OldParticleDescription = T_OldParticleDescription;
+        using type = ParticleDescription<
             typename OldParticleDescription::Name,
             typename OldParticleDescription::SuperCellSize,
             typename ToSeq<T_NewValueTypeSeq>::type,
             typename OldParticleDescription::FlagsList,
             typename OldParticleDescription::HandleGuardRegion,
             typename OldParticleDescription::MethodsList,
-            typename OldParticleDescription::FrameExtensionList>
-            type;
+            typename OldParticleDescription::FrameExtensionList>;
     };
 
     /** Get ParticleDescription with a new FrameExtensionSeq
@@ -111,16 +109,15 @@ namespace pmacc
     template<typename T_OldParticleDescription, typename T_FrameExtensionSeq>
     struct ReplaceFrameExtensionSeq
     {
-        typedef T_OldParticleDescription OldParticleDescription;
-        typedef ParticleDescription<
+        using OldParticleDescription = T_OldParticleDescription;
+        using type = ParticleDescription<
             typename OldParticleDescription::Name,
             typename OldParticleDescription::SuperCellSize,
             typename OldParticleDescription::ValueTypeSeq,
             typename OldParticleDescription::FlagsList,
             typename OldParticleDescription::HandleGuardRegion,
             typename OldParticleDescription::MethodsList,
-            typename ToSeq<T_FrameExtensionSeq>::type>
-            type;
+            typename ToSeq<T_FrameExtensionSeq>::type>;
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -44,32 +44,31 @@ namespace pmacc
     template<typename T_ParticleDescription, class T_MappingDesc, typename T_DeviceHeap>
     class ParticlesBase : public SimulationFieldHelper<T_MappingDesc>
     {
-        typedef T_ParticleDescription ParticleDescription;
-        typedef T_MappingDesc MappingDesc;
+        using ParticleDescription = T_ParticleDescription;
+        using MappingDesc = T_MappingDesc;
 
     public:
         /* Type of used particles buffer
          */
-        typedef ParticlesBuffer<
+        using BufferType = ParticlesBuffer<
             ParticleDescription,
             typename MappingDesc::SuperCellSize,
             T_DeviceHeap,
-            MappingDesc::Dim>
-            BufferType;
+            MappingDesc::Dim>;
 
         /* Type of frame in particles buffer
          */
-        typedef typename BufferType::FrameType FrameType;
+        using FrameType = typename BufferType::FrameType;
         /* Type of border frame in a particle buffer
          */
-        typedef typename BufferType::FrameTypeBorder FrameTypeBorder;
+        using FrameTypeBorder = typename BufferType::FrameTypeBorder;
 
         /* Type of the particle box which particle buffer create
          */
-        typedef typename BufferType::ParticlesBoxType ParticlesBoxType;
+        using ParticlesBoxType = typename BufferType::ParticlesBoxType;
 
         /* Policies for handling particles in guard cells */
-        typedef typename ParticleDescription::HandleGuardRegion HandleGuardRegion;
+        using HandleGuardRegion = typename ParticleDescription::HandleGuardRegion;
 
         enum
         {
@@ -79,14 +78,14 @@ namespace pmacc
         };
 
         /* Mark this simulation data as a particle type */
-        typedef ParticlesTag SimulationDataTag;
+        using SimulationDataTag = ParticlesTag;
 
     protected:
         BufferType* particlesBuffer;
 
         ParticlesBase(const std::shared_ptr<T_DeviceHeap>& deviceHeap, MappingDesc description)
             : SimulationFieldHelper<MappingDesc>(description)
-            , particlesBuffer(NULL)
+            , particlesBuffer(nullptr)
         {
             particlesBuffer = new BufferType(
                 deviceHeap,
@@ -94,7 +93,7 @@ namespace pmacc
                 MappingDesc::SuperCellSize::toRT());
         }
 
-        virtual ~ParticlesBase()
+        ~ParticlesBase() override
         {
             delete this->particlesBuffer;
         }
@@ -217,7 +216,7 @@ namespace pmacc
         }
 
         /* set all internal objects to initial state*/
-        virtual void reset(uint32_t currentStep);
+        void reset(uint32_t currentStep) override;
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/boostExtension/InheritGenerators.hpp
+++ b/include/pmacc/particles/boostExtension/InheritGenerators.hpp
@@ -58,7 +58,7 @@ namespace pmacc
     template<class Head, class Vec>
     struct TypelistLinearInherit<Head, Vec, false>
     {
-        typedef LinearInheritFork<Head, typename LinearInherit<Vec>::type> type;
+        using type = LinearInheritFork<Head, typename LinearInherit<Vec>::type>;
     };
 
 
@@ -67,7 +67,7 @@ namespace pmacc
     template<template<class> class Head, class Vec>
     struct TypelistLinearInherit<Head<pmacc::NullFrame>, Vec, false>
     {
-        typedef Head<typename LinearInherit<Vec>::type> type;
+        using type = Head<typename LinearInherit<Vec>::type>;
     };
 
 
@@ -78,7 +78,7 @@ namespace pmacc
     template<class Head, class Vec>
     struct TypelistLinearInherit<Head, Vec, true>
     {
-        typedef Head type;
+        using type = Head;
     };
 
 
@@ -93,9 +93,9 @@ namespace pmacc
     template<typename vec_>
     struct LinearInherit
     {
-        typedef
+        using type =
             typename TypelistLinearInherit<typename bmpl::front<vec_>::type, typename bmpl::pop_front<vec_>::type>::
-                type type;
+                type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/memory/boxes/ExchangePopDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePopDataBox.hpp
@@ -32,7 +32,7 @@ namespace pmacc
     class ExchangePopDataBox : public DataBox<PitchedBox<VALUE, DIM1>>
     {
     public:
-        typedef ExchangeMemoryIndex<TYPE, DIM> PopType;
+        using PopType = ExchangeMemoryIndex<TYPE, DIM>;
 
         HDINLINE ExchangePopDataBox(
             DataBox<PitchedBox<VALUE, DIM1>> data,

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -38,7 +38,7 @@ namespace pmacc
     class ExchangePushDataBox : public DataBox<PitchedBox<VALUE, DIM1>>
     {
     public:
-        typedef ExchangeMemoryIndex<TYPE, DIM> PushType;
+        using PushType = ExchangeMemoryIndex<TYPE, DIM>;
 
         HDINLINE ExchangePushDataBox(
             VALUE* data,

--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -44,14 +44,14 @@ namespace pmacc
     {
     private:
         PMACC_ALIGN(m_deviceHeapHandle, T_DeviceHeapHandle);
-        PMACC_ALIGN(hostMemoryOffset, int64_t);
+        PMACC_ALIGN(hostMemoryOffset, int64_t){0};
 
     public:
-        typedef T_Frame FrameType;
-        typedef FramePointer<FrameType> FramePtr;
-        typedef SuperCell<FrameType> SuperCellType;
-        typedef DataBox<PitchedBox<SuperCell<FrameType>, DIM>> BaseType;
-        typedef T_DeviceHeapHandle DeviceHeapHandle;
+        using FrameType = T_Frame;
+        using FramePtr = FramePointer<FrameType>;
+        using SuperCellType = SuperCell<FrameType>;
+        using BaseType = DataBox<PitchedBox<SuperCell<FrameType>, DIM>>;
+        using DeviceHeapHandle = T_DeviceHeapHandle;
 
         static constexpr uint32_t Dim = DIM;
 
@@ -60,16 +60,14 @@ namespace pmacc
          * \warning after this call the object is in a invalid state and must be
          * initialized with an assignment of a valid ParticleBox
          */
-        HDINLINE ParticlesBox() : hostMemoryOffset(0)
-        {
-        }
+        HDINLINE ParticlesBox() = default;
 
         HDINLINE ParticlesBox(
             const DataBox<PitchedBox<SuperCellType, DIM>>& superCells,
             const DeviceHeapHandle& deviceHeapHandle)
             : BaseType(superCells)
             , m_deviceHeapHandle(deviceHeapHandle)
-            , hostMemoryOffset(0)
+
         {
         }
 
@@ -148,7 +146,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1)
             return devPtr;
 #else
-            int64_t useOffset = hostMemoryOffset * static_cast<int64_t>(devPtr.ptr != 0);
+            int64_t useOffset = hostMemoryOffset * static_cast<int64_t>(devPtr.ptr != nullptr);
             return FramePtr(reinterpret_cast<FrameType*>(reinterpret_cast<char*>(devPtr.ptr) - useOffset));
 #endif
         }

--- a/include/pmacc/particles/memory/boxes/TileDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/TileDataBox.hpp
@@ -32,8 +32,8 @@ namespace pmacc
     class VectorDataBox : public DataBox<PitchedBox<TYPE, DIM1>>
     {
     public:
-        typedef DataBox<PitchedBox<TYPE, DIM1>> BaseType;
-        typedef TYPE type;
+        using BaseType = DataBox<PitchedBox<TYPE, 1U>>;
+        using type = TYPE;
 
         template<class>
         struct result;
@@ -41,13 +41,13 @@ namespace pmacc
         template<class F, typename T>
         struct result<F(T)>
         {
-            typedef TYPE& type;
+            using type = TYPE&;
         };
 
         template<class F, typename T>
         struct result<const F(T)>
         {
-            typedef const TYPE& type;
+            using type = const TYPE&;
         };
 
         HDINLINE VectorDataBox(TYPE* pointer, const DataSpace<DIM1>& offset = DataSpace<DIM1>(0))
@@ -55,9 +55,7 @@ namespace pmacc
         {
         }
 
-        HDINLINE VectorDataBox()
-        {
-        }
+        HDINLINE VectorDataBox() = default;
     };
 
     /**
@@ -69,7 +67,7 @@ namespace pmacc
     class TileDataBox : public VectorDataBox<TYPE>
     {
     public:
-        typedef VectorDataBox<TYPE> BaseType;
+        using BaseType = VectorDataBox<TYPE>;
 
         HDINLINE TileDataBox(TYPE* pointer, const DataSpace<DIM1>& offset = DataSpace<DIM1>(0), uint32_t size = 0)
             : BaseType(pointer, offset)
@@ -88,9 +86,7 @@ namespace pmacc
         }
 
         /*object is not  initialized valid, copy a valid instance to this object to get a valid instance*/
-        HDINLINE TileDataBox()
-        {
-        }
+        HDINLINE TileDataBox() = default;
 
 
     protected:

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -82,7 +82,7 @@ namespace pmacc
     public:
         MallocMCBuffer(const std::shared_ptr<T_DeviceHeap>&);
 
-        virtual ~MallocMCBuffer() = default;
+        ~MallocMCBuffer() override = default;
 
         SimulationDataId getUniqueId() override
         {

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -67,9 +67,8 @@ namespace pmacc
             template<typename X>
             struct apply
             {
-                typedef bmpl::
-                    pair<X, StaticArray<typename traits::Resolve<X>::type::type, bmpl::integral_c<uint32_t, T_size>>>
-                        type;
+                using type = bmpl::
+                    pair<X, StaticArray<typename traits::Resolve<X>::type::type, bmpl::integral_c<uint32_t, T_size>>>;
             };
         };
 
@@ -80,50 +79,49 @@ namespace pmacc
          *   - start position inside the exchange stack for frames
          *   - number of frames corresponding to the superCell position
          */
-        typedef ExchangeMemoryIndex<vint_t, DIM - 1> BorderFrameIndex;
+        using BorderFrameIndex = ExchangeMemoryIndex<vint_t, DIM - 1>;
 
-        typedef SuperCellSize_ SuperCellSize;
+        using SuperCellSize = SuperCellSize_;
 
-        typedef typename MakeSeq<typename T_ParticleDescription::ValueTypeSeq, localCellIdx, multiMask>::type
-            ParticleAttributeList;
+        using ParticleAttributeList =
+            typename MakeSeq<typename T_ParticleDescription::ValueTypeSeq, localCellIdx, multiMask>::type;
 
-        typedef typename MakeSeq<typename T_ParticleDescription::ValueTypeSeq, localCellIdx>::type
-            ParticleAttributeListBorder;
+        using ParticleAttributeListBorder =
+            typename MakeSeq<typename T_ParticleDescription::ValueTypeSeq, localCellIdx>::type;
 
-        typedef typename ReplaceValueTypeSeq<T_ParticleDescription, ParticleAttributeList>::type
-            FrameDescriptionWithManagementAttributes;
+        using FrameDescriptionWithManagementAttributes =
+            typename ReplaceValueTypeSeq<T_ParticleDescription, ParticleAttributeList>::type;
 
         /** double linked list pointer */
-        typedef typename MakeSeq<PreviousFramePtr<>, NextFramePtr<>>::type LinkedListPointer;
+        using LinkedListPointer = typename MakeSeq<PreviousFramePtr<>, NextFramePtr<>>::type;
 
         /* extent particle description with pointer to a frame*/
-        typedef typename ReplaceFrameExtensionSeq<FrameDescriptionWithManagementAttributes, LinkedListPointer>::type
-            FrameDescription;
+        using FrameDescription =
+            typename ReplaceFrameExtensionSeq<FrameDescriptionWithManagementAttributes, LinkedListPointer>::type;
 
         /** frame definition
          *
          * a group of particles is stored as frame
          */
-        typedef Frame<
+        using FrameType = Frame<
             OperatorCreatePairStaticArray<pmacc::math::CT::volume<SuperCellSize>::type::value>,
-            FrameDescription>
-            FrameType;
+            FrameDescription>;
 
-        typedef typename ReplaceValueTypeSeq<T_ParticleDescription, ParticleAttributeListBorder>::type
-            FrameDescriptionBorder;
+        using FrameDescriptionBorder =
+            typename ReplaceValueTypeSeq<T_ParticleDescription, ParticleAttributeListBorder>::type;
 
         /** frame which is used to communicate particles to neighbors
          *
          * - each frame contains only one particle
          * - local administration attributes of a particle are removed
          */
-        typedef Frame<OperatorCreatePairStaticArray<1u>, FrameDescriptionBorder> FrameTypeBorder;
+        using FrameTypeBorder = Frame<OperatorCreatePairStaticArray<1U>, FrameDescriptionBorder>;
 
-        typedef SuperCell<FrameType> SuperCellType;
+        using SuperCellType = SuperCell<FrameType>;
 
-        typedef T_DeviceHeap DeviceHeap;
+        using DeviceHeap = T_DeviceHeap;
         /* Type of the particle box which particle buffer create */
-        typedef ParticlesBox<FrameType, typename DeviceHeap::AllocatorHandle, DIM> ParticlesBoxType;
+        using ParticlesBoxType = ParticlesBox<FrameType, typename DeviceHeap::AllocatorHandle, DIM>;
 
     private:
         /* this enum is used only for internal calculations */

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -64,12 +64,12 @@ namespace pmacc
     template<typename T_FrameType, typename T_ValueTypeSeq = typename T_FrameType::ValueTypeSeq>
     struct Particle : public InheritLinearly<typename T_FrameType::MethodsList>
     {
-        typedef T_FrameType FrameType;
-        typedef T_ValueTypeSeq ValueTypeSeq;
-        typedef typename FrameType::Name Name;
-        typedef typename FrameType::SuperCellSize SuperCellSize;
-        typedef Particle<FrameType, ValueTypeSeq> ThisType;
-        typedef typename FrameType::MethodsList MethodsList;
+        using FrameType = T_FrameType;
+        using ValueTypeSeq = T_ValueTypeSeq;
+        using Name = typename FrameType::Name;
+        using SuperCellSize = typename FrameType::SuperCellSize;
+        using ThisType = Particle<FrameType, ValueTypeSeq>;
+        using MethodsList = typename FrameType::MethodsList;
 
         /** index of particle inside the Frame*/
         PMACC_ALIGN(idx, uint32_t);
@@ -163,17 +163,17 @@ namespace pmacc
         struct HasIdentifier<pmacc::Particle<T_FrameType, T_ValueTypeSeq>, T_Key>
         {
         private:
-            typedef pmacc::Particle<T_FrameType, T_ValueTypeSeq> ParticleType;
-            typedef typename ParticleType::ValueTypeSeq ValueTypeSeq;
+            using ParticleType = pmacc::Particle<T_FrameType, T_ValueTypeSeq>;
+            using ValueTypeSeq = typename ParticleType::ValueTypeSeq;
 
         public:
             /* If T_Key can not be found in the T_ValueTypeSeq of this Particle class,
              * SolvedAliasName will be void_.
              * Look-up is also valid if T_Key is an alias.
              */
-            typedef typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type SolvedAliasName;
+            using SolvedAliasName = typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type;
 
-            typedef bmpl::contains<ValueTypeSeq, SolvedAliasName> type;
+            using type = bmpl::contains<ValueTypeSeq, SolvedAliasName>;
         };
 
         template<typename T_Key, typename T_FrameType, typename T_ValueTypeSeq>
@@ -209,26 +209,26 @@ namespace pmacc
                     pmacc::Particle<T_FrameType1, T_ValueTypeSeq1>,
                     pmacc::Particle<T_FrameType2, T_ValueTypeSeq2>>
                 {
-                    typedef pmacc::Particle<T_FrameType1, T_ValueTypeSeq1> Dest;
-                    typedef pmacc::Particle<T_FrameType2, T_ValueTypeSeq2> Src;
+                    using Dest = pmacc::Particle<T_FrameType1, T_ValueTypeSeq1>;
+                    using Src = pmacc::Particle<T_FrameType2, T_ValueTypeSeq2>;
 
-                    typedef typename Dest::ValueTypeSeq DestTypeSeq;
-                    typedef typename Src::ValueTypeSeq SrcTypeSeq;
+                    using DestTypeSeq = typename Dest::ValueTypeSeq;
+                    using SrcTypeSeq = typename Src::ValueTypeSeq;
 
                     /* create attribute list with a subset of common attributes in two sequences
                      * bmpl::contains has lower complexity than traits::HasIdentifier
                      * and was used for this reason
                      */
-                    typedef typename bmpl::copy_if<
+                    using CommonTypeSeq = typename bmpl::copy_if<
                         DestTypeSeq,
                         bmpl::contains<SrcTypeSeq, bmpl::_1>,
-                        bmpl::back_inserter<bmpl::vector0<>>>::type CommonTypeSeq;
+                        bmpl::back_inserter<bmpl::vector0<>>>::type;
 
                     /* create sequences with disjunct attributes from `DestTypeSeq` */
-                    typedef typename bmpl::copy_if<
+                    using UniqueInDestTypeSeq = typename bmpl::copy_if<
                         DestTypeSeq,
                         bmpl::not_<bmpl::contains<SrcTypeSeq, bmpl::_1>>,
-                        bmpl::back_inserter<bmpl::vector0<>>>::type UniqueInDestTypeSeq;
+                        bmpl::back_inserter<bmpl::vector0<>>>::type;
 
                     /** Assign particle attributes
                      *
@@ -257,20 +257,20 @@ namespace pmacc
                 template<typename T_MPLSeqWithObjectsToRemove, typename T_FrameType, typename T_ValueTypeSeq>
                 struct Deselect<T_MPLSeqWithObjectsToRemove, pmacc::Particle<T_FrameType, T_ValueTypeSeq>>
                 {
-                    typedef T_FrameType FrameType;
-                    typedef T_ValueTypeSeq ValueTypeSeq;
-                    typedef pmacc::Particle<FrameType, ValueTypeSeq> ParticleType;
-                    typedef T_MPLSeqWithObjectsToRemove MPLSeqWithObjectsToRemove;
+                    using FrameType = T_FrameType;
+                    using ValueTypeSeq = T_ValueTypeSeq;
+                    using ParticleType = pmacc::Particle<FrameType, ValueTypeSeq>;
+                    using MPLSeqWithObjectsToRemove = T_MPLSeqWithObjectsToRemove;
 
                     /* translate aliases to full specialized identifier*/
-                    typedef typename ResolveAliases<
+                    using ResolvedSeqWithObjectsToRemove = typename ResolveAliases<
                         MPLSeqWithObjectsToRemove,
                         ValueTypeSeq,
-                        errorHandlerPolicies::ReturnValue>::type ResolvedSeqWithObjectsToRemove;
+                        errorHandlerPolicies::ReturnValue>::type;
                     /* remove types from original particle attribute list*/
-                    typedef typename RemoveFromSeq<ValueTypeSeq, ResolvedSeqWithObjectsToRemove>::type NewValueTypeSeq;
+                    using NewValueTypeSeq = typename RemoveFromSeq<ValueTypeSeq, ResolvedSeqWithObjectsToRemove>::type;
                     /* new particle type*/
-                    typedef pmacc::Particle<FrameType, NewValueTypeSeq> ResultType;
+                    using ResultType = pmacc::Particle<FrameType, NewValueTypeSeq>;
 
                     template<class>
                     struct result;
@@ -278,7 +278,7 @@ namespace pmacc
                     template<class F, class T_Obj>
                     struct result<F(T_Obj)>
                     {
-                        typedef ResultType type;
+                        using type = ResultType;
                     };
 
                     HDINLINE

--- a/include/pmacc/particles/memory/dataTypes/Pointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Pointer.hpp
@@ -37,9 +37,7 @@ namespace pmacc
         using PtrType = type*;
         using ConstPtrType = const type*;
 
-        HDINLINE Pointer() : ptr{nullptr}
-        {
-        }
+        HDINLINE Pointer() = default;
 
         HDINLINE Pointer(PtrType const ptrIn) : ptr(ptrIn)
         {
@@ -99,7 +97,7 @@ namespace pmacc
             return ptr != nullptr;
         }
 
-        PMACC_ALIGN(ptr, PtrType);
+        PMACC_ALIGN(ptr, PtrType){nullptr};
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
+++ b/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
@@ -33,7 +33,7 @@ namespace pmacc
     {
     public:
         static constexpr uint32_t size = T_size::value;
-        typedef T_Type Type;
+        using Type = T_Type;
 
     private:
         Type data[size];
@@ -45,13 +45,13 @@ namespace pmacc
         template<class F, typename TKey>
         struct result<F(TKey)>
         {
-            typedef Type& type;
+            using type = Type&;
         };
 
         template<class F, typename TKey>
         struct result<const F(TKey)>
         {
-            typedef const Type& type;
+            using type = const Type&;
         };
 
         HDINLINE

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -32,7 +32,7 @@ namespace pmacc
     class SuperCell
     {
     public:
-        HDINLINE SuperCell() : firstFramePtr(nullptr), lastFramePtr(nullptr), numParticles(0), mustShiftVal(false)
+        HDINLINE SuperCell() : firstFramePtr(nullptr), lastFramePtr(nullptr)
         {
         }
 
@@ -87,8 +87,8 @@ namespace pmacc
         PMACC_ALIGN(lastFramePtr, T_FrameType*);
 
     private:
-        PMACC_ALIGN(numParticles, uint32_t);
-        PMACC_ALIGN(mustShiftVal, bool);
+        PMACC_ALIGN(numParticles, uint32_t){0};
+        PMACC_ALIGN(mustShiftVal, bool){false};
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -68,20 +68,20 @@ namespace pmacc
               typename T_ParticleDescription::FrameExtensionList,
               bmpl::apply1<bmpl::_1, Frame<T_CreatePairOperator, T_ParticleDescription>>>::type>
     {
-        typedef T_ParticleDescription ParticleDescription;
-        typedef typename ParticleDescription::Name Name;
-        typedef typename ParticleDescription::SuperCellSize SuperCellSize;
-        typedef typename ParticleDescription::ValueTypeSeq ValueTypeSeq;
-        typedef typename ParticleDescription::MethodsList MethodsList;
-        typedef typename ParticleDescription::FlagsList FlagList;
-        typedef typename ParticleDescription::FrameExtensionList FrameExtensionList;
-        typedef Frame<T_CreatePairOperator, ParticleDescription> ThisType;
+        using ParticleDescription = T_ParticleDescription;
+        using Name = typename ParticleDescription::Name;
+        using SuperCellSize = typename ParticleDescription::SuperCellSize;
+        using ValueTypeSeq = typename ParticleDescription::ValueTypeSeq;
+        using MethodsList = typename ParticleDescription::MethodsList;
+        using FlagList = typename ParticleDescription::FlagsList;
+        using FrameExtensionList = typename ParticleDescription::FrameExtensionList;
+        using ThisType = Frame<T_CreatePairOperator, ParticleDescription>;
         /* definition of the MapTupel where we inherit from*/
-        typedef pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData>
-            BaseType;
+        using BaseType
+            = pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData>;
 
         /* type of a single particle*/
-        typedef pmacc::Particle<ThisType> ParticleType;
+        using ParticleType = pmacc::Particle<ThisType>;
 
         /* define boost result_of results
          * normaly result_of defines operator() result, in this case we define the result for
@@ -94,16 +94,16 @@ namespace pmacc
         template<class F, class TKey>
         struct result<const F(TKey)>
         {
-            typedef typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type Key;
-            typedef typename boost::result_of<const BaseType(Key)>::type type;
+            using Key = typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type;
+            using type = typename boost::result_of<const BaseType(Key)>::type;
         };
 
         /* non const operator[]*/
         template<class F, class TKey>
         struct result<F(TKey)>
         {
-            typedef typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type Key;
-            typedef typename boost::result_of<BaseType(Key)>::type type;
+            using Key = typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type;
+            using type = typename boost::result_of<BaseType(Key)>::type;
         };
 
         /** access the Nth particle*/
@@ -127,7 +127,7 @@ namespace pmacc
         template<typename T_Key>
         HDINLINE typename boost::result_of<ThisType(T_Key)>::type getIdentifier(const T_Key)
         {
-            typedef typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type Key;
+            using Key = typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type;
             return BaseType::operator[](Key());
         }
 
@@ -135,7 +135,7 @@ namespace pmacc
         template<typename T_Key>
         HDINLINE typename boost::result_of<const ThisType(T_Key)>::type getIdentifier(const T_Key) const
         {
-            typedef typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type Key;
+            using Key = typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type;
             return BaseType::operator[](Key());
         }
 
@@ -151,39 +151,39 @@ namespace pmacc
         struct HasIdentifier<pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>, T_IdentifierName>
         {
         private:
-            typedef pmacc::Frame<T_CreatePairOperator, T_ParticleDescription> FrameType;
+            using FrameType = pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>;
 
         public:
-            typedef typename FrameType::ValueTypeSeq ValueTypeSeq;
+            using ValueTypeSeq = typename FrameType::ValueTypeSeq;
             /* if T_IdentifierName is void_ than we have no T_IdentifierName in our Sequence.
              * check is also valid if T_Key is a alias
              */
-            typedef typename GetKeyFromAlias<ValueTypeSeq, T_IdentifierName>::type SolvedAliasName;
+            using SolvedAliasName = typename GetKeyFromAlias<ValueTypeSeq, T_IdentifierName>::type;
 
-            typedef bmpl::contains<ValueTypeSeq, SolvedAliasName> type;
+            using type = bmpl::contains<ValueTypeSeq, SolvedAliasName>;
         };
 
         template<typename T_IdentifierName, typename T_CreatePairOperator, typename T_ParticleDescription>
         struct HasFlag<pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>, T_IdentifierName>
         {
         private:
-            typedef pmacc::Frame<T_CreatePairOperator, T_ParticleDescription> FrameType;
-            typedef typename GetFlagType<FrameType, T_IdentifierName>::type SolvedAliasName;
-            typedef typename FrameType::FlagList FlagList;
+            using FrameType = pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>;
+            using SolvedAliasName = typename GetFlagType<FrameType, T_IdentifierName>::type;
+            using FlagList = typename FrameType::FlagList;
 
         public:
-            typedef bmpl::contains<FlagList, SolvedAliasName> type;
+            using type = bmpl::contains<FlagList, SolvedAliasName>;
         };
 
         template<typename T_IdentifierName, typename T_CreatePairOperator, typename T_ParticleDescription>
         struct GetFlagType<pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>, T_IdentifierName>
         {
         private:
-            typedef pmacc::Frame<T_CreatePairOperator, T_ParticleDescription> FrameType;
-            typedef typename FrameType::FlagList FlagList;
+            using FrameType = pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>;
+            using FlagList = typename FrameType::FlagList;
 
         public:
-            typedef typename GetKeyFromAlias<FlagList, T_IdentifierName>::type type;
+            using type = typename GetKeyFromAlias<FlagList, T_IdentifierName>::type;
         };
 
     } // namespace traits

--- a/include/pmacc/particles/operations/CountParticles.hpp
+++ b/include/pmacc/particles/operations/CountParticles.hpp
@@ -80,7 +80,7 @@ namespace pmacc
             using SuperCellSize = typename T_Mapping::SuperCellSize;
 
             DataSpace<dim> const threadIndex(cupla::threadIdx(acc));
-            uint32_t const workerIdx
+            auto const workerIdx
                 = static_cast<uint32_t>(DataSpaceOperations<dim>::template map<SuperCellSize>(threadIndex));
 
             DataSpace<dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc))));
@@ -218,8 +218,8 @@ namespace pmacc
             const Space& size,
             T_ParticleFilter& parFilter)
         {
-            typedef bmpl::vector<typename GetPositionFilter<Space::Dim>::type> usedFilters;
-            typedef typename FilterFactory<usedFilters>::FilterType MyParticleFilter;
+            using usedFilters = bmpl::vector<typename GetPositionFilter<Space::Dim>::type>;
+            using MyParticleFilter = typename FilterFactory<usedFilters>::FilterType;
             MyParticleFilter filter;
             filter.setStatus(true); /*activeate filter pipline*/
             filter.setWindowPosition(origin, size);

--- a/include/pmacc/particles/operations/Deselect.hpp
+++ b/include/pmacc/particles/operations/Deselect.hpp
@@ -55,8 +55,8 @@ namespace pmacc
                 typename boost::result_of<detail::Deselect<typename ToSeq<T_Exclude>::type, T_Object>(T_Object)>::type
                 deselect(T_Object& object)
             {
-                typedef typename ToSeq<T_Exclude>::type DeselectSeq;
-                typedef detail::Deselect<DeselectSeq, T_Object> BaseType;
+                using DeselectSeq = typename ToSeq<T_Exclude>::type;
+                using BaseType = detail::Deselect<DeselectSeq, T_Object>;
 
                 return BaseType()(object);
             }

--- a/include/pmacc/particles/operations/SetAttributeToDefault.hpp
+++ b/include/pmacc/particles/operations/SetAttributeToDefault.hpp
@@ -33,7 +33,7 @@ namespace pmacc
     template<typename T_Attribute>
     struct SetAttributeToDefault
     {
-        typedef T_Attribute Attribute;
+        using Attribute = T_Attribute;
 
         /** set an attribute to their default value
          *
@@ -42,7 +42,7 @@ namespace pmacc
         template<typename T_Particle>
         HDINLINE void operator()(T_Particle& particle)
         {
-            typedef typename pmacc::traits::Resolve<Attribute>::type ResolvedAttr;
+            using ResolvedAttr = typename pmacc::traits::Resolve<Attribute>::type;
             /* set attribute to it's user defined default value */
             particle[Attribute()] = ResolvedAttr::getValue();
         }

--- a/include/pmacc/particles/particleFilter/FilterFactory.hpp
+++ b/include/pmacc/particles/particleFilter/FilterFactory.hpp
@@ -40,8 +40,8 @@ namespace pmacc
     class FilterFactory
     {
     public:
-        typedef
-            typename LinearInherit<typename MakeSeq<DefaultFilter<>, UserTypeList, TrueFilter>::type>::type FilterType;
+        using FilterType =
+            typename LinearInherit<typename MakeSeq<DefaultFilter<>, UserTypeList, TrueFilter>::type>::type;
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/particleFilter/PositionFilter.hpp
+++ b/include/pmacc/particles/particleFilter/PositionFilter.hpp
@@ -43,9 +43,7 @@ namespace pmacc
             DataSpace<dim> superCellIdx;
 
         public:
-            HDINLINE PositionFilter()
-            {
-            }
+            HDINLINE PositionFilter() = default;
 
             HDINLINE void setWindowPosition(DataSpace<dim> offset, DataSpace<dim> size)
             {
@@ -97,13 +95,13 @@ namespace pmacc
     template<>
     struct GetPositionFilter<DIM3>
     {
-        typedef PositionFilter3D<> type;
+        using type = PositionFilter3D<>;
     };
 
     template<>
     struct GetPositionFilter<DIM2>
     {
-        typedef PositionFilter2D<> type;
+        using type = PositionFilter2D<>;
     };
 
 

--- a/include/pmacc/particles/particleFilter/system/DefaultFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/DefaultFilter.hpp
@@ -31,12 +31,10 @@ namespace pmacc
     class DefaultFilter : public Base
     {
     private:
-        bool filterActive;
+        bool filterActive{false};
 
     public:
-        HDINLINE DefaultFilter() : filterActive(false)
-        {
-        }
+        HDINLINE DefaultFilter() = default;
 
         template<class FRAME>
         HDINLINE bool operator()(FRAME& frame, lcellId_t id)
@@ -63,12 +61,10 @@ namespace pmacc
     class DefaultFilter<NullFrame>
     {
     private:
-        bool alwaysTrue;
+        bool alwaysTrue{true};
 
     public:
-        HDINLINE DefaultFilter() : alwaysTrue(true)
-        {
-        }
+        HDINLINE DefaultFilter() = default;
 
         template<class FRAME>
         HDINLINE bool operator()(FRAME& frame, lcellId_t id)

--- a/include/pmacc/particles/particleFilter/system/TrueFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/TrueFilter.hpp
@@ -30,9 +30,7 @@ namespace pmacc
     class TrueFilter
     {
     public:
-        HDINLINE TrueFilter()
-        {
-        }
+        HDINLINE TrueFilter() = default;
 
         template<class FRAME>
         HDINLINE bool operator()(FRAME&, lcellId_t)

--- a/include/pmacc/particles/tasks/ParticleFactory.hpp
+++ b/include/pmacc/particles/tasks/ParticleFactory.hpp
@@ -81,9 +81,11 @@ namespace pmacc
             return instance;
         }
 
-        ParticleFactory(){};
+        ParticleFactory() = default;
+        ;
 
-        ParticleFactory(const ParticleFactory&){};
+        ParticleFactory(const ParticleFactory&) = default;
+        ;
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/tasks/ParticleFactory.tpp
+++ b/include/pmacc/particles/tasks/ParticleFactory.tpp
@@ -35,7 +35,7 @@ namespace pmacc
     template<class ParBase>
     inline EventTask ParticleFactory::createTaskParticlesReceive(ParBase& parBase, ITask* registeringTask)
     {
-        TaskParticlesReceive<ParBase>* task = new TaskParticlesReceive<ParBase>(parBase);
+        auto* task = new TaskParticlesReceive<ParBase>(parBase);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }
@@ -46,7 +46,7 @@ namespace pmacc
         uint32_t exchange,
         ITask* registeringTask)
     {
-        TaskReceiveParticlesExchange<ParBase>* task = new TaskReceiveParticlesExchange<ParBase>(parBase, exchange);
+        auto* task = new TaskReceiveParticlesExchange<ParBase>(parBase, exchange);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }
@@ -54,7 +54,7 @@ namespace pmacc
     template<class ParBase>
     inline EventTask ParticleFactory::createTaskParticlesSend(ParBase& parBase, ITask* registeringTask)
     {
-        TaskParticlesSend<ParBase>* task = new TaskParticlesSend<ParBase>(parBase);
+        auto* task = new TaskParticlesSend<ParBase>(parBase);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }
@@ -65,7 +65,7 @@ namespace pmacc
         uint32_t exchange,
         ITask* registeringTask)
     {
-        TaskSendParticlesExchange<ParBase>* task = new TaskSendParticlesExchange<ParBase>(parBase, exchange);
+        auto* task = new TaskSendParticlesExchange<ParBase>(parBase, exchange);
 
         return Environment<>::get().Factory().startTask(*task, registeringTask);
     }

--- a/include/pmacc/particles/tasks/TaskParticlesReceive.hpp
+++ b/include/pmacc/particles/tasks/TaskParticlesReceive.hpp
@@ -32,10 +32,10 @@ namespace pmacc
     class TaskParticlesReceive : public MPITask
     {
     public:
-        typedef T_Particles Particles;
-        typedef typename Particles::HandleGuardRegion HandleGuardRegion;
-        typedef typename HandleGuardRegion::HandleExchanged HandleExchanged;
-        typedef typename HandleGuardRegion::HandleNotExchanged HandleNotExchanged;
+        using Particles = T_Particles;
+        using HandleGuardRegion = typename Particles::HandleGuardRegion;
+        using HandleExchanged = typename HandleGuardRegion::HandleExchanged;
+        using HandleNotExchanged = typename HandleGuardRegion::HandleNotExchanged;
 
         enum
         {
@@ -47,7 +47,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             state = Init;
             EventTask serialEvent = __getTransactionEvent();
@@ -72,7 +72,7 @@ namespace pmacc
             state = WaitForReceived;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(state)
             {
@@ -100,16 +100,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskParticlesReceive()
+        ~TaskParticlesReceive() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskParticlesReceive";
         }

--- a/include/pmacc/particles/tasks/TaskParticlesSend.hpp
+++ b/include/pmacc/particles/tasks/TaskParticlesSend.hpp
@@ -31,10 +31,10 @@ namespace pmacc
     class TaskParticlesSend : public MPITask
     {
     public:
-        typedef T_Particles Particles;
-        typedef typename Particles::HandleGuardRegion HandleGuardRegion;
-        typedef typename HandleGuardRegion::HandleExchanged HandleExchanged;
-        typedef typename HandleGuardRegion::HandleNotExchanged HandleNotExchanged;
+        using Particles = T_Particles;
+        using HandleGuardRegion = typename Particles::HandleGuardRegion;
+        using HandleExchanged = typename HandleGuardRegion::HandleExchanged;
+        using HandleNotExchanged = typename HandleGuardRegion::HandleNotExchanged;
 
         enum
         {
@@ -46,7 +46,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             state = Init;
             EventTask serialEvent = __getTransactionEvent();
@@ -71,7 +71,7 @@ namespace pmacc
             state = WaitForSend;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(state)
             {
@@ -86,16 +86,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskParticlesSend()
+        ~TaskParticlesSend() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskParticlesSend";
         }

--- a/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
@@ -48,7 +48,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             state = Init;
             lastReceiveEvent = parBase.getParticlesBuffer().asyncReceiveParticles(initDependency, exchange);
@@ -56,7 +56,7 @@ namespace pmacc
             state = WaitForReceive;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(state)
             {
@@ -106,16 +106,16 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskReceiveParticlesExchange()
+        ~TaskReceiveParticlesExchange() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskReceiveParticlesExchange";
         }

--- a/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
@@ -49,7 +49,7 @@ namespace pmacc
         {
         }
 
-        virtual void init()
+        void init() override
         {
             state = Init;
             __startTransaction(initDependency);
@@ -58,7 +58,7 @@ namespace pmacc
             state = WaitForBash;
         }
 
-        bool executeIntern()
+        bool executeIntern() override
         {
             switch(state)
             {
@@ -113,7 +113,7 @@ namespace pmacc
             return false;
         }
 
-        virtual ~TaskSendParticlesExchange()
+        ~TaskSendParticlesExchange() override
         {
             notify(this->myId, RECVFINISHED, nullptr);
             if(retryCounter != 0)
@@ -125,11 +125,11 @@ namespace pmacc
             }
         }
 
-        void event(id_t, EventType, IEventData*)
+        void event(id_t, EventType, IEventData*) override
         {
         }
 
-        std::string toString()
+        std::string toString() override
         {
             return "TaskSendParticlesExchange";
         }

--- a/include/pmacc/particles/traits/FilterByFlag.hpp
+++ b/include/pmacc/particles/traits/FilterByFlag.hpp
@@ -41,16 +41,16 @@ namespace pmacc
             template<typename T_MPLSeq, typename T_Flag>
             struct FilterByFlag
             {
-                typedef T_MPLSeq MPLSeq;
-                typedef T_Flag Flag;
+                using MPLSeq = T_MPLSeq;
+                using Flag = T_Flag;
 
                 template<typename T_Species>
                 struct HasFlag
                 {
-                    typedef typename ::pmacc::traits::HasFlag<typename T_Species::FrameType, Flag>::type type;
+                    using type = typename ::pmacc::traits::HasFlag<typename T_Species::FrameType, Flag>::type;
                 };
 
-                typedef typename bmpl::copy_if<MPLSeq, HasFlag<bmpl::_>>::type type;
+                using type = typename bmpl::copy_if<MPLSeq, HasFlag<bmpl::_>>::type;
             };
 
         } // namespace traits

--- a/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
+++ b/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
@@ -70,15 +70,15 @@ namespace pmacc
             template<typename T_SpeciesType, template<typename, typename> class T_Object, typename T_AnyType>
             struct ResolveAliasFromSpecies<T_SpeciesType, T_Object<T_AnyType, pmacc::pmacc_isAlias>>
             {
-                typedef T_SpeciesType SpeciesType;
-                typedef T_Object<T_AnyType, pmacc::pmacc_isAlias> Alias;
-                typedef typename SpeciesType::FrameType FrameType;
+                using SpeciesType = T_SpeciesType;
+                using Alias = T_Object<T_AnyType, pmacc::pmacc_isAlias>;
+                using FrameType = typename SpeciesType::FrameType;
 
                 /* The following line only fetches the alias */
-                typedef typename pmacc::traits::GetFlagType<FrameType, Alias>::type FoundAlias;
+                using FoundAlias = typename pmacc::traits::GetFlagType<FrameType, Alias>::type;
 
                 /* This now resolves the alias into the actual object type */
-                typedef typename pmacc::traits::Resolve<FoundAlias>::type type;
+                using type = typename pmacc::traits::Resolve<FoundAlias>::type;
             }; // struct ResolveAliasFromSpecies
 
         } // namespace traits

--- a/include/pmacc/pluginSystem/INotify.hpp
+++ b/include/pmacc/pluginSystem/INotify.hpp
@@ -31,16 +31,12 @@ namespace pmacc
     class INotify
     {
     protected:
-        uint32_t lastNotify;
+        uint32_t lastNotify{0};
 
     public:
-        INotify() : lastNotify(0)
-        {
-        }
+        INotify() = default;
 
-        virtual ~INotify()
-        {
-        }
+        virtual ~INotify() = default;
 
         /** Notification callback
          *

--- a/include/pmacc/pluginSystem/IPlugin.hpp
+++ b/include/pmacc/pluginSystem/IPlugin.hpp
@@ -54,13 +54,9 @@ namespace pmacc
     class IPlugin : public INotify
     {
     public:
-        IPlugin() : loaded(false), lastCheckpoint(0)
-        {
-        }
+        IPlugin() = default;
 
-        virtual ~IPlugin()
-        {
-        }
+        ~IPlugin() override = default;
 
         virtual void load()
         {
@@ -156,7 +152,7 @@ namespace pmacc
             /* override this function if necessary */
         }
 
-        bool loaded;
-        uint32_t lastCheckpoint;
+        bool loaded{false};
+        uint32_t lastCheckpoint{0};
     };
 } // namespace pmacc

--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -72,7 +72,7 @@ namespace pmacc
         void loadPlugins()
         {
             // load all plugins
-            for(std::list<IPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
             {
                 if(!(*iter)->isLoaded())
                 {
@@ -87,7 +87,7 @@ namespace pmacc
         void unloadPlugins()
         {
             // unload all plugins
-            for(std::list<IPlugin*>::reverse_iterator iter = plugins.rbegin(); iter != plugins.rend(); ++iter)
+            for(auto iter = plugins.rbegin(); iter != plugins.rend(); ++iter)
             {
                 if((*iter)->isLoaded())
                 {
@@ -105,7 +105,7 @@ namespace pmacc
         {
             std::list<po::options_description> help_options;
 
-            for(std::list<IPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
             {
                 // create a new help options section for this plugin,
                 // fill it and add to list of options
@@ -143,7 +143,7 @@ namespace pmacc
          */
         void notifyPlugins(uint32_t currentStep)
         {
-            for(NotificationList::iterator iter = notificationList.begin(); iter != notificationList.end(); ++iter)
+            for(auto iter = notificationList.begin(); iter != notificationList.end(); ++iter)
             {
                 if(containsStep((*iter).second, currentStep))
                 {
@@ -162,7 +162,7 @@ namespace pmacc
          */
         void checkpointPlugins(uint32_t currentStep, const std::string checkpointDirectory)
         {
-            for(std::list<IPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
             {
                 (*iter)->checkpoint(currentStep, checkpointDirectory);
                 (*iter)->setLastCheckpoint(currentStep);
@@ -177,7 +177,7 @@ namespace pmacc
          */
         void restartPlugins(uint32_t restartStep, const std::string restartDirectory)
         {
-            for(std::list<IPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
             {
                 (*iter)->restart(restartStep, restartDirectory);
             }
@@ -193,9 +193,9 @@ namespace pmacc
         std::vector<Plugin*> getPluginsFromType()
         {
             std::vector<Plugin*> result;
-            for(std::list<IPlugin*>::iterator iter = plugins.begin(); iter != plugins.end(); iter++)
+            for(auto iter = plugins.begin(); iter != plugins.end(); iter++)
             {
-                Plugin* plugin = dynamic_cast<Plugin*>(*iter);
+                auto* plugin = dynamic_cast<Plugin*>(*iter);
                 if(plugin != nullptr)
                     result.push_back(plugin);
             }
@@ -220,13 +220,9 @@ namespace pmacc
             return instance;
         }
 
-        PluginConnector()
-        {
-        }
+        PluginConnector() = default;
 
-        virtual ~PluginConnector()
-        {
-        }
+        virtual ~PluginConnector() = default;
 
         std::list<IPlugin*> plugins;
         NotificationList notificationList;

--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -35,18 +35,18 @@ namespace pmacc
         template<class T_RNGProvider>
         struct RNGHandle
         {
-            typedef T_RNGProvider RNGProvider;
+            using RNGProvider = T_RNGProvider;
             static constexpr uint32_t rngDim = RNGProvider::dim;
-            typedef typename RNGProvider::DataBoxType RNGBox;
-            typedef typename RNGProvider::RNGMethod RNGMethod;
-            typedef typename RNGMethod::StateType RNGState;
-            typedef pmacc::DataSpace<rngDim> RNGSpace;
+            using RNGBox = typename RNGProvider::DataBoxType;
+            using RNGMethod = typename RNGProvider::RNGMethod;
+            using RNGState = typename RNGMethod::StateType;
+            using RNGSpace = pmacc::DataSpace<rngDim>;
 
             template<class T_Distribution>
             struct GetRandomType
             {
-                typedef typename T_Distribution::template applyMethod<RNGMethod>::type Distribution;
-                typedef Random<Distribution, RNGMethod, RNGState*> type;
+                using Distribution = typename T_Distribution::template applyMethod<RNGMethod>::type;
+                using type = Random<Distribution, RNGMethod, RNGState*>;
             };
 
             /**

--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -42,22 +42,22 @@ namespace pmacc
         {
         public:
             static constexpr uint32_t dim = T_dim;
-            typedef T_RNGMethod RNGMethod;
-            typedef DataSpace<dim> Space;
+            using RNGMethod = T_RNGMethod;
+            using Space = DataSpace<dim>;
 
         private:
-            typedef typename RNGMethod::StateType RNGState;
+            using RNGState = typename RNGMethod::StateType;
 
         public:
-            typedef HostDeviceBuffer<RNGState, dim> Buffer;
-            typedef typename Buffer::DataBoxType DataBoxType;
-            typedef RNGHandle<RNGProvider> Handle;
+            using Buffer = HostDeviceBuffer<RNGState, dim>;
+            using DataBoxType = typename Buffer::DataBoxType;
+            using Handle = RNGHandle<RNGProvider>;
 
             template<class T_Distribution>
             struct GetRandomType
             {
-                typedef typename T_Distribution::template applyMethod<RNGMethod>::type Distribution;
-                typedef Random<Distribution, RNGMethod, Handle> type;
+                using Distribution = typename T_Distribution::template applyMethod<RNGMethod>::type;
+                using type = Random<Distribution, RNGMethod, Handle>;
             };
 
             /**
@@ -68,7 +68,7 @@ namespace pmacc
              *          (as returned by \ref getName()) is used
              */
             RNGProvider(const Space& size, const std::string& uniqueId = "");
-            virtual ~RNGProvider()
+            ~RNGProvider() override
             {
                 __delete(buffer)
             }

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -101,7 +101,7 @@ namespace pmacc
             T_dim,
             T_RNGMethod>::createRandom(const std::string& id)
         {
-            typedef typename GetRandomType<T_Distribution>::type ResultType;
+            using ResultType = typename GetRandomType<T_Distribution>::type;
             return ResultType(createHandle());
         }
 

--- a/include/pmacc/random/RNGState.hpp
+++ b/include/pmacc/random/RNGState.hpp
@@ -35,12 +35,10 @@ namespace pmacc
         class RNGState
         {
         public:
-            typedef T_RNGMethod RNGMethod;
-            typedef typename RNGMethod::StateType StateType;
+            using RNGMethod = T_RNGMethod;
+            using StateType = typename RNGMethod::StateType;
 
-            HDINLINE RNGState()
-            {
-            }
+            HDINLINE RNGState() = default;
 
             HDINLINE RNGState(const StateType& other) : state(other)
             {

--- a/include/pmacc/random/Random.hpp
+++ b/include/pmacc/random/Random.hpp
@@ -43,11 +43,11 @@ namespace pmacc
             : private T_Distribution
             , private T_RNGStatePtrOrHandle
         {
-            typedef T_RNGMethod RNGMethod;
+            using RNGMethod = T_RNGMethod;
             /* RNGHandle assumed */
-            typedef T_RNGStatePtrOrHandle RNGHandle;
-            typedef T_Distribution Distribution;
-            typedef typename boost::result_of<Distribution(typename RNGHandle::RNGState&)>::type result_type;
+            using RNGHandle = T_RNGStatePtrOrHandle;
+            using Distribution = T_Distribution;
+            using result_type = typename boost::result_of<Distribution(typename RNGHandle::RNGState&)>::type;
 
             /** This can be constructed with either the RNGBox (like the RNGHandle) or from an RNGHandle instance */
             template<class T_RNGBoxOrHandle>
@@ -80,10 +80,10 @@ namespace pmacc
         template<class T_Distribution, class T_RNGMethod, class T_RNGState>
         struct Random<T_Distribution, T_RNGMethod, T_RNGState*> : private T_Distribution
         {
-            typedef T_RNGMethod RNGMethod;
-            typedef T_RNGState RNGState;
-            typedef T_Distribution Distribution;
-            typedef typename boost::result_of<Distribution(RNGState&)>::type result_type;
+            using RNGMethod = T_RNGMethod;
+            using RNGState = T_RNGState;
+            using Distribution = T_Distribution;
+            using result_type = typename boost::result_of<Distribution(RNGState&)>::type;
 
             HDINLINE Random() : m_rngState(nullptr)
             {

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp
@@ -43,11 +43,11 @@ namespace pmacc
                     T_RNGMethod,
                     typename bmpl::if_c<std::is_integral<T_Type>::value && sizeof(T_Type) <= 4, void, T_Type>::type>
                 {
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
 
                 public:
-                    typedef T_Type result_type;
+                    using result_type = T_Type;
 
                     template<typename T_Acc>
                     DINLINE result_type operator()(T_Acc const& acc, StateType& state)

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
@@ -44,11 +44,11 @@ namespace pmacc
                     T_RNGMethod,
                     typename bmpl::if_c<std::is_integral<T_Type>::value && sizeof(T_Type) == 8, void, T_Type>::type>
                 {
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
 
                 public:
-                    typedef T_Type result_type;
+                    using result_type = T_Type;
 
                     template<typename T_Acc>
                     DINLINE result_type operator()(T_Acc const& acc, StateType& state)

--- a/include/pmacc/random/distributions/uniform/Uniform_double.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_double.hpp
@@ -41,9 +41,9 @@ namespace pmacc
                 class Uniform<uniform::ExcludeZero<double>, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef double result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = double;
 
                     template<typename T_Acc>
                     DINLINE double operator()(T_Acc const& acc, StateType& state) const
@@ -62,9 +62,9 @@ namespace pmacc
                 class Uniform<uniform::ExcludeOne<double>::SwapOneToZero, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef double result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = double;
 
                     template<typename T_Acc>
                     DINLINE double operator()(T_Acc const& acc, StateType& state) const
@@ -87,9 +87,9 @@ namespace pmacc
                 class Uniform<uniform::ExcludeOne<double>::Reduced, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef double result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = double;
 
                     template<typename T_Acc>
                     DINLINE double operator()(T_Acc const& acc, StateType& state) const
@@ -109,9 +109,9 @@ namespace pmacc
                 class Uniform<typename uniform::ExcludeOne<double>::Repeat, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef double result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = double;
 
                     template<typename T_Acc>
                     DINLINE result_type operator()(T_Acc const& acc, StateType& state) const

--- a/include/pmacc/random/distributions/uniform/Uniform_float.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_float.hpp
@@ -41,9 +41,9 @@ namespace pmacc
                 class Uniform<uniform::ExcludeZero<float>, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef float result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = float;
 
                     template<typename T_Acc>
                     DINLINE float operator()(T_Acc const& acc, StateType& state) const
@@ -62,9 +62,9 @@ namespace pmacc
                 class Uniform<uniform::ExcludeOne<float>::SwapOneToZero, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef float result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = float;
 
                     template<typename T_Acc>
                     DINLINE float operator()(T_Acc const& acc, StateType& state) const
@@ -87,9 +87,9 @@ namespace pmacc
                 class Uniform<uniform::ExcludeOne<float>::Reduced, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef float result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = float;
 
                     template<typename T_Acc>
                     DINLINE float operator()(T_Acc const& acc, StateType& state) const
@@ -109,9 +109,9 @@ namespace pmacc
                 class Uniform<typename uniform::ExcludeOne<float>::Repeat, T_RNGMethod, void>
                 {
                 public:
-                    typedef T_RNGMethod RNGMethod;
-                    typedef typename RNGMethod::StateType StateType;
-                    typedef float result_type;
+                    using RNGMethod = T_RNGMethod;
+                    using StateType = typename RNGMethod::StateType;
+                    using result_type = float;
 
                     template<typename T_Acc>
                     DINLINE float operator()(T_Acc const& acc, StateType& state) const

--- a/include/pmacc/result_of_Functor.hpp
+++ b/include/pmacc/result_of_Functor.hpp
@@ -47,7 +47,7 @@ namespace pmacc
             typename dummy = mpl::void_>
         struct Functor
         {
-            typedef typename _Functor::result_type type;
+            using type = typename _Functor::result_type;
         };
 
     } // namespace result_of

--- a/include/pmacc/simulationControl/SimulationDescription.hpp
+++ b/include/pmacc/simulationControl/SimulationDescription.hpp
@@ -104,10 +104,10 @@ namespace pmacc
             std::string author;
 
             /** maximum step to run this simulation to */
-            uint32_t runSteps;
+            uint32_t runSteps{0};
 
             /** current time step of simulation */
-            uint32_t currentStep;
+            uint32_t currentStep{0};
 
         private:
             friend struct detail::Environment;
@@ -118,7 +118,7 @@ namespace pmacc
                 return instance;
             }
 
-            SimulationDescription() : author(""), runSteps(0), currentStep(0)
+            SimulationDescription() : author("")
             {
             }
         };

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -65,21 +65,17 @@ namespace pmacc
          *
          */
         SimulationHelper()
-            : runSteps(0)
-            , checkpointDirectory("checkpoints")
-            , numCheckpoints(0)
-            , restartStep(-1)
+            : checkpointDirectory("checkpoints")
             , restartDirectory("checkpoints")
-            , restartRequested(false)
             , CHECKPOINT_MASTER_FILE("checkpoints.txt")
             , author("")
-            , useMpiDirect(false)
+
         {
             tSimulation.toggleStart();
             tInit.toggleStart();
         }
 
-        virtual ~SimulationHelper()
+        ~SimulationHelper() override
         {
             tSimulation.toggleEnd();
             if(output)
@@ -316,7 +312,7 @@ namespace pmacc
             } // softRestarts loop
         }
 
-        virtual void pluginRegisterHelp(po::options_description& desc)
+        void pluginRegisterHelp(po::options_description& desc) override
         {
             // clang-format off
             desc.add_options()
@@ -345,12 +341,12 @@ namespace pmacc
             // clang-format on
         }
 
-        std::string pluginGetName() const
+        std::string pluginGetName() const override
         {
             return "SimulationHelper";
         }
 
-        void pluginLoad()
+        void pluginLoad() override
         {
             Environment<>::get().SimulationDescription().setRunSteps(runSteps);
             Environment<>::get().SimulationDescription().setAuthor(author);
@@ -363,21 +359,21 @@ namespace pmacc
                 restartRequested = true;
         }
 
-        void pluginUnload()
+        void pluginUnload() override
         {
         }
 
-        void restart(uint32_t, const std::string)
+        void restart(uint32_t, const std::string) override
         {
         }
 
-        void checkpoint(uint32_t, const std::string)
+        void checkpoint(uint32_t, const std::string) override
         {
         }
 
     protected:
         /* number of simulation steps to compute */
-        uint32_t runSteps;
+        uint32_t runSteps{0};
 
         /** Presentations: loop the whole simulation `softRestarts` times from
          *                 initial step to runSteps */
@@ -393,16 +389,16 @@ namespace pmacc
         std::string checkpointDirectory;
 
         /* number of checkpoints written */
-        uint32_t numCheckpoints;
+        uint32_t numCheckpoints{0};
 
         /* checkpoint step to restart from */
-        int32_t restartStep;
+        int32_t restartStep{-1};
 
         /* common directory for restarts */
         std::string restartDirectory;
 
         /* restart requested */
-        bool restartRequested;
+        bool restartRequested{false};
 
         /* filename for checkpoint master file with all checkpoint timesteps */
         const std::string CHECKPOINT_MASTER_FILE;
@@ -411,7 +407,7 @@ namespace pmacc
         std::string author;
 
         //! enable MPI gpu direct
-        bool useMpiDirect;
+        bool useMpiDirect{false};
 
         bool tryRestart = false;
 

--- a/include/pmacc/static_assert.hpp
+++ b/include/pmacc/static_assert.hpp
@@ -36,7 +36,7 @@ namespace pmacc
     template<typename T_Type = StaticAssertError>
     struct GetStaticAssertInfoType
     {
-        typedef T_Type type;
+        using type = T_Type;
     };
 } // namespace pmacc
 

--- a/include/pmacc/traits/GetComponentsType.hpp
+++ b/include/pmacc/traits/GetComponentsType.hpp
@@ -42,7 +42,7 @@ namespace pmacc
         template<typename T_Type>
         struct GetComponentsType<T_Type, true>
         {
-            typedef T_Type type;
+            using type = T_Type;
         };
 
     } // namespace traits

--- a/include/pmacc/traits/GetInitializedInstance.hpp
+++ b/include/pmacc/traits/GetInitializedInstance.hpp
@@ -38,7 +38,7 @@ namespace pmacc
         template<typename T_Type>
         struct GetInitializedInstance
         {
-            typedef T_Type Type;
+            using Type = T_Type;
 
             template<typename ValueType>
             HDINLINE Type operator()(const ValueType& value) const

--- a/include/pmacc/traits/GetStringProperties.hpp
+++ b/include/pmacc/traits/GetStringProperties.hpp
@@ -42,12 +42,10 @@ namespace pmacc
          */
         struct StringProperty : public std::map<std::string, StringProperty>
         {
-            typedef std::map<std::string, StringProperty> StringPropertyMap;
+            using StringPropertyMap = std::map<std::string, StringProperty>;
 
             //! empty constructor
-            StringProperty()
-            {
-            }
+            StringProperty() = default;
 
             /** constructor
              *

--- a/include/pmacc/traits/GetUniqueTypeId.hpp
+++ b/include/pmacc/traits/GetUniqueTypeId.hpp
@@ -94,8 +94,8 @@ namespace pmacc
         template<typename T_Type, typename T_ResultType = uint64_t>
         struct GetUniqueTypeId
         {
-            typedef T_ResultType ResultType;
-            typedef T_Type Type;
+            using ResultType = T_ResultType;
+            using Type = T_Type;
 
             /** create unique id
              *

--- a/include/pmacc/traits/GetValueType.hpp
+++ b/include/pmacc/traits/GetValueType.hpp
@@ -28,7 +28,7 @@ namespace pmacc
         template<typename T>
         struct GetValueType
         {
-            typedef typename T::ValueType ValueType;
+            using ValueType = typename T::ValueType;
         };
     } // namespace traits
 } // namespace pmacc

--- a/include/pmacc/traits/GetValueType.tpp
+++ b/include/pmacc/traits/GetValueType.tpp
@@ -28,7 +28,7 @@ namespace pmacc
         template<typename Type>
         struct GetValueType<Type*>
         {
-            typedef Type ValueType;
+            using ValueType = Type;
         };
     } // namespace traits
 } // namespace pmacc

--- a/include/pmacc/traits/Resolve.hpp
+++ b/include/pmacc/traits/Resolve.hpp
@@ -39,7 +39,7 @@ namespace pmacc
         template<typename T_Object>
         struct Resolve
         {
-            typedef T_Object type;
+            using type = T_Object;
         };
 
     } // namespace traits


### PR DESCRIPTION
This PR runs clang-tidy with the modernize checks according to: https://github.com/ComputationalRadiationPhysics/contributing/blob/master/formatting-tools/.clang-tidy

For clang-tidy to work, PMacc needs to be included as non-SYSTEM headers.

I ran clang-tidy like this from the SPEC example .build folder:
```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
run-clang-tidy -fix -header-filter='^((?!/thirdParty/).)*$'
```
Then I revered changes to the cpp files of thirdParty tools.