### PR TITLE
Add a doxygen warning to not remove gamma filter in transition radiation

### DIFF
--- a/include/picongpu/param/transitionRadiation.param
+++ b/include/picongpu/param/transitionRadiation.param
@@ -179,7 +179,7 @@ namespace picongpu
             //! example of a filter for the relativistic Lorentz factor gamma
             struct GammaFilterFunctor
             {
-                //! Gamma value above which the radiation is calculated
+                //! Gamma value above which the radiation is calculated, must be positive
                 static constexpr float_X filterGamma = 5.0;
 
                 template<typename T_Particle>
@@ -198,6 +198,9 @@ namespace picongpu
              * to activate the filter:
              *   - goto file `speciesDefinition.param`
              *   - add the attribute `transitionRadiationMask` to the particle species
+             *
+             * @warning Do not remove this filter. Otherwise still standing electrons would generate NaNs in the
+             * output of the plugin and transition radiation is scaling proportionally to gamma^2.
              */
             using GammaFilter = picongpu::particles::manipulators::generic::Free<GammaFilterFunctor>;
 

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
@@ -175,7 +175,7 @@ namespace picongpu
             //! example of a filter for the relativistic Lorentz factor gamma
             struct GammaFilterFunctor
             {
-                //! Gamma value above which the radiation is calculated
+                //! Gamma value above which the radiation is calculated, must be positive
                 static constexpr float_X filterGamma = 5.0;
 
                 template<typename T_Particle>
@@ -194,6 +194,9 @@ namespace picongpu
              * to activate the filter:
              *   - goto file `speciesDefinition.param`
              *   - add the attribute `transitionRadiationMask` to the particle species
+             *
+             * @warning Do not remove this filter. Otherwise still standing electrons would generate NaNs in the
+             * output of the plugin and transition radiation is scaling proportionally to gamma^2.
              */
             using GammaFilter = picongpu::particles::manipulators::generic::Free<GammaFilterFunctor>;
 


### PR DESCRIPTION
As suggested [here](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3090#issuecomment-938458722)