### PR TITLE
add combined derived attributes

### DIFF
--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -150,9 +150,9 @@ namespace picongpu
          */
         HINLINE EventTask asyncCommunicationGather(EventTask serialEvent);
 
-        /** Compute current density created by a species in an area
+        /** Compute an attribute derived from species in an area
          *
-         * @tparam T_area area to compute currents in
+         * @tparam AREA area to compute values in
          * @tparam T_Species particle species type
          * @tparam Filter particle filter used to filter contributing particles
          *         (default is all particles contribute)
@@ -162,6 +162,18 @@ namespace picongpu
          */
         template<uint32_t AREA, class FrameSolver, typename Filter = particles::filter::All, class ParticlesClass>
         HINLINE void computeValue(ParticlesClass& parClass, uint32_t currentStep);
+
+        /** Modify this field by an another field
+         *
+         * @tparam AREA area where the values are modified
+         * @tparam T_ModifyingOperation a binary operation defining the result of the modification as a function
+         *  of two values. The 1st value is this field and the 2nd value is the modifying field.
+         * @tparam T_ModifyingField type of the second field
+         *
+         * @param modifyingField the second field
+         */
+        template<uint32_t AREA, typename T_ModifyingOperation, typename T_ModifyingField>
+        HINLINE void modifyByField(T_ModifyingField& modifyingField);
 
         /** Bash particles in a direction.
          * Copy all particles from the guard of a direction to the device exchange buffer

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -131,4 +131,43 @@ namespace picongpu
         }
     };
 
+    /** Kernel used in the modifyField method
+     *
+     * @tparam T_numWorkers number of workers
+     * @tparam T_ModifyingOperation a binary operation used to modify one field by another one
+     * @tparam T_SuperCellSize compile-time  supercell size vector
+     */
+    template<uint32_t T_numWorkers, typename T_ModifyingOperation, typename T_SuperCellSize>
+    struct ModifyByFieldKernel
+    {
+        /** Kernel implementation
+         *
+         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Mapper mapper type
+         * @tparam T_Box1 1st data box type
+         * @tparam T_Box2 2nd data box type
+         * @param acc alpaka accelerator
+         * @param mapper functor to map a block to a supercell
+         * @param box1 data box of the first field
+         * @param box2 data box of the second field
+         */
+        template<typename T_Acc, typename T_Mapper, typename T_Box1, typename T_Box2>
+        DINLINE void operator()(T_Acc const& acc, T_Mapper const mapper, T_Box1& box1, T_Box2 const& box2) const
+        {
+            // Shift the fields to the supercell processed by current block.
+            DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const blockCell = block * T_SuperCellSize::toRT();
+            auto box1Block = box1.shift(blockCell);
+            auto box2Block = box2.shift(blockCell);
+
+            // Call the binary operation for a pair of field values for each cell in the supercell.
+            constexpr uint32_t numWorkers = T_numWorkers;
+            uint32_t const workerIdx = cupla::threadIdx(acc).x;
+            using BlockAreaConfiguration = pmacc::SuperCellDescription<T_SuperCellSize>;
+            ThreadCollective<BlockAreaConfiguration, numWorkers> applyOperationToCells(workerIdx);
+            T_ModifyingOperation binaryOperation;
+            applyOperationToCells(acc, binaryOperation, box1Block, box2Block);
+        }
+    };
+
 } // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/CombinedDerive.def
