### PR TITLE
Fix a bug in particle boundaries in 2d simulations

### DIFF
--- a/include/picongpu/particles/boundary/Utility.hpp
+++ b/include/picongpu/particles/boundary/Utility.hpp
@@ -42,7 +42,8 @@ namespace picongpu
             HINLINE std::vector<uint32_t> getAllAxisAlignedExchanges()
             {
                 auto const numExchanges = NumberOfExchanges<simDim>::value;
-                auto allExchanges = std::vector<uint32_t>(numExchanges);
+                // We need the range 1 <= exchange < numExchanges, so -1 here
+                auto allExchanges = std::vector<uint32_t>(numExchanges - 1);
                 std::iota(allExchanges.begin(), allExchanges.end(), 1);
                 auto result = std::vector<uint32_t>{};
                 std::copy_if(


### PR DESCRIPTION
Thanks to Long Yang for pointing out the bug.

For 3d it was also going one extra. But in 2d that one passed the filter and caused a bug, and for 3d it never got through the filter and so had no effect.