### PR TITLE
"PIConGPU in 5 Minutes": Short Introduction for new Users

### DIFF
--- a/docs/source/in5min.rst
+++ b/docs/source/in5min.rst
@@ -1,0 +1,124 @@
+.. _in5min:
+
+PIConGPU in 5 Minutes
+=====================
+
+A guide to run, but not understand PIConGPU.
+It is aimed at existing and preconfigured high performance computing clusters (“supercomputers”, also: HPC systems).
+For more information on the individual steps please refer to the manual.
+
+This guide needs **shell access** (probably via ``ssh``) and **some auxilliary programs** (e.g. ``git``).
+Consider getting familiar with the shell and git.
+Please also read the tutorial for your local HPC cluster.
+
+We will use the following directories:
+
+- ``~/src/picongpu``: source files from github
+- ``~/picongpu.profile``: load the dependencies for your local environment
+- ``~/picongpu-projects``: scenarios to simulate
+- ``/scratch/mydir``: result data of the simulation runs
+
+Please replace them whenever appropriate.
+
+Get the source
+--------------
+
+Use git to obtain the source and use the current ``dev`` branch and put it into ``~/src/picongpu``::
+
+  mkdir -p ~/src
+  git clone -b dev https://github.com/ComputationalRadiationPhysics/picongpu ~/src/picongpu
+
+Setup
+-----
+
+You need :ref:`a lot of dependencies <install-dependencies>`.
+
+If you are on a known cluster you can take a shortcut:
+Select a profile file (``NAME.profile.example``) for your local HPC cluster from ``etc/picongpu`` and copy it to your home directory::
+
+  cp ~/src/picongpu/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example ~/picongpu.profile
+
+This profile determines which part of the HPC cluster (“partition”, also: “queue”) – and thereby the type of GPUs – you will use.
+
+**Maybe you have to adjust this profile file.**
+Use your favorite editor.
+If unsure use nano: ``nano ~/picongpu.profile`` (Save with Ctrl+O, exit with Ctrl+X)
+Read the file (it’s short) and apply changes if appropriate.
+
+For this guide, add after the last line::
+
+  export SCRATCH=/scratch/mydir
+
+This is the location where runtime data and all results will be stored.
+Obviously change the path according to your local setup.
+Consult the documentation of your HPC cluster where to save your data.
+**On HPC clusters this is probably not your home directory.**
+
+Now activate your profile::
+
+  source ~/picongpu.profile
+
+You will have to repeat the last command every time you want to use PIConGPU.
+
+Create a Scenario
+-----------------
+
+Create a directory and copy an example::
+
+  mkdir -p ~/picongpu-projects/tinkering
+  pic-create $PIC_EXAMPLES/LaserWakefield ~/picongpu-projects/tinkering/try01
+  cd ~/picongpu-projects/tinkering/try01
+
+Usually you would now adjust the files in the newly created directory ``~/picongpu-projects/tinkering/try01`` – for this introduction we will use the parameters as provided.
+Also note how the variable ``$PIC_EXAMPLES`` has been provided becauses you executed ``source ~/picongpu.profile`` in the previous step.
+
+Compile and Run
+---------------
+
+**Now use a compute node.**
+Your profile probably provides a helper command for that::
+
+  getDevice
+
+(You can now run ``hostname`` to see which node you are using.)
+
+Now build (from inside your scenario directory, maybe use ``cd ~/picongpu-projects/tinkering/try01``)::
+
+  pic-build
+
+This will take a while, go grab a coffee.
+If this fails, read the manual or ask a colleague.
+
+After a successfull build, run (still on the compute node, from inside your scenario directory, maybe use ``cd ~/picongpu-projects/tinkering/try01``)::
+
+  tbg -s bash -c etc/picongpu/1.cfg -t etc/picongpu/bash/mpiexec.tpl $SCRATCH/tinkering/try01/run01
+
+- ``tbg``: tool provided by PIConGPU
+- ``bash``: the “submit system”, e.g. use ``sbatch`` for slurm
+- ``etc/picongpu/1.cfg``: runtime options (number of GPUs, etc.)
+- ``etc/picongpu/bash/mpiexec.tpl``: options for the chosen submit system
+- ``$SCRATCH/tinkering/try01/run01``: not-yet-existing destination for your result files
+
+E.g. for “Hypnos” the invocation could be (invoke from the login node)::
+
+  tbg -s qsub -c etc/picongpu/1.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $SCRATCH/tinkering/try01/run01
+
+Examine the results
+-------------------
+
+Results are located at ``$SCRATCH/tinkering/try01/run01``.
+
+To view pretty pictures from a linux workstation you can use the following process (execute on your workstation, **not the HPC cluster**):
+
+0. Create a “mount point” (empty directory): ``mkdir -p ~/mnt/scratch``
+1. Mount the data directory using sshfs:
+   ``sshfs -o default_permissions -o idmap=user -o uid=$(id -u) -o gid=$(id -g) HOST:DATADIR ~/mnt/scratch/``
+   Substitute HOST with the hostname (``ssh HOST`` should connect to the HPC cluster) and DATADIR with the full path to your data directory, e.g. ``/scratch/mydir``
+2. Browse the directory using a file browser/image viewer
+   (e.g. ``gwenview``). Check out ``~/mnt/scratch/tinkering/try01/run01/simOutput/pngElectronsYX/`` for image files.
+
+Further reading
+---------------
+
+You now know the process of using PIConGPU.
+Carry on reading the documentation to understand it.