+++ b/include/picongpu/particles/particleToGrid/CombinedDerive.def
@@ -1,0 +1,149 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+#include "picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.def"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            /** Solver type for a CombinedDeriveAttribute
+             *
+             * @tparam T_BaseAttributeSolver solver for the 1st attribute(specialized ComputeGridValuePerFrame)
+             * @tparam T_ModifierAttributeSolver solver for the 2nd attribute(specialized ComputeGridValuePerFrame)
+             * @tparam T_ModifyingOperation functor defining the function of the two attributes (specified for a
+             * species type)
+             * @tparam T_AttributeDescription  class providing unit and name for the resulting attribute
+             */
+            template<
+                typename T_BaseAttributeSolver,
+                typename T_ModifierAttributeSolver,
+                typename T_ModifyingOperation,
+                typename T_AttributeDescription>
+            struct CombinedDeriveSolver
+            {
+                using BaseAttributeSolver = T_BaseAttributeSolver;
+                using ModifierAttributeSolver = T_ModifierAttributeSolver;
+                using ModifyingOperation = T_ModifyingOperation;
+
+                using LowerMargin = typename pmacc::math::CT::max<
+                    typename BaseAttributeSolver::LowerMargin,
+                    typename ModifierAttributeSolver::LowerMargin>::type;
+                using UpperMargin = typename pmacc::math::CT::max<
+                    typename BaseAttributeSolver::UpperMargin,
+                    typename ModifierAttributeSolver::UpperMargin>::type;
+
+                HDINLINE float1_64 getUnit() const;
+
+                HINLINE std::vector<float_64> getUnitDimension() const;
+
+                HINLINE static std::string getName();
+            };
+
+            /** Returns a solver type for a given CombinedAttribute and Species
+             *
+             * @tparam CombinedDeriveAttribute combined attribute type
+             * @tparam T_Species species type
+             */
+            template<typename CombinedDeriveAttribute, typename T_Species>
+            struct GetCombinedSolver;
+
+            template<
+                typename T_BaseDerivedAttribute,
+                typename T_ModifyingDerivedAttribute,
+                typename T_ModifyingOperation,
+                typename T_AttributeDescription,
+                typename T_Species>
+            struct GetCombinedSolver<
+                CombinedDeriveAttribute<
+                    T_BaseDerivedAttribute,
+                    T_ModifyingDerivedAttribute,
+                    T_ModifyingOperation,
+                    T_AttributeDescription>,
+                T_Species>
+            {
+                using ModifyingDerivedAttribute = T_ModifyingDerivedAttribute;
+                using BaseShapeType = detail::GetAttributeShape_t<T_Species, T_BaseDerivedAttribute>;
+                using ModifierShapeType = detail::GetAttributeShape_t<T_Species, T_ModifyingDerivedAttribute>;
+
+                using BaseAttributeSolver = ComputeGridValuePerFrame<BaseShapeType, T_BaseDerivedAttribute>;
+                using ModifierAttributeSolver = ComputeGridValuePerFrame<ModifierShapeType, ModifyingDerivedAttribute>;
+                using type = CombinedDeriveSolver<
+                    BaseAttributeSolver,
+                    ModifierAttributeSolver,
+                    typename T_ModifyingOperation::template apply<T_Species>::type,
+                    T_AttributeDescription>;
+            };
+
+            template<typename T_Species, typename T_Filter, typename... T>
+            struct CreateFieldTmpOperation<T_Species, CombinedDeriveAttribute<T...>, T_Filter>
+            {
+                using DerivedAttribute = CombinedDeriveAttribute<T...>;
+
+                using Solver = typename GetCombinedSolver<DerivedAttribute, T_Species>::type;
+                using type = FieldTmpOperation<Solver, T_Species, T_Filter>;
+            };
+
+
+            // Returns number of extra fieldTmp slots required for deriving an attribute
+            template<typename T_Solver>
+            struct RequiredExtraSlots;
+
+            template<typename... T_SolverArgs>
+            struct RequiredExtraSlots<ComputeGridValuePerFrame<T_SolverArgs...>>
+            {
+                using type = std::integral_constant<uint32_t, 0u>;
+            };
+
+            template<typename... T_SolverArgs>
+            struct RequiredExtraSlots<CombinedDeriveSolver<T_SolverArgs...>>
+            {
+                using type = std::integral_constant<uint32_t, 1u>;
+            };
+
+
+        } // namespace particleToGrid
+        namespace traits
+        {
+            template<
+                typename T_Species,
+                typename T_BaseDerivedAttribute,
+                typename T_ModifyingDerivedAttribute,
+                typename... T>
+            struct SpeciesEligibleForSolver<
+                T_Species,
+                particleToGrid::CombinedDeriveAttribute<T_BaseDerivedAttribute, T_ModifyingDerivedAttribute, T...>>
+            {
+                using EligibleForBaseAttribute =
+                    typename particles::traits::SpeciesEligibleForSolver<T_Species, T_BaseDerivedAttribute>::type;
+                using EligibleForModifierAttribute =
+                    typename particles::traits::SpeciesEligibleForSolver<T_Species, T_ModifyingDerivedAttribute>::type;
+                using type = typename bmpl::and_<EligibleForBaseAttribute, EligibleForModifierAttribute>;
+            };
+        } // namespace traits
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/CombinedDerive.hpp
+++ b/include/picongpu/particles/particleToGrid/CombinedDerive.hpp
@@ -1,0 +1,79 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#include "picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.hpp"
+
+#include <string>
+#include <vector>
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            template<
+                typename T_BaseAttributeSolver,
+                typename T_ModifierAttributeSolver,
+                typename T_ModifyingOperation,
+                typename T_AttributeDescription>
+            HDINLINE float1_64 CombinedDeriveSolver<
+                T_BaseAttributeSolver,
+                T_ModifierAttributeSolver,
+                T_ModifyingOperation,
+                T_AttributeDescription>::getUnit() const
+            {
+                return T_AttributeDescription().getUnit();
+            }
+
+            template<
+                typename T_BaseAttributeSolver,
+                typename T_ModifierAttributeSolver,
+                typename T_ModifyingOperation,
+                typename T_AttributeDescription>
+            HINLINE std::vector<float_64> CombinedDeriveSolver<
+                T_BaseAttributeSolver,
+                T_ModifierAttributeSolver,
+                T_ModifyingOperation,
+                T_AttributeDescription>::getUnitDimension() const
+            {
+                return T_AttributeDescription().getUnitDimension();
+            }
+
+            template<
+                typename T_BaseAttributeSolver,
+                typename T_ModifierAttributeSolver,
+                typename T_ModifyingOperation,
+                typename T_AttributeDescription>
+            HINLINE std::string CombinedDeriveSolver<
+                T_BaseAttributeSolver,
+                T_ModifierAttributeSolver,
+                T_ModifyingOperation,
+                T_AttributeDescription>::getName()
+            {
+                return T_AttributeDescription::getName();
+            }
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            /** Derived Attribute as a function of two attributes directly derived from particles
+             *
+             * @tparam T_BaseDerivedAttribute first parameter (derived attribute)
+             * @tparam T_ModifyingDerivedAttribute second parameter (derived attribute)
+             * @tparam T_ModifyingOperation functor defining the function of the two parameters
+             * @tparam T_AttributeDescription class providing unit and name for the resulting attribute
+             */
+            template<
+                typename T_BaseDerivedAttribute,
+                typename T_ModifyingDerivedAttribute,
+                typename T_ModifyingOperation,
+                typename T_AttributeDescription>
+            struct CombinedDeriveAttribute
+            {
+            };
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
@@ -118,7 +118,7 @@ namespace picongpu
                     fieldTmp1.template computeValue<AREA, typename CombinedSolver::BaseAttributeSolver, T_Filter>(
                         *speciesTmp,
                         currentStep);
