### PR TITLE
crusher hipcc profile

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -40,6 +40,27 @@ and providing default parameters for :ref:`TBG <usage-tbg>`.
 .. literalinclude:: profiles/bash/bash_picongpu.profile.example
    :language: bash
 
+Crusher (ORNL)
+--------------
+
+**System overview:** `link <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#system-overview>`_
+
+**Production directory:** usually ``$PROJWORK/$proj/`` (`link <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#data-and-storage>`_).
+Note that ``$HOME`` is mounted on compute nodes as read-only.
+
+For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and openPMD <install-dependencies>` manually.
+
+MI250X GPUs using hipcc (recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/crusher-ornl/batch_hipcc_picongpu.profile.example
+   :language: bash
+
+MI250X GPUs using craycc
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/crusher-ornl/batch_craycc_picongpu.profile.example
+  :language: bash
 
 Hemera (HZDR)
 -------------

--- a/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
@@ -1,13 +1,16 @@
-printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
-printf "@ Do not forget to increase the GCD's reserved memory in  @\n"
-printf "@ memory.param by setting                                 @\n"
-printf "@   constexpr size_t reservedGpuMemorySize =              @\n"
-printf "@       uint64_t(2147483648); // 2 GiB                    @\n"
-printf "@ Further, set the initial buffer size in your ADIOS2     @\n"
-printf "@ configuration of your job's *.cfg file to 28GiB,        @\n"
-printf "@ and do not use more than this amount of memory per GCD  @\n"
-printf "@ in your setup, or you will see out-of-memory errors.    @\n"
-printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" >&2
+printf "@ Do not forget to increase the GCD's reserved memory in  @\n" >&2
+printf "@ memory.param by setting                                 @\n" >&2
+printf "@   constexpr size_t reservedGpuMemorySize =              @\n" >&2
+printf "@       uint64_t(2147483648); // 2 GiB                    @\n" >&2
+printf "@ Further, set the initial buffer size in your ADIOS2     @\n" >&2
+printf "@ configuration of your job's *.cfg file to 28GiB,        @\n" >&2
+printf "@ and do not use more than this amount of memory per GCD  @\n" >&2
+printf "@ in your setup, or you will see out-of-memory errors.    @\n" >&2
+printf "@                                                         @\n" >&2
+printf "@ WARNING: Using CRAY CC is not recommended!              @\n" >&2
+printf "@          Tests showed hipcc is two times faster.        @\n" >&2
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" >&2
 
 # Name and Path of this Script ############################### (DO NOT change!)
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)

--- a/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
@@ -1,0 +1,132 @@
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" >&2
+printf "@ Do not forget to increase the GCD's reserved memory in  @\n" >&2
+printf "@ memory.param by setting                                 @\n" >&2
+printf "@   constexpr size_t reservedGpuMemorySize =              @\n" >&2
+printf "@       uint64_t(2147483648); // 2 GiB                    @\n" >&2
+printf "@ Further, set the initial buffer size in your ADIOS2     @\n" >&2
+printf "@ configuration of your job's *.cfg file to 28GiB,        @\n" >&2
+printf "@ and do not use more than this amount of memory per GCD  @\n" >&2
+printf "@ in your setup, or you will see out-of-memory errors.    @\n" >&2
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" >&2
+
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+
+# Project Information ######################################## (edit this line)
+#   - project for allocation and shared directories
+export PROJID=<yourProject>
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="vim"
+
+# General modules #############################################################
+#
+# There are a lot of required modules already loaded when connecting
+# such as mpi, libfabric and others.
+# The following modules just add to these.
+module load PrgEnv-cray/8.2.0 # Compiling with cray compiler wrapper CC
+
+module load craype-accel-amd-gfx90a
+module load rocm/4.5.2
+export CXX=hipcc
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+module load cray-mpich/8.1.12
+
+module load cmake/3.21.3
+module load zlib/1.2.11
+
+module load boost/1.77.0-cxx17
+
+module load git/2.31.1
+
+# Other Software ##############################################################
+#
+module load c-blosc/1.21.0 adios2/2.7.1 hdf5/1.12.0
+export CMAKE_PREFIX_PATH="$OLCF_C_BLOSC_ROOT:$OLCF_ADIOS2_ROOT:$HDF5_ROOT:$CMAKE_PREFIX_PATH"
+
+module load libpng/1.6.37 freetype/2.11.0
+
+# Self-Build Software #########################################################
+# Optional, not required.
+#
+# needs to be compiled by the user
+export PIC_LIBS=$HOME/lib/crusher
+
+# (not really) optionally install openPMD-api yourself
+# required when using picongpu > 0.6.0
+#   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#openpmd-api
+export OPENPMD_API_ROOT=$PIC_LIBS/openPMD-api
+export CMAKE_PREFIX_PATH="$OPENPMD_API_ROOT:$CMAKE_PREFIX_PATH"
+export LD_LIBRARY_PATH="$OPENPMD_API_ROOT/lib64:$LD_LIBRARY_PATH"
+
+# optionally install pngwriter yourself:
+#   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#pngwriter
+# But add option `-DCMAKE_CXX_COMPILER=$(which CC)` to `cmake` invocation
+export PNGwriter_ROOT=$PIC_LIBS/pngwriter-0.7.0
+export CMAKE_PREFIX_PATH=$PNGwriter_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$PNGwriter_ROOT/lib:$LD_LIBRARY_PATH
+
+# Environment #################################################################
+#
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="hip:gfx90a"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "caar" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/crusher-ornl/batch.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates two interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+}
+
+# allocate an interactive shell for one hour
+#   getDevice 2  # allocates two interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        if [ "$1" -gt 8 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
+    fi
+    srun  --time=1:00:00 --nodes=1 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi
+


### PR DESCRIPTION
- rename existing profile in `batch_craycc_picongpu.profile.example`
  - add warning which recomended to use hipcc instead of CRAY CC
- add hipcc profile `batch_hippcc.profile.example`