### PR TITLE
PMacc: header include validation

### DIFF
--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -38,23 +38,7 @@
 #include "pmacc/pluginSystem/PluginConnector.hpp"
 #include "pmacc/simulationControl/SimulationDescription.hpp"
 
-#include <cstdlib> // std::getenv
-#include <iostream>
-#include <stdexcept> // std::invalid_argument
-
 #include <mpi.h>
-
-#if !defined(ALPAKA_API_PREFIX)
-/* ALPAKA_API_PREFIX was removed in alpaka 1.0.0 but is required to get access cuda/hip functions directly.
- * @todo find a better way to access native cuda/Hip functions or try to avoid accessing these at all.
- */
-#    include "pmacc/ppFunctions.hpp"
-#    if(BOOST_LANG_CUDA)
-#        define ALPAKA_API_PREFIX(name) PMACC_JOIN(cuda, name)
-#    elif(BOOST_LANG_HIP)
-#        define ALPAKA_API_PREFIX(name) PMACC_JOIN(hip, name)
-#    endif
-#endif
 
 namespace pmacc
 {
@@ -78,98 +62,55 @@ namespace pmacc
              *
              * @return instance of StreamController
              */
-            pmacc::StreamController& StreamController()
-            {
-                PMACC_ASSERT_MSG(
-                    EnvironmentContext::getInstance().isDeviceSelected(),
-                    "Environment< DIM >::initDevices() must be called before this method!");
-                return StreamController::getInstance();
-            }
+            HINLINE pmacc::StreamController& StreamController();
 
             /** get the singleton EnvironmentController
              *
              * @return instance of EnvironmentController
              */
-            pmacc::EnvironmentController& EnvironmentController()
-            {
-                PMACC_ASSERT_MSG(
-                    EnvironmentContext::getInstance().isMpiInitialized(),
-                    "Environment< DIM >::initDevices() must be called before this method!");
-                return EnvironmentController::getInstance();
-            }
+            HINLINE pmacc::EnvironmentController& EnvironmentController();
 
             /** get the singleton Factory
              *
              * @return instance of Factory
              */
-            pmacc::Factory& Factory()
-            {
-                PMACC_ASSERT_MSG(
-                    EnvironmentContext::getInstance().isMpiInitialized()
-                        && EnvironmentContext::getInstance().isDeviceSelected(),
-                    "Environment< DIM >::initDevices() must be called before this method!");
-                return Factory::getInstance();
-            }
+            HINLINE pmacc::Factory& Factory();
 
             /** get the singleton EventPool
              *
              * @return instance of EventPool
              */
-            pmacc::EventPool& EventPool()
-            {
-                PMACC_ASSERT_MSG(
-                    EnvironmentContext::getInstance().isDeviceSelected(),
-                    "Environment< DIM >::initDevices() must be called before this method!");
-                return EventPool::getInstance();
-            }
+            HINLINE pmacc::EventPool& EventPool();
 
             /** get the singleton ParticleFactory
              *
              * @return instance of ParticleFactory
              */
-            pmacc::ParticleFactory& ParticleFactory()
-            {
-                return ParticleFactory::getInstance();
-            }
+            HINLINE pmacc::ParticleFactory& ParticleFactory();
 
             /** get the singleton DataConnector
              *
              * @return instance of DataConnector
              */
-            pmacc::DataConnector& DataConnector()
-            {
-                return DataConnector::getInstance();
-            }
+            HINLINE pmacc::DataConnector& DataConnector();
 
             /** get the singleton PluginConnector
              *
              * @return instance of PluginConnector
              */
-            pmacc::PluginConnector& PluginConnector()
-            {
-                return PluginConnector::getInstance();
-            }
+            HINLINE pmacc::PluginConnector& PluginConnector();
 
             /** get the singleton MemoryInfo
              *
              * @return instance of MemoryInfo
              */
-            device::MemoryInfo& MemoryInfo()
-            {
-                PMACC_ASSERT_MSG(
-                    EnvironmentContext::getInstance().isDeviceSelected(),
-                    "Environment< DIM >::initDevices() must be called before this method!");
-                return device::MemoryInfo::getInstance();
-            }
+            HINLINE device::MemoryInfo& MemoryInfo();
 
             /** get the singleton SimulationDescription
              *
              * @return instance of SimulationDescription
              */
-            simulationControl::SimulationDescription& SimulationDescription()
-            {
-                return simulationControl::SimulationDescription::getInstance();
-            }
+            HINLINE simulationControl::SimulationDescription& SimulationDescription();
         };
     } // namespace detail
 
@@ -179,48 +120,27 @@ namespace pmacc
     class Environment : public detail::Environment
     {
     public:
-        void enableMpiDirect()
-        {
-            detail::EnvironmentContext::getInstance().enableMpiDirect();
-        }
+        HINLINE void enableMpiDirect();
 
-        bool isMpiDirectEnabled() const
-        {
-            return detail::EnvironmentContext::getInstance().isMpiDirectEnabled();
-        }
+        HINLINE bool isMpiDirectEnabled() const;
 
         /** get the singleton GridController
          *
          * @return instance of GridController
          */
-        pmacc::GridController<T_dim>& GridController()
-        {
-            PMACC_ASSERT_MSG(
-                detail::EnvironmentContext::getInstance().isMpiInitialized(),
-                "Environment< DIM >::initDevices() must be called before this method!");
-            return pmacc::GridController<T_dim>::getInstance();
-        }
+        HINLINE pmacc::GridController<T_dim>& GridController();
 
         /** get the singleton SubGrid
          *
          * @return instance of SubGrid
          */
-        pmacc::SubGrid<T_dim>& SubGrid()
-        {
-            PMACC_ASSERT_MSG(
-                detail::EnvironmentContext::getInstance().isSubGridDefined(),
-                "Environment< DIM >::initGrids() must be called before this method!");
-            return pmacc::SubGrid<T_dim>::getInstance();
-        }
+        HINLINE pmacc::SubGrid<T_dim>& SubGrid();
 
         /** get the singleton Filesystem
          *
          * @return instance of Filesystem
          */
-        pmacc::Filesystem<T_dim>& Filesystem()
-        {
-            return pmacc::Filesystem<T_dim>::getInstance();
-        }
+        HINLINE pmacc::Filesystem<T_dim>& Filesystem();
 
         /** get the singleton Environment< DIM >
          *
@@ -241,26 +161,7 @@ namespace pmacc
          * @param periodic periodicity each simulation dimension
          *                 (0 == not periodic, 1 == periodic)
          */
-        void initDevices(DataSpace<T_dim> devices, DataSpace<T_dim> periodic)
-        {
-            // initialize the MPI context
-            detail::EnvironmentContext::getInstance().init();
-
-            // create singleton instances
-            GridController().init(devices, periodic);
-
-            EnvironmentController();
-
-            Filesystem();
-
-            detail::EnvironmentContext::getInstance().setDevice(static_cast<int>(GridController().getHostRank()));
-
-            StreamController().activate();
-
-            MemoryInfo();
-
-            SimulationDescription();
-        }
+        HINLINE void initDevices(DataSpace<T_dim> devices, DataSpace<T_dim> periodic);
 
         /** initialize the computing domain information of PMacc
          *
@@ -268,24 +169,10 @@ namespace pmacc
          * @param localDomainSize size of the local simulation domain [cells]
          * @param localDomainOffset local domain offset [cells]
          */
-        void initGrids(
+        HINLINE void initGrids(
             DataSpace<T_dim> globalDomainSize,
             DataSpace<T_dim> localDomainSize,
-            DataSpace<T_dim> localDomainOffset)
-        {
-            PMACC_ASSERT_MSG(
-                detail::EnvironmentContext::getInstance().isMpiInitialized(),
-                "Environment< DIM >::initDevices() must be called before this method!");
-
-            detail::EnvironmentContext::getInstance().m_isSubGridDefined = true;
-
-            // create singleton instances
-            SubGrid().init(localDomainSize, globalDomainSize, localDomainOffset);
-
-            DataConnector();
-
-            PluginConnector();
-        }
+            DataSpace<T_dim> localDomainOffset);
 
         Environment(const Environment&) = delete;
 
@@ -297,210 +184,6 @@ namespace pmacc
         ~Environment() = default;
     };
 