-                    /* Particles can contribute to cells in GUARD (due to their shape) this values need to be
+                    /* Particles can contribute to cells in GUARD (due to their shape) these values need to be
                      * added to the neighbouring GPU BORDERs.
                      * Start adding field contribution from the GUARD to the adjacent GPUs while the second attribute
                      * is computed. */

--- a/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
@@ -1,0 +1,143 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/FieldTmp.hpp"
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+#include <pmacc/Environment.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            /** Compute a derived particle attribute
+             *
+             * @tparam AREA area to compute values in
+             * @tparam T_Solver derived attribute solver
+             * @tparam T_Species particle species to derive the attribute from
+             * @tparam T_Filter particle filter used to filter contributing particles
+             */
+            template<uint32_t AREA, typename T_Solver, typename T_Species, typename T_Filter>
+            struct ComputeFieldValue
+            {
+                /** Functor implementation
+                 *
+                 * @param fieldTmp tmp field for storing the result
+                 * @param currentStep current simulation step
+                 * @param extraSlotNr fieldTmp memory slot to use for processing additional tmp fields possibly
+                 * required for the computation. Can be reused after calling this functor.
+                 *
+                 * @returns pointer to a TaskEvent for handling a possibly unfinished asynchronous communication task
+                 * One should call
+                 * @code{c++}
+                 *  if (returnedPointer != nullPtr)
+                 *      __setTransactionEvent(*returnedPointer);
+                 *     @endcode
+                 * after calling this functor.
+                 * Moving this outside of this functor allows for doing it just before the field values are needed and
+                 * possibly taking an advantage of parallel execution alongside with other tasks. The nullPtr check is
+                 * needed since some specializations of this method may not need it and will return a nullptr instead.
+                 */
+                HINLINE std::unique_ptr<EventTask> operator()(
+                    FieldTmp& fieldTmp,
+                    uint32_t const& currentStep,
+                    uint32_t const& extraSlotNr) const;
+            };
+
+
+            // TODO: Consider using std::optional<EventTask> instead of std::unique_ptr<EventTask>
+            // after switching to c++17.
+            //! Specialization for normal derived attributes
+            template<uint32_t AREA, typename T_Species, typename T_Filter, typename... T>
+            struct ComputeFieldValue<AREA, ComputeGridValuePerFrame<T...>, T_Species, T_Filter>
+            {
+                HINLINE std::unique_ptr<EventTask> operator()(
+                    FieldTmp& fieldTmp,
+                    uint32_t const& currentStep,
+                    uint32_t const& extraSlotNr) const
+                {
+                    using Solver = ComputeGridValuePerFrame<T...>;
+                    DataConnector& dc = Environment<>::get().DataConnector();
+                    /*load particle without copy particle data to host*/
+                    auto speciesTmp = dc.get<T_Species>(T_Species::FrameType::getName(), true);
+
+                    fieldTmp.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType::create(0.0));
+                    /*run algorithm*/
+                    fieldTmp.template computeValue<AREA, Solver, T_Filter>(*speciesTmp, currentStep);
+                    // Particles can contribute to cells in GUARD (due to their shape) this values need to be
+                    //  added to the neighbouring GPU BOARDERs.
+                    return std::make_unique<EventTask>(fieldTmp.asyncCommunication(__getTransactionEvent()));
+                }
+            };
+
+            //! Specialization for attributes that are a function of two derived attributes
+            template<uint32_t AREA, typename T_Species, typename T_Filter, typename... T>
+            struct ComputeFieldValue<AREA, CombinedDeriveSolver<T...>, T_Species, T_Filter>
+            {
+                HINLINE std::unique_ptr<EventTask> operator()(
+                    FieldTmp& fieldTmp1,
+                    uint32_t const& currentStep,
+                    uint32_t const& extraSlotNr) const
+                {
+                    using CombinedSolver = CombinedDeriveSolver<T...>;
+
+                    DataConnector& dc = Environment<>::get().DataConnector();
+                    // Get the second tmp field for the second function argument.
+                    auto fieldTmp2 = dc.get<FieldTmp>(FieldTmp::getUniqueId(extraSlotNr), true);
+                    // Load particles without copy particle data to host.
+                    auto speciesTmp = dc.get<T_Species>(T_Species::FrameType::getName(), true);
+                    // initialize both fields with zero
+                    fieldTmp1.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType::create(0.0));
+                    fieldTmp2->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType::create(0.0));
+
+                    // Derive the first attribute from the particle data.
+                    fieldTmp1.template computeValue<AREA, typename CombinedSolver::BaseAttributeSolver, T_Filter>(
+                        *speciesTmp,
+                        currentStep);
+                    /* Particles can contribute to cells in GUARD (due to their shape) this values need to be
+                     * added to the neighbouring GPU BORDERs.
+                     * Start adding field contribution from the GUARD to the adjacent GPUs while the second attribute
+                     * is computed. */
+                    EventTask fieldTmpEvent1 = fieldTmp1.asyncCommunication(__getTransactionEvent());
+                    // Derive the second attribute from the particle data
+                    fieldTmp2->template computeValue<AREA, typename CombinedSolver::ModifierAttributeSolver, T_Filter>(
+                        *speciesTmp,
+                        currentStep);
+                    EventTask fieldTmpEvent2 = fieldTmp2->asyncCommunication(__getTransactionEvent());
+
+                    // Wait for the communication between the GPUs to finish.
+                    __setTransactionEvent(fieldTmpEvent1);
+                    __setTransactionEvent(fieldTmpEvent2);
+
+                    // Modify the 1st field by the values in the 2nd field according to the ModifyingOperation.
+                    fieldTmp1.template modifyByField<AREA, typename CombinedSolver::ModifyingOperation>(*fieldTmp2);
+                    return nullptr;
+                }
+            };
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
@@ -1,0 +1,74 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/Density.def"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace combinedAttributes
+            {
+                //! Compute an average value using a total per cell value and number density
+                struct AverageDivideOperation
+                {
+                    template<typename T_Species>
+                    struct apply
+                    {
+                        using type = AverageDivideOperation;
+                    };
+
+                    /** Functor implementation
+                     *
+                     * Result overwrites the dst value.
+                     *
+                     * @tparam T_Acc alpaka accelerator type
+                     * @param acc alpaka accelerator
+                     * @param dst total per cell value and result destination
+                     * @param dens number density
+                     */
+                    template<typename T_Acc>
+                    HDINLINE void operator()(T_Acc const& acc, float1_X& dst, const float1_X& dens) const;
+                };
+
+                //! Provides description for an averaged attribute
+                template<typename T_DerivedAttribute>
+                struct AverageAttributeDescription;
+
+                /** Average (per particle) value of a derived attribute
+                 *
+                 * @tparam T_DerivedAttribute derived attribute class that should be averaged
+                 */
+                template<typename T_DerivedAttribute>
+                using AverageAttribute = CombinedDeriveAttribute<
+                    T_DerivedAttribute,
+                    particleToGrid::derivedAttributes::Density,
+                    AverageDivideOperation,
+                    AverageAttributeDescription<T_DerivedAttribute>>;
+            } // namespace combinedAttributes
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
@@ -39,7 +39,8 @@ namespace picongpu
                     const
                 {
                     // avoid dividing by zero. Return zero if density is close to zero.
-                    if(dens[0] <= std::numeric_limits<float_X>::min())
+                    if(dens[0] * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME
+                       <= std::numeric_limits<float_X>::min())
                     {
                         dst = float1_X{0.0};
                     }

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
@@ -1,0 +1,78 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def"
+
+#include <limits>
+#include <string>
+#include <vector>
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace combinedAttributes
+            {
+                template<typename T_Acc>
+                HDINLINE void AverageDivideOperation::operator()(T_Acc const& acc, float1_X& dst, const float1_X& dens)
+                    const
+                {
+                    // avoid dividing by zero. Return zero if density is close to zero.
+                    if(dens[0] <= std::numeric_limits<float_X>::min())
+                    {
+                        dst = float1_X{0.0};
+                    }
+                    else
+                    {
+                        // average value is total value over number of particles
+                        // number of particles is density * CELL_VOLUME
+                        dst /= dens * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME;
+                    }
+                }
+
+
+                template<typename T_DerivedAttribute>
+                struct AverageAttributeDescription
+                {
+                    HDINLINE float1_64 getUnit() const
+                    {
+                        // Average quantity has the same unit as the total quantity
+                        return T_DerivedAttribute().getUnit();
+                    }
+
+                    HINLINE std::vector<float_64> getUnitDimension() const
+                    {
+                        return T_DerivedAttribute().getUnitDimension();
+                    }
+
+                    HINLINE static std::string getName()
+                    {
+                        return "Average_" + T_DerivedAttribute().getName();
+                    }
+                };
+
+            } // namespace combinedAttributes
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+/* Copyright 2021 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -19,5 +19,5 @@
 
 #pragma once
 
-#include "picongpu/particles/particleToGrid/CombinedDerive.hpp"
-#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp"
+#include "picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def"
+#include "picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.def"

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+/* Copyright 2021 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -19,5 +19,5 @@
 
 #pragma once
 
-#include "picongpu/particles/particleToGrid/CombinedDerive.hpp"
-#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp"
+#include "picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp"
+#include "picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp"

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.def
@@ -1,0 +1,65 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace combinedAttributes
+            {
+                //! Implementation for the RelativisticDensityOperation
+                template<typename T_Species>
+                struct RelativisticDensityOperationImpl;
+
+                //! Compute the relativistic density from number density and energy density
+                struct RelativisticDensityOperation
+                {
+                    template<typename T_Species>
+                    struct apply
+                    {
+                        using type = RelativisticDensityOperationImpl<T_Species>;
+                    };
+                };
+
+                struct RelativisticDensityDescription;
+
+                /** number density with a relativistic correction
+                 *
+                 * This attribute is equal to \f$ \frac{1}{<\gamma>^2} n $\f
+                 * with \f$<\gamma> - average gamma value, \f$n$\f - number density.
+                 * Average gamma is calculated from energy density and number density.
+                 */
+                using RelativisticDensity = CombinedDeriveAttribute<
+                    particleToGrid::derivedAttributes::Density,
+                    particleToGrid::derivedAttributes::EnergyDensity,
+                    RelativisticDensityOperation,
+                    RelativisticDensityDescription>;
+            } // namespace combinedAttributes
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
@@ -1,0 +1,90 @@
+/* Copyright 2021 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def"
+
+#include <limits>
+#include <string>
+#include <vector>
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace combinedAttributes
+            {
+                template<typename T_Species>
+                struct RelativisticDensityOperationImpl
+                {
+                    /** Functor implementation
+                     *
+                     * Result overwrites the density value.
+                     *
+                     * @tparam T_Acc alpaka accelerator type
+                     * @param acc alpaka accelerator
+                     * @param density number density value and the result destination
+                     * @param energyDensity  energy density value
+                     */
+                    template<typename T_Acc>
+                    HDINLINE void operator()(T_Acc const& acc, float1_X& density, const float1_X& energyDensity) const
+                    {
+                        const float_X densityPICUnits
+                            = density[0] * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+                        // avoid dividing by zero.
+                        if(densityPICUnits > std::numeric_limits<float_X>::min())
+                        {
+                            const float_X averageEnergy = energyDensity[0] / densityPICUnits;
+                            const float_X particleMass = frame::getMass<typename T_Species::FrameType>();
+                            const float_X averageGamma
+                                = averageEnergy / (particleMass * SPEED_OF_LIGHT * SPEED_OF_LIGHT) + 1.0_X;
+                            const float_X invAverageGammaSquared = 1.0_X / averageGamma / averageGamma;
+                            density *= invAverageGammaSquared;
+                        }
+                    }
+                };
+
+
+                struct RelativisticDensityDescription
+                {
+                    HDINLINE float1_64 getUnit() const
+                    {
+                        // gamma is unitless so the unit stays unchanged
+                        return derivedAttributes::Density().getUnit();
+                    }
+
+                    HINLINE std::vector<float_64> getUnitDimension() const
+                    {
+                        return derivedAttributes::Density().getUnitDimension();
+                    }
+
+                    HINLINE static std::string getName()
+                    {
+                        return "relativisticDensity";
+                    }
+                };
+
+            } // namespace combinedAttributes
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -134,7 +134,7 @@ namespace picongpu
                     constexpr uint32_t requiredExtraSlots
                         = particles::particleToGrid::RequiredExtraSlots<FrameSolver>::type::value;
                     PMACC_CASSERT_MSG(
-                        _please_allocate_at_least_one_or_two_when_using_combined_attributes_FieldTmp_in_memory_param,
+                        _please_allocate_at_least_one_FieldTmp_slot_in_memory_param_or_two_when_using_combined_attributes,
                         fieldTmpNumSlots >= 1u + requiredExtraSlots);
 
                     auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -28,6 +28,8 @@
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
 #include "picongpu/particles/filter/filter.hpp"
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/openPMDWriteMeta.hpp"
@@ -524,17 +526,21 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     /*## update field ##*/
 
                     /*load FieldTmp without copy data to host*/
