### PR TITLE
adjust taurus k80 modules to work with c++17

### DIFF
--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -22,12 +22,12 @@ export proj=$(groups | awk '{print $1}')
 module purge
 module load modenv/scs5
 
-module load CUDA/11.1.1-GCC-10.2.0
-module load OpenMPI/4.0.5-GCC-10.2.0
+module load CUDA/11.0.2-GCC-9.3.0
+module load OpenMPI/4.0.4-GCC-9.3.0
 module load CMake/3.18.4-GCCcore-10.2.0
-module load libpng/1.6.37-GCCcore-10.2.0
-module load git/2.28.0-GCCcore-10.2.0-nodocs
-module load Python/3.8.6-GCCcore-10.2.0
+module load libpng/1.6.37-GCCcore-9.3.0
+module load git/2.23.0-GCCcore-9.3.0-nodocs
+module load Python/3.8.2-GCCcore-9.3.0
 
 # Self-Build Software ##########################################################
 #


### PR DESCRIPTION
This pull request adjust the modules loaded on taurus (k80) to work with C++17. 
With the introduction #3949 the gcc 10.2.0 with CUDA 11.1.1 fails with the following error:
```
/software/haswell/GCCcore/10.2.0/include/c++/10.2.0/tuple(566): error #1921: pack "_UElements" does not have the same number of elements as "_Elements"                                                                                                                         
          detected during:                                                                                                                                                                                                                                                      
            instantiation of "__nv_bool std::tuple<_Elements...>::__nothrow_constructible<_UElements...>() [with _Elements=<const int &>, _UElements=<>]"                                                                                                                       
/software/haswell/GCCcore/10.2.0/include/c++/10.2.0/bits/stl_map.h(502): here                                                                                                                                                                                                   
            instantiation of "std::map<_Key, _Tp, _Compare, _Alloc>::mapped_type &std::map<_Key, _Tp, _Compare, _Alloc>::operator[](const std::map<_Key, _Tp, _Compare, _Alloc>::key_type &) [with _Key=int, _Tp=std::unique_ptr<cupla::cupla_cuda_async::AccDev, std::default_d
elete<cupla::cupla_cuda_async::AccDev>>, _Compare=std::less<int>, _Alloc=std::allocator<std::pair<const int, std::unique_ptr<cupla::cupla_cuda_async::AccDev, std::default_delete<cupla::cupla_cuda_async::AccDev>>>>]"                                                         
/scratch/ws/1/aaa-PIConGPU_test/picongpu/thirdParty/cupla/include/cupla/manager/Device.hpp(91): here                                                                                                                                                                       
            instantiation of "auto cupla::cupla_cuda_async::manager::Device<T_DeviceType>::device(int)->cupla::cupla_cuda_async::manager::Device<T_DeviceType>::DeviceType & [with T_DeviceType=cupla::cupla_cuda_async::AccDev]"                                               
/scratch/ws/1/aaa-PIConGPU_test/picongpu/thirdParty/cupla/src/device.cpp(47): here                                                                                                                                                                        
``` 
This pull request now reduces the versions accordingly to 
 - gcc 9.3.0
 - cuda 11.0.2
 
 Please be aware that CMake still relies on a more modern gcc - but this does not influence the compile process.
 
 The new setup has been tested using the Bunch example. 