### PR TITLE
Refactor DataBox

### DIFF
--- a/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
+++ b/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
@@ -24,58 +24,40 @@
 
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
-#include "pmacc/types.hpp"
+
+#include <cstdint>
 
 namespace pmacc
 {
-    template<class T_Base>
-    class DataBoxDim1Access : protected T_Base
+    template<typename T_Base>
+    struct DataBoxDim1Access : protected T_Base
     {
-    public:
         using Base = T_Base;
-        static constexpr uint32_t Dim = Base::Dim;
-
-
+        static constexpr std::uint32_t Dim = Base::Dim;
         using ValueType = typename Base::ValueType;
         using RefValueType = typename Base::RefValueType;
 
-
-        HDINLINE RefValueType operator()(const pmacc::DataSpace<DIM1>& idx = pmacc::DataSpace<DIM1>()) const
+        HDINLINE DataBoxDim1Access(DataSpace<Dim> const& originalSize) : Base(), originalSize(originalSize)
         {
-            const pmacc::DataSpace<Dim> real_idx(DataSpaceOperations<Dim>::map(originalSize, idx.x()));
-            return Base::operator()(real_idx);
         }
 
-        HDINLINE RefValueType operator()(const pmacc::DataSpace<DIM1>& idx = pmacc::DataSpace<DIM1>())
-        {
-            const pmacc::DataSpace<Dim> real_idx(DataSpaceOperations<Dim>::map(originalSize, idx.x()));
-            return Base::operator()(real_idx);
-        }
-
-        HDINLINE RefValueType operator[](const int idx) const
-        {
-            const pmacc::DataSpace<Dim> real_idx(DataSpaceOperations<Dim>::map(originalSize, idx));
-            return Base::operator()(real_idx);
-        }
-
-        HDINLINE RefValueType operator[](const int idx)
-        {
-            const pmacc::DataSpace<Dim> real_idx(DataSpaceOperations<Dim>::map(originalSize, idx));
-            return Base::operator()(real_idx);
-        }
-
-        HDINLINE DataBoxDim1Access(const Base base, const pmacc::DataSpace<Dim> originalSize)
-            : Base(base)
+        HDINLINE DataBoxDim1Access(Base base, DataSpace<Dim> const& originalSize)
+            : Base(std::move(base))
             , originalSize(originalSize)
         {
         }
 
-        HDINLINE DataBoxDim1Access(const pmacc::DataSpace<Dim> originalSize) : Base(), originalSize(originalSize)
+        HDINLINE RefValueType operator()(DataSpace<DIM1> const& idx = {}) const
         {
+            return (*this)[idx.x()];
+        }
+
+        HDINLINE RefValueType operator[](const int idx) const
+        {
+            return Base::operator()(DataSpaceOperations<Dim>::map(originalSize, idx));
         }
 
     private:
-        PMACC_ALIGN(originalSize, const pmacc::DataSpace<Dim>);
+        PMACC_ALIGN(originalSize, const DataSpace<Dim>);
     };
-
 } // namespace pmacc