-    namespace detail
-    {
-        void EnvironmentContext::init()
-        {
-            m_isMpiInitialized = true;
-
-            char const* env_value = std::getenv("PIC_USE_THREADED_MPI");
-            if(env_value)
-            {
-                int required_level{};
-                if(strcmp(env_value, "MPI_THREAD_SINGLE") == 0)
-                {
-                    required_level = MPI_THREAD_SINGLE;
-                }
-                else if(strcmp(env_value, "MPI_THREAD_FUNNELED") == 0)
-                {
-                    required_level = MPI_THREAD_FUNNELED;
-                }
-                else if(strcmp(env_value, "MPI_THREAD_SERIALIZED") == 0)
-                {
-                    required_level = MPI_THREAD_SERIALIZED;
-                }
-                else if(strcmp(env_value, "MPI_THREAD_MULTIPLE") == 0)
-                {
-                    required_level = MPI_THREAD_MULTIPLE;
-                }
-                else
-                {
-                    throw std::runtime_error(
-                        "Environment variable PIC_USE_THREADED_MPI must be one of MPI_THREAD_SINGLE, "
-                        "MPI_THREAD_FUNNELED, MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE.");
-                }
-                // MPI_Init with NULL is allowed since MPI 2.0
-                MPI_CHECK(MPI_Init_thread(nullptr, nullptr, required_level, nullptr));
-            }
-            else
-            {
-                // MPI_Init with NULL is allowed since MPI 2.0
-                MPI_CHECK(MPI_Init(nullptr, nullptr));
-            }
-        }
-
-        void EnvironmentContext::finalize()
-        {
-            if(m_isMpiInitialized)
-            {
-                eventSystem::waitForAllTasks();
-                // Required by scorep for flushing the buffers
-                cuplaDeviceSynchronize();
-                m_isMpiInitialized = false;
-                /*
-                 * When using the combination of MPI_Comm_Accept() and MPI_Open_Port() (as is done by the MPI-based
-                 * implementation of the ADIOS2 SST engine), the current (2023-01-06) Cray MPI implementation
-                 * on Crusher/Frontier will hang inside MPI_Finalize().
-                 * The workaround is to replace it with an MPI_Barrier().
-                 */
-                char const* env_value = std::getenv("PIC_WORKAROUND_CRAY_MPI_FINALIZE");
-                bool use_cray_workaround = false;
-                if(env_value)
-                {
-                    try
-                    {
-                        int env_value_int = std::stoi(env_value);
-                        use_cray_workaround = env_value_int != 0;
-                    }
-                    catch(std::invalid_argument const& e)
-                    {
-                        std::cerr
-                            << "Warning: PIC_WORKAROUND_CRAY_MPI_FINALIZE must have an integer value, received: '"
-                            << env_value << "'. Will ignore." << std::endl;
-                    }
-                }
-                /* Free the MPI context.
-                 * The gpu context is freed by the `StreamController`, because
-                 * MPI and CUDA are independent.
-                 */
-                if(use_cray_workaround)
-                {
-                    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-                }
-                else
-                {
-                    MPI_CHECK(MPI_Finalize());
-                }
-            }
-        }
-
-        void EnvironmentContext::setDevice(int deviceNumber)
-        {
-            int num_gpus = 0; // number of gpus
-            cuplaGetDeviceCount(&num_gpus);
-#if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-            //##ERROR handling
-            if(num_gpus < 1) // check if cupla device is found
-            {
-                throw std::runtime_error("no CUDA capable devices detected");
-            }
-#endif
-
-            int maxTries = num_gpus;
-            bool deviceSelectionSuccessful = false;
-
-            cuplaError rc;
-
-            // search the first selectable device in the compute node
-            for(int deviceOffset = 0; deviceOffset < maxTries; ++deviceOffset)
-            {
-                /* Modulo 'num_gpus' avoids invalid device indices for systems where the environment variable
-                 * `CUDA_VISIBLE_DEVICES` is used to pre-select a device.
-                 */
-                const int tryDeviceId = (deviceOffset + deviceNumber) % num_gpus;
-
-                log<ggLog::CUDA_RT>("Trying to allocate device %1%.") % tryDeviceId;
-
-#if(BOOST_LANG_CUDA || BOOST_LANG_HIP)
-#    if(BOOST_LANG_CUDA)
-                cudaDeviceProp devProp;
-#    elif(BOOST_LANG_HIP)
-                hipDeviceProp_t devProp;
-#    endif
-
-                CUDA_CHECK((cuplaError_t) ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, tryDeviceId));
-
-                /* If the cuda gpu compute mode is 'default'
-                 * (https://docs.nvidia.com/cuda/cuda-c-programming-guide/#compute-modes)
-                 * then we try to get a device only once.
-                 * The index used to select a device is based on the local MPI rank so
-                 * that each rank tries a different device.
-                 */
-                if(devProp.computeMode == ALPAKA_API_PREFIX(ComputeModeDefault))
-                {
-                    maxTries = 1;
-                    log<ggLog::CUDA_RT>("Device %1% is running in default mode.") % tryDeviceId;
-                }
-#endif
-
-                rc = cuplaSetDevice(tryDeviceId);
-
-                if(rc == cuplaSuccess)
-                {
-                    cuplaStream_t stream;
-                    /* \todo: Check if this workaround is needed
-                     *
-                     * - since NVIDIA change something in driver cuplaSetDevice never
-                     * return an error if another process already use the selected
-                     * device if gpu compute mode is set "process exclusive"
-                     * - create a dummy stream to check if the device is already used by
-                     * an other process.
-                     * - cuplaStreamCreate fails if gpu is already in use
-                     */
-                    rc = cuplaStreamCreate(&stream);
-                }
-
-                if(rc == cuplaSuccess)
-                {
-#if(BOOST_LANG_CUDA || BOOST_LANG_HIP)
-                    CUDA_CHECK((cuplaError_t) ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, tryDeviceId));
-                    log<ggLog::CUDA_RT>("Set device to %1%: %2%") % tryDeviceId % devProp.name;
-                    if(ALPAKA_API_PREFIX(ErrorSetOnActiveProcess)
-                       == ALPAKA_API_PREFIX(SetDeviceFlags)(ALPAKA_API_PREFIX(DeviceScheduleSpin)))
-                    {
-                        cuplaGetLastError(); // reset all errors
-                        /* - because of cuplaStreamCreate was called cuplaSetDeviceFlags crashed
-                         * - to set the flags reset the device and set flags again
-                         */
-                        CUDA_CHECK(cuplaDeviceReset());
-                        CUDA_CHECK(
-                            (cuplaError_t) ALPAKA_API_PREFIX(SetDeviceFlags)(ALPAKA_API_PREFIX(DeviceScheduleSpin)));
-                    }
-#endif
-                    CUDA_CHECK(cuplaGetLastError());
-                    deviceSelectionSuccessful = true;
-                    break;
-                }
-                else if(
-                    rc == cuplaErrorDeviceAlreadyInUse
-#if(PMACC_CUDA_ENABLED == 1)
-                    || rc == (cuplaError) cudaErrorDevicesUnavailable
-#endif
-                )
-                {
-                    cuplaGetLastError(); // reset all errors
-                    log<ggLog::CUDA_RT>("Device %1% already in use, try next.") % tryDeviceId;
-                    continue;
-                }
-                else
-                {
-                    CUDA_CHECK(rc); /*error message*/
-                }
-            }
-            if(!deviceSelectionSuccessful)
-            {
-                std::cerr << "Failed to select one of the " << num_gpus << " devices." << std::endl;
-                throw std::runtime_error("Compute device selection failed.");
-            }
-
-            m_isDeviceSelected = true;
-        }
-
-    } // namespace detail
 } // namespace pmacc
 
-/* No namespace for macro defines */
-
-#include "pmacc/eventSystem/events/CudaEvent.hpp"
-#include "pmacc/eventSystem/tasks/Factory.tpp"
-#include "pmacc/particles/tasks/ParticleFactory.tpp"
+#include "pmacc/Environment.tpp"

