### PR TITLE
Add a runtime option to set particle density file

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -100,6 +100,12 @@ TBG_periodic="--periodic 1 0 1"
 TBG_particleBoundaries="--e_boundary periodic absorbing thermal --e_boundaryOffset 0 10 5 --e_boundaryTemperature 0 0 20.0"
 
 
+# Specify runtime density file for given species, 'e' in the example.
+# Only has effect when FromOpenPMDImpl<Param> density is used for the species and its Param::filename is empty.
+# In case the species has multiple such FromOpenPMDImpl invocations, same runtime value is used for all of them.
+TBG_runtimeDensityFile="--e_runtimeDensityFile /bigdata/hplsim/production/someDirectory/density.bp"
+
+
 # Set absorber type of absorbing boundaries.
 # Supported values: exponential, pml (default).
 # When changing absorber type, one should normally adjust NUM_CELLS in fieldAbsorber.param

--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -237,6 +237,10 @@ namespace picongpu
             FromOpenPMDParam,
             /** Path to the openPMD input file
              *
+             * This value can alternatively be controlled at runtime by setting it to "" here and providing
+             * command-line option <species>_runtimeDensityFile. Refer to description of this command-line option for
+             * details. Note that runtime option only exists for this parameter, and not others in this struct.
+             *
              * File-based iteration format is also supported, with the usual openPMD API naming scheme.
              *
              * It is recommended to use a full path to make it independent of how PIConGPU is launched.

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -38,6 +38,7 @@
 #    include <memory>
 #    include <numeric>
 #    include <stdexcept>
+#    include <string>
 
 #    include <openPMD/openPMD.hpp>
 
@@ -45,229 +46,280 @@ namespace picongpu
 {
     namespace densityProfiles
     {
-        template<typename T_ParamClass>
-        struct FromOpenPMDImpl : public T_ParamClass
+        /** Static storage for runtime density for a species
+         *
+         * Used to propagate runtime values to FromOpenPMDImpl.
+         * Same runtime value is used for all FromOpenPMDImpl<> invocations for the same species with no compile-time
+         * value set.
+         *
+         * @tparam T_SpeciesType species type
+         */
+        template<typename T_SpeciesType>
+        struct RuntimeDensityFile
         {
-            //! Parameters type
-            using ParamClass = T_ParamClass;
-
-            //! Hook for boost::mpl::apply
-            template<typename T_SpeciesType>
-            struct apply
+            //! Access the statically stored value
+            static std::string& get()
             {
-                using type = FromOpenPMDImpl<ParamClass>;
-            };
-
-            /** Initialize the functor on the host side, includes loading the file
-             *
-             * This is MPI collective operation, must be called by all ranks.
-             *
-             * @param currentStep current time iteration
-             */
-            HINLINE FromOpenPMDImpl(uint32_t currentStep)
-            {
-                auto const& subGrid = Environment<simDim>::get().SubGrid();
-                totalLocalDomainOffset = subGrid.getGlobalDomain().offset + subGrid.getLocalDomain().offset;
-                loadFile();
+                static auto value = std::string{};
+                return value;
             }
+        };
 
-            /** Calculate the normalized density based on the file contents
+        namespace detail
+        {
+            /** Implementation of loading density from a file
              *
-             * @param totalCellOffset total offset including all slides [in cells]
+             * @tparam T_ParamClass parameter type
+             * @tparam T_SpeciesType species type
              */
-            HDINLINE float_X operator()(DataSpace<simDim> const& totalCellOffset)
+            template<typename T_ParamClass, typename T_SpeciesType>
+            struct FromOpenPMDImpl : public T_ParamClass
             {
-                auto const idx = totalCellOffset - totalLocalDomainOffset;
-                return precisionCast<float_X>(deviceDataBox(idx).x());
-            }
+                //! Parameters type
+                using ParamClass = T_ParamClass;
 