-                    PMACC_CASSERT_MSG(_please_allocate_at_least_one_FieldTmp_in_memory_param, fieldTmpNumSlots > 0);
+                    constexpr uint32_t requiredExtraSlots
+                        = particles::particleToGrid::RequiredExtraSlots<Solver>::type::value;
+                    PMACC_CASSERT_MSG(
+                        _please_allocate_at_least_one_or_two_when_using_combined_attributes_FieldTmp_in_memory_param,
+                        fieldTmpNumSlots >= 1u + requiredExtraSlots);
                     auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
-                    /*load particle without copy particle data to host*/
-                    auto speciesTmp = dc.get<Species>(Species::FrameType::getName(), true);
-
-                    fieldTmp->getGridBuffer().getDeviceBuffer().setValue(ValueType::create(0.0));
-                    /*run algorithm*/
-                    fieldTmp->template computeValue<CORE + BORDER, Solver, Filter>(*speciesTmp, params->currentStep);
-
-                    EventTask fieldTmpEvent = fieldTmp->asyncCommunication(__getTransactionEvent());
-                    __setTransactionEvent(fieldTmpEvent);
+                    // compute field values
+                    auto eventPtr
+                        = particles::particleToGrid::ComputeFieldValue<CORE + BORDER, Solver, Species, Filter>()(
+                            *fieldTmp,
+                            params->currentStep,
+                            1u);
+                    // wait for unfinished asynchronous communication
+                    if(eventPtr != nullptr)
+                        __setTransactionEvent(*eventPtr);
                     /* copy data to host that we can write same to disk*/
                     fieldTmp->getGridBuffer().deviceToHost();
                     /*## finish update field ##*/

