### PR TITLE
Add a new functor for start position and weightings of macroparticles

### DIFF
--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -123,8 +123,11 @@ namespace picongpu
                  *  unit: none */
                 static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
             };
-            /** definition of random particle start */
+            /** definition of random particle position */
             using Random = RandomImpl<RandomParameter>;
+
+            /** definition of random particle position and weighting, same template parameter */
+            using RandomPositionAndWeighting = RandomPositionAndWeightingImpl<RandomParameter>;
 
             struct QuietParam
             {

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -64,7 +64,8 @@ namespace picongpu
          * The sampling process operates independently for each cell, as follows:
          *    - Evaluate the amount of real particles in the cell, Nr, using T_DensityFunctor.
          *    - If Nr > 0, decide how to represent it with macroparticles using T_PositionFunctor:
-         *        - (For simplicity we describe how all currently used functors operate, see below for customization)
+         *        - (For simplicity we describe how all currently used functors but RandomPositionAndWeightingImpl
+         *           operate, see below for customization)
          *        - Try to have exactly T_PositionFunctor::numParticlesPerCell macroparticles
          *          with same weighting w = Nr / T_PositionFunctor::numParticlesPerCell.
          *        - If such w < MIN_WEIGHTING, instead use fewer macroparticles and higher weighting.
@@ -75,7 +76,7 @@ namespace picongpu
          * In principle, one could override the logic inside the (If Nr > 0) block by implementing a custom functor.
          * Then one could have an arbitrary number of macroparticles and weight distribution between them.
          * The only requirement is that together it matches Nr.
-         * However, the description above holds for all preset position functors provided by PIConGPU.
+         * For an example of non-uniform weight distribution @see startPosition::RandomPositionAndWeightingImpl.
          * Note that in this scheme almost all non-vacuum cells will start with the same number of macroparticles.
          * Having a higher density in a cell would mean larger weighting, but not more macroparticles.
          *

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def
@@ -1,0 +1,66 @@
+/* Copyright 2014-2021 Rene Widera, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/startPosition/generic/FreeRng.def"
+
+#include <pmacc/random/distributions/Uniform.hpp>
+
+#include <boost/mpl/integral_c.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace startPosition
+        {
+            namespace acc
+            {
+                /** Set the in cell position and weighting randomly
+                 *
+                 * @see startPosition::RandomPositionAndWeightingImpl
+                 *
+                 * @tparam T_ParamClass parameter class, must define ::numParticlesPerCell
+                 */
+                template<typename T_ParamClass>
+                struct RandomPositionAndWeightingImpl;
+
+            } // namespace acc
+
+
+            /** Set the in cell position and weighting randomly
+             *
+             * The new position is uniformly distributed inside the cell.
+             * The weightings are sampled randomly and uniformly around the weighting value of RandomImpl.
+             * All weightings are guaranteed to be >= MIN_WEIGHTING and combined weightings in a cell correspond
+             * to the represented density.
+             *
+             * @tparam T_ParamClass parameter class, must define ::numParticlesPerCell
+             */
+            template<typename T_ParamClass>
+            using RandomPositionAndWeightingImpl = generic::FreeRng<
+                acc::RandomPositionAndWeightingImpl<T_ParamClass>,
+                pmacc::random::distributions::Uniform<float_X>>;
+        } // namespace startPosition
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
@@ -1,0 +1,110 @@
+/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+ *                     Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/startPosition/detail/WeightMacroParticles.hpp"
+#include "picongpu/particles/startPosition/generic/FreeRng.def"
+
+#include <boost/mpl/integral_c.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace startPosition
+        {
+            namespace acc
+            {
+                template<typename T_ParamClass>
+                struct RandomPositionAndWeightingImpl
+                {
+                    /** set in-cell position and weighting
+                     *
+                     * @tparam T_Rng functor::misc::RngWrapper, type of the random number generator
+                     * @tparam T_Particle pmacc::Particle, particle type
+                     * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+                     *
+                     * @param rng random number generator
+                     * @param particle particle to be manipulated
+                     * @param ... unused particles
+                     */
+                    template<typename T_Rng, typename T_Particle, typename... T_Args>
+                    HDINLINE void operator()(T_Rng& rng, T_Particle& particle, T_Args&&...)
+                    {
+                        floatD_X tmpPos;
+                        for(uint32_t d = 0; d < simDim; ++d)
+                            tmpPos[d] = rng();
+                        particle[position_] = tmpPos;
+
+                        // The last macroparticle of a cell gets the remaining weight
+                        if(m_remainingMacroparticles <= 1)
+                        {
+                            particle[weighting_] = math::max(m_totalRemainingWeighting, MIN_WEIGHTING);
+                            m_totalRemainingWeighting = 0.0_X;
+                            m_remainingMacroparticles = 0;
+                        }
+                        else
+                        {
+                            m_remainingMacroparticles--;
+                            // Generate a weighting uniformly distributed in [0, 2x average weighting]
+                            auto weighting = rng() * 2.0_X * m_averageWeighting;
+                            /* Clump it to the valid range: it has to be at least MIN_WEIGHTING and
+                             * all remaining macroparticles also have at least MIN_WEIGHTING
+                             */
+                            auto const maxWeighting = m_totalRemainingWeighting
+                                - MIN_WEIGHTING * static_cast<float_X>(m_remainingMacroparticles);
+                            weighting = math::max(math::min(weighting, maxWeighting), MIN_WEIGHTING);
+                            particle[weighting_] = weighting;
+                            m_totalRemainingWeighting -= weighting;
+                        }
+                    }
+
+                    template<typename T_Particle>
+                    HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                    {
+                        m_remainingMacroparticles = startPosition::detail::WeightMacroParticles{}(
+                            realParticlesPerCell,
+                            T_ParamClass::numParticlesPerCell,
+                            m_averageWeighting);
+                        m_totalRemainingWeighting = m_averageWeighting * m_remainingMacroparticles;
+                        return m_remainingMacroparticles;
+                    }
+
+                    /** Average weighting of a macroparticle
+                     *
+                     * Due to the initialization logic, will always be >= MIN_WEIGHTING
+                     */
+                    float_X m_averageWeighting;
+
+                    //! Total weighting for remaining macroparticles
+                    float_X m_totalRemainingWeighting;
+
+                    //! Number of macroparticles remaining to be generated
+                    uint32_t m_remainingMacroparticles;
+                };
+
+            } // namespace acc
+        } // namespace startPosition
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/startPosition/functors.def
+++ b/include/picongpu/particles/startPosition/functors.def
@@ -23,5 +23,6 @@
 #include "picongpu/particles/startPosition/OnePositionImpl.def"
 #include "picongpu/particles/startPosition/QuietImpl.def"
 #include "picongpu/particles/startPosition/RandomImpl.def"