-        private:
-            //! Load density from the file to a device buffer
-            void loadFile()
-            {
-                auto& dc = Environment<>::get().DataConnector();
-                PMACC_CASSERT_MSG(_please_allocate_at_least_one_FieldTmp_in_memory_param, fieldTmpNumSlots > 0);
-                auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
-                auto& fieldBuffer = fieldTmp->getGridBuffer();
-                // Set all values to the default values, the values present in the file will be overwritten
-                fieldBuffer.getHostBuffer().setValue(ParamClass::defaultDensity);
-                auto const guards = fieldBuffer.getGridLayout().getGuard();
-                deviceDataBox = fieldBuffer.getDeviceBuffer().getDataBox().shift(guards);
+                //! Species type
+                using SpeciesType = T_SpeciesType;
 
-                /* Open a series (this does not read the dataset itself).
-                 * This is MPI collective and so has to be done by all ranks.
+                /** Initialize the functor on the host side, includes loading the file
+                 *
+                 * This is MPI collective operation, must be called by all ranks.
+                 *
+                 * @param currentStep current time iteration
                  */
-                auto& gc = Environment<simDim>::get().GridController();
-                auto series = ::openPMD::Series{
-                    ParamClass::filename,
-                    ::openPMD::Access::READ_ONLY,
-                    gc.getCommunicator().getMPIComm()};
-                auto mesh = series.iterations[ParamClass::iteration].meshes[ParamClass::datasetName];
-                ::openPMD::MeshRecordComponent dataset = mesh[::openPMD::RecordComponent::SCALAR];
-                auto const indexConverter = IndexConverter{mesh};
-                auto const datasetExtent = indexConverter.openPMDToXyz(dataset.getExtent());
-
-                // Offset of the local domain in file coordinates: global coordinates, no guards, no moving window
-                auto const& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
-                bool readFromFile = true;
-                // All indices are in PIConGPU x-y-z coordinates, unless explicitly stated otherwise
-                // Where the fieldBuffer data is starting from (no guards), so inside the local domain
-                auto localDataBoxStart = pmacc::DataSpace<simDim>::create(0);
-                // Start and extend of the file for the local domain
-                auto chunkOffset = ::openPMD::Offset(simDim, 0);
-                auto chunkExtent = ::openPMD::Extent(simDim, 0);
-                for(uint32_t d = 0; d < simDim; ++d)
+                HINLINE FromOpenPMDImpl(uint32_t currentStep)
                 {
-                    localDataBoxStart[d] = std::max(ParamClass::offset[d] - totalLocalDomainOffset[d], 0);
-                    chunkOffset[d] = std::max(totalLocalDomainOffset[d] - ParamClass::offset[d], 0);
-                    // Here we take care, as chunkExtent is unsigned
-                    int32_t extent = std::min(
-                        static_cast<int32_t>(localDomain.size[d] - localDataBoxStart[d]),
-                        static_cast<int32_t>(datasetExtent[d] - chunkOffset[d]));
-                    if(extent <= 0)
-                        readFromFile = false;
-                    else
-                        chunkExtent[d] = extent;
+                    auto const& subGrid = Environment<simDim>::get().SubGrid();
+                    totalLocalDomainOffset = subGrid.getGlobalDomain().offset + subGrid.getLocalDomain().offset;
+                    loadFile();
                 }
 
-                using ValueType = FieldTmp::ValueType::type;
-                auto data = std::shared_ptr<ValueType>{nullptr};
-                if(readFromFile)
-                {
-                    data = dataset.loadChunk<ValueType>(
-                        indexConverter.xyzToOpenPMD(chunkOffset),
-                        indexConverter.xyzToOpenPMD(chunkExtent));
-                }
-                // This is MPI collective and so has to be done by all ranks
-                series.flush();
-
-                if(readFromFile)
-                {
-                    auto const* rawData = data.get();
-                    auto const numElements = std::accumulate(
-                        std::begin(chunkExtent),
-                        std::end(chunkExtent),
-                        1u,
-                        std::multiplies<uint32_t>());
-                    auto hostDataBox = fieldBuffer.getHostBuffer().getDataBox().shift(guards + localDataBoxStart);
-                    for(uint32_t linearIdx = 0u; linearIdx < numElements; linearIdx++)
-                    {
-                        auto const idx = indexConverter.linearToXyz(linearIdx, chunkExtent);
-                        hostDataBox(idx) = rawData[linearIdx];
-                    }
-                }
-
-                // Copy host data to the device
-                fieldBuffer.hostToDevice();
-                __getTransactionEvent().waitForFinished();
-            }
-
-            /** Helper class to convert indices between x-y-z coordinates and a system defined by openPMD API mesh
-             *
-             * The latter is defined by a combination of axisLabels and dataOrder of the given mesh object.
-             * Thus, the transformation is bound to the mesh object given in the constructor, not to openPMD API in
-             * general. However, for brevity in this class it is called "openPMD coordinates"
-             */
-            class IndexConverter
-            {
-            public:
-                /** Create an index converter for the given mesh
+                /** Calculate the normalized density based on the file contents
                  *
-                 * @param mesh openPMD API mesh
+                 * @param totalCellOffset total offset including all slides [in cells]
                  */
-                IndexConverter(::openPMD::Mesh const& mesh)
+                HDINLINE float_X operator()(DataSpace<simDim> const& totalCellOffset)
                 {
-                    if(mesh.dataOrder() != ::openPMD::Mesh::DataOrder::C)
-                        throw std::runtime_error(
-                            "Unsupported dataOrder in FromOpenPMD density dataset, only C is supported");
-                    auto axisLabels = std::vector<std::string>{mesh.axisLabels()};
-                    // When the attribute is not set, openPMD API currently makes it a vector of single "x"
-                    if(axisLabels.size() <= 1)
-                        axisLabels = std::vector<std::string>{"x", "y", "z"};
-                    std::array<std::string, 3> supportedAxes = {"x", "y", "z"};
-                    for(auto d = 0; d < simDim; d++)
-                    {
-                        auto it = std::find(begin(supportedAxes), begin(supportedAxes) + simDim, axisLabels[d]);
-                        if(it != std::end(supportedAxes))
-                        {
-                            openPMDAxisIndex[d] = std::distance(begin(supportedAxes), it);
-                            xyzAxisIndex[openPMDAxisIndex[d]] = d;
-                        }
-                        else
-                            throw std::runtime_error(
-                                "Unsupported axis label " + axisLabels[d] + " in FromOpenPMD density dataset");
-                    }
-                }
-
-                /** Convert a multidimentional index from x-y-z to the openPMD coordinates
-                 *
-                 * @tparam T_Vector vector type, compatible to std::vector
-                 *
-                 * @param vector input vector
-                 */
-                template<typename T_Vector>
-                T_Vector xyzToOpenPMD(T_Vector const& vector) const
-                {
-                    auto result = vector;
-                    for(auto d = 0; d < simDim; d++)
-                        result[openPMDAxisIndex[d]] = vector[d];
-                    return result;
-                }
-
-                /** Convert a multidimentional index from openPMD to the x-y-z coordinates
-                 *
-                 * @tparam T_Vector vector type, compatible to std::vector
-                 *
-                 * @param vector input vector
-                 */
-                template<typename T_Vector>
-                T_Vector openPMDToXyz(T_Vector const& vector) const
-                {
-                    auto result = vector;
-                    for(int32_t d = 0; d < simDim; d++)
-                        result[xyzAxisIndex[d]] = vector[d];
-                    return result;
-                }
-
-                /** Convert a linear index in openPMD chunk to a multidimentional x-y-z index.
-                 *
-                 * @param openPMDLinearIndex linear index inside openPMD chunk
-                 * @param xyzChunkExtent multidimentional chunk extent in xyz
-                 */
-                pmacc::DataSpace<simDim> linearToXyz(uint32_t openPMDLinearIndex, ::openPMD::Extent xyzChunkExtent)
-                    const
-                {
-                    // Convert xyz extent to openPMD one
-                    auto const openPMDChunkExtent = xyzToOpenPMD(xyzChunkExtent);
-                    // This is index in the openPMD coordinate system, the calculation relies on the C data order
-                    pmacc::DataSpace<simDim> openPMDIdx;
-                    auto tmpIndex = openPMDLinearIndex;
-                    for(int32_t d = simDim - 1; d >= 0; d--)
-                    {
-                        openPMDIdx[d] = tmpIndex % openPMDChunkExtent[d];
-                        tmpIndex /= openPMDChunkExtent[d];
-                    }
-                    // Now we convert it to the xyz coordinates
-                    return openPMDToXyz(openPMDIdx);
+                    auto const idx = totalCellOffset - totalLocalDomainOffset;
+                    return precisionCast<float_X>(deviceDataBox(idx).x());
                 }
 
             private:
-                // openPMDAxisIndex[0] is openPMD axis index for x, [1] - for y, [2] - for z
-                pmacc::DataSpace<simDim> openPMDAxisIndex;
+                //! Load density from the file to a device buffer
+                void loadFile()
+                {
+                    auto& dc = Environment<>::get().DataConnector();
+                    PMACC_CASSERT_MSG(_please_allocate_at_least_one_FieldTmp_in_memory_param, fieldTmpNumSlots > 0);
+                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
+                    auto& fieldBuffer = fieldTmp->getGridBuffer();
+                    // Set all values to the default values, the values present in the file will be overwritten
+                    fieldBuffer.getHostBuffer().setValue(ParamClass::defaultDensity);
+                    auto const guards = fieldBuffer.getGridLayout().getGuard();
+                    deviceDataBox = fieldBuffer.getDeviceBuffer().getDataBox().shift(guards);
 
-                // xyzAxisIndex[0] is x axis index in openPMD, [1] - y, [2] - z
-                pmacc::DataSpace<simDim> xyzAxisIndex;
+                    /* Open a series (this does not read the dataset itself).
+                     * This is MPI collective and so has to be done by all ranks.
+                     */
+                    auto& gc = Environment<simDim>::get().GridController();
+                    auto const filename = getFilename();
+                    log<picLog::PHYSICS>("Loading density for species \"%1%\" from file \"%2%\"")
+                        % SpeciesType::FrameType::getName() % filename;
+                    auto series
+                        = ::openPMD::Series{filename, ::openPMD::Access::READ_ONLY, gc.getCommunicator().getMPIComm()};
+                    auto mesh = series.iterations[ParamClass::iteration].meshes[ParamClass::datasetName];
+                    ::openPMD::MeshRecordComponent dataset = mesh[::openPMD::RecordComponent::SCALAR];
+                    auto const indexConverter = IndexConverter{mesh};
+                    auto const datasetExtent = indexConverter.openPMDToXyz(dataset.getExtent());
+
+                    // Offset of the local domain in file coordinates: global coordinates, no guards, no moving window
+                    auto const& localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
+                    bool readFromFile = true;
+                    // All indices are in PIConGPU x-y-z coordinates, unless explicitly stated otherwise
+                    // Where the fieldBuffer data is starting from (no guards), so inside the local domain
+                    auto localDataBoxStart = pmacc::DataSpace<simDim>::create(0);
+                    // Start and extend of the file for the local domain
+                    auto chunkOffset = ::openPMD::Offset(simDim, 0);
+                    auto chunkExtent = ::openPMD::Extent(simDim, 0);
+                    for(uint32_t d = 0; d < simDim; ++d)
+                    {
+                        localDataBoxStart[d] = std::max(ParamClass::offset[d] - totalLocalDomainOffset[d], 0);
+                        chunkOffset[d] = std::max(totalLocalDomainOffset[d] - ParamClass::offset[d], 0);
+                        // Here we take care, as chunkExtent is unsigned
+                        int32_t extent = std::min(
+                            static_cast<int32_t>(localDomain.size[d] - localDataBoxStart[d]),
+                            static_cast<int32_t>(datasetExtent[d] - chunkOffset[d]));
+                        if(extent <= 0)
+                            readFromFile = false;
+                        else
+                            chunkExtent[d] = extent;
+                    }
+
+                    using ValueType = FieldTmp::ValueType::type;
+                    auto data = std::shared_ptr<ValueType>{nullptr};
+                    if(readFromFile)
+                    {
+                        data = dataset.loadChunk<ValueType>(
+                            indexConverter.xyzToOpenPMD(chunkOffset),
+                            indexConverter.xyzToOpenPMD(chunkExtent));
+                    }
+                    // This is MPI collective and so has to be done by all ranks
+                    series.flush();
+
+                    if(readFromFile)
+                    {
+                        auto const* rawData = data.get();
+                        auto const numElements = std::accumulate(
+                            std::begin(chunkExtent),
+                            std::end(chunkExtent),
+                            1u,
+                            std::multiplies<uint32_t>());
+                        auto hostDataBox = fieldBuffer.getHostBuffer().getDataBox().shift(guards + localDataBoxStart);
+                        for(uint32_t linearIdx = 0u; linearIdx < numElements; linearIdx++)
+                        {
+                            auto const idx = indexConverter.linearToXyz(linearIdx, chunkExtent);
+                            hostDataBox(idx) = rawData[linearIdx];
+                        }
+                    }
+
+                    // Copy host data to the device
+                    fieldBuffer.hostToDevice();
+                    __getTransactionEvent().waitForFinished();
+                }
+
+                //! Get file name to load density from
+                std::string getFilename() const
+                {
+                    auto const isCompileTimeSet = (ParamClass::filename != "");
+                    if(isCompileTimeSet)
+                        return ParamClass::filename;
+                    else
+                        return RuntimeDensityFile<SpeciesType>::get();
+                }
+
+                /** Helper class to convert indices between x-y-z coordinates and a system defined by openPMD API mesh
+                 *
+                 * The latter is defined by a combination of axisLabels and dataOrder of the given mesh object.
+                 * Thus, the transformation is bound to the mesh object given in the constructor, not to openPMD API in
+                 * general. However, for brevity in this class it is called "openPMD coordinates"
+                 */
+                class IndexConverter
+                {
+                public:
+                    /** Create an index converter for the given mesh
+                     *
+                     * @param mesh openPMD API mesh
+                     */
+                    IndexConverter(::openPMD::Mesh const& mesh)
+                    {
+                        if(mesh.dataOrder() != ::openPMD::Mesh::DataOrder::C)
+                            throw std::runtime_error(
+                                "Unsupported dataOrder in FromOpenPMD density dataset, only C is supported");
+                        auto axisLabels = std::vector<std::string>{mesh.axisLabels()};
+                        // When the attribute is not set, openPMD API currently makes it a vector of single "x"
+                        if(axisLabels.size() <= 1)
+                            axisLabels = std::vector<std::string>{"x", "y", "z"};
+                        std::array<std::string, 3> supportedAxes = {"x", "y", "z"};
+                        for(auto d = 0; d < simDim; d++)
+                        {
+                            auto it = std::find(begin(supportedAxes), begin(supportedAxes) + simDim, axisLabels[d]);
+                            if(it != std::end(supportedAxes))
+                            {
+                                openPMDAxisIndex[d] = std::distance(begin(supportedAxes), it);
+                                xyzAxisIndex[openPMDAxisIndex[d]] = d;
+                            }
+                            else
+                                throw std::runtime_error(
+                                    "Unsupported axis label " + axisLabels[d] + " in FromOpenPMD density dataset");
+                        }
+                    }
+
+                    /** Convert a multidimentional index from x-y-z to the openPMD coordinates
+                     *
+                     * @tparam T_Vector vector type, compatible to std::vector
+                     *
+                     * @param vector input vector
+                     */
+                    template<typename T_Vector>
+                    T_Vector xyzToOpenPMD(T_Vector const& vector) const
+                    {
+                        auto result = vector;
+                        for(auto d = 0; d < simDim; d++)
+                            result[openPMDAxisIndex[d]] = vector[d];
+                        return result;
+                    }
+
+                    /** Convert a multidimentional index from openPMD to the x-y-z coordinates
+                     *
+                     * @tparam T_Vector vector type, compatible to std::vector
+                     *
+                     * @param vector input vector
+                     */
+                    template<typename T_Vector>
+                    T_Vector openPMDToXyz(T_Vector const& vector) const
+                    {
+                        auto result = vector;
+                        for(int32_t d = 0; d < simDim; d++)
+                            result[xyzAxisIndex[d]] = vector[d];
+                        return result;
+                    }
+
+                    /** Convert a linear index in openPMD chunk to a multidimentional x-y-z index.
+                     *
+                     * @param openPMDLinearIndex linear index inside openPMD chunk
+                     * @param xyzChunkExtent multidimentional chunk extent in xyz
+                     */
+                    pmacc::DataSpace<simDim> linearToXyz(uint32_t openPMDLinearIndex, ::openPMD::Extent xyzChunkExtent)
+                        const
+                    {
+                        // Convert xyz extent to openPMD one
+                        auto const openPMDChunkExtent = xyzToOpenPMD(xyzChunkExtent);
+                        // This is index in the openPMD coordinate system, the calculation relies on the C data order
+                        pmacc::DataSpace<simDim> openPMDIdx;
+                        auto tmpIndex = openPMDLinearIndex;
+                        for(int32_t d = simDim - 1; d >= 0; d--)
+                        {
+                            openPMDIdx[d] = tmpIndex % openPMDChunkExtent[d];
+                            tmpIndex /= openPMDChunkExtent[d];
+                        }
+                        // Now we convert it to the xyz coordinates
+                        return openPMDToXyz(openPMDIdx);
+                    }
+
+                private:
+                    // openPMDAxisIndex[0] is openPMD axis index for x, [1] - for y, [2] - for z
+                    pmacc::DataSpace<simDim> openPMDAxisIndex;
+
+                    // xyzAxisIndex[0] is x axis index in openPMD, [1] - y, [2] - z
+                    pmacc::DataSpace<simDim> xyzAxisIndex;
+                };
+
+                /** Device data box with density values
+                 *
+                 * Density at given totalCellIdx is given by element (totalCellIdx - totalLocalDomainOffset).
+                 */
+                PMACC_ALIGN(deviceDataBox, FieldTmp::DataBoxType);
+
+                //! Total offset of the local domain in cells
+                PMACC_ALIGN(totalLocalDomainOffset, DataSpace<simDim>);
             };