--- a/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#include "pmacc/dimensions/DataSpace.hpp"
-#include "pmacc/types.hpp"
-
+#include <cstdint>
 
 namespace pmacc
 {
@@ -34,24 +32,19 @@ namespace pmacc
      *         - template parameter of functor is the input type for the functor
      *         - functor must have defined the result type as ::result
      */
-    template<class T_Base, template<typename> class T_UnaryFunctor>
+    template<typename T_Base, template<typename> class T_UnaryFunctor>
     class DataBoxUnaryTransform : public T_Base
     {
     public:
         using Base = T_Base;
-        using BaseValueType = typename Base::ValueType;
-
-        using UnaryFunctor = T_UnaryFunctor<BaseValueType>;
-
+        using UnaryFunctor = T_UnaryFunctor<typename Base::ValueType>;
         using ValueType = typename UnaryFunctor::result;
         using RefValueType = ValueType;
-        static constexpr uint32_t Dim = Base::Dim;
+        static constexpr std::uint32_t Dim = Base::Dim;
 
-        HDINLINE DataBoxUnaryTransform(const Base& base) : Base(base)
-        {
-        }
+        HDINLINE DataBoxUnaryTransform() = default;
 
-        HDINLINE DataBoxUnaryTransform() : Base()
+        HDINLINE DataBoxUnaryTransform(Base base) : Base(std::move(base))
         {
         }
 
@@ -62,22 +55,9 @@ namespace pmacc
         }
 
         template<typename T_Index>
-        HDINLINE ValueType operator()(const T_Index& idx)
-        {
-            return UnaryFunctor()(Base::operator()(idx));
-        }
-
-        template<typename T_Index>
-        HDINLINE ValueType operator[](const T_Index idx)
-        {
-            return UnaryFunctor()(Base::operator[](idx));
-        }
-
-        template<typename T_Index>
         HDINLINE ValueType operator[](const T_Index idx) const
         {
             return UnaryFunctor()(Base::operator[](idx));
         }
     };
-
 } // namespace pmacc

--- a/include/pmacc/memory/boxes/SharedBox.hpp
+++ b/include/pmacc/memory/boxes/SharedBox.hpp
@@ -22,16 +22,35 @@
 #pragma once
 
 #include "pmacc/math/Vector.hpp"
-#include "pmacc/math/vector/Float.hpp"
 #include "pmacc/memory/Array.hpp"
 #include "pmacc/memory/shared/Allocate.hpp"
 #include "pmacc/types.hpp"
 
 #include "pmacc/cuSTL/cursor/compile-time/BufferCursor.hpp"
 
