### PR TITLE
Adjust laser in incident field example for a more realistic setup

### DIFF
--- a/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
@@ -38,15 +38,17 @@ TBG_devices_z=1
 
 TBG_numCells=128
 TBG_gridSize="!TBG_numCells !TBG_numCells !TBG_numCells"
-TBG_steps="1000"
+TBG_steps="10000"
 
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# png image output (rough electron density and laser preview)
-TBG_png="--e_png.period 20                     \
+# png image output (rough laser preview)
+# it stops at iteration 3500 as png auto-normalization starts picking up the remaining reflections/noise,
+# and due to laser being set up as incident field it's not possible to use png normalization to laser
+TBG_png="--e_png.period 0:3500:100               \
            --e_png.axis yx --e_png.slicePoint 0.5 \
            --e_png.folder png"
 
@@ -56,7 +58,7 @@ TBG_openPMD="--openPMD.period 100   \
              --openPMD.file simData \
              --openPMD.ext h5"
 
-TBG_plugins="--fields_energy.period 10 !TBG_png"
+TBG_plugins="--fields_energy.period 100 !TBG_png !TBG_openPMD"
 
 
 #################################

--- a/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
@@ -36,9 +36,9 @@ TBG_devices_x=1
 TBG_devices_y=1
 TBG_devices_z=1
 
-TBG_numCells=128
+TBG_numCells=256
 TBG_gridSize="!TBG_numCells !TBG_numCells !TBG_numCells"
-TBG_steps="10000"
+TBG_steps="1000"
 
 
 #################################
@@ -46,19 +46,19 @@ TBG_steps="10000"
 #################################
 
 # png image output (rough laser preview)
-# it stops at iteration 3500 as png auto-normalization starts picking up the remaining reflections/noise,
+# it stops at iteration 650 as png auto-normalization starts picking up the remaining reflections/noise,
 # and due to laser being set up as incident field it's not possible to use png normalization to laser
-TBG_png="--e_png.period 0:3500:100               \
+TBG_png="--e_png.period 0:650:10                  \
            --e_png.axis yx --e_png.slicePoint 0.5 \
            --e_png.folder png"
 
 
 # file I/O with openPMD-HDF5
-TBG_openPMD="--openPMD.period 100   \
+TBG_openPMD="--openPMD.period 50   \
              --openPMD.file simData \
              --openPMD.ext h5"
 
-TBG_plugins="--fields_energy.period 100 !TBG_png !TBG_openPMD"
+TBG_plugins="--fields_energy.period 10 !TBG_png !TBG_openPMD"
 
 
 #################################

--- a/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
@@ -36,19 +36,19 @@ TBG_devices_x=2
 TBG_devices_y=2
 TBG_devices_z=1
 
-# Num cells needs to be changed together with the laser center
 TBG_numCells=128
 TBG_gridSize="!TBG_numCells !TBG_numCells !TBG_numCells"
-TBG_steps="600"
+TBG_steps="10000"
 
-TBG_periodic="--periodic 0 0 1"
 
 #################################
 ## Section: Optional Variables ##
 #################################
 
-# png image output (rough electron density and laser preview)
-TBG_png="--e_png.period 20                     \
+# png image output (rough laser preview)
+# it stops at iteration 3500 as png auto-normalization starts picking up the remaining reflections/noise,
+# and due to laser being set up as incident field it's not possible to use png normalization to laser
+TBG_png="--e_png.period 0:3500:100               \
            --e_png.axis yx --e_png.slicePoint 0.5 \
            --e_png.folder png"
 
@@ -58,7 +58,7 @@ TBG_openPMD="--openPMD.period 100   \
              --openPMD.file simData \
              --openPMD.ext h5"
 
-TBG_plugins="--fields_energy.period 10 !TBG_png"
+TBG_plugins="--fields_energy.period 100 !TBG_png !TBG_openPMD"
 
 
 #################################
@@ -70,7 +70,6 @@ TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
 TBG_programParams="-d !TBG_deviceDist \
                    -g !TBG_gridSize   \
                    -s !TBG_steps      \
-                   !TBG_periodic      \
                    !TBG_plugins       \
                    --versionOnce"
 

--- a/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
@@ -36,9 +36,9 @@ TBG_devices_x=2
 TBG_devices_y=2
 TBG_devices_z=1
 
-TBG_numCells=128
+TBG_numCells=256
 TBG_gridSize="!TBG_numCells !TBG_numCells !TBG_numCells"
-TBG_steps="10000"
+TBG_steps="1000"
 
 
 #################################
