### PR TITLE
Unroll interpolation

### DIFF
--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <pmacc/attribute/unroll.hpp>
 #include <pmacc/result_of_Functor.hpp>
 #include <pmacc/types.hpp>
 
@@ -67,13 +68,17 @@ namespace picongpu
         {
             using type = typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type;
 
+            constexpr auto iterations = T_end - T_begin + 1;
             auto result_z = type(0.0);
+            PMACC_UNROLL(iterations)
             for(int z = T_begin; z <= T_end; ++z)
             {
                 auto result_y = type(0.0);
+                PMACC_UNROLL(iterations)
                 for(int y = T_begin; y <= T_end; ++y)
                 {
                     auto result_x = type(0.0);
+                    PMACC_UNROLL(iterations)
                     for(int x = T_begin; x <= T_end; ++x)
                         /* a form factor is the "amount of particle" that is affected by this cell
                          * so we have to sum over: cell_value * form_factor

--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -24,6 +24,7 @@
 
 #include "picongpu/algorithms/ShiftCoordinateSystem.hpp"
 
+#include <pmacc/attribute/unroll.hpp>
 #include <pmacc/cuSTL/algorithm/functor/GetComponent.hpp>
 #include <pmacc/cuSTL/cursor/FunctorCursor.hpp>
 #include <pmacc/math/Vector.hpp>
@@ -76,6 +77,7 @@ namespace picongpu
             using Supports = typename pmacc::math::CT::make_Int<simDim, supp>::type;
 
             typename Cursor::ValueType result;
+            PMACC_UNROLL(Cursor::ValueType::dim)
             for(uint32_t i = 0; i < Cursor::ValueType::dim; i++)
             {
                 auto fieldComponent

--- a/include/pmacc/attribute/unroll.hpp
+++ b/include/pmacc/attribute/unroll.hpp
@@ -1,0 +1,43 @@
+/* Copyright 2021 Bernhard Manfred Gruber
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef PMACC_UNROLL
+#    define PMACC_PRAGMA(x) _Pragma(#    x)
+
+#    if defined(__clang__) || defined(__INTEL_LLVM_COMPILER) || defined(__NVCC__)
+#        define PMACC_UNROLL(var) PMACC_PRAGMA(unroll var)
+#    elif defined(__INTEL_COMPILER) // check Intel before g++, because Intel defines __GNUG__
+#        define PMACC_UNROLL(var) PMACC_PRAGMA(unroll(var))
+#    elif defined(__GNUG__)
+// g++ does support an unroll pragma but it does not accept the value of a template argument (at least until g++-11.2)
+// see also: https://stackoverflow.com/q/63404539/2406044
+// #define PMACC_UNROLL(var) PMACC_PRAGMA(GCC unroll var)
+#        define PMACC_UNROLL(var)
+#    elif defined(_MSC_VER)
+// MSVC does not support a pragma for unrolling
+#        define PMACC_UNROLL(var)
+#    else
+#        define PMACC_UNROLL(var)
+#        warning PMACC_UNROLL is not implemented for your compiler
+#    endif
+#endif


### PR DESCRIPTION
This PR places a few ` #pragma unroll`s to request the compiler to unroll the 3 loops across for the trilinear interpolation and the 1 loop over the simulation dimensions. This change mostly affects the `MoveAndMark` kernel.

SPEC benchmark is run on NVIDIA GeForce RTX 2060.

Without unrolling:
```
	dev
		calculation  simulation time: 16sec 796msec = 16.796 sec
	llama (P: SoA, F: AoS)
		calculation  simulation time: 16sec 510msec = 16.510 sec
	llama (P: SoA, F: AoSSplit)
		calculation  simulation time: 26sec 350msec = 26.350 sec
```

With unrolling:
```
	dev
		calculation  simulation time: 16sec 464msec = 16.464 sec
	llama (P: SoA, F: AoS) #pragma unroll in AssignedTrilinearInterpolation.hpp:
		calculation  simulation time: 17sec 793msec = 17.793 sec
	llama (P: SoA, F: AoSSplit) #pragma unroll in AssignedTrilinearInterpolation.hpp
		calculation  simulation time: 29sec 148msec = 29.148 sec
	llama (P: SoA, F: AoS) #pragma unroll in AssignedTrilinearInterpolation.hpp and FieldToParticleInterpolation.hpp
		calculation  simulation time: 16sec 708msec = 16.708 sec
	llama (P: SoA, F: AoSSplit) #pragma unroll in AssignedTrilinearInterpolation.hpp and FieldToParticleInterpolation.hpp
		calculation  simulation time: 16sec 601msec = 16.601 sec
```

While the unrolling has little to no effect on the current `dev` branch (although CUDA now requires less registers and is a few ms faster). The effect is VERY noticable when more LLAMA magic is involved. See especially the `llama (P: SoA, F: AoSSplit)` run. The reason for the big improvement is that the cuSTL Cursors backed by LLAMA are more complex than the BufferCursor. This comlexity can mostly be folded away when enough code is inlined and unrolled together. Also note that applying the unrolling only to the `AssignedTrilinearInterpolation` has a worsening effect.

I am too hesitant yet to propose this change as it could make the register count explode if the trilinear interpolation accesses a larger range of values. However, with LLAMA such a change is absolutely needed.

- [x] do not merge before 0.6.0 branch is created
- [x] rebase against #3880