+        } // namespace detail
 
-            /** Device data box with density values
-             *
-             * Density at given totalCellIdx is given by element (totalCellIdx - totalLocalDomainOffset).
-             */
-            PMACC_ALIGN(deviceDataBox, FieldTmp::DataBoxType);
-
-            //! Total offset of the local domain in cells
-            PMACC_ALIGN(totalLocalDomainOffset, DataSpace<simDim>);
+        /** Wrapper to be used in density.param, compatible with other density definitions
+         *
+         * Hooks internal implementation in detail:: to boost::mpl::apply
+         *
+         * @tparam T_ParamClass parameter type
+         */
+        template<typename T_ParamClass>
+        struct FromOpenPMDImpl : public T_ParamClass
+        {
+            template<typename T_SpeciesType>
+            struct apply
+            {
+                using type = detail::FromOpenPMDImpl<T_ParamClass, T_SpeciesType>;
+            };
         };
+
     } // namespace densityProfiles
 } // namespace picongpu
 

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -54,6 +54,7 @@
 #include "picongpu/simulation/stage/ParticleIonization.hpp"
 #include "picongpu/simulation/stage/ParticlePush.hpp"
 #include "picongpu/simulation/stage/PopulationKinetics.hpp"
+#include "picongpu/simulation/stage/RuntimeDensityFile.hpp"
 #include "picongpu/simulation/stage/SynchrotronRadiation.hpp"
 #include "picongpu/versionFormat.hpp"
 
