### PR TITLE
Fix incorrect assignment of Jz in 2d EmZ implementation

### DIFF
--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2021 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -25,6 +25,7 @@
 #include "picongpu/fields/currentDeposition/RelayPoint.hpp"
 
 #include <pmacc/cuSTL/cursor/Cursor.hpp>
+#include <pmacc/meta/InvokeIf.hpp>
 
 
 namespace picongpu
@@ -104,16 +105,10 @@ namespace picongpu
                     line.m_pos1[d] = calc_InCellPos(relayPoint[d], I[0][d]);
                 }
 
-                const bool twoParticlesNeeded = I[0] != I[1];
-
-                deposit(
-                    acc,
-                    dataBoxJ.shift(I[0]).toCursor(),
-                    line,
-                    chargeDensity,
-                    velocity.z() * (twoParticlesNeeded ? float_X(0.5) : float_X(1.0)));
+                deposit(acc, dataBoxJ.shift(I[0]).toCursor(), line, chargeDensity);
 
                 /* detect if there is a second virtual particle */
+                const bool twoParticlesNeeded = (I[0] != I[1]);
                 if(twoParticlesNeeded)
                 {
                     /* calculate positions for the second virtual particle */
@@ -123,8 +118,47 @@ namespace picongpu
                         line.m_pos1[d] = calc_InCellPos(posEnd[d], I[1][d]);
                         line.m_pos0[d] = calc_InCellPos(relayPoint[d], I[1][d]);
                     }
-                    deposit(acc, dataBoxJ.shift(I[1]).toCursor(), line, chargeDensity, velocity.z() * float_X(0.5));
+                    deposit(acc, dataBoxJ.shift(I[1]).toCursor(), line, chargeDensity);
                 }
+
+                /* 2d case requires special handling of Jz as explained in #3889.
+                 * Pass dataBoxJ as auto&& to defer evaluation for 3d case.
+                 */
+                pmacc::meta::invokeIf<simDim == 2>(
+                    [&, this](auto&& dataBoxJ)
+                    {
+                        /* For Jz we consider the whole movement on a step.
+                         * This movement it is not necessarily on support.
+                         * So extend the bounds in x, y by 1 and use general assignment function.
+                         *
+                         * We have to calculate everything relative to I[1], not I[0].
+                         * The reason is I[1] corresponds to the current cell of a particle,
+                         * from where the margins are counted.
+                         * I[1] with begin and end extended by 1 both sides is guaranteed to fit the general margins of
+                         * this functor. This is because I[0] can differ from I[1] by 1 in any direction and for each
+                         * the original begin and end fit.
+                         */
+                        for(uint32_t d = 0; d < simDim; ++d)
+                        {
+                            line.m_pos0[d] = this->calc_InCellPos(posStart[d], I[1][d]);
+                            line.m_pos1[d] = this->calc_InCellPos(posEnd[d], I[1][d]);
+                        }
+                        /* Have to use DIM2, otherwise 3d case wouldn't compile due to
+                         * no computeCurrentZ() method.
+                         * In this case it is parsed even though the invokeIf condition is false and dataBoxJ is passed
+                         * as auto&&.
+                         */
+                        emz::DepositCurrent<
+                            typename T_Strategy::BlockReductionOp,
+                            typename T_ParticleShape::ChargeAssignment,
+                            begin - 1,
+                            end + 1,
+                            DIM2>
+                            depositZ;
+                        depositZ
+                            .computeCurrentZ(acc, dataBoxJ.shift(I[1]).toCursor(), line, velocity.z() * chargeDensity);
+                    },
+                    dataBoxJ);
             }
 
             static pmacc::traits::StringProperty getStringProperties()


### PR DESCRIPTION
In case two virtual particles were used, the implementation was incorrect.
It resulted in proper total amount of Jz, but generally incorrect distribution in x, y.
See #3889 for more details.

This PR implements [the suggested fix](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3889#issuecomment-952019984).
Now it produces same Jz values as `Esirkepov` implementation.

Solves #3889.

We have to port this fix to the release candidate branch. This error also seems to have been present in all PIConGPU versions on github.

It is hard to evaluate what was the effect of it. The bug affected only 2d case, and only particles with the two-virtual-particles schema, so the particles that changed the closest cell or half-cell (depending on even/odd shape support) in x or y due to movement during the last time step. For those particles, EmZ violated the continuity equation in the Jz term. Values of Jx, Jy were always calculated correctly (i.e. same as in Esirkepov). With enough particles and a stable regime it may have been not a big difference, as the total current was preserved and distributed among same grid nodes, but with somewhat off coefficients. However in an instability scenario it could have all be going wrong because of this effect. Need to recheck #3234 (in case that was 2d) and the ongoing hunt for instability.