--- a/share/picongpu/tests/compileCombinedAttributes/README.rst
+++ b/share/picongpu/tests/compileCombinedAttributes/README.rst
@@ -1,0 +1,4 @@
+Compile Test for Iteration Start Pipeline
+=========================================
+
+This test compiles an openPMD plugin with combined derived attributes

--- a/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/fileOutput.param
@@ -108,11 +108,23 @@ namespace picongpu
     using MomentumComponent_Seq
         = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::MomentumComponent<0>>;
 
+    using AverageEnergy_Seq = deriveField::CreateEligible_t<
+        VectorAllSpecies,
+        deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::Energy>>;
+    using RelativisticDensity_Seq
+        = deriveField::CreateEligible_t<PIC_Electrons, deriveField::combinedAttributes::RelativisticDensity>;
+
+
     /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
      *
      * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
      */
-    using FieldTmpSolvers = MakeSeq_t<ChargeDensity_Seq, EnergyDensity_Seq, MomentumComponent_Seq>;
+    using FieldTmpSolvers = MakeSeq_t<
+        ChargeDensity_Seq,
+        EnergyDensity_Seq,
+        MomentumComponent_Seq,
+        AverageEnergy_Seq,
+        RelativisticDensity_Seq>;
 
 
     /** FileOutputFields: Groups all Fields that shall be dumped *************/