--- a/include/pmacc/Environment.tpp
+++ b/include/pmacc/Environment.tpp
@@ -1,0 +1,406 @@
+/* Copyright 2014-2021 Felix Schmitt, Conrad Schumann,
+ *                     Alexander Grund, Axel Huebl
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/Environment.hpp"
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+#include "pmacc/communication/manager_common.hpp"
+#include "pmacc/types.hpp"
+
+
+#if !defined(ALPAKA_API_PREFIX)
+/* ALPAKA_API_PREFIX was removed in alpaka 1.0.0 but is required to get access cuda/hip functions directly.
+ * @todo find a better way to access native cuda/Hip functions or try to avoid accessing these at all.
+ */
+#    include "pmacc/ppFunctions.hpp"
+#    if(BOOST_LANG_CUDA)
+#        define ALPAKA_API_PREFIX(name) PMACC_JOIN(cuda, name)
+#    elif(BOOST_LANG_HIP)
+#        define ALPAKA_API_PREFIX(name) PMACC_JOIN(hip, name)
+#    endif
+#endif
+
+namespace pmacc
+{
+    namespace detail
+    {
+        pmacc::StreamController& Environment::StreamController()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!");
+            return StreamController::getInstance();
+        }
+
+        pmacc::EnvironmentController& Environment::EnvironmentController()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isMpiInitialized(),
+                "Environment< DIM >::initDevices() must be called before this method!");
+            return EnvironmentController::getInstance();
+        }
+
+
+        pmacc::Factory& Environment::Factory()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isMpiInitialized()
+                    && EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!");
+            return Factory::getInstance();
+        }
+
+        pmacc::EventPool& Environment::EventPool()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!");
+            return EventPool::getInstance();
+        }
+
+
+        pmacc::ParticleFactory& Environment::ParticleFactory()
+        {
+            return ParticleFactory::getInstance();
+        }
+
+
+        pmacc::DataConnector& Environment::DataConnector()
+        {
+            return DataConnector::getInstance();
+        }
+
+
+        pmacc::PluginConnector& Environment::PluginConnector()
+        {
+            return PluginConnector::getInstance();
+        }
+
+        device::MemoryInfo& Environment::MemoryInfo()
+        {
+            PMACC_ASSERT_MSG(
+                EnvironmentContext::getInstance().isDeviceSelected(),
+                "Environment< DIM >::initDevices() must be called before this method!");
+            return device::MemoryInfo::getInstance();
+        }
+
+
+        simulationControl::SimulationDescription& Environment::SimulationDescription()
+        {
+            return simulationControl::SimulationDescription::getInstance();
+        }
+
+    } // namespace detail
+
+    template<uint32_t T_dim>
+    void Environment<T_dim>::enableMpiDirect()
+    {
+        detail::EnvironmentContext::getInstance().enableMpiDirect();
+    }
+
+    template<uint32_t T_dim>
+    bool Environment<T_dim>::isMpiDirectEnabled() const
+    {
+        return detail::EnvironmentContext::getInstance().isMpiDirectEnabled();
+    }
+
+    template<uint32_t T_dim>
+    pmacc::GridController<T_dim>& Environment<T_dim>::GridController()
+    {
+        PMACC_ASSERT_MSG(
+            detail::EnvironmentContext::getInstance().isMpiInitialized(),
+            "Environment< DIM >::initDevices() must be called before this method!");
+        return pmacc::GridController<T_dim>::getInstance();
+    }
+
+    template<uint32_t T_dim>
+    pmacc::SubGrid<T_dim>& Environment<T_dim>::SubGrid()
+    {
+        PMACC_ASSERT_MSG(
+            detail::EnvironmentContext::getInstance().isSubGridDefined(),
+            "Environment< DIM >::initGrids() must be called before this method!");
+        return pmacc::SubGrid<T_dim>::getInstance();
+    }
+
+    template<uint32_t T_dim>
+    pmacc::Filesystem<T_dim>& Environment<T_dim>::Filesystem()
+    {
+        return pmacc::Filesystem<T_dim>::getInstance();
+    }
+
+
+    template<uint32_t T_dim>
+    void Environment<T_dim>::initDevices(DataSpace<T_dim> devices, DataSpace<T_dim> periodic)
+    {
+        // initialize the MPI context
+        detail::EnvironmentContext::getInstance().init();
+
+        // create singleton instances
+        GridController().init(devices, periodic);
+
+        EnvironmentController();
+
+        Filesystem();
+
+        detail::EnvironmentContext::getInstance().setDevice(static_cast<int>(GridController().getHostRank()));
+
+        StreamController().activate();
+
+        MemoryInfo();
+
+        SimulationDescription();
+    }
+
+    template<uint32_t T_dim>
+    void Environment<T_dim>::initGrids(
+        DataSpace<T_dim> globalDomainSize,
+        DataSpace<T_dim> localDomainSize,
+        DataSpace<T_dim> localDomainOffset)
+    {
+        PMACC_ASSERT_MSG(
+            detail::EnvironmentContext::getInstance().isMpiInitialized(),
+            "Environment< DIM >::initDevices() must be called before this method!");
+
+        detail::EnvironmentContext::getInstance().m_isSubGridDefined = true;
+
+        // create singleton instances
+        SubGrid().init(localDomainSize, globalDomainSize, localDomainOffset);
+
+        DataConnector();
+
+        PluginConnector();
+    }
+
+
+    namespace detail
+    {
+        void EnvironmentContext::init()
+        {
+            m_isMpiInitialized = true;
+
+            char const* env_value = std::getenv("PIC_USE_THREADED_MPI");
+            if(env_value)
+            {
+                int required_level{};
+                if(strcmp(env_value, "MPI_THREAD_SINGLE") == 0)
+                {
+                    required_level = MPI_THREAD_SINGLE;
+                }
+                else if(strcmp(env_value, "MPI_THREAD_FUNNELED") == 0)
+                {
+                    required_level = MPI_THREAD_FUNNELED;
+                }
+                else if(strcmp(env_value, "MPI_THREAD_SERIALIZED") == 0)
+                {
+                    required_level = MPI_THREAD_SERIALIZED;
+                }
+                else if(strcmp(env_value, "MPI_THREAD_MULTIPLE") == 0)
+                {
+                    required_level = MPI_THREAD_MULTIPLE;
+                }
+                else
+                {
+                    throw std::runtime_error(
+                        "Environment variable PIC_USE_THREADED_MPI must be one of MPI_THREAD_SINGLE, "
+                        "MPI_THREAD_FUNNELED, MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE.");
+                }
+                // MPI_Init with NULL is allowed since MPI 2.0
+                MPI_CHECK(MPI_Init_thread(nullptr, nullptr, required_level, nullptr));
+            }
+            else
+            {
+                // MPI_Init with NULL is allowed since MPI 2.0
+                MPI_CHECK(MPI_Init(nullptr, nullptr));
+            }
+        }
+
+        void EnvironmentContext::finalize()
+        {
+            if(m_isMpiInitialized)
+            {
+                eventSystem::waitForAllTasks();
+                // Required by scorep for flushing the buffers
+                cuplaDeviceSynchronize();
+                m_isMpiInitialized = false;
+                /*
+                 * When using the combination of MPI_Comm_Accept() and MPI_Open_Port() (as is done by the MPI-based
+                 * implementation of the ADIOS2 SST engine), the current (2023-01-06) Cray MPI implementation
+                 * on Crusher/Frontier will hang inside MPI_Finalize().
+                 * The workaround is to replace it with an MPI_Barrier().
+                 */
+                char const* env_value = std::getenv("PIC_WORKAROUND_CRAY_MPI_FINALIZE");
+                bool use_cray_workaround = false;
+                if(env_value)
+                {
+                    try
+                    {
+                        int env_value_int = std::stoi(env_value);
+                        use_cray_workaround = env_value_int != 0;
+                    }
+                    catch(std::invalid_argument const& e)
+                    {
+                        std::cerr
+                            << "Warning: PIC_WORKAROUND_CRAY_MPI_FINALIZE must have an integer value, received: '"
+                            << env_value << "'. Will ignore." << std::endl;
+                    }
+                }
+                /* Free the MPI context.
+                 * The gpu context is freed by the `StreamController`, because
+                 * MPI and CUDA are independent.
+                 */
+                if(use_cray_workaround)
+                {
+                    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+                }
+                else
+                {
+                    MPI_CHECK(MPI_Finalize());
+                }
+            }
+        }
+
+        void EnvironmentContext::setDevice(int deviceNumber)
+        {
+            int num_gpus = 0; // number of gpus
+            cuplaGetDeviceCount(&num_gpus);
+#if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
+            //##ERROR handling
+            if(num_gpus < 1) // check if cupla device is found
+            {
+                throw std::runtime_error("no CUDA capable devices detected");
+            }
+#endif
+
+            int maxTries = num_gpus;
+            bool deviceSelectionSuccessful = false;
+
+            cuplaError rc;
+
+            // search the first selectable device in the compute node
+            for(int deviceOffset = 0; deviceOffset < maxTries; ++deviceOffset)
+            {
+                /* Modulo 'num_gpus' avoids invalid device indices for systems where the environment variable
+                 * `CUDA_VISIBLE_DEVICES` is used to pre-select a device.
+                 */
+                const int tryDeviceId = (deviceOffset + deviceNumber) % num_gpus;
+
+                log<ggLog::CUDA_RT>("Trying to allocate device %1%.") % tryDeviceId;
+
+#if(BOOST_LANG_CUDA || BOOST_LANG_HIP)
+#    if(BOOST_LANG_CUDA)
+                cudaDeviceProp devProp;
+#    elif(BOOST_LANG_HIP)
+                hipDeviceProp_t devProp;
+#    endif
+
+                CUDA_CHECK((cuplaError_t) ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, tryDeviceId));
+
+                /* If the cuda gpu compute mode is 'default'
+                 * (https://docs.nvidia.com/cuda/cuda-c-programming-guide/#compute-modes)
+                 * then we try to get a device only once.
+                 * The index used to select a device is based on the local MPI rank so
+                 * that each rank tries a different device.
+                 */
+                if(devProp.computeMode == ALPAKA_API_PREFIX(ComputeModeDefault))
+                {
+                    maxTries = 1;
+                    log<ggLog::CUDA_RT>("Device %1% is running in default mode.") % tryDeviceId;
+                }
+#endif
+
+                rc = cuplaSetDevice(tryDeviceId);
+
+                if(rc == cuplaSuccess)
+                {
+                    cuplaStream_t stream;
+                    /* \todo: Check if this workaround is needed
+                     *
+                     * - since NVIDIA change something in driver cuplaSetDevice never
+                     * return an error if another process already use the selected
+                     * device if gpu compute mode is set "process exclusive"
+                     * - create a dummy stream to check if the device is already used by
+                     * an other process.
+                     * - cuplaStreamCreate fails if gpu is already in use
+                     */
+                    rc = cuplaStreamCreate(&stream);
+                }
+
+                if(rc == cuplaSuccess)
+                {
+#if(BOOST_LANG_CUDA || BOOST_LANG_HIP)
+                    CUDA_CHECK((cuplaError_t) ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, tryDeviceId));
+                    log<ggLog::CUDA_RT>("Set device to %1%: %2%") % tryDeviceId % devProp.name;
+                    if(ALPAKA_API_PREFIX(ErrorSetOnActiveProcess)
+                       == ALPAKA_API_PREFIX(SetDeviceFlags)(ALPAKA_API_PREFIX(DeviceScheduleSpin)))
+                    {
+                        cuplaGetLastError(); // reset all errors
+                        /* - because of cuplaStreamCreate was called cuplaSetDeviceFlags crashed
+                         * - to set the flags reset the device and set flags again
+                         */
+                        CUDA_CHECK(cuplaDeviceReset());
+                        CUDA_CHECK(
+                            (cuplaError_t) ALPAKA_API_PREFIX(SetDeviceFlags)(ALPAKA_API_PREFIX(DeviceScheduleSpin)));
+                    }
+#endif
+                    CUDA_CHECK(cuplaGetLastError());
+                    deviceSelectionSuccessful = true;
+                    break;
+                }
+                else if(
+                    rc == cuplaErrorDeviceAlreadyInUse
+#if(PMACC_CUDA_ENABLED == 1)
+                    || rc == (cuplaError) cudaErrorDevicesUnavailable
+#endif
+                )
+                {
+                    cuplaGetLastError(); // reset all errors
+                    log<ggLog::CUDA_RT>("Device %1% already in use, try next.") % tryDeviceId;
+                    continue;
+                }
+                else
+                {
+                    CUDA_CHECK(rc); /*error message*/
+                }
+            }
+            if(!deviceSelectionSuccessful)
+            {
+                std::cerr << "Failed to select one of the " << num_gpus << " devices." << std::endl;
+                throw std::runtime_error("Compute device selection failed.");
+            }
+
+            m_isDeviceSelected = true;
+        }
+
+    } // namespace detail
+} // namespace pmacc
+
+/* PMACC_NO_TPP_INCLUDE is only defined if pmaccHeaderCheck is running.
+ * In this case the current tested hpp file can include a file which depend on the tested hpp file.
+ * This will build a cyclic include we can only solve if we write everywhere clean header files without
+ * implementations.
+ */
+#if !defined(PMACC_NO_TPP_INCLUDE)
+#    include "pmacc/eventSystem/tasks/Factory.tpp"
+#    include "pmacc/fields/tasks/FieldFactory.tpp"
+#    include "pmacc/particles/tasks/ParticleFactory.tpp"
+#endif

