### PR TITLE
Update summit profile

### DIFF
--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -18,7 +18,7 @@ export proj=<yourProject>
 #export EDITOR="nano"
 
 # basic environment ###########################################################
-module load gcc/6.4.0  e4s/21.02  spectrum-mpi/10.3.1.2-20200121
+module load gcc/9.3.0 spectrum-mpi/10.4.0.3-20210112
 
 export CC=$(which gcc)
 export CXX=$(which g++)
@@ -26,20 +26,21 @@ export CXX=$(which g++)
 # required tools and libs
 module load git/2.29.0
 module load cmake/3.20.2
-module load cuda/10.2.89
-module load boost/1.66.0
+module load cuda/11.0.3
+module load boost/1.74.0
 
 # plugins (optional) ##########################################################
 module load hdf5/1.10.7
 module load c-blosc/1.21.0 zfp/0.5.5 sz/2.1.11.1 lz4/1.9.3
 module load adios2/2.7.1
-module load openpmd-api/0.13.2
+
+module load openpmd-api/0.13.4
 
 #export T3PIO_ROOT=$PROJWORK/$proj/lib/t3pio
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$T3PIO_ROOT/lib
 
 module load zlib/1.2.11
-module load libpng/1.6.37 freetype/2.9.1
+module load libpng/1.6.37 freetype/2.10.4
 # optionally install pngwriter yourself:
 #   https://github.com/pngwriter/pngwriter#install
 # export PNGwriter_ROOT=<your pngwriter install directory>  # e.g., ${HOME}/sw/pngwriter


### PR DESCRIPTION
After the system upgrade to RHEL8 some of the previously used modules are not available anymore.
This PR fixes the selection of modules.