--- a/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/memory.param
@@ -1,0 +1,117 @@
+/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
+#pragma once
+#include <pmacc/mappings/kernel/MappingDescription.hpp>
+#include <pmacc/math/Vector.hpp>
+
+#include <array>
+
+
+namespace picongpu
+{
+    /* We have to hold back 350MiB for gpu-internal operations:
+     *   - random number generator
+     *   - reduces
+     *   - ...
+     */
+    constexpr size_t reservedGpuMemorySize = 350 * 1024 * 1024;
+
+    /* short namespace*/
+    namespace mCT = pmacc::math::CT;
+    /** size of a superCell
+     *
+     * volume of a superCell must be <= 1024
+     */
+    using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
+
+    /** define mapper which is used for kernel call mappings */
+    using MappingDesc = MappingDescription<simDim, SuperCellSize>;
+
+    /** define the size of the core, border and guard area
+     *
+     * PIConGPU uses spatial domain-decomposition for parallelization
+     * over multiple devices with non-shared memory architecture.
+     * The global spatial domain is organized per device in three
+     * sections: the GUARD area contains copies of neighboring
+     * devices (also known as "halo"/"ghost").
+     * The BORDER area is the outermost layer of cells of a device,
+     * equally to what neighboring devices see as GUARD area.
+     * The CORE area is the innermost area of a device. In union with
+     * the BORDER area it defines the "active" spatial domain on a device.
+     *
+     * GuardSize is defined in units of SuperCellSize per dimension.
+     */
+    using GuardSize = typename mCT::shrinkTo<mCT::Int<1, 1, 1>, simDim>::type;
+
+    /** bytes reserved for species exchange buffer
+     *
+     * This is the default configuration for species exchanges buffer sizes.
+     * The default exchange buffer sizes can be changed per species by adding
+     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
+     * to its flag list.
+     */
+    struct DefaultExchangeMemCfg
+    {
+        // memory used for a direction
+        static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EDGES = 32 * 1024; // 32 kiB
+        static constexpr uint32_t BYTES_CORNER = 8 * 1024; // 8 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
+    };
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 2u;
+
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = true;
+
+} // namespace picongpu


