### PR TITLE
backport to 0.6.0-rc1

### DIFF
--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -27,6 +27,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerCPU
 #SBATCH --mem=!TBG_memPerNode
 # must be 1 else we can not use hyperthreading
@@ -104,6 +105,6 @@ export OMPI_MCA_io=^ompio
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \
     !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -30,6 +30,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
@@ -107,12 +108,12 @@ export OMPI_MCA_io=^ompio
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health
-  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
 fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -28,6 +28,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
@@ -105,12 +106,12 @@ export OMPI_MCA_io=^ompio
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health
-  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
 fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -30,6 +30,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
@@ -107,13 +108,13 @@ export OMPI_MCA_io=^ompio
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health
-  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
 fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
     !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -62,6 +62,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
@@ -167,13 +168,13 @@ export OMPI_MCA_io=^ompio
 
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
-  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
 fi
 
 if [ $? -eq 0 ] ; then
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
     $stepSetup !TBG_author $programParams
 fi
 

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -30,6 +30,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
@@ -107,12 +108,12 @@ export OMPI_MCA_io=^ompio
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health
-  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
 fi
 
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 fi

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -62,6 +62,7 @@ TBG_queue=${TBG_partition:-"k80"}
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_mpiTasksPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem=!TBG_memPerNode
@@ -168,13 +169,13 @@ export OMPI_MCA_io=^ompio
 
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
-  mpiexec !TBG_dstPath/input/bin/cuda_memtest.sh
+  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
 else
   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
 fi
 
 if [ $? -eq 0 ] ; then
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
     $stepSetup !TBG_author $programParams
 fi
 

--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -47,6 +47,7 @@ namespace picongpu
                 // simple layout: only one global JSON object was passed
                 // forward this one directly to openPMD
                 m_patterns.emplace_back("", std::make_shared<nlohmann::json>(config));
+                m_defaultConfig = config;
             }
             else if(config.is_array())
             {
@@ -133,9 +134,14 @@ namespace picongpu
                 auto const& datasetConfig = backend.matcher.get(datasetPath);
                 if(datasetConfig.empty())
                 {
-                    continue;
+                    // ensure that there actually is an object to erase this from
+                    result[backend.backendName]["dataset"] = {};
+                    result[backend.backendName].erase("dataset");
                 }
-                result[backend.backendName]["dataset"] = datasetConfig;
+                else
+                {
+                    result[backend.backendName]["dataset"] = datasetConfig;
+                }
             }
             return result.dump();
         }
@@ -148,9 +154,14 @@ namespace picongpu
                 auto const& datasetConfig = backend.matcher.getDefault();
                 if(datasetConfig.empty())
                 {
-                    continue;
+                    // ensure that there actually is an object to erase this from
+                    result[backend.backendName]["dataset"] = {};
+                    result[backend.backendName].erase("dataset");
                 }
-                result[backend.backendName]["dataset"] = datasetConfig;
+                else
+                {
+                    result[backend.backendName]["dataset"] = datasetConfig;
+                }
             }
             return result.dump();
         }

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -7,8 +7,6 @@
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     PIC_CMAKE_ARGS: "-DALPAKA_HIP_ARCH=900 -DCMAKE_MODULE_PATH=/opt/rocm/hip/cmake"
-    # use VEGA64 GPU
-    HIP_VISIBLE_DEVICES: "2"
     # ISAAC is not working with HIP
     DISABLE_ISAAC: "yes"
   script:

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -22,7 +22,11 @@ CMAKE_ARGS="${PIC_CONST_ARGS} ${PIC_CMAKE_ARGS} -DCMAKE_CXX_COMPILER=${CXX_VERSI
 # enforce optional dependencies
 CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON"
 
-if [ -z "$DISABLE_ISAAC" ] ; then
+# ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
+if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* ]] ; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
+    export CI_CPUS=1
+elif [ -z "$DISABLE_ISAAC" ] ; then
   CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
 fi
 


### PR DESCRIPTION
- Add --ntasks-per-node and -np to .tpl files on Hemera #3940
- Extended JSON configuration of openPMD plugin: Erase dataset options if no default is given #3945
- CI: change AMD CI node configuration #3942
  - Due to code changes in the dev branch it was required to port the commits by hand instead of cherry-picking.
  - The commit wrongly used HIP CMake variable is not ported, the alpaka version used within 0.6.0 is different from the dev brach.