### PR TITLE
HIP: allow full architecture definition

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -52,7 +52,9 @@ help()
 
 get_backend_flags()
 {
-    backend_cfg=(${1//:/ })
+    # Everything before the first : is the backend, the rest is the architecture definition which could contain : too.
+    cfg="$(echo -n $1 | sed 's/:/=/')"
+    backend_cfg=(${cfg//=/ })
     num_options="${#backend_cfg[@]}"
     if [ $num_options -gt 2 ] ; then
         echo "-b|--backend must be contain 'backend:arch' or 'backend'" >&2


### PR DESCRIPTION
The architecture string for AMD GPUs could contain `:`. The old way how we
separated the backend from the architecture details is therefore not
working.

```
pic-build -b "hip:gfx906:sramecc+:xnack-"
```

I marked this behavior as bug but it is somehow more a feature. There is no need to backport this PR to the current ongoing release process of 0.6.0.