### PR DESCRIPTION
# Combined derived attributes

This PR introduces derived attributes which are a function of two primary derived attributes (such like we had until now). This is something I need for my online Faraday Rotation calculation but I found this a generally useful feature. 

What I needed was 1/gamma^2 * density, where gamma is the Lorentz factor for the average kinetic energy in the cell. Because of the square it wasn't possible to just add another usual derived field. This new combined field is introduced as `RelativisticDensity`. 

This PR also includes a template for an average value of any derived quantity `AverageAttribute` ( from: average value = total quantity density / number density) as an example of a more general use of this feature. 

I also changed how the `computeValue` algorithm is called in the `openPMD` and `isaac` plugins so that the same syntax can be used for computing a normal and combined derived attribute. 

I think in most cases writing both fields individually would be a simpler solution but when fields are written or streamed for a large number of iterations and output size starts to really matter this could be a great help (definitely would be in my Faraday Rotation simulations that I was running earlier this year).  And it can be used internally , wherever a more general solution is needed (like in my `Scatterer` stage implelemtation). 

I tested this for  `AverageAttribute<Energy>` with the `FoilLTC` example and could verify that it is same as writing `EnergyDensity` and `Denisty` individually and dividing the first by the second (and setting to 0 wherever Density is 0).

@ComputationalRadiationPhysics/picongpu-maintainers 