### PR TITLE
backport: fix missing communication in XrayScattering

### DIFF
--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -494,7 +494,7 @@ namespace picongpu
                     // Calculate density.
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
                     // Particles can contribute to cells in GUARD (due to their shape) this values need to be
-                    // added to the neighbouring GPU BOARDERs. 
+                    // added to the neighbouring GPU BOARDERs.
                     EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
                     __setTransactionEvent(fieldTmpEvent);
                     // Get the field data box.

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -493,6 +493,10 @@ namespace picongpu
                     using ElectronDensitySolver = typename DetermineElectronDensitySolver<T_ParticlesType>::type;
                     // Calculate density.
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
+                    // Particles can contribute to cells in GUARD (due to their shape) this values need to be
+                    // added to the neighbouring GPU BOARDERs. 
+                    EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
+                    __setTransactionEvent(fieldTmpEvent);
                     // Get the field data box.
                     FieldTmp::DataBoxType tmpFieldBox = tmpField->getGridBuffer().getDeviceBuffer().getDataBox();
                     return tmpFieldBox;

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -495,7 +495,7 @@ namespace picongpu
                     tmpField->template computeValue<CORE + BORDER, ElectronDensitySolver>(*species, currentStep);
                     // Particles can contribute to cells in GUARD (due to their shape) this values need to be
                     // added to the neighbouring GPU BOARDERs.
-                    EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
+                    EventTask fieldTmpEvent = tmpField->asyncCommunication(__getTransactionEvent());
                     __setTransactionEvent(fieldTmpEvent);
                     // Get the field data box.
                     FieldTmp::DataBoxType tmpFieldBox = tmpField->getGridBuffer().getDeviceBuffer().getDataBox();


### PR DESCRIPTION
backport: `Add missing communication in XrayScattering` #3937 to 0.6.0-rc1