### PR TITLE
Extended JSON configuration of openPMD plugin: Erase dataset options if no default is given

### DIFF
--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -47,6 +47,7 @@ namespace picongpu
                 // simple layout: only one global JSON object was passed
                 // forward this one directly to openPMD
                 m_patterns.emplace_back("", std::make_shared<nlohmann::json>(config));
+                m_defaultConfig = config;
             }
             else if(config.is_array())
             {
@@ -133,9 +134,14 @@ namespace picongpu
                 auto const& datasetConfig = backend.matcher.get(datasetPath);
                 if(datasetConfig.empty())
                 {
-                    continue;
+                    // ensure that there actually is an object to erase this from
+                    result[backend.backendName]["dataset"] = {};
+                    result[backend.backendName].erase("dataset");
                 }
-                result[backend.backendName]["dataset"] = datasetConfig;
+                else
+                {
+                    result[backend.backendName]["dataset"] = datasetConfig;
+                }
             }
             return result.dump();
         }
@@ -148,9 +154,14 @@ namespace picongpu
                 auto const& datasetConfig = backend.matcher.getDefault();
                 if(datasetConfig.empty())
                 {
-                    continue;
+                    // ensure that there actually is an object to erase this from
+                    result[backend.backendName]["dataset"] = {};
+                    result[backend.backendName].erase("dataset");
                 }
-                result[backend.backendName]["dataset"] = datasetConfig;
+                else
+                {
+                    result[backend.backendName]["dataset"] = datasetConfig;
+                }
             }
             // note that at this point, config[<backend>][dataset] is no longer
             // a list, the list has been resolved by the previous loop


### PR DESCRIPTION
I noticed this while testing that #3933 actually fixes the bugs fixed by it (it does). If using the extended PIConGPU-defined JSON schema for specifying dataset-specific compression and *not* specifying a default pattern, the pattern list under `json[<backend>]["dataset"]` will be forwarded as-is to the openPMD-api. This does not actually make the openPMD-api crash, but it's still a bug on PIConGPU's side.

Fix: If no pattern is found, delete that key.

```json
{
  "adios2": {
    "unused": "parameter",
    "engine": {
      "usesteps": true,
      "rabimmel": "rambamel",
      "parameters": {
        "InitialBufferSize": "2Gb",
        "Profile": "On"
      }
    },
    "dataset": [
      {"cfg": {}}, // <--- default pattern
      {
        "select": ".*/E/.*",
        "cfg": {
          "operators": [
            {
              "type": "bzip2"
            }
          ]
        }
      }
    ]
  }
}
```