### PR TITLE
Add crusher profile, update spock profile, update openPMD-api doc

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -259,7 +259,7 @@ c-blosc
 
 openPMD API
 """""""""""
-- 0.12.0+ (bare minimum) / 0.13.0+ (for streaming IO)
+- 0.14.3+
 - *Spack*: ``spack install openpmd-api``
 - For usage in PIConGPU, the openPMD API must have been built either with support for ADIOS2 or HDF5 (or both).
   When building the openPMD API from source (described below), these dependencies must be built and installed first.
@@ -281,7 +281,7 @@ openPMD API
 - environment:* (assumes install from source in ``$HOME/lib/openPMD-api``)
 
   - ``export CMAKE_PREFIX_PATH="$HOME/lib/openPMD-api:$CMAKE_PREFIX_PATH"``
-  - ``export LD_LIBRARY_PATH="$HOME/lib/openPMD-api/lib:$LD_LIBRARY_PATH"``
+  - ``export LD_LIBRARY_PATH="$HOME/lib/openPMD-api/lib64:$HOME/lib/openPMD-api/lib:$LD_LIBRARY_PATH"``
 - If PIConGPU is built with openPMD output enabled, the JSON library
   nlohmann_json will automatically be used, found in the ``thirdParty/``
   directory.

--- a/etc/picongpu/crusher-ornl/batch.tpl
+++ b/etc/picongpu/crusher-ornl/batch.tpl
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov, Klaus Steinger
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for crusher's SLURM batch system
+
+#SBATCH --account=!TBG_nameProject
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_devicesPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-gpu=!TBG_memPerDevice
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --chdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+## calculations will be performed by tbg ##
+.TBG_queue="batch"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${PROJID:-""}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted devices per node in the system
+.TBG_numHostedDevicesPerNode=8
+
+# host memory per device
+.TBG_memPerDevice=64000
+
+# number of CPU cores to block per GPU
+# we have 8 CPU cores per GPU (64cores/8gpus ~ 8cores)
+.TBG_coresPerGPU=8
+
+# Assign one OpenMP thread per available core per GPU (=task)
+export OMP_NUM_THREADS=!TBG_coresPerGPU
+
+# required GPUs per node for the current job
+.TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
+
+# We only start 1 MPI task per device
+.TBG_mpiTasksPerNode="$(( TBG_devicesPerNode * 1 ))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_devicesPerNode - 1 ) / TBG_devicesPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# cuda_memtest is available only on CUDA hardware
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+fi
+

--- a/etc/picongpu/crusher-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_picongpu.profile.example
@@ -1,0 +1,131 @@
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+printf "@ Do not forget to increase the GCD's reserved memory in  @\n"
+printf "@ memory.param by setting                                 @\n"
+printf "@   constexpr size_t reservedGpuMemorySize =              @\n"
+printf "@       uint64_t(2147483648); // 2 GiB                    @\n"
+printf "@ Further, set the initial buffer size in your ADIOS2     @\n"
+printf "@ configuration of your job's *.cfg file to 28GiB,        @\n"
+printf "@ and do not use more than this amount of memory per GCD  @\n"
+printf "@ in your setup, or you will see out-of-memory errors.    @\n"
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+
+# Project Information ######################################## (edit this line)
+#   - project for allocation and shared directories
+export PROJID=<yourProject>
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="vim"
+
+# General modules #############################################################
+#
+# There are a lot of required modules already loaded when connecting
+# such as mpi, libfabric and others.
+# The following modules just add to these.
+module load PrgEnv-cray/8.2.0 # Compiling with cray compiler wrapper CC
+
+module load craype-accel-amd-gfx90a
+module load rocm/4.5.2
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+module load cray-mpich/8.1.12
+
+module load cmake/3.21.3
+module load zlib/1.2.11
+
+module load boost/1.77.0-cxx17
+
+module load git/2.31.1
+
+# Other Software ##############################################################
+#
+module load c-blosc/1.21.0 adios2/2.7.1 hdf5/1.12.0
+export CMAKE_PREFIX_PATH="$OLCF_C_BLOSC_ROOT:$OLCF_ADIOS2_ROOT:$HDF5_ROOT:$CMAKE_PREFIX_PATH"
+
+module load libpng/1.6.37 freetype/2.11.0
+
+# Self-Build Software #########################################################
+# Optional, not required.
+#
+# needs to be compiled by the user
+export PIC_LIBS=$HOME/lib/crusher
+
+# (not really) optionally install openPMD-api yourself
+# required when using picongpu > 0.6.0
+#   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#openpmd-api
+export OPENPMD_API_ROOT=$PIC_LIBS/openPMD-api
+export CMAKE_PREFIX_PATH="$OPENPMD_API_ROOT:$CMAKE_PREFIX_PATH"
+export LD_LIBRARY_PATH="$OPENPMD_API_ROOT/lib64:$LD_LIBRARY_PATH"
+
+# optionally install pngwriter yourself:
+#   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#pngwriter
+# But add option `-DCMAKE_CXX_COMPILER=$(which CC)` to `cmake` invocation
+export PNGwriter_ROOT=$PIC_LIBS/pngwriter-0.7.0
+export CMAKE_PREFIX_PATH=$PNGwriter_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$PNGwriter_ROOT/lib:$LD_LIBRARY_PATH
+
+# Environment #################################################################
+#
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="hip:gfx90a"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "caar" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/crusher-ornl/batch.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates two interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+}
+
+# allocate an interactive shell for one hour
+#   getDevice 2  # allocates two interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        if [ "$1" -gt 8 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
+    fi
+    srun  --time=1:00:00 --nodes=1 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi
+

--- a/etc/picongpu/spock-ornl/caar_picongpu.profile.example
+++ b/etc/picongpu/spock-ornl/caar_picongpu.profile.example
@@ -24,21 +24,28 @@ export PROJID=<yourProject>
 # such as mpi, libfabric and others.
 # The following modules just add to these.
 module load craype-accel-amd-gfx908
-module load rocm/4.3.0 # Note setting of environment variables further below
+module load PrgEnv-cray/8.2.0
+module load rocm/4.5.0
+export CXX=hipcc
 
+export MPICH_GPU_SUPPORT_ENABLED=1
+module load cray-mpich/8.1.10
+
+## These must be set before running
+export MPIR_CVAR_GPU_EAGER_DEVICE_MEM=0
+export MPICH_GPU_SUPPORT_ENABLED=1
+export MPICH_SMP_SINGLE_COPY_MODE=CMA
+
+module load cmake/3.21.3
+module load zlib/1.2.11
+module load boost/1.77.0-cxx17
 module load git/2.31.1
-module load cmake/3.20.2
-module load boost/1.73.0
 
 # Other Software ##############################################################
 #
-module load c-blosc/1.21.0
-module load cray-python/3.8.5.1
-module load hdf5/1.10.7 # dependency of openpmd-api module (no other possible)
-module load adios2/2.7.1 # dependency of openpmd-api module
-module load openpmd-api/0.13.4
+module load c-blosc/1.21.0 hdf5/1.12.0 adios2/2.7.1
 
-module load libpng/1.6.37
+module load libpng/1.6.37 freetype/2.11.0
 
 # Self-Build Software #########################################################
 # Optional, not required.
@@ -47,22 +54,27 @@ module load libpng/1.6.37
 # Check the install script at
 # https://gist.github.com/steindev/a063a0a0ab61c5bed3352ef1f5e07962
 #
-export PROJECT=/ccs/proj/$PROJID/PIConGPU
+export PIC_LIBS=$HOME/lib/spock
 
-export PIC_LIBS=$PROJECT/lib
-export ZLIB_ROOT=$PIC_LIBS/zlib-1.2.11
+# install openPMD-api 0.14.3+ yourself
+# required when using picongpu > 0.6.0
+#   https://picongpu.readthedocs.io/en/latest/install/dependencies.html#openpmd-api
+export OPENPMD_API_ROOT=$PIC_LIBS/openPMD-api
+export CMAKE_PREFIX_PATH="$OPENPMD_API_ROOT:$CMAKE_PREFIX_PATH"
+export LD_LIBRARY_PATH="$OPENPMD_API_ROOT/lib64:$LD_LIBRARY_PATH"
+
+# optionally install pngwriter yourself:
+#   https://picongpu.readthedocs.io/en/latest/install/dependencies.html#pngwriter
+####### Really?: But add option `-DCMAKE_CXX_COMPILER=$(which CC)` to `cmake` invocation
 export PNGwriter_ROOT=$PIC_LIBS/pngwriter-0.7.0
-
-export LD_LIBRARY_PATH=$ZLIB_ROOT/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS:$CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=$PNGwriter_ROOT/lib:$LD_LIBRARY_PATH
-
-export CMAKE_PREFIX_PATH=$ZLIB_ROOT:$CMAKE_PREFIX_PATH
 
 # Environment #################################################################
 #
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
-export PIC_BACKEND="hip:908"
+export PIC_BACKEND="hip:gfx908"
 
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
@@ -73,10 +85,7 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export HIP_PATH=$ROCM_PATH/hip # has to be set in order to be able to compile
 export CMAKE_MODULE_PATH=$HIP_PATH/cmake:$CMAKE_MODULE_PATH
 export HIPCC_COMPILE_FLAGS_APPEND="$HIPCC_COMPILE_FLAGS_APPEND -I${MPICH_DIR}/include"
-export HIPCC_LINK_FLAGS_APPEND="$HIPCC_LINK_FLAGS_APPEND -L${MPICH_DIR}/lib -lmpi -L/opt/cray/pe/mpich/8.1.7/gtl/lib -lmpi_gtl_hsa"
-
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_ROOT/lib
-export CMAKE_PREFIX_PATH=$BOOST_ROOT:$CMAKE_PREFIX_PATH
+export HIPCC_LINK_FLAGS_APPEND="$HIPCC_LINK_FLAGS_APPEND -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa"
 
 # "tbg" default options #######################################################
 #   - SLURM (sbatch)
@@ -92,7 +101,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=16 --gres=gpu:4 --mem-per-gpu=64000 -p caar -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=16 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p caar -A $PROJID --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -108,7 +117,7 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=16 --gres=gpu:$numGPUs --mem-per-gpu=64000 -p caar -A $PROJID --pty bash
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=16 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p caar -A $PROJID --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
Adding a profile for crusher@OLCF.

While setting up PIConGPU for crusher@OLCF, I also saw that the modules on spock@OLCF changed and updated accordingly.
This is a separate commit.

Further, with changing to C++17 in dev we forgot to update our openPMD-api dependency section in the manual.
This is fixed in another separate commit, too.
However, it is part of this PR as the openPMD-api installation procedure in the docs is referred to in both profiles added/updated with this PR.

PIConGPU KHI example compiles and runs with openPMD output on crusher with this profile.
It compiles and runs without openPMD output on spock with this profile.
While compiling with openPMD output works on spock, running produces an `hipErrorOutOfMemory` when using ADIOS2 and HDF5 directly at start-up.
Will need to further investigate. (Since I am not allows to use more than 28GiB per MI250X GCD on crusher and an MI100 on spock has 32GiB, I know that the setup itself is not too large, so something else must be going on.)
However, this is independent of this PR in my opinion.