### PR TITLE
Update profile for taurus k80 partition

### DIFF
--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -21,25 +21,24 @@ export proj=$(groups | awk '{print $1}')
 #
 module purge
 module load modenv/scs5
-module load gompic/2019b # loads GCC/8.3.0 CUDA/10.1.243 zlib/1.2.11 OpenMPI/3.1.4
-# gompic/2020b does not have a corresponding boost module
-module load CMake/3.15.3-GCCcore-8.3.0
-module load Boost/1.71.0-gompic-2019b
-module load git/2.23.0-GCCcore-8.3.0-nodocs
-module load libpng/1.6.37-GCCcore-8.3.0
-module load HDF5/1.10.5-gompic-2019b
-module load Python/3.7.4-GCCcore-8.3.0
+
+module load CUDA/11.1.1-GCC-10.2.0
+module load OpenMPI/4.0.5-GCC-10.2.0
+module load CMake/3.18.4-GCCcore-10.2.0
+module load libpng/1.6.37-GCCcore-10.2.0
+module load git/2.28.0-GCCcore-10.2.0-nodocs
+module load Python/3.8.6-GCCcore-10.2.0
 
 # Self-Build Software ##########################################################
 #
 # needs to be compiled by the user
 # Check the install script at
-# https://gist.github.com/steindev/86df43bef49586e2b33d2fb0a372f09c
+# https://gist.github.com/finnolec/3004deeb6251d1e76f2250f99a8a2170
 #
 # path to own libraries:
 export PIC_LIBS=$HOME/lib
 
-export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.0
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.1
 export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
 
 export PNGwriter_ROOT=$PIC_LIBS/pngwriter-0.7.0
@@ -49,12 +48,17 @@ export LD_LIBRARY_PATH=$PNGwriter_ROOT/lib:$LD_LIBRARY_PATH
 export ADIOS2_ROOT=$PIC_LIBS/adios2-2.7.1
 export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
 
-export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.14.1
+export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.14.3
 export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
 
+export HDF5_ROOT=$PIC_LIBS/hdf5-1.12.1
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+
+export BOOST_ROOT=$PIC_LIBS/BOOST_1_74_0
+export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
 
 # Environment #################################################################
-#
+
 export PROJECT=/projects/$proj
 
 export PICSRC=$HOME/src/picongpu
@@ -73,6 +77,7 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/k80.tpl"
 
+alias getDevice='srun -p gpu2-interactive --gres=gpu:1 --ntasks=1 --pty --mem=8G -t 1:00:00 bash'
 alias getNode='srun -p gpu2-interactive --gres=gpu:4 -n 1 --pty --mem=0 -t 2:00:00 bash'
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
I updated the k80 profile for taurus. One has to build c-blosc, PNGwriter, ADIOS2, HDF5, openPMD-api and Boost themselves with the [mentioned script](https://gist.github.com/finnolec/3004deeb6251d1e76f2250f99a8a2170). I ran a `LaserWakefield` simulation on the current `dev` branch with ADIOS2 output and one with HDF5 output and both didn't crash. So I think that this script + this profile should work.
Additionally I added a `getDevice` command :)