### PR TITLE
Fix treatment of bool particle attributes in openPMD plugin

### DIFF
--- a/include/picongpu/plugins/openPMD/GetComponentsType.hpp
+++ b/include/picongpu/plugins/openPMD/GetComponentsType.hpp
@@ -1,0 +1,50 @@
+/* Copyright 2021 Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/traits/GetComponentsType.hpp>
+
+#include <type_traits>
+
+namespace pmacc
+{
+    namespace traits
+    {
+        /** Get component type trait for bools in openPMD output
+         *
+         * Specializes the general trait in pmacc/traits/GetComponentsType.hpp.
+         * For use with the openPMD API, both files must be included.
+         *
+         * The reason is that ADIOS2 backend of openPMD API currently does not support bool datasets #3732.
+         * So with this specialization, PIConGPU particle attributes of type bool (e.g. radiationMask,
+         * transitionRadiationMask) are treated as chars.
+         *
+         * This requires sizeof(bool) == sizeof(char), ::type is defined only in this case.
+         */
+        template<>
+        struct GetComponentsType<bool>
+        {
+            using type = std::enable_if_t<sizeof(bool) == sizeof(char), char>;
+        };
+
+    } // namespace traits
+} // namespace pmacc

--- a/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/plugins/openPMD/GetComponentsType.hpp"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
 #include "picongpu/traits/PICToOpenPMD.hpp"
 

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -22,6 +22,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/plugins/openPMD/GetComponentsType.hpp"
 #include "picongpu/plugins/openPMD/openPMDDimension.hpp"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
 #include "picongpu/traits/PICToOpenPMD.tpp"


### PR DESCRIPTION
ADIOS2 backend does not support bools which caused exceptions.
Redefine `GetComponentsType` trait to treat bools as chars.

Fixes #3732

@Anton-Le I checked that this version compiles, writes checkpoints, and restarts from them on our dev machine. I had no easy way to check if the read values are correct. Could you check it? In case you use some older PIConGPU, should be no problem, could apply the same changes.