### PR TITLE
Refactor and extend Vector

### DIFF
--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -53,7 +53,7 @@ namespace pmacc
                 {
                     static constexpr int dim = 1;
 
-                    typename math::Size_t<3>::BaseType cuplaGridDim(const math::Size_t<1>& size) const
+                    math::Size_t<3> cuplaGridDim(const math::Size_t<1>& size) const
                     {
                         return math::Size_t<3>(size.x() / BlockSize::x::value, 1u, 1u);
                     }
@@ -82,7 +82,7 @@ namespace pmacc
                 {
                     static constexpr int dim = 2;
 
-                    typename math::Size_t<3>::BaseType cuplaGridDim(const math::Size_t<2>& size) const
+                    math::Size_t<3> cuplaGridDim(const math::Size_t<2>& size) const
                     {
                         return math::Size_t<3>(size.x() / BlockSize::x::value, size.y() / BlockSize::y::value, 1u);
                     }
@@ -116,7 +116,7 @@ namespace pmacc
                 {
                     static constexpr int dim = 3;
 
-                    typename math::Size_t<3>::BaseType cuplaGridDim(const math::Size_t<3>& size) const
+                    math::Size_t<3> cuplaGridDim(const math::Size_t<3>& size) const
                     {
                         return math::Size_t<3>(
                             size.x() / BlockSize::x::value,
@@ -153,9 +153,7 @@ namespace pmacc
                 {
                     static constexpr int dim = 1;
 
-                    typename math::Size_t<3>::BaseType cuplaGridDim(
-                        const math::Size_t<1>& size,
-                        const math::Size_t<3>& blockSize) const
+                    math::Size_t<3> cuplaGridDim(const math::Size_t<1>& size, const math::Size_t<3>& blockSize) const
                     {
                         return math::Size_t<3>(size.x() / blockSize.x(), 1u, 1u);
                     }
@@ -190,9 +188,7 @@ namespace pmacc
                 {
                     static constexpr int dim = 2;
 
-                    typename math::Size_t<3>::BaseType cuplaGridDim(
-                        const math::Size_t<2>& size,
-                        const math::Size_t<3>& blockSize) const
+                    math::Size_t<3> cuplaGridDim(const math::Size_t<2>& size, const math::Size_t<3>& blockSize) const
                     {
                         return math::Size_t<3>(size.x() / blockSize.x(), size.y() / blockSize.y(), 1);
                     }
@@ -229,9 +225,7 @@ namespace pmacc
                 {
                     static constexpr int dim = 3;
 
-                    typename math::Size_t<3>::BaseType cuplaGridDim(
-                        const math::Size_t<3>& size,
-                        const math::Size_t<3>& blockSize) const
+                    math::Size_t<3> cuplaGridDim(const math::Size_t<3>& size, const math::Size_t<3>& blockSize) const
                     {
                         return math::Size_t<3>(
                             size.x() / blockSize.x(),

--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -140,7 +140,7 @@ namespace pmacc
         PMACC_VERIFY(this->_blockDim.y() <= cudaSpecs::MaxNumThreadsPerBlockDim::y::value);                           \
         PMACC_VERIFY(this->_blockDim.z() <= cudaSpecs::MaxNumThreadsPerBlockDim::z::value);                           \
                                                                                                                       \
-        typename math::Size_t<3>::BaseType blockSize(this->_blockDim.x(), this->_blockDim.y(), this->_blockDim.z());  \
+        math::Size_t<3> blockSize(this->_blockDim.x(), this->_blockDim.y(), this->_blockDim.z());                     \
         uint32_t numWorkers = traits::GetNumWorkers<cudaSpecs::MaxNumThreadsPerBlockDim::x::value>::value;            \
         if(numWorkers > blockSize.productOfComponents())                                                              \
             numWorkers = blockSize.productOfComponents();                                                             \

--- a/include/pmacc/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Reduce.tpp
@@ -45,7 +45,7 @@ namespace pmacc
 
                 typedef std::pair<Int<dim>, bool> PosFlag;
                 PosFlag posFlag;
-                posFlag.first = (Int<dim>) con.getPosition();
+                posFlag.first = con.getPosition();
                 posFlag.second = setThisAsRoot;
 
                 int numWorldRanks;

--- a/include/pmacc/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -50,9 +50,7 @@ namespace pmacc
             HDINLINE Data operator()(const Data& data, const math::Int<dim>& jump) const
             {
                 char* result = (char*) data;
-                result += pmacc::math::dot(
-                    static_cast<typename math::Int<dim>::BaseType>(jump),
-                    static_cast<typename math::Int<dim>::BaseType>(this->factor));
+                result += pmacc::math::dot(jump, this->factor);
                 return (Data) result;
             }
 

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -80,7 +80,7 @@ namespace pmacc
             }
         }
 
-        HDINLINE DataSpace(const DataSpace<T_Dim>& value) : BaseType(value)
+        HDINLINE DataSpace(const DataSpace<T_Dim>& value) : BaseType(static_cast<const BaseType&>(value))
         {
         }
 

--- a/include/pmacc/kernel/operation/Atomic.hpp
+++ b/include/pmacc/kernel/operation/Atomic.hpp
@@ -52,12 +52,10 @@ namespace pmacc
                     int T_dim,
                     typename T_DstAccessor,
                     typename T_DstNavigator,
-                    template<typename, int>
-                    class T_DstStorage,
+                    typename T_DstStorage,
                     typename T_SrcAccessor,
                     typename T_SrcNavigator,
-                    template<typename, int>
-                    class T_SrcStorage>
+                    typename T_SrcStorage>
                 HDINLINE void operator()(
                     T_Acc const& acc,
                     pmacc::math::Vector<T_Type, T_dim, T_DstAccessor, T_DstNavigator, T_DstStorage>& dst,

--- a/include/pmacc/math/ConstVector.hpp
+++ b/include/pmacc/math/ConstVector.hpp
@@ -103,9 +103,13 @@
             }                                                                                                         \
         };                                                                                                            \
         /*define a const vector type, ConstArrayStorage is used as Storage policy*/                                   \
-        typedef const pmacc::math::                                                                                   \
-            Vector<Type, Dim, pmacc::math::StandardAccessor, pmacc::math::StandardNavigator, ConstArrayStorage>       \
-                PMACC_JOIN(Name, _t);                                                                                 \
+        typedef const pmacc::math::Vector<                                                                            \
+            Type,                                                                                                     \
+            Dim,                                                                                                      \
+            pmacc::math::StandardAccessor,                                                                            \
+            pmacc::math::StandardNavigator,                                                                           \
+            ConstArrayStorage<Type, Dim>>                                                                             \
+            PMACC_JOIN(Name, _t);                                                                                     \
     } /* namespace pmacc_static_const_storage + id */                                                                 \
     using namespace PMACC_JOIN(pmacc_static_const_storage, id)
 

--- a/include/pmacc/math/vector/Float.hpp
+++ b/include/pmacc/math/vector/Float.hpp
@@ -28,43 +28,6 @@ namespace pmacc
     namespace math
     {
         template<int dim>
-        struct Float : public Vector<float, dim>
-        {
-            using BaseType = Vector<float, dim>;
-
-            HDINLINE Float()
-            {
-            }
-
-            HDINLINE Float(float x) : BaseType(x)
-            {
-            }
-
-            HDINLINE Float(float x, float y) : BaseType(x, y)
-            {
-            }
-
-            HDINLINE Float(float x, float y, float z) : BaseType(x, y, z)
-            {
-            }
-
-            /*! only allow explicit cast*/
-            template<
-                typename T_OtherType,
-                typename T_OtherAccessor,
-                typename T_OtherNavigator,
-                template<typename, int>
-                class T_OtherStorage>
-            HDINLINE explicit Float(
-                const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec)
-                : BaseType(vec)
-            {
-            }
-
-            HDINLINE Float(const BaseType& vec) : BaseType(vec)
-            {
-            }
-        };
-
+        using Float = Vector<float, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/Int.hpp
+++ b/include/pmacc/math/vector/Int.hpp
@@ -28,43 +28,6 @@ namespace pmacc
     namespace math
     {
         template<int dim>
-        struct Int : public Vector<int, dim>
-        {
-            using BaseType = Vector<int, dim>;
-
-            HDINLINE Int()
-            {
-            }
-
-            HDINLINE Int(int x) : BaseType(x)
-            {
-            }
-
-            HDINLINE Int(int x, int y) : BaseType(x, y)
-            {
-            }
-
-            HDINLINE Int(int x, int y, int z) : BaseType(x, y, z)
-            {
-            }
-
-            /*! only allow explicit cast*/
-            template<
-                typename T_OtherType,
-                typename T_OtherAccessor,
-                typename T_OtherNavigator,
-                template<typename, int>
-                class T_OtherStorage>
-            HDINLINE explicit Int(
-                const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec)
-                : BaseType(vec)
-            {
-            }
-
-            HDINLINE Int(const BaseType& vec) : BaseType(vec)
-            {
-            }
-        };
-
+        using Int = Vector<int, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/Size_t.hpp
+++ b/include/pmacc/math/vector/Size_t.hpp
@@ -28,43 +28,6 @@ namespace pmacc
     namespace math
     {
         template<int dim>
-        struct Size_t : public Vector<size_t, dim>
-        {
-            using BaseType = Vector<size_t, dim>;
-
-            HDINLINE Size_t()
-            {
-            }
-
-            HDINLINE Size_t(size_t x) : BaseType(x)
-            {
-            }
-
-            HDINLINE Size_t(size_t x, size_t y) : BaseType(x, y)
-            {
-            }
-
-            HDINLINE Size_t(size_t x, size_t y, size_t z) : BaseType(x, y, z)
-            {
-            }
-
-            /*! only allow explicit cast*/
-            template<
-                typename T_OtherType,
-                typename T_OtherAccessor,
-                typename T_OtherNavigator,
-                template<typename, int>
-                class T_OtherStorage>
-            HDINLINE explicit Size_t(
-                const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec)
-                : BaseType(vec)
-            {
-            }
-
-            HDINLINE Size_t(const BaseType& vec) : BaseType(vec)
-            {
-            }
-        };
-
+        using Size_t = Vector<size_t, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -42,8 +42,7 @@ namespace pmacc
                 int T_Dim,
                 typename T_Accessor,
                 typename T_Navigator,
-                template<typename, int>
-                class T_Storage>
+                typename T_Storage>
             struct TwistComponents<T_Axes, math::Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>>
             {
                 using type = math::Vector<

--- a/include/pmacc/math/vector/UInt32.hpp
+++ b/include/pmacc/math/vector/UInt32.hpp
@@ -28,43 +28,6 @@ namespace pmacc
     namespace math
     {
         template<int dim>
-        struct UInt32 : public Vector<uint32_t, dim>
-        {
-            using BaseType = Vector<uint32_t, dim>;
-
-            HDINLINE UInt32()
-            {
-            }
-
-            HDINLINE UInt32(uint32_t x) : BaseType(x)
-            {
-            }
-
-            HDINLINE UInt32(uint32_t x, uint32_t y) : BaseType(x, y)
-            {
-            }
-
-            HDINLINE UInt32(uint32_t x, uint32_t y, uint32_t z) : BaseType(x, y, z)
-            {
-            }
-
-            /*! only allow explicit cast*/
-            template<
-                typename T_OtherType,
-                typename T_OtherAccessor,
-                typename T_OtherNavigator,
-                template<typename, int>
-                class T_OtherStorage>
-            HDINLINE explicit UInt32(
-                const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec)
-                : BaseType(vec)
-            {
-            }
-
-            HDINLINE UInt32(const BaseType& vec) : BaseType(vec)
-            {
-            }
-        };
-
+        using UInt32 = Vector<uint32_t, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/UInt64.hpp
+++ b/include/pmacc/math/vector/UInt64.hpp
@@ -28,43 +28,6 @@ namespace pmacc
     namespace math
     {
         template<int dim>
-        struct UInt64 : public Vector<uint64_t, dim>
-        {
-            using BaseType = Vector<uint64_t, dim>;
-
-            HDINLINE UInt64()
-            {
-            }
-
-            HDINLINE UInt64(uint64_t x) : BaseType(x)
-            {
-            }
-
-            HDINLINE UInt64(uint64_t x, uint64_t y) : BaseType(x, y)
-            {
-            }
-
-            HDINLINE UInt64(uint64_t x, uint64_t y, uint64_t z) : BaseType(x, y, z)
-            {
-            }
-
-            /*! only allow explicit cast*/
-            template<
-                typename T_OtherType,
-                typename T_OtherAccessor,
-                typename T_OtherNavigator,
-                template<typename, int>
-                class T_OtherStorage>
-            HDINLINE explicit UInt64(
-                const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& vec)
-                : BaseType(vec)
-            {
-            }
-
-            HDINLINE UInt64(const BaseType& vec) : BaseType(vec)
-            {
-            }
-        };
-
+        using UInt64 = Vector<uint64_t, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -122,19 +122,18 @@ namespace pmacc
             int T_dim,
             typename T_Accessor = StandardAccessor,
             typename T_Navigator = StandardNavigator,
-            template<typename, int> class T_Storage = detail::Vector_components>
+            typename T_Storage = detail::Vector_components<T_Type, T_dim>>
         struct Vector
-            : private T_Storage<T_Type, T_dim>
+            : private T_Storage
             , protected T_Accessor
             , protected T_Navigator
         {
-            using Storage = T_Storage<T_Type, T_dim>;
+            using Storage = T_Storage;
             using type = typename Storage::type;
             static constexpr int dim = Storage::dim;
             using tag = tag::Vector;
             using Accessor = T_Accessor;
             using Navigator = T_Navigator;
-            using This = Vector<type, dim, Accessor, Navigator, T_Storage>;
             using ParamType = typename boost::call_traits<type>::param_type;
 
             /*Vectors without elements are not allowed*/
@@ -185,17 +184,24 @@ namespace pmacc
             }
 
             HDINLINE
-            constexpr Vector(const This& other)
+            constexpr Vector(const Vector& other)
             {
                 detail::CopyElementWise<Storage::isConst>()(*this, other);
+            }
+
+            template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
+            HDINLINE Vector(const Vector<T_Type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
+                : Storage{}
+            {
+                for(int i = 0; i < dim; i++)
+                    (*this)[i] = other[i];
             }
 
             template<
                 typename T_OtherType,
                 typename T_OtherAccessor,
                 typename T_OtherNavigator,
-                template<typename, int>
-                class T_OtherStorage>
+                typename T_OtherStorage>
             HDINLINE explicit Vector(
                 const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
@@ -217,28 +223,28 @@ namespace pmacc
              * @return new Vector<...>
              */
             HDINLINE
-            static This create(ParamType value)
+            static Vector create(ParamType value)
             {
-                This result;
+                Vector result;
                 for(int i = 0; i < dim; i++)
                     result[i] = value;
 
                 return result;
             }
 
-            HDINLINE const This& toRT() const
+            HDINLINE const Vector& toRT() const
             {
                 return *this;
             }
 
-            HDINLINE This& toRT()
+            HDINLINE Vector& toRT()
             {
                 return *this;
             }
 
-            HDINLINE This revert()
+            HDINLINE Vector revert()
             {
-                This invertedVector;
+                Vector invertedVector;
                 for(int i = 0; i < dim; i++)
                     invertedVector[dim - 1 - i] = (*this)[i];
 
@@ -247,8 +253,8 @@ namespace pmacc
 
             constexpr HDINLINE Vector& operator=(const Vector&) = default;
 
-            template<typename T_OtherAccessor, typename T_OtherNavigator, template<typename, int> class T_OtherStorage>
-            HDINLINE This& operator=(const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
+            template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
+            HDINLINE Vector& operator=(const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
             {
                 for(int i = 0; i < dim; i++)
                     (*this)[i] = rhs[i];
@@ -363,8 +369,8 @@ namespace pmacc
              * @param other instance with same type and dimension like the left instance
              * @return reference to manipulated left instance
              */
-            template<typename T_OtherAccessor, typename T_OtherNavigator, template<typename, int> class T_OtherStorage>
-            HDINLINE This& operator+=(
+            template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
+            HDINLINE Vector& operator+=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
                 for(int i = 0; i < dim; i++)
@@ -376,8 +382,8 @@ namespace pmacc
              * @param other instance with same type and dimension like the left instance
              * @return reference to manipulated left instance
              */
-            template<typename T_OtherAccessor, typename T_OtherNavigator, template<typename, int> class T_OtherStorage>
-            HDINLINE This& operator-=(
+            template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
+            HDINLINE Vector& operator-=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
                 for(int i = 0; i < dim; i++)
@@ -389,8 +395,8 @@ namespace pmacc
              * @param other instance with same type and dimension like the left instance
              * @return reference to manipulated left instance
              */
-            template<typename T_OtherAccessor, typename T_OtherNavigator, template<typename, int> class T_OtherStorage>
-            HDINLINE This& operator*=(
+            template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
+            HDINLINE Vector& operator*=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
                 for(int i = 0; i < dim; i++)
@@ -402,8 +408,8 @@ namespace pmacc
              * @param other instance with same type and dimension like the left instance
              * @return reference to manipulated left instance
              */
-            template<typename T_OtherAccessor, typename T_OtherNavigator, template<typename, int> class T_OtherStorage>
-            HDINLINE This& operator/=(
+            template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
+            HDINLINE Vector& operator/=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
                 for(int i = 0; i < dim; i++)
@@ -411,28 +417,28 @@ namespace pmacc
                 return *this;
             }
 
-            HDINLINE This& operator+=(ParamType other)
+            HDINLINE Vector& operator+=(ParamType other)
             {
                 for(int i = 0; i < dim; i++)
                     (*this)[i] += other;
                 return *this;
             }
 
-            HDINLINE This& operator-=(ParamType other)
+            HDINLINE Vector& operator-=(ParamType other)
             {
                 for(int i = 0; i < dim; i++)
                     (*this)[i] -= other;
                 return *this;
             }
 
-            HDINLINE This& operator*=(ParamType other)
+            HDINLINE Vector& operator*=(ParamType other)
             {
                 for(int i = 0; i < dim; i++)
                     (*this)[i] *= other;
                 return *this;
             }
 
-            HDINLINE This& operator/=(ParamType other)
+            HDINLINE Vector& operator/=(ParamType other)
             {
                 for(int i = 0; i < dim; i++)
                     (*this)[i] /= other;
@@ -447,7 +453,7 @@ namespace pmacc
              * @param other Vector to compare to
              * @return true if all components in both vectors are equal, else false
              */
-            HDINLINE bool operator==(const This& rhs) const
+            HDINLINE bool operator==(const Vector& rhs) const
             {
                 bool result = true;
                 for(int i = 0; i < dim; i++)
@@ -463,7 +469,7 @@ namespace pmacc
              * @param other Vector to compare to
              * @return true if one component in both vectors are not equal, else false
              */
-            HDINLINE bool operator!=(const This& rhs) const
+            HDINLINE bool operator!=(const Vector& rhs) const
             {
                 return !((*this) == rhs);
             }
@@ -512,6 +518,30 @@ namespace pmacc
                 return result;
             }
         };
+
+        template<
+            std::size_t I,
+            typename T_Type,
+            int T_dim,
+            typename T_Accessor,
+            typename T_Navigator,
+            typename T_Storage>
+        auto get(const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& v)
+        {
+            return v[I];
+        }
+
+        template<
+            std::size_t I,
+            typename T_Type,
+            int T_dim,
+            typename T_Accessor,
+            typename T_Navigator,
+            typename T_Storage>
+        auto& get(Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& v)
+        {
+            return v[I];
+        }
 
         template<typename Type>
         struct Vector<Type, 0>
@@ -566,12 +596,10 @@ namespace pmacc
             int T_Dim,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE Vector<T_Type, T_Dim> operator+(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
@@ -583,13 +611,7 @@ namespace pmacc
             return result;
         }
 
-        template<
-            typename T_Type,
-            int T_Dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         HDINLINE Vector<T_Type, T_Dim> operator+(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
@@ -606,12 +628,10 @@ namespace pmacc
             int T_Dim,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE Vector<T_Type, T_Dim> operator-(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
@@ -623,13 +643,7 @@ namespace pmacc
             return result;
         }
 
-        template<
-            typename T_Type,
-            int T_Dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         HDINLINE Vector<T_Type, T_Dim> operator-(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
@@ -646,12 +660,10 @@ namespace pmacc
             int T_Dim,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE Vector<T_Type, T_Dim> operator*(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
@@ -668,12 +680,10 @@ namespace pmacc
             int T_Dim,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE Vector<T_Type, T_Dim> operator/(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
@@ -685,13 +695,7 @@ namespace pmacc
             return result;
         }
 
-        template<
-            typename T_Type,
-            int T_Dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         HDINLINE Vector<T_Type, T_Dim> operator*(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
@@ -703,13 +707,7 @@ namespace pmacc
             return result;
         }
 
-        template<
-            typename T_Type,
-            int T_Dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         HDINLINE Vector<T_Type, T_Dim> operator*(
             typename boost::call_traits<T_Type>::param_type lhs,
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& rhs)
@@ -721,13 +719,7 @@ namespace pmacc
             return result;
         }
 
-        template<
-            typename T_Type,
-            int T_Dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         HDINLINE Vector<T_Type, T_Dim> operator/(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
@@ -739,13 +731,7 @@ namespace pmacc
             return result;
         }
 
-        template<
-            typename T_Type,
-            int T_Dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         HDINLINE Vector<T_Type, T_Dim> operator-(const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& vec)
         {
             /* to avoid allocation side effects the result is always a vector
@@ -762,12 +748,10 @@ namespace pmacc
             int T_Dim,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE Vector<bool, T_Dim> operator>=(
             const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
             const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
@@ -784,12 +768,10 @@ namespace pmacc
             typename T_Type,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE T_Type linearize(
             const Vector<T_Type, 1, T_Accessor, T_Navigator, T_Storage>& size,
             const Vector<T_Type, 2, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& pos)
@@ -801,12 +783,10 @@ namespace pmacc
             typename T_Type,
             typename T_Accessor,
             typename T_Navigator,
-            template<typename, int>
-            class T_Storage,
+            typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
-            template<typename, int>
-            class T_OtherStorage>
+            typename T_OtherStorage>
         HDINLINE T_Type linearize(
             const Vector<T_Type, 2, T_Accessor, T_Navigator, T_Storage>& size,
             const Vector<T_Type, 3, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& pos)
@@ -858,3 +838,18 @@ namespace pmacc
 
     } // namespace result_of
 } // namespace pmacc
+
+namespace std
+{
+    template<typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+    struct tuple_size<pmacc::math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
+    {
+        static constexpr std::size_t value = T_dim;
+    };
+
+    template<std::size_t I, typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+    struct tuple_element<I, pmacc::math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
+    {
+        using type = T_Type;
+    };
+} // namespace std

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -53,13 +53,7 @@ namespace pmacc
             static constexpr uint32_t value = (uint32_t) pmacc::math::Vector<T_DataType, T_Dim>::dim;
         };
 
-        template<
-            typename T_Type,
-            int T_dim,
-            typename T_Accessor,
-            typename T_Navigator,
-            template<typename, int>
-            class T_Storage>
+        template<typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         struct GetInitializedInstance<math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
         {
             using Type = math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>;
@@ -259,13 +253,7 @@ namespace pmacc
     {
         namespace precisionCast
         {
-            template<
-                typename CastToType,
-                int dim,
-                typename T_Accessor,
-                typename T_Navigator,
-                template<typename, int>
-                class T_Storage>
+            template<typename CastToType, int dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
             struct TypeCast<CastToType, ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>>
             {
                 using result = const ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>&;
@@ -282,8 +270,7 @@ namespace pmacc
                 int dim,
                 typename T_Accessor,
                 typename T_Navigator,
-                template<typename, int>
-                class T_Storage>
+                typename T_Storage>
             struct TypeCast<CastToType, ::pmacc::math::Vector<OldType, dim, T_Accessor, T_Navigator, T_Storage>>
             {
                 using result = ::pmacc::math::Vector<CastToType, dim>;


### PR DESCRIPTION
* simplify `T_Storage` policy to a normal type parameter
* make derived vectors for specific types aliases
* implement tuple interface for Vector (allows structured bindings)
* replace alias `This` by injected class name `Vector`

This PR fell out of the LLAMA integration.