### PR TITLE
Set back Esirkepov as default current solver

### DIFF
--- a/docs/source/usage/workflows/tracerParticles.rst
+++ b/docs/source/usage/workflows/tracerParticles.rst
@@ -25,7 +25,7 @@ Adding ``probeE`` creates a tracer species stores the interpolated electric fiel
           particlePusher< particles::pusher::Boris >,
           shape< UsedParticleShape >,
           interpolation< UsedField2Particle >,
-          currentSolver::EmZ<UsedParticleCurrentSolver>
+          currentSolver::Esirkepov<UsedParticleCurrentSolver>
       >;
 
       using TracerElectron = Particles<

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
@@ -81,7 +81,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
 /** particle pusher configuration
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
@@ -82,7 +82,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
 #ifndef PARAM_CURRENTSOLVER
-#    define PARAM_CURRENTSOLVER EmZ<UsedParticleShape>
+#    define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>
 #endif
     using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
 

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
@@ -81,7 +81,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
 /** particle pusher configuration
  *


### PR DESCRIPTION
Revert #3599 and switch back to Esirkepov as the default current solver.

@steindev and me working currently on the EmZ publication. There are some open questions, therefore we decided to switch back to the well-known and understood Esirkepov current deposition method until all open questions are answered.

Note: all our tests show that EmZ is charge conserving and not introducing any artificially heating.

This PR will be ported back to 0.6.0 before the release.