### PR TITLE
Cleanup current deposition implementation

### DIFF
--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -101,8 +101,8 @@ namespace picongpu
                 /* calculate positions for the second virtual particle */
                 for(uint32_t d = 0; d < simDim; ++d)
                 {
-                    line.m_pos0[d] = calc_InCellPos(posStart[d], I[0][d]);
-                    line.m_pos1[d] = calc_InCellPos(relayPoint[d], I[0][d]);
+                    line.m_pos0[d] = posStart[d] - I[0][d];
+                    line.m_pos1[d] = relayPoint[d] - I[0][d];
                 }
 
                 deposit(acc, dataBoxJ.shift(I[0]).toCursor(), line, chargeDensity);
@@ -115,8 +115,8 @@ namespace picongpu
                     for(uint32_t d = 0; d < simDim; ++d)
                     {
                         /* switched start and end point */
-                        line.m_pos1[d] = calc_InCellPos(posEnd[d], I[1][d]);
-                        line.m_pos0[d] = calc_InCellPos(relayPoint[d], I[1][d]);
+                        line.m_pos1[d] = posEnd[d] - I[1][d];
+                        line.m_pos0[d] = relayPoint[d] - I[1][d];
                     }
                     deposit(acc, dataBoxJ.shift(I[1]).toCursor(), line, chargeDensity);
                 }
@@ -139,8 +139,8 @@ namespace picongpu
                         for(uint32_t d = 0; d < simDim; ++d)
                         {
                             I[1][d] = math::min(I[0][d], I[1][d]);
-                            line.m_pos0[d] = this->calc_InCellPos(posStart[d], I[1][d]);
-                            line.m_pos1[d] = this->calc_InCellPos(posEnd[d], I[1][d]);
+                            line.m_pos0[d] = posStart[d] - I[1][d];
+                            line.m_pos1[d] = posEnd[d] - I[1][d];
                         }
                         /* Have to use DIM2, otherwise 3d case wouldn't compile due to
                          * no computeCurrentZ() method.
@@ -164,18 +164,6 @@ namespace picongpu
             {
                 pmacc::traits::StringProperty propList("name", "EmZ");
                 return propList;
-            }
-
-
-            /** get normalized in cell particle position
-             *
-             * @param x position of the particle
-             * @param i shift of grid (only integral positions are allowed)
-             * @return in cell position
-             */
-            DINLINE float_X calc_InCellPos(const float_X x, const float_X i) const
-            {
-                return x - i;
             }
         };
 

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Base.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Base.hpp
@@ -1,0 +1,75 @@
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/currentDeposition/Esirkepov/Line.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace currentSolver
+    {
+        /** Helper base class for Esirkepov and Esirkepov-like current deposition implementation
+         *
+         * Implements basic calculations for the given particle assignment function.
+         * Naming matches the Esirkepov paper, however indexing is from PIConGPU.
+         * For a fully paper-conforming notation see EsirkepovNative implementation.
+         *
+         * @tparam T_ParticleAssignFunctor assignment functor type
+         */
+        template<typename T_ParticleAssignFunctor>
+        struct Base
+        {
+            using ParticleAssignFunctor = T_ParticleAssignFunctor;
+
+            /** Calculate terms depending on particle position and assignment function
+             *
+             * @param line element with previous and current position of the particle
+             * @param gridPoint used grid point to evaluate assignment shape
+             * @param d dimension range {0,1,2} means {x,y,z}
+             *          different to Esirkepov paper, here we use C style
+             * @{
+             */
+
+            //! Calculate term in S0 for the start position
+            DINLINE static float_X S0(const Line<floatD_X>& line, const float_X gridPoint, const uint32_t d)
+            {
+                return ParticleAssignFunctor()(gridPoint - line.m_pos0[d]);
+            }
+
+            //! Calculate term in S1 for end position
+            DINLINE static float_X S1(const Line<floatD_X>& line, const float_X gridPoint, const uint32_t d)
+            {
+                return ParticleAssignFunctor()(gridPoint - line.m_pos1[d]);
+            }
+
+            //! Calculate difference term in DS
+            DINLINE static float_X DS(const Line<floatD_X>& line, const float_X gridPoint, const uint32_t d)
+            {
+                return S1(line, gridPoint, d) - S0(line, gridPoint, d);
+            }
+
+            /*! @} */
+        };
+
+    } // namespace currentSolver
+} // namespace picongpu

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/algorithms/Velocity.hpp"
+#include "picongpu/fields/currentDeposition/Esirkepov/Base.hpp"
 #include "picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp"
 #include "picongpu/fields/currentDeposition/Esirkepov/Line.hpp"
 