--- a/include/pmacc/algorithms/TypeCast.hpp
+++ b/include/pmacc/algorithms/TypeCast.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+
 namespace pmacc
 {
     namespace algorithms

--- a/include/pmacc/communication/AsyncCommunication.hpp
+++ b/include/pmacc/communication/AsyncCommunication.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "pmacc/eventSystem/events/EventTask.hpp"
+
 namespace pmacc
 {
     namespace communication

--- a/include/pmacc/communication/manager_common.hpp
+++ b/include/pmacc/communication/manager_common.hpp
@@ -25,6 +25,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <mpi.h>
+
 const int GridManagerRank = 0;
 
 enum

--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/Environment.def"
 #include "pmacc/assert.hpp"
 #include "pmacc/dataManagement/AbstractInitialiser.hpp"
 #include "pmacc/dataManagement/ISimulationData.hpp"

--- a/include/pmacc/device/MemoryInfo.hpp
+++ b/include/pmacc/device/MemoryInfo.hpp
@@ -22,7 +22,10 @@
 #pragma once
 
 
+#include "pmacc/Environment.def"
 #include "pmacc/types.hpp"
+
+#include <pmacc/communication/manager_common.hpp>
 
 #include <cstring> // memset
 

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "pmacc/Environment.def"
 #include "pmacc/debug/VerboseLog.hpp"
 #include "pmacc/eventSystem/events/CudaEvent.hpp"
 #include "pmacc/eventSystem/events/CudaEventHandle.hpp"

--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -24,84 +24,19 @@
 
 #include "pmacc/Environment.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/exec/KernelLauncher.hpp"
+#include "pmacc/exec/KernelMetaData.hpp"
+#include "pmacc/exec/KernelWithDynSharedMem.hpp"
 #include "pmacc/traits/GetNComponents.hpp"
 #include "pmacc/types.hpp"
 
 #include <string>
 
 
-/* No namespace in this file since we only declare macro defines */
-
-/*if this flag is defined all kernel calls would be checked and synchronize
- * this flag must set by the compiler or inside of the Makefile
- */
-#if(PMACC_SYNC_KERNEL == 1)
-#    define CUDA_CHECK_KERNEL_MSG(...) CUDA_CHECK_MSG(__VA_ARGS__)
-#else
-/*no synchronize and check of kernel calls*/
-#    define CUDA_CHECK_KERNEL_MSG(...) ;
-#endif
-
-
 namespace pmacc::exec
 {
     namespace detail
     {
-        /** Kernel with dynamic shared memory
-         *
-         * This implements the possibility to define dynamic shared memory without
-         * specializing the needed alpaka trait BlockSharedMemDynSizeBytes for each kernel with shared memory.
-         * The trait BlockSharedMemDynSizeBytes is defined by PMacc for all types of KernelWithDynSharedMem.
-         */
-        template<typename T_Kernel>
-        struct KernelWithDynSharedMem : public T_Kernel
-        {
-            size_t const m_dynSharedMemBytes;
-
-            KernelWithDynSharedMem(T_Kernel const& kernel, size_t const& dynSharedMemBytes)
-                : T_Kernel(kernel)
-                , m_dynSharedMemBytes(dynSharedMemBytes)
-            {
-            }
-        };
-
-        //! Meta data of a device kernel
-        class KernelMetaData
-        {
-            //! file name
-            std::string const m_file;
-            //! line number
-            size_t const m_line;
-
-        public:
-            KernelMetaData(std::string const& file, size_t const line) : m_file(file), m_line(line)
-            {
-            }
-
-            //! file name from where the kernel is called
-            std::string getFile() const
-            {
-                return m_file;
-            }
-
-            //! line number in the file where the kernel is called
-            size_t getLine() const
-            {
-                return m_line;
-            }
-        };
-
-
-        /** Object to launch the kernel functor on the device.
-         *
-         * This objects contains the kernel functor, kernel meta information and the launch parameters.
-         * Object is used to enqueue the kernel with user arguments on the device.
-         *
-         * @tparam T_Kernel pmacc Kernel object
-         */
-        template<typename T_Kernel>
-        struct KernelLauncher;
-
         /** Wraps a user kernel functor to prepare the execution on the device.
          *
          * This objects contains the kernel functor, kernel meta information.
@@ -149,89 +84,6 @@ namespace pmacc::exec
                 size_t const sharedMemByte) const -> KernelLauncher<KernelWithDynSharedMem<T_KernelFunctor>>;
             /**@}*/
         };
-
-
-        template<typename T_Kernel>
-        struct KernelLauncher
-        {
-            //! kernel functor
-            T_Kernel const m_kernel;
-            //! Debug meta data for the kernel functor.
-            KernelMetaData const m_metaData;
-            //! grid extents for the kernel
-            cupla::dim3 const m_gridExtent;
-            //! block extents for the kernel
-            cupla::dim3 const m_blockExtent;
-
-            /** kernel starter object
-             *
-             * @param kernel pmacc Kernel
-             */
-            template<typename T_VectorGrid, typename T_VectorBlock>
-            HINLINE KernelLauncher(
-                T_Kernel const& kernel,
-                detail::KernelMetaData const& kernelMetaData,
-                T_VectorGrid const& gridExtent,
-                T_VectorBlock const& blockExtent)
-                : m_kernel(kernel)
-                , m_metaData(kernelMetaData)
-                , m_gridExtent(DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toDim3())
-                , m_blockExtent(DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toDim3())
-            {
-            }
-
-            /** Enqueue the kernel functor with the given arguments for execution.
-             *
-             * The stream into which the kernel is enqueued is automatically chosen by PMacc's event system.
-             *
-             * @tparam T_Args types of the arguments
-             * @param args arguments for the kernel functor
-             */
-            template<typename... T_Args>
-            HINLINE void operator()(T_Args&&... args) const
-            {
-                std::string const kernelName = typeid(m_kernel).name();
-                std::string const kernelInfo = kernelName + std::string(" [") + m_metaData.getFile() + std::string(":")
-                    + std::to_string(m_metaData.getLine()) + std::string(" ]");
-
-                CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash before kernel call ") + kernelInfo);
-
-                pmacc::TaskKernel* taskKernel = pmacc::Environment<>::get().Factory().createTaskKernel(kernelName);
-
-                /* The next 3 lines cast pmacc vectors or integral values used for the execution extents into alpaka
-                 * vectors.
-                 * Note to be cupla compatible we use currently always 3-dimensional kernels.
-                 *
-                 * @todo find a better way to write this part of code, in general alpaka understands PMacc vectors but
-                 * PMacc has no easy way t cast integral numbers to an 3-dimensional vector.
-                 */
-                auto gridExtent = cupla::IdxVec3(m_gridExtent.z, m_gridExtent.y, m_gridExtent.x);
-                auto blockExtent = cupla::IdxVec3(m_blockExtent.z, m_blockExtent.y, m_blockExtent.x);
-                auto elemExtent = cupla::IdxVec3::ones();
-                auto workDiv
-                    = ::alpaka::WorkDivMembers<cupla::KernelDim, cupla::IdxType>(gridExtent, blockExtent, elemExtent);
-
-                auto const kernelTask
-                    = ::alpaka::createTaskKernel<cupla::Acc>(workDiv, m_kernel, std::forward<T_Args>(args)...);
-
-                auto cuplaStream = taskKernel->getCudaStream();
-                auto& stream = cupla::manager::Stream<cupla::AccDev, cupla::AccStream>::get().stream(cuplaStream);
-
-                ::alpaka::enqueue(stream, kernelTask);
-
-                CUDA_CHECK_KERNEL_MSG(
-                    cuplaGetLastError(),
-                    std::string("Last error after kernel launch ") + kernelInfo);
-                CUDA_CHECK_KERNEL_MSG(
-                    cuplaDeviceSynchronize(),
-                    std::string("Crash after kernel launch ") + kernelInfo);
-                taskKernel->activateChecks();
-                CUDA_CHECK_KERNEL_MSG(
-                    cuplaDeviceSynchronize(),
-                    std::string("Crash after kernel activation") + kernelInfo);
-            }
-        };
-
     } // namespace detail
 
     /** Creates a kernel object.
@@ -292,3 +144,4 @@ namespace alpaka
 
 
 #include "pmacc/eventSystem/events/kernelEvents.tpp"
+#include "pmacc/exec/KernelLauncher.tpp"

--- a/include/pmacc/eventSystem/tasks/Factory.hpp
+++ b/include/pmacc/eventSystem/tasks/Factory.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "pmacc/Environment.def"
+#include "pmacc/eventSystem/events/EventTask.hpp"
 #include "pmacc/eventSystem/streams/EventStream.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/tasks/TaskKernel.hpp"

--- a/include/pmacc/eventSystem/tasks/TaskReceive.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceive.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc/Environment.hpp"
+#include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventDataReceive.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"
 

--- a/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -26,7 +26,6 @@
 #include "pmacc/communication/ICommunicator.hpp"
 #include "pmacc/eventSystem/events/EventDataReceive.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"
-#include "pmacc/memory/buffers/Buffer.hpp"
 
 #include <memory>
 
@@ -47,7 +46,7 @@ namespace pmacc
 
         void init() override
         {
-            Buffer<TYPE, DIM>* dst = exchange->getCommunicationBuffer();
+            auto* dst = exchange->getCommunicationBuffer();
 
             this->request = Environment<DIM>::get().EnvironmentController().getCommunicator().startReceive(
                 exchange->getExchangeType(),

--- a/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
@@ -25,7 +25,6 @@
 #include "pmacc/Environment.hpp"
 #include "pmacc/communication/ICommunicator.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"
-#include "pmacc/memory/buffers/Buffer.hpp"
 
 #include <mpi.h>
 
@@ -44,7 +43,7 @@ namespace pmacc
 
         void init() override
         {
-            Buffer<TYPE, DIM>* src = exchange->getCommunicationBuffer();
+            auto* src = exchange->getCommunicationBuffer();
 
             this->request = Environment<DIM>::get().EnvironmentController().getCommunicator().startSend(
                 exchange->getExchangeType(),

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -25,7 +25,7 @@
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/eventSystem/tasks/StreamTask.hpp"
 #include "pmacc/lockstep.hpp"
-#include "pmacc/lockstep/lockstep.hpp"
+#include "pmacc/lockstep/WorkerCfg.hpp"
 #include "pmacc/mappings/simulation/EnvironmentController.hpp"
 #include "pmacc/memory/boxes/DataBox.hpp"
 #include "pmacc/memory/buffers/DeviceBuffer.hpp"

--- a/include/pmacc/exec/KernelLauncher.hpp
+++ b/include/pmacc/exec/KernelLauncher.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2022 Alexander Grund
+/* Copyright 2022 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -21,31 +21,16 @@
 
 #pragma once
 
-#include <cstdint>
 
-namespace pmacc
+namespace pmacc::exec::detail
 {
-    namespace particles
-    {
-        namespace policies
-        {
-            /**
-             * Policy for HandleGuardParticles that removes all particles from guard cells
-             */
-            struct DeleteParticles
-            {
-                template<class T_Particles>
-                void handleOutgoing(T_Particles& par, int32_t direction) const
-                {
-                    par.deleteGuardParticles(direction);
-                }
-
-                template<class T_Particles>
-                void handleIncoming(T_Particles& par, int32_t direction) const
-                {
-                }
-            };
-
-        } // namespace policies
-    } // namespace particles
-} // namespace pmacc
+    /** Object to launch the kernel functor on the device.
+     *
+     * This objects contains the kernel functor, kernel meta information and the launch parameters.
+     * Object is used to enqueue the kernel with user arguments on the device.
+     *
+     * @tparam T_Kernel pmacc Kernel object
+     */
+    template<typename T_Kernel>
+    struct KernelLauncher;
+} // namespace pmacc::exec::detail