@@ -131,6 +132,7 @@ namespace picongpu
             fieldAbsorber.registerHelp(desc);
             fieldBackground.registerHelp(desc);
             particleBoundaries.registerHelp(desc);
+            runtimeDensityFile.registerHelp(desc);
             // clang-format off
             desc.add_options()(
                 "versionOnce", po::value<bool>(&showVersionOnce)->zero_tokens(),
@@ -320,6 +322,9 @@ namespace picongpu
 
             // initialize particle boundaries
             particleBoundaries.init();
+
+            // initialize runtime density file paths
+            runtimeDensityFile.init();
 
             // Initialize random number generator and synchrotron functions, if there are synchrotron or bremsstrahlung
             // Photons
@@ -632,6 +637,10 @@ namespace picongpu
         // Particle boundaries stage, has to live always as it is used for registering options like a plugin.
         // Because of it, has a special init() method that has to be called during initialization of the simulation
         simulation::stage::ParticleBoundaries particleBoundaries;
+
+        // Runtime density file stage, has to live always as it is used for registering options like a plugin.
+        // Because of it, has a special init() method that has to be called during initialization of the simulation
+        simulation::stage::RuntimeDensityFile runtimeDensityFile;
 
 #if(PMACC_CUDA_ENABLED == 1)
         // creates lookup tables for the bremsstrahlung effect

--- a/include/picongpu/simulation/stage/RuntimeDensityFile.hpp
+++ b/include/picongpu/simulation/stage/RuntimeDensityFile.hpp
@@ -1,0 +1,124 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/Particles.hpp"
+#include "picongpu/particles/boundary/Kind.hpp"
+#include "picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/meta/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+
+namespace picongpu
+{
+    namespace simulation
+    {
+        namespace stage
+        {
+            namespace detail
+            {
+                /** Functor to set runtime density file for the given species via command-line parameters
+                 *
+                 * @tparam T_Species particle species type
+                 */
+                template<typename T_Species>
+                class RuntimeDensityFileCommandLine
+                {
+                public:
+                    //! Create runtime density file functor
+                    RuntimeDensityFileCommandLine() : prefix(T_Species::FrameType::getName())
+                    {
+                    }
+
+                    /** Register command-line options
+                     *
+                     * Done as operator() to simplify invoking with pmacc::meta::ForEach
+                     */
+                    void operator()(po::options_description& desc)
+                    {
+                        // Density from openPMD is conditionally enabled, so use same condition
+#if(ENABLE_OPENPMD == 1)
+                        auto* filename = &densityProfiles::RuntimeDensityFile<T_Species>::get();
+                        desc.add_options()(
+                            (prefix + "_runtimeDensityFile").c_str(),
+                            po::value<std::string>(filename),
+                            std::string(
+                                "Runtime density file name for species '" + prefix
+                                + "'\n. Only has effect when FromOpenPMDImpl<Param> density is used for the species "
+                                  "and its Param::filename is empty.\n")
+                                .c_str());
+#endif
+                    }
+
+                private:
+                    //! Prefix for the given species
+                    std::string prefix;
+                };
+
+            } // namespace detail
+
+            /** Functor for setting up runtime path for density from file
+             *
+             * Affects invocations of FromOpenPMDImpl<Param> with empty Param::filename.
+             * This stage allows to effectively set its value in runtime using a prefix of species it is applied to.
+             * In case there are several invocations for the same species, the same runtime parameter is used for all.
+             *
+             * Note that this is merely a runtime convenience hook for what normally is a compile-time variable.
+             * It does not perform calculations by itself, nor affects other parameters or logic of FromOpenPMDImpl.
+             */
+            class RuntimeDensityFile
+            {
+            public:
+                /** Register program options for runtime density file
+                 *
+                 * @param desc program options following boost::program_options::options_description
+                 */
+                void registerHelp(po::options_description& desc)
+                {
+                    processSpecies(desc);
+                }
+
+                /** Initialize runtime density file stage
+                 *
+                 * Sets default paths values for all affected species.
+                 */
+                void init()
+                {
+                    // All work is already done, this method exists for consistency with other similar stages
+                }
+
+            private:
+                //! Functor to process all species
+                meta::ForEach<VectorAllSpecies, detail::RuntimeDensityFileCommandLine<bmpl::_1>> processSpecies;
+            };
+
+        } // namespace stage
+    } // namespace simulation
+} // namespace picongpu


### PR DESCRIPTION
Implements suggestion #3960. After starting the implementation i realized [my original idea](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3960#issuecomment-1011018768) does not fit very well with the existing code.

So it is adjusted as follows. The `FromOpenPMDParam` struct in `density.param` is exactly the same as before. But now one could set `filename` to an empty string `""` which is treated as a special value. If such a density is applied for e.g. electrons, the path can be set as PIConGPU command-line option `--e_runtimeDensityFile`. Note that the density parameter struct itself does not know for which species it will be applied, but a user does know. The other values are still taken from the struct, however i imagine the same issue was with the file name.

I also added a log output at `PHYSICS` level that outputs that density for species `x` is loaded from file `y`, hopefully that also helps.