### PR TITLE
Avoid overaligning particle frame data

### DIFF
--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -28,7 +28,6 @@
 #include "picongpu/particles/manipulators/manipulators.def"
 
 #include <pmacc/Environment.hpp>
-#include <pmacc/math/MapTuple.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
 #include <pmacc/traits/GetFlagType.hpp>

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -28,7 +28,6 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/communication/AsyncCommunication.hpp>
-#include <pmacc/math/MapTuple.hpp>
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
 #include <pmacc/traits/HasFlag.hpp>
 #if(PMACC_CUDA_ENABLED == 1)

--- a/include/picongpu/particles/access/Cell2Particle.tpp
+++ b/include/picongpu/particles/access/Cell2Particle.tpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include <pmacc/lockstep.hpp>
-#include <pmacc/math/MapTuple.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
 

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -62,8 +62,7 @@ namespace pmacc
     struct Frame
         : public InheritLinearly<typename T_ParticleDescription::MethodsList>
         , protected pmath::MapTuple<
-              typename SeqToMap<typename T_ParticleDescription::ValueTypeSeq, T_CreatePairOperator>::type,
-              pmath::AlignedData>
+              typename SeqToMap<typename T_ParticleDescription::ValueTypeSeq, T_CreatePairOperator>::type>
         , public InheritLinearly<typename OperateOnSeq<
               typename T_ParticleDescription::FrameExtensionList,
               bmpl::apply1<bmpl::_1, Frame<T_CreatePairOperator, T_ParticleDescription>>>::type>
@@ -77,8 +76,7 @@ namespace pmacc
         using FrameExtensionList = typename ParticleDescription::FrameExtensionList;
         using ThisType = Frame<T_CreatePairOperator, ParticleDescription>;
         /* definition of the MapTupel where we inherit from*/
-        using BaseType
-            = pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type, pmath::AlignedData>;
+        using BaseType = pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type>;
 
         /* type of a single particle*/
         using ParticleType = pmacc::Particle<ThisType>;


### PR DESCRIPTION
During my experiments with LLAMA I found that if the particle frame data is not overaligned with `PMACC_ALIGN` we have slight performance gains.

E.g. running the SPEC example on fwk394:
```
./picongpu -d 1 1 1 -g 256 256 256  -s 100 -p 5 --periodic 1 1 1 # dev
calculation  simulation time: 30sec 607msec = 30.607 sec

./picongpu -d 1 1 1 -g 256 256 256  -s 100 -p 5 --periodic 1 1 1 # this PR
calculation  simulation time: 29sec 512msec = 29.512 sec
```
That is a speedup of 1.037. I wonder if that effect is also visible in larger benchmarks. If it is, I would recommend merging this PR.

----------------------
update by @psychocoderHPC:
- [x] merge after 0.6.0 release branch is created