### PR TITLE
backport last fixes for the release 0.6.0

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -137,6 +137,16 @@ PIConGPU command line option          description
    #. dump all species data each 128th time step, use HDF5 backend.
    #. dump all field data each 1000th time step, use the default ADIOS backend.
 
+Backend-specific notes
+^^^^^^^^^^^^^^^^^^^^^^
+
+ADIOS2
+======
+
+The memory usage of some engines in ADIOS2 can be reduced by specifying the environment variable ``openPMD_USE_STORECHUNK_SPAN=1``.
+This makes PIConGPU use the `span-based Put() API <https://adios2.readthedocs.io/en/latest/components/components.html#put-modes-and-memory-contracts>`_ of ADIOS2 which avoids buffer copies, but does not allow for compression.
+Do *not* use this optimization in combination with compression, otherwise the resulting datasets will not be usable.
+
 Memory Complexity
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/workflows/tracerParticles.rst
+++ b/docs/source/usage/workflows/tracerParticles.rst
@@ -25,7 +25,7 @@ Adding ``probeE`` creates a tracer species stores the interpolated electric fiel
           particlePusher< particles::pusher::Boris >,
           shape< UsedParticleShape >,
           interpolation< UsedField2Particle >,
-          currentSolver::EmZ<UsedParticleCurrentSolver>
+          currentSolver::Esirkepov<UsedParticleCurrentSolver>
       >;
 
       using TracerElectron = Particles<

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -20,6 +20,9 @@
 
 #include "openPMD/openPMD.hpp"
 
+#include <cstdlib> // std::getenv
+#include <memory>
+#include <string> // std::stoull
 #include <utility> // std::declval
 
 #if OPENPMDAPI_VERSION_GE(0, 13, 0)
@@ -85,6 +88,7 @@ namespace picongpu
                     ::openPMD::RecordComponent& rc,
                     ::openPMD::Offset offset,
                     ::openPMD::Extent extent,
+                    bool /* useSpanAPI */, // only used in the specialization below
                     Functor&& createBaseBuffer)
                 {
                     using extent_t = ::openPMD::Extent::value_type;
@@ -114,10 +118,15 @@ namespace picongpu
                 using DynamicMemoryView = decltype(std::declval<RecordComponent>().template storeChunk<ValueType>(
                     std::declval<::openPMD::Offset>(),
                     std::declval<::openPMD::Extent>()));
-                DynamicMemoryView m_buffer;
+
+                bool m_useSpanAPI; // depending on the value of this, use either m_bufferFallback or m_bufferSpan
+                // need a pointer here since DynamicMemoryView has no default constructor
+                std::unique_ptr<DynamicMemoryView> m_bufferSpan;
+                std::shared_ptr<ValueType> m_bufferFallback;
+
                 ValueType* currentBuffer()
                 {
-                    return m_buffer.currentBuffer().data();
+                    return m_useSpanAPI ? m_bufferSpan->currentBuffer().data() : m_bufferFallback.get();
                 }
 
                 template<typename Functor>
@@ -125,12 +134,28 @@ namespace picongpu
                     ::openPMD::RecordComponent& rc,
                     ::openPMD::Offset offset,
                     ::openPMD::Extent extent,
+                    bool useSpanAPI,
                     Functor&& createBaseBuffer)
-                    : m_buffer{rc.storeChunk<ValueType>(
-                        std::move(offset),
-                        std::move(extent),
-                        std::forward<Functor>(createBaseBuffer))}
+                    : m_useSpanAPI(useSpanAPI)
                 {
+                    if(m_useSpanAPI)
+                    {
+                        m_bufferSpan = std::make_unique<DynamicMemoryView>(rc.storeChunk<ValueType>(
+                            std::move(offset),
+                            std::move(extent),
+                            std::forward<Functor>(createBaseBuffer)));
+                    }
+                    else
+                    {
+                        using extent_t = ::openPMD::Extent::value_type;
+                        extent_t scalarExtent = 1;
+                        for(auto val : extent)
+                        {
+                            scalarExtent *= val;
+                        }
+                        m_bufferFallback = std::forward<Functor>(createBaseBuffer)(scalarExtent);
+                        rc.storeChunk(m_bufferFallback, std::move(offset), std::move(extent));
+                    }
                 }
             };
         } // namespace detail
@@ -156,10 +181,40 @@ namespace picongpu
             ::openPMD::Extent extent,
             Functor&& createBaseBuffer) -> detail::openPMDSpan<ValueType>
         {
+            bool useSpanAPI = false;
+            {
+                auto value = std::getenv("openPMD_USE_STORECHUNK_SPAN");
+                unsigned long long valueAsLong{};
+                if(value)
+                {
+                    try
+                    {
+                        valueAsLong = std::stoull(value);
+                    }
+                    catch(std::invalid_argument const&)
+                    {
+                        throw std::runtime_error("Environment variable 'openPMD_USE_STORECHUNK_SPAN' may only be set "
+                                                 "to values '0' or '1'.");
+                    }
+                    switch(valueAsLong)
+                    {
+                    case 0:
+                        useSpanAPI = false;
+                        break;
+                    case 1:
+                        useSpanAPI = true;
+                        break;
+                    default:
+                        throw std::runtime_error("Environment variable 'openPMD_USE_STORECHUNK_SPAN' may only be set "
+                                                 "to values '0' or '1'.");
+                    }
+                }
+            }
             return detail::openPMDSpan<ValueType>(
                 rc,
                 std::move(offset),
                 std::move(extent),
+                useSpanAPI,
                 std::forward<Functor>(createBaseBuffer));
         }
     } // namespace openPMD

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
@@ -81,7 +81,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
 /** particle pusher configuration
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
@@ -78,7 +78,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
     /** particle pusher configuration
      *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
@@ -82,7 +82,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
 #ifndef PARAM_CURRENTSOLVER
-#    define PARAM_CURRENTSOLVER EmZ<UsedParticleShape>
+#    define PARAM_CURRENTSOLVER Esirkepov<UsedParticleShape>
 #endif
     using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER;
 

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
@@ -81,7 +81,7 @@ namespace picongpu
      * - currentSolver::strategy::NonCachedSupercells
      * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
      */
-    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
 
 /** particle pusher configuration
  *


### PR DESCRIPTION
PR's:
- Set back Esirkepov as default current solver #3932
- Make the span-based storeChunk API opt-in in various openPMD-based IO routines #3933