--- a/include/pmacc/exec/KernelLauncher.tpp
+++ b/include/pmacc/exec/KernelLauncher.tpp
@@ -1,0 +1,125 @@
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include "pmacc/Environment.hpp"
+#include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/exec/KernelLauncher.hpp"
+#include "pmacc/exec/KernelMetaData.hpp"
+#include "pmacc/traits/GetNComponents.hpp"
+#include "pmacc/types.hpp"
+
+#include <string>
+
+
+/* No namespace in this file since we only declare macro defines */
+
+/*if this flag is defined all kernel calls would be checked and synchronize
+ * this flag must set by the compiler or inside of the Makefile
+ */
+#if(PMACC_SYNC_KERNEL == 1)
+#    define CUDA_CHECK_KERNEL_MSG(...) CUDA_CHECK_MSG(__VA_ARGS__)
+#else
+/*no synchronize and check of kernel calls*/
+#    define CUDA_CHECK_KERNEL_MSG(...) ;
+#endif
+
+
+namespace pmacc::exec::detail
+{
+    template<typename T_Kernel>
+    struct KernelLauncher
+    {
+        //! kernel functor
+        T_Kernel const m_kernel;
+        //! Debug meta data for the kernel functor.
+        KernelMetaData const m_metaData;
+        //! grid extents for the kernel
+        cupla::dim3 const m_gridExtent;
+        //! block extents for the kernel
+        cupla::dim3 const m_blockExtent;
+
+        /** kernel starter object
+         *
+         * @param kernel pmacc Kernel
+         */
+        template<typename T_VectorGrid, typename T_VectorBlock>
+        HINLINE KernelLauncher(
+            T_Kernel const& kernel,
+            detail::KernelMetaData const& kernelMetaData,
+            T_VectorGrid const& gridExtent,
+            T_VectorBlock const& blockExtent)
+            : m_kernel(kernel)
+            , m_metaData(kernelMetaData)
+            , m_gridExtent(DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toDim3())
+            , m_blockExtent(DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toDim3())
+        {
+        }
+
+        /** Enqueue the kernel functor with the given arguments for execution.
+         *
+         * The stream into which the kernel is enqueued is automatically chosen by PMacc's event system.
+         *
+         * @tparam T_Args types of the arguments
+         * @param args arguments for the kernel functor
+         */
+        template<typename... T_Args>
+        HINLINE void operator()(T_Args&&... args) const
+        {
+            std::string const kernelName = typeid(m_kernel).name();
+            std::string const kernelInfo = kernelName + std::string(" [") + m_metaData.getFile() + std::string(":")
+                + std::to_string(m_metaData.getLine()) + std::string(" ]");
+
+            CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash before kernel call ") + kernelInfo);
+
+            pmacc::TaskKernel* taskKernel = pmacc::Environment<>::get().Factory().createTaskKernel(kernelName);
+
+            /* The next 3 lines cast pmacc vectors or integral values used for the execution extents into alpaka
+             * vectors.
+             * Note to be cupla compatible we use currently always 3-dimensional kernels.
+             *
+             * @todo find a better way to write this part of code, in general alpaka understands PMacc vectors but
+             * PMacc has no easy way t cast integral numbers to an 3-dimensional vector.
+             */
+            auto gridExtent = cupla::IdxVec3(m_gridExtent.z, m_gridExtent.y, m_gridExtent.x);
+            auto blockExtent = cupla::IdxVec3(m_blockExtent.z, m_blockExtent.y, m_blockExtent.x);
+            auto elemExtent = cupla::IdxVec3::ones();
+            auto workDiv
+                = ::alpaka::WorkDivMembers<cupla::KernelDim, cupla::IdxType>(gridExtent, blockExtent, elemExtent);
+
+            auto const kernelTask
+                = ::alpaka::createTaskKernel<cupla::Acc>(workDiv, m_kernel, std::forward<T_Args>(args)...);
+
+            auto cuplaStream = taskKernel->getCudaStream();
+            auto& stream = cupla::manager::Stream<cupla::AccDev, cupla::AccStream>::get().stream(cuplaStream);
+
+            ::alpaka::enqueue(stream, kernelTask);
+
+            CUDA_CHECK_KERNEL_MSG(cuplaGetLastError(), std::string("Last error after kernel launch ") + kernelInfo);
+            CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash after kernel launch ") + kernelInfo);
+            taskKernel->activateChecks();
+            CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash after kernel activation") + kernelInfo);
+        }
+    };
+
+} // namespace pmacc::exec::detail

