### PR TITLE
Remove boost::result_of

### DIFF
--- a/include/picongpu/fields/cellType/Centered.hpp
+++ b/include/picongpu/fields/cellType/Centered.hpp
@@ -51,16 +51,6 @@ namespace picongpu
             using PosType = pmacc::math::Vector<float_X, T_simDim>;
             using ReturnType = const pmacc::math::Vector<PosType, DIM3>;
 
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = ReturnType;
-            };
-
             HDINLINE FieldPosition()
             {
             }
@@ -93,15 +83,6 @@ namespace picongpu
              *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector2D3V = const ::pmacc::math::Vector<float2_X, DIM3>;
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = VectorVector2D3V;
-            };
 
             HDINLINE FieldPosition()
             {
@@ -126,15 +107,6 @@ namespace picongpu
              *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector3D3V = const ::pmacc::math::Vector<float3_X, DIM3>;
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = VectorVector3D3V;
-            };
 
             HDINLINE FieldPosition()
             {
@@ -159,16 +131,6 @@ namespace picongpu
         {
             using FieldPos = pmacc::math::Vector<float_X, T_simDim>;
             using ReturnType = pmacc::math::Vector<FieldPos, DIM1>;
-
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = ReturnType;
-            };
 
             HDINLINE FieldPosition()
             {

--- a/include/picongpu/fields/cellType/Yee.hpp
+++ b/include/picongpu/fields/cellType/Yee.hpp
@@ -51,15 +51,6 @@ namespace picongpu
              *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector2D3V = const ::pmacc::math::Vector<float2_X, DIM3>;
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = VectorVector2D3V;
-            };
 
             HDINLINE FieldPosition() = default;
 
@@ -83,16 +74,6 @@ namespace picongpu
              */
             using VectorVector3D3V = const ::pmacc::math::Vector<float3_X, DIM3>;
 
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = VectorVector3D3V;
-            };
-
             HDINLINE FieldPosition() = default;
 
             HDINLINE VectorVector3D3V operator()() const
@@ -114,15 +95,6 @@ namespace picongpu
              *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector2D3V = const ::pmacc::math::Vector<float2_X, DIM3>;
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = VectorVector2D3V;
-            };
 
             HDINLINE FieldPosition() = default;
 
@@ -145,16 +117,6 @@ namespace picongpu
              *  @tparam DIM3     Fields (E/B/J) have 3 components, even in 1 or 2D !
              */
             using VectorVector3D3V = const ::pmacc::math::Vector<float3_X, DIM3>;
-
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = VectorVector3D3V;
-            };
 
             HDINLINE FieldPosition() = default;
 
