### PR TITLE
Rename type to Reference in Cursor

### DIFF
--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -38,7 +38,7 @@ namespace pmacc
         template<typename T_Cursor>
         struct Functor<picongpu::AssignedTrilinearInterpolation, T_Cursor>
         {
-            using type = typename std::remove_reference_t<typename T_Cursor::type>;
+            using type = typename T_Cursor::ValueType;
         };
 
     } // namespace result_of

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -49,7 +49,7 @@ namespace picongpu
                         ::pmacc::cursor::tools::LinearInterp<float_X>,
                         ::pmacc::cursor::BufferCursor<float_X, DIM1>>::type;
 
-                    using type = float_X;
+                    using Reference = float_X;
 
                     LinInterpCursor linInterpCursor;
 

--- a/include/pmacc/cuSTL/cursor/Cursor.hpp
+++ b/include/pmacc/cuSTL/cursor/Cursor.hpp
@@ -50,8 +50,8 @@ namespace pmacc
             , _Navigator
         {
         public:
-            using type = typename _Accessor::type;
-            typedef typename std::remove_reference_t<type> ValueType;
+            using Reference = typename _Accessor::Reference;
+            using ValueType = std::remove_reference_t<Reference>;
             using Accessor = _Accessor;
             using Navigator = _Navigator;
             using Marker = _Marker;
@@ -75,7 +75,7 @@ namespace pmacc
              * Typically a reference to the current selected single datum.
              */
             HDINLINE
-            type operator*()
+            Reference operator*()
             {
                 return Accessor::operator()(this->marker);
             }
@@ -86,7 +86,7 @@ namespace pmacc
              * the same as for the non-const method above.
              */
             HDINLINE
-            type operator*() const
+            Reference operator*() const
             {
                 return Accessor::operator()(this->marker);
             }
@@ -135,13 +135,13 @@ namespace pmacc
 
             /* jump and access in one call */
             template<typename Jump>
-            HDINLINE type operator[](const Jump& jump)
+            HDINLINE Reference operator[](const Jump& jump)
             {
                 return *((*this)(jump));
             }
 
             template<typename Jump>
-            HDINLINE type operator[](const Jump& jump) const
+            HDINLINE Reference operator[](const Jump& jump) const
             {
                 return *((*this)(jump));
             }
@@ -187,7 +187,7 @@ namespace pmacc
 
         namespace traits
         {
-            /* type trait to get the cursor's dimension if it has one */
+            /* Reference trait to get the cursor's dimension if it has one */
             template<typename _Accessor, typename _Navigator, typename _Marker>
             struct dim<pmacc::cursor::Cursor<_Accessor, _Navigator, _Marker>>
             {

--- a/include/pmacc/cuSTL/cursor/FunctorCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/FunctorCursor.hpp
@@ -40,10 +40,7 @@ namespace pmacc
          * @param functor User functor acting as a filter.
          */
         template<typename TCursor, typename Functor>
-        HDINLINE Cursor<
-            FunctorAccessor<Functor, typename std::remove_reference_t<typename TCursor::type>>,
-            CursorNavigator,
-            TCursor>
+        HDINLINE Cursor<FunctorAccessor<Functor, typename TCursor::ValueType>, CursorNavigator, TCursor>
         make_FunctorCursor(const TCursor& cursor, const Functor& functor)
         {
             return make_Cursor(

--- a/include/pmacc/cuSTL/cursor/accessor/CursorAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/CursorAccessor.hpp
@@ -30,9 +30,9 @@ namespace pmacc
         template<typename TCursor>
         struct CursorAccessor
         {
-            using type = typename TCursor::type;
+            using Reference = typename TCursor::Reference;
 
-            HDINLINE type operator()(TCursor& cursor)
+            HDINLINE Reference operator()(TCursor& cursor)
             {
                 return *cursor;
             }

--- a/include/pmacc/cuSTL/cursor/accessor/FunctorAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/FunctorAccessor.hpp
@@ -32,14 +32,14 @@ namespace pmacc
         {
             _Functor functor;
 
-            using type = typename ::pmacc::result_of::Functor<_Functor, ArgType>::type;
+            using Reference = typename ::pmacc::result_of::Functor<_Functor, ArgType>::type;
 
             HDINLINE FunctorAccessor(const _Functor& functor) : functor(functor)
             {
             }
 
             template<typename TCursor>
-            HDINLINE type operator()(TCursor& cursor)
+            HDINLINE Reference operator()(TCursor& cursor)
             {
                 return this->functor(*cursor);
             }

--- a/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
@@ -42,7 +42,7 @@ namespace pmacc
         struct LinearInterpAccessor<T_Cursor, DIM1>
         {
             using Cursor = T_Cursor;
-            using type = typename Cursor::ValueType;
+            using Reference = typename Cursor::ValueType;
 
             Cursor cursor;
 
@@ -54,7 +54,7 @@ namespace pmacc
             }
 
             template<typename T_Position>
-            HDINLINE type operator()(const T_Position pos) const
+            HDINLINE Reference operator()(const T_Position pos) const
             {
                 BOOST_STATIC_ASSERT(T_Position::dim == DIM1);
 
@@ -65,12 +65,12 @@ namespace pmacc
 
                 const math::Int<DIM1> idx1D(static_cast<int>(intPart[0]));
 
-                type result = pmacc::traits::GetInitializedInstance<type>()(0.0);
+                Reference result = pmacc::traits::GetInitializedInstance<Reference>()(0.0);
                 using PositionComp = typename T_Position::type;
                 for(int i = 0; i < 2; i++)
                 {
                     const PositionComp weighting1D = (i == 0 ? (PositionComp(1.0) - fracPart[0]) : fracPart[0]);
-                    result += static_cast<type>(weighting1D * this->cursor[idx1D + math::Int<DIM1>(i)]);
+                    result += static_cast<Reference>(weighting1D * this->cursor[idx1D + math::Int<DIM1>(i)]);
                 }
 
                 return result;
@@ -81,7 +81,7 @@ namespace pmacc
         struct LinearInterpAccessor<T_Cursor, DIM2>
         {
             using Cursor = T_Cursor;
-            using type = typename T_Cursor::ValueType;
+            using Reference = typename T_Cursor::ValueType;
 
             Cursor cursor;
 
@@ -93,7 +93,7 @@ namespace pmacc
             }
 
             template<typename T_Position>
-            HDINLINE type operator()(const T_Position pos) const
+            HDINLINE Reference operator()(const T_Position pos) const
             {
                 BOOST_STATIC_ASSERT(T_Position::dim == DIM2);
 
@@ -105,7 +105,7 @@ namespace pmacc
 
                 const math::Int<DIM2> idx2D(static_cast<int>(intPart[0]), static_cast<int>(intPart[1]));
 
-                type result = pmacc::traits::GetInitializedInstance<type>()(0.0);
+                Reference result = pmacc::traits::GetInitializedInstance<Reference>()(0.0);
                 using PositionComp = typename T_Position::type;
                 for(int i = 0; i < 2; i++)
                 {
@@ -114,7 +114,7 @@ namespace pmacc
                     {
                         const PositionComp weighting2D
                             = weighting1D * (j == 0 ? (PositionComp(1.0) - fracPart[1]) : fracPart[1]);
-                        result += static_cast<type>(weighting2D * this->cursor[idx2D + math::Int<DIM2>(i, j)]);
+                        result += static_cast<Reference>(weighting2D * this->cursor[idx2D + math::Int<DIM2>(i, j)]);
                     }
                 }
 
@@ -126,7 +126,7 @@ namespace pmacc
         struct LinearInterpAccessor<T_Cursor, DIM3>
         {
             using Cursor = T_Cursor;
-            using type = typename T_Cursor::ValueType;
+            using Reference = typename T_Cursor::ValueType;
 
             Cursor cursor;
 
@@ -138,7 +138,7 @@ namespace pmacc
             }
 
             template<typename T_Position>
-            HDINLINE type operator()(const T_Position pos) const
+            HDINLINE Reference operator()(const T_Position pos) const
             {
                 BOOST_STATIC_ASSERT(T_Position::dim == DIM3);
 
@@ -154,7 +154,7 @@ namespace pmacc
                     static_cast<int>(intPart[1]),
                     static_cast<int>(intPart[2]));
 
-                type result = pmacc::traits::GetInitializedInstance<type>()(0.0);
+                Reference result = pmacc::traits::GetInitializedInstance<Reference>()(0.0);
                 using PositionComp = typename T_Position::type;
                 for(int i = 0; i < 2; i++)
                 {
@@ -167,7 +167,8 @@ namespace pmacc
                         {
                             const PositionComp weighting3D
                                 = weighting2D * (k == 0 ? (PositionComp(1.0) - fracPart[2]) : fracPart[2]);
-                            result += static_cast<type>(weighting3D * this->cursor[idx3D + math::Int<DIM3>(i, j, k)]);
+                            result += static_cast<Reference>(
+                                weighting3D * this->cursor[idx3D + math::Int<DIM3>(i, j, k)]);
                         }
                     }
                 }

--- a/include/pmacc/cuSTL/cursor/accessor/MarkerAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/MarkerAccessor.hpp
@@ -28,7 +28,7 @@ namespace pmacc
         template<typename Marker>
         struct MarkerAccessor
         {
-            using type = const Marker;
+            using Reference = const Marker;
             /** returns the cursor's marker.
              *
              * Here a copy of marker is returned because the cursor object
@@ -37,7 +37,7 @@ namespace pmacc
              * FunctorAccessor or Cursor::getMarker().
              */
             HDINLINE
-            type operator()(const Marker& marker) const
+            Reference operator()(const Marker& marker) const
             {
                 return marker;
             }

--- a/include/pmacc/cuSTL/cursor/accessor/PointerAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/PointerAccessor.hpp
@@ -28,7 +28,7 @@ namespace pmacc
         template<typename Type>
         struct PointerAccessor
         {
-            using type = Type&;
+            using Reference = Type&;
 
             /** Returns the dereferenced pointer of type 'Type'
              *
@@ -37,7 +37,7 @@ namespace pmacc
              * There is no danger if the cursor object is temporary.
              */
             template<typename Data>
-            HDINLINE type operator()(Data& data) const
+            HDINLINE Reference operator()(Data& data) const
             {
                 return *((Type*) data);
             }

--- a/include/pmacc/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
@@ -31,19 +31,19 @@ namespace pmacc
         template<typename TCursor, typename Axes>
         struct TwistAxesAccessor
         {
-            using type = typename math::result_of::TwistComponents<Axes, typename TCursor::ValueType>::type;
+            using Reference = typename math::result_of::TwistComponents<Axes, typename TCursor::ValueType>::type;
 
             /** Returns a reference to the result of '*cursor' (with twisted axes).
              *
              * Be aware that the underlying cursor must not be a temporary object if '*cursor'
              * refers to something inside the cursor.
              */
-            HDINLINE type operator()(TCursor& cursor)
+            HDINLINE Reference operator()(TCursor& cursor)
             {
                 return math::twistComponents<Axes>(*cursor);
             }
 
-            ///\todo: implement const method here with a const TCursor& argument and 'type' as return type.
+            ///\todo: implement const method here with a const TCursor& argument and 'Reference' as return type.
         };
 
     } // namespace cursor


### PR DESCRIPTION
This PR renames `type` in Cursor to `Reference` to better reflect their semantic.