### PR TITLE
fix warnings and check for warnings in CI

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -284,26 +284,30 @@ add_definitions(-DCMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION})
 # Warnings
 ################################################################################
 
-# GNU
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
-# ICC
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-# PGI
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
-# MSVS
-elseif(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-    # Required for MSVS 15.8+ due to alignment change
-    # https://devblogs.microsoft.com/cppblog/stl-features-and-fixes-in-vs-2017-15-8/
-    if(MSVC_VERSION GREATER_EQUAL 1916)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _ENABLE_EXTENDED_ALIGNED_STORAGE")
+option(PIC_CI_COMPILE "Enable strict error checking." OFF)
+if(PIC_CI_COMPILE)
+    # GNU
+    if(CMAKE_COMPILER_IS_GNUCXX)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    # ICC
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    # PGI
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
+    # MSVS
+    elseif(MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+        # Required for MSVS 15.8+ due to alignment change
+        # https://devblogs.microsoft.com/cppblog/stl-features-and-fixes-in-vs-2017-15-8/
+        if(MSVC_VERSION GREATER_EQUAL 1916)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _ENABLE_EXTENDED_ALIGNED_STORAGE")
+        endif()
     endif()
 endif()
 

--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -69,6 +69,7 @@ namespace picongpu
             using type = typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type;
 
             constexpr auto iterations = T_end - T_begin + 1;
+            alpaka::ignore_unused(iterations);
             auto result_z = type(0.0);
             PMACC_UNROLL(iterations)
             for(int z = T_begin; z <= T_end; ++z)

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -171,7 +171,7 @@ namespace picongpu
                             if(frameCtx[idx].isValid())
                             {
                                 particlesInSuperCellCtx[idx] = numParticlesPerFrame;
-                                for(int i = 0; i < numVirtualBlocks && frameCtx[idx].isValid(); ++i)
+                                for(uint32_t i = 0; i < numVirtualBlocks && frameCtx[idx].isValid(); ++i)
                                 {
                                     frameCtx[idx] = boxPar.getPreviousFrame(frameCtx[idx]);
                                 }

--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -109,8 +109,9 @@ namespace picongpu
                     GridLayout<simDim> const& gridLayout,
                     Thickness const& globalThickness,
                     DataBox box)
-                    : guardSize(gridLayout.getGuard())
-                    , box(box)
+                    : box(box)
+                    , guardSize(gridLayout.getGuard())
+
                 {
                     auto const negativeSize = globalThickness.getNegativeBorder();
                     auto const positiveSize = globalThickness.getPositiveBorder();

--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -244,8 +244,8 @@ namespace picongpu
                      * @param parameters PML parameters for a local domain
                      */
                     UpdateEFunctor(FieldBox fieldPsiE, LocalParameters const parameters)
-                        : parameters(parameters)
-                        , fieldPsiE(fieldPsiE)
+                        : fieldPsiE(fieldPsiE)
+                        , parameters(parameters)
                     {
                     }
 
@@ -339,8 +339,8 @@ namespace picongpu
                      * up-to-date
                      */
                     UpdateBHalfFunctor(FieldBox fieldPsiB, LocalParameters const parameters, bool updatePsiB)
-                        : parameters(parameters)
-                        , fieldPsiB(fieldPsiB)
+                        : fieldPsiB(fieldPsiB)
+                        , parameters(parameters)
                         , updatePsiB(updatePsiB)
                     {
                     }

--- a/include/picongpu/fields/background/templates/TWTS/BField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.tpp
@@ -61,13 +61,13 @@ namespace picongpu
                 , w_x_SI(w_x_SI)
                 , w_y_SI(w_y_SI)
                 , phi(phi)
+                , phiPositive(float_X(1.0))
                 , beta_0(beta_0)
                 , tdelay_user_SI(tdelay_user_SI)
                 , dt(SI::DELTA_T_SI)
                 , unit_length(UNIT_LENGTH)
                 , auto_tdelay(auto_tdelay)
                 , pol(pol)
-                , phiPositive(float_X(1.0))
             {
                 /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
                  * on host (see fieldBackground.param), this is no problem.

--- a/include/picongpu/fields/background/templates/TWTS/EField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.tpp
@@ -60,13 +60,14 @@ namespace picongpu
                 , w_x_SI(w_x_SI)
                 , w_y_SI(w_y_SI)
                 , phi(phi)
+                , phiPositive(float_X(1.0))
                 , beta_0(beta_0)
                 , tdelay_user_SI(tdelay_user_SI)
                 , dt(SI::DELTA_T_SI)
                 , unit_length(UNIT_LENGTH)
+                , tdelay(0.0)
                 , auto_tdelay(auto_tdelay)
                 , pol(pol)
-                , phiPositive(float_X(1.0))
             {
                 /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
                          on host (see fieldBackground.param), this is no problem.

--- a/include/picongpu/fields/background/templates/twtsfast/BField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.tpp
@@ -59,13 +59,14 @@ namespace picongpu
                 , pulselength_SI(pulselength_SI)
                 , w_x_SI(w_x_SI)
                 , phi(phi)
+                , phiPositive(float_X(1.0))
                 , beta_0(beta_0)
                 , tdelay_user_SI(tdelay_user_SI)
                 , dt(SI::DELTA_T_SI)
                 , unit_length(UNIT_LENGTH)
                 , auto_tdelay(auto_tdelay)
                 , pol(pol)
-                , phiPositive(float_X(1.0))
+
             {
                 /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
                  * on host (see fieldBackground.param), this is no problem.

--- a/include/picongpu/fields/background/templates/twtsfast/EField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.tpp
@@ -58,13 +58,13 @@ namespace picongpu
                 , pulselength_SI(pulselength_SI)
                 , w_x_SI(w_x_SI)
                 , phi(phi)
+                , phiPositive(float_X(1.0))
                 , beta_0(beta_0)
                 , tdelay_user_SI(tdelay_user_SI)
                 , dt(SI::DELTA_T_SI)
                 , unit_length(UNIT_LENGTH)
                 , auto_tdelay(auto_tdelay)
                 , pol(pol)
-                , phiPositive(float_X(1.0))
             {
                 /* Note: Enviroment-objects cannot be instantiated on CUDA GPU device. Since this is done
                          on host (see fieldBackground.param), this is no problem.

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -89,7 +89,7 @@ namespace picongpu
                 DataSpace<simDim> leaveCell;
 
                 /* calculate the offset for the virtual coordinate system */
-                for(int d = 0; d < simDim; ++d)
+                for(uint32_t d = 0; d < simDim; ++d)
                 {
                     int iStart;
                     int iEnd;

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -92,7 +92,7 @@ namespace picongpu
                 DataSpace<DIM2> leaveCell;
 
                 /* calculate the offset for the virtual coordinate system */
-                for(int d = 0; d < simDim; ++d)
+                for(uint32_t d = 0; d < simDim; ++d)
                 {
                     int iStart;
                     int iEnd;

--- a/include/picongpu/fields/laserProfiles/BaseFunctor.hpp
+++ b/include/picongpu/fields/laserProfiles/BaseFunctor.hpp
@@ -111,8 +111,8 @@ namespace picongpu
                         DataSpace<simDim> const& offsetToTotalDomain,
                         float3_X const& elong)
                         : m_dataBoxE(dataBoxE)
-                        , m_offsetToTotalDomain(offsetToTotalDomain)
                         , m_superCellToLocalOriginCellOffset(superCellToLocalOriginCellOffset)
+                        , m_offsetToTotalDomain(offsetToTotalDomain)
                         , m_elong(elong)
                     {
                     }

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -375,8 +375,6 @@ namespace picongpu
             template<typename T_CellDescription>
             HINLINE void operator()(T_CellDescription cellDesc, const uint32_t currentStep) const
             {
-                DataConnector& dc = Environment<>::get().DataConnector();
-
                 // only if an ionizer has been specified, this is executed
                 using hasIonizers = typename HasFlag<FrameType, ionizers<>>::type;
                 if(hasIonizers::value)

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -186,9 +186,6 @@ namespace picongpu
                      */
                     while(sourceFrame.isValid())
                     {
-                        auto isParticleCtx = forEachParticle(
-                            [&](uint32_t const linearIdx) -> bool
-                            { return static_cast<bool>(sourceFrame[linearIdx][multiMask_]); });
                         forEachParticle(
                             [&](lockstep::Idx const idx)
                             {

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -202,9 +202,6 @@ namespace picongpu
                     ValueType_B bField
                         = Field2ParticleInterpolation()(cachedB.shift(localCell).toCursor(), pos, fieldPosB());
 
-                    /* define number of bound macro electrons before ionization */
-                    float_X prevBoundElectrons = particle[boundElectrons_];
-
                     IonizationAlgorithm ionizeAlgo;
                     /* determine number of new macro electrons to be created and energy used for ionization */
                     auto retValue = ionizeAlgo(bField, eField, particle, this->randomGen(acc));

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -188,9 +188,6 @@ namespace picongpu
                     ValueType_E eField
                         = Field2ParticleInterpolation()(cachedE.shift(localCell).toCursor(), pos, fieldPosE());
 
-                    /* define number of bound macro electrons before ionization */
-                    float_X prevBoundElectrons = particle[boundElectrons_];
-
                     /* this is the point where actual ionization takes place */
                     IonizationAlgorithm ionizeAlgo{};
                     auto retValue = ionizeAlgo(eField, particle);

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -202,9 +202,6 @@ namespace picongpu
                     ValueType_B bField
                         = Field2ParticleInterpolation()(cachedB.shift(localCell).toCursor(), pos, fieldPosB());
 
-                    /* define number of bound macro electrons before ionization */
-                    float_X prevBoundElectrons = particle[boundElectrons_];
-
                     IonizationAlgorithm ionizeAlgo;
                     /* determine number of new macro electrons to be created and energy used for ionization */
                     auto retValue = ionizeAlgo(bField, eField, particle, this->randomGen(acc));

--- a/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -202,7 +202,6 @@ namespace picongpu
 
                     const float_X c2 = c * c;
                     const float_X charge2 = charge * charge;
-                    const float3_X beta = velocity / c;
 
                     const float_X prefactorRR = 2. / 3. * charge2 * charge2 / (4. * PI * EPS0 * mass * mass * c2 * c2);
                     const float3_X lorentz = fieldE + conversionMomentum2Beta * c * pmacc::math::cross(mom, fieldB);

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -355,9 +355,9 @@ namespace picongpu
         }
 
         BinEnergyParticles(std::shared_ptr<plugins::multi::IHelp>& help, size_t const id, MappingDesc* cellDescription)
-            : m_help(std::static_pointer_cast<Help>(help))
+            : m_cellDescription(cellDescription)
+            , m_help(std::static_pointer_cast<Help>(help))
             , m_id(id)
-            , m_cellDescription(cellDescription)
         {
             filename = m_help->getOptionPrefix() + "_" + m_help->filter.get(m_id) + ".dat";
 

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -349,9 +349,9 @@ namespace picongpu
         }
 
         CalcEmittance(std::shared_ptr<plugins::multi::IHelp>& help, size_t const id, MappingDesc* cellDescription)
-            : m_help(std::static_pointer_cast<Help>(help))
+            : m_cellDescription(cellDescription)
+            , m_help(std::static_pointer_cast<Help>(help))
             , m_id(id)
-            , m_cellDescription(cellDescription)
         {
             filename = m_help->getOptionPrefix() + "_" + m_help->filter.get(m_id) + ".dat";
 

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -306,9 +306,9 @@ namespace picongpu
         }
 
         EnergyParticles(std::shared_ptr<plugins::multi::IHelp>& help, size_t const id, MappingDesc* cellDescription)
-            : m_help(std::static_pointer_cast<Help>(help))
+            : m_cellDescription(cellDescription)
+            , m_help(std::static_pointer_cast<Help>(help))
             , m_id(id)
-            , m_cellDescription(cellDescription)
         {
             filename = m_help->getOptionPrefix() + "_" + m_help->filter.get(m_id) + ".dat";
 

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -288,8 +288,8 @@ namespace picongpu
         private:
             ParticlesBoxType pb;
             FramePtr frame;
-            int i;
             int frameSize;
+            int i;
         };
 
 
@@ -405,22 +405,9 @@ namespace picongpu
 #    endif
 #endif
                 >;
-            VisualizationType* visualization;
+            VisualizationType* visualization = nullptr;
 
             IsaacPlugin()
-                : visualization(nullptr)
-                , cellDescription(nullptr)
-                , movingWindow(false)
-                , renderInterval(1)
-                , step(0)
-                , drawingTime(0)
-                , simulationTime(0)
-                , cellCount(0)
-                , particleCount(0)
-                , lastNotify(0)
-                , runSteps(-10)
-                , timingsFileExist(0)
-                , recording(false)
             {
                 Environment<>::get().PluginConnector().registerPlugin(this);
             }
@@ -658,7 +645,7 @@ namespace picongpu
             }
 
         private:
-            MappingDesc* cellDescription;
+            MappingDesc* cellDescription = nullptr;
             std::string notifyPeriod;
             std::string url;
             std::string name;
@@ -669,7 +656,7 @@ namespace picongpu
             uint32_t jpeg_quality;
             int rank;
             int numProc;
-            bool movingWindow;
+            bool movingWindow = false;
             SourceList sources;
             VectorFieldSourceList vecFieldSources;
             ParticleList particleSources;
@@ -677,20 +664,20 @@ namespace picongpu
              *
              * render each n-th time step within an interval defined by notifyPeriod
              */
-            uint32_t renderInterval;
-            uint32_t step;
-            int drawingTime;
-            int simulationTime;
-            bool directPause;
-            int cellCount;
-            int particleCount;
-            uint64_t lastNotify;
-            bool reconnect;
+            uint32_t renderInterval = 1;
+            uint32_t step = 0;
+            int drawingTime = 0;
+            int simulationTime = 0;
+            bool directPause = false;
+            int cellCount = 0;
+            int particleCount = 0;
+            uint64_t lastNotify = 0;
+            bool reconnect = false;
 
             // storage for timings and control variables
-            bool timingsFileExist;
-            bool recording;
-            int runSteps;
+            bool timingsFileExist = false;
+            bool recording = false;
+            int runSteps = 0;
             std::ofstream timingsFile;
             std::string timingsFilename;
 

--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
@@ -99,8 +99,6 @@ namespace picongpu
                 softwareVersion << "-" << PICONGPU_VERSION_LABEL;
             series.setSoftware(software, softwareVersion.str());
 
-            pmacc::GridController<simDim>& gc = pmacc::Environment<simDim>::get().GridController();
-
             /** calculate GUARD offset in the source hBuffer *****************/
             const uint32_t rGuardCells
                 = SuperCellSize().toRT()[axis_element.space] * GuardSize::toRT()[axis_element.space];

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -46,9 +46,9 @@ namespace picongpu
         std::shared_ptr<plugins::multi::IHelp>& help,
         size_t const id,
         MappingDesc* cellDescription)
-        : m_help(std::static_pointer_cast<Help>(help))
+        : m_cellDescription(cellDescription)
+        , m_help(std::static_pointer_cast<Help>(help))
         , m_id(id)
-        , m_cellDescription(cellDescription)
     {
         // unit is m_species c (for a single "real" particle)
         float_X pRangeSingle_unit(frame::getMass<typename Species::FrameType>() * SPEED_OF_LIGHT);

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -105,7 +105,7 @@ namespace picongpu
             /* out-of-range bins back to min/max */
             if(p_bin < 0)
                 p_bin = 0;
-            if(p_bin >= num_pbins)
+            if(p_bin >= static_cast<int32_t>(num_pbins))
                 p_bin = num_pbins - 1;
 
             /** \todo take particle shape into account */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1191,7 +1191,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     field_no_guard = field_layout.getDataSpaceWithoutGuarding();
                     field_guard = field_layout.getGuard();
 
-                    DataConnector& dc = Environment<>::get().DataConnector();
                     fieldsSizeDims = precisionCast<uint64_t>(params->gridLayout.getDataSpaceWithoutGuarding());
 
                     /* Scan the PML buffer local size along all local domains

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -138,7 +138,6 @@ namespace picongpu
 
                     log<picLog::INPUT_OUTPUT>("openPMD: Read from field '%1%'") % objectName;
 
-                    auto ndim = rc.getDimensionality();
                     ::openPMD::Offset start = asStandardVector<DataSpace<simDim>&, ::openPMD::Offset>(domain_offset);
                     ::openPMD::Extent count
                         = asStandardVector<DataSpace<simDim>&, ::openPMD::Extent>(local_domain_size);

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -641,15 +641,14 @@ namespace picongpu
             std::string notifyPeriod,
             DataSpace<DIM2> transpose,
             float_X slicePoint)
-            : m_output(output)
-            , pluginName(name)
-            , cellDescription(nullptr)
-            , particleTag(ParticlesType::FrameType::getName())
+            : particleTag(ParticlesType::FrameType::getName())
             , m_notifyPeriod(notifyPeriod)
-            , m_transpose(transpose)
             , m_slicePoint(slicePoint)
-            , isMaster(false)
+            , pluginName(name)
+            , m_transpose(transpose)
             , header(nullptr)
+            , m_output(output)
+            , isMaster(false)
             , reduce(1024)
         {
             sliceDim = 0;

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -111,13 +111,13 @@ namespace picongpu
                 // yaw
                 int32_t yawBin = calorimeterPos.x() * static_cast<float_X>(numBinsYaw);
                 // catch out-of-range values
-                yawBin = yawBin >= numBinsYaw ? numBinsYaw - 1 : yawBin;
+                yawBin = yawBin >= static_cast<int32_t>(numBinsYaw) ? numBinsYaw - 1 : yawBin;
                 yawBin = yawBin < 0 ? 0 : yawBin;
 
                 // pitch
                 int32_t pitchBin = calorimeterPos.y() * static_cast<float_X>(numBinsPitch);
                 // catch out-of-range values
-                pitchBin = pitchBin >= numBinsPitch ? numBinsPitch - 1 : pitchBin;
+                pitchBin = pitchBin >= static_cast<int32_t>(numBinsPitch) ? numBinsPitch - 1 : pitchBin;
                 pitchBin = pitchBin < 0 ? 0 : pitchBin;
 
                 // energy

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -100,21 +100,21 @@ namespace picongpu
                 radiation_frequencies::InitFreqFunctor freqInit;
                 radiation_frequencies::FreqFunctor freqFkt;
 
-                MappingDesc* cellDescription;
+                MappingDesc* cellDescription = nullptr;
                 std::string notifyPeriod;
-                uint32_t dumpPeriod;
+                uint32_t dumpPeriod = 0;
                 uint32_t radStart;
                 uint32_t radEnd;
 
-                std::string speciesName;
                 std::string pluginName;
+                std::string speciesName;
                 std::string pluginPrefix;
                 std::string filename_prefix;
-                bool totalRad;
-                bool lastRad;
+                bool totalRad = false;
+                bool lastRad = false;
                 std::string folderLastRad;
                 std::string folderTotalRad;
-                bool radPerGPU;
+                bool radPerGPU = false;
                 std::string folderRadPerGPU;
                 DataSpace<simDim> lastGPUpos;
                 int numJobs;
@@ -129,10 +129,10 @@ namespace picongpu
                 std::vector<vector_64> detectorPositions;
                 std::vector<float_64> detectorFrequencies;
 
-                bool isMaster;
+                bool isMaster = false;
 
-                uint32_t currentStep;
-                uint32_t lastStep;
+                uint32_t currentStep = 0;
+                uint32_t lastStep = 0;
 
                 std::string pathRestart;
                 std::string meshesPathName;
@@ -146,14 +146,6 @@ namespace picongpu
                     , speciesName(ParticlesType::FrameType::getName())
                     , pluginPrefix(speciesName + std::string("_radiation"))
                     , filename_prefix(pluginPrefix)
-                    , cellDescription(nullptr)
-                    , dumpPeriod(0)
-                    , totalRad(false)
-                    , lastRad(false)
-                    , isMaster(false)
-                    , currentStep(0)
-                    , radPerGPU(false)
-                    , lastStep(0)
                     , meshesPathName("DetectorMesh/")
                 {
                     Environment<>::get().PluginConnector().registerPlugin(this);
@@ -722,7 +714,7 @@ namespace picongpu
                                       .currentBuffer();
 
                             // select data
-                            for(int copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
+                            for(uint32_t copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
                             {
                                 span[copyIndex] = reinterpret_cast<picongpu::float_64*>(
                                     values.data())[ampIndex + Amplitude::numComponents * copyIndex];
@@ -782,10 +774,10 @@ namespace picongpu
                                       .currentBuffer();
 
                             // select data
-                            for(int copyIndex = 0; copyIndex < parameters::N_observer; ++copyIndex)
+                            for(uint32_t copyIndex = 0u; copyIndex < parameters::N_observer; ++copyIndex)
                             {
                                 span[copyIndex] = reinterpret_cast<picongpu::float_64*>(
-                                    detectorPositions.data())[detectorDim + 3 * copyIndex];
+                                    detectorPositions.data())[detectorDim + 3u * copyIndex];
                             }
 
                             // flush data now
@@ -904,7 +896,7 @@ namespace picongpu
 
                             openPMDdataFile.flush();
 
-                            for(int copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
+                            for(uint32_t copyIndex = 0u; copyIndex < N_tmpBuffer; ++copyIndex)
                             {
                                 /* convert data directly because Amplitude is just 6 float_32 */
                                 ((picongpu::float_64*) values.data())[ampIndex + Amplitude::numComponents * copyIndex]

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -271,7 +271,7 @@ namespace picongpu
                                                 // set z component to zero in case of simDim==DIM2
                                                 particle_locationNow[2] = 0.0;
                                                 // run over all components and compute gobal position
-                                                for(int i = 0; i < simDim; ++i)
+                                                for(uint32_t i = 0; i < simDim; ++i)
                                                     particle_locationNow[i]
                                                         = (float_X(globalPos[i]) + pos[i]) * cellSize[i];
 
@@ -354,7 +354,7 @@ namespace picongpu
 
 
                             // run over all  valid omegas for this thread
-                            for(int o = workerIdx; o < radiation_frequencies::N_omega; o += T_numWorkers)
+                            for(uint32_t o = workerIdx; o < radiation_frequencies::N_omega; o += T_numWorkers)
                             {
                                 /* storage for amplitude (complex 3D vector)
                                  * it  is initialized with zeros (  0 +  i 0 )

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -73,9 +73,9 @@ namespace picongpu
                     const vector_X& momentumOld_set,
                     const vector_X& momentumNow_set,
                     const picongpu::float_X mass_set)
-                    : location_now(locationNow_set)
+                    : momentum_now(momentumNow_set)
                     , momentum_old(momentumOld_set)
-                    , momentum_now(momentumNow_set)
+                    , location_now(locationNow_set)
                     , mass(mass_set)
                 {
                 }

--- a/include/picongpu/plugins/transitionRadiation/Particle.hpp
+++ b/include/picongpu/plugins/transitionRadiation/Particle.hpp
@@ -34,19 +34,19 @@ namespace picongpu
             class Particle
             {
             private:
-                float3_X const momentum;
                 float3_X location;
                 float3_X beta;
                 float_X const mass;
                 float_X gamma;
                 float_X betaAbs;
+                float3_X const momentum;
 
             public:
                 HDINLINE
                 Particle(float3_X const& locationSet, float3_X const& momentumSet, float_X const massSet)
-                    : momentum(momentumSet)
-                    , location(locationSet)
+                    : location(locationSet)
                     , mass(massSet)
+                    , momentum(momentumSet)
                 {
                     gamma = calcGamma();
                     beta = calcBeta();

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -104,11 +104,11 @@ namespace picongpu
                 std::string notifyPeriod;
                 uint32_t timeStep;
 
-                std::string speciesName;
                 std::string pluginName;
+                std::string speciesName;
                 std::string pluginPrefix;
-                std::string filenamePrefix;
                 std::string folderTransRad;
+                std::string filenamePrefix;
 
                 float3_X* detectorPositions = nullptr;
                 float_X* detectorFrequencies = nullptr;

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -243,7 +243,7 @@ namespace picongpu
                                                 // set z component to zero in case of simDim==DIM2
                                                 particleLocation[2] = 0.0;
                                                 // run over all components and compute gobal position
-                                                for(int i = 0; i < simDim; ++i)
+                                                for(uint32_t i = 0; i < simDim; ++i)
                                                     particleLocation[i]
                                                         = (float_X(globalPos[i]) + pos[i]) * cellSize[i];
 
@@ -288,7 +288,8 @@ namespace picongpu
                             cupla::__syncthreads(acc);
 
                             // run over all  valid omegas for this thread
-                            for(int o = workerIdx; o < transitionRadiation::frequencies::nOmega; o += T_numWorkers)
+                            for(uint32_t o = workerIdx; o < transitionRadiation::frequencies::nOmega;
+                                o += T_numWorkers)
                             {
                                 float_X itrSum = 0.0;
                                 float_X totalParticles = 0.0;
@@ -316,7 +317,8 @@ namespace picongpu
                                     ctrSumPerp += energyPerp_s[j] * formfactor;
                                 }
 
-                                int const index = theta_idx * transitionRadiation::frequencies::nOmega + o;
+                                uint32_t const index
+                                    = static_cast<uint32_t>(theta_idx) * transitionRadiation::frequencies::nOmega + o;
                                 incTransRad[index] += itrSum;
                                 numParticles[index] += totalParticles;
                                 cohTransRadPara[index] += ctrSumPara;

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -104,8 +104,8 @@ namespace picongpu
 
                 // Variables for plugin options:
                 std::string notifyPeriod;
-                std::string speciesName;
                 std::string pluginName;
+                std::string speciesName;
                 std::string pluginPrefix;
                 std::string fileName;
                 std::string fileExtension;
@@ -145,16 +145,15 @@ namespace picongpu
             public:
                 //! XrayScattering object initializer.
                 XrayScattering()
-                    : pluginName("xrayScattering: Calculate the SAXS scattering intensity of a "
+                    : // this is bodged so it passes the verification at
+                      // MappingDescription.hpp:79
+                    cellDescription(DataSpace<simDim>(SuperCellSize::toRT()))
+                    , currentStep(0)
+                    , pluginName("xrayScattering: Calculate the SAXS scattering intensity of a "
                                  "species.")
                     , speciesName(T_ParticlesType::FrameType::getName())
                     , pluginPrefix(speciesName + std::string("_xrayScattering"))
-                    ,
-                    // this is bodged so it passes the verification at
-                    // MappingDescription.hpp:79
-                    cellDescription(DataSpace<simDim>(SuperCellSize::toRT()))
                     , isMaster(false)
-                    , currentStep(0)
                     , accumulatedRotations(0)
                 {
                     Environment<>::get().PluginConnector().registerPlugin(this);

--- a/include/picongpu/plugins/xrayScattering/XrayScatteringWriter.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScatteringWriter.hpp
@@ -124,12 +124,12 @@ namespace picongpu
                     float_64 const unit,
                     uint32_t const totalSimulationCells)
                     : fileName(fileName)
-                    , dir(dir)
                     , fileExtension(fileExtension)
+                    , dir(dir)
                     , outputMemoryLayout(outputMemoryLayout)
                     , globalExtent(globalExtent)
-                    , gridSpacing(gridSpacing)
                     , unit(unit)
+                    , gridSpacing(gridSpacing)
                 {
                     if(outputMemoryLayout == OutputMemoryLayout::Distribute)
                     {

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -68,10 +68,10 @@ namespace picongpu
                      * @param useDuplicateField flag to store duplicate of the field
                      */
                     ApplyFieldBackground(MappingDesc const cellDescription, bool const useDuplicateField)
-                        : cellDescription(cellDescription)
+                        : isEnabled(FieldBackground::InfluenceParticlePusher)
                         , useDuplicateField(useDuplicateField)
                         , restoreFromDuplicateField(false)
-                        , isEnabled(FieldBackground::InfluenceParticlePusher)
+                        , cellDescription(cellDescription)
                     {
                         if(isEnabled && useDuplicateField)
                         {

--- a/include/pmacc/eventSystem/tasks/TaskKernel.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskKernel.hpp
@@ -31,7 +31,7 @@ namespace pmacc
     class TaskKernel : public StreamTask
     {
     public:
-        TaskKernel(std::string kernelName) : StreamTask(), kernelName(kernelName), canBeChecked(false)
+        TaskKernel(std::string kernelName) : StreamTask(), canBeChecked(false), kernelName(kernelName)
         {
         }
 

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -36,9 +36,9 @@ namespace pmacc
     public:
         TaskFieldReceiveAndInsertExchange(Field& buffer, uint32_t exchange)
             : m_buffer(buffer)
-            , m_exchange(exchange)
             , m_state(Constructor)
             , initDependency(__getTransactionEvent())
+            , m_exchange(exchange)
         {
         }
 

--- a/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
@@ -36,9 +36,9 @@ namespace pmacc
     public:
         TaskFieldSendExchange(Field& buffer, uint32_t exchange)
             : m_buffer(buffer)
-            , m_exchange(exchange)
             , m_state(Constructor)
             , m_initDependency(__getTransactionEvent())
+            , m_exchange(exchange)
         {
         }
 

--- a/include/pmacc/lockstep/Idx.hpp
+++ b/include/pmacc/lockstep/Idx.hpp
@@ -40,8 +40,8 @@ namespace pmacc
              * @param workerElemIndex virtual workers linear index of the work item
              */
             HDINLINE Idx(uint32_t const domElemIndex, uint32_t const workerElemIndex)
-                : domElemIdx(std::move(domElemIndex))
-                , workerElemIdx(std::move(workerElemIndex))
+                : workerElemIdx(std::move(workerElemIndex))
+                , domElemIdx(std::move(domElemIndex))
             {
             }
 

--- a/include/pmacc/memory/buffers/Buffer.hpp
+++ b/include/pmacc/memory/buffers/Buffer.hpp
@@ -53,9 +53,9 @@ namespace pmacc
          */
         Buffer(DataSpace<DIM> size, DataSpace<DIM> physicalMemorySize)
             : data_space(size)
-            , data1D(true)
-            , current_size(nullptr)
             , m_physicalMemorySize(physicalMemorySize)
+            , current_size(nullptr)
+            , data1D(true)
         {
             CUDA_CHECK(cuplaMallocHost((void**) &current_size, sizeof(size_t)));
             *current_size = size.productOfComponents();

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -51,9 +51,9 @@ namespace pmacc
          */
         DeviceBufferIntern(DataSpace<DIM> size, bool sizeOnDevice = false, bool useVectorAsBase = false)
             : DeviceBuffer<TYPE, DIM>(size, size)
+            , offset(DataSpace<DIM>())
             , sizeOnDevice(sizeOnDevice)
             , useOtherMemory(false)
-            , offset(DataSpace<DIM>())
         {
             // create size on device before any use of setCurrentSize
             if(useVectorAsBase)
@@ -77,8 +77,8 @@ namespace pmacc
             DataSpace<DIM> offset,
             bool sizeOnDevice = false)
             : DeviceBuffer<TYPE, DIM>(size, source.getPhysicalMemorySize())
-            , sizeOnDevice(sizeOnDevice)
             , offset(offset + source.getOffset())
+            , sizeOnDevice(sizeOnDevice)
             , data(source.getCudaPitched())
             , useOtherMemory(true)
         {

--- a/include/pmacc/memory/buffers/ExchangeIntern.hpp
+++ b/include/pmacc/memory/buffers/ExchangeIntern.hpp
@@ -54,8 +54,8 @@ namespace pmacc
             uint32_t area = BORDER,
             bool sizeOnDevice = false)
             : Exchange<TYPE, DIM>(exchange, communicationTag)
-            , deviceDoubleBuffer(nullptr)
             , hostBuffer(nullptr)
+            , deviceDoubleBuffer(nullptr)
         {
             PMACC_ASSERT(!guardingCells.isOneDimensionGreaterThan(memoryLayout.getGuard()));
 
@@ -99,8 +99,8 @@ namespace pmacc
             uint32_t communicationTag,
             bool sizeOnDevice = false)
             : Exchange<TYPE, DIM>(exchange, communicationTag)
-            , deviceDoubleBuffer(nullptr)
             , hostBuffer(nullptr)
+            , deviceDoubleBuffer(nullptr)
         {
             using DeviceBuffer = DeviceBufferIntern<TYPE, DIM>;
             deviceBuffer = std::make_unique<DeviceBuffer>(exchangeDataSpace, sizeOnDevice);

--- a/include/pmacc/memory/buffers/GridBuffer.hpp
+++ b/include/pmacc/memory/buffers/GridBuffer.hpp
@@ -96,8 +96,8 @@ namespace pmacc
          */
         GridBuffer(const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false)
             : Parent(gridLayout.getDataSpace(), sizeOnDevice)
-            , gridLayout(gridLayout)
             , hasOneExchange(false)
+            , gridLayout(gridLayout)
             , maxExchange(0)
         {
             init();
@@ -115,8 +115,8 @@ namespace pmacc
          */
         GridBuffer(const DataSpace<DIM>& dataSpace, bool sizeOnDevice = false)
             : Parent(dataSpace, sizeOnDevice)
-            , gridLayout(dataSpace)
             , hasOneExchange(false)
+            , gridLayout(dataSpace)
             , maxExchange(0)
         {
             init();
@@ -138,8 +138,8 @@ namespace pmacc
             const GridLayout<DIM>& gridLayout,
             bool sizeOnDevice = false)
             : Parent(otherDeviceBuffer, gridLayout.getDataSpace(), sizeOnDevice)
-            , gridLayout(gridLayout)
             , hasOneExchange(false)
+            , gridLayout(gridLayout)
             , maxExchange(0)
         {
             init();
@@ -159,8 +159,8 @@ namespace pmacc
                 offsetDevice,
                 gridLayout.getDataSpace(),
                 sizeOnDevice)
-            , gridLayout(gridLayout)
             , hasOneExchange(false)
+            , gridLayout(gridLayout)
             , maxExchange(0)
         {
             init();

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -86,7 +86,7 @@ namespace pmacc
             PMACC_SMEM(acc, lastFrame, FramePtr);
             PMACC_SMEM(acc, gapIndices_sh, memory::Array<int, frameSize>);
             PMACC_SMEM(acc, numGaps, int);
-            PMACC_SMEM(acc, numParticles, int);
+            PMACC_SMEM(acc, numParticles, uint32_t);
             PMACC_SMEM(acc, srcGap, int);
 
             uint32_t const workerIdx = cupla::threadIdx(acc).x;
@@ -96,7 +96,7 @@ namespace pmacc
                 {
                     lastFrame = pb.getLastFrame(superCellIdx);
                     numGaps = 0;
-                    numParticles = 0;
+                    numParticles = 0u;
                     srcGap = 0;
                 });
 
@@ -407,7 +407,7 @@ namespace pmacc
              */
             PMACC_SMEM(acc, destFrames, memory::Array<FramePtr, numExchanges * 2>);
             // count particles per frame
-            PMACC_SMEM(acc, destFramesCounter, memory::Array<int, numExchanges>);
+            PMACC_SMEM(acc, destFramesCounter, memory::Array<uint32_t, numExchanges>);
 
             PMACC_SMEM(acc, frame, FramePtr);
             PMACC_SMEM(acc, isProcessedSupercell, bool);
@@ -442,7 +442,7 @@ namespace pmacc
                 [&](lockstep::Idx const idx)
                 {
                     uint32_t const linearIdx = idx;
-                    destFramesCounter[linearIdx] = 0;
+                    destFramesCounter[linearIdx] = 0u;
                     destFrames[linearIdx] = FramePtr();
                     destFrames[linearIdx + numExchanges] = FramePtr();
                     /* neighborSuperCellIdx should not be stored in a context variable.
@@ -456,7 +456,7 @@ namespace pmacc
 
                         if(tmpFrame.isValid())
                         {
-                            int32_t const particlesInFrame = pb.getSuperCell(neighborSuperCellIdx).getSizeLastFrame();
+                            uint32_t const particlesInFrame = pb.getSuperCell(neighborSuperCellIdx).getSizeLastFrame();
                             // do not use the neighbor's last frame if it is full
                             if(particlesInFrame < frameSize)
                             {
@@ -493,7 +493,7 @@ namespace pmacc
                             destParticleIdxCtx[idx] = cupla::atomicAdd(
                                 acc,
                                 &(destFramesCounter[direction]),
-                                1,
+                                1u,
                                 ::alpaka::hierarchy::Threads{});
                         }
                         return direction;
@@ -512,7 +512,7 @@ namespace pmacc
                          * supercell fit into the `low frame`, a second frame is created to
                          * contain further particles, the `high frame` (default: invalid).
                          */
-                        if(destFramesCounter[linearIdx] > 0)
+                        if(destFramesCounter[linearIdx] > 0u)
                         {
                             /* neighborSuperCellIdx should not be stored in a context variable.
                              * Using a context variable results into 16bit reads.
@@ -887,7 +887,7 @@ namespace pmacc
             using FramePtr = typename T_ParBox::FramePtr;
 
             PMACC_SMEM(acc, frame, FramePtr);
-            PMACC_SMEM(acc, elementCount, int);
+            PMACC_SMEM(acc, elementCount, uint32_t);
             PMACC_SMEM(acc, exchangeChunk, TileDataBox<T_ExchangeValueType>);
 
 
@@ -903,7 +903,7 @@ namespace pmacc
                 {
                     exchangeChunk = exchangeBox.get(cupla::blockIdx(acc).x, compressedSuperCellIdxCtx[idx]);
                     elementCount = exchangeChunk.getSize();
-                    if(elementCount > 0)
+                    if(elementCount > 0u)
                     {
                         frame = pb.getEmptyFrame(acc);
                     }
@@ -936,7 +936,7 @@ namespace pmacc
             onlyMaster(
                 [&](lockstep::Idx const idx)
                 {
-                    if(elementCount > 0)
+                    if(elementCount > 0u)
                     {
                         // compute the super cell position in target frame to insert into
                         //! @todo: offset == simulation border should be passed to this func instead of being created

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -46,9 +46,9 @@ namespace pmacc
             TYPE maxSize,
             PushDataBox<TYPE, PushType> virtualMemory)
             : DataBox<PitchedBox<VALUE, DIM1>>(PitchedBox<VALUE, DIM1>(data))
+            , virtualMemory(virtualMemory)
             , currentSizePointer(currentSizePointer)
             , maxSize(maxSize)
-            , virtualMemory(virtualMemory)
         {
         }
 
@@ -97,8 +97,8 @@ namespace pmacc
 
     protected:
         PMACC_ALIGN8(virtualMemory, PushDataBox<TYPE, PushType>);
-        PMACC_ALIGN(maxSize, TYPE);
         PMACC_ALIGN(currentSizePointer, TYPE*);
+        PMACC_ALIGN(maxSize, TYPE);
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/memory/boxes/PushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/PushDataBox.hpp
@@ -98,7 +98,7 @@ namespace pmacc
         }
 
     protected:
-        PMACC_ALIGN(maxSize, TYPE);
         PMACC_ALIGN(currentSize, TYPE*);
+        PMACC_ALIGN(maxSize, TYPE);
     };
 } // namespace pmacc

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -143,9 +143,9 @@ namespace pmacc
             const std::shared_ptr<DeviceHeap>& deviceHeap,
             DataSpace<DIM> layout,
             DataSpace<DIM> superCellSize)
-            : m_deviceHeap(deviceHeap)
-            , superCellSize(superCellSize)
+            : superCellSize(superCellSize)
             , gridSize(layout)
+            , m_deviceHeap(deviceHeap)
         {
             exchangeMemoryIndexer = std::make_unique<GridBuffer<BorderFrameIndex, DIM1>>(DataSpace<DIM1>(0));
             framesExchanges = std::make_unique<GridBuffer<FrameType, DIM1, FrameTypeBorder>>(DataSpace<DIM1>(0));

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -71,15 +71,15 @@ namespace pmacc
         using ThisType = Particle<FrameType, ValueTypeSeq>;
         using MethodsList = typename FrameType::MethodsList;
 
-        /** index of particle inside the Frame*/
-        PMACC_ALIGN(idx, uint32_t);
-
         /** pointer to parent frame where this particle is from
          *
          * ATTENTION: The pointer must be the last member to avoid local memory usage
          *            https://github.com/ComputationalRadiationPhysics/picongpu/pull/762
          */
         PMACC_ALIGN(frame, FrameType*);
+
+        /** index of particle inside the Frame*/
+        PMACC_ALIGN(idx, uint32_t);
 
         /** set particle handle to invalid
          *

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -200,7 +200,7 @@ namespace pmacc
                                     ++vThreadMasterIdx;
 
                                     // load empty frame if virtual thread is the master
-                                    if(vThreadMasterIdx == idx)
+                                    if(vThreadMasterIdx == static_cast<int32_t>(idx))
                                     {
                                         /* counter[2] -> number of used frames */
                                         kernel::atomicAllInc(acc, &(counter[2]), ::alpaka::hierarchy::Blocks{});

--- a/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
@@ -40,10 +40,10 @@ namespace pmacc
 
         TaskReceiveParticlesExchange(ParBase& parBase, uint32_t exchange)
             : parBase(parBase)
-            , exchange(exchange)
             , state(Constructor)
-            , maxSize(parBase.getParticlesBuffer().getReceiveExchangeStack(exchange).getMaxParticlesCount())
             , initDependency(__getTransactionEvent())
+            , exchange(exchange)
+            , maxSize(parBase.getParticlesBuffer().getReceiveExchangeStack(exchange).getMaxParticlesCount())
             , lastSize(0)
         {
         }

--- a/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
@@ -39,12 +39,12 @@ namespace pmacc
 
         TaskSendParticlesExchange(ParBase& parBase, uint32_t exchange)
             : parBase(parBase)
-            , exchange(exchange)
             , state(Constructor)
-            , maxSize(parBase.getParticlesBuffer().getSendExchangeStack(exchange).getMaxParticlesCount())
-            , initDependency(__getTransactionEvent())
-            , lastSize(0)
             , lastSendEvent(EventTask())
+            , initDependency(__getTransactionEvent())
+            , exchange(exchange)
+            , maxSize(parBase.getParticlesBuffer().getSendExchangeStack(exchange).getMaxParticlesCount())
+            , lastSize(0)
             , retryCounter(0)
         {
         }

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -51,7 +51,7 @@ namespace pmacc
                     forEachCell(
                         [&](uint32_t const linearIdx)
                         {
-                            uint32_t const linearTid = cupla::blockIdx(acc).x * T_blockSize + linearIdx;
+                            int32_t const linearTid = cupla::blockIdx(acc).x * T_blockSize + linearIdx;
                             if(linearTid >= size.productOfComponents())
                                 return;
 
@@ -66,8 +66,8 @@ namespace pmacc
         template<uint32_t T_dim, class T_RNGMethod>
         RNGProvider<T_dim, T_RNGMethod>::RNGProvider(const Space& size, const std::string& uniqueId)
             : m_size(size)
-            , m_uniqueId(uniqueId.empty() ? getName() : uniqueId)
             , buffer(std::make_unique<Buffer>(size))
+            , m_uniqueId(uniqueId.empty() ? getName() : uniqueId)
         {
             if(m_size.productOfComponents() == 0)
                 throw std::invalid_argument("Cannot create RNGProvider with zero size");

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -16,7 +16,7 @@ fi
 
 PIC_CONST_ARGS=""
 # to save compile time reduce the isaac functor chain length to one
-PIC_CONST_ARGS="${PIC_CONST_ARGS} -DISAAC_MAX_FUNCTORS=1 -DCMAKE_BUILD_TYPE=${PIC_BUILD_TYPE}"
+PIC_CONST_ARGS="${PIC_CONST_ARGS} -DPIC_CI_COMPILE=ON -DISAAC_MAX_FUNCTORS=1 -DCMAKE_BUILD_TYPE=${PIC_BUILD_TYPE}"
 CMAKE_ARGS="${PIC_CONST_ARGS} ${PIC_CMAKE_ARGS} -DCMAKE_CXX_COMPILER=${CXX_VERSION} -DBOOST_ROOT=/opt/boost/${BOOST_VERSION}"
 
 # check and activate if clang should be used as CUDA device compiler

--- a/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
@@ -124,6 +124,9 @@ namespace picongpu
         /** Add this additional field for pushing particles */
         static constexpr bool InfluenceParticlePusher = PARAM_INCLUDE_FIELDBACKGROUND;
 
+        /** We use this to calculate your SI input back to our unit system */
+        PMACC_ALIGN(m_unitField, const float3_64);
+
         /** TWTS B-fields need to be initialized on host,
          *  so they can look up global grid dimensions.
          *
@@ -135,9 +138,6 @@ namespace picongpu
 #else
         const templates::twts::BField twtsFieldB;
 #endif
-
-        /** We use this to calculate your SI input back to our unit system */
-        PMACC_ALIGN(m_unitField, const float3_64);
 
         HINLINE FieldBackgroundB(const float3_64 unitField)
             : m_unitField(unitField)

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/density.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/density.param
@@ -66,8 +66,8 @@ namespace picongpu
             {
                 const float_64 x(position_SI.x());
                 const float_64 y(position_SI.y());
-                const uint64_t xCellId(uint64_t(position_SI.x() / cellSize_SI[0]));
-                const uint64_t yCellId(uint64_t(position_SI.y() / cellSize_SI[1]));
+                const uint64_t xCellId(uint64_t(x / cellSize_SI[0]));
+                const uint64_t yCellId(uint64_t(y / cellSize_SI[1]));
                 constexpr uint32_t cellsY = 128;
                 constexpr uint32_t cellsX = 128;
                 constexpr uint32_t w = 8;


### PR DESCRIPTION
- Add CMake option `PIC_CI_COMPILE` to enable more strict compile errors.
- CI: enable strict warning/error checks
- fix compile error when using `-Wall`

We always enabled strict warnings together with GCC but never enabled that those warnings are errors in the CI.
This PR is now switching compile warnings for GCC into compile-time errors.