### PR TITLE
Expand documentation on running interactively

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -7,16 +7,39 @@
 picongpu.profile
 ================
 
-.. sectionauthor:: Axel Huebl
+.. sectionauthor:: Axel Huebl, Klaus Steiniger
 
-Use a ``picongpu.profile`` file to set up your software environment without colliding with other software.
-Ideally, store that file directly in your ``$HOME/`` and source it after connecting to the machine:
+We recommend to use a ``picongpu.profile`` file, located directly in your ``$HOME/`` directory,
+to set up the environment within which PIConGPU will run by conviently performing
 
 .. code-block:: bash
 
    source $HOME/picongpu.profile
 
-We listed some example ``picongpu.profile`` files below which can be used to set up PIConGPU's dependencies on various HPC systems.
+on the command line after logging in to a system.
+PIConGPU is shipped with a number of ready-to-use profiles for different systems which are located in
+``etc/picongpu/<cluster>-<institute>/`` within PIConGPU's main folder.
+Have a look into this directory in order to see for which HPC systems profiles are already available.
+If you are working on one of these systems, just copy the respective ``*_picongpu.profile.example``
+from within this directory into your ``$HOME`` and make the necessary changes, such as e-mail address
+or PIConGPU source code location defined by ``$PICSRC``.
+If you are working on an HPC system for which no profile is available, feel free to create one and
+contribute it to PIConGPU by opening a pull request.
+
+A selection of available profiles is presented below.
+Beware, these may not be up-to-date with the latest available software on the respective system,
+as we do not have continuous access to all of these.
+
+
+Your Workstation
+----------------
+
+This is a very basic ``picongpu.profile`` enabling compilation on CPUs by setting the OpenMP backend, declaring commonly required directories,
+and providing default parameters for :ref:`TBG <usage-tbg>`.
+
+.. literalinclude:: profiles/bash/bash_picongpu.profile.example
+   :language: bash
+
 
 Hemera (HZDR)
 -------------
@@ -26,6 +49,13 @@ Hemera (HZDR)
 **User guide:** *None*
 
 **Production directory:** ``/bigdata/hplsim/`` with ``external/``, ``scratch/``, ``development/`` and ``production/``
+
+Profile for HZDR's home cluster hemera.
+Sets up software environment, i.e. providing libraries to satisfy PIConGPU's dependencies, by loading modules,
+setting common paths and options, as well as defining the ``getDevice()`` and ``getNode()`` aliases.
+The latter are shorthands to request resources for an interactive session from the batch system.
+Together with the `-s bash` option of :ref:`TBG <usage-tbg>`, these allow to run PIConGPU interactively on an HPC system.
+
 
 For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` manually.
 

--- a/docs/source/usage/tbg.rst
+++ b/docs/source/usage/tbg.rst
@@ -3,7 +3,7 @@
 TBG
 ===
 
-.. sectionauthor:: Axel Huebl
+.. sectionauthor:: Axel Huebl, Klaus Steiniger
 .. moduleauthor:: René Widera
 
 Our tool *template batch generator* (``tbg``) abstracts program runtime options from technical details of supercomputers.
@@ -48,7 +48,17 @@ Feel free to copy & paste sections of the files below into your ``.cfg``, e.g. t
 Batch System Examples
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. sectionauthor:: Axel Huebl, Richard Pausch
+.. sectionauthor:: Axel Huebl, Richard Pausch, Klaus Steiniger
+
+
+Linux workstation
+"""""""""""""""""
+
+PIConGPU can run on your laptop or workstation, even if there is no dedicated GPU available.
+In this case it will run on the CPU.
+
+In order to run PIConGPU on your machine, use ``bash`` as the submit command, i.e.
+``tbg -s bash -t etc/picongpu/bash/mpirun.tpl -c etc/picongpu/1.cfg $SCRATCH/picRuns/001``
 
 Slurm
 """""

--- a/etc/picongpu/bash/bash_picongpu.profile.example
+++ b/etc/picongpu/bash/bash_picongpu.profile.example
@@ -1,0 +1,49 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# Self-Build Software #########################################################
+# Optional, not required.
+# Needs to be compiled by the user.
+# Set environment variables required for compiling and linking PIConGPU here.
+#export PIC_LIBS=$HOME/lib
+
+# For example install openPMD-api yourself
+#   https://picongpu.readthedocs.io/en/latest/install/dependencies.html#openpmd-api
+#export OPENPMD_ROOT=$PIC_LIBS/openPMD-api
+#export CMAKE_PREFIX_PATH="$OPENPMD_ROOT:$CMAKE_PREFIX_PATH"
+#export LD_LIBRARY_PATH="$OPENPMD_ROOT/lib:$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH"
+
+# For example install pngwriter yourself:
+#   https://picongpu.readthedocs.io/en/latest/install/dependencies.html#pngwriter
+#export PNGwriter_ROOT=$PIC_LIBS/pngwriter-0.7.0
+#export CMAKE_PREFIX_PATH=$PNGwriter_ROOT:$CMAKE_PREFIX_PATH
+#export LD_LIBRARY_PATH=$PNGwriter_ROOT/lib:$LD_LIBRARY_PATH
+
+# Environment #################################################################
+#
+export PIC_BACKEND="omp2b:native" # running on cpu
+# For more examples on possible backends, depending on your hardware, see
+# https://picongpu.readthedocs.io/en/latest/usage/basics.html#pic-configure
+# or the provided profiles of other systems.
+
+export PICSRC=$HOME/WORK/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+export TBG_SUBMIT="bash"
+export TBG_TPLFILE="etc/picongpu/bash/mpirun.tpl"
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi
+


### PR DESCRIPTION
Adds a profile for system 'bash' and adds a paragraph in docs on how to run interactively using TBG.
Hopefully this helps new users to follow our introduction on their local workstation or laptop and decreases the effort to 'just  try' PIConGPU.

To be in line with this thought, the value of `PIC_BACKEND="omp2b:native"` in the profile is chosen on purpose to allow compilation and running on standard hardware.
I am not sure whether the 'native' in this definition is actually required or may not be required but rather a 'fail-safe' setting.
Please comment and I will change if necessary.