### PR TITLE
Spack load: no more "-r"

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-2004/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-2004/Dockerfile
@@ -61,7 +61,7 @@ RUN        spack install $PIC_PACKAGE && \
 
 # load spack & picongpu environment on login
 RUN        /bin/echo -e "source $SPACK_ROOT/share/spack/setup-env.sh\n" \
-                        "spack load -r $PIC_PACKAGE\n" \
+                        "spack load $PIC_PACKAGE\n" \
                         'if [ $(id -u) -eq 0 ]; then\n' \
                         '   function mpirun { $(which mpirun) --allow-run-as-root $@; }\n' \
                         '   export -f mpirun\n' \


### PR DESCRIPTION
The `-r` argument was removed from `spack load` and is now implied.

X-ref: https://github.com/ComputationalRadiationPhysics/spack-repo/pull/14