@@ -187,16 +149,6 @@ namespace picongpu
         {
             using FieldPos = pmacc::math::Vector<float_X, T_simDim>;
             using ReturnType = pmacc::math::Vector<FieldPos, DIM1>;
-
-            /// boost::result_of hints
-            template<class>
-            struct result;
-
-            template<class F>
-            struct result<F()>
-            {
-                using type = ReturnType;
-            };
 
             HDINLINE FieldPosition() = default;
 

--- a/include/pmacc/math/MapTuple.hpp
+++ b/include/pmacc/math/MapTuple.hpp
@@ -103,21 +103,6 @@ namespace pmacc
             static constexpr int dim = bmpl::size<Map>::type::value;
             using Base = InheritLinearly<T_Map, T_PodType>;
 
-            template<class>
-            struct result;
-
-            template<class T_F, class T_Key>
-            struct result<T_F(T_Key)>
-            {
-                using type = typename bmpl::at<Map, T_Key>::type&;
-            };
-
-            template<class T_F, class T_Key>
-            struct result<const T_F(T_Key)>
-            {
-                using type = const typename bmpl::at<Map, T_Key>::type&;
-            };
-
             /** access a datum with a key
              *
              * @tparam T_Key key type
@@ -125,13 +110,13 @@ namespace pmacc
              * @{
              */
             template<typename T_Key>
-            HDINLINE typename boost::result_of<MapTuple(T_Key)>::type operator[](const T_Key& key)
+            HDINLINE auto& operator[](const T_Key& key)
             {
                 return (*(static_cast<T_PodType<bmpl::pair<T_Key, typename bmpl::at<Map, T_Key>::type>>*>(this)))[key];
             }
 
             template<typename T_Key>
-            HDINLINE typename boost::result_of<const MapTuple(T_Key)>::type operator[](const T_Key& key) const
+            HDINLINE const auto& operator[](const T_Key& key) const
             {
                 return (*(
                     static_cast<const T_PodType<bmpl::pair<T_Key, typename bmpl::at<Map, T_Key>::type>>*>(this)))[key];
@@ -145,16 +130,13 @@ namespace pmacc
              * @{
              */
             template<int T_i>
-            HDINLINE typename boost::result_of<MapTuple(typename bmpl::at<Map, bmpl::int_<T_i>>::type::first)>::type
-            at()
+            HDINLINE auto& at()
             {
                 return (*this)[typename bmpl::at<Map, bmpl::int_<T_i>>::type::first()];
             }
 
             template<int T_i>
-            HDINLINE
-                typename boost::result_of<const MapTuple(typename bmpl::at<Map, bmpl::int_<T_i>>::type::first)>::type
-                at() const
+            HDINLINE const auto& at() const
             {
                 return (*this)[typename bmpl::at<Map, bmpl::int_<T_i>>::type::first()];
             }

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -139,21 +139,6 @@ namespace pmacc
             /*Vectors without elements are not allowed*/
             PMACC_CASSERT_MSG(math_Vector__with_DIM_0_is_not_allowed, dim > 0);
 
-            template<class>
-            struct result;
-
-            template<class F, typename T>
-            struct result<F(T)>
-            {
-                using type = typename F::type&;
-            };
-
-            template<class F, typename T>
-            struct result<const F(T)>
-            {
-                using type = const typename F::type&;
-            };
-
             HDINLINE
             constexpr Vector()
             {

--- a/include/pmacc/particles/memory/boxes/TileDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/TileDataBox.hpp
@@ -35,21 +35,6 @@ namespace pmacc
         using BaseType = DataBox<PitchedBox<TYPE, 1U>>;
         using type = TYPE;
 
-        template<class>
-        struct result;
-
-        template<class F, typename T>
-        struct result<F(T)>
-        {
-            using type = TYPE&;
-        };
-
-        template<class F, typename T>
-        struct result<const F(T)>
-        {
-            using type = const TYPE&;
-        };
-
         HDINLINE VectorDataBox(TYPE* pointer, const DataSpace<DIM1>& offset = {})
             : BaseType(BaseType(PitchedBox<TYPE, DIM1>(pointer)).shift(offset))
         {

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -128,9 +128,7 @@ namespace pmacc
          * @return result of operator[] of the Frame
          */
         template<typename T_Key>
-        HDINLINE typename boost::result_of<
-            typename std::remove_reference_t<typename boost::result_of<FrameType(T_Key)>::type>(uint32_t)>::type
-        operator[](const T_Key key)
+        HDINLINE auto& operator[](const T_Key key)
         {
             PMACC_CASSERT_MSG_TYPE(key_not_available, T_Key, traits::HasIdentifier<Particle, T_Key>::type::value);
 
@@ -139,9 +137,7 @@ namespace pmacc
 
         /** const version of method operator(const T_Key) */
         template<typename T_Key>
-        HDINLINE typename boost::result_of<
-            typename std::remove_reference_t<typename boost::result_of<const FrameType(T_Key)>::type>(uint32_t)>::type
-        operator[](const T_Key key) const
+        HDINLINE const auto& operator[](const T_Key key) const
         {
             PMACC_CASSERT_MSG_TYPE(key_not_available, T_Key, traits::HasIdentifier<Particle, T_Key>::type::value);
 
@@ -271,15 +267,6 @@ namespace pmacc
                     using NewValueTypeSeq = typename RemoveFromSeq<ValueTypeSeq, ResolvedSeqWithObjectsToRemove>::type;
                     /* new particle type*/
                     using ResultType = pmacc::Particle<FrameType, NewValueTypeSeq>;
-
-                    template<class>
-                    struct result;
-
-                    template<class F, class T_Obj>
-                    struct result<F(T_Obj)>
-                    {
-                        using type = ResultType;
-                    };
 
                     HDINLINE
                     ResultType operator()(const ParticleType& particle)

--- a/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
+++ b/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
@@ -39,21 +39,6 @@ namespace pmacc
         Type data[size];
 
     public:
-        template<class>
-        struct result;
-
-        template<class F, typename TKey>
-        struct result<F(TKey)>
-        {
-            using type = Type&;
-        };
-
-        template<class F, typename TKey>
-        struct result<const F(TKey)>
-        {
-            using type = const Type&;
-        };
-
         HDINLINE
         Type& operator[](const int idx)
         {

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -83,29 +83,6 @@ namespace pmacc
         /* type of a single particle*/
         using ParticleType = pmacc::Particle<ThisType>;
 
-        /* define boost result_of results
-         * normaly result_of defines operator() result, in this case we define the result for
-         * operator[]
-         */
-        template<class>
-        struct result;
-
-        /* const operator[]*/
-        template<class F, class TKey>
-        struct result<const F(TKey)>
-        {
-            using Key = typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type;
-            using type = typename boost::result_of<const BaseType(Key)>::type;
-        };
-
-        /* non const operator[]*/
-        template<class F, class TKey>
-        struct result<F(TKey)>
-        {
-            using Key = typename GetKeyFromAlias<ValueTypeSeq, TKey, errorHandlerPolicies::ThrowValueNotFound>::type;
-            using type = typename boost::result_of<BaseType(Key)>::type;
-        };
-
         /** access the Nth particle*/
         HDINLINE ParticleType operator[](const uint32_t idx)
         {
@@ -125,17 +102,17 @@ namespace pmacc
          * @return result of operator[] of MapTupel
          */
         template<typename T_Key>
-        HDINLINE typename boost::result_of<ThisType(T_Key)>::type getIdentifier(const T_Key)
+        HDINLINE auto& getIdentifier(const T_Key)
         {
-            using Key = typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type;
+            using Key = typename GetKeyFromAlias<ValueTypeSeq, T_Key, errorHandlerPolicies::ThrowValueNotFound>::type;
             return BaseType::operator[](Key());
         }
 
         /** const version of method getIdentifier(const T_Key) */
         template<typename T_Key>
-        HDINLINE typename boost::result_of<const ThisType(T_Key)>::type getIdentifier(const T_Key) const
+        HDINLINE const auto& getIdentifier(const T_Key) const
         {
-            using Key = typename GetKeyFromAlias<ValueTypeSeq, T_Key>::type;
+            using Key = typename GetKeyFromAlias<ValueTypeSeq, T_Key, errorHandlerPolicies::ThrowValueNotFound>::type;
             return BaseType::operator[](Key());
         }
 

--- a/include/pmacc/particles/operations/Deselect.hpp
+++ b/include/pmacc/particles/operations/Deselect.hpp
@@ -39,7 +39,6 @@ namespace pmacc
             {
                 /* functor for deselect attributes of an object
                  *
-                 * - must be boost result_of compatible
                  * - must define a operator()(T_Object)
                  *
                  * @tparam T_Sequence any boost mpl sequence
@@ -51,9 +50,7 @@ namespace pmacc
             } // namespace detail
 
             template<typename T_Exclude, typename T_Object>
-            HDINLINE
-                typename boost::result_of<detail::Deselect<typename ToSeq<T_Exclude>::type, T_Object>(T_Object)>::type
-                deselect(T_Object& object)
+            HDINLINE decltype(auto) deselect(T_Object& object)
             {
                 using DeselectSeq = typename ToSeq<T_Exclude>::type;
                 using BaseType = detail::Deselect<DeselectSeq, T_Object>;

--- a/include/pmacc/random/Random.hpp
+++ b/include/pmacc/random/Random.hpp
@@ -47,7 +47,7 @@ namespace pmacc
             /* RNGHandle assumed */
             using RNGHandle = T_RNGStatePtrOrHandle;
             using Distribution = T_Distribution;
-            using result_type = typename boost::result_of<Distribution(typename RNGHandle::RNGState&)>::type;
+            using result_type = typename Distribution::result_type;
 
             /** This can be constructed with either the RNGBox (like the RNGHandle) or from an RNGHandle instance */
             template<class T_RNGBoxOrHandle>
@@ -83,7 +83,7 @@ namespace pmacc
             using RNGMethod = T_RNGMethod;
             using RNGState = T_RNGState;
             using Distribution = T_Distribution;
-            using result_type = typename boost::result_of<Distribution(RNGState&)>::type;
+            using result_type = typename Distribution::result_type;
 
             HDINLINE Random() : m_rngState(nullptr)
             {


### PR DESCRIPTION
This PR removes all machinery related to `boost::result_of`, which in many cases can be replaced by C++11 deduction features.