### PR TITLE
Update hemera profiles and documentation for current cmake requirements

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -52,7 +52,7 @@ gcc
 
 CMake
 """""
-- 3.15.0 or higher
+- 3.18.0 or higher
 - *Debian/Ubuntu:* ``sudo apt-get install cmake file cmake-curses-gui``
 - *Arch Linux:* ``sudo pacman --sync cmake``
 - *Spack:* ``spack install cmake``

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/7.3.0
-module load cmake/3.15.2
+module load cmake/3.20.2
 module load openmpi/4.0.4-csk
 module load boost/1.68.0
 

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/7.3.0
-module load cmake/3.15.2
+module load cmake/3.20.2
 module load cuda/11.2
 module load openmpi/4.0.4-cuda112
 module load boost/1.68.0

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/7.3.0
-module load cmake/3.15.2
+module load cmake/3.20.2
 module load cuda/11.2
 module load openmpi/4.0.4-cuda112
 module load boost/1.68.0

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/7.3.0
-module load cmake/3.15.2
+module load cmake/3.20.2
 module load cuda/11.2
 module load openmpi/4.0.4-cuda112
 module load boost/1.68.0

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/7.3.0
-module load cmake/3.15.2
+module load cmake/3.20.2
 module load cuda/11.2
 module load openmpi/4.0.4-cuda112
 module load boost/1.68.0


### PR DESCRIPTION
This PR updates the profiles for hemera to fulfill the current CMake version requirement. It also updates the documentation for the current requirement.