### PR TITLE
Remove more old boost includes and replace with std:: counterparts

### DIFF
--- a/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -26,19 +26,10 @@
 #include <pmacc/cuSTL/cursor/navigator/PlusNavigator.hpp>
 #include <pmacc/cuSTL/cursor/tools/LinearInterp.hpp>
 
-#include <boost/array.hpp>
-#if(BOOST_VERSION == 106400)
-/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
- * the error
- * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
- * in boost 1.64.0
- * see boost issue https://svn.boost.org/trac/boost/ticket/12516
- */
-#    include <boost/serialization/array_wrapper.hpp>
-#endif
 #include <boost/math/tools/minima.hpp>
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 
+#include <array>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -160,7 +151,7 @@ namespace picongpu
                     {
                         namespace odeint = boost::numeric::odeint;
 
-                        using state_type = boost::array<float_64, 1>;
+                        using state_type = std::array<float_64, 1>;
 
                         state_type integral_result = {0.0};
                         const float_64 lowerLimit = 0.0;

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -29,18 +29,6 @@
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
 #include <pmacc/particles/traits/ResolveAliasFromSpecies.hpp>
 
-#include <boost/array.hpp>
-#if(BOOST_VERSION == 106400)
-/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
- * the error
- * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
- * in boost 1.64.0
- * see boost issue https://svn.boost.org/trac/boost/ticket/12516
- */
-#    include <boost/serialization/array_wrapper.hpp>
-#endif
-#include <boost/numeric/odeint/integrate/integrate.hpp>
-
 #include <limits>
 #include <memory>
 

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -23,18 +23,9 @@
 
 #include "picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp"
 
-#include <boost/array.hpp>
-#if(BOOST_VERSION == 106400)
-/* `array_wrapper.hpp` must be included before `integrate.hpp` to avoid
- * the error
- * `boost/numeric/ublas/matrix.hpp(5977): error: namespace "boost::serialization" has no member "make_array"`
- * in boost 1.64.0
- * see boost issue https://svn.boost.org/trac/boost/ticket/12516
- */
-#    include <boost/serialization/array_wrapper.hpp>
-#endif
 #include <boost/numeric/odeint/integrate/integrate.hpp>
 
+#include <array>
 
 namespace picongpu
 {
@@ -77,7 +68,7 @@ namespace picongpu
                     return float_64(0.0);
 
                 using namespace boost::numeric::odeint;
-                using state_type = boost::array<float_64, 1>;
+                using state_type = std::array<float_64, 1>;
 
                 state_type integral_result = {0.0};
                 const float_64 upper_bound(SYNC_FUNCS_F1_INTEGRAL_BOUND);

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -30,8 +30,6 @@
 #include "pmacc/cuSTL/container/copier/Memcopy.hpp"
 #include "pmacc/static_assert.hpp"
 
-#include <boost/utility/enable_if.hpp>
-
 #include <exception>
 #include <sstream>
 #include <type_traits>
@@ -132,8 +130,8 @@ namespace pmacc
             }
 
             template<typename HBuffer>
-            HINLINE typename boost::
-                enable_if<std::is_same<typename HBuffer::memoryTag, allocator::tag::host>, DeviceBuffer&>::type
+            HINLINE typename std::
+                enable_if_t<std::is_same<typename HBuffer::memoryTag, allocator::tag::host>::value, DeviceBuffer&>
                 operator=(const HBuffer& rhs)
             {
                 PMACC_CASSERT(std::is_same<typename HBuffer::type, Type>::value);

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -28,8 +28,8 @@
 #include "pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp"
 #include "pmacc/cuSTL/container/copier/D2DCopier.hpp"
 #include "pmacc/cuSTL/container/copier/Memcopy.hpp"
+#include "pmacc/static_assert.hpp"
 
-#include <boost/assert.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <exception>
@@ -136,8 +136,8 @@ namespace pmacc
                 enable_if<std::is_same<typename HBuffer::memoryTag, allocator::tag::host>, DeviceBuffer&>::type
                 operator=(const HBuffer& rhs)
             {
-                BOOST_STATIC_ASSERT((std::is_same<typename HBuffer::type, Type>::value));
-                BOOST_STATIC_ASSERT(HBuffer::dim == T_dim);
+                PMACC_CASSERT(std::is_same<typename HBuffer::type, Type>::value);
+                PMACC_CASSERT(HBuffer::dim == T_dim);
                 if(rhs.size() != this->size())
                     throw std::invalid_argument(static_cast<std::stringstream&>(
                                                     std::stringstream()

--- a/include/pmacc/cuSTL/container/HostBuffer.hpp
+++ b/include/pmacc/cuSTL/container/HostBuffer.hpp
@@ -29,8 +29,6 @@
 #include "pmacc/cuSTL/container/copier/Memcopy.hpp"
 #include "pmacc/static_assert.hpp"
 
-#include <boost/utility/enable_if.hpp>
-
 #include <exception>
 #include <sstream>
 #include <type_traits>
@@ -146,8 +144,8 @@ namespace pmacc
             }
 
             template<typename DBuffer>
-            HINLINE typename boost::
-                enable_if<std::is_same<typename DBuffer::memoryTag, allocator::tag::device>, HostBuffer&>::type
+            HINLINE typename std::
+                enable_if_t<std::is_same<typename DBuffer::memoryTag, allocator::tag::device>::value, HostBuffer&>
                 operator=(const DBuffer& rhs)
             {
                 PMACC_CASSERT(std::is_same<typename DBuffer::type, Type>::value);

--- a/include/pmacc/cuSTL/container/HostBuffer.hpp
+++ b/include/pmacc/cuSTL/container/HostBuffer.hpp
@@ -27,8 +27,8 @@
 #include "pmacc/cuSTL/container/assigner/HostMemAssigner.hpp"
 #include "pmacc/cuSTL/container/copier/H2HCopier.hpp"
 #include "pmacc/cuSTL/container/copier/Memcopy.hpp"
+#include "pmacc/static_assert.hpp"
 
-#include <boost/assert.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <exception>
@@ -150,8 +150,8 @@ namespace pmacc
                 enable_if<std::is_same<typename DBuffer::memoryTag, allocator::tag::device>, HostBuffer&>::type
                 operator=(const DBuffer& rhs)
             {
-                BOOST_STATIC_ASSERT((std::is_same<typename DBuffer::type, Type>::value));
-                BOOST_STATIC_ASSERT(DBuffer::dim == T_dim);
+                PMACC_CASSERT(std::is_same<typename DBuffer::type, Type>::value);
+                PMACC_CASSERT(DBuffer::dim == T_dim);
                 if(rhs.size() != this->size())
                     throw std::invalid_argument(static_cast<std::stringstream&>(
                                                     std::stringstream()

--- a/include/pmacc/math/Tuple.hpp
+++ b/include/pmacc/math/Tuple.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/static_assert.hpp"
 #include "pmacc/types.hpp"
 
 #include <boost/mpl/at.hpp>
@@ -37,7 +38,6 @@
 #include <boost/preprocessor/repetition/enum_params.hpp>
 #include <boost/preprocessor/repetition/enum_shifted_params.hpp>
 #include <boost/preprocessor/repetition/repeat_from_to.hpp>
-#include <boost/static_assert.hpp>
 
 namespace pmacc
 {
@@ -53,7 +53,7 @@ namespace pmacc
         : value(arg0)                                                                                                 \
         , base(BOOST_PP_ENUM_SHIFTED_PARAMS(N, arg))                                                                  \
     {                                                                                                                 \
-        BOOST_STATIC_ASSERT(dim == N);                                                                                \
+        PMACC_CASSERT(dim == N);                                                                                      \
     }
 
         namespace mpl = boost::mpl;
@@ -88,7 +88,7 @@ namespace pmacc
 
             HDINLINE Tuple(Value arg0) : value(arg0)
             {
-                BOOST_STATIC_ASSERT(dim == 1);
+                PMACC_CASSERT(dim == 1);
             }
 
             BOOST_PP_REPEAT_FROM_TO(2, BOOST_PP_INC(TUPLE_MAX_DIM), CONSTRUCTOR, _)

--- a/include/pmacc/traits/GetUniqueTypeId.hpp
+++ b/include/pmacc/traits/GetUniqueTypeId.hpp
@@ -24,8 +24,7 @@
 
 #include "pmacc/types.hpp"
 
-#include <boost/numeric/conversion/bounds.hpp>
-
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -101,7 +100,7 @@ namespace pmacc
              *
              * @param maxValue largest allowed id
              */
-            static const ResultType uid(uint64_t maxValue = boost::numeric::bounds<ResultType>::highest())
+            static const ResultType uid(uint64_t maxValue = std::numeric_limits<ResultType>::max())
             {
                 const uint64_t id = detail::TypeId<Type>::id;
 

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -57,7 +57,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/mpl/placeholders.hpp>
-#include <boost/typeof/std/utility.hpp>
 
 #include <cupla.hpp>
 


### PR DESCRIPTION
Among easily removable Boost parts I think only `result_of` is remaining.