### PR TITLE
Version bump: openPMD-api from 0.12.0 to 0.14.3

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -316,7 +316,7 @@ PIC_dependency(openPMD "API for IO" AUTO)
 
 if(PIC_SEARCH_openPMD)
     # find openPMD installation
-    find_package(openPMD 0.12.0 CONFIG COMPONENTS MPI)
+    find_package(openPMD 0.14.3 CONFIG COMPONENTS MPI)
     if(openPMD_FOUND)
         if(openPMD_HAVE_ADIOS2 OR openPMD_HAVE_HDF5)
             message(STATUS "Found openPMD: ${openPMD_DIR}")

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -35,57 +35,10 @@ namespace picongpu
          */
         namespace detail
         {
-            // As std::void_t in C++17.
-            template<typename>
-            using void_t = void;
-
-            template<typename ValueType, typename = ::openPMD::RecordComponent, typename = void>
+            template<typename ValueType>
             struct openPMDSpan
             {
-                // default implementation if the span-based storeChunk API is
-                // not available in openPMD
-
-                std::shared_ptr<ValueType> m_buffer;
-                ValueType* currentBuffer() const
-                {
-                    return m_buffer.get();
-                }
-
-                template<typename Functor>
-                openPMDSpan(
-                    ::openPMD::RecordComponent& rc,
-                    ::openPMD::Offset offset,
-                    ::openPMD::Extent extent,
-                    bool /* useSpanAPI */, // only used in the specialization below
-                    Functor&& createBaseBuffer)
-                {
-                    using extent_t = ::openPMD::Extent::value_type;
-                    extent_t scalarExtent = 1;
-                    for(auto val : extent)
-                    {
-                        scalarExtent *= val;
-                    }
-                    m_buffer = std::forward<Functor>(createBaseBuffer)(scalarExtent);
-                    rc.storeChunk(m_buffer, std::move(offset), std::move(extent));
-                }
-            };
-
-            template<typename ValueType, typename RecordComponent>
-            struct openPMDSpan<
-                ValueType,
-                RecordComponent,
-                // check for existence of span-based storeChunk API
-                void_t<decltype(std::declval<RecordComponent>().template storeChunk<ValueType>(
-                    std::declval<::openPMD::Offset>(),
-                    std::declval<::openPMD::Extent>()))>>
-            {
-                // pass-through to the span-based storeChunk API
-
-                // We cannot use ::openPMD::DynamicMemoryView directly since that is non-dependent lookup
-                // so, use a dependent type
-                using DynamicMemoryView = decltype(std::declval<RecordComponent>().template storeChunk<ValueType>(
-                    std::declval<::openPMD::Offset>(),
-                    std::declval<::openPMD::Extent>()));
+                using DynamicMemoryView = ::openPMD::DynamicMemoryView<ValueType>;
 
                 bool m_useSpanAPI; // depending on the value of this, use either m_bufferFallback or m_bufferSpan
                 // need a pointer here since DynamicMemoryView has no default constructor

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -47,30 +47,6 @@ namespace picongpu
             template<typename>
             using void_t = void;
 
-            template<typename = ::openPMD::Dataset, typename = void>
-            struct SetDatasetOptions
-            {
-                static void run(::openPMD::Dataset const&, std::string const& options)
-                {
-                    if(options != "{}")
-                    {
-                        std::cerr
-                            << "[openPMD plugin] Setting dataset-specific JSON options requires openPMD API 0.13.0 "
-                               "or later."
-                            << std::endl;
-                    }
-                }
-            };
-
-            template<typename Dataset>
-            struct SetDatasetOptions<Dataset, void_t<decltype(Dataset::options)>>
-            {
-                static void run(Dataset& ds, std::string options)
-                {
-                    ds.options = std::move(options);
-                }
-            };
-
             template<typename ValueType, typename = ::openPMD::RecordComponent, typename = void>
             struct openPMDSpan
             {
@@ -159,11 +135,6 @@ namespace picongpu
                 }
             };
         } // namespace detail
