### PR TITLE
Add a new particle manipulator combining total cell offset and rng

### DIFF
--- a/include/picongpu/particles/manipulators/manipulators.def
+++ b/include/picongpu/particles/manipulators/manipulators.def
@@ -34,5 +34,6 @@
 #include "picongpu/particles/manipulators/unary/CopyAttribute.def"
 #include "picongpu/particles/manipulators/unary/Drift.def"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.def"
+#include "picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.def"
 #include "picongpu/particles/manipulators/unary/RandomPosition.def"
 #include "picongpu/particles/manipulators/unary/Temperature.def"

--- a/include/picongpu/particles/manipulators/manipulators.hpp
+++ b/include/picongpu/particles/manipulators/manipulators.hpp
@@ -23,4 +23,5 @@
 #include "picongpu/particles/manipulators/generic/FreeRng.hpp"
 #include "picongpu/particles/manipulators/unary/Drift.hpp"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp"
+#include "picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp"
 #include "picongpu/particles/manipulators/unary/Temperature.hpp"

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.def
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.def
@@ -1,0 +1,75 @@
+/* Copyright 2017-2021 Rene Widera, Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <boost/mpl/integral_c.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace manipulators
+        {
+            namespace unary
+            {
+                /** Call simple free user defined functor and provide the cell information and rng functor
+                 *
+                 * This functor is effectively a combination of two wrappers around T_Functor:
+                 * FreeTotalCellOffset and FreeRng.
+                 * Currently there is no easy way to achieve such a combination via sequantial application.
+                 * So here is a special wrapper for it.
+                 *
+                 * @tparam T_Functor user-defined unary functor
+                 * @tparam T_Distribution pmacc::random::distributions, random number distribution
+                 *
+                 * example (no physical meaning, just for interface):
+                 *   @code{.cpp}
+                 *   struct FunctorCellRng
+                 *   {
+                 *       template< typename T_Rng, typename T_Particle >
+                 *       HDINLINE void operator()(
+                 *          DataSpace< simDim > const & particleOffsetToTotalOrigin,
+                 *          T_Rng& rng,
+                 *          T_Particle & particle
+                 *       )
+                 *       {
+                 *           if (particleOffsetToTotalOrigin.y() < 10)
+                 *               particle[position_].y() = rng();
+                 *       }
+                 *       static constexpr char const * name = "functorCellRng";
+                 *   };
+                 *
+                 *   using CellRng = unary::FreeTotalCellOffsetRng<
+                 *      FunctorCellRng,
+                 *      pmacc::random::distributions::Uniform< float_X >
+                 *   >;
+                 *   @endcode
+                 */
+                template<typename T_Functor, typename T_Distribution>
+                struct FreeTotalCellOffsetRng;
+
+            } // namespace unary
+        } // namespace manipulators
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp
@@ -1,0 +1,147 @@
+/* Copyright 2015-2021 Rene Widera, Alexander Grund, Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/functor/misc/TotalCellOffset.hpp"
+#include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.def"
+
+#include <string>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace manipulators
+        {
+            namespace unary
+            {
+                namespace acc
+                {
+                    /** Device-side functor
+                     *
+                     * @tparam T_Functor user-defined unary functor
+                     * @tparam T_RngType rng functor type
+                     */
+                    template<typename T_Functor, typename T_RngType>
+                    struct FreeTotalCellOffsetRng : private T_Functor
+                    {
+                        using Functor = T_Functor;
+                        using RngType = T_RngType;
+
+                        HDINLINE FreeTotalCellOffsetRng(
+                            Functor const& functor,
+                            DataSpace<simDim> const& superCellToLocalOriginCellOffset,
+                            RngType const& rng)
+                            : T_Functor(functor)
+                            , m_superCellToLocalOriginCellOffset(superCellToLocalOriginCellOffset)
+                            , m_rng(rng)
+                        {
+                        }
+
+                        /** call user functor
+                         *
+                         * @tparam T_Particle type of the particle to manipulate
+                         * @tparam T_Acc alpaka accelerator type
+                         *
+                         * @param alpaka accelerator
+                         * @param particle particle which is given to the user functor
+                         */
+                        template<typename T_Particle, typename T_Acc>
+                        HDINLINE void operator()(T_Acc const&, T_Particle& particle)
+                        {
+                            DataSpace<simDim> const cellInSuperCell(
+                                DataSpaceOperations<simDim>::template map<SuperCellSize>(particle[localCellIdx_]));
+                            Functor::operator()(m_superCellToLocalOriginCellOffset + cellInSuperCell, m_rng, particle);
+                        }
+
+                    private:
+                        DataSpace<simDim> const m_superCellToLocalOriginCellOffset;
+                        RngType m_rng;
+                    };
+                } // namespace acc
+
+                template<typename T_Functor, typename T_Distribution>
+                struct FreeTotalCellOffsetRng
+                    : protected functor::User<T_Functor>
+                    , private functor::misc::TotalCellOffset
+                    , private functor::misc::Rng<T_Distribution>
+                {
+                    using CellOffsetFunctor = functor::misc::TotalCellOffset;
+                    using Functor = functor::User<T_Functor>;
+
+                    using RngGenerator = functor::misc::Rng<T_Distribution>;
+                    using RngType = typename RngGenerator::RandomGen;
+                    using Distribution = T_Distribution;
+
+                    template<typename T_SpeciesType>
+                    struct apply
+                    {
+                        using type = FreeTotalCellOffsetRng;
+                    };
+
+                    /** constructor
+                     *
+                     * @param currentStep current simulation time step
+                     */
+                    HINLINE FreeTotalCellOffsetRng(uint32_t currentStep)
+                        : Functor(currentStep)
+                        , CellOffsetFunctor(currentStep)
+                        , RngGenerator(currentStep)
+                    {
+                    }
+
+                    /** Create functor for the accelerator
+                     *
+                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
+                     * @tparam T_Acc alpaka accelerator type
+                     *
+                     * @param alpaka accelerator
+                     * @param localSupercellOffset offset (in superCells, without any guards) relative
+                     *                             to the origin of the local domain
+                     * @param workerCfg configuration of the worker
+                     */
+                    template<typename T_WorkerCfg, typename T_Acc>
+                    HDINLINE auto operator()(
+                        T_Acc const& acc,
+                        DataSpace<simDim> const& localSupercellOffset,
+                        T_WorkerCfg const& workerCfg) const -> acc::FreeTotalCellOffsetRng<Functor, RngType>
+                    {
+                        auto& cellOffsetFunctor = *static_cast<CellOffsetFunctor const*>(this);
+                        RngType const rng
+                            = (*static_cast<RngGenerator const*>(this))(acc, localSupercellOffset, workerCfg);
+                        return acc::FreeTotalCellOffsetRng<Functor, RngType>(
+                            *static_cast<Functor const*>(this),
+                            cellOffsetFunctor(acc, localSupercellOffset, workerCfg),
+                            rng);
+                    }
+
+                    static HINLINE std::string getName()
+                    {
+                        return Functor::name;
+                    }
+                };
+
+            } // namespace unary
+        } // namespace manipulators
+    } // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
This functor is effectively a combination of two wrappers around `T_Functor`: `FreeTotalCellOffset` and `FreeRng`. Currently there is no easy way to achieve such a combination via sequantial application. So here is a special wrapper for it. We discussed with @psychocoderHPC a few times that ideally we should have some generic way for a functor to describe used resources (not in redgrapes sense, but logically it is similar) so that we don't have to specialize for each new case.

This functor is to enable work on thermal particle boundaries.