### PR TITLE
fix -d in 1.cfg in SingleParticleExample

### DIFF
--- a/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
@@ -61,7 +61,7 @@ TBG_plugins="!TBG_openPMD \
 
 TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 
-TBG_programParams="!TBG_deviceDist \
+TBG_programParams="-d !TBG_deviceDist \
                    -g !TBG_gridSize   \
                    -s !TBG_steps      \
                    !TBG_periodic      \


### PR DESCRIPTION
I discovered a missing -d flag. So when specifying a number of devices for the different axis that can be used, which wasn't possible without -d