### PR TITLE
fix using host function in device code

### DIFF
--- a/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
+++ b/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
@@ -220,7 +220,9 @@ namespace picongpu
                                 {
                                     a = 3.0_COLL * math::exp(-1.0_COLL * s12);
                                 }
-                                float_COLL bracket = math::exp(-1.0_COLL * a) + 2.0_COLL * u * std::sinh(a);
+                                // on host std::sinh will be used and on device the HIP/CUDA equivalent
+                                using std::sinh;
+                                float_COLL bracket = math::exp(-1.0_COLL * a) + 2.0_COLL * u * sinh(a);
                                 float_COLL cosXi = math::log(bracket) / a;
                                 if(cosXi < -1.0_COLL || cosXi > 1.0_COLL)
                                 {


### PR DESCRIPTION
`std::sinh` can not be used on device side.
The bug was showing up with HIP 4.5 but in general the code should be wrong in CUDA too.

This bug should be backported to 0.6.0.