-
-        void setDatasetOptions(::openPMD::Dataset& ds, std::string options)
-        {
-            detail::SetDatasetOptions<>::run(ds, std::move(options));
-        }
 
         /*
          * This mocks the span-based storeChunk API available in openPMD with

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -25,14 +25,6 @@
 #include <string> // std::stoull
 #include <utility> // std::declval
 
-#if OPENPMDAPI_VERSION_GE(0, 13, 0)
-// Streaming API is available, use it
-#    define WRITE_ITERATIONS writeIterations()
-#else
-// Not available, don't use it
-#    define WRITE_ITERATIONS iterations
-#endif
-
 namespace picongpu
 {
     namespace openPMD

--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -77,7 +77,7 @@ namespace picongpu
                         }
                     }
 
-                    ::openPMD::Iteration iteration = series.WRITE_ITERATIONS[currentStep];
+                    ::openPMD::Iteration iteration = series.writeIterations()[currentStep];
                     iteration.setAttribute("particleBoundary", listParticleBoundary);
                     iteration.setAttribute("particleBoundaryParameters", listParticleBoundaryParam);
                 }

--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -22,7 +22,6 @@
 
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/currentInterpolation/CurrentInterpolation.hpp"
-#include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/stringHelpers.hpp"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
 #include "picongpu/traits/SIBaseUnits.hpp"

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -23,7 +23,6 @@
 
 #include "picongpu/plugins/ILightweightPlugin.hpp"
 #include "picongpu/plugins/common/openPMDAttributes.hpp"
-#include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/openPMDWriteMeta.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -247,7 +247,7 @@ namespace picongpu
             // avoid deadlock between not finished pmacc tasks and collective or blocking MPI calls in openPMD
             __getTransactionEvent().waitForFinished();
 
-            auto iteration = m_Series->WRITE_ITERATIONS[currentStep];
+            auto iteration = m_Series->writeIterations()[currentStep];
 
             auto mesh = iteration.meshes["makroParticlePerSupercell"];
             auto dataset = mesh[::openPMD::RecordComponent::SCALAR];

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
 
 #include <pmacc/Environment.hpp>

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -86,7 +86,7 @@ namespace picongpu
 
                 ::openPMD::Series& series = *params.openPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
-                    = series.WRITE_ITERATIONS[params.currentStep].meshes[baseName + "_" + group][dataset];
+                    = series.writeIterations()[params.currentStep].meshes[baseName + "_" + group][dataset];
 
                 if(!attrName.empty())
                 {

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -341,7 +341,7 @@ namespace picongpu
                 const std::string speciesGroup(T_Species::getName());
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Iteration iteration = series.WRITE_ITERATIONS[params->currentStep];
+                ::openPMD::Iteration iteration = series.writeIterations()[params->currentStep];
                 const std::string basename = series.particlesPath() + speciesGroup;
 
                 // enforce that the filter interface is fulfilled

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -295,7 +295,7 @@ namespace picongpu
                     const float_64 mass(getMassOrZero());
                     auto& massRecord = record["mass"];
                     auto& massComponent = massRecord[::openPMD::RecordComponent::SCALAR];
-                    setDatasetOptions(dataSet, matcher.get(basename + "/mass"));
+                    dataSet.options = matcher.get(basename + "/mass");
                     massComponent.resetDataset(dataSet);
                     massComponent.makeConstant(mass);
 
@@ -315,7 +315,7 @@ namespace picongpu
                     const float_64 charge(getChargeOrZero());
                     auto& chargeRecord = record["charge"];
                     auto& chargeComponent = chargeRecord[::openPMD::RecordComponent::SCALAR];
-                    setDatasetOptions(dataSet, matcher.get(basename + "/charge"));
+                    dataSet.options = matcher.get(basename + "/charge");
                     chargeComponent.resetDataset(dataSet);
                     chargeComponent.makeConstant(charge);
 
@@ -470,9 +470,9 @@ namespace picongpu
                     ::openPMD::PatchRecordComponent numParticlesOffset
                         = particlePatches["numParticlesOffset"][::openPMD::RecordComponent::SCALAR];
 
-                    setDatasetOptions(ds, params->jsonMatcher->get(basename + "/particlePatches/numParticles"));
+                    ds.options = params->jsonMatcher->get(basename + "/particlePatches/numParticles");
                     numParticles.resetDataset(ds);
-                    setDatasetOptions(ds, params->jsonMatcher->get(basename + "/particlePatches/numParticlesOffset"));
+                    ds.options = params->jsonMatcher->get(basename + "/particlePatches/numParticlesOffset");
                     numParticlesOffset.resetDataset(ds);
 
                     /* It is safe to use the mpi rank to write the data even if the rank can differ between simulation
@@ -489,13 +489,9 @@ namespace picongpu
                     {
                         ::openPMD::PatchRecordComponent offset_x = offset[name_lookup[d]];
                         ::openPMD::PatchRecordComponent extent_x = extent[name_lookup[d]];
-                        setDatasetOptions(
-                            ds,
-                            params->jsonMatcher->get(basename + "/particlePatches/offset/" + name_lookup[d]));
+                        ds.options = params->jsonMatcher->get(basename + "/particlePatches/offset/" + name_lookup[d]);
                         offset_x.resetDataset(ds);
-                        setDatasetOptions(
-                            ds,
-                            params->jsonMatcher->get(basename + "/particlePatches/extent/" + name_lookup[d]));
+                        ds.options = params->jsonMatcher->get(basename + "/particlePatches/extent/" + name_lookup[d]);
                         extent_x.resetDataset(ds);
 
                         offset_x.store<index_t>(mpiRank, particleOffset[d]);

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -24,7 +24,6 @@
 
 #include "picongpu/particles/traits/GetSpeciesFlagName.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
-#include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/kernel/CopySpecies.kernel"
 #include "picongpu/plugins/openPMD/openPMDDimension.hpp"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -107,7 +107,7 @@ namespace picongpu
         {
             std::vector<uint64_t> v = asStandardVector(globalDimensions);
             ::openPMD::Dataset dataset{datatype, std::move(v)};
-            setDatasetOptions(dataset, jsonMatcher->get(datasetName));
+            dataset.options = jsonMatcher->get(datasetName);
             recordComponent.resetDataset(std::move(dataset));
             return recordComponent;
         }

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -587,7 +587,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 rngProvider->synchronize();
                 auto const name = rngProvider->getName();
 
-                ::openPMD::Iteration iteration = params->openPMDSeries->WRITE_ITERATIONS[params->currentStep];
+                ::openPMD::Iteration iteration = params->openPMDSeries->writeIterations()[params->currentStep];
                 ::openPMD::Mesh mesh = iteration.meshes[name];
 
                 auto const unitDimension = std::vector<float_64>(7, 0.0);
@@ -651,7 +651,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 auto rngProvider = dc.get<RNGProvider>(RNGProvider::getName());
                 auto const name = rngProvider->getName();
 
-                ::openPMD::Iteration iteration = params->openPMDSeries->WRITE_ITERATIONS[params->currentStep];
+                ::openPMD::Iteration iteration = params->openPMDSeries->writeIterations()[params->currentStep];
                 ::openPMD::Mesh mesh = iteration.meshes[name];
                 ::openPMD::MeshRecordComponent mrc = mesh[::openPMD::RecordComponent::SCALAR];
 
@@ -1056,7 +1056,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                 log<picLog::INPUT_OUTPUT>("openPMD: write field: %1% %2% %3%") % name % nComponents % ptr;
 
-                ::openPMD::Iteration iteration = params->openPMDSeries->WRITE_ITERATIONS[params->currentStep];
+                ::openPMD::Iteration iteration = params->openPMDSeries->writeIterations()[params->currentStep];
                 ::openPMD::Mesh mesh = iteration.meshes[name];
 
                 // set mesh attributes
@@ -1363,13 +1363,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 WriteMeta writeMetaAttributes;
                 writeMetaAttributes(
                     *threadParams->openPMDSeries,
-                    (*threadParams->openPMDSeries).WRITE_ITERATIONS[threadParams->currentStep],
+                    (*threadParams->openPMDSeries).writeIterations()[threadParams->currentStep],
                     threadParams->currentStep);
 
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 __getTransactionEvent().waitForFinished();
-                mThreadParams.openPMDSeries->WRITE_ITERATIONS[mThreadParams.currentStep].close();
+                mThreadParams.openPMDSeries->writeIterations()[mThreadParams.currentStep].close();
 
                 return;
             }


### PR DESCRIPTION
openPMD-api version 0.14.3 has recently been [released](https://github.com/openPMD/openPMD-api/commit/00532a7873f1ec3eff9aa4238f303597bd039b6b) and includes fixes that are necessary for usage with C++17. With older versions, there are ABI incompatibilities if building openPMD-api with C++14, but including it into a C++17 project.

Since PIConGPU is currently being released (still on C++14), this marks a good time for bumping the minimum required version once the release is out. This also removes a number of workarounds for newer features (namely: the streaming API, the span-based storeChunk() API, dataset-specific backend configuration) that were not available in openPMD-api 0.12.0.

TODO:
- [x] Maybe wait for PIConGPU release before merging this into dev
- [x] Update CI containers ([see also](https://gitlab.com/hzdr/crp/alpaka-group-container/-/merge_requests/30))
- [x] Check HDF5 still working in parallel
    Update: There seem to be issues with chunking. This can be deactivated, but should be clarified before merging this one.