### PR TITLE
adjust physics log output

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
@@ -44,17 +44,20 @@ namespace picongpu
                  * The default implementation checks the basic explicit PIC assumption c * dt <= min(dx, dy, dz).
                  * Note that generally FDTD-type field solvers have a more strict condition, and have to provide a
                  * specialization.
+                 *
+                 * @return value of 'X' to fulfill the condition 'c * dt <= X`
                  */
-                void operator()() const
+                float_X operator()() const
                 {
+                    constexpr auto minCellSize = std::min({CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH});
                     /* Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
                      * (in this case, could have depended on T_FieldSolver as well)
                      */
                     PMACC_CASSERT_MSG(
                         Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
-                        (SPEED_OF_LIGHT * DELTA_T / CELL_WIDTH <= 1.0)
-                            && (SPEED_OF_LIGHT * DELTA_T / CELL_HEIGHT <= 1.0)
-                            && (SPEED_OF_LIGHT * DELTA_T / CELL_DEPTH <= 1.0) && sizeof(T_Defer*) != 0);
+                        (SPEED_OF_LIGHT * DELTA_T / minCellSize <= 1.0) && sizeof(T_Defer*) != 0);
+
+                    return minCellSize;
                 }
             };
 

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -25,7 +25,6 @@
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/fields/LaserPhysics.hpp"
-#include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/FDTD/FDTD.def"
 #include "picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel"
 #include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
@@ -59,7 +58,6 @@ namespace picongpu
 
                 FDTD(MappingDesc const cellDescription) : cellDescription(cellDescription)
                 {
-                    CFLChecker<FDTD>{}();
                     LaserChecker<FDTD>{}();
                     DataConnector& dc = Environment<>::get().DataConnector();
                     fieldE = dc.get<FieldE>(FieldE::getName(), true);

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -21,7 +21,6 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/None/None.def"
 #include "picongpu/fields/cellType/Yee.hpp"
@@ -46,8 +45,6 @@ namespace picongpu
 
                 None(MappingDesc)
                 {
-                    // Note: the default CFL checker is sufficient, thus it is not specialized for None
-                    CFLChecker<None>{}();
                     LaserChecker<None>{}();
                 }
 

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -41,14 +41,19 @@ namespace picongpu
             template<typename T_Defer>
             struct CFLChecker<Yee, T_Defer>
             {
-                //! Check the CFL condition, doesn't compile when failed
-                void operator()() const
+                /** Check the CFL condition, doesn't compile when failed
+                 *
+                 * @return value of 'X' to fulfill the condition 'c * dt <= X`
+                 */
+                float_X operator()() const
                 {
                     // Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
                     PMACC_CASSERT_MSG(
                         Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
                         (SPEED_OF_LIGHT * SPEED_OF_LIGHT * DELTA_T * DELTA_T * INV_CELL2_SUM) <= 1.0
                             && sizeof(T_Defer*) != 0);
+
+                    return 1.0_X / math::sqrt(INV_CELL2_SUM);
                 }
             };
 


### PR DESCRIPTION
fix #3201

Simplify the log output for the field solver condition and omega_p.

@sbastrakov The field condition for our Lehe solver is currently `c * dt <= min(dx, dy, dz)` is this correct. 
I assume that we do not know the correct condition and therefore we fall back to the default.