--- a/include/pmacc/exec/KernelMetaData.hpp
+++ b/include/pmacc/exec/KernelMetaData.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2022 Alexander Grund
+/* Copyright 2022 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -21,31 +21,36 @@
 
 #pragma once
 
-#include <cstdint>
+#include "pmacc/types.hpp"
 
-namespace pmacc
+#include <string>
+
+
+namespace pmacc::exec::detail
 {
-    namespace particles
+    //! Meta data of a device kernel
+    class KernelMetaData
     {
-        namespace policies
+        //! file name
+        std::string const m_file;
+        //! line number
+        size_t const m_line;
+
+    public:
+        KernelMetaData(std::string const& file, size_t const line) : m_file(file), m_line(line)
         {
-            /**
-             * Policy for HandleGuardParticles that removes all particles from guard cells
-             */
-            struct DeleteParticles
-            {
-                template<class T_Particles>
-                void handleOutgoing(T_Particles& par, int32_t direction) const
-                {
-                    par.deleteGuardParticles(direction);
-                }
+        }
 
-                template<class T_Particles>
-                void handleIncoming(T_Particles& par, int32_t direction) const
-                {
-                }
-            };
+        //! file name from where the kernel is called
+        std::string getFile() const
+        {
+            return m_file;
+        }
 
-        } // namespace policies
-    } // namespace particles
-} // namespace pmacc
+        //! line number in the file where the kernel is called
+        size_t getLine() const
+        {
+            return m_line;
+        }
+    };
+} // namespace pmacc::exec::detail

--- a/include/pmacc/exec/KernelWithDynSharedMem.hpp
+++ b/include/pmacc/exec/KernelWithDynSharedMem.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2022 Alexander Grund
+/* Copyright 2022 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -21,31 +21,27 @@
 
 #pragma once
 
-#include <cstdint>
 
-namespace pmacc
+#include <string>
+
+
+namespace pmacc::exec::detail
 {
-    namespace particles
+    /** Kernel with dynamic shared memory
+     *
+     * This implements the possibility to define dynamic shared memory without
+     * specializing the needed alpaka trait BlockSharedMemDynSizeBytes for each kernel with shared memory.
+     * The trait BlockSharedMemDynSizeBytes is defined by PMacc for all types of KernelWithDynSharedMem.
+     */
+    template<typename T_Kernel>
+    struct KernelWithDynSharedMem : public T_Kernel
     {
-        namespace policies
+        size_t const m_dynSharedMemBytes;
+
+        KernelWithDynSharedMem(T_Kernel const& kernel, size_t const& dynSharedMemBytes)
+            : T_Kernel(kernel)
+            , m_dynSharedMemBytes(dynSharedMemBytes)
         {
-            /**
-             * Policy for HandleGuardParticles that removes all particles from guard cells
-             */
-            struct DeleteParticles
-            {
-                template<class T_Particles>
-                void handleOutgoing(T_Particles& par, int32_t direction) const
-                {
-                    par.deleteGuardParticles(direction);
-                }
-
-                template<class T_Particles>
-                void handleIncoming(T_Particles& par, int32_t direction) const
-                {
-                }
-            };
-
-        } // namespace policies
-    } // namespace particles
-} // namespace pmacc
+        }
+    };
+} // namespace pmacc::exec::detail

--- a/include/pmacc/fields/operations/AddExchangeToBorder.hpp
+++ b/include/pmacc/fields/operations/AddExchangeToBorder.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc/fields/tasks/FieldFactory.hpp"
+#include "pmacc/lockstep.hpp"
 #include "pmacc/mappings/kernel/ExchangeMapping.hpp"
 #include "pmacc/mappings/kernel/MappingDescription.hpp"
 #include "pmacc/math/Vector.hpp"

--- a/include/pmacc/fields/operations/CopyGuardToExchange.hpp
+++ b/include/pmacc/fields/operations/CopyGuardToExchange.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc/fields/tasks/FieldFactory.hpp"
+#include "pmacc/lockstep.hpp"
 #include "pmacc/mappings/kernel/ExchangeMapping.hpp"
 #include "pmacc/mappings/kernel/MappingDescription.hpp"
 #include "pmacc/math/Vector.hpp"

--- a/include/pmacc/fields/tasks/FieldFactory.hpp
+++ b/include/pmacc/fields/tasks/FieldFactory.hpp
@@ -83,5 +83,3 @@ namespace pmacc
     };
 
 } // namespace pmacc
-
-#include "pmacc/fields/tasks/FieldFactory.tpp"

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 
+#include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventDataReceive.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 
+#include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventDataReceive.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"

--- a/include/pmacc/fields/tasks/TaskFieldSend.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSend.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 
+#include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventDataReceive.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"

--- a/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
@@ -22,11 +22,11 @@
 #pragma once
 
 
+#include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventDataReceive.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/tasks/MPITask.hpp"
 #include "pmacc/fields/tasks/FieldFactory.hpp"
