### PR TITLE
fix Summit(ORNL) MPI collectives

### DIFF
--- a/etc/picongpu/summit-ornl/gpu_batch.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch.tpl
@@ -82,6 +82,10 @@ fi
 mkdir simOutput 2> /dev/null
 cd simOutput
 
+# fix MPI collectives by disabling IBM's optimized barriers
+# https://github.com/ComputationalRadiationPhysics/picongpu/issues/3814
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
 #jsrun  -N 1 -n !TBG_nodes !TBG_dstPath/input/bin/cuda_memtest.sh
 
 #if [ $? -eq 0 ] ; then

--- a/etc/picongpu/summit-ornl/gpu_batch_pipe.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch_pipe.tpl
@@ -90,7 +90,10 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 mkdir -p openPMD
 
-#if [ $? -eq 0 ] ; then
+# fix MPI collectives by disabling IBM's optimized barriers
+# https://github.com/ComputationalRadiationPhysics/picongpu/issues/3814
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
 export OMP_NUM_THREADS=!TBG_coresPerGPU
 
 # Note: chunk distribution strategies are not yet mainlined in openPMD
@@ -118,4 +121,3 @@ jsrun --nrs !TBG_pipeInstances --tasks_per_rs 1 --cpu_per_rs !TBG_coresPerPipeIn
 wait
 
 # note: instead of the PIConGPU binary, one can also debug starting "js_task_info | sort"
-#fi

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -56,6 +56,10 @@ export PATH=$PATH:$PICSRC/src/tools/bin
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
+# fix MPI collectives by disabling IBM's optimized barriers
+# https://github.com/ComputationalRadiationPhysics/picongpu/issues/3814
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
 alias getNode="bsub -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"
 
 # "tbg" default options #######################################################


### PR DESCRIPTION
fix #3814

Workaround IBM optimized barriers.

Co-authored-by: Axel Huebl <axel.huebl@plasma.ninja>


Note: I added the bash variable which is required to work around the bug to the profile and template to take care that interactive sessions started with `getNode` were fixed too.