--- a/docs/source/in5min.rst
+++ b/docs/source/in5min.rst
@@ -40,7 +40,7 @@ Select a profile file (``NAME.profile.example``) for your local HPC cluster from
 
   cp ~/src/picongpu/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example ~/picongpu.profile
 
-This profile determines which part of the HPC cluster (“partition”, also: “queue”) – and thereby the type of GPUs – you will use.
+This profile determines which part of the HPC cluster (“partition”, also: “queue”) – and thereby the hardware (type of CPUs/GPUs) – you will use.
 
 **Maybe you have to adjust this profile file.**
 Use your favorite editor.

--- a/docs/source/in5min.rst
+++ b/docs/source/in5min.rst
@@ -26,7 +26,9 @@ Get the Source
 Use git to obtain the source and use the current ``dev`` branch and put it into ``~/src/picongpu``::
 
   mkdir -p ~/src
-  git clone -b dev https://github.com/ComputationalRadiationPhysics/picongpu ~/src/picongpu
+  git clone https://github.com/ComputationalRadiationPhysics/picongpu ~/src/picongpu
+  cd ~/src/picongpu
+  git checkout dev
 
 Setup
 -----

--- a/docs/source/in5min.rst
+++ b/docs/source/in5min.rst
@@ -72,7 +72,9 @@ Create a directory and copy an example::
   cd ~/picongpu-projects/tinkering/try01
 
 Usually you would now adjust the files in the newly created directory ``~/picongpu-projects/tinkering/try01`` – for this introduction we will use the parameters as provided.
-Also note how the variable ``$PIC_EXAMPLES`` has been provided becauses you executed ``source ~/picongpu.profile`` in the previous step.
+
+Also note how the command ``pic-create`` and the variable ``$PIC_EXAMPLES`` have been provided because you loaded the file ``~/picongpu.profile`` in the previous step.
+If this fails (producing ``pic-create: command not found``), make sure you load the PIConGPU profile by executing ``source ~/picongpu.profile``.
 
 Compile and Run
 ---------------

--- a/docs/source/in5min.rst
+++ b/docs/source/in5min.rst
@@ -40,7 +40,7 @@ Select a profile file (``NAME.profile.example``) for your local HPC cluster from
 
   cp ~/src/picongpu/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example ~/picongpu.profile
 
-This profile determines which part of the HPC cluster (“partition”, also: “queue”) – and thereby the hardware (type of CPUs/GPUs) – you will use.
+This profile determines which part of the HPC cluster (“partition”, also: “queue”) – and thereby the compute device(s) (type of CPUs/GPUs) – you will use.
 
 **Maybe you have to adjust this profile file.**
 Use your favorite editor.

--- a/docs/source/in5min.rst
+++ b/docs/source/in5min.rst
@@ -20,7 +20,7 @@ We will use the following directories:
 
 Please replace them whenever appropriate.
 
-Get the source
+Get the Source
 --------------
 
 Use git to obtain the source and use the current ``dev`` branch and put it into ``~/src/picongpu``::
@@ -103,7 +103,7 @@ E.g. for “Hypnos” the invocation could be (invoke from the login node)::
 
   tbg -s qsub -c etc/picongpu/1.cfg -t etc/picongpu/hypnos-hzdr/k20.tpl $SCRATCH/tinkering/try01/run01
 
-Examine the results
+Examine the Results
 -------------------
 
 Results are located at ``$SCRATCH/tinkering/try01/run01``.
@@ -117,7 +117,7 @@ To view pretty pictures from a linux workstation you can use the following proce
 2. Browse the directory using a file browser/image viewer
    (e.g. ``gwenview``). Check out ``~/mnt/scratch/tinkering/try01/run01/simOutput/pngElectronsYX/`` for image files.
 
-Further reading
+Further Reading
 ---------------
 
 You now know the process of using PIConGPU.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,12 +40,6 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
 .. _wiki: https://github.com/ComputationalRadiationPhysics/picongpu/wiki
 .. _official homepage: http://picongpu.hzdr.de
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   in5min
-
 ************
 Installation
 ************
@@ -59,6 +53,16 @@ Installation
    install/dependencies
    install/profile
    install/changelog.md
+
+*********
+Tutorials
+*********
+.. toctree::
+   :caption: TUTORIALS
+   :maxdepth: 1
+   :hidden:
+
+   tutorials/hemeraIn5min
 
 *****
 Usage

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,12 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
 .. _wiki: https://github.com/ComputationalRadiationPhysics/picongpu/wiki
 .. _official homepage: http://picongpu.hzdr.de
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   in5min
+
 ************
 Installation
 ************

--- a/docs/source/tutorials/hemeraIn5min.rst
+++ b/docs/source/tutorials/hemeraIn5min.rst
@@ -1,4 +1,4 @@
-.. _in5min:
+.. _hemeraIn5min:
 
 PIConGPU in 5 Minutes on Hemera
 ===============================

--- a/docs/source/tutorials/hemeraIn5min.rst
+++ b/docs/source/tutorials/hemeraIn5min.rst
@@ -8,16 +8,16 @@ It is aimed at users of the high performance computing (HPC) cluster `"Hemera" a
 but should be applicable to other HPC clusters with slight adjustments.
 
 This guide needs **shell access** (probably via :command:`ssh`) and :command:`git`.
-Consider getting familiar with the shell and git.
+Consider getting familiar with the shell (*command line*, usually :command:`bash`) and git.
 Please also read the tutorial for your local HPC cluster.
 
 .. seealso::
-   resources on the command line (bash)
+   resources for the command line (bash)
      `a tutorial <http://www.bu.edu/tech/files/2018/05/2018-Summer-Tutorial-Intro-to-Linux.pdf>`_ |
      `another tutorial <https://cscar.research.umich.edu/wp-content/uploads/sites/5/2016/09/Intro-to-Command-Line.pdf>`_ |
      `scripting by examples <https://learnxinyminutes.com/docs/bash/>`_
 
-   resources on git
+   resources for git
      `official tutorial <https://git-scm.com/docs/gittutorial>`_ (also available as man page :manpage:`gittutorial(7)`) |
      `w3school tutorial <https://www.w3schools.com/git/default.asp>`_ |
      `brief introduction <https://learnxinyminutes.com/docs/git/>`_ |
@@ -25,7 +25,7 @@ Please also read the tutorial for your local HPC cluster.
 
    Hemera at HZDR
      `official website <https://www.hzdr.de/db/Cms?pOid=12231&pNid=852>`_ |
-     `presentation <https://www.hzdr.de/db/Cms?pOid=61949>`_ |
+     `presentation <https://www.hzdr.de/db/Cms?pOid=61949>`_
      internal links:
      `wiki <https://fwcc.pages.hzdr.de/infohub/hpc/hemera.html>`_ |
      `storage layout <https://fwcc.pages.hzdr.de/infohub/hpc/storage.html>`_
@@ -76,22 +76,22 @@ Go to the end of the file and add a new line::
 
 (Please replace ``alice`` with your username.)
 
-You can supply additional settings like your email address and notification settings if you want.
-
 .. note::
     This is the location where runtime data and all results will be stored.
     If you're not on Hemera make sure you select the correct directory:
     Consult the documentation of your HPC cluster where to save your data.
     **On HPC clusters this is probably not your home directory.**
 
+In the profile file you can also supply additional settings, like your email address and notification settings.
+
 Now activate your profile::
 
   source ~/k80_picongpu.profile
 
 .. warning::
-   You will have to repeat this command every time you want to use PIConGPU on a new shell, i.e. after logging in.
+   You will have to repeat this command **every time** you want to use PIConGPU on a new shell, i.e. after logging in.
 
-Test your new profile::
+Now test your new profile::
 
   echo $SCRATCH
 
@@ -101,7 +101,7 @@ If that works make sure that this directory actually exists by executing::
   mkdir -p $SCRATCH
   ls -lah $SCRATCH
 
-If you see this output everything worked and you can carry on::
+If you see output similar to this one everything worked and you can carry on::
 
   total 0
   drwxr-xr-x  2 alice    fwt   40 Nov 12 10:09 .
@@ -110,7 +110,7 @@ If you see this output everything worked and you can carry on::
 Create a Scenario
 -----------------
 
-As an example we will use the predefined `*LaserWakefield* example <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/examples/LaserWakefield>`_.
+As an example we will use the predefined `LaserWakefield example <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/examples/LaserWakefield>`_.
 Create a directory and copy it::
 
   mkdir -p ~/picongpu-projects/tinkering
@@ -153,7 +153,8 @@ After a successfull build, run (still on the compute node, still inside your sce
 - :file:`$SCRATCH/tinkering/try01/run01`: not-yet-existing destination for your result files
 
 .. note::
-   Usually you would use the *workload manager* (e.g. `SLURM <https://slurm.schedmd.com/>`_ on Hemera) to submit your jobs.
+   Usually you would use the *workload manager* (`SLURM <https://slurm.schedmd.com/>`_ on Hemera) to submit your jobs
+   instead of running them interactively like we just did.
    You can try that with::
 
      # go back to the login node
@@ -163,11 +164,15 @@ After a successfull build, run (still on the compute node, still inside your sce
 
      # resubmit your simulation with a new directory:
      tbg -s sbatch -c etc/picongpu/1.cfg -t etc/picongpu/hemera-hzdr/k80.tpl $SCRATCH/tinkering/try01/run02
-     # you will get a confirmation, e.g.
-     # Submitted batch job 3769365
 
-   The output of you job will not be displayed!
-   By invoking ``squeue -u $USER`` you can view the current status of your job.
+   This will print a confirmation message (e.g. ``Submitted batch job 3769365``),
+   but no output of PIConGPU itself will be printed.
+   Using ``squeue -u $USER`` you can view the current status of your job.
+
+   Note that we not only used a different "submit system" ``sbatch``,
+   but also changed the template file to :file:`etc/picongpu/hemera-hzdr/k80.tpl`.
+   Both profile and template file are built for the same compute device, the NVIDIA Tesla "K80" GPU.
+   
 
 Examine the Results
 -------------------
@@ -180,12 +185,11 @@ To view pretty pictures from a linux workstation you can use the following proce
   mkdir -p ~/mnt/scratch
 
   # Mount the data directory using sshfs
-  sshfs -o default_permissions -o idmap=user -o uid=$(id -u) -o gid=$(id -g) HOST:DATADIR ~/mnt/scratch/
+  sshfs -o default_permissions -o idmap=user -o uid=$(id -u) -o gid=$(id -g) hemera5:DATADIR ~/mnt/scratch/
 
-Substitute HOST with the hostname (``ssh HOST`` should connect to the HPC cluster)
-and DATADIR with the full path to your data directory, e.g. :file:`/bigdata/hplsim/extern/alice`.
+Substitute DATADIR with the full path to your data (*scratch*) directory, e.g. :file:`/bigdata/hplsim/extern/alice`.
 
-Browse the directory using a file browser/image viewer (e.g. :command:`gwenview`).
+Browse the directory using a file browser/image viewer.
 Check out :file:`~/mnt/scratch/tinkering/try01/run01/simOutput/pngElectronsYX/` for image files.
 
 Further Reading


### PR DESCRIPTION
Dear Maintainer,

I'm currently working through the documentation of PIConGPU and getting familiar with the software.
I oftentimes found myself lacking context, and generally missing a good *overview* over the matters discussed in the individual sections.

(I'd propose creating a new manual section "Overview" outlining general architecture, capabilities, usage, an FAQ for further reading and some short guides -- a "REAMDE++" if you will. However writing and maintaining such a section would consume considerable ressources.)

As an intermediary solution I want to contribute a very brief guide which touches some of those aspects named "PIConGPU in 5 Minutes". It explains how to get a basic example scenario running from scratch. It assumes that the reader:

- uses an existing HPC cluster with an available profile
- has a basic understanding of how a cluster works & can perform simple tasks using it
- can use the shell on a basic level

> Note: I have a good understanding of a HPC cluster, can perform advanced tasks on it and can use the shell on a more than advanced level.
> Maybe this assumptions about the reader (or the level of detail in the explanations) have to be changed.

The following questions should be discussed before accepting this PR:
(Should I open seperate issues for those?)

## Where should this guide be placed?
Currently I moved it into the documentation where an "Overview" section would be located: It is the very first TOC entry.
**This breaks the current style that all top-level TOC entries are chapters.**

![toc](https://user-images.githubusercontent.com/80697868/140289258-c366a62b-f482-4b83-af50-c4852538f070.png)

I considered moving it into "Installation", but that seems wrong as it covers more than just installation.

## Where should this guide be referenced from?
This PR does not include links to this new guide.
Should those be added in the doc intro & readme?

## What should this guide reference?
Please propose links to specific ressources (other documentation sections, external guides etc.) that should be linked from inside the guide.
(e.g. git into, shell intro, 

## How to explain the the example scenario (`LaserWakefield`)?
Is it sufficient for a new user to read the [description provided with the scenario](share/picongpu/examples/LaserWakefield/README.rst) in `share/picongpu/examples/LaserWakefield/README.rst`?
Should that be rephrased with a different level of detail/focus?

## Is "Further Reading" sufficient?
I did not know what should be recommended as further reading apart from "Read the remaining manual".
A short table "if you want to do X look at section Y" would be great, but I don't have enough insights to competently write that.

## Are 5 Minutes enough?
5 min might be a very tight promise -- should that guide be renamed to "PIConGPU in [10,15] Minutes" in order to keep it's promise?