### PR TITLE
Fix warning and MSVC error

### DIFF
--- a/include/picongpu/particles/boundary/Utility.hpp
+++ b/include/picongpu/particles/boundary/Utility.hpp
@@ -125,7 +125,6 @@ namespace picongpu
                 {
                     auto axis = pmacc::boundary::getAxis(exchangeType);
                     auto offsetCells = getOffsetCells(species, exchangeType);
-                    SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
                     if(pmacc::boundary::isMinSide(exchangeType))
                         (*begin)[axis] += offsetCells;
                     if(pmacc::boundary::isMaxSide(exchangeType))

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -105,7 +105,7 @@ namespace pmacc
         template<uint32_t T_area>
         void shiftParticles()
         {
-            this->template shiftParticles(StrideAreaMapperFactory<T_area, 3>{});
+            this->shiftParticles(StrideAreaMapperFactory<T_area, 3>{});
         }
 
         /** Shift all particles in the area defined by the given factory


### PR DESCRIPTION
This PR fixes a warning on an unused variable and an error when compiling with MSVC.