### PR TITLE
CI: change AMD CI node configuration

### DIFF
--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -9,7 +9,7 @@
     # -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0 workaround for CMake issue
     #  "Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND)"
     #  gfx900 is the VEGA64 GPU in the CI node
-    PIC_CMAKE_ARGS: "-DALPAKA_HIP_ARCH=gfx900 -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
+    PIC_CMAKE_ARGS: "-DGPU_TARGETS=gfx900 -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
     # ISAAC is not working with HIP
     DISABLE_ISAAC: "yes"
   script:

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -8,9 +8,8 @@
     GIT_SUBMODULE_STRATEGY: normal
     # -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0 workaround for CMake issue
     #  "Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND)"
+    #  gfx900 is the VEGA64 GPU in the CI node
     PIC_CMAKE_ARGS: "-DALPAKA_HIP_ARCH=gfx900 -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
-    # use VEGA64 GPU
-    HIP_VISIBLE_DEVICES: "2"
     # ISAAC is not working with HIP
     DISABLE_ISAAC: "yes"
   script:

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -27,7 +27,11 @@ fi
 # enforce optional dependencies
 CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON"
 
-if [ -z "$DISABLE_ISAAC" ] ; then
+# ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
+if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* ]] ; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
+    export CI_CPUS=1
+elif [ -z "$DISABLE_ISAAC" ] ; then
     CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
 fi
 


### PR DESCRIPTION
- The old AMD Fiji double slot GPU from the CI is removed therefore we must use device zero (default).
- The second commit is disabling ISAAC usage for the foilLCT test because the CI is very often running out of memory.
- fix that we build HIP tests for the wrong architecture, this was overseen in #3915


Backport to 0.6.0 required