### PR TITLE
License Header: Update 2022

### DIFF
--- a/bin/cuda_memtest.sh
+++ b/bin/cuda_memtest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/bin/egetopt
+++ b/bin/egetopt
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2021 Rene Widera
+# Copyright 2014-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/bin/pic-build
+++ b/bin/pic-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/bin/pic-compile
+++ b/bin/pic-compile
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/bin/pic-create
+++ b/bin/pic-create
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/bin/pic-edit
+++ b/bin/pic-edit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/bin/tbg
+++ b/bin/tbg
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/buildsystem/CompileSuite/color.sh
+++ b/buildsystem/CompileSuite/color.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/buildsystem/CompileSuite/compileSet.sh
+++ b/buildsystem/CompileSuite/compileSet.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/buildsystem/CompileSuite/exec_helper.sh
+++ b/buildsystem/CompileSuite/exec_helper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/buildsystem/CompileSuite/help.sh
+++ b/buildsystem/CompileSuite/help.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/buildsystem/CompileSuite/options.sh
+++ b/buildsystem/CompileSuite/options.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/buildsystem/CompileSuite/path.sh
+++ b/buildsystem/CompileSuite/path.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau,
+# Copyright 2014-2022 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau,
 #                     Franz Poeschel, Sergei Bastrakov
 #
 # This file is part of PIConGPU.

--- a/docs/propose_changelog.py
+++ b/docs/propose_changelog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # License: GPLv3+
 #

--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -1,7 +1,7 @@
 """Ionization prediction module and example.
 
 This file is part of the PIConGPU.
-Copyright 2019-2021 PIConGPU contributors
+Copyright 2019-2022 PIConGPU contributors
 Authors: Marco Garten
 License: GPLv3+
 """

--- a/docs/source/usage/workflows/memoryPerDevice.py
+++ b/docs/source/usage/workflows/memoryPerDevice.py
@@ -3,7 +3,7 @@
 """
 This file is part of PIConGPU.
 
-Copyright 2018-2021 PIConGPU contributors
+Copyright 2018-2022 PIConGPU contributors
 Authors: Marco Garten, Pawel Ordyna
 License: GPLv3+
 """

--- a/etc/picongpu/aris-grnet/gpu.tpl
+++ b/etc/picongpu/aris-grnet/gpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov,
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov,
 #                     Jian Fuh Ong
 #
 # This file is part of PIConGPU.

--- a/etc/picongpu/bash/mpiexec.tpl
+++ b/etc/picongpu/bash/mpiexec.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/bash/mpirun.tpl
+++ b/etc/picongpu/bash/mpirun.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/cori-nersc/a100.tpl
+++ b/etc/picongpu/cori-nersc/a100.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2021 Axel Huebl
+# Copyright 2021-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/cori-nersc/knl.tpl
+++ b/etc/picongpu/cori-nersc/knl.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Alexander Matthes
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Alexander Matthes
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/cpuNumaStarter.sh
+++ b/etc/picongpu/cpuNumaStarter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2021 Rene Widera, Alexander Matthes
+# Copyright 2017-2022 Rene Widera, Alexander Matthes
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/davide-cineca/gpu.tpl
+++ b/etc/picongpu/davide-cineca/gpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/davinci-rice/picongpu.tpl
+++ b/etc/picongpu/davinci-rice/picongpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/draco-mpcdf/general.tpl
+++ b/etc/picongpu/draco-mpcdf/general.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/handleSlurmSignals.sh
+++ b/etc/picongpu/handleSlurmSignals.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2021 Rene Widera
+# Copyright 2021-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera,
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera,
 #                     Marco Garten, Alexander Debus
 #
 # This file is part of PIConGPU.

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Marco Garten
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Marco Garten
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Anton Helm, Richard Pausch, Rene Widera,
+# Copyright 2013-2022 Axel Huebl, Anton Helm, Richard Pausch, Rene Widera,
 #                     Marco Garten
 #
 # This file is part of PIConGPU.

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
+# Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
 #                     Bifeng Lei, Marco Garten
 #
 # This file is part of PIConGPU.

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Anton Helm, Richard Pausch, Rene Widera,
+# Copyright 2013-2022 Axel Huebl, Anton Helm, Richard Pausch, Rene Widera,
 #                     Marco Garten
 #
 # This file is part of PIConGPU.

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
+# Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
 #                     Bifeng Lei, Marco Garten
 #
 # This file is part of PIConGPU.

--- a/etc/picongpu/jureca-jsc/batch.tpl
+++ b/etc/picongpu/jureca-jsc/batch.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/jureca-jsc/booster.tpl
+++ b/etc/picongpu/jureca-jsc/booster.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/jureca-jsc/gpus.tpl
+++ b/etc/picongpu/jureca-jsc/gpus.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/juwels-jsc/batch.tpl
+++ b/etc/picongpu/juwels-jsc/batch.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/juwels-jsc/booster.tpl
+++ b/etc/picongpu/juwels-jsc/booster.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2020 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/juwels-jsc/gpus.tpl
+++ b/etc/picongpu/juwels-jsc/gpus.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/lawrencium-lbnl/fermi.tpl
+++ b/etc/picongpu/lawrencium-lbnl/fermi.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/lawrencium-lbnl/k20.tpl
+++ b/etc/picongpu/lawrencium-lbnl/k20.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl
+# Copyright 2013-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/pizdaint-cscs/large.tpl
+++ b/etc/picongpu/pizdaint-cscs/large.tpl
@@ -1,5 +1,5 @@
 #!/bin/bash -l
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/pizdaint-cscs/normal.tpl
+++ b/etc/picongpu/pizdaint-cscs/normal.tpl
@@ -1,5 +1,5 @@
 #!/bin/bash -l
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/spock-ornl/caar.tpl
+++ b/etc/picongpu/spock-ornl/caar.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov, Klaus Steinger
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov, Klaus Steinger
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/submitAction.sh
+++ b/etc/picongpu/submitAction.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/summit-ornl/gpu_batch.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2019-2021 Axel Huebl, Rene Widera
+# Copyright 2019-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/summit-ornl/gpu_batch_pipe.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch_pipe.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2019-2021 Axel Huebl, Rene Widera, Franz Poeschel
+# Copyright 2019-2022 Axel Huebl, Rene Widera, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/taurus-tud/V100_restart.tpl
+++ b/etc/picongpu/taurus-tud/V100_restart.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/taurus-tud/k20x.tpl
+++ b/etc/picongpu/taurus-tud/k20x.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/taurus-tud/k80.tpl
+++ b/etc/picongpu/taurus-tud/k80.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/etc/picongpu/taurus-tud/knl.tpl
+++ b/etc/picongpu/taurus-tud/knl.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2021 Axel Huebl, Richard Pausch, Alexander Matthes
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Alexander Matthes
 #
 # This file is part of PIConGPU.
 #

--- a/include/mpiInfo/CMakeLists.txt
+++ b/include/mpiInfo/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of mpiInfo.
 #

--- a/include/mpiInfo/mpiInfo.cpp
+++ b/include/mpiInfo/mpiInfo.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021  Rene Widera
+/* Copyright 2013-2022  Rene Widera
  *
  * This file is part of mpiInfo.
  *

--- a/include/picongpu/ArgsParser.cpp
+++ b/include/picongpu/ArgsParser.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/ArgsParser.hpp
+++ b/include/picongpu/ArgsParser.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Benjamin Schneider, Felix Schmitt, Heiko Burau,
+# Copyright 2013-2022 Axel Huebl, Benjamin Schneider, Felix Schmitt, Heiko Burau,
 #                     Rene Widera, Alexander Grund, Alexander Matthes,
 #                     Franz Poeschel, Richard Pausch
 #

--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten, Finn-Ole Carstens, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten, Finn-Ole Carstens, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/_defaultUnitless.loader
+++ b/include/picongpu/_defaultUnitless.loader
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Marco Garten, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolationNative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/Gamma.def
+++ b/include/picongpu/algorithms/Gamma.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/Gamma.hpp
+++ b/include/picongpu/algorithms/Gamma.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/KinEnergy.hpp
+++ b/include/picongpu/algorithms/KinEnergy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2017-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/LinearInterpolateWithUpper.hpp
+++ b/include/picongpu/algorithms/LinearInterpolateWithUpper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau, Rene Widera
+/* Copyright 2015-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/Set.hpp
+++ b/include/picongpu/algorithms/Set.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
+++ b/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/ShiftCoordinateSystemNative.hpp
+++ b/include/picongpu/algorithms/ShiftCoordinateSystemNative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/algorithms/Velocity.hpp
+++ b/include/picongpu/algorithms/Velocity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/debug/PIConGPUVerbose.hpp
+++ b/include/picongpu/debug/PIConGPUVerbose.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/extensionParam.loader
+++ b/include/picongpu/extensionParam.loader
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/extensionUnitless.loader
+++ b/include/picongpu/extensionUnitless.loader
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/CellType.hpp
+++ b/include/picongpu/fields/CellType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/EMFieldBase.hpp
+++ b/include/picongpu/fields/EMFieldBase.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/EMFieldBase.tpp
+++ b/include/picongpu/fields/EMFieldBase.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldB.hpp
+++ b/include/picongpu/fields/FieldB.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldB.tpp
+++ b/include/picongpu/fields/FieldB.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldE.hpp
+++ b/include/picongpu/fields/FieldE.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldE.tpp
+++ b/include/picongpu/fields/FieldE.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldTmp.hpp
+++ b/include/picongpu/fields/FieldTmp.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Marco Garten, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/Fields.def
+++ b/include/picongpu/fields/Fields.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Axel Huebl, Pawel Ordyna
+/* Copyright 2013-2022 Rene Widera, Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/Fields.hpp
+++ b/include/picongpu/fields/Fields.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/Fields.tpp
+++ b/include/picongpu/fields/Fields.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/LaserPhysics.def
+++ b/include/picongpu/fields/LaserPhysics.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/LaserPhysics.hpp
+++ b/include/picongpu/fields/LaserPhysics.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.def
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Derivative.def
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Derivative.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Derivative.hpp
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Derivative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Weights.hpp
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Weights.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.def
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2019-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/FDTD/StencilFunctor.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/StencilFunctor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2021-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/LaserChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/LaserChecker.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.def
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
  *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
  *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.def
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
  *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Remi Lehe,
  *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/MaxwellSolver/None/None.def
+++ b/include/picongpu/fields/MaxwellSolver/None/None.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Solvers.def
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Solvers.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.def
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2019-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/Absorber.tpp
+++ b/include/picongpu/fields/absorber/Absorber.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/exponential/Exponential.hpp
+++ b/include/picongpu/fields/absorber/exponential/Exponential.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/exponential/Exponential.kernel
+++ b/include/picongpu/fields/absorber/exponential/Exponential.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/none/None.hpp
+++ b/include/picongpu/fields/absorber/none/None.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/pml/Field.hpp
+++ b/include/picongpu/fields/absorber/pml/Field.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/absorber/pml/Parameters.hpp
+++ b/include/picongpu/fields/absorber/pml/Parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov
+/* Copyright 2019-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/pml/Pml.hpp
+++ b/include/picongpu/fields/absorber/pml/Pml.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov
+/* Copyright 2019-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov
+/* Copyright 2019-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/cellwiseOperation.hpp
+++ b/include/picongpu/fields/background/cellwiseOperation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/BField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/BField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/BField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/EField.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/EField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/EField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/GetInitialTimeDelay_SI.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/RotateField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/RotateField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Rene Widera
+/* Copyright 2014-2022 Alexander Debus, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/TWTS.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/TWTS.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/TWTS.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/TWTS.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/getFieldPositions_SI.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/getFieldPositions_SI.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/TWTS/numComponents.hpp
+++ b/include/picongpu/fields/background/templates/TWTS/numComponents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/BField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/BField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/EField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/EField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/GetInitialTimeDelay_SI.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/GetInitialTimeDelay_SI.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/RotateField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/RotateField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Rene Widera
+/* Copyright 2014-2022 Alexander Debus, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/getFieldPositions_SI.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/getFieldPositions_SI.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/numComponents.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/numComponents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/twtsfast.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/twtsfast.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/background/templates/twtsfast/twtsfast.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/twtsfast.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Alexander Debus
+/* Copyright 2014-2022 Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/cellType/Centered.hpp
+++ b/include/picongpu/fields/cellType/Centered.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/cellType/Yee.hpp
+++ b/include/picongpu/fields/cellType/Yee.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Cache.hpp
+++ b/include/picongpu/fields/currentDeposition/Cache.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Rene Widera
+/* Copyright 2020-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Deposit.hpp
+++ b/include/picongpu/fields/currentDeposition/Deposit.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Rene Widera
+/* Copyright 2020-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.def
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2016-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Line.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Line.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/RelayPoint.hpp
+++ b/include/picongpu/fields/currentDeposition/RelayPoint.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Solver.def
+++ b/include/picongpu/fields/currentDeposition/Solver.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Solver.hpp
+++ b/include/picongpu/fields/currentDeposition/Solver.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/Strategy.def
+++ b/include/picongpu/fields/currentDeposition/Strategy.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Rene Widera
+/* Copyright 2020-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentInterpolation/Binomial.hpp
+++ b/include/picongpu/fields/currentInterpolation/Binomial.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Benjamin Worpitz, Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2015-2022 Axel Huebl, Benjamin Worpitz, Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentInterpolation/CurrentInterpolation.hpp
+++ b/include/picongpu/fields/currentInterpolation/CurrentInterpolation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Sergei Bastrakov
+/* Copyright 2015-2022 Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/currentInterpolation/None.hpp
+++ b/include/picongpu/fields/currentInterpolation/None.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Benjamin Worpitz, Sergei Bastrakov
+/* Copyright 2015-2022 Axel Huebl, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/BackwardDerivative.hpp
+++ b/include/picongpu/fields/differentiation/BackwardDerivative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/Curl.def
+++ b/include/picongpu/fields/differentiation/Curl.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/Curl.hpp
+++ b/include/picongpu/fields/differentiation/Curl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/Derivative.def
+++ b/include/picongpu/fields/differentiation/Derivative.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/Derivative.hpp
+++ b/include/picongpu/fields/differentiation/Derivative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/ForwardDerivative.hpp
+++ b/include/picongpu/fields/differentiation/ForwardDerivative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/Traits.hpp
+++ b/include/picongpu/fields/differentiation/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/differentiation/ZeroDerivative.hpp
+++ b/include/picongpu/fields/differentiation/ZeroDerivative.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/DerivativeCoefficients.hpp
+++ b/include/picongpu/fields/incidentField/DerivativeCoefficients.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/Profiles.def
+++ b/include/picongpu/fields/incidentField/Profiles.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/Profiles.hpp
+++ b/include/picongpu/fields/incidentField/Profiles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/BaseFunctor.hpp
+++ b/include/picongpu/fields/laserProfiles/BaseFunctor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Ilja Goethel,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Ilja Goethel,
  *                     Anton Helm, Alexander Debus, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.def
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Ilja Goethel, Axel Huebl
+/* Copyright 2018-2022 Ilja Goethel, Axel Huebl
  *
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Ilja Goethel, Axel Huebl
+/* Copyright 2018-2022 Ilja Goethel, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/GaussianBeam.def
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/None.def
+++ b/include/picongpu/fields/laserProfiles/None.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl
+/* Copyright 2013-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/None.hpp
+++ b/include/picongpu/fields/laserProfiles/None.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/PlaneWave.def
+++ b/include/picongpu/fields/laserProfiles/PlaneWave.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl
+/* Copyright 2013-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/PlaneWave.hpp
+++ b/include/picongpu/fields/laserProfiles/PlaneWave.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/Polynom.def
+++ b/include/picongpu/fields/laserProfiles/Polynom.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/Polynom.hpp
+++ b/include/picongpu/fields/laserProfiles/Polynom.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/PulseFrontTilt.def
+++ b/include/picongpu/fields/laserProfiles/PulseFrontTilt.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Anton Helm, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Anton Helm, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Anton Helm, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Anton Helm, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/Wavepacket.def
+++ b/include/picongpu/fields/laserProfiles/Wavepacket.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Stefan Tietze
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/Wavepacket.hpp
+++ b/include/picongpu/fields/laserProfiles/Wavepacket.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Stefan Tietze
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/profiles.def
+++ b/include/picongpu/fields/laserProfiles/profiles.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Ilja Goethel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/laserProfiles/profiles.hpp
+++ b/include/picongpu/fields/laserProfiles/profiles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Ilja Goethel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/initialization/IInitPlugin.hpp
+++ b/include/picongpu/initialization/IInitPlugin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/initialization/InitPluginNone.hpp
+++ b/include/picongpu/initialization/InitPluginNone.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/initialization/ParserGridDistribution.cpp
+++ b/include/picongpu/initialization/ParserGridDistribution.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/initialization/ParserGridDistribution.hpp
+++ b/include/picongpu/initialization/ParserGridDistribution.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/initialization/SimStartInitialiser.hpp
+++ b/include/picongpu/initialization/SimStartInitialiser.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/main.cpp
+++ b/include/picongpu/main.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/bremsstrahlung.param
+++ b/include/picongpu/param/bremsstrahlung.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/collision.param
+++ b/include/picongpu/param/collision.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/components.param
+++ b/include/picongpu/param/components.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm,
  *                     Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/dimension.param
+++ b/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/fieldAbsorber.param
+++ b/include/picongpu/param/fieldAbsorber.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2019-2022 Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/fieldBackground.param
+++ b/include/picongpu/param/fieldBackground.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Alexander Debus, Richard Pausch
+/* Copyright 2014-2022 Axel Huebl, Alexander Debus, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/fieldSolver.param
+++ b/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/fileOutput.param
+++ b/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/flylite.param
+++ b/include/picongpu/param/flylite.param
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/grid.param
+++ b/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/ionizationEnergies.param
+++ b/include/picongpu/param/ionizationEnergies.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Axel Huebl
+/* Copyright 2014-2022 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/ionizer.param
+++ b/include/picongpu/param/ionizer.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Axel Huebl
+/* Copyright 2014-2022 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/isaac.param
+++ b/include/picongpu/param/isaac.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Matthes, Pawel Ordyna
+/* Copyright 2016-2022 Alexander Matthes, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/iterationStart.param
+++ b/include/picongpu/param/iterationStart.param
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/laser.param
+++ b/include/picongpu/param/laser.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
  *                     Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/mallocMC.param
+++ b/include/picongpu/param/mallocMC.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Carlchristian Eckert
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/memory.param
+++ b/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/particleCalorimeter.param
+++ b/include/picongpu/param/particleCalorimeter.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/particleFilters.param
+++ b/include/picongpu/param/particleFilters.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/particleMerger.param
+++ b/include/picongpu/param/particleMerger.param
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/physicalConstants.param
+++ b/include/picongpu/param/physicalConstants.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Marco Garten
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/png.param
+++ b/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/pngColorScales.param
+++ b/include/picongpu/param/pngColorScales.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/precision.param
+++ b/include/picongpu/param/precision.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/pusher.param
+++ b/include/picongpu/param/pusher.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/radiation.param
+++ b/include/picongpu/param/radiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/random.param
+++ b/include/picongpu/param/random.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl,
+/* Copyright 2014-2022 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl,
  *                     Heiko Burau
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/param/speciesConstants.param
+++ b/include/picongpu/param/speciesConstants.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/speciesDefinition.param
+++ b/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/speciesInitialization.param
+++ b/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/starter.param
+++ b/include/picongpu/param/starter.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/synchrotronPhotons.param
+++ b/include/picongpu/param/synchrotronPhotons.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/transitionRadiation.param
+++ b/include/picongpu/param/transitionRadiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/unit.param
+++ b/include/picongpu/param/unit.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/param/xrayScattering.param
+++ b/include/picongpu/param/xrayScattering.param
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/InterpolationForPusher.hpp
+++ b/include/picongpu/particles/InterpolationForPusher.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Richard Pausch
+/* Copyright 2015-2022 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/Manipulate.hpp
+++ b/include/picongpu/particles/Manipulate.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/MoveParticle.hpp
+++ b/include/picongpu/particles/MoveParticle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
  *                     Marco Garten, Alexander Grund, Richard Pausch,
  *                     Lennert Sprenger
  *

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Marco Garten, Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Wen Fu,
  *                     Marco Garten, Alexander Grund, Richard Pausch,
  *                     Lennert Sprenger
  *

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt,
  *                     Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Marco Garten, Alexander Grund,
+/* Copyright 2014-2022 Rene Widera, Marco Garten, Alexander Grund,
  *                     Heiko Burau, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/access/Cell2Particle.hpp
+++ b/include/picongpu/particles/access/Cell2Particle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/access/Cell2Particle.tpp
+++ b/include/picongpu/particles/access/Cell2Particle.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Absorbing.hpp
+++ b/include/picongpu/particles/boundary/Absorbing.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Apply.hpp
+++ b/include/picongpu/particles/boundary/Apply.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/ApplyImpl.hpp
+++ b/include/picongpu/particles/boundary/ApplyImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Description.hpp
+++ b/include/picongpu/particles/boundary/Description.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Kind.hpp
+++ b/include/picongpu/particles/boundary/Kind.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov, Lennert Sprenger
+/* Copyright 2021-2022 Sergei Bastrakov, Lennert Sprenger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Parameters.hpp
+++ b/include/picongpu/particles/boundary/Parameters.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Lennert Sprenger, Sergei Bastrakov
+/* Copyright 2021-2022 Lennert Sprenger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Reflecting.hpp
+++ b/include/picongpu/particles/boundary/Reflecting.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov, Lennert Sprenger
+/* Copyright 2021-2022 Sergei Bastrakov, Lennert Sprenger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/RemoveOuterParticles.hpp
+++ b/include/picongpu/particles/boundary/RemoveOuterParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Thermal.hpp
+++ b/include/picongpu/particles/boundary/Thermal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov, Lennert Sprenger
+/* Copyright 2021-2022 Sergei Bastrakov, Lennert Sprenger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/boundary/Utility.hpp
+++ b/include/picongpu/particles/boundary/Utility.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
+++ b/include/picongpu/particles/bremsstrahlung/PhotonEmissionAngle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
+++ b/include/picongpu/particles/bremsstrahlung/ScaledSpectrum.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/Collider.def
+++ b/include/picongpu/particles/collision/Collider.def
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/Collider.hpp
+++ b/include/picongpu/particles/collision/Collider.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/IBinary.def
+++ b/include/picongpu/particles/collision/IBinary.def
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/WithPeer.hpp
+++ b/include/picongpu/particles/collision/WithPeer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.def
+++ b/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2015-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
+++ b/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2015-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/collision.def
+++ b/include/picongpu/particles/collision/collision.def
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Axel Huebl, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/collision.hpp
+++ b/include/picongpu/particles/collision/collision.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Axel Huebl, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/detail/CollisionContext.hpp
+++ b/include/picongpu/particles/collision/detail/CollisionContext.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/detail/ListEntry.hpp
+++ b/include/picongpu/particles/collision/detail/ListEntry.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/collision/detail/cellDensity.hpp
+++ b/include/picongpu/particles/collision/detail/cellDensity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/creation/creation.hpp
+++ b/include/picongpu/particles/creation/creation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2015-2022 Marco Garten, Axel Huebl, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/debyeLength/Check.hpp
+++ b/include/picongpu/particles/debyeLength/Check.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/debyeLength/Estimate.hpp
+++ b/include/picongpu/particles/debyeLength/Estimate.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/EveryNthCellImpl.def
+++ b/include/picongpu/particles/densityProfiles/EveryNthCellImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/FreeFormulaImpl.def
+++ b/include/picongpu/particles/densityProfiles/FreeFormulaImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.def
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/GaussianCloudImpl.def
+++ b/include/picongpu/particles/densityProfiles/GaussianCloudImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.def
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/HomogenousImpl.def
+++ b/include/picongpu/particles/densityProfiles/HomogenousImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/HomogenousImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/HomogenousImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/IProfile.def
+++ b/include/picongpu/particles/densityProfiles/IProfile.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/IProfile.hpp
+++ b/include/picongpu/particles/densityProfiles/IProfile.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/LinearExponentialImpl.def
+++ b/include/picongpu/particles/densityProfiles/LinearExponentialImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/SphereFlanksImpl.def
+++ b/include/picongpu/particles/densityProfiles/SphereFlanksImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/profiles.def
+++ b/include/picongpu/particles/densityProfiles/profiles.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Alexander Grund
+/* Copyright 2014-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/densityProfiles/profiles.hpp
+++ b/include/picongpu/particles/densityProfiles/profiles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/All.def
+++ b/include/picongpu/particles/filter/All.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/IUnary.def
+++ b/include/picongpu/particles/filter/IUnary.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.def
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/filter/filter.def
+++ b/include/picongpu/particles/filter/filter.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/filter.hpp
+++ b/include/picongpu/particles/filter/filter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/IFlyLite.hpp
+++ b/include/picongpu/particles/flylite/IFlyLite.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/flylite/NonLTE.def
+++ b/include/picongpu/particles/flylite/NonLTE.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/flylite/NonLTE.hpp
+++ b/include/picongpu/particles/flylite/NonLTE.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/NonLTE.tpp
+++ b/include/picongpu/particles/flylite/NonLTE.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl, Rene Widera
+/* Copyright 2017-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl, Rene Widera
+/* Copyright 2017-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/helperFields/LocalRateMatrix.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalRateMatrix.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/flylite/types/Superconfig.hpp
+++ b/include/picongpu/particles/flylite/types/Superconfig.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/User.def
+++ b/include/picongpu/particles/functor/User.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/User.hpp
+++ b/include/picongpu/particles/functor/User.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/functor.def
+++ b/include/picongpu/particles/functor/functor.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Axel Huebl
+/* Copyright 2014-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/functor.hpp
+++ b/include/picongpu/particles/functor/functor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Axel Huebl
+/* Copyright 2014-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/Parametrized.def
+++ b/include/picongpu/particles/functor/misc/Parametrized.def
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/Parametrized.hpp
+++ b/include/picongpu/particles/functor/misc/Parametrized.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/Rng.def
+++ b/include/picongpu/particles/functor/misc/Rng.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund
+/* Copyright 2015-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/RngWrapper.hpp
+++ b/include/picongpu/particles/functor/misc/RngWrapper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/TotalCellOffset.def
+++ b/include/picongpu/particles/functor/misc/TotalCellOffset.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
+++ b/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
+++ b/include/picongpu/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Richard Pausch
+/* Copyright 2016-2022 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/None/AlgorithmNone.hpp
+++ b/include/picongpu/particles/ionization/None/AlgorithmNone.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten
+/* Copyright 2014-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Marco Garten, Axel Huebl
+/* Copyright 2016-2022 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Marco Garten
+/* Copyright 2016-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Marco Garten, Axel Huebl
+/* Copyright 2016-2022 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/collisionalIonizationCalc.def
+++ b/include/picongpu/particles/ionization/byCollision/collisionalIonizationCalc.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/collisionalIonizationCalc.hpp
+++ b/include/picongpu/particles/ionization/byCollision/collisionalIonizationCalc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/ionizers.def
+++ b/include/picongpu/particles/ionization/byCollision/ionizers.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byCollision/ionizers.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ionizers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/ADK/ADK.def
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Jakob Trojok
+/* Copyright 2015-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Jakob Trojok
+/* Copyright 2015-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Jakob Trojok
+/* Copyright 2015-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Jakob Trojok
+/* Copyright 2014-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Jakob Trojok
+/* Copyright 2014-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Jakob Trojok
+/* Copyright 2014-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/BSI/BSI.def
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Jakob Trojok
+/* Copyright 2015-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Jakob Trojok
+/* Copyright 2015-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Jakob Trojok
+/* Copyright 2020-2022 Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Jakob Trojok
+/* Copyright 2020-2022 Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Jakob Trojok
+/* Copyright 2020-2022 Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Jakob Trojok
+/* Copyright 2020-2022 Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Jakob Trojok
+/* Copyright 2020-2022 Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Marco Garten, Jakob Trojok
+/* Copyright 2016-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Marco Garten, Jakob Trojok
+/* Copyright 2016-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Marco Garten, Jakob Trojok
+/* Copyright 2016-2022 Marco Garten, Jakob Trojok
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/fieldIonizationCalc.def
+++ b/include/picongpu/particles/ionization/byField/fieldIonizationCalc.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/fieldIonizationCalc.hpp
+++ b/include/picongpu/particles/ionization/byField/fieldIonizationCalc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/ionizers.def
+++ b/include/picongpu/particles/ionization/byField/ionizers.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/byField/ionizers.hpp
+++ b/include/picongpu/particles/ionization/byField/ionizers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten
+/* Copyright 2015-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/ionization/utilities.hpp
+++ b/include/picongpu/particles/ionization/utilities.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Marco Garten, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Marco Garten, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/IBinary.def
+++ b/include/picongpu/particles/manipulators/IBinary.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/IUnary.def
+++ b/include/picongpu/particles/manipulators/IUnary.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/binary/Assign.def
+++ b/include/picongpu/particles/manipulators/binary/Assign.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/binary/DensityWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/DensityWeighting.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/ProtonTimesWeighting.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
+++ b/include/picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/generic/Free.def
+++ b/include/picongpu/particles/manipulators/generic/Free.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/generic/Free.hpp
+++ b/include/picongpu/particles/manipulators/generic/Free.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/generic/FreeRng.def
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund
+/* Copyright 2015-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/generic/None.def
+++ b/include/picongpu/particles/manipulators/generic/None.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/manipulators.def
+++ b/include/picongpu/particles/manipulators/manipulators.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Axel Huebl
+/* Copyright 2014-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/manipulators.hpp
+++ b/include/picongpu/particles/manipulators/manipulators.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Axel Huebl
+/* Copyright 2014-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/CopyAttribute.def
+++ b/include/picongpu/particles/manipulators/unary/CopyAttribute.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/Drift.def
+++ b/include/picongpu/particles/manipulators/unary/Drift.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/Drift.hpp
+++ b/include/picongpu/particles/manipulators/unary/Drift.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Axel Huebl
+/* Copyright 2017-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Axel Huebl
+/* Copyright 2017-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.def
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2017-2022 Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund, Axel Huebl, Sergei Bastrakov
+/* Copyright 2015-2022 Rene Widera, Alexander Grund, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/RandomPosition.def
+++ b/include/picongpu/particles/manipulators/unary/RandomPosition.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/Temperature.def
+++ b/include/picongpu/particles/manipulators/unary/Temperature.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/manipulators/unary/Temperature.hpp
+++ b/include/picongpu/particles/manipulators/unary/Temperature.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Marco Garten, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/FilteredDerivedAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/FilteredDerivedAttribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Pawel Ordyna
+/* Copyright 2014-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Density.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Density.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Density.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Density.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Richard Pausch
+/* Copyright 2015-2022 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Richard Pausch
+/* Copyright 2015-2022 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Energy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Heiko Burau
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Heiko Burau, Marco Garten
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Heiko Burau, Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/Traits.hpp
+++ b/include/picongpu/particles/pusher/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAcceleration.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera,
  *                     Richard Pausch, Klaus Steiniger
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/pusher/particlePusherAxel.hpp
+++ b/include/picongpu/particles/pusher/particlePusherAxel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/pusher/particlePusherBoris.hpp
+++ b/include/picongpu/particles/pusher/particlePusherBoris.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/particlePusherComposite.hpp
+++ b/include/picongpu/particles/pusher/particlePusherComposite.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/particlePusherFree.hpp
+++ b/include/picongpu/particles/pusher/particlePusherFree.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/particlePusherPhoton.hpp
+++ b/include/picongpu/particles/pusher/particlePusherPhoton.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/pusher/particlePusherProbe.hpp
+++ b/include/picongpu/particles/pusher/particlePusherProbe.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
+++ b/include/picongpu/particles/pusher/particlePusherReducedLandauLifshitz.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/pusher/particlePusherVay.hpp
+++ b/include/picongpu/particles/pusher/particlePusherVay.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes.hpp
+++ b/include/picongpu/particles/shapes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes/CIC.hpp
+++ b/include/picongpu/particles/shapes/CIC.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes/NGP.hpp
+++ b/include/picongpu/particles/shapes/NGP.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes/PCS.hpp
+++ b/include/picongpu/particles/shapes/PCS.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2015-2022 Rene Widera, Axel Huebl, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes/PQS.hpp
+++ b/include/picongpu/particles/shapes/PQS.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/OnePositionImpl.def
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl, Rene Widera
+/* Copyright 2016-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/OnePositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/QuietImpl.def
+++ b/include/picongpu/particles/startPosition/QuietImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/QuietImpl.hpp
+++ b/include/picongpu/particles/startPosition/QuietImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/RandomImpl.def
+++ b/include/picongpu/particles/startPosition/RandomImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/RandomImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
+++ b/include/picongpu/particles/startPosition/detail/WeightMacroParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/particles/startPosition/functors.def
+++ b/include/picongpu/particles/startPosition/functors.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/functors.hpp
+++ b/include/picongpu/particles/startPosition/functors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/generic/Free.def
+++ b/include/picongpu/particles/startPosition/generic/Free.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/generic/FreeRng.def
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund
+/* Copyright 2015-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.def
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/PhotonCreator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
+++ b/include/picongpu/particles/synchrotronPhotons/SynchrotronFunctions.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp
+++ b/include/picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetAtomicNumbers.hpp
+++ b/include/picongpu/particles/traits/GetAtomicNumbers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Rene Widera
+/* Copyright 2015-2022 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetCurrentSolver.hpp
+++ b/include/picongpu/particles/traits/GetCurrentSolver.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetDensityRatio.hpp
+++ b/include/picongpu/particles/traits/GetDensityRatio.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Richard Pausch
+/* Copyright 2015-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetEffectiveNuclearCharge.hpp
+++ b/include/picongpu/particles/traits/GetEffectiveNuclearCharge.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Marco Garten, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetExchangeMemCfg.hpp
+++ b/include/picongpu/particles/traits/GetExchangeMemCfg.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetInterpolation.hpp
+++ b/include/picongpu/particles/traits/GetInterpolation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetIonizationEnergies.hpp
+++ b/include/picongpu/particles/traits/GetIonizationEnergies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Marco Garten, Rene Widera
+/* Copyright 2015-2022 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetIonizerList.hpp
+++ b/include/picongpu/particles/traits/GetIonizerList.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Axel Huebl
+/* Copyright 2014-2022 Marco Garten, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetMarginPusher.hpp
+++ b/include/picongpu/particles/traits/GetMarginPusher.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Richard Pausch, Sergei Bastrakov
+/* Copyright 2015-2022 Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetPhotonCreator.hpp
+++ b/include/picongpu/particles/traits/GetPhotonCreator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetPusher.hpp
+++ b/include/picongpu/particles/traits/GetPusher.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch
+/* Copyright 2014-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetShape.hpp
+++ b/include/picongpu/particles/traits/GetShape.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/GetSpeciesFlagName.hpp
+++ b/include/picongpu/particles/traits/GetSpeciesFlagName.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/MacroWeighted.hpp
+++ b/include/picongpu/particles/traits/MacroWeighted.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/SpeciesEligibleForSolver.hpp
+++ b/include/picongpu/particles/traits/SpeciesEligibleForSolver.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/traits/WeightingPower.hpp
+++ b/include/picongpu/particles/traits/WeightingPower.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau,
  *                     Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/ChargeConservation.hpp
+++ b/include/picongpu/plugins/ChargeConservation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/Checkpoint.hpp
+++ b/include/picongpu/plugins/Checkpoint.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Franz Poeschel
+/* Copyright 2017-2022 Rene Widera, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau,
  *                     Rene Widera, Richard Pausch, Benjamin Worpitz,
  *                     Sophie Rudat
  *

--- a/include/picongpu/plugins/EnergyFields.hpp
+++ b/include/picongpu/plugins/EnergyFields.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau,
  *                     Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/ILightweightPlugin.hpp
+++ b/include/picongpu/plugins/ILightweightPlugin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Felix Schmitt
+/* Copyright 2014-2022 Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/ISimulationPlugin.hpp
+++ b/include/picongpu/plugins/ISimulationPlugin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/IntensityPlugin.hpp
+++ b/include/picongpu/plugins/IntensityPlugin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 Alexander Matthes, Pawel Ordyna
+ * Copyright 2013-2022 Alexander Matthes, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/PhaseSpace/AxisDescription.hpp
+++ b/include/picongpu/plugins/PhaseSpace/AxisDescription.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Richard Pausch, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Richard Pausch, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Benjamin Schneider, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Benjamin Schneider, Felix Schmitt,
  *                     Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Erik Zenker, Finn-Ole Carstens,
  *                     Franz Poeschel

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/PositionsParticles.hpp
+++ b/include/picongpu/plugins/PositionsParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/ResourceLog.cpp
+++ b/include/picongpu/plugins/ResourceLog.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Erik Zenker, Axel Huebl
+/* Copyright 2016-2022 Erik Zenker, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/picongpu/plugins/ResourceLog.hpp
+++ b/include/picongpu/plugins/ResourceLog.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Erik Zenker
+/* Copyright 2016-2022 Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/picongpu/plugins/SliceFieldPrinter.hpp
+++ b/include/picongpu/plugins/SliceFieldPrinter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/SliceFieldPrinter.tpp
+++ b/include/picongpu/plugins/SliceFieldPrinter.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/SliceFieldPrinterMulti.hpp
+++ b/include/picongpu/plugins/SliceFieldPrinterMulti.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/SliceFieldPrinterMulti.tpp
+++ b/include/picongpu/plugins/SliceFieldPrinterMulti.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Felix Schmitt, Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/common/openPMDAttributes.hpp
+++ b/include/picongpu/plugins/common/openPMDAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Franz Poeschel
+/* Copyright 2020-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Franz Poeschel
+/* Copyright 2013-2022 Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/stringHelpers.cpp
+++ b/include/picongpu/plugins/common/stringHelpers.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/stringHelpers.hpp
+++ b/include/picongpu/plugins/common/stringHelpers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/txtFileHandling.hpp
+++ b/include/picongpu/plugins/common/txtFileHandling.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Richard Pausch
+/* Copyright 2015-2022 Axel Huebl, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch
+/* Copyright 2014-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/AppendName.hpp
+++ b/include/picongpu/plugins/misc/AppendName.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/ComponentNames.cpp
+++ b/include/picongpu/plugins/misc/ComponentNames.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/ComponentNames.hpp
+++ b/include/picongpu/plugins/misc/ComponentNames.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
+++ b/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/SpeciesFilter.hpp
+++ b/include/picongpu/plugins/misc/SpeciesFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/concatenateToString.hpp
+++ b/include/picongpu/plugins/misc/concatenateToString.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/containsObject.hpp
+++ b/include/picongpu/plugins/misc/containsObject.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/misc.hpp
+++ b/include/picongpu/plugins/misc/misc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/removeSpaces.cpp
+++ b/include/picongpu/plugins/misc/removeSpaces.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/removeSpaces.hpp
+++ b/include/picongpu/plugins/misc/removeSpaces.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/splitString.cpp
+++ b/include/picongpu/plugins/misc/splitString.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/misc/splitString.hpp
+++ b/include/picongpu/plugins/misc/splitString.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/multi/IHelp.hpp
+++ b/include/picongpu/plugins/multi/IHelp.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/multi/IInstance.hpp
+++ b/include/picongpu/plugins/multi/IInstance.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/multi/Master.hpp
+++ b/include/picongpu/plugins/multi/Master.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/multi/Option.hpp
+++ b/include/picongpu/plugins/multi/Option.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/multi/multi.hpp
+++ b/include/picongpu/plugins/multi/multi.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/GetComponentsType.hpp
+++ b/include/picongpu/plugins/openPMD/GetComponentsType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/Json.hpp
+++ b/include/picongpu/plugins/openPMD/Json.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/Json_private.hpp
+++ b/include/picongpu/plugins/openPMD/Json_private.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund, Franz Poeschel
+/* Copyright 2016-2022 Alexander Grund, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2014-2022 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Alexander Grund, Franz Poeschel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/openPMD/openPMDDimension.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDDimension.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Franz Poeschel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Felix Schmitt, Axel Huebl, Franz Poeschel
+/* Copyright 2014-2022 Felix Schmitt, Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz, Alexander Grund, Franz Poeschel,
  *                     Pawel Ordyna, Sergei Bastrakov
  *

--- a/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera, Franz Poeschel
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl, Franz Poeschel
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *                     Benjamin Worpitz, Franz Poeschel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Franz Poeschel
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/output/ConstSpeciesAttributes.hpp
+++ b/include/picongpu/plugins/output/ConstSpeciesAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2014-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Franz Poeschel, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/output/GatherSlice.hpp
+++ b/include/picongpu/plugins/output/GatherSlice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/IIOBackend.hpp
+++ b/include/picongpu/plugins/output/IIOBackend.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Felix Schmitt
+/* Copyright 2014-2022 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/header/ColorHeader.hpp
+++ b/include/picongpu/plugins/output/header/ColorHeader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/header/DataHeader.hpp
+++ b/include/picongpu/plugins/output/header/DataHeader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/header/MessageHeader.hpp
+++ b/include/picongpu/plugins/output/header/MessageHeader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/header/NodeHeader.hpp
+++ b/include/picongpu/plugins/output/header/NodeHeader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/header/SimHeader.hpp
+++ b/include/picongpu/plugins/output/header/SimHeader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/header/WindowHeader.hpp
+++ b/include/picongpu/plugins/output/header/WindowHeader.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/images/PngCreator.hpp
+++ b/include/picongpu/plugins/output/images/PngCreator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/images/PngCreator.tpp
+++ b/include/picongpu/plugins/output/images/PngCreator.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2016-2022 Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.hpp
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
+++ b/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/ExecuteParticleFilter.hpp
+++ b/include/picongpu/plugins/radiation/ExecuteParticleFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/GetRadiationMask.hpp
+++ b/include/picongpu/plugins/radiation/GetRadiationMask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/plugins/radiation/VectorTypes.hpp
+++ b/include/picongpu/plugins/radiation/VectorTypes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/check_consistency.hpp
+++ b/include/picongpu/plugins/radiation/check_consistency.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_lin_freq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_list_freq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
+++ b/include/picongpu/plugins/radiation/frequencies/radiation_log_freq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
+++ b/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/taylor.hpp
+++ b/include/picongpu/plugins/radiation/taylor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/utilities.hpp
+++ b/include/picongpu/plugins/radiation/utilities.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/radiation/windowFunctions.hpp
+++ b/include/picongpu/plugins/radiation/windowFunctions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Richard Pausch
+/* Copyright 2014-2022 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.hpp
+++ b/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau, Xeinia Bastrakova, Sergei Bastrakov
+/* Copyright 2017-2022 Heiko Burau, Xeinia Bastrakova, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.kernel
+++ b/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau, Xeinia Bastrakova, Sergei Bastrakov
+/* Copyright 2017-2022 Heiko Burau, Xeinia Bastrakova, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/randomizedParticleMerger/VoronoiCell.hpp
+++ b/include/picongpu/plugins/randomizedParticleMerger/VoronoiCell.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau, Xeinia Bastrakova, Sergei Bastrakov
+/* Copyright 2017-2022 Heiko Burau, Xeinia Bastrakova, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/Calculator.hpp
+++ b/include/picongpu/plugins/transitionRadiation/Calculator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/ExecuteParticleFilter.hpp
+++ b/include/picongpu/plugins/transitionRadiation/ExecuteParticleFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Finn-Ole Carstens
+/* Copyright 2017-2022 Rene Widera, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/GammaMask.hpp
+++ b/include/picongpu/plugins/transitionRadiation/GammaMask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Finn-Ole Carstens
+/* Copyright 2017-2022 Rene Widera, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/Particle.hpp
+++ b/include/picongpu/plugins/transitionRadiation/Particle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz
  *                     Finn-Ole Carstens
  *

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz,
  *                     Finn-Ole Carstens
  *

--- a/include/picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Finn-Ole Carstens
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/DetermineElectronDensitySolver.hpp
+++ b/include/picongpu/plugins/xrayScattering/DetermineElectronDensitySolver.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/GetScatteringVector.hpp
+++ b/include/picongpu/plugins/xrayScattering/GetScatteringVector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Klaus Steiniger, Felix Schmitt, Benjamin Worpitz,
  *                     Juncheng E, Pawel Ordyna
  *

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.kernel
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/XrayScatteringWriter.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScatteringWriter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/AxisSwap.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/AxisSwap.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/CoordinateTransform.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/CoordinateTransform.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/ProbingBeam.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/ProbingBeam.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/SecondaryRotation.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/SecondaryRotation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/Side.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/Side.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/XrayScatteringBeam.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/XrayScatteringBeam.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/beamProfiles/ConstProfile.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/beamProfiles/ConstProfile.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/beamProfiles/GaussianProfile.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/beamProfiles/GaussianProfile.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/beamProfiles/profiles.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/beamProfiles/profiles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/beamShapes/ConstShape.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/beamShapes/ConstShape.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/beam/beamShapes/shapes.hpp
+++ b/include/picongpu/plugins/xrayScattering/beam/beamShapes/shapes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/xrayScattering/xrayScatteringUtilities.hpp
+++ b/include/picongpu/plugins/xrayScattering/xrayScatteringUtilities.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/pmacc_renamings.hpp
+++ b/include/picongpu/pmacc_renamings.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/random/seed/ISeed.hpp
+++ b/include/picongpu/random/seed/ISeed.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/random/seed/Seed.cpp
+++ b/include/picongpu/random/seed/Seed.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/random/seed/Seed.hpp
+++ b/include/picongpu/random/seed/Seed.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/control/DomainAdjuster.hpp
+++ b/include/picongpu/simulation/control/DomainAdjuster.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/control/ISimulationStarter.hpp
+++ b/include/picongpu/simulation/control/ISimulationStarter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/control/MovingWindow.hpp
+++ b/include/picongpu/simulation/control/MovingWindow.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt, Alexander Debus
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/control/SimulationStarter.hpp
+++ b/include/picongpu/simulation/control/SimulationStarter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/control/Window.hpp
+++ b/include/picongpu/simulation/control/Window.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/stage/Bremsstrahlung.hpp
+++ b/include/picongpu/simulation/stage/Bremsstrahlung.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/Collision.hpp
+++ b/include/picongpu/simulation/stage/Collision.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera
+/* Copyright 2019-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/stage/CurrentBackground.hpp
+++ b/include/picongpu/simulation/stage/CurrentBackground.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/CurrentDeposition.hpp
+++ b/include/picongpu/simulation/stage/CurrentDeposition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/CurrentReset.hpp
+++ b/include/picongpu/simulation/stage/CurrentReset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/FieldAbsorber.hpp
+++ b/include/picongpu/simulation/stage/FieldAbsorber.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/IterationStart.hpp
+++ b/include/picongpu/simulation/stage/IterationStart.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/stage/MomentumBackup.hpp
+++ b/include/picongpu/simulation/stage/MomentumBackup.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/ParticleBoundaries.hpp
+++ b/include/picongpu/simulation/stage/ParticleBoundaries.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation/stage/ParticleIonization.hpp
+++ b/include/picongpu/simulation/stage/ParticleIonization.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/ParticlePush.hpp
+++ b/include/picongpu/simulation/stage/ParticlePush.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/PopulationKinetics.hpp
+++ b/include/picongpu/simulation/stage/PopulationKinetics.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
+++ b/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Marco Garten,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *

--- a/include/picongpu/simulation_classTypes.hpp
+++ b/include/picongpu/simulation_classTypes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation_defines.hpp
+++ b/include/picongpu/simulation_defines.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/simulation_types.hpp
+++ b/include/picongpu/simulation_types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/FieldPosition.hpp
+++ b/include/picongpu/traits/FieldPosition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/GetCellType.hpp
+++ b/include/picongpu/traits/GetCellType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/GetCurl.hpp
+++ b/include/picongpu/traits/GetCurl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/GetDataBoxType.hpp
+++ b/include/picongpu/traits/GetDataBoxType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/GetMargin.hpp
+++ b/include/picongpu/traits/GetMargin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/IsFieldDomainBound.hpp
+++ b/include/picongpu/traits/IsFieldDomainBound.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/IsFieldOutputOptional.hpp
+++ b/include/picongpu/traits/IsFieldOutputOptional.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/PICToOpenPMD.hpp
+++ b/include/picongpu/traits/PICToOpenPMD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/PICToOpenPMD.tpp
+++ b/include/picongpu/traits/PICToOpenPMD.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Axel Huebl
+/* Copyright 2016-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/SIBaseUnits.hpp
+++ b/include/picongpu/traits/SIBaseUnits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/Unit.hpp
+++ b/include/picongpu/traits/Unit.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/UnitDimension.hpp
+++ b/include/picongpu/traits/UnitDimension.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/attribute/GetCharge.hpp
+++ b/include/picongpu/traits/attribute/GetCharge.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Axel Huebl
+/* Copyright 2014-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/attribute/GetChargeState.hpp
+++ b/include/picongpu/traits/attribute/GetChargeState.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten, Rene Widera
+/* Copyright 2014-2022 Marco Garten, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/attribute/GetMass.hpp
+++ b/include/picongpu/traits/attribute/GetMass.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/frame/GetCharge.hpp
+++ b/include/picongpu/traits/frame/GetCharge.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/traits/frame/GetMass.hpp
+++ b/include/picongpu/traits/frame/GetMass.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/bremsstrahlung.unitless
+++ b/include/picongpu/unitless/bremsstrahlung.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/checkpoints.unitless
+++ b/include/picongpu/unitless/checkpoints.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt, Benjamin Worpitz,
  *                     Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/unitless/collision.unitless
+++ b/include/picongpu/unitless/collision.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/density.unitless
+++ b/include/picongpu/unitless/density.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/unitless/fieldAbsorber.unitless
+++ b/include/picongpu/unitless/fieldAbsorber.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2019-2022 Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/fieldBackground.unitless
+++ b/include/picongpu/unitless/fieldBackground.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/fileOutput.unitless
+++ b/include/picongpu/unitless/fileOutput.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/grid.unitless
+++ b/include/picongpu/unitless/grid.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/unitless/ionizer.unitless
+++ b/include/picongpu/unitless/ionizer.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Marco Garten
+/* Copyright 2014-2022 Marco Garten
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/particle.unitless
+++ b/include/picongpu/unitless/particle.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/physicalConstants.unitless
+++ b/include/picongpu/unitless/physicalConstants.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Marco Garten, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/png.unitless
+++ b/include/picongpu/unitless/png.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/precision.unitless
+++ b/include/picongpu/unitless/precision.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/pusher.unitless
+++ b/include/picongpu/unitless/pusher.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch, Annegret Roeszler
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch, Annegret Roeszler
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/radiation.unitless
+++ b/include/picongpu/unitless/radiation.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/speciesAttributes.unitless
+++ b/include/picongpu/unitless/speciesAttributes.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Alexander Grund, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/unitless/speciesConstants.unitless
+++ b/include/picongpu/unitless/speciesConstants.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/speciesDefinition.unitless
+++ b/include/picongpu/unitless/speciesDefinition.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/speciesInitialization.unitless
+++ b/include/picongpu/unitless/speciesInitialization.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/starter.unitless
+++ b/include/picongpu/unitless/starter.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/synchrotronPhotons.unitless
+++ b/include/picongpu/unitless/synchrotronPhotons.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/unitless/transitionRadiation.unitless
+++ b/include/picongpu/unitless/transitionRadiation.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/version.hpp
+++ b/include/picongpu/version.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/versionFormat.cpp
+++ b/include/picongpu/versionFormat.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl, Franz Poeschel
+/* Copyright 2015-2022 Axel Huebl, Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/versionFormat.hpp
+++ b/include/picongpu/versionFormat.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2021 Erik Zenker, Alexander Grund
+# Copyright 2015-2022 Erik Zenker, Alexander Grund
 #
 # This file is part of PMacc.
 #

--- a/include/pmacc/Environment.def
+++ b/include/pmacc/Environment.def
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Felix Schmitt, Conrad Schumann,
+/* Copyright 2014-2022 Felix Schmitt, Conrad Schumann,
  *                     Alexander Grund, Axel Huebl
  *
  * This file is part of PMacc.

--- a/include/pmacc/HandleGuardRegion.hpp
+++ b/include/pmacc/HandleGuardRegion.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 Erik Zenker, Rene Widera, Axel Huebl
+# Copyright 2015-2022 Erik Zenker, Rene Widera, Axel Huebl
 #
 # This file is part of PMacc.
 #

--- a/include/pmacc/algorithms/GlobalReduce.hpp
+++ b/include/pmacc/algorithms/GlobalReduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/PromoteType.hpp
+++ b/include/pmacc/algorithms/PromoteType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/TypeCast.hpp
+++ b/include/pmacc/algorithms/TypeCast.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math.hpp
+++ b/include/pmacc/algorithms/math.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Debus
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/abs.hpp
+++ b/include/pmacc/algorithms/math/defines/abs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/bessel.hpp
+++ b/include/pmacc/algorithms/math/defines/bessel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Debus
+/* Copyright 2016-2022 Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/comparison.hpp
+++ b/include/pmacc/algorithms/math/defines/comparison.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/cross.hpp
+++ b/include/pmacc/algorithms/math/defines/cross.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/dot.hpp
+++ b/include/pmacc/algorithms/math/defines/dot.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/exp.hpp
+++ b/include/pmacc/algorithms/math/defines/exp.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/floatingPoint.hpp
+++ b/include/pmacc/algorithms/math/defines/floatingPoint.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/modf.hpp
+++ b/include/pmacc/algorithms/math/defines/modf.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Sergei Bastrakov
+/* Copyright 2018-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/defines/trigo.hpp
+++ b/include/pmacc/algorithms/math/defines/trigo.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Alexander Debus
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/doubleMath/abs.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/abs.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/doubleMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/bessel.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Debus
+/* Copyright 2016-2022 Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/doubleMath/comparison.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/comparison.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Benjamin Worpitz, Richard Pausch
+/* Copyright 2015-2022 Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/doubleMath/exp.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/exp.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/doubleMath/floatingPoint.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/floatingPoint.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/algorithms/math/doubleMath/modf.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/modf.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/doubleMath/trigo.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/trigo.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Axel Huebl, Alexander Debus
  *
  * This file is part of PMacc.

--- a/include/pmacc/algorithms/math/floatMath/abs.tpp
+++ b/include/pmacc/algorithms/math/floatMath/abs.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/floatMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/floatMath/bessel.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Debus
+/* Copyright 2016-2022 Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/floatMath/comparison.tpp
+++ b/include/pmacc/algorithms/math/floatMath/comparison.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Benjamin Worpitz, Richard Pausch
+/* Copyright 2015-2022 Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/floatMath/exp.tpp
+++ b/include/pmacc/algorithms/math/floatMath/exp.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/floatMath/floatingPoint.tpp
+++ b/include/pmacc/algorithms/math/floatMath/floatingPoint.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/algorithms/math/floatMath/modf.tpp
+++ b/include/pmacc/algorithms/math/floatMath/modf.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/algorithms/math/floatMath/trigo.tpp
+++ b/include/pmacc/algorithms/math/floatMath/trigo.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Axel Huebl, Alexander Debus
  *
  * This file is part of PMacc.

--- a/include/pmacc/algorithms/reverseBits.hpp
+++ b/include/pmacc/algorithms/reverseBits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/assert.hpp
+++ b/include/pmacc/assert.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2016-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/attribute/Constexpr.hpp
+++ b/include/pmacc/attribute/Constexpr.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/attribute/FunctionSpecifier.hpp
+++ b/include/pmacc/attribute/FunctionSpecifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/attribute/unroll.hpp
+++ b/include/pmacc/attribute/unroll.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Bernhard Manfred Gruber
+/* Copyright 2021-2022 Bernhard Manfred Gruber
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/boost_workaround.hpp
+++ b/include/pmacc/boost_workaround.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Rene Widera
+/* Copyright 2020-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/boundary/Utility.hpp
+++ b/include/pmacc/boundary/Utility.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/pmacc/communication/AsyncCommunication.hpp
+++ b/include/pmacc/communication/AsyncCommunication.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/communication/ICommunicator.hpp
+++ b/include/pmacc/communication/ICommunicator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/communication/manager_common.hpp
+++ b/include/pmacc/communication/manager_common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Wolfgang Hoenig, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Wolfgang Hoenig, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/cuplaBlock/Foreach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/functor/Add.hpp
+++ b/include/pmacc/cuSTL/algorithm/functor/Add.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/functor/AssignValue.hpp
+++ b/include/pmacc/cuSTL/algorithm/functor/AssignValue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/functor/GetComponent.hpp
+++ b/include/pmacc/cuSTL/algorithm/functor/GetComponent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/host/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/host/Foreach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/FFT.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/FFT.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/FFT.tpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/FFT.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/Foreach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/ForeachBlock.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/Reduce.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/Reduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/ForeachKernel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau
+/* Copyright 2013-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/run-time/Foreach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/mpi/Gather.hpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Gather.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau
+/* Copyright 2013-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/mpi/Gather.tpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Gather.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/mpi/Reduce.hpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Reduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau
+/* Copyright 2013-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/algorithm/mpi/Reduce.tpp
+++ b/include/pmacc/cuSTL/algorithm/mpi/Reduce.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/CartBuffer.hpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/CartBuffer.tpp
+++ b/include/pmacc/cuSTL/container/CartBuffer.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/cuSTL/container/HostBuffer.hpp
+++ b/include/pmacc/cuSTL/container/HostBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/IndexBuffer.hpp
+++ b/include/pmacc/cuSTL/container/IndexBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/PNGBuffer.hpp
+++ b/include/pmacc/cuSTL/container/PNGBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/HostMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/HostMemAllocator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/allocator/tag.hpp
+++ b/include/pmacc/cuSTL/container/allocator/tag.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
+++ b/include/pmacc/cuSTL/container/assigner/DeviceMemAssigner.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/cuSTL/container/assigner/HostMemAssigner.hpp
+++ b/include/pmacc/cuSTL/container/assigner/HostMemAssigner.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/include/pmacc/cuSTL/container/compile-time/CartBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/include/pmacc/cuSTL/container/compile-time/CartBuffer.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/compile-time/SharedBuffer.hpp
+++ b/include/pmacc/cuSTL/container/compile-time/SharedBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/copier/D2DCopier.hpp
+++ b/include/pmacc/cuSTL/container/copier/D2DCopier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/cuSTL/container/copier/H2HCopier.hpp
+++ b/include/pmacc/cuSTL/container/copier/H2HCopier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/cuSTL/container/copier/Memcopy.hpp
+++ b/include/pmacc/cuSTL/container/copier/Memcopy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/tag.hpp
+++ b/include/pmacc/cuSTL/container/tag.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/container/view/View.hpp
+++ b/include/pmacc/cuSTL/container/view/View.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/BufferCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/BufferCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/Cursor.hpp
+++ b/include/pmacc/cuSTL/cursor/Cursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/FunctorCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/FunctorCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/MultiIndexCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/MultiIndexCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/NestedCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/NestedCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/SafeCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/SafeCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/accessor/CursorAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/CursorAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/accessor/FunctorAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/FunctorAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/LinearInterpAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/accessor/MarkerAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/MarkerAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/accessor/PointerAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/PointerAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
+++ b/include/pmacc/cuSTL/cursor/accessor/TwistAxesAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/compile-time/BufferCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/compile-time/BufferCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp
+++ b/include/pmacc/cuSTL/cursor/compile-time/SafeCursor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/BufferNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/BufferNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/CartNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/CartNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/CursorNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/CursorNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/EmptyNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/EmptyNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/MapTo1DNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/MultiIndexNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/PlusNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/PlusNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/compile-time/BufferNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/compile-time/TwistAxesNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/navigator/tag.hpp
+++ b/include/pmacc/cuSTL/cursor/navigator/tag.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/tools/LinearInterp.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/LinearInterp.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/tools/slice.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/slice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/tools/twistAxes.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/twistAxes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
+++ b/include/pmacc/cuSTL/cursor/tools/twistVectorFieldAxes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/cursor/traits.hpp
+++ b/include/pmacc/cuSTL/cursor/traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/zone/SphericZone.hpp
+++ b/include/pmacc/cuSTL/zone/SphericZone.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/zone/StaggeredZone.hpp
+++ b/include/pmacc/cuSTL/zone/StaggeredZone.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/zone/ToricZone.hpp
+++ b/include/pmacc/cuSTL/zone/ToricZone.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuSTL/zone/compile-time/SphericZone.hpp
+++ b/include/pmacc/cuSTL/zone/compile-time/SphericZone.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cudaSpecs.hpp
+++ b/include/pmacc/cudaSpecs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/cuplaHelper/ValidateCall.hpp
+++ b/include/pmacc/cuplaHelper/ValidateCall.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund, Sergei Bastrakov
  *

--- a/include/pmacc/dataManagement/AbstractInitialiser.hpp
+++ b/include/pmacc/dataManagement/AbstractInitialiser.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/dataManagement/ISimulationData.hpp
+++ b/include/pmacc/dataManagement/ISimulationData.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Benjamin Worpitz,
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/debug/DebugBuffers.hpp
+++ b/include/pmacc/debug/DebugBuffers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/debug/DebugDataSpace.hpp
+++ b/include/pmacc/debug/DebugDataSpace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/debug/DebugExchangeTypes.hpp
+++ b/include/pmacc/debug/DebugExchangeTypes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/debug/PMaccVerbose.hpp
+++ b/include/pmacc/debug/PMaccVerbose.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/debug/VerboseLog.hpp
+++ b/include/pmacc/debug/VerboseLog.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/debug/VerboseLogMakros.hpp
+++ b/include/pmacc/debug/VerboseLogMakros.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/debug/abortWithError.hpp
+++ b/include/pmacc/debug/abortWithError.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/device/MemoryInfo.hpp
+++ b/include/pmacc/device/MemoryInfo.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/device/Reduce.hpp
+++ b/include/pmacc/device/Reduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/device/reduce/Kernel.hpp
+++ b/include/pmacc/device/reduce/Kernel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/dimensions/DataSpace.tpp
+++ b/include/pmacc/dimensions/DataSpace.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/dimensions/DataSpaceOperations.hpp
+++ b/include/pmacc/dimensions/DataSpaceOperations.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/dimensions/Definition.hpp
+++ b/include/pmacc/dimensions/Definition.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera
+/* Copyright 2019-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/dimensions/GridLayout.hpp
+++ b/include/pmacc/dimensions/GridLayout.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/dimensions/SuperCellDescription.hpp
+++ b/include/pmacc/dimensions/SuperCellDescription.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/EventSystem.hpp
+++ b/include/pmacc/eventSystem/EventSystem.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/EventSystem.tpp
+++ b/include/pmacc/eventSystem/EventSystem.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/EventType.hpp
+++ b/include/pmacc/eventSystem/EventType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/eventSystem/Manager.hpp
+++ b/include/pmacc/eventSystem/Manager.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/Manager.tpp
+++ b/include/pmacc/eventSystem/Manager.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/CudaEvent.def
+++ b/include/pmacc/eventSystem/events/CudaEvent.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/CudaEvent.hpp
+++ b/include/pmacc/eventSystem/events/CudaEvent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/CudaEventHandle.hpp
+++ b/include/pmacc/eventSystem/events/CudaEventHandle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/EventDataReceive.hpp
+++ b/include/pmacc/eventSystem/events/EventDataReceive.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/events/EventNotify.hpp
+++ b/include/pmacc/eventSystem/events/EventNotify.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/events/EventNotify.tpp
+++ b/include/pmacc/eventSystem/events/EventNotify.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/EventTask.hpp
+++ b/include/pmacc/eventSystem/events/EventTask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/EventTask.tpp
+++ b/include/pmacc/eventSystem/events/EventTask.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/IEvent.hpp
+++ b/include/pmacc/eventSystem/events/IEvent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/events/IEventData.hpp
+++ b/include/pmacc/eventSystem/events/IEventData.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/events/kernelEvents.tpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/streams/EventStream.hpp
+++ b/include/pmacc/eventSystem/streams/EventStream.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/streams/StreamController.hpp
+++ b/include/pmacc/eventSystem/streams/StreamController.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/Factory.hpp
+++ b/include/pmacc/eventSystem/tasks/Factory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/tasks/ITask.hpp
+++ b/include/pmacc/eventSystem/tasks/ITask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/MPITask.hpp
+++ b/include/pmacc/eventSystem/tasks/MPITask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/tasks/StreamTask.hpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/tasks/StreamTask.tpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyDeviceToDevice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskCopyDeviceToHost.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyDeviceToHost.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskCopyHostToDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopyHostToDevice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskKernel.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskKernel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskKernel.tpp
+++ b/include/pmacc/eventSystem/tasks/TaskKernel.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskReceive.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceive.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceiveMPI.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskSend.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSend.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSendMPI.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Wolfgang Hoenig,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/transactions/Transaction.hpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/eventSystem/transactions/Transaction.tpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/transactions/TransactionManager.hpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/eventSystem/transactions/TransactionManager.tpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/fields/SimulationFieldHelper.hpp
+++ b/include/pmacc/fields/SimulationFieldHelper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/fields/operations/AddExchangeToBorder.hpp
+++ b/include/pmacc/fields/operations/AddExchangeToBorder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/fields/operations/CopyGuardToExchange.hpp
+++ b/include/pmacc/fields/operations/CopyGuardToExchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Marco Garten,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/fields/tasks/FieldFactory.hpp
+++ b/include/pmacc/fields/tasks/FieldFactory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/fields/tasks/FieldFactory.tpp
+++ b/include/pmacc/fields/tasks/FieldFactory.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsert.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsert.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldReceiveAndInsertExchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/fields/tasks/TaskFieldSend.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSend.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
+++ b/include/pmacc/fields/tasks/TaskFieldSendExchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/filter/Interface.hpp
+++ b/include/pmacc/filter/Interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/filter/operators/And.hpp
+++ b/include/pmacc/filter/operators/And.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/filter/operators/Or.hpp
+++ b/include/pmacc/filter/operators/Or.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/functor/Call.hpp
+++ b/include/pmacc/functor/Call.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/functor/Filtered.hpp
+++ b/include/pmacc/functor/Filtered.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2017-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/identifier/alias.hpp
+++ b/include/pmacc/identifier/alias.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Benjamin Worpitz,
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/identifier/identifier.hpp
+++ b/include/pmacc/identifier/identifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/identifier/named_type.hpp
+++ b/include/pmacc/identifier/named_type.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/kernel/atomic.hpp
+++ b/include/pmacc/kernel/atomic.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund
+/* Copyright 2015-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/kernel/operation/Atomic.hpp
+++ b/include/pmacc/kernel/operation/Atomic.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Rene Widera
+/* Copyright 2020-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/kernel/warp.hpp
+++ b/include/pmacc/kernel/warp.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund
+/* Copyright 2015-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/lockstep.hpp
+++ b/include/pmacc/lockstep.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Rene Widera
+/* Copyright 2021-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/lockstep/Config.hpp
+++ b/include/pmacc/lockstep/Config.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/lockstep/ForEach.hpp
+++ b/include/pmacc/lockstep/ForEach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/lockstep/Idx.hpp
+++ b/include/pmacc/lockstep/Idx.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/lockstep/Variable.hpp
+++ b/include/pmacc/lockstep/Variable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/lockstep/Worker.hpp
+++ b/include/pmacc/lockstep/Worker.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/AreaMapping.hpp
+++ b/include/pmacc/mappings/kernel/AreaMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/AreaMappingMethods.hpp
+++ b/include/pmacc/mappings/kernel/AreaMappingMethods.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/BorderMapping.hpp
+++ b/include/pmacc/mappings/kernel/BorderMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Alexander Grund
+/* Copyright 2013-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/ExchangeMapping.hpp
+++ b/include/pmacc/mappings/kernel/ExchangeMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/ExchangeMappingMethods.hpp
+++ b/include/pmacc/mappings/kernel/ExchangeMappingMethods.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/IntervalMapping.hpp
+++ b/include/pmacc/mappings/kernel/IntervalMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/MapperConcept.hpp
+++ b/include/pmacc/mappings/kernel/MapperConcept.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/MappingDescription.hpp
+++ b/include/pmacc/mappings/kernel/MappingDescription.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/StrideIntervalMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideIntervalMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/StrideMapperFactory.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapperFactory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/StrideMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/kernel/StrideMappingMethods.hpp
+++ b/include/pmacc/mappings/kernel/StrideMappingMethods.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/simulation/EnvironmentController.hpp
+++ b/include/pmacc/mappings/simulation/EnvironmentController.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/simulation/Filesystem.hpp
+++ b/include/pmacc/mappings/simulation/Filesystem.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Felix Schmitt
+/* Copyright 2014-2022 Felix Schmitt
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/simulation/GridController.hpp
+++ b/include/pmacc/mappings/simulation/GridController.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/mappings/simulation/ResourceMonitor.hpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Erik Zenker
+/* Copyright 2016-2022 Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/simulation/ResourceMonitor.tpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Erik Zenker
+/* Copyright 2016-2022 Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/simulation/Selection.hpp
+++ b/include/pmacc/mappings/simulation/Selection.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Felix Schmitt
+/* Copyright 2014-2022 Felix Schmitt
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/simulation/SubGrid.hpp
+++ b/include/pmacc/mappings/simulation/SubGrid.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mappings/threads/ThreadCollective.hpp
+++ b/include/pmacc/mappings/threads/ThreadCollective.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/Complex.hpp
+++ b/include/pmacc/math/Complex.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Debus
+/* Copyright 2015-2022 Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/ConstVector.hpp
+++ b/include/pmacc/math/ConstVector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2014-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/MapTuple.hpp
+++ b/include/pmacc/math/MapTuple.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/RungeKutta.hpp
+++ b/include/pmacc/math/RungeKutta.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Richard Pausch
+/* Copyright 2015-2022 Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/RungeKutta/RungeKutta4.hpp
+++ b/include/pmacc/math/RungeKutta/RungeKutta4.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Richard Pausch
+/* Copyright 2015-2022 Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/Tuple.hpp
+++ b/include/pmacc/math/Tuple.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/Vector.hpp
+++ b/include/pmacc/math/Vector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/VectorOperations.hpp
+++ b/include/pmacc/math/VectorOperations.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/complex/Bessel.hpp
+++ b/include/pmacc/math/complex/Bessel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2021 Alexander Debus, C. Bond
+/* Copyright 2003-2022 Alexander Debus, C. Bond
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/complex/Bessel.tpp
+++ b/include/pmacc/math/complex/Bessel.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2003-2021 Alexander Debus, C. Bond
+/* Copyright 2003-2022 Alexander Debus, C. Bond
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/complex/Complex.hpp
+++ b/include/pmacc/math/complex/Complex.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch,
  *                     Alexander Debus, Benjamin Worpitz, Finn-Ole Carstens
  *
  * This file is part of PMacc.

--- a/include/pmacc/math/operation.hpp
+++ b/include/pmacc/math/operation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Rene Widera
+/* Copyright 2021-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/operation/Add.hpp
+++ b/include/pmacc/math/operation/Add.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/operation/Assign.hpp
+++ b/include/pmacc/math/operation/Assign.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/operation/Max.hpp
+++ b/include/pmacc/math/operation/Max.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/operation/Min.hpp
+++ b/include/pmacc/math/operation/Min.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/operation/Mul.hpp
+++ b/include/pmacc/math/operation/Mul.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/operation/Sub.hpp
+++ b/include/pmacc/math/operation/Sub.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/Float.hpp
+++ b/include/pmacc/math/vector/Float.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/Int.hpp
+++ b/include/pmacc/math/vector/Int.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/Size_t.hpp
+++ b/include/pmacc/math/vector/Size_t.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/UInt32.hpp
+++ b/include/pmacc/math/vector/UInt32.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/UInt64.hpp
+++ b/include/pmacc/math/vector/UInt64.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund, Axel Huebl
  *
  * This file is part of PMacc.

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Sergei Bastrakov
  *
  * This file is part of PMacc.

--- a/include/pmacc/math/vector/accessor/StandardAccessor.hpp
+++ b/include/pmacc/math/vector/accessor/StandardAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/Float.hpp
+++ b/include/pmacc/math/vector/compile-time/Float.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/Int.hpp
+++ b/include/pmacc/math/vector/compile-time/Int.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/Size_t.hpp
+++ b/include/pmacc/math/vector/compile-time/Size_t.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/TwistComponents.hpp
+++ b/include/pmacc/math/vector/compile-time/TwistComponents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/UInt32.hpp
+++ b/include/pmacc/math/vector/compile-time/UInt32.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/UInt64.hpp
+++ b/include/pmacc/math/vector/compile-time/UInt64.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/navigator/PermutedNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/PermutedNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/navigator/StackedNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/StackedNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2014-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/math/vector/navigator/StandardNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/StandardNavigator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/Align.hpp
+++ b/include/pmacc/memory/Align.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/memory/Array.hpp
+++ b/include/pmacc/memory/Array.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/IndexPool.hpp
+++ b/include/pmacc/memory/IndexPool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Heiko Burau
+/* Copyright 2017-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/boxes/CachedBox.hpp
+++ b/include/pmacc/memory/boxes/CachedBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/boxes/DataBox.hpp
+++ b/include/pmacc/memory/boxes/DataBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
+++ b/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/boxes/PitchedBox.hpp
+++ b/include/pmacc/memory/boxes/PitchedBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/boxes/SharedBox.hpp
+++ b/include/pmacc/memory/boxes/SharedBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/Buffer.hpp
+++ b/include/pmacc/memory/buffers/Buffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/memory/buffers/Exchange.hpp
+++ b/include/pmacc/memory/buffers/Exchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/ExchangeIntern.hpp
+++ b/include/pmacc/memory/buffers/ExchangeIntern.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/GridBuffer.hpp
+++ b/include/pmacc/memory/buffers/GridBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/HostBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/HostBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/HostBufferIntern.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/memory/buffers/HostDeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostDeviceBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/HostDeviceBuffer.tpp
+++ b/include/pmacc/memory/buffers/HostDeviceBuffer.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/memory/buffers/MappedBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/MappedBufferIntern.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Axel Huebl, Benjamin Worpitz,
+/* Copyright 2014-2022 Rene Widera, Axel Huebl, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/memory/dataTypes/Mask.hpp
+++ b/include/pmacc/memory/dataTypes/Mask.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Wolfgang Hoenig,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/memory/shared/Allocate.hpp
+++ b/include/pmacc/memory/shared/Allocate.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/AllCombinations.hpp
+++ b/include/pmacc/meta/AllCombinations.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2014-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/ForEach.hpp
+++ b/include/pmacc/meta/ForEach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/GetKeyFromAlias.hpp
+++ b/include/pmacc/meta/GetKeyFromAlias.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/InvokeIf.hpp
+++ b/include/pmacc/meta/InvokeIf.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/String.hpp
+++ b/include/pmacc/meta/String.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/accessors/First.hpp
+++ b/include/pmacc/meta/accessors/First.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/accessors/Identity.hpp
+++ b/include/pmacc/meta/accessors/Identity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/accessors/Second.hpp
+++ b/include/pmacc/meta/accessors/Second.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/accessors/Type.hpp
+++ b/include/pmacc/meta/accessors/Type.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/ApplyGuard.hpp
+++ b/include/pmacc/meta/conversion/ApplyGuard.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera
+/* Copyright 2019-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/JoinToSeq.hpp
+++ b/include/pmacc/meta/conversion/JoinToSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/MakeSeq.hpp
+++ b/include/pmacc/meta/conversion/MakeSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/MakeSeqFromNestedSeq.hpp
+++ b/include/pmacc/meta/conversion/MakeSeqFromNestedSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/OperateOnSeq.hpp
+++ b/include/pmacc/meta/conversion/OperateOnSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/RemoveFromSeq.hpp
+++ b/include/pmacc/meta/conversion/RemoveFromSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/ResolveAliases.hpp
+++ b/include/pmacc/meta/conversion/ResolveAliases.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/ResolveAndRemoveFromSeq.hpp
+++ b/include/pmacc/meta/conversion/ResolveAndRemoveFromSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Alexander Grund
+/* Copyright 2014-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/SeqToMap.hpp
+++ b/include/pmacc/meta/conversion/SeqToMap.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/ToSeq.hpp
+++ b/include/pmacc/meta/conversion/ToSeq.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/TypeToAliasPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToAliasPair.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/TypeToPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToPair.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/conversion/TypeToPointerPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToPointerPair.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/errorHandlerPolicies/ReturnType.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ReturnType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/errorHandlerPolicies/ReturnValue.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ReturnValue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/misc/splitString.hpp
+++ b/include/pmacc/misc/splitString.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/GetMPI_Op.hpp
+++ b/include/pmacc/mpi/GetMPI_Op.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/GetMPI_StructAsArray.hpp
+++ b/include/pmacc/mpi/GetMPI_StructAsArray.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/GetMPI_StructAsArray.tpp
+++ b/include/pmacc/mpi/GetMPI_StructAsArray.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/MPIReduce.hpp
+++ b/include/pmacc/mpi/MPIReduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/MPI_StructAsArray.hpp
+++ b/include/pmacc/mpi/MPI_StructAsArray.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/SeedPerRank.hpp
+++ b/include/pmacc/mpi/SeedPerRank.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Alexander Grund
+/* Copyright 2014-2022 Axel Huebl, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/reduceMethods/AllReduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/AllReduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/mpi/reduceMethods/Reduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/Reduce.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/AsyncCommunicationImpl.hpp
+++ b/include/pmacc/particles/AsyncCommunicationImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/IdProvider.def
+++ b/include/pmacc/particles/IdProvider.def
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/IdProvider.hpp
+++ b/include/pmacc/particles/IdProvider.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/Identifier.hpp
+++ b/include/pmacc/particles/Identifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Alexander Grund, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Alexander Grund, Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/ParticleDescription.hpp
+++ b/include/pmacc/particles/ParticleDescription.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/ParticlesBase.tpp
+++ b/include/pmacc/particles/ParticlesBase.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/algorithm/CallForEach.hpp
+++ b/include/pmacc/particles/algorithm/CallForEach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2019-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl, Rene Widera, Sergei Bastrakov
+/* Copyright 2017-2022 Axel Huebl, Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/boostExtension/InheritGenerators.hpp
+++ b/include/pmacc/particles/boostExtension/InheritGenerators.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/boostExtension/InheritLinearly.hpp
+++ b/include/pmacc/particles/boostExtension/InheritLinearly.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/frame_types.hpp
+++ b/include/pmacc/particles/frame_types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/boxes/ExchangePopDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePopDataBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/particles/memory/boxes/PushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/PushDataBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/include/pmacc/particles/memory/boxes/TileDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/TileDataBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Alexander Grund
+/* Copyright 2015-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/buffers/StackExchangeBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/StackExchangeBuffer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Felix Schmitt, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
+++ b/include/pmacc/particles/memory/dataTypes/ExchangeMemoryIndex.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/FramePointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/FramePointer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/ListPointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/ListPointer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/Pointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Pointer.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021  Rene Widera
+/* Copyright 2014-2022  Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
+++ b/include/pmacc/particles/memory/dataTypes/StaticArray.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/memory/frames/NullFrame.hpp
+++ b/include/pmacc/particles/memory/frames/NullFrame.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/meta/FindByNameOrType.hpp
+++ b/include/pmacc/particles/meta/FindByNameOrType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/Assign.hpp
+++ b/include/pmacc/particles/operations/Assign.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/ConcatListOfFrames.hpp
+++ b/include/pmacc/particles/operations/ConcatListOfFrames.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/CopyIdentifier.hpp
+++ b/include/pmacc/particles/operations/CopyIdentifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/CountParticles.hpp
+++ b/include/pmacc/particles/operations/CountParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Erik Zenker
+/* Copyright 2013-2022 Rene Widera, Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/Deselect.hpp
+++ b/include/pmacc/particles/operations/Deselect.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/SetAttributeToDefault.hpp
+++ b/include/pmacc/particles/operations/SetAttributeToDefault.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Alexander Grund
+/* Copyright 2014-2022 Rene Widera, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/particleFilter/FilterFactory.hpp
+++ b/include/pmacc/particles/particleFilter/FilterFactory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/particleFilter/PositionFilter.hpp
+++ b/include/pmacc/particles/particleFilter/PositionFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/particleFilter/system/DefaultFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/DefaultFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/particleFilter/system/FalseFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/FalseFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/particleFilter/system/TrueFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/TrueFilter.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/policies/DeleteParticles.hpp
+++ b/include/pmacc/particles/policies/DeleteParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/policies/DoNothing.hpp
+++ b/include/pmacc/particles/policies/DoNothing.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/policies/ExchangeParticles.hpp
+++ b/include/pmacc/particles/policies/ExchangeParticles.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/tasks/ParticleFactory.hpp
+++ b/include/pmacc/particles/tasks/ParticleFactory.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/tasks/ParticleFactory.tpp
+++ b/include/pmacc/particles/tasks/ParticleFactory.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/tasks/TaskParticlesReceive.hpp
+++ b/include/pmacc/particles/tasks/TaskParticlesReceive.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/tasks/TaskParticlesSend.hpp
+++ b/include/pmacc/particles/tasks/TaskParticlesSend.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/traits/FilterByFlag.hpp
+++ b/include/pmacc/particles/traits/FilterByFlag.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau
+/* Copyright 2015-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/traits/FilterByIdentifier.hpp
+++ b/include/pmacc/particles/traits/FilterByIdentifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Heiko Burau, Rene Widera
+/* Copyright 2015-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
+++ b/include/pmacc/particles/traits/ResolveAliasFromSpecies.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/pluginSystem/INotify.hpp
+++ b/include/pmacc/pluginSystem/INotify.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl,
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl,
  *                     Richard Pausch
  *
  * This file is part of PMacc.

--- a/include/pmacc/pluginSystem/IPlugin.hpp
+++ b/include/pmacc/pluginSystem/IPlugin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Richard Pausch
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl, Benjamin Worpitz,
+/* Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl, Benjamin Worpitz,
  *                     Heiko Burau
  *
  * This file is part of PMacc.

--- a/include/pmacc/pluginSystem/TimeSlice.hpp
+++ b/include/pmacc/pluginSystem/TimeSlice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/pluginSystem/containsStep.hpp
+++ b/include/pmacc/pluginSystem/containsStep.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/pluginSystem/toTimeSlice.hpp
+++ b/include/pmacc/pluginSystem/toTimeSlice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/ppFunctions.hpp
+++ b/include/pmacc/ppFunctions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/preprocessor/facilities.hpp
+++ b/include/pmacc/preprocessor/facilities.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/preprocessor/size.hpp
+++ b/include/pmacc/preprocessor/size.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Sergei Bastrakov
+/* Copyright 2018-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/preprocessor/struct.hpp
+++ b/include/pmacc/preprocessor/struct.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera
+/* Copyright 2015-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/RNGProvider.hpp
+++ b/include/pmacc/random/RNGProvider.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Sergei Bastrakov
+/* Copyright 2015-2022 Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Sergei Bastrakov
+/* Copyright 2015-2022 Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/RNGState.hpp
+++ b/include/pmacc/random/RNGState.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/Random.hpp
+++ b/include/pmacc/random/Random.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/Normal.hpp
+++ b/include/pmacc/random/distributions/Normal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/Uniform.hpp
+++ b/include/pmacc/random/distributions/Uniform.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/distributions.hpp
+++ b/include/pmacc/random/distributions/distributions.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/misc/MullerBox.hpp
+++ b/include/pmacc/random/distributions/misc/MullerBox.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/normal/Normal_double.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_double.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/normal/Normal_float.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_float.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/normal/Normal_generic.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_generic.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/uniform/Range.hpp
+++ b/include/pmacc/random/distributions/uniform/Range.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund
+/* Copyright 2015-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/uniform/Uniform_double.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_double.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/uniform/Uniform_float.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_float.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/distributions/uniform/Uniform_generic.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_generic.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/methods/MRG32k3aMin.hpp
+++ b/include/pmacc/random/methods/MRG32k3aMin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund, Rene Widera
+/* Copyright 2016-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/methods/RngPlaceholder.hpp
+++ b/include/pmacc/random/methods/RngPlaceholder.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Alexander Grund, Rene Widera
+/* Copyright 2015-2022 Alexander Grund, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/random/methods/methods.hpp
+++ b/include/pmacc/random/methods/methods.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/result_of_Functor.hpp
+++ b/include/pmacc/result_of_Functor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/simulationControl/SimulationDescription.hpp
+++ b/include/pmacc/simulationControl/SimulationDescription.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Axel Huebl
+/* Copyright 2015-2022 Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
  *
  * This file is part of PMacc.

--- a/include/pmacc/simulationControl/TimeInterval.hpp
+++ b/include/pmacc/simulationControl/TimeInterval.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/simulationControl/signal.hpp
+++ b/include/pmacc/simulationControl/signal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
  *                     Benjamin Worpitz, Alexander Grund
  *
  * This file is part of PMacc.

--- a/include/pmacc/static_assert.hpp
+++ b/include/pmacc/static_assert.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Felix Schmitt, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/PMaccFixture.hpp
+++ b/include/pmacc/test/PMaccFixture.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/memory/HostBufferIntern/copyFrom.hpp
+++ b/include/pmacc/test/memory/HostBufferIntern/copyFrom.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Erik Zenker
+/* Copyright 2015-2022 Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/memory/HostBufferIntern/reset.hpp
+++ b/include/pmacc/test/memory/HostBufferIntern/reset.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Erik Zenker
+/* Copyright 2015-2022 Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/memory/HostBufferIntern/setValue.hpp
+++ b/include/pmacc/test/memory/HostBufferIntern/setValue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Erik Zenker
+/* Copyright 2015-2022 Erik Zenker
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/memory/memoryUT.cpp
+++ b/include/pmacc/test/memory/memoryUT.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Erik Zenker, Alexander Grund
+/* Copyright 2015-2022 Erik Zenker, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/particles/IdProvider.hpp
+++ b/include/pmacc/test/particles/IdProvider.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/particles/memory/SuperCell.hpp
+++ b/include/pmacc/test/particles/memory/SuperCell.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/particles/particlesUT.cpp
+++ b/include/pmacc/test/particles/particlesUT.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Grund
+/* Copyright 2016-2022 Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/test/random/CMakeLists.txt
+++ b/include/pmacc/test/random/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 Alexander Grund
+# Copyright 2016-2022 Alexander Grund
 #
 # This file is part of PMacc.
 #

--- a/include/pmacc/traits/GetCTName.hpp
+++ b/include/pmacc/traits/GetCTName.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2021 Rene Widera
+/* Copyright 2018-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetComponentsType.hpp
+++ b/include/pmacc/traits/GetComponentsType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetFlagType.hpp
+++ b/include/pmacc/traits/GetFlagType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetInitializedInstance.hpp
+++ b/include/pmacc/traits/GetInitializedInstance.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetNComponents.hpp
+++ b/include/pmacc/traits/GetNComponents.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetNumWorkers.hpp
+++ b/include/pmacc/traits/GetNumWorkers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Rene Widera
+/* Copyright 2017-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetStringProperties.hpp
+++ b/include/pmacc/traits/GetStringProperties.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetUniqueTypeId.hpp
+++ b/include/pmacc/traits/GetUniqueTypeId.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Sergei Bastrakov
+/* Copyright 2015-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetValueType.hpp
+++ b/include/pmacc/traits/GetValueType.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/GetValueType.tpp
+++ b/include/pmacc/traits/GetValueType.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/HasFlag.hpp
+++ b/include/pmacc/traits/HasFlag.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/HasIdentifier.hpp
+++ b/include/pmacc/traits/HasIdentifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/HasIdentifiers.hpp
+++ b/include/pmacc/traits/HasIdentifiers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2017-2021 Axel Huebl
+/* Copyright 2017-2022 Axel Huebl
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/IsBaseTemplateOf.hpp
+++ b/include/pmacc/traits/IsBaseTemplateOf.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/Limits.hpp
+++ b/include/pmacc/traits/Limits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/Limits.tpp
+++ b/include/pmacc/traits/Limits.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/NumberOfExchanges.hpp
+++ b/include/pmacc/traits/NumberOfExchanges.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/traits/Resolve.hpp
+++ b/include/pmacc/traits/Resolve.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera
+/* Copyright 2014-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/include/pmacc/type/Area.hpp
+++ b/include/pmacc/type/Area.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/type/Exchange.hpp
+++ b/include/pmacc/type/Exchange.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/type/Integral.hpp
+++ b/include/pmacc/type/Integral.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Felix Schmitt, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Felix Schmitt, Heiko Burau, Rene Widera,
  *                     Wolfgang Hoenig, Benjamin Worpitz,
  *                     Alexander Grund
  *

--- a/include/pmacc/verify.hpp
+++ b/include/pmacc/verify.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Rene Widera
+/* Copyright 2016-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/lib/python/picongpu/input/parameters.py
+++ b/lib/python/picongpu/input/parameters.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke, Jeffrey Kelling
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/XrayScatteringData.py
+++ b/lib/python/picongpu/plugins/data/XrayScatteringData.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Pawel Ordyna
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/base_reader.py
+++ b/lib/python/picongpu/plugins/data/base_reader.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/emittance.py
+++ b/lib/python/picongpu/plugins/data/emittance.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sophie Rudat, Axel Huebl
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/plugins/data/energy_histogram.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Axel Huebl
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/phase_space.py
+++ b/lib/python/picongpu/plugins/data/phase_space.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Axel Huebl
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/png.py
+++ b/lib/python/picongpu/plugins/data/png.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/data/radiation.py
+++ b/lib/python/picongpu/plugins/data/radiation.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 Richard Pausch
+# Copyright 2016-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/lib/python/picongpu/plugins/data/sliceFieldReader.py
+++ b/lib/python/picongpu/plugins/data/sliceFieldReader.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 Richard Pausch, Klaus Steiniger
+# Copyright 2014-2022 Richard Pausch, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #

--- a/lib/python/picongpu/plugins/data/transitionradiation.py
+++ b/lib/python/picongpu/plugins/data/transitionradiation.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Axel Huebl, Finn-Ole Carstens
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/base_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/energy_histogram_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/phase_space_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/png_widget.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/jupyter_widgets/utils.py
+++ b/lib/python/picongpu/plugins/jupyter_widgets/utils.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/base_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/base_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/emittance_evolution_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/emittance_evolution_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/energy_histogram_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/energy_histogram_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/energy_waterfall_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/energy_waterfall_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/phase_space_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/png_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/slice_emittance_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/slice_emittance_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/plugins/plot_mpl/slice_emittance_waterfall_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/slice_emittance_waterfall_visualizer.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke
 License: GPLv3+
 """

--- a/lib/python/picongpu/utils/field_ionization.py
+++ b/lib/python/picongpu/utils/field_ionization.py
@@ -1,7 +1,7 @@
 """Field ionization models implemented in PIConGPU.
 
 This file is part of the PIConGPU.
-Copyright 2019-2021 PIConGPU contributors
+Copyright 2019-2022 PIConGPU contributors
 Authors: Marco Garten
 License: GPLv3+
 """

--- a/lib/python/picongpu/utils/find_time.py
+++ b/lib/python/picongpu/utils/find_time.py
@@ -1,7 +1,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Axel Huebl
 License: GPLv3+
 """

--- a/lib/python/picongpu/utils/memory_calculator.py
+++ b/lib/python/picongpu/utils/memory_calculator.py
@@ -6,7 +6,7 @@ This file is part of PIConGPU.
 It is supposed to give an estimate for the memory requirement of a PIConGPU
 simulation per device.
 
-Copyright 2018-2021 PIConGPU contributors
+Copyright 2018-2022 PIConGPU contributors
 Authors: Marco Garten, Sergei Bastrakov
 License: GPLv3+
 """

--- a/lib/python/picongpu/utils/param_parser.py
+++ b/lib/python/picongpu/utils/param_parser.py
@@ -2,7 +2,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke
 License: GPLv3+
 """

--- a/share/picongpu/benchmarks/SPEC/cmakeFlags
+++ b/share/picongpu/benchmarks/SPEC/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/benchmarks/SPEC/etc/picongpu/1.cfg
+++ b/share/picongpu/benchmarks/SPEC/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/benchmarks/SPEC/etc/picongpu/1_radiation.cfg
+++ b/share/picongpu/benchmarks/SPEC/etc/picongpu/1_radiation.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/density.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/grid.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/isaac.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/isaac.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Matthes
+/* Copyright 2016-2022 Alexander Matthes
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/memory.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/particle.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/precision.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/precision.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiation.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/radiationObserver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/benchmarks/SPEC/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/Bremsstrahlung/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/Bremsstrahlung/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Heiko Burau, Richard Pausch, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/bremsstrahlung.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/bremsstrahlung.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Heiko Burau
+/* Copyright 2016-2022 Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/density.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/laser.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/cmakeFlags
+++ b/share/picongpu/examples/Bunch/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/Bunch/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/Bunch/etc/picongpu/32.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Richard Pausch, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Richard Pausch, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/Bunch/include/picongpu/param/components.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/components.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Anton Helm, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Anton Helm, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/density.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Alexander Debus, Richard Pausch
+/* Copyright 2014-2022 Axel Huebl, Alexander Debus, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/laser.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
+/* Copyright 2013-2022 Anton Helm, Richard Pausch, Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/png.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Bunch/include/picongpu/param/starter.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/starter.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Richard Pausch
+/* Copyright 2013-2022 Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/Empty/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/Empty/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FieldAbsorberTest/cmakeFlags
+++ b/share/picongpu/examples/FieldAbsorberTest/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FieldAbsorberTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/FieldAbsorberTest/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+# Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FieldAbsorberTest/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/FieldAbsorberTest/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+# Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2014-2022 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldAbsorber.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldAbsorber.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2019-2022 Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Alexander Debus, Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2014-2022 Axel Huebl, Alexander Debus, Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FoilLCT/bin/plot_charge_density.py
+++ b/share/picongpu/examples/FoilLCT/bin/plot_charge_density.py
@@ -3,7 +3,7 @@
 """
 This file is part of the PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Axel Huebl
 License: GPLv3+
 """

--- a/share/picongpu/examples/FoilLCT/cmakeFlags
+++ b/share/picongpu/examples/FoilLCT/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch, Jakob Trojok
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch, Jakob Trojok
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 Axel Huebl, Franz Poeschel
+# Copyright 2017-2022 Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/4_isaac.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/4_isaac.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 Axel Huebl, Franz Poeschel
+# Copyright 2017-2022 Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/8_isaac.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/8_isaac.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/density.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl
+/* Copyright 2014-2022 Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/fieldAbsorber.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/fieldAbsorber.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2019-2022 Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/laser.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch,
  *                     Alexander Debus
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/IncidentField/cmakeFlags
+++ b/share/picongpu/examples/IncidentField/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+# Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
+# Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2014-2022 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Sergei Bastrakov
+/* Copyright 2020-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/png.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz, Sergei Bastrakov
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/KelvinHelmholtz/cmakeFlags
+++ b/share/picongpu/examples/KelvinHelmholtz/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/16.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1_bench.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1_bench.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_bench.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_bench.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl, Franz Poeschel
+# Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_bench.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_bench.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/density.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particleFilters.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particleFilters.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/png.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/cmakeFlags
+++ b/share/picongpu/examples/LaserWakefield/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/16.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1_isaac.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/32.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4_gui.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4_gui.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4_isaac.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8_isaac.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/density.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Marco Garten
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/laser.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
+/* Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera, Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/png.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Marco Garten, Richard Pausch,
+/* Copyright 2013-2022 Rene Widera, Marco Garten, Richard Pausch,
  *                     Benjamin Worpitz, Axel Huebl
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/starter.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/starter.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 
-Copyright 2017-2021 PIConGPU contributors
+Copyright 2017-2022 PIConGPU contributors
 Authors: Sebastian Starke, Jeffrey Kelling
 License: GPLv3+
 

--- a/share/picongpu/examples/SingleParticleTest/cmakeFlags
+++ b/share/picongpu/examples/SingleParticleTest/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/SingleParticleTest/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl,
+# Copyright 2013-2022 Heiko Burau, Rene Widera, Felix Schmitt, Axel Huebl,
 #                     Franz Poeschel
 #
 # This file is part of PIConGPU.

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/density.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/dimension.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera, Richard Pausch
+/* Copyright 2014-2022 Axel Huebl, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Alexander Debus
+/* Copyright 2014-2022 Axel Huebl, Alexander Debus
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/32.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Heiko Burau, Felix Schmitt, Axel Huebl
+# Copyright 2013-2022 Heiko Burau, Felix Schmitt, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/64.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/64.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/ThermalTest/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/ThermalTest/etc/picongpu/8.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
+# Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/ThermalTest/executeOnClone
+++ b/share/picongpu/examples/ThermalTest/executeOnClone
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Heiko Burau
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Heiko Burau
 #
 # This file is part of PIConGPU. 
 # 

--- a/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/ThermalTestSimulation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Axel Huebl
+/* Copyright 2013-2022 Heiko Burau, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/components.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/components.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/density.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/include/picongpu/param/starter.param
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/param/starter.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/include/picongpu/unitless/starter.unitless
+++ b/share/picongpu/examples/ThermalTest/include/picongpu/unitless/starter.unitless
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/ThermalTest/tools/dispersion.py
+++ b/share/picongpu/examples/ThermalTest/tools/dispersion.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2021 Heiko Burau, Axel Huebl
+# Copyright 2013-2022 Heiko Burau, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Richard Pausch, Felix Schmitt, Axel Huebl, Finn-Ole Carstens
+# Copyright 2013-2022 Richard Pausch, Felix Schmitt, Axel Huebl, Finn-Ole Carstens
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Richard Pausch, Felix Schmitt, Axel Huebl, Finn-Ole Carstens
+# Copyright 2013-2022 Richard Pausch, Felix Schmitt, Axel Huebl, Finn-Ole Carstens
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/density.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Axel Huebl
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/png.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau,
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Finn-Ole Carstens
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WarmCopper/cmakeFlags
+++ b/share/picongpu/examples/WarmCopper/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/WarmCopper/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/WarmCopper/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Franz Poeschel
+# Copyright 2013-2022 Axel Huebl, Franz Poeschel
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/density.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/WarmCopper/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WeibelTransverse/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/WeibelTransverse/etc/picongpu/4.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/density.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/png.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/png.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/cmakeFlags
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/CollisionsBeamRelaxation/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Axel Huebl, Franz Poeschel, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Franz Poeschel, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/collision.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/collision.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/density.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Pawel Ordyna
+/* Copyright 2014-2022 Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particleFilters.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particleFilters.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2013-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl, Pawel Ordyna
+/* Copyright 2015-2022 Rene Widera, Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/cmakeFlags
+++ b/share/picongpu/tests/CollisionsThermalisation/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/CollisionsThermalisation/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/CollisionsThermalisation/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Axel Huebl, Franz Poeschel, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Franz Poeschel, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/collision.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/collision.param
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Rene Widera, Pawel Ordyna
+/* Copyright 2019-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/density.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Pawel Ordyna
+/* Copyright 2014-2022 Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl, Pawel Ordyna
+/* Copyright 2015-2022 Rene Widera, Axel Huebl, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/cmakeFlags
+++ b/share/picongpu/tests/XrayScattering/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Pawel Ordyna
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/XrayScattering/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/XrayScattering/etc/picongpu/1.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
 #              Pawel Ordyna
 #
 # This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/etc/picongpu/1_ions.cfg
+++ b/share/picongpu/tests/XrayScattering/etc/picongpu/1_ions.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
 #              Pawel Ordyna
 #
 # This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/etc/picongpu/1_mirror.cfg
+++ b/share/picongpu/tests/XrayScattering/etc/picongpu/1_mirror.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
 #              Pawel Ordyna
 #
 # This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/etc/picongpu/2.cfg
+++ b/share/picongpu/tests/XrayScattering/etc/picongpu/2.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
 #              Pawel Ordyna
 #
 # This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/density.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch, Pawel Ordyna
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/precision.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/precision.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger, Pawel Ordyna
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/xrayScattering.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/xrayScattering.param
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 Pawel Ordyna
+/* Copyright 2020-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/cmakeFlags
+++ b/share/picongpu/tests/compileCurrentSolver/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/density.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/isaac.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Matthes
+/* Copyright 2016-2022 Alexander Matthes
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/particleFilters.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/particleFilters.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/precision.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/precision.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileFieldSolver/cmakeFlags
+++ b/share/picongpu/tests/compileFieldSolver/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/fieldSolver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/grid.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch,
  *                     Benjamin Worpitz
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/isaac.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Matthes
+/* Copyright 2016-2022 Alexander Matthes
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileFieldSolver/include/picongpu/param/precision.param
+++ b/share/picongpu/tests/compileFieldSolver/include/picongpu/param/precision.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/iterationStart.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/iterationStart.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Richard Pausch, Sergei Bastrakov
+/* Copyright 2013-2022 Rene Widera, Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau, Sergei Bastrakov
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileIterationStart/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileParticlePusher/cmakeFlags
+++ b/share/picongpu/tests/compileParticlePusher/cmakeFlags
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Sergei Bastrakov
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Sergei Bastrakov
 #
 # This file is part of PIConGPU.
 #

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/density.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Axel Huebl, Rene Widera
+/* Copyright 2014-2022 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/fileOutput.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt,
  *                     Benjamin Worpitz, Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/isaac.param
@@ -1,4 +1,4 @@
-/* Copyright 2016-2021 Alexander Matthes
+/* Copyright 2016-2022 Alexander Matthes
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/precision.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/precision.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2021 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 Rene Widera, Axel Huebl
+/* Copyright 2015-2022 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *

--- a/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Rene Widera, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Axel Huebl
 #
 # This file is part of PMacc.
 #

--- a/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Marco Garten
+/* Copyright 2013-2022 Rene Widera, Marco Garten
  *
  * This file is part of PMacc.
  *

--- a/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera,
  *                     Maximilian Knespel, Benjamin Worpitz
  *
  * This file is part of PMacc.

--- a/share/pmacc/examples/gameOfLife2D/include/PngCreator.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/PngCreator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Heiko Burau, Rene Widera
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera, Maximilian Knespel, Alexander Grund
+/* Copyright 2013-2022 Rene Widera, Maximilian Knespel, Alexander Grund
  *
  * This file is part of PMacc.
  *

--- a/share/pmacc/examples/gameOfLife2D/include/types.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/types.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/share/pmacc/examples/gameOfLife2D/main.cpp
+++ b/share/pmacc/examples/gameOfLife2D/main.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Rene Widera
+/* Copyright 2013-2022 Rene Widera
  *
  * This file is part of PMacc.
  *

--- a/share/pmacc/examples/gameOfLife2D/submit/1.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/1.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PMacc.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/2.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/2.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PMacc.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/4.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/4.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PMacc.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
+++ b/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Rene Widera, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Axel Huebl
 #
 # This file is part of PMacc.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
+++ b/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Rene Widera, Axel Huebl
+# Copyright 2013-2022 Rene Widera, Axel Huebl
 #
 # This file is part of PMacc.
 #

--- a/src/tools/bin/BinEnergyPlot.sh
+++ b/src/tools/bin/BinEnergyPlot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/addLicense
+++ b/src/tools/bin/addLicense
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/create.sh
+++ b/src/tools/bin/create.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/findAndDo
+++ b/src/tools/bin/findAndDo
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/newVersion.sh
+++ b/src/tools/bin/newVersion.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/nextstep_from_period.sh
+++ b/src/tools/bin/nextstep_from_period.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2021 Axel Huebl, Ilja Goethel
+# Copyright 2017-2022 Axel Huebl, Ilja Goethel
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/plotIntensity
+++ b/src/tools/bin/plotIntensity
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/plotNumericalHeating
+++ b/src/tools/bin/plotNumericalHeating
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 Richard Pausch
+# Copyright 2015-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/plotRadiation
+++ b/src/tools/bin/plotRadiation
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2021 Richard Pausch
+# Copyright 2013-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/plotSumEnergyRange
+++ b/src/tools/bin/plotSumEnergyRange
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Axel Huebl, Rene Widera
+# Copyright 2013-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/plot_chargeConservation.py
+++ b/src/tools/bin/plot_chargeConservation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2015-2021 Richard Pausch
+# Copyright 2015-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/plot_chargeConservation_overTime.py
+++ b/src/tools/bin/plot_chargeConservation_overTime.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 Richard Pausch, Axel Huebl, Rene Widera
+# Copyright 2015-2022 Richard Pausch, Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/png2video.sh
+++ b/src/tools/bin/png2video.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/position2Trace.sh
+++ b/src/tools/bin/position2Trace.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Rene Widera, Richard Pausch
+# Copyright 2013-2022 Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/printField.py
+++ b/src/tools/bin/printField.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2021 Richard Pausch
+# Copyright 2013-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/radiationSyntheticDetector
+++ b/src/tools/bin/radiationSyntheticDetector
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2021 Richard Pausch
+# Copyright 2013-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/smooth.py
+++ b/src/tools/bin/smooth.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Richard Pausch
+# Copyright 2013-2022 Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/bin/transpose
+++ b/src/tools/bin/transpose
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/share/awk/BinEnergyPlot.awk
+++ b/src/tools/share/awk/BinEnergyPlot.awk
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/share/awk/SumEnergyRange.awk
+++ b/src/tools/share/awk/SumEnergyRange.awk
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2021 Rene Widera
+# Copyright 2013-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/src/tools/share/gnuplot/BinEnergyPlot.gnuplot
+++ b/src/tools/share/gnuplot/BinEnergyPlot.gnuplot
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Axel Huebl, Richard Pausch
+# Copyright 2013-2022 Axel Huebl, Richard Pausch
 #
 # This file is part of PIConGPU.
 #

--- a/test/correctBranchPR
+++ b/test/correctBranchPR
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2021 Axel Huebl
+# Copyright 2017-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasCudaGlobalKeyword
+++ b/test/hasCudaGlobalKeyword
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Rene Widera
+# Copyright 2016-2022 Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasEOLwhiteSpace
+++ b/test/hasEOLwhiteSpace
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Axel Huebl, Rene Widera
+# Copyright 2016-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasExtLibIncludeBrackets
+++ b/test/hasExtLibIncludeBrackets
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Axel Huebl, Rene Widera
+# Copyright 2016-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasNonASCII
+++ b/test/hasNonASCII
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Axel Huebl, Rene Widera
+# Copyright 2016-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasSpaceBeforePrecompiler
+++ b/test/hasSpaceBeforePrecompiler
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Axel Huebl
+# Copyright 2016-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasTabs
+++ b/test/hasTabs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Axel Huebl
+# Copyright 2016-2022 Axel Huebl
 #
 # This file is part of PIConGPU.
 #

--- a/test/hasWrongDoxygenStyle
+++ b/test/hasWrongDoxygenStyle
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2021 Axel Huebl, Rene Widera
+# Copyright 2016-2022 Axel Huebl, Rene Widera
 #
 # This file is part of PIConGPU.
 #


### PR DESCRIPTION
Updating years in header files is cumbersome, so we update all files to include 2022 at once.

Updated via
```
grep -iR "Copyright 20" . | grep -v git | awk -F: '{print $1}' | \
  xargs -n1 -P1 -I{} sed -i 's/\(Copyright 20..\) /\1-2022 /g' {}
grep -iR "Copyright 20" . | grep -v git | awk -F: '{print $1}' | \
  xargs -n1 -P1 -I{} sed -i 's/\(Copyright 20..-20\).. /\122 /g' {}
```

**and manually changed back [this symbolic link](https://github.com/ComputationalRadiationPhysics/picongpu/blob/dev/etc/picongpu/ascent-ornl/gpu_batch.tpl)**  (the script above replaced it with contents of linked-to file)

and commited via

```
git checkout thirdParty/

GIT_AUTHOR_NAME="Tools" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git commit -a
```