### PR TITLE
Fix restarting with moving window

### DIFF
--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -40,6 +40,7 @@
 #include <boost/mpl/vector.hpp>
 
 #include <cassert>
+#include <stdexcept>
 
 #include <openPMD/openPMD.hpp>
 
@@ -206,21 +207,21 @@ namespace picongpu
                 }
 
                 // Note: the global domain offset is already included in params->window.globalDimensions.offset
-                DataSpace<simDim> const patchOffset = params->window.globalDimensions.offset
-                    + params->window.localDimensions.offset;
+                DataSpace<simDim> const patchOffset
+                    = params->window.globalDimensions.offset + params->window.localDimensions.offset;
                 DataSpace<simDim> const patchExtent = params->window.localDimensions.size;
 
-                size_t patchIdx = 0;
                 // search the patch index based on the offset and extents of local domain size
                 for(size_t i = 0; i < numRanks; ++i)
                 {
                     if(patchOffset == offsets[i] && patchExtent == extents[i])
-                    {
-                        patchIdx = i;
-                        break;
-                    }
+                        return i;
                 }
-                return patchIdx;
+                // If no patch fits the conditions, something went wrong before
+                throw std::runtime_error(
+                    "Error while restarting: no particle patch matches the required offset and extent");
+                // Fake return still needed to avoid warnings
+                return 0;
             }
         };
 

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -205,8 +205,8 @@ namespace picongpu
                     }
                 }
 
-                pmacc::Selection<simDim> const globalDomain = Environment<simDim>::get().SubGrid().getGlobalDomain();
-                DataSpace<simDim> const patchOffset = globalDomain.offset + params->window.globalDimensions.offset
+                // Note: the global domain offset is already included in params->window.globalDimensions.offset
+                DataSpace<simDim> const patchOffset = params->window.globalDimensions.offset
                     + params->window.localDimensions.offset;
                 DataSpace<simDim> const patchExtent = params->window.localDimensions.size;
 


### PR DESCRIPTION
The error was reported in #3899.

It seems the wrong logic was introduced in #3507. The patch offset calculation was wrong. It double-counted the shift of the moving window. So after the window have slided, the domains were loading wrong patches, which could have led to all sorts of trouble: incorrect results, crashes, etc.

We investigated with @psychocoderHPC , found the issue and made the fix. The second commit also adds a check that this situation is reported more clearly (e.g. would have helped to find this one).