### PR TITLE
Replace PitchedBox ctor with offset by DataBox.shift()

### DIFF
--- a/include/picongpu/plugins/output/GatherSlice.hpp
+++ b/include/picongpu/plugins/output/GatherSlice.hpp
@@ -115,7 +115,6 @@ namespace picongpu
 
             Box dstBox = Box(PitchedBox<ValueType, DIM2>(
                 (ValueType*) filteredData,
-                DataSpace<DIM2>(),
                 header.sim.size,
                 header.sim.size.x() * sizeof(ValueType)));
 
@@ -176,7 +175,6 @@ namespace picongpu
                 /*create box with valid memory*/
                 dstBox = Box(PitchedBox<ValueType, DIM2>(
                     (ValueType*) filteredData,
-                    DataSpace<DIM2>(),
                     header.sim.size,
                     header.sim.size.x() * sizeof(ValueType)));
 
@@ -189,7 +187,6 @@ namespace picongpu
                         % head->node.offset.toString();
                     Box srcBox = Box(PitchedBox<ValueType, DIM2>(
                         (ValueType*) (fullData + displs[i]),
-                        DataSpace<DIM2>(),
                         head->node.maxSize,
                         head->node.maxSize.x() * sizeof(ValueType)));
 

--- a/include/pmacc/memory/boxes/PitchedBox.hpp
+++ b/include/pmacc/memory/boxes/PitchedBox.hpp
@@ -82,13 +82,7 @@ namespace pmacc
         {
         }
 
-        ///@todo(bgruber): is this functionality not provide by DataBox::shift?
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM1>& offset) : Base{pointer + offset[0]}
-        {
-        }
-
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM1>& offset, const DataSpace<DIM1>&, const size_t)
-            : PitchedBox(pointer, offset)
+        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM1>& /*memSize*/, const size_t /*pitch*/) : Base(pointer)
         {
         }
 
@@ -113,15 +107,9 @@ namespace pmacc
         {
         }
 
-        ///@todo(bgruber): is this functionality not provide by DataBox::shift?
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM2>& offset, size_t pitch)
-            : Base{(TYPE*) ((char*) pointer + offset[1] * pitch) + offset[0]}
+        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM2>& /*memSize*/, const size_t pitch)
+            : Base{pointer}
             , pitch(pitch)
-        {
-        }
-
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM2>& offset, const DataSpace<DIM2>&, const size_t pitch)
-            : PitchedBox(pointer, offset, pitch)
         {
         }
 
@@ -160,12 +148,8 @@ namespace pmacc
          * @param pitch number of bytes in one line (first dimension)
          */
         ///@todo(bgruber): is this functionality not provide by DataBox::shift?
-        HDINLINE PitchedBox(
-            TYPE* pointer,
-            const DataSpace<DIM3>& offset,
-            const DataSpace<DIM3>& memSize,
-            const size_t pitch)
-            : Base{(TYPE*) ((char*) pointer + offset[2] * (memSize[1] * pitch) + offset[1] * pitch) + offset[0]}
+        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM3>& memSize, const size_t pitch)
+            : Base{pointer}
             , pitch(pitch)
             , pitch2D(memSize[1] * pitch)
         {

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -118,8 +118,8 @@ namespace pmacc
         DataBoxType getDataBox() override
         {
             __startOperation(ITask::TASK_DEVICE);
-            return DataBoxType(
-                PitchedBox<TYPE, DIM>((TYPE*) data.ptr, offset, this->getPhysicalMemorySize(), data.pitch));
+            return DataBoxType(PitchedBox<TYPE, DIM>((TYPE*) data.ptr, this->getPhysicalMemorySize(), data.pitch))
+                .shift(offset);
         }
 
         TYPE* getPointer() override

--- a/include/pmacc/memory/buffers/HostBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/HostBufferIntern.hpp
@@ -138,7 +138,6 @@ namespace pmacc
             __startOperation(ITask::TASK_HOST);
             return DataBoxType(PitchedBox<TYPE, DIM>(
                 pointer,
-                DataSpace<DIM>(),
                 this->getPhysicalMemorySize(),
                 this->getPhysicalMemorySize()[0] * sizeof(TYPE)));
         }

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -45,7 +45,7 @@ namespace pmacc
             TYPE* currentSizePointer,
             TYPE maxSize,
             PushDataBox<TYPE, PushType> virtualMemory)
-            : DataBox<PitchedBox<VALUE, DIM1>>(PitchedBox<VALUE, DIM1>(data, DataSpace<DIM1>()))
+            : DataBox<PitchedBox<VALUE, DIM1>>(PitchedBox<VALUE, DIM1>(data))
             , currentSizePointer(currentSizePointer)
             , maxSize(maxSize)
             , virtualMemory(virtualMemory)

--- a/include/pmacc/particles/memory/boxes/PushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/PushDataBox.hpp
@@ -47,8 +47,9 @@ namespace pmacc
          * @param offset relative offset to pointer start address
          * @param currentSize size of the buffer data points to
          */
-        HDINLINE PushDataBox(VALUE* data, TYPE* currentSize, DataSpace<DIM1> offset = DataSpace<DIM1>(0))
-            : DataBox<PitchedBox<VALUE, DIM1>>(PitchedBox<VALUE, DIM1>(data, offset))
+        HDINLINE PushDataBox(VALUE* data, TYPE* currentSize, DataSpace<DIM1> offset = {})
+            : DataBox<PitchedBox<VALUE, DIM1>>(
+                DataBox<PitchedBox<VALUE, DIM1>>{PitchedBox<VALUE, DIM1>(data)}.shift(offset))
             , currentSize(currentSize)
             , maxSize(0) /*\todo implement max size*/
         {

--- a/include/pmacc/particles/memory/boxes/TileDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/TileDataBox.hpp
@@ -50,8 +50,8 @@ namespace pmacc
             using type = const TYPE&;
         };
 
-        HDINLINE VectorDataBox(TYPE* pointer, const DataSpace<DIM1>& offset = DataSpace<DIM1>(0))
-            : BaseType(PitchedBox<TYPE, DIM1>(pointer, offset))
+        HDINLINE VectorDataBox(TYPE* pointer, const DataSpace<DIM1>& offset = {})
+            : BaseType(BaseType(PitchedBox<TYPE, DIM1>(pointer)).shift(offset))
         {
         }
 


### PR DESCRIPTION
Replace `PitchedBox` ctor with offset by `DataBox.shift()`. This unifies the shifting with how `SharedBox` is shifted and simplifies the ctor overload set of `PitchedBox`.

No change in CUDA register consumption.