### PR TITLE
Update JUWELS booster profile

### DIFF
--- a/etc/picongpu/juwels-jsc/booster.tpl
+++ b/etc/picongpu/juwels-jsc/booster.tpl
@@ -57,7 +57,7 @@
 .TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
 
 # host memory per device
-.TBG_memPerDevice="$((515712 / $TBG_devicesPerNode))"
+.TBG_memPerDevice="$((499712 / $TBG_devicesPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerDevice * TBG_devicesPerNode))"
 

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -96,12 +96,12 @@ function getNode() {
     else
         numNodes=$1
     fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+    if [ $numNodes -gt 4 ] ; then
+        echo "The maximal number of interactive nodes is 4." 1>&2
         return 1
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=515712 -A $account -p gpus bash
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=488G -A $account -p develbooster bash
 }
 
 # allocate an interactive shell for one hour
@@ -117,7 +117,7 @@ function getDevice() {
             numDevices=$1
         fi
     fi
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=515712 -A $account -p develbooster --pty bash
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p develbooster --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
The old srun option for memory in getDevice() and getNode() did not work anymore.
Juelich says, the nodes have 512G memory of which *at least* 20G are taken by the system.
Also the partition for getDevice() is changed to `develbooster`, since `gpu` is a different partition with its own profile.
The `booster.tpl` is updated as well.