### PR TITLE
Add optionDefined() to plugins::multi::Option struct

### DIFF
--- a/include/picongpu/plugins/multi/Option.hpp
+++ b/include/picongpu/plugins/multi/Option.hpp
@@ -77,7 +77,7 @@ namespace picongpu
                  *
                  * @return name
                  */
-                std::string getName()
+                std::string getName() const
                 {
                     return m_name;
                 }
@@ -146,6 +146,15 @@ namespace picongpu
                     return ss.str();
                 }
 
+                /** Has the option been specified on the command line at index idx?
+                 *
+                 * Does not consider default values.
+                 */
+                bool optionDefined(uint32_t idx) const
+                {
+                    return idx < StorageType::size();
+                }
+
                 /** get the value set by the user
                  *
                  * Throw an exception if there is no default value defined and idx is
@@ -157,7 +166,7 @@ namespace picongpu
                  */
                 T_ValueType get(uint32_t idx)
                 {
-                    if(StorageType::size() <= idx)
+                    if(not optionDefined(idx))
                     {
                         if(!m_hasDefaultValue)
                             throw std::runtime_error(std::string(

--- a/include/picongpu/plugins/multi/Option.hpp
+++ b/include/picongpu/plugins/multi/Option.hpp
@@ -166,7 +166,7 @@ namespace picongpu
                  */
                 T_ValueType get(uint32_t idx)
                 {
-                    if(not optionDefined(idx))
+                    if(!optionDefined(idx))
                     {
                         if(!m_hasDefaultValue)
                             throw std::runtime_error(std::string(

--- a/include/picongpu/plugins/multi/Option.hpp
+++ b/include/picongpu/plugins/multi/Option.hpp
@@ -164,7 +164,7 @@ namespace picongpu
                  * @return if number of user provided option <= idx then the user defined
                  *         value else the default value if defined
                  */
-                T_ValueType get(uint32_t idx)
+                T_ValueType get(uint32_t idx) const
                 {
                     if(!optionDefined(idx))
                     {


### PR DESCRIPTION
I need this in the TOML PR. The logic was already being used inside `Option::get<>()`, this extracts it to another method and also uses that inside `get()`.

Also, make `getName()` a `const` method, I also need that for the TOML PR.