-
 
 namespace pmacc
 {

--- a/include/pmacc/filter/operators/And.hpp
+++ b/include/pmacc/filter/operators/And.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/filter/operators/Or.hpp
+++ b/include/pmacc/filter/operators/Or.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/lockstep/Worker.hpp"
+#include "pmacc/static_assert.hpp"
 #include "pmacc/types.hpp"
 
 #include <boost/core/ignore_unused.hpp>

--- a/include/pmacc/kernel/operation/Atomic.hpp
+++ b/include/pmacc/kernel/operation/Atomic.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/kernel/atomic.hpp"
+#include "pmacc/math/Vector.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc

--- a/include/pmacc/lockstep.hpp
+++ b/include/pmacc/lockstep.hpp
@@ -22,7 +22,4 @@
 
 #pragma once
 
-#include "pmacc/lockstep/ForEach.hpp"
-#include "pmacc/lockstep/Idx.hpp"
-#include "pmacc/lockstep/Variable.hpp"
-#include "pmacc/lockstep/Worker.hpp"
+#include "pmacc/lockstep/lockstep.hpp"

--- a/include/pmacc/lockstep/Kernel.hpp
+++ b/include/pmacc/lockstep/Kernel.hpp
@@ -23,10 +23,12 @@
 
 
 #include "pmacc/eventSystem/events/kernelEvents.hpp"
+#include "pmacc/exec/KernelLauncher.hpp"
+#include "pmacc/exec/KernelMetaData.hpp"
+#include "pmacc/exec/KernelWithDynSharedMem.hpp"
 #include "pmacc/lockstep/Worker.hpp"
 #include "pmacc/lockstep/WorkerCfg.hpp"
 #include "pmacc/types.hpp"
-
 
 namespace pmacc::lockstep
 {

--- a/include/pmacc/mappings/kernel/BorderMapping.hpp
+++ b/include/pmacc/mappings/kernel/BorderMapping.hpp
@@ -25,6 +25,7 @@
 #include "pmacc/assert.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/mappings/kernel/MapperConcept.hpp"
+#include "pmacc/memory/dataTypes/Mask.hpp"
 #include "pmacc/types.hpp"
 
 #include <stdexcept>

--- a/include/pmacc/mappings/kernel/MapperConcept.hpp
+++ b/include/pmacc/mappings/kernel/MapperConcept.hpp
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include <pmacc/types.hpp>
-
+#include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/types.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/mappings/kernel/StrideIntervalMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideIntervalMapping.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/dimensions/DataSpaceOperations.hpp"
 #include "pmacc/mappings/kernel/MapperConcept.hpp"
 #include "pmacc/types.hpp"
 

--- a/include/pmacc/mappings/kernel/StrideMapperFactory.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapperFactory.hpp
@@ -25,6 +25,7 @@
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
 #include "pmacc/mappings/kernel/AreaMapping.hpp"
+#include "pmacc/mappings/kernel/IntervalMapping.hpp"
 #include "pmacc/mappings/kernel/StrideIntervalMapping.hpp"
 #include "pmacc/mappings/kernel/StrideMapping.hpp"
 #include "pmacc/types.hpp"

--- a/include/pmacc/mappings/simulation/SubGrid.hpp
+++ b/include/pmacc/mappings/simulation/SubGrid.hpp
@@ -22,9 +22,9 @@
 #pragma once
 
 #include "Selection.hpp"
+#include "pmacc/Environment.def"
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/dimensions/GridLayout.hpp"
-#include "pmacc/mappings/simulation/GridController.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/math/RungeKutta/RungeKutta4.hpp
+++ b/include/pmacc/math/RungeKutta/RungeKutta4.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+
 namespace pmacc
 {
     namespace math

--- a/include/pmacc/math/complex/Bessel.hpp
+++ b/include/pmacc/math/complex/Bessel.hpp
@@ -59,6 +59,7 @@
 
 #pragma once
 
+#include "pmacc/math/ConstVector.hpp"
 #include "pmacc/types.hpp"
 
 

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -21,8 +21,10 @@
 
 #pragma once
 
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/math/vector/navigator/PermutedNavigator.hpp"
 #include "pmacc/math/vector/navigator/StackedNavigator.hpp"
+#include "pmacc/result_of_Functor.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/math/vector/compile-time/Int.hpp
+++ b/include/pmacc/math/vector/compile-time/Int.hpp
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include "pmacc/math/Vector.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/traits/Limits.hpp"
 
 #include <boost/mpl/integral_c.hpp>
 
 #include <cstdint>
+
+#include "pmacc/math/vector/compile-time/Vector.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/math/vector/compile-time/Size_t.hpp
+++ b/include/pmacc/math/vector/compile-time/Size_t.hpp
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include "pmacc/math/Vector.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/traits/Limits.hpp"
 
 #include <boost/mpl/integral_c.hpp>
 
 #include <cstdint>
+
+#include "pmacc/math/vector/compile-time/Vector.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/math/vector/compile-time/UInt32.hpp
+++ b/include/pmacc/math/vector/compile-time/UInt32.hpp
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include "pmacc/math/Vector.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/traits/Limits.hpp"
 
 #include <boost/mpl/integral_c.hpp>
 
 #include <cstdint>
+
+#include "pmacc/math/vector/compile-time/Vector.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/math/vector/compile-time/UInt64.hpp
+++ b/include/pmacc/math/vector/compile-time/UInt64.hpp
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include "pmacc/math/Vector.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/traits/Limits.hpp"
 
 #include <boost/mpl/integral_c.hpp>
 
 #include <cstdint>
+
+#include "pmacc/math/vector/compile-time/Vector.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "pmacc/math/Vector.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/types.hpp"
 
 #include <boost/mpl/accumulate.hpp>

--- a/include/pmacc/memory/IndexPool.hpp
+++ b/include/pmacc/memory/IndexPool.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/memory/Array.hpp"
+#include "pmacc/static_assert.hpp"
 #include "pmacc/types.hpp"
 
 #include <limits>

--- a/include/pmacc/memory/boxes/CachedBox.hpp
+++ b/include/pmacc/memory/boxes/CachedBox.hpp
@@ -26,6 +26,7 @@
 #include "pmacc/memory/boxes/SharedBox.hpp"
 #include "pmacc/types.hpp"
 
+
 namespace pmacc
 {
     namespace CachedBox

--- a/include/pmacc/memory/boxes/DataBox.hpp
+++ b/include/pmacc/memory/boxes/DataBox.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
 
 namespace pmacc

--- a/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
+++ b/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
@@ -24,6 +24,7 @@
 
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
+#include "pmacc/types.hpp"
 
 #include <cstdint>
 

--- a/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "pmacc/types.hpp"
+
 #include <cstdint>
 
 namespace pmacc

--- a/include/pmacc/meta/conversion/TypeToAliasPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToAliasPair.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/identifier/alias.hpp"
 #include "pmacc/meta/conversion/TypeToPair.hpp"
 #include "pmacc/types.hpp"
 

--- a/include/pmacc/meta/conversion/Unique.hpp
+++ b/include/pmacc/meta/conversion/Unique.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/meta/conversion/MakeSeq.hpp"
 #include "pmacc/meta/conversion/ToSeq.hpp"
 
 #include <boost/mpl/empty.hpp>

--- a/include/pmacc/mpi/GetMPI_StructAsArray.hpp
+++ b/include/pmacc/mpi/GetMPI_StructAsArray.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
 #include "pmacc/mpi/MPI_StructAsArray.hpp"
 #include "pmacc/types.hpp"
 
@@ -36,7 +37,7 @@ namespace pmacc
         } // namespace def
 
         template<typename Type>
-        pmacc::mpi::MPI_StructAsArray getMPI_StructAsArray()
+        HINLINE pmacc::mpi::MPI_StructAsArray getMPI_StructAsArray()
         {
             return def::GetMPI_StructAsArray<Type>()();
         }

--- a/include/pmacc/mpi/MPIReduce.hpp
+++ b/include/pmacc/mpi/MPIReduce.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/Environment.hpp"
 #include "pmacc/assert.hpp"
 #include "pmacc/communication/manager_common.hpp"
 #include "pmacc/mpi/GetMPI_Op.hpp"

--- a/include/pmacc/mpi/reduceMethods/AllReduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/AllReduce.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/Environment.hpp"
 #include "pmacc/communication/manager_common.hpp"
 #include "pmacc/types.hpp"
 

--- a/include/pmacc/mpi/reduceMethods/Reduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/Reduce.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/Environment.hpp"
 #include "pmacc/communication/manager_common.hpp"
 #include "pmacc/types.hpp"
 

--- a/include/pmacc/particles/IdProvider.hpp
+++ b/include/pmacc/particles/IdProvider.hpp
@@ -25,6 +25,7 @@
 #include "pmacc/Environment.hpp"
 #include "pmacc/algorithms/reverseBits.hpp"
 #include "pmacc/debug/PMaccVerbose.hpp"
+#include "pmacc/eventSystem/events/kernelEvents.hpp"
 #include "pmacc/kernel/atomic.hpp"
 #include "pmacc/memory/buffers/HostDeviceBuffer.hpp"
 

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -29,6 +29,7 @@
 #include "pmacc/mappings/kernel/AreaMapping.hpp"
 #include "pmacc/particles/algorithm/detail/ForEach.hpp"
 #include "pmacc/particles/frame_types.hpp"
+#include "pmacc/traits/GetNumWorkers.hpp"
 
 #include <cstdint>
 #include <type_traits>

--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -26,7 +26,9 @@
 #    include <mallocMC/mallocMC.hpp>
 #endif
 #include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/memory/boxes/DataBox.hpp"
 #include "pmacc/memory/boxes/PitchedBox.hpp"
+#include "pmacc/particles/Identifier.hpp"
 #include "pmacc/particles/frame_types.hpp"
 #include "pmacc/particles/memory/dataTypes/FramePointer.hpp"
 #include "pmacc/particles/memory/dataTypes/SuperCell.hpp"

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -24,6 +24,7 @@
 #include "pmacc/dataManagement/ISimulationData.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -50,8 +50,6 @@
 
 namespace pmacc
 {
-    namespace pmath = pmacc::math;
-
     /** A single particle of a @see Frame
      *
      * A instance of this Particle is a representation ("pointer") to the memory

--- a/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
+++ b/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
@@ -21,13 +21,13 @@
 
 #pragma once
 
-#include "pmacc/types.hpp"
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+
+#include <cstdint>
 
 
 namespace pmacc
 {
-    namespace pmath = pmacc::math;
-
     template<typename T_Type, typename T_size>
     class StaticArray
     {

--- a/include/pmacc/particles/operations/ConcatListOfFrames.hpp
+++ b/include/pmacc/particles/operations/ConcatListOfFrames.hpp
@@ -23,6 +23,8 @@
 
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
 #include "pmacc/lockstep/Worker.hpp"
+#include "pmacc/particles/Identifier.hpp"
+#include "pmacc/particles/operations/Deselect.hpp"
 #include "pmacc/types.hpp"
 
 #include "pmacc/math/vector/compile-time/Vector.hpp"

--- a/include/pmacc/particles/operations/CopyIdentifier.hpp
+++ b/include/pmacc/particles/operations/CopyIdentifier.hpp
@@ -21,15 +21,10 @@
 
 #pragma once
 
-#include "pmacc/particles/Identifier.hpp"
-#include "pmacc/traits/HasIdentifier.hpp"
-#include "pmacc/types.hpp"
+#include "pmacc/attribute/FunctionSpecifier.hpp"
 
 namespace pmacc
 {
-    namespace pmath = pmacc::math;
-
-
     template<typename T_Key>
     struct CopyIdentifier
     {

--- a/include/pmacc/particles/particleFilter/PositionFilter.hpp
+++ b/include/pmacc/particles/particleFilter/PositionFilter.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc/dimensions/DataSpaceOperations.hpp"
+#include "pmacc/particles/Identifier.hpp"
 #include "pmacc/particles/frame_types.hpp"
 #include "pmacc/particles/memory/frames/NullFrame.hpp"
 #include "pmacc/types.hpp"

--- a/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
@@ -22,7 +22,10 @@
 
 #pragma once
 
+#include "pmacc/Environment.hpp"
 #include "pmacc/assert.hpp"
+#include "pmacc/eventSystem/Manager.hpp"
+#include "pmacc/eventSystem/tasks/MPITask.hpp"
 #include "pmacc/traits/NumberOfExchanges.hpp"
 
 namespace pmacc

--- a/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
@@ -22,7 +22,10 @@
 
 #pragma once
 
+#include "pmacc/Environment.hpp"
 #include "pmacc/assert.hpp"
+#include "pmacc/eventSystem/Manager.hpp"
+#include "pmacc/eventSystem/tasks/MPITask.hpp"
 #include "pmacc/type/Exchange.hpp"
 
 namespace pmacc

--- a/include/pmacc/pluginSystem/INotify.hpp
+++ b/include/pmacc/pluginSystem/INotify.hpp
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace pmacc
 {
     /*

--- a/include/pmacc/pluginSystem/containsStep.hpp
+++ b/include/pmacc/pluginSystem/containsStep.hpp
@@ -36,7 +36,7 @@ namespace pmacc
          * @param timeStep simulation time step to check
          * @return true if step is included in the interval list else false
          */
-        HINLINE bool containsStep(std::vector<pluginSystem::Slice> const& seqTimeSlices, uint32_t const timeStep)
+        inline bool containsStep(std::vector<pluginSystem::Slice> const& seqTimeSlices, uint32_t const timeStep)
         {
             for(auto const& timeSlice : seqTimeSlices)
             {

--- a/include/pmacc/pluginSystem/toSlice.hpp
+++ b/include/pmacc/pluginSystem/toSlice.hpp
@@ -27,12 +27,12 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstdint>
 #include <iostream>
 #include <regex>
 #include <string>
 #include <vector>
-
 
 namespace pmacc
 {
@@ -45,7 +45,7 @@ namespace pmacc
              * @param str string to check
              * @return true if str contains only digits else false
              */
-            HINLINE bool is_number(std::string const& str)
+            inline bool is_number(std::string const& str)
             {
                 return std::all_of(str.begin(), str.end(), ::isdigit);
             }
@@ -63,7 +63,7 @@ namespace pmacc
          *
          * @param str Comma separated list of slices. Empty slices will be skipped.
          */
-        HINLINE std::vector<Slice> toTimeSlice(std::string const& str)
+        inline std::vector<Slice> toTimeSlice(std::string const& str)
         {
             std::vector<Slice> result;
             auto const seqOfSlices = misc::splitString(str, ",");
@@ -117,7 +117,7 @@ namespace pmacc
          *
          * @param str Comma separated list of slices. Empty slices will be skipped.
          */
-        HINLINE std::vector<Slice> toRangeSlice(std::string const& str)
+        inline std::vector<Slice> toRangeSlice(std::string const& str)
         {
             std::vector<Slice> result;
             auto const seqOfSlices = misc::splitString(str, ",");

--- a/include/pmacc/simulationControl/SimulationDescription.hpp
+++ b/include/pmacc/simulationControl/SimulationDescription.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/Environment.def"
 #include "pmacc/types.hpp"
 
 #include <string>

--- a/include/pmacc/test/memory/HostBuffer/copyFrom.hpp
+++ b/include/pmacc/test/memory/HostBuffer/copyFrom.hpp
@@ -23,6 +23,8 @@
 
 /* #includes in "test/memoryUT.cu" */
 
+#include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/memory/buffers/HostBuffer.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/test/memory/HostBuffer/reset.hpp
+++ b/include/pmacc/test/memory/HostBuffer/reset.hpp
@@ -23,6 +23,8 @@
 
 /* #includes in "test/memoryUT.cu" */
 
+#include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/memory/buffers/HostBuffer.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/test/memory/HostBuffer/setValue.hpp
+++ b/include/pmacc/test/memory/HostBuffer/setValue.hpp
@@ -22,7 +22,8 @@
 #pragma once
 
 /* #includes in "test/memoryUT.cu" */
-
+#include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/memory/buffers/HostBuffer.hpp"
 
 namespace pmacc
 {

--- a/include/pmacc/traits/GetNComponents.hpp
+++ b/include/pmacc/traits/GetNComponents.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "pmacc/static_assert.hpp"
+
 #include <cstdint>
 #include <type_traits>
 

--- a/include/pmacc/traits/GetStringProperties.hpp
+++ b/include/pmacc/traits/GetStringProperties.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+
 #include <iostream>
 #include <map>
 #include <string>

--- a/include/pmacc/traits/HasIdentifiers.hpp
+++ b/include/pmacc/traits/HasIdentifiers.hpp
@@ -46,10 +46,13 @@ namespace pmacc
         template<typename T_Object, typename T_SeqKeys>
         struct HasIdentifiers
         {
-            using SeqHasIdentifiers = typename bmpl::transform<T_SeqKeys, HasIdentifier<T_Object, bmpl::_1>>::type;
+            using SeqHasIdentifiers =
+                typename boost::mpl::transform<T_SeqKeys, HasIdentifier<T_Object, boost::mpl::_1>>::type;
 
-            using type =
-                typename bmpl::accumulate<SeqHasIdentifiers, bmpl::bool_<true>, bmpl::and_<bmpl::_1, bmpl::_2>>::type;
+            using type = typename boost::mpl::accumulate<
+                SeqHasIdentifiers,
+                boost::mpl::bool_<true>,
+                boost::mpl::and_<boost::mpl::_1, boost::mpl::_2>>::type;
         };
 
         template<typename T_Object, typename T_SeqKeys>

--- a/share/ci/run_pmacc_tests.sh
+++ b/share/ci/run_pmacc_tests.sh
@@ -85,11 +85,6 @@ get_backend_flags()
 # build an run tests
 ###################################################
 
-# use one build directory for all build configurations
-cd $HOME
-mkdir buildPMaccCI
-cd buildPMaccCI
-
 export code_DIR=$CI_PROJECT_DIR
 
 PMACC_PARALLEL_BUILDS=$(nproc)
@@ -135,6 +130,19 @@ echo -e "/////////////////////////////////////////////////// \033[0m \n\n"
 export OMPI_MCA_btl_base_warn_component_unused=0
 export LD_LIBRARY_PATH=/opt/boost/${BOOST_VERSION}/lib:$LD_LIBRARY_PATH
 
+# compile header include consistency check
+# use one build directory for all build configurations
+cd $HOME
+mkdir buildPMaccHeaderCI
+cd buildPMaccHeaderCI
+cmake $CMAKE_ARGS $code_DIR/test/pmaccHeaderCheck
+make -j $(nproc)
+
+# compile and run catch2 tests
+# use one build directory for all build configurations
+cd $HOME
+mkdir buildPMaccCI
+cd buildPMaccCI
 cmake $CMAKE_ARGS $code_DIR/include/pmacc
 make
 

--- a/test/pmaccHeaderCheck/CMakeLists.txt
+++ b/test/pmaccHeaderCheck/CMakeLists.txt
@@ -1,0 +1,89 @@
+#
+# Copyright 2014-2020 Benjamin Worpitz, Axel Huebl, Jan Stephan, Rene Widera
+#
+# This file is part of PIConGPU.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+cmake_minimum_required(VERSION 3.18)
+project(PMaccHeaderTest)
+
+# Add common functions from alpaka.
+# Always use the alpaka files shipped with PIConGPU/cupla from the thirdParty directory.
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../thirdParty/cupla/alpaka/cmake/common.cmake)
+
+################################################################################
+# Directory of this file.
+################################################################################
+set(PMACC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../include/pmacc)
+
+# Normalize the path (e.g. remove ../)
+get_filename_component(PMACC_ROOT_DIR "${PMACC_ROOT_DIR}" ABSOLUTE)
+
+###############################################################################
+# Language Flags
+###############################################################################
+
+# enforce C++17
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
+
+################################################################################
+# PMacc
+################################################################################
+find_package(PMacc REQUIRED CONFIG PATHS "${PMACC_ROOT_DIR}")
+
+
+set(_TARGET_NAME "headerCheckTest")
+
+###############################################################################
+# Catch2
+###############################################################################
+
+add_subdirectory(${PMACC_ROOT_DIR}/../../thirdParty/catch2/catch_main ${CMAKE_BINARY_DIR}/catch2)
+
+#---------------------------------------------------------------------------
+# Create source files.
+set(PMACC_SUFFIXED_INCLUDE_DIR "${PMACC_ROOT_DIR}")
+append_recursive_files("${PMACC_SUFFIXED_INCLUDE_DIR}" "hpp" "PMACC_FILES_HEADER")
+# remove pmacc/test to avoid pulling tests cases where catch is used
+list(FILTER PMACC_FILES_HEADER EXCLUDE REGEX ".*pmacc/test.*")
+
+set(_GENERATED_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/src")
+
+file(REMOVE_RECURSE ${_GENERATED_SOURCE_DIR})
+
+foreach (_HEADER_FILE ${PMACC_FILES_HEADER})
+    # Remove the parent directory from the path.
+    # NOTE: This is not correct because it does not only replace at the beginning of the string.
+    #  "STRING(REGEX REPLACE" would be correct if there was an easy way to escape arbitrary strings.
+    string(
+            REPLACE "${PMACC_SUFFIXED_INCLUDE_DIR}/" ""
+            _HEADER_FILE
+            "${_HEADER_FILE}")
+    set(_SOURCE_FILE "${_GENERATED_SOURCE_DIR}/${_HEADER_FILE}.cpp")
+    file(WRITE "${_SOURCE_FILE}" "#include <pmacc/${_HEADER_FILE}>\n#include <pmacc/Environment.hpp>\n")
+endforeach ()
+
+#---------------------------------------------------------------------------
+# Add executable.
+
+append_recursive_files_add_to_src_group("${_GENERATED_SOURCE_DIR}" "${_GENERATED_SOURCE_DIR}" "cpp" "_FILES_SOURCE")
+list(APPEND _FILES_SOURCE "src/main.cpp")
+
+# Always add all files to the target executable build call to add them to the build project.
+cupla_add_executable(
+        ${_TARGET_NAME}
+        ${_FILES_SOURCE})
+
+target_link_libraries(${_TARGET_NAME} PUBLIC CatchMain)
+target_compile_definitions(${_TARGET_NAME} PRIVATE "PMACC_NO_TPP_INCLUDE")
+target_link_libraries(${_TARGET_NAME} PRIVATE pmacc::pmacc)
+
+set_target_properties(headerCheckTest PROPERTIES FOLDER "headerCheck")
+
+add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/pmaccHeaderCheck/src/main.cpp
+++ b/test/pmaccHeaderCheck/src/main.cpp
@@ -1,0 +1,27 @@
+/* Copyright 2021 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("headerCheckMain", "[headerCheck]")
+{
+    REQUIRE(true);
+}


### PR DESCRIPTION
- remove unused files 
- fix PMacc dependencies to PIConGPU simulation dimension and data types.  (will be provided as separate PR too)
- add a test case based on alpaka's header check implementation.

This check is not removing all cyclic dependencies. The test case `pmaccHeaderCheck` is defining `PMACC_NO_TPP_INCLUDE` to avoid including some `tpp` files in `Environment.tpp`. This workaround is required to be able to check each header file from PMacc. Even with this workaround, it is a big step to avoid including issues when using PMacc.