### PR TITLE
Fix supercell indexing for non-zero-offset particle boundaries

### DIFF
--- a/include/picongpu/particles/boundary/Utility.hpp
+++ b/include/picongpu/particles/boundary/Utility.hpp
@@ -158,7 +158,8 @@ namespace picongpu
                 uint32_t const axis = pmacc::boundary::getAxis(exchangeType);
                 numSupercells[axis] = 1;
                 auto const offsetCells = getOffsetCells(species, exchangeType);
-                auto const offsetSupercells = offsetCells / SuperCellSize::toRT()[axis];
+                auto const offsetSupercells
+                    = (offsetCells + SuperCellSize::toRT()[axis] - 1) / SuperCellSize::toRT()[axis];
                 auto const guardSupercells = mappingDescription.getGuardingSuperCells()[axis];
                 if(pmacc::boundary::isMinSide(exchangeType))
                     beginSupercell[axis] = guardSupercells - 1 + offsetSupercells;


### PR DESCRIPTION
The code incorrectly used lower integer part of division instead of upper part. I introduced the bug very recently in #3776 , it had no effect for the default offset=0 case.

Thanks to @lennertsprenger for looking together on his branch, which allowed to quickly find the bug.