### PR TITLE
fix rad restart

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -875,7 +875,7 @@ namespace picongpu
                 {
                     std::ostringstream filename;
                     /* add to standard file ending */
-                    filename << name << timeStep << ".h5";
+                    filename << name << timeStep << "_0_0_0.h5";
 
                     /* check if restart file exists */
                     if(!boost::filesystem::exists(filename.str()))

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -880,7 +880,7 @@ namespace picongpu
                     /* check if restart file exists */
                     if(!boost::filesystem::exists(filename.str()))
                     {
-                        log<picLog::INPUT_OUTPUT>(
+                        log<radLog::SIMULATION_STATE>(
                             "Radiation (%1%): restart file not found (%2%) - start with zero values")
                             % speciesName % filename.str();
                     }
@@ -915,7 +915,8 @@ namespace picongpu
                         delete[] tmpBuffer;
                         openPMDdataFile.iterations[timeStep].close();
 
-                        log<picLog::INPUT_OUTPUT>("Radiation (%1%): read radiation data from openPMD") % speciesName;
+                        log<radLog::SIMULATION_STATE>("Radiation (%1%): read radiation data from openPMD")
+                            % speciesName;
                     }
                 }
 


### PR DESCRIPTION
This pull request fixes the issue #3959.

- [x] test that restarts work

The error was caused by the inconsistent naming of checkpoint file. In order to keep compatibility with the old python modules that were based on sequential libSplash output, files are still written with a `%T_0_0_0.h5` suffix. But the restart routine was looking for a more modern style `%T.h5`. The error was most likely introduced while refactoring the pull request #3566. 

Additionally, the radiation plugin defaults to not fail when not finding a restart file but to assume zeros. Since the warning is written to the PIConGPU IO log (by default not active)  instead to the radiation standard log (by default active) the warning was not prompted. 

Thus this pull request:
 - fixes file naming
 - switches log level 
 
 **For all those effected (e.g. @Anton-Le):**
 You can restart by changing the naming from `*%T_0_0_0.h5` to `*%T.h5`.
  
For data analysis, the loading of the restart files from PIConGPU is not needed. You just need to load them manually and add them accordingly. (Please be aware that any non-complex output like totalRad (or lastRad) are still wrong - but with using the openPMD output, there should be no problem if your simulation did not restart from the radiation checkpoint. - That's why PIConGPU does  not fail when it does not find a radiation restart file.) 