+#include "picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def"
 #include "picongpu/particles/startPosition/generic/Free.def"
 #include "picongpu/particles/startPosition/generic/FreeRng.def"

--- a/include/picongpu/particles/startPosition/functors.hpp
+++ b/include/picongpu/particles/startPosition/functors.hpp
@@ -23,5 +23,6 @@
 #include "picongpu/particles/startPosition/OnePositionImpl.hpp"
 #include "picongpu/particles/startPosition/QuietImpl.hpp"
 #include "picongpu/particles/startPosition/RandomImpl.hpp"
+#include "picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp"
 #include "picongpu/particles/startPosition/generic/Free.hpp"
 #include "picongpu/particles/startPosition/generic/FreeRng.hpp"

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/particle.param
@@ -32,14 +32,14 @@ namespace picongpu
     {
         namespace startPosition
         {
-            struct QuietParam25ppc
+            struct RandomParam25ppc
             {
-                /** Count of particles per cell per direction at initial state
+                /** Count of particles per cell at initial state
                  *  unit: none
                  */
-                using numParticlesPerDimension = typename mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type;
+                static constexpr uint32_t numParticlesPerCell = 25;
             };
-            using Quiet25ppc = QuietImpl<QuietParam25ppc>;
+            using RandomPositionAndWeighting25ppc = RandomPositionAndWeightingImpl<RandomParam25ppc>;
 
         } // namespace startPosition
 
@@ -53,8 +53,7 @@ namespace picongpu
          *  number of particles per cell for normalization of weighted
          *  particle attributes.
          */
-        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL
-            = mCT::volume<startPosition::QuietParam25ppc::numParticlesPerDimension>::type::value;
+        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = startPosition::RandomParam25ppc::numParticlesPerCell;
 
         namespace manipulators
         {

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesInitialization.param
@@ -40,7 +40,7 @@ namespace picongpu
          * the functors are called in order (from first to last functor)
          */
         using InitPipeline = bmpl::vector<
-            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet25ppc, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::RandomPositionAndWeighting25ppc, PIC_Electrons>,
             Manipulate<manipulators::AddTemperature, PIC_Electrons>>;
 
     } // namespace particles


### PR DESCRIPTION
It generates both randomly.
In terms of position, it is same uniformly distributed as in `RandomImpl`.
The weightings are sampled randomly, guaranteed to be within the constraints.

This is what we discussed on a dev meeting today.