### PR TITLE
Use multidim access instead of two subscripts

### DIFF
--- a/include/picongpu/plugins/output/GatherSlice.hpp
+++ b/include/picongpu/plugins/output/GatherSlice.hpp
@@ -216,7 +216,7 @@ namespace picongpu
             {
                 for(int x = 0; x < srcSize.x(); ++x)
                 {
-                    dst[y + offsetToSimNull.y()][x + offsetToSimNull.x()] = src[y][x];
+                    dst({x + offsetToSimNull.x(), y + offsetToSimNull.y()}) = src({x, y});
                 }
             }
         }

--- a/include/picongpu/plugins/output/images/PngCreator.tpp
+++ b/include/picongpu/plugins/output/images/PngCreator.tpp
@@ -67,7 +67,7 @@ namespace picongpu
         {
             for(int x = 0; x < size.x(); ++x)
             {
-                float3_X p = data[y][x];
+                float3_X p = data({x, y});
                 png.plot(x + 1, size.y() - y, p.x(), p.y(), p.z());
             }
         }

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -789,10 +789,10 @@ namespace picongpu
 
             if(picongpu::white_box_per_GPU)
             {
-                hostBox[0][0] = float3_X(1.0, 1.0, 1.0);
-                hostBox[size.y() - 1][0] = float3_X(1.0, 1.0, 1.0);
-                hostBox[0][size.x() - 1] = float3_X(1.0, 1.0, 1.0);
-                hostBox[size.y() - 1][size.x() - 1] = float3_X(1.0, 1.0, 1.0);
+                hostBox({0, 0}) = float3_X(1.0, 1.0, 1.0);
+                hostBox({0, size.y() - 1}) = float3_X(1.0, 1.0, 1.0);
+                hostBox({size.x() - 1, 0}) = float3_X(1.0, 1.0, 1.0);
+                hostBox({size.x() - 1, size.y() - 1}) = float3_X(1.0, 1.0, 1.0);
             }
             auto resultBox = gather(hostBox, *header);
             if(isMaster)


### PR DESCRIPTION
This PR replaces chained uses of the subscript operator on `DataBox`es by their corresponding call operators. This eases a potential later LLAMA integration.