### PR TITLE
PML: avoid `stack frames` in GPU kernel

### DIFF
--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -180,11 +180,11 @@ namespace picongpu
                         {
                             /* Note: here we could have returned the result directly,
                              * but chose to have a single return for potential
-                             * performance gains on GPU. The break is not required,
-                             * since each valid index belonds to exactly one layer.
+                             * performance gains on GPU.
+                             * 'break' can be used too because the if condition will evaluate only for one layer to
+                             * true but this would create 'stack frame' usage within GPU kernel.
                              */
                             result = currentLayerBeginIdx + layer.getLinearIdx(idx);
-                            break;
                         }
                         else
                             currentLayerBeginIdx += layer.getVolume();


### PR DESCRIPTION
fix: one part of #3870

dev branch:
```
ptxas info    : Compiling entry function '_ZN6alpaka16uniform_cuda_hip6detail20uniformCudaHipKernelINS_12AccGpuCudaRtISt17integral_constantImLm3EEjEES5_jN5cupla16cupla_cuda_async11CuplaKernelIN8picongpu6fields13maxwellSolver4fdtd17KernelUpdateFieldILj256EEEEEJN5pmacc11AreaMappingILj2ENSH_18MappingDescriptionILj3ENSH_4math2CT6VectorIN4mpl_10integral_cIiLi8EEESP_NSO_IiLi4EEEEEEEEENSB_8absorber3pml18UpdateBHalfFunctorINSB_15differentiation4CurlINSX_7ForwardEEEEENSH_7DataBoxINSH_10PitchedBoxINSK_6VectorIfLi3ENSK_16StandardAccessorENSK_17StandardNavigatorENSK_6detail17Vector_componentsIfLi3EEEEELj3EEEEES1C_EEEvNS_3VecIT0_T1_EET2_DpT3_' for 'sm_70'
ptxas info    : Function properties for _ZN6alpaka16uniform_cuda_hip6detail20uniformCudaHipKernelINS_12AccGpuCudaRtISt17integral_constantImLm3EEjEES5_jN5cupla16cupla_cuda_async11CuplaKernelIN8picongpu6fields13maxwellSolver4fdtd17KernelUpdateFieldILj256EEEEEJN5pmacc11AreaMappingILj2ENSH_18MappingDescriptionILj3ENSH_4math2CT6VectorIN4mpl_10integral_cIiLi8EEESP_NSO_IiLi4EEEEEEEEENSB_8absorber3pml18UpdateBHalfFunctorINSB_15differentiation4CurlINSX_7ForwardEEEEENSH_7DataBoxINSH_10PitchedBoxINSK_6VectorIfLi3ENSK_16StandardAccessorENSK_17StandardNavigatorENSK_6detail17Vector_componentsIfLi3EEEEELj3EEEEES1C_EEEvNS_3VecIT0_T1_EET2_DpT3_
    336 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 42 registers, 4864 bytes smem, 800 bytes cmem[0]
```

this PR:
```
ptxas info    : Compiling entry function '_ZN6alpaka16uniform_cuda_hip6detail20uniformCudaHipKernelINS_12AccGpuCudaRtISt17integral_constantImLm3EEjEES5_jN5cupla16cupla_cuda_async11CuplaKernelIN8picongpu6fields13maxwellSolver4fdtd17KernelUpdateFieldILj256EEEEEJN5pmacc11AreaMappingILj2ENSH_18MappingDescriptionILj3ENSH_4math2CT6VectorIN4mpl_10integral_cIiLi8EEESP_NSO_IiLi4EEEEEEEEENSB_8absorber3pml18UpdateBHalfFunctorINSB_15differentiation4CurlINSX_7ForwardEEEEENSH_7DataBoxINSH_10PitchedBoxINSK_6VectorIfLi3ENSK_16StandardAccessorENSK_17StandardNavigatorENSK_6detail17Vector_componentsIfLi3EEEEELj3EEEEES1C_EEEvNS_3VecIT0_T1_EET2_DpT3_' for 'sm_70'
ptxas info    : Function properties for _ZN6alpaka16uniform_cuda_hip6detail20uniformCudaHipKernelINS_12AccGpuCudaRtISt17integral_constantImLm3EEjEES5_jN5cupla16cupla_cuda_async11CuplaKernelIN8picongpu6fields13maxwellSolver4fdtd17KernelUpdateFieldILj256EEEEEJN5pmacc11AreaMappingILj2ENSH_18MappingDescriptionILj3ENSH_4math2CT6VectorIN4mpl_10integral_cIiLi8EEESP_NSO_IiLi4EEEEEEEEENSB_8absorber3pml18UpdateBHalfFunctorINSB_15differentiation4CurlINSX_7ForwardEEEEENSH_7DataBoxINSH_10PitchedBoxINSK_6VectorIfLi3ENSK_16StandardAccessorENSK_17StandardNavigatorENSK_6detail17Vector_componentsIfLi3EEEEELj3EEEEES1C_EEEvNS_3VecIT0_T1_EET2_DpT3_
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
```

By using an break within a for loop we triggered using stack frame usage
in the GPU kernel.