### PR TITLE
update zenodo and README file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,126 +1,258 @@
 {
-    "creators": [
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Huebl, Axel",
-        "orcid": "0000-0003-1943-7141"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Widera, René",
-        "orcid": "0000-0003-1642-0459"
-      },
-      {
-        "affiliation": "LogMeIn, Inc.",
-        "name": "Worpitz, Benjamin"
-      },
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Pausch, Richard",
-        "orcid": "0000-0001-7990-9564"
-      },
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Burau, Heiko"
-      },
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Garten, Marco",
-        "orcid": "0000-0001-6994-2475"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Starke, Sebastian"
-      },
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Grund, Alexander",
-        "orcid": "0000-0002-7196-8452"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Debus, Alexander",
-        "orcid": "0000-0002-3844-3697"
-      },
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Matthes, Alexander",
-        "orcid": "0000-0002-6702-2015"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Bastrakov, Sergei",
-        "orcid": "0000-0003-3396-6154"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Steiniger, Klaus",
-        "orcid": "0000-0001-8965-1149"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Göthel, Ilja"
-      },
-      {
-        "affiliation": "HZDR, TU Dresden",
-        "name": "Rudat, Sophie"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Kelling, Jeffrey",
-        "orcid": "0000-0003-1761-2591"
-      },
-      {
-        "affiliation": "HZDR",
-        "name": "Bussmann, Michael",
-        "orcid": "0000-0002-8258-3881"
-      }
-    ],
-    "grants": [
-      {
-        "acronym": "EUCALL",
-        "code": "654220",
-        "funder": {
-          "acronyms": [
-            "EC"
-          ],
-          "doi": "10.13039/501100000780",
-          "links": {
-            "self": "https://zenodo.org/api/funders/10.13039/501100000780"
-          },
-          "name": "European Commission"
-        },
-        "links": {
-          "self": "https://zenodo.org/api/grants/10.13039/501100000780::654220"
-        },
-        "program": "H2020",
-        "title": "European Cluster of Advanced Laser Light Sources"
-      }
-    ],
-    "keywords": [
-      "PIConGPU",
-      "CUDA",
-      "OpenMP",
-      "manycore",
-      "Plasma Physics",
-      "GPU"
-    ],
-    "language": "eng",
-    "access_right": "open",
-    "license": {
-      "id": "GPL-3.0"
+  "creators":[
+    {
+      "affiliation":"HZDR",
+      "name":"Bastrakov, Sergei",
+      "orcid":"0000-0003-3396-6154"
     },
-    "references": [
-      "L. V. Keldysh (1965). Ionization in the field of a strong electromagnetic wave.",
-      "D. Bauer and P. Mulser (1999). Exact field ionization rates in the barrier-suppression regime from numerical time-dependent Schr\u00f6dinger-equation calculations. DOI:10.1103/PhysRevA.59.569",
-      "R. Pausch et al. (2014). How to test and verify radiation diagnostics simulations within particle-in-cell frameworks. DOI:10.1016/j.nima.2013.10.073",
-      "A. Huebl (2014). Injection Control for Electrons in Laser-Driven Plasma Wakes on the Femtosecond Time Scale. DOI:10.5281/zenodo.15924",
-      "A. Gonoskov et al. (2015). Extended particle-in-cell schemes for physics in ultrastrong laser fields: Review and developments. DOI:10.1103/PhysRevE.92.023305",
-      "A. Huebl et al. (2015). openPMD: A meta data standard for particle and mesh based data. DOI:10.5281/zenodo.591699",
-      "M. Vranic et al. (2016). Classical radiation reaction in particle-in-cell simulations. DOI:10.1016/j.cpc.2016.04.002",
-      "A. Matthes et al. (2016). In situ, steerable, hardware-independent and data-structure agnostic visualization with ISAAC. DOI:10.14529/jsfi160403",
-      "A. Huebl et al. (2017). On the Scalability of Data Reduction Techniques in Current and Upcoming HPC Systems from an Application Perspective. DOI:10.1007/978-3-319-67630-2_2",
-      "R. Pausch et al. (2018). Quantitatively consistent computation of coherent and incoherent radiation in particle-in-cell codes - a general form factor formalism for macro-particles. DOI:10.1016/j.nima.2018.02.020",
-      "A. Huebl (2019). PIConGPU: Predictive Simulations of Laser-Particle Accelerators with Manycore Hardware. DOI:10.5281/zenodo.3266820"
-    ]
+    {
+      "affiliation":"HZDR",
+      "name":"Bastrakova, Kseniia"
+    },
+    {
+      "name":"Marre, Brian Edward",
+      "affiliation":"HZDR, TU Dresden"
+    },
+    {
+      "affiliation":"HZDR",
+      "name":"Debus, Alexander",
+      "orcid":"0000-0002-3844-3697"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Garten, Marco",
+      "orcid":"0000-0001-6994-2475"
+    },
+    {
+      "name":"Gruber, Bernhard Manfred",
+      "affiliation":"CASUS, HZDR, CERN",
+      "orcid":"0000-0001-7848-1690"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden, LBNL",
+      "name":"Huebl, Axel",
+      "orcid":"0000-0003-1943-7141"
+    },
+    {
+      "name":"Trojok, Jakob",
+      "affiliation":"HZDR, TU Dresden"
+    },
+    {
+      "affiliation":"HZDR",
+      "name":"Kelling, Jeffrey",
+      "orcid":"0000-0003-1761-2591"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Lebedev, Anton"
+    },
+    {
+      "name":"Meyer, Felix",
+      "affiliation":"HZDR"
+    },
+    {
+      "name":"Ordyna, Paweł",
+      "affiliation":"HZDR, TU Dresden"
+    },
+    {
+      "name":"Poeschel, Franz",
+      "affiliation":"CASUS, HZDR",
+      "orcid":"0000-0001-7042-5088"
+    },
+    {
+      "name":"Sprenger, Lennert",
+      "affiliation":"HZDR, TU Dresden"
+    },
+    {
+      "affiliation":"HZDR",
+      "name":"Steiniger, Klaus",
+      "orcid":"0000-0001-8965-1149"
+    },
+    {
+      "name":"Wang, Manhui",
+      "affiliation":"University of Liverpool"
+    },
+    {
+      "affiliation":"HZDR",
+      "name":"Starke, Sebastian"
+    },
+    {
+      "name":"Thévenet, Maxence",
+      "affiliation":"Desy"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Pausch, Richard",
+      "orcid":"0000-0001-7990-9564"
+    },
+    {
+      "affiliation":"HZDR",
+      "name":"Widera, René",
+      "orcid":"0000-0003-1642-0459"
+    }
+  ],
+  "contributors":[
+    {
+      "affiliation":"LOA",
+      "name":"Andriyash, Igor",
+      "type":"Other"
+    },
+    {
+      "affiliation":"University Jena",
+      "name":"Bifeng, Lei",
+      "type":"Other"
+    },
+    {
+      "affiliation":"ELI-NP",
+      "name":"Berceanu, Andrei",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Burau, Heiko",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, CASUS",
+      "name":"Bussmann, Michael",
+      "orcid":"0000-0002-8258-3881",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Carstens, Finn-Ole",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Eckert, Carlchristian",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Göthel, Ilja",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Grund, Alexander",
+      "orcid":"0000-0002-7196-8452",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Hahn, Sebastian",
+      "type":"Other"
+    },
+    {
+      "affiliation":"TU-Dresden",
+      "name":"Hoehnig, Wolfgang",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Knespel, Maximilian",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Matthes, Alexander",
+      "orcid":"0000-0002-6702-2015",
+      "type":"Other"
+    },
+    {
+      "affiliation":"ELI-NP",
+      "name":"Ong, Jian Fuh",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU Dresden",
+      "name":"Rudat, Sophie",
+      "type":"Other"
+    },
+    {
+      "affiliation":"TU-Dresden",
+      "name":"Winkler, Frank",
+      "type":"Other"
+    },
+    {
+      "affiliation":"LogMeIn, Inc.",
+      "name":"Worpitz, Benjamin",
+      "type":"Other"
+    },
+    {
+      "affiliation":"TU-Dresden",
+      "name":"Schmitt, Felix",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Schneider, Benjamin",
+      "type":"Other"
+    },
+    {
+      "affiliation":"TU-Dresden",
+      "name":"Schumann, Conrad",
+      "type":"Other"
+    },
+    {
+      "affiliation":"University Jena",
+      "name":"Tietze, Stefan",
+      "type":"Other"
+    },
+    {
+      "affiliation":"HZDR, TU-Dresden",
+      "name":"Zenker, Erik",
+      "type":"Other"
+    }
+  ],
+  "grants":[
+    {
+      "acronym":"EUCALL",
+      "code":"654220",
+      "funder":{
+        "acronyms":[
+          "EC"
+        ],
+        "doi":"10.13039/501100000780",
+        "links":{
+          "self":"https://zenodo.org/api/funders/10.13039/501100000780"
+        },
+        "name":"European Commission"
+      },
+      "links":{
+        "self":"https://zenodo.org/api/grants/10.13039/501100000780::654220"
+      },
+      "program":"H2020",
+      "title":"European Cluster of Advanced Laser Light Sources"
+    }
+  ],
+  "keywords":[
+    "PIConGPU",
+    "CUDA",
+    "OpenMP",
+    "manycore",
+    "Plasma Physics",
+    "GPU",
+    "HIP",
+    "C++"
+  ],
+  "language":"eng",
+  "access_right":"open",
+  "license":{
+    "id":"GPL-3.0"
+  },
+  "references":[
+    "L. V. Keldysh (1965). Ionization in the field of a strong electromagnetic wave.",
+    "D. Bauer and P. Mulser (1999). Exact field ionization rates in the barrier-suppression regime from numerical time-dependent Schrödinger-equation calculations. DOI:10.1103/PhysRevA.59.569",
+    "R. Pausch et al. (2014). How to test and verify radiation diagnostics simulations within particle-in-cell frameworks. DOI:10.1016/j.nima.2013.10.073",
+    "A. Huebl (2014). Injection Control for Electrons in Laser-Driven Plasma Wakes on the Femtosecond Time Scale. DOI:10.5281/zenodo.15924",
+    "A. Gonoskov et al. (2015). Extended particle-in-cell schemes for physics in ultrastrong laser fields: Review and developments. DOI:10.1103/PhysRevE.92.023305",
+    "A. Huebl et al. (2015). openPMD: A meta data standard for particle and mesh based data. DOI:10.5281/zenodo.591699",
+    "M. Vranic et al. (2016). Classical radiation reaction in particle-in-cell simulations. DOI:10.1016/j.cpc.2016.04.002",
+    "A. Matthes et al. (2016). In situ, steerable, hardware-independent and data-structure agnostic visualization with ISAAC. DOI:10.14529/jsfi160403",
+    "A. Huebl et al. (2017). On the Scalability of Data Reduction Techniques in Current and Upcoming HPC Systems from an Application Perspective. DOI:10.1007/978-3-319-67630-2_2",
+    "R. Pausch et al. (2018). Quantitatively consistent computation of coherent and incoherent radiation in particle-in-cell codes - a general form factor formalism for macro-particles. DOI:10.1016/j.nima.2018.02.020",
+    "A. Huebl (2019). PIConGPU: Predictive Simulations of Laser-Particle Accelerators with Manycore Hardware. DOI:10.5281/zenodo.3266820"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ Active Team
 ### Scientific Supervision
 
 - Dr. Michael Bussmann
-- Dr. Axel Huebl
 
 ### Maintainers* and core developers
 
@@ -209,11 +208,10 @@ Active Team
 - Dr. Alexander Debus
 - Marco Garten*
 - Dr. Axel Huebl*
-- Alexander Matthes
+- Pawel Ordyna 
 - Dr. Richard Pausch*
-- Sophie Rudat
-- Sebastian Starke
-- Dr. Klaus Steiniger
+- Franz Poeschel
+- Dr. Klaus Steiniger*
 - Rene Widera*
 
 ### Former Members, Contributions and Thanks
@@ -223,8 +221,12 @@ The PIConGPU Team expresses its gratitude to:
 Florian Berninger, Heiko Burau, Robert Dietrich, Carlchristian Eckert,
 Wen Fu, Ph.D., Alexander Grund, Sebastian Hahn, Anton Helm, Wolfgang Hoehnig,
 Dr.-Ing. Guido Juckeland, Jeffrey Kelling, Maximilian Knespel, Dr. Remi Lehe,
-Felix Schmitt, Benjamin Schneider, Joseph Schuchart, Conrad Schumann,
-Stefan Tietze, Marija Vranic, Ph.D., Benjamin Worpitz, and Erik Zenker.
+Felix Schmitt, Frank Winkler, Benjamin Schneider, Joseph Schuchart, Conrad Schumann,
+Stefan Tietze, Marija Vranic, Ph.D., Benjamin Worpitz, Erik Zenker,
+Sophie Rudat, Sebastian Starke, Alexander Matthes, Kseniia Bastrakova, 
+Brian Edward Marre, Bernhard Manfred Gruber, Jakob Trojok, Anton Lebedev, 
+Felix Meyer, Lennert Sprenger, Manhui Wang, Maxence Thevenet, Ilja Goethel
+and Finn-Ole Carstens.
 
 Kudos to everyone, mentioned or unmentioned, who contributed further in any
 way!


### PR DESCRIPTION
This PR is opened against the release 0.6.0 and will be merged back into the development branch as soon as we released 0.6.0.

Add missing contributors and update creators of the current release.

I updated the creators and contributors for the zenodo file, I followed the rules we used for alpaka [[link](https://github.com/alpaka-group/alpaka/pull/1236)] too.

# Rules zenodo file

- **creators** are everyone how contributed to the current release version e.g. 0.6.0
  - the list is alphabetically ordered
- **contributors** everyone who contributed in the past
  - the list is alphabetically ordered
- affiliation based on the time of the contributions

In the README file, I kept the maintainer and core developers list shorter to reduce the maintenance overhead for the list.
A core developer is someone who is regularly providing improvements, fixes, and contributes via to issues. It is very hard to decide who should be on the list and who should be in the section `Former Members, Contributions and Thanks`.

@ComputationalRadiationPhysics/picongpu-developers Please check your entry in the zenodo file, if you have an `ORCID` or the affiliation at the moment of the contribution is not correct, response to this PR.



Command used to generate the creator list:
```
git log b87fe1909734b7f29aeb7648655dbc5649e16304..HEAD** | grep Author | sort | uniq | sed "s/ \+/ /g; s/^ //" | cut -d" " -f2-3 | uniq
```