@@ -44,7 +45,7 @@ namespace picongpu
          *  with an arbitrary form-factor"
          */
         template<typename T_ParticleShape, typename T_Strategy>
-        struct Esirkepov<T_ParticleShape, T_Strategy, DIM2>
+        struct Esirkepov<T_ParticleShape, T_Strategy, DIM2> : public Base<typename T_ParticleShape::ChargeAssignment>
         {
             using ParticleAssign = typename T_ParticleShape::ChargeAssignment;
             static constexpr int supp = ParticleAssign::support;
@@ -152,17 +153,17 @@ namespace picongpu
                  * in-cell particle `position` (and it's change in DELTA_T) is normalize to [0,1)
                  */
                 const float_X currentSurfaceDensity
-                    = this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * cellEdgeLength;
+                    = this->charge * (1.0_X / float_X(CELL_VOLUME * DELTA_T)) * cellEdgeLength;
 
                 for(int j = begin; j < end + 1; ++j)
                     if(j < end + leaveCell[1])
                     {
-                        const float_X s0j = S0(line, j, 1);
-                        const float_X dsj = S1(line, j, 1) - s0j;
+                        const float_X s0j = this->S0(line, j, 1);
+                        const float_X dsj = this->S1(line, j, 1) - s0j;
 
-                        float_X tmp = -currentSurfaceDensity * (s0j + float_X(0.5) * dsj);
+                        float_X tmp = -currentSurfaceDensity * (s0j + 0.5_X * dsj);
 
-                        auto accumulated_J = float_X(0.0);
+                        auto accumulated_J = 0.0_X;
                         /* attention: inner loop has no upper bound `end + 1` because
                          * the current for the point `end` is always zero,
                          * therefore we skip the calculation
@@ -174,7 +175,7 @@ namespace picongpu
                                  * from Esirkepov paper. All coordinates are rotated before thus we can always use C
                                  * style W(i,j,k,0).
                                  */
-                                const float_X W = DS(line, i, 0) * tmp;
+                                const float_X W = this->DS(line, i, 0) * tmp;
                                 accumulated_J += W;
                                 auto const atomicOp = typename T_Strategy::BlockReductionOp{};
                                 atomicOp(acc, (*cursorJ(i, j)).x(), accumulated_J);
@@ -190,67 +191,30 @@ namespace picongpu
                 const Line<float2_X>& line,
                 const float_X v_z)
             {
-                if(v_z == float_X(0.0))
+                if(v_z == 0.0_X)
                     return;
 
-                const float_X currentSurfaceDensityZ = this->charge * (float_X(1.0) / float_X(CELL_VOLUME)) * v_z;
+                const float_X currentSurfaceDensityZ = this->charge * (1.0_X / float_X(CELL_VOLUME)) * v_z;
 
                 for(int j = begin; j < end + 1; ++j)
                     if(j < end + leaveCell[1])
                     {
-                        const float_X s0j = S0(line, j, 1);
-                        const float_X dsj = S1(line, j, 1) - s0j;
+                        const float_X s0j = this->S0(line, j, 1);
+                        const float_X dsj = this->S1(line, j, 1) - s0j;
 
                         for(int i = begin; i < end + 1; ++i)
                             if(i < end + leaveCell[0])
                             {
-                                const float_X s0i = S0(line, i, 0);
-                                const float_X dsi = S1(line, i, 0) - s0i;
-                                float_X W = s0i * S0(line, j, 1) + float_X(0.5) * (dsi * s0j + s0i * dsj)
-                                    + (float_X(1.0) / float_X(3.0)) * dsi * dsj;
+                                const float_X s0i = this->S0(line, i, 0);
+                                const float_X dsi = this->S1(line, i, 0) - s0i;
+                                float_X W = s0i * this->S0(line, j, 1) + 0.5_X * (dsi * s0j + s0i * dsj)
+                                    + (1.0_X / 3.0_X) * dsi * dsj;
 
                                 const float_X j_z = W * currentSurfaceDensityZ;
                                 auto const atomicOp = typename T_Strategy::BlockReductionOp{};
                                 atomicOp(acc, (*cursorJ(i, j)).z(), j_z);
                             }
                     }
-            }
-
-            /**
-             * @}
-             */
-
-            /** calculate S0 (see paper)
-             * @param line element with previous and current position of the particle
-             * @param gridPoint used grid point to evaluate assignment shape
-             * @param d dimension range {0,1} means {x,y}
-             *          different to Esirkepov paper, here we use C style
-             */
-            DINLINE float_X S0(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
-            {
-                return ParticleAssign()(gridPoint - line.m_pos0[d]);
-            }
-
-            /** calculate S1 (see paper)
-             * @param line element with previous and current position of the particle
-             * @param gridPoint used grid point to evaluate assignment shape
-             * @param d dimension range {0,1,2} means {x,y,z}
-             *          different to Esirkepov paper, here we use C style
-             */
-            DINLINE float_X S1(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
-            {
-                return ParticleAssign()(gridPoint - line.m_pos1[d]);
-            }
-
-            /** calculate DS (see paper)
-             * @param line element with previous and current position of the particle
-             * @param gridPoint used grid point to evaluate assignment shape
-             * @param d dimension range {0,1} means {x,y}
-             *          different to Esirkepov paper, here we use C style
-             */
-            DINLINE float_X DS(const Line<float2_X>& line, const float_X gridPoint, const uint32_t d)
-            {
-                return ParticleAssign()(gridPoint - line.m_pos1[d]) - ParticleAssign()(gridPoint - line.m_pos0[d]);
             }
 
             static pmacc::traits::StringProperty getStringProperties()

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -122,7 +122,7 @@ namespace picongpu
                 meanPos.z() -= math::floor(meanPos.z());
 
                 // for the formulas used in here see Villasenor/Buneman paper page 314
-                const float_X tmp = deltaPos.x() * deltaPos.y() * deltaPos.z() * (float_X(1.0) / float_X(12.0));
+                const float_X tmp = deltaPos.x() * deltaPos.y() * deltaPos.z() * (1.0_X / 12.0_X);
 
                 // j = rho * v
                 //   = rho * dr / dt
@@ -149,53 +149,35 @@ namespace picongpu
                 //   Q.x() = charge * deltaPos_real.x() / cellsize.x()
                 //       = charge * deltaPos.x() / 1.0
                 //
-                const float_X rho_dtX = charge * (float_X(1.0) / (CELL_HEIGHT * CELL_DEPTH * deltaTime));
-                const float_X rho_dtY = charge * (float_X(1.0) / (CELL_WIDTH * CELL_DEPTH * deltaTime));
-                const float_X rho_dtZ = charge * (float_X(1.0) / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
+                const float_X rho_dtX = charge * (1.0_X / (CELL_HEIGHT * CELL_DEPTH * deltaTime));
+                const float_X rho_dtY = charge * (1.0_X / (CELL_WIDTH * CELL_DEPTH * deltaTime));
+                const float_X rho_dtZ = charge * (1.0_X / (CELL_WIDTH * CELL_HEIGHT * deltaTime));
 
                 auto const atomicOp = typename T_Strategy::BlockReductionOp{};
 
                 atomicOp(acc, mem[1][1][0].x(), rho_dtX * (deltaPos.x() * meanPos.y() * meanPos.z() + tmp));
-                atomicOp(
-                    acc,
-                    mem[1][0][0].x(),
-                    rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * meanPos.z() - tmp));
-                atomicOp(
-                    acc,
-                    mem[0][1][0].x(),
-                    rho_dtX * (deltaPos.x() * meanPos.y() * (float_X(1.0) - meanPos.z()) - tmp));
+                atomicOp(acc, mem[1][0][0].x(), rho_dtX * (deltaPos.x() * (1.0_X - meanPos.y()) * meanPos.z() - tmp));
+                atomicOp(acc, mem[0][1][0].x(), rho_dtX * (deltaPos.x() * meanPos.y() * (1.0_X - meanPos.z()) - tmp));
                 atomicOp(
                     acc,
                     mem[0][0][0].x(),
-                    rho_dtX * (deltaPos.x() * (float_X(1.0) - meanPos.y()) * (float_X(1.0) - meanPos.z()) + tmp));
+                    rho_dtX * (deltaPos.x() * (1.0_X - meanPos.y()) * (1.0_X - meanPos.z()) + tmp));
 
                 atomicOp(acc, mem[1][0][1].y(), rho_dtY * (deltaPos.y() * meanPos.z() * meanPos.x() + tmp));
-                atomicOp(
-                    acc,
-                    mem[0][0][1].y(),
-                    rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * meanPos.x() - tmp));
-                atomicOp(
-                    acc,
-                    mem[1][0][0].y(),
-                    rho_dtY * (deltaPos.y() * meanPos.z() * (float_X(1.0) - meanPos.x()) - tmp));
+                atomicOp(acc, mem[0][0][1].y(), rho_dtY * (deltaPos.y() * (1.0_X - meanPos.z()) * meanPos.x() - tmp));
+                atomicOp(acc, mem[1][0][0].y(), rho_dtY * (deltaPos.y() * meanPos.z() * (1.0_X - meanPos.x()) - tmp));
                 atomicOp(
                     acc,
                     mem[0][0][0].y(),
-                    rho_dtY * (deltaPos.y() * (float_X(1.0) - meanPos.z()) * (float_X(1.0) - meanPos.x()) + tmp));
+                    rho_dtY * (deltaPos.y() * (1.0_X - meanPos.z()) * (1.0_X - meanPos.x()) + tmp));
 
                 atomicOp(acc, mem[0][1][1].z(), rho_dtZ * (deltaPos.z() * meanPos.x() * meanPos.y() + tmp));
-                atomicOp(
-                    acc,
-                    mem[0][1][0].z(),
-                    rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * meanPos.y() - tmp));
-                atomicOp(
-                    acc,
-                    mem[0][0][1].z(),
-                    rho_dtZ * (deltaPos.z() * meanPos.x() * (float_X(1.0) - meanPos.y()) - tmp));
+                atomicOp(acc, mem[0][1][0].z(), rho_dtZ * (deltaPos.z() * (1.0_X - meanPos.x()) * meanPos.y() - tmp));
+                atomicOp(acc, mem[0][0][1].z(), rho_dtZ * (deltaPos.z() * meanPos.x() * (1.0_X - meanPos.y()) - tmp));
                 atomicOp(
                     acc,
                     mem[0][0][0].z(),
-                    rho_dtZ * (deltaPos.z() * (float_X(1.0) - meanPos.x()) * (float_X(1.0) - meanPos.y()) + tmp));
+                    rho_dtZ * (deltaPos.z() * (1.0_X - meanPos.x()) * (1.0_X - meanPos.y()) + tmp));
             }
 
             // calculates the intersection point of the [pos1,pos2] beam with an y,z-plane at position x0
@@ -240,16 +222,16 @@ namespace picongpu
                         newPos,
                         math::max(pmacc::math::float2int_rd(oldPos.z()), pmacc::math::float2int_rd(newPos.z())));
                     float3_X deltaPos = interPos - oldPos;
-                    float3_X meanPos = oldPos + float_X(0.5) * deltaPos;
+                    float3_X meanPos = oldPos + 0.5_X * deltaPos;
                     addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
 
                     deltaPos = newPos - interPos;
-                    meanPos = interPos + float_X(0.5) * deltaPos;
+                    meanPos = interPos + 0.5_X * deltaPos;
                     addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
                     return;
                 }
                 const float3_X deltaPos = newPos - oldPos;
-                const float3_X meanPos = oldPos + float_X(0.5) * deltaPos;
+                const float3_X meanPos = oldPos + 0.5_X * deltaPos;
                 addCurrentToSingleCell(acc, meanPos, deltaPos, charge, mem, deltaTime);
             }
 


### PR DESCRIPTION
Move duplicated code to shared base class, cleanup constants' suffixes, improve naming of EmZ grid shifts.

Solves #3893.