@@ -46,19 +46,19 @@ TBG_steps="10000"
 #################################
 
 # png image output (rough laser preview)
-# it stops at iteration 3500 as png auto-normalization starts picking up the remaining reflections/noise,
+# it stops at iteration 650 as png auto-normalization starts picking up the remaining reflections/noise,
 # and due to laser being set up as incident field it's not possible to use png normalization to laser
-TBG_png="--e_png.period 0:3500:100               \
+TBG_png="--e_png.period 0:650:10                  \
            --e_png.axis yx --e_png.slicePoint 0.5 \
            --e_png.folder png"
 
 
 # file I/O with openPMD-HDF5
-TBG_openPMD="--openPMD.period 100   \
+TBG_openPMD="--openPMD.period 50   \
              --openPMD.file simData \
              --openPMD.ext h5"
 
-TBG_plugins="--fields_energy.period 100 !TBG_png !TBG_openPMD"
+TBG_plugins="--fields_energy.period 10 !TBG_png !TBG_openPMD"
 
 
 #################################

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/grid.param
@@ -24,15 +24,7 @@ namespace picongpu
 {
     namespace SI
     {
-        /** This setup is based on section 7.11.1 of
-         *  A. Taflove, S.C. Hagness. Computational Electrodynamics
-         *  The Finite-Difference Time-Domain Method. 3rd Edition.
-         *  The difference is we consider both 2D and 3D cases,
-         *  and grid size is increased due to our absorber being part of
-         *  the simulation area, not located outside of it as in the book.
-         */
-
-        constexpr float_64 CELL_SIZE_SI = 1.0e-3; // 1 mm
+        constexpr float_64 CELL_SIZE_SI = 0.5e-3; // 0.5 mm
 
         /** equals X
          *  unit: meter */

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -38,31 +38,37 @@ namespace picongpu
             {
             public:
                 // Constants for pulse generation
-                static constexpr float_64 TIME_PERIOD_SI = 0.038e-9; // 0.038 ns
+                static constexpr float_64 TIME_PERIOD_SI = 0.0211e-9; // 0.0211 ns
                 static constexpr float_64 WAVE_LENGTH_SI = TIME_PERIOD_SI * SI::SPEED_OF_LIGHT_SI;
                 static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -1.0 / WAVE_LENGTH_SI * SI::ELECTRON_MASS_SI
                     * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
                 static constexpr float_64 A0 = 8.0;
                 static constexpr float_64 AMPLITUDE_SI = A0 * UNITCONV_A0_to_Amplitude_SI;
-                static constexpr float_64 DURATION_SI = 0.6e-9; // 0.6 ns
+                static constexpr float_64 DURATION_SI = 0.026e-9; // 0.026 ns
 
                 /// These need to be changed together with grid size
-                static constexpr float_64 CENTER_X_SI = 80.0e-3; // 80 mm
-                static constexpr float_64 WIDTH_X_SI = 40.0e-3; // 40 mm
-                static constexpr float_64 CENTER_Y_SI = 40.0e-3; // 40 mm
-                static constexpr float_64 WIDTH_Y_SI = 20.0e-3; // 20 mm
+                static constexpr float_64 LASER_CENTER_X_SI = 80.0e-3; // 80 mm
+                static constexpr float_64 LASER_WIDTH_X_SI = 8.0e-3; // 8 mm
+                static constexpr float_64 LASER_CENTER_Y_SI = 40.0e-3; // 40 mm
+                static constexpr float_64 LASER_WIDTH_Y_SI = 8.0e-3; // 8 mm
+                static constexpr float_64 LASER_CENTER_Z_SI = 64.0e-3; // 64 mm
+                static constexpr float_64 LASER_WIDTH_Z_SI = 10.0e-3; // 10 mm
 
                 // Convert to grid units
                 static constexpr uint32_t DURATION_STEPS = DURATION_SI / SI::DELTA_T_SI;
-                static constexpr uint32_t CENTER_X_CELLS = CENTER_X_SI / SI::CELL_WIDTH_SI;
-                static constexpr uint32_t WIDTH_X_CELLS = WIDTH_X_SI / SI::CELL_WIDTH_SI;
-                static constexpr uint32_t CENTER_Y_CELLS = CENTER_Y_SI / SI::CELL_HEIGHT_SI;
-                static constexpr uint32_t WIDTH_Y_CELLS = WIDTH_Y_SI / SI::CELL_HEIGHT_SI;
+                static constexpr uint32_t LASER_CENTER_X_CELLS = LASER_CENTER_X_SI / SI::CELL_WIDTH_SI;
+                static constexpr uint32_t LASER_WIDTH_X_CELLS = LASER_WIDTH_X_SI / SI::CELL_WIDTH_SI;
+                static constexpr uint32_t LASER_CENTER_Y_CELLS = LASER_CENTER_Y_SI / SI::CELL_HEIGHT_SI;
+                static constexpr uint32_t LASER_WIDTH_Y_CELLS = LASER_WIDTH_Y_SI / SI::CELL_HEIGHT_SI;
+                static constexpr uint32_t LASER_CENTER_Z_CELLS = LASER_CENTER_Z_SI / SI::CELL_DEPTH_SI;
+                static constexpr uint32_t LASER_WIDTH_Z_CELLS = LASER_WIDTH_Z_SI / SI::CELL_DEPTH_SI;
+
+                // Delay at initialization to ensure a smooth start
+                static constexpr float_64 initializationDurationSI = 16.0 * DURATION_SI;
 
                 // Get value to calculate Ey / Bz for the XMin source
                 HDINLINE float_X getXMinSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const initializationDurationSI = 16.0 * DURATION_SI;
                     auto const normalizedDuration
                         = (currentStep * SI::DELTA_T_SI - 0.5 * initializationDurationSI) / DURATION_SI;
                     auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
@@ -71,15 +77,17 @@ namespace picongpu
                     // note: one could also add x influence to normalizedDuration under exp
                     auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
                         * sin(k * (x - SI::SPEED_OF_LIGHT_SI * t));
-                    auto const normalizedY = (totalCellIdx.y() - CENTER_Y_CELLS) / WIDTH_Y_CELLS;
-                    auto const transversal = math::exp(-normalizedY * normalizedY);
+                    auto const normalizedY = (totalCellIdx.y() - LASER_CENTER_Y_CELLS) / LASER_WIDTH_Y_CELLS;
+                    auto normalizedZ = 0.0;
+                    if constexpr(simDim == 3)
+                        normalizedZ = (totalCellIdx.z() - LASER_CENTER_Z_CELLS) / LASER_WIDTH_Z_CELLS;
+                    auto const transversal = math::exp(-(normalizedY * normalizedY + normalizedZ * normalizedZ));
                     return AMPLITUDE_SI * longitudinal * transversal;
                 }
 
                 // Get value to calculate Ex / Bz for the XMax source
                 HDINLINE float_X getYMaxSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const initializationDurationSI = 16.0 * DURATION_SI;
                     auto const normalizedDuration
                         = (currentStep * SI::DELTA_T_SI - 0.5 * initializationDurationSI) / DURATION_SI;
                     auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
@@ -88,8 +96,11 @@ namespace picongpu
                     // note: one could also add y influence to normalizedDuration under exp
                     auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
                         * sin(k * (y + SI::SPEED_OF_LIGHT_SI * t));
-                    auto const normalizedX = (totalCellIdx.x() - CENTER_Y_CELLS) / WIDTH_X_CELLS;
-                    auto const transversal = math::exp(-normalizedX * normalizedX);
+                    auto const normalizedX = (totalCellIdx.x() - LASER_CENTER_Y_CELLS) / LASER_WIDTH_X_CELLS;
+                    auto normalizedZ = 0.0;
+                    if constexpr(simDim == 3)
+                        normalizedZ = (totalCellIdx.z() - LASER_CENTER_Z_CELLS) / LASER_WIDTH_Z_CELLS;
+                    auto const transversal = math::exp(-(normalizedX * normalizedX + normalizedZ * normalizedZ));
                     return AMPLITUDE_SI * longitudinal * transversal;
                 }
             };