-
 namespace pmacc
 {
+    namespace detail
+    {
+        template<typename T_Vector, typename T_TYPE>
+        HDINLINE auto& subscript(T_TYPE* p, int const idx, std::integral_constant<uint32_t, 1>)
+        {
+            return p[idx];
+        }
+
+        template<typename T_Vector, typename T_TYPE>
+        HDINLINE auto* subscript(T_TYPE* p, int const idx, std::integral_constant<uint32_t, 2>)
+        {
+            return p + idx * T_Vector::x::value;
+        }
+
+        template<typename T_Vector, typename T_TYPE>
+        HDINLINE auto* subscript(T_TYPE* p, int const idx, std::integral_constant<uint32_t, 3>)
+        {
+            return p + idx * (T_Vector::x::value * T_Vector::y::value);
+        }
+    } // namespace detail
+
     /** create shared memory on gpu
      *
      * @tparam T_TYPE type of memory objects
@@ -40,102 +59,30 @@ namespace pmacc
      *              (is needed if more than one instance of shared memory in one kernel is used)
      * @tparam T_dim dimension of the memory (supports DIM1,DIM2 and DIM3)
      */
-    template<typename T_TYPE, class T_Vector, uint32_t T_id = 0, uint32_t T_dim = T_Vector::dim>
-    class SharedBox;
-
-    template<typename T_TYPE, class T_Vector, uint32_t T_id>
-    class SharedBox<T_TYPE, T_Vector, T_id, DIM1>
+    template<typename T_TYPE, typename T_Vector, uint32_t T_id = 0, uint32_t T_dim = T_Vector::dim>
+    struct SharedBox
     {
-    public:
-        enum
-        {
-            Dim = DIM1
-        };
+        static constexpr std::uint32_t Dim = T_dim;
+
         using ValueType = T_TYPE;
         using RefValueType = ValueType&;
         using Size = T_Vector;
-        using ReducedType = SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id>;
-        using This = SharedBox<ValueType, T_Vector, T_id, 1U>;
 
-        HDINLINE RefValueType operator[](const int idx)
-        {
-            return fixedPointer[idx];
-        }
-
-        HDINLINE RefValueType operator[](const int idx) const
-        {
-            return fixedPointer[idx];
-        }
-
-        HDINLINE SharedBox(ValueType* pointer) : fixedPointer(pointer)
+        HDINLINE
+        SharedBox(ValueType* pointer = nullptr) : fixedPointer(pointer)
         {
         }
 
-        DINLINE SharedBox() : fixedPointer(nullptr)
-        {
-        }
-
-        /*!return the first value in the box (list)
-         * @return first value
-         */
-        HDINLINE RefValueType operator*()
-        {
-            return *(fixedPointer);
-        }
-
-        HDINLINE ValueType const* getPointer() const
-        {
-            return fixedPointer;
-        }
-        HDINLINE ValueType* getPointer()
-        {
-            return fixedPointer;
-        }
-
-        /** create a shared memory box
-         *
-         * This call synchronizes a block and must be called from all threads and
-         * not inside a if clauses
-         */
-        template<typename T_Acc>
-        static DINLINE SharedBox init(T_Acc const& acc)
-        {
-            auto& mem_sh
-                = pmacc::memory::shared::allocate<T_id, memory::Array<ValueType, math::CT::volume<Size>::type::value>>(
-                    acc);
-            return SharedBox(mem_sh.data());
-        }
-
-    protected:
-        PMACC_ALIGN(fixedPointer, ValueType*);
-    };
-
-    template<typename T_TYPE, class T_Vector, uint32_t T_id>
-    class SharedBox<T_TYPE, T_Vector, T_id, DIM2>
-    {
-    public:
-        enum
-        {
-            Dim = DIM2
-        };
-        using ValueType = T_TYPE;
-        using RefValueType = ValueType&;
-        using Size = T_Vector;
-        using ReducedType = SharedBox<ValueType, math::CT::Int<Size::x::value>, T_id>;
-        using This = SharedBox<ValueType, T_Vector, T_id, 2U>;
-
-        HDINLINE SharedBox(ValueType* pointer = nullptr) : fixedPointer(pointer)
-        {
-        }
-
-        HDINLINE ReducedType operator[](const int idx)
-        {
-            return ReducedType(this->fixedPointer + idx * Size::x::value);
-        }
+        using ReducedType1D = T_TYPE&;
+        using ReducedType2D = SharedBox<T_TYPE, math::CT::Int<T_Vector::x::value>, T_id>;
+        using ReducedType3D = SharedBox<T_TYPE, math::CT::Int<T_Vector::x::value, T_Vector::y::value>, T_id>;
+        using ReducedType
+            = std::conditional_t<Dim == 1, ReducedType1D, std::conditional_t<Dim == 2, ReducedType2D, ReducedType3D>>;
 
         HDINLINE ReducedType operator[](const int idx) const
         {
-            return ReducedType(this->fixedPointer + idx * Size::x::value);
+            ///@todo(bgruber): inline and replace this by if constexpr in C++17
+            return {detail::subscript<T_Vector>(fixedPointer, idx, std::integral_constant<uint32_t, T_dim>{})};
         }
 
         /*!return the first value in the box (list)
@@ -143,7 +90,7 @@ namespace pmacc
          */
         HDINLINE RefValueType operator*()
         {
-            return *((ValueType*) fixedPointer);
+            return *fixedPointer;
         }
 
         HDINLINE ValueType const* getPointer() const
@@ -155,88 +102,17 @@ namespace pmacc
             return fixedPointer;
         }
 
-        /** create a shared memory box
-         *
-         * This call synchronizes a block and must be called from all threads and
-         * not inside a if clauses
-         */
-        template<typename T_Acc>
-        static DINLINE SharedBox init(T_Acc const& acc)
-        {
-            auto& mem_sh
-                = pmacc::memory::shared::allocate<T_id, memory::Array<ValueType, math::CT::volume<Size>::type::value>>(
-                    acc);
-            return SharedBox(mem_sh.data());
-        }
+        using CursorPitch1d = math::CT::Int<>;
+        using CursorPitch2d = math::CT::Int<sizeof(T_TYPE) * T_Vector::x::value>;
+        using CursorPitch3d = math::CT::
+            Int<sizeof(T_TYPE) * T_Vector::x::value, sizeof(T_TYPE) * T_Vector::x::value * T_Vector::y::value>;
+        using CursorPitch
+            = std::conditional_t<Dim == 1, CursorPitch1d, std::conditional_t<Dim == 2, CursorPitch2d, CursorPitch3d>>;
 
-        HDINLINE pmacc::cursor::CT::BufferCursor<ValueType, ::pmacc::math::CT::Int<sizeof(ValueType) * Size::x::value>>
-        toCursor() const
+        HDINLINE
+        cursor::CT::BufferCursor<T_TYPE, CursorPitch> toCursor() const
         {
-            return pmacc::cursor::CT::
-                BufferCursor<ValueType, ::pmacc::math::CT::Int<sizeof(ValueType) * Size::x::value>>(
-                    (ValueType*) fixedPointer);
-        }
-
-    protected:
-        PMACC_ALIGN(fixedPointer, ValueType*);
-    };
-
-    template<typename T_TYPE, class T_Vector, uint32_t T_id>
-    class SharedBox<T_TYPE, T_Vector, T_id, DIM3>
-    {
-    public:
-        enum
-        {
-            Dim = DIM3
-        };
-        using ValueType = T_TYPE;
-        using RefValueType = ValueType&;
-        using Size = T_Vector;
-        using ReducedType = SharedBox<ValueType, math::CT::Int<Size::x::value, Size::y::value>, T_id>;
-        using This = SharedBox<ValueType, T_Vector, T_id, 3U>;
-
-        HDINLINE ReducedType operator[](const int idx)
-        {
-            return ReducedType(this->fixedPointer + idx * (Size::x::value * Size::y::value));
-        }
-
-        HDINLINE ReducedType operator[](const int idx) const
-        {
-            return ReducedType(this->fixedPointer + idx * (Size::x::value * Size::y::value));
-        }
-
-        HDINLINE SharedBox(ValueType* pointer = nullptr) : fixedPointer(pointer)
-        {
-        }
-
-        /*!return the first value in the box (list)
-         * @return first value
-         */
-        HDINLINE RefValueType operator*()
-        {
-            return *(fixedPointer);
-        }
-
-        HDINLINE ValueType const* getPointer() const
-        {
-            return fixedPointer;
-        }
-        HDINLINE ValueType* getPointer()
-        {
-            return fixedPointer;
-        }
-
-        HDINLINE pmacc::cursor::CT::BufferCursor<
-            ValueType,
-            ::pmacc::math::CT::
-                Int<sizeof(ValueType) * Size::x::value, sizeof(ValueType) * Size::x::value * Size::y::value>>
-        toCursor() const
-        {
-            return pmacc::cursor::CT::BufferCursor<
-                ValueType,
-                ::pmacc::math::CT::
-                    Int<sizeof(ValueType) * Size::x::value, sizeof(ValueType) * Size::x::value * Size::y::value>>(
-                (ValueType*) fixedPointer);
+            return {const_cast<T_TYPE*>(this->fixedPointer)};
         }
 
         /** create a shared memory box
@@ -248,14 +124,11 @@ namespace pmacc
         static DINLINE SharedBox init(T_Acc const& acc)
         {
             auto& mem_sh
-                = pmacc::memory::shared::allocate<T_id, memory::Array<ValueType, math::CT::volume<Size>::type::value>>(
-                    acc);
-            return SharedBox(mem_sh.data());
+                = memory::shared::allocate<T_id, memory::Array<ValueType, math::CT::volume<Size>::type::value>>(acc);
+            return {mem_sh.data()};
         }
 
     protected:
         PMACC_ALIGN(fixedPointer, ValueType*);
     };
-
-
 } // namespace pmacc


### PR DESCRIPTION
This PR simplifies `DataBox` and its related classes.

Here are two quick runs on fwk394:
PR:
calculation  simulation time: 31sec 423msec = 31.423 sec
calculation  simulation time: 32sec 870msec = 32.870 sec

dev:
calculation  simulation time: 31sec 311msec = 31.311 sec
calculation  simulation time: 32sec 903msec = 32.903 sec