### PR TITLE
Fix warning: add explicit braces to avoid dangling else [-Wdangling-else]

### DIFF
--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -215,10 +215,12 @@ namespace picongpu
                      */
                     auto incidentFieldBaseShift = floatD_X::create(0.0_X);
                     if(parameters.direction > 0)
+                    {
                         if(isUpdatedFieldTotal)
                             incidentFieldBaseShift[dir0] = -1.0_X;
                         else
                             incidentFieldBaseShift[dir0] = 1.0_X;
+                    }
                     auto incidentFieldPositions = traits::FieldPosition<cellType::Yee, T_IncidentField>{}();
                     functor.inCellShift1 = incidentFieldBaseShift + incidentFieldPositions[functor.incidentComponent1];
                     functor.inCellShift2 = incidentFieldBaseShift + incidentFieldPositions[functor.incidentComponent2];


### PR DESCRIPTION
Was noticed by @psychocoderHPC when testing on an AMD system. This warning is both in `dev` and #3860 (this part didn't change there). Perhaps we should also port this fix to the release candidate branch.