### PR TITLE
Add missing string property output for reflecting and thermal particle boundaries

### DIFF
--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -190,6 +190,7 @@ namespace picongpu
             for(auto exchange : particles::boundary::getAllAxisAlignedExchanges())
             {
                 auto const axis = pmacc::boundary::getAxis(exchange);
+                auto const temperature = boundaryDescription()[axis].temperature;
 
                 const std::string directionName = ExchangeTypeNames()[exchange];
                 propList[directionName]["param"] = std::string("none");
@@ -201,6 +202,14 @@ namespace picongpu
                 case particles::boundary::Kind::Absorbing:
                     propList[directionName]["name"] = "absorbing";
                     propList[directionName]["param"] = std::string("without field correction");
+                    break;
+                case particles::boundary::Kind::Reflecting:
+                    propList[directionName]["name"] = "reflecting";
+                    break;
+                case particles::boundary::Kind::Thermal:
+                    propList[directionName]["name"] = "thermal";
+                    propList[directionName]["param"]
+                        = std::string("temperature ") + std::to_string(temperature) + " keV";
                     break;
                 default:
                     propList[directionName]["name"] = "unknown";


### PR DESCRIPTION
This resulted in some imprecise meta information in the output. Did not affect calculations. So i think it is not necessary to port to the release candidate.