### PR TITLE
fix performance issue with HIP 4.3+

### DIFF
--- a/include/pmacc/kernel/atomic.hpp
+++ b/include/pmacc/kernel/atomic.hpp
@@ -67,11 +67,10 @@ namespace pmacc
                 }
             };
 
-#if(!defined(__CUDA__) && ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) < 401)
-            /** HIP backend specialization for atomic add
+#if(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) < 401)
+            /** HIP backend specialization for atomic add float
              *
              * Uses the intrinsic atomicAddNoRet available for AMD gpus only.
-             * Not compatible with HIP-nvcc.
              */
             template<typename T_Hierarchy, typename... T_AccArgs>
             struct AtomicOpNoRet<::alpaka::AtomicAdd, alpaka::AccGpuHipRt<T_AccArgs...>, float, T_Hierarchy>
@@ -83,6 +82,45 @@ namespace pmacc
                     T_Hierarchy const& hierarchy)
                 {
                     ::atomicAddNoRet(ptr, value);
+                }
+            };
+#elif(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) >= 403)
+            /** HIP backend specialization for atomic add float
+             *
+             * atomicAdd(float*,float) into shared memory is very slow for HIP 4.3+.
+             * HIP 4.3 introduced scoped atomics, it looks like atomicAdd for float, even on shared memory data, is
+             * always actually executed in global memory. This spezilization is only overwriting the atomicAdd
+             * implementation for float, for atomics between threads.
+             *
+             * Note: The HIP atomicAdd implementation for double is not effected by this performance bug.
+             */
+            template<typename... T_AccArgs>
+            struct AtomicOpNoRet<
+                ::alpaka::AtomicAdd,
+                alpaka::AccGpuHipRt<T_AccArgs...>,
+                float,
+                ::alpaka::hierarchy::Threads>
+            {
+                template<typename T_Hierarchy>
+                DINLINE void operator()(
+                    alpaka::AccGpuHipRt<T_AccArgs...> const& acc,
+                    float* address,
+                    float const val,
+                    T_Hierarchy const& hierarchy)
+                {
+                    unsigned int* address_as_u(reinterpret_cast<unsigned int*>(address));
+                    unsigned int old = __atomic_load_n(address_as_u, __ATOMIC_RELAXED);
+                    unsigned int assumed;
+                    do
+                    {
+                        assumed = old;
+                        old = ::atomicCAS(
+                            address_as_u,
+                            assumed,
+                            static_cast<unsigned int>(
+                                __float_as_uint(val + __uint_as_float(static_cast<unsigned int>(assumed)))));
+                        // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+                    } while(assumed != old);
                 }
             };
 #endif


### PR DESCRIPTION
When running PIConGPU with HIP 4.3+ and in single precision the
performance is by a factor 3 worse compared to HIP 4.2.

The reason are slow shared memory atomicAdd operations.

Solution: Add a float specialization for atomics between threads which
is emulating atomicAdd via atomicCAS (as in good old days^^)


Note: This fix should be ported to alpaka too to provide better performance to other projects too.