@@ -235,7 +246,7 @@ namespace picongpu
              *
              * Each type has to be either Source<> or None.
              *
-             * Here we generate a plane wave from the X min border.
+             * Here we generate Gaussian pulses propagating inwards from X min and Y Max borders.
              */
             using XMin = MyXMinSource;
             using XMax = None;

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -38,26 +38,35 @@ namespace picongpu
             {
             public:
                 // Constants for pulse generation
-                static constexpr float_64 TIME_PERIOD_SI = 20 * SI::DELTA_T_SI;
+                static constexpr float_64 TIME_PERIOD_SI = 0.038e-9; // 0.038 ns
                 static constexpr float_64 WAVE_LENGTH_SI = TIME_PERIOD_SI * SI::SPEED_OF_LIGHT_SI;
                 static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -1.0 / WAVE_LENGTH_SI * SI::ELECTRON_MASS_SI
                     * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
                 static constexpr float_64 A0 = 8.0;
                 static constexpr float_64 AMPLITUDE_SI = A0 * UNITCONV_A0_to_Amplitude_SI;
-                static constexpr uint32_t DURATION_STEPS = 300;
+                static constexpr float_64 DURATION_SI = 0.6e-9; // 0.6 ns
+
                 /// These need to be changed together with grid size
-                static constexpr uint32_t CENTER_X_CELLS = 80;
-                static constexpr uint32_t WIDTH_X_CELLS = 40;
-                static constexpr uint32_t CENTER_Y_CELLS = 40;
-                static constexpr uint32_t WIDTH_Y_CELLS = 20;
+                static constexpr float_64 CENTER_X_SI = 80.0e-3; // 80 mm
+                static constexpr float_64 WIDTH_X_SI = 40.0e-3; // 40 mm
+                static constexpr float_64 CENTER_Y_SI = 40.0e-3; // 40 mm
+                static constexpr float_64 WIDTH_Y_SI = 20.0e-3; // 20 mm
+
+                // Convert to grid units
+                static constexpr uint32_t DURATION_STEPS = DURATION_SI / SI::DELTA_T_SI;
+                static constexpr uint32_t CENTER_X_CELLS = CENTER_X_SI / SI::CELL_WIDTH_SI;
+                static constexpr uint32_t WIDTH_X_CELLS = WIDTH_X_SI / SI::CELL_WIDTH_SI;
+                static constexpr uint32_t CENTER_Y_CELLS = CENTER_Y_SI / SI::CELL_HEIGHT_SI;
+                static constexpr uint32_t WIDTH_Y_CELLS = WIDTH_Y_SI / SI::CELL_HEIGHT_SI;
 
                 // Get value to calculate Ey / Bz for the XMin source
                 HDINLINE float_X getXMinSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const durationStepsMiddle = DURATION_STEPS / 2;
-                    auto const normalizedDuration = (currentStep - durationStepsMiddle) / durationStepsMiddle;
+                    auto const initializationDurationSI = 16.0 * DURATION_SI;
+                    auto const normalizedDuration
+                        = (currentStep * SI::DELTA_T_SI - 0.5 * initializationDurationSI) / DURATION_SI;
                     auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
-                    auto const x = totalCellIdx.x() * SI::CELL_HEIGHT_SI;
+                    auto const x = totalCellIdx.x() * SI::CELL_WIDTH_SI;
                     auto const t = currentStep * SI::DELTA_T_SI;
                     // note: one could also add x influence to normalizedDuration under exp
                     auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
@@ -70,8 +79,9 @@ namespace picongpu
                 // Get value to calculate Ex / Bz for the XMax source
                 HDINLINE float_X getYMaxSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const durationStepsMiddle = DURATION_STEPS / 2;
-                    auto const normalizedDuration = (currentStep - durationStepsMiddle) / durationStepsMiddle;
+                    auto const initializationDurationSI = 16.0 * DURATION_SI;
+                    auto const normalizedDuration
+                        = (currentStep * SI::DELTA_T_SI - 0.5 * initializationDurationSI) / DURATION_SI;
                     auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
                     auto const y = totalCellIdx.y() * SI::CELL_HEIGHT_SI;
                     auto const t = currentStep * SI::DELTA_T_SI;

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -33,14 +33,15 @@ namespace picongpu
     {
         namespace incidentField
         {
+            // This base class is merely to keep all laser-related things together
             class FunctorBase
             {
             public:
                 // Constants for pulse generation
                 static constexpr float_64 TIME_PERIOD_SI = 20 * SI::DELTA_T_SI;
-                static constexpr float_64 WAVE_LENGTH_SI = 2.0 * PI * TIME_PERIOD_SI * SI::SPEED_OF_LIGHT_SI;
-                static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
-                    * SI::ELECTRON_MASS_SI * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
+                static constexpr float_64 WAVE_LENGTH_SI = TIME_PERIOD_SI * SI::SPEED_OF_LIGHT_SI;
+                static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -1.0 / WAVE_LENGTH_SI * SI::ELECTRON_MASS_SI
+                    * SI::SPEED_OF_LIGHT_SI * SI::SPEED_OF_LIGHT_SI / SI::ELECTRON_CHARGE_SI;
                 static constexpr float_64 A0 = 8.0;
                 static constexpr float_64 AMPLITUDE_SI = A0 * UNITCONV_A0_to_Amplitude_SI;
                 static constexpr uint32_t DURATION_STEPS = 300;
@@ -50,25 +51,36 @@ namespace picongpu
                 static constexpr uint32_t CENTER_Y_CELLS = 40;
                 static constexpr uint32_t WIDTH_Y_CELLS = 20;
 
-                HDINLINE float_X getTimeComponentSI(const float_X currentStep) const
+                // Get value to calculate Ey / Bz for the XMin source
+                HDINLINE float_X getXMinSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
                     auto const durationStepsMiddle = DURATION_STEPS / 2;
                     auto const normalizedDuration = (currentStep - durationStepsMiddle) / durationStepsMiddle;
-                    auto const timeSI = currentStep * SI::DELTA_T_SI;
-                    const float_X sinArg = precisionCast<float_X>(timeSI / TIME_PERIOD_SI * 2.0 * PI);
-                    return AMPLITUDE_SI * math::exp(-normalizedDuration * normalizedDuration) * math::sin(sinArg);
+                    auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
+                    auto const x = totalCellIdx.x() * SI::CELL_HEIGHT_SI;
+                    auto const t = currentStep * SI::DELTA_T_SI;
+                    // note: one could also add x influence to normalizedDuration under exp
+                    auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
+                        * sin(k * (x - SI::SPEED_OF_LIGHT_SI * t));
+                    auto const normalizedY = (totalCellIdx.y() - CENTER_Y_CELLS) / WIDTH_Y_CELLS;
+                    auto const transversal = math::exp(-normalizedY * normalizedY);
+                    return AMPLITUDE_SI * longitudinal * transversal;
                 }
 
-                HDINLINE float_X getTransversalXComponentSI(const floatD_X& totalCellIdx) const
+                // Get value to calculate Ex / Bz for the XMax source
+                HDINLINE float_X getYMaxSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const normalizedX = (totalCellIdx[0] - CENTER_X_CELLS) / WIDTH_X_CELLS;
-                    return math::exp(-normalizedX * normalizedX);
-                }
-
-                HDINLINE float_X getTransversalYComponentSI(const floatD_X& totalCellIdx) const
-                {
-                    auto const normalizedY = (totalCellIdx[1] - CENTER_Y_CELLS) / WIDTH_Y_CELLS;
-                    return math::exp(-normalizedY * normalizedY);
+                    auto const durationStepsMiddle = DURATION_STEPS / 2;
+                    auto const normalizedDuration = (currentStep - durationStepsMiddle) / durationStepsMiddle;
+                    auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
+                    auto const y = totalCellIdx.y() * SI::CELL_HEIGHT_SI;
+                    auto const t = currentStep * SI::DELTA_T_SI;
+                    // note: one could also add y influence to normalizedDuration under exp
+                    auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
+                        * sin(k * (y + SI::SPEED_OF_LIGHT_SI * t));
+                    auto const normalizedX = (totalCellIdx.x() - CENTER_Y_CELLS) / WIDTH_X_CELLS;
+                    auto const transversal = math::exp(-normalizedX * normalizedX);
+                    return AMPLITUDE_SI * longitudinal * transversal;
                 }
             };
 
@@ -97,7 +109,7 @@ namespace picongpu
                  */
                 HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(totalCellIdx);
+                    auto const valueSI = getXMinSourceValueSI(totalCellIdx, currentStep);
                     auto const fieldSI = float3_X(0.0_X, valueSI, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -128,7 +140,7 @@ namespace picongpu
                  */
                 HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalYComponentSI(totalCellIdx);
+                    auto const valueSI = getXMinSourceValueSI(totalCellIdx, currentStep);
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -159,7 +171,7 @@ namespace picongpu
                  */
                 HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(totalCellIdx);
+                    auto const valueSI = getYMaxSourceValueSI(totalCellIdx, currentStep);
                     auto const fieldSI = float3_X(valueSI, 0.0_X, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -190,7 +202,7 @@ namespace picongpu
                  */
                 HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
                 {
-                    auto const valueSI = getTimeComponentSI(currentStep) * getTransversalXComponentSI(totalCellIdx);
+                    auto const valueSI = getYMaxSourceValueSI(totalCellIdx, currentStep);
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }


### PR DESCRIPTION
The goal is to make it easier to build an own setup based on the example.

The laser parameters are now defined in SI, and only converted to cell values when necessary. Proper delay added to avoid a steep jump of amplitude from 0, which caused artifacts as it should have with TF/SF. Png output is reduced in time to stop when only noise and artifacts remain (since there is no convenient way to make a proper axis scaling of png in such a setup).

Note that it is **not** what caused #3954, however was found while investigating it.