### PR TITLE
Fix EnergyHistogram and clarify usage

### DIFF
--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -95,7 +95,7 @@ You can quickly load and interact with the data in Python with:
 
    from picongpu.plugins.data import EnergyHistogramData
 
-   eh_data = EnergyHistogramData('/home/axel/runs/lwfa_001')
+   eh_data = EnergyHistogramData('path/to/run_dir') # the directory in which simOutput is located
 
    # show available iterations
    eh_data.get_iterations(species='e')
@@ -127,8 +127,10 @@ You can quickly plot the data in Python with:
    # create a figure and axes
    fig, ax = plt.subplots(1, 1)
 
-   # create the visualizer
-   eh_vis = EnergyHistogramMPL('path/to/run_dir', ax)
+   ## create the visualizer
+   # pass a list of ('identifier', 'run_dir') tuples to
+   # visualize several simulations at once
+   eh_vis = EnergyHistogramMPL(('short identifier for plot label', 'path/to/run_dir'), ax)
 
    eh_vis.visualize(iteration=200, species='e')
 

--- a/lib/python/picongpu/plugins/plot_mpl/energy_histogram_visualizer.py
+++ b/lib/python/picongpu/plugins/plot_mpl/energy_histogram_visualizer.py
@@ -53,7 +53,7 @@ class Visualizer(BaseVisualizer):
             return
 
         self.plt_obj[idx] = self.ax.semilogy(
-            bins, counts, nonposy='clip', label=label,
+            bins, counts, nonpositive='clip', label=label,
             color=self.colors[idx])[0]
 
     def _update_plt_obj(self, idx):


### PR DESCRIPTION
Fix wrong call of `pyplot.symlogy()`.
Possibly required due to upstream api change.

The updated usage in the example script avoids a warning message
that is printed otherwise.