### PR TITLE
add python env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@
 # Visual Studio Code configuration files
 .vscode
 
-# JetBrains project files
+# JetBrains project files and tmp's
 .idea/
+/venv/
 
 # python byte code
 *.pyc


### PR DESCRIPTION
Cline is creating a python environment within the project, this environment should not be checked in.