### PR TITLE
Add missing communication in XrayScattering

### DIFF
--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -494,7 +494,7 @@ namespace picongpu
                     // Calculate density.
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
                     // Particles can contribute to cells in GUARD (due to their shape) this values need to be
-                    // added to the neighbouring GPU BOARDERs. 
+                    // added to the neighbouring GPU BOARDERs.
                     EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
                     __setTransactionEvent(fieldTmpEvent);
                     // Get the field data box.

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -493,6 +493,10 @@ namespace picongpu
                     using ElectronDensitySolver = typename DetermineElectronDensitySolver<T_ParticlesType>::type;
                     // Calculate density.
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
+                    // Particles can contribute to cells in GUARD (due to their shape) this values need to be
+                    // added to the neighbouring GPU BOARDERs. 
+                    EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
+                    __setTransactionEvent(fieldTmpEvent);
                     // Get the field data box.
                     FieldTmp::DataBoxType tmpFieldBox = tmpField->getGridBuffer().getDeviceBuffer().getDataBox();
                     return tmpFieldBox;

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -495,7 +495,7 @@ namespace picongpu
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
                     // Particles can contribute to cells in GUARD (due to their shape) this values need to be
                     // added to the neighbouring GPU BOARDERs.
-                    EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
+                    EventTask fieldTmpEvent = tmpField->asyncCommunication(__getTransactionEvent());
                     __setTransactionEvent(fieldTmpEvent);
                     // Get the field data box.
                     FieldTmp::DataBoxType tmpFieldBox = tmpField->getGridBuffer().getDeviceBuffer().getDataBox();


### PR DESCRIPTION
I think we discussed when I was writing  the `XrayScattering` plugin that the `GUARD` to `BORDER` communication is not required but I think this was wrong. I finally understood what this does and I think this is missing. Without the communication the contributions from particles on the edges of the GPUs are not correctly added to the adjacent GPU borders. I was using `Counter` particle shape in my tests back then so this never caused any problems. Note, this is how it is done in other places in `PIConGPU`.