### PR TITLE
Move yee::StencilFunctor to fdtd::StencilFunctor

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
@@ -21,7 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/MaxwellSolver/Yee/StencilFunctor.hpp"
+#include "picongpu/fields/MaxwellSolver/FDTD/StencilFunctor.hpp"
 
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
 #include <pmacc/dimensions/SuperCellDescription.hpp>
@@ -47,7 +47,7 @@ namespace picongpu
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlB>
-                class UpdateEFunctor : public yee::StencilFunctor<T_CurlB>
+                class UpdateEFunctor : public StencilFunctor<T_CurlB>
                 {
                 public:
                     /** Update electric field at the given position
@@ -83,7 +83,7 @@ namespace picongpu
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlE>
-                class UpdateBHalfFunctor : public yee::StencilFunctor<T_CurlE>
+                class UpdateBHalfFunctor : public StencilFunctor<T_CurlE>
                 {
                 public:
                     /** Update magnetic field at the given position

--- a/include/picongpu/fields/MaxwellSolver/FDTD/StencilFunctor.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/StencilFunctor.hpp
@@ -30,7 +30,7 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
-            namespace yee
+            namespace fdtd
             {
                 /** Base stencil functor to update fields inside the kernel
                  *
@@ -69,7 +69,7 @@ namespace picongpu
                         T_DestBox destBox);
                 };
 
-            } // namespace yee
+            } // namespace fdtd
         } // namespace maxwellSolver
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -21,7 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/MaxwellSolver/Yee/StencilFunctor.hpp"
+#include "picongpu/fields/MaxwellSolver/FDTD/StencilFunctor.hpp"
 #include "picongpu/fields/absorber/pml/Parameters.hpp"
 
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
@@ -235,7 +235,7 @@ namespace picongpu
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlB>
-                class UpdateEFunctor : public maxwellSolver::yee::StencilFunctor<T_CurlB>
+                class UpdateEFunctor : public maxwellSolver::fdtd::StencilFunctor<T_CurlB>
                 {
                 public:
                     /** Create a functor instance on the host side
@@ -328,7 +328,7 @@ namespace picongpu
                  *                 adheres to the Curl concept
                  */
                 template<typename T_CurlE>
-                class UpdateBHalfFunctor : public maxwellSolver::yee::StencilFunctor<T_CurlE>
+                class UpdateBHalfFunctor : public maxwellSolver::fdtd::StencilFunctor<T_CurlE>
                 {
                 public:
                     /** Create a functor instance on the host side


### PR DESCRIPTION
This functor "concept" was introduced at the same time the general FDTD part of the `Yee` solver was separated. So this general functor stayed at Yee because of this (mis)ordering. Move it now to FDTD directory and namespace where it is more fitting.