### PR TITLE
Replace mpl by mp11 (part 2/2)

### DIFF
--- a/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
+++ b/include/picongpu/algorithms/ShiftCoordinateSystem.hpp
@@ -23,8 +23,6 @@
 #include <pmacc/meta/ForEach.hpp>
 #include <pmacc/types.hpp>
 
-#include <boost/mpl/placeholders.hpp>
-
 namespace picongpu
 {
     /** shift to new coordinate system

--- a/include/picongpu/fields/absorber/exponential/Exponential.kernel
+++ b/include/picongpu/fields/absorber/exponential/Exponential.kernel
@@ -158,7 +158,7 @@ namespace picongpu
 
                         using SimulationDimensions = pmacc::mp_iota<pmacc::mp_int<simDim>>;
 
-                        meta::ForEach<SimulationDimensions, detail::AbsorbInOneDirection<boost::mpl::_1>>
+                        meta::ForEach<SimulationDimensions, detail::AbsorbInOneDirection<pmacc::_1>>
                             absorbInAllDirections;
 
                         absorbInAllDirections(worker, field, thickness, absorberStrength, mapper, relExchangeDir);

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -34,6 +34,7 @@
 
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Vector.hpp>
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/meta/ForEach.hpp>
 #include <pmacc/meta/conversion/MakeSeq.hpp>
 #include <pmacc/traits/IsBaseTemplateOf.hpp>
@@ -633,10 +634,10 @@ namespace picongpu
                     parameters.direction = 1.0_X;
                     parameters.sourceTimeIteration = sourceTimeIteration;
                     parameters.timeIncrement = maxwellSolver::getTimeStep();
-                    meta::ForEach<T_MinProfiles, ApplyUpdateE<boost::mpl::_1>> applyMinProfiles;
+                    meta::ForEach<T_MinProfiles, ApplyUpdateE<pmacc::_1>> applyMinProfiles;
                     applyMinProfiles(parameters);
                     parameters.direction = -1.0_X;
-                    meta::ForEach<T_MaxProfiles, ApplyUpdateE<boost::mpl::_1>> applyMaxProfiles;
+                    meta::ForEach<T_MaxProfiles, ApplyUpdateE<pmacc::_1>> applyMaxProfiles;
                     applyMaxProfiles(parameters);
                 }
 
@@ -682,10 +683,10 @@ namespace picongpu
                     parameters.direction = 1.0_X;
                     parameters.sourceTimeIteration = sourceTimeIteration;
                     parameters.timeIncrement = 0.5_X * maxwellSolver::getTimeStep();
-                    meta::ForEach<T_MinProfiles, ApplyUpdateB<boost::mpl::_1>> applyMinProfiles;
+                    meta::ForEach<T_MinProfiles, ApplyUpdateB<pmacc::_1>> applyMinProfiles;
                     applyMinProfiles(parameters);
                     parameters.direction = -1.0_X;
-                    meta::ForEach<T_MaxProfiles, ApplyUpdateB<boost::mpl::_1>> applyMaxProfiles;
+                    meta::ForEach<T_MaxProfiles, ApplyUpdateB<pmacc::_1>> applyMaxProfiles;
                     applyMaxProfiles(parameters);
                 }
 

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -35,6 +35,7 @@
 #include <pmacc/Environment.hpp>
 #include <pmacc/algorithms/math/defines/pi.hpp>
 #include <pmacc/assert.hpp>
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/pluginSystem/PluginConnector.hpp>
 
 namespace picongpu
@@ -98,7 +99,7 @@ namespace picongpu
          * Calculate omega_p for each given species and create a `picLog::PHYSICS`
          * log message
          */
-        template<typename T_Species = boost::mpl::_1>
+        template<typename T_Species = pmacc::_1>
         struct LogOmegaP
         {
             void operator()()
@@ -229,8 +230,7 @@ namespace picongpu
         {
             using namespace fields;
             using IncidentFieldProfiles = fields::incidentField::UniqueEnabledProfiles;
-            meta::ForEach<IncidentFieldProfiles, PrintIncidentFieldDispersion<boost::mpl::_1>>
-                printIncidentFieldDispersion;
+            meta::ForEach<IncidentFieldProfiles, PrintIncidentFieldDispersion<pmacc::_1>> printIncidentFieldDispersion;
             printIncidentFieldDispersion();
         }
     };

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -28,13 +28,13 @@
 #include "picongpu/particles/manipulators/manipulators.def"
 
 #include <pmacc/Environment.hpp>
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
 #include <pmacc/traits/GetFlagType.hpp>
 #include <pmacc/traits/HasFlag.hpp>
 #include <pmacc/traits/Resolve.hpp>
 
-#include <boost/mpl/apply.hpp>
 
 namespace picongpu
 {
@@ -85,18 +85,18 @@ namespace picongpu
          * @tparam T_SpeciesType type or name as PMACC_CSTRING of the used species,
          *                       see speciesDefinition.param
          */
-        template<typename T_DensityFunctor, typename T_PositionFunctor, typename T_SpeciesType = boost::mpl::_1>
+        template<typename T_DensityFunctor, typename T_PositionFunctor, typename T_SpeciesType = pmacc::_1>
         struct CreateDensity
         {
             using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
             using FrameType = typename SpeciesType::FrameType;
 
 
-            using UserDensityFunctor = typename boost::mpl::apply1<T_DensityFunctor, SpeciesType>::type;
+            using UserDensityFunctor = pmacc::Apply<T_DensityFunctor, SpeciesType>;
             /* add interface for compile time interface validation*/
             using DensityFunctor = densityProfiles::IProfile<UserDensityFunctor>;
 
-            using UserPositionFunctor = typename boost::mpl::apply1<T_PositionFunctor, SpeciesType>::type;
+            using UserPositionFunctor = pmacc::Apply<T_PositionFunctor, SpeciesType>;
             /* add interface for compile time interface validation*/
             using PositionFunctor = manipulators::IUnary<UserPositionFunctor>;
 
@@ -137,7 +137,7 @@ namespace picongpu
         template<
             typename T_Manipulator,
             typename T_SrcSpeciesType,
-            typename T_DestSpeciesType = boost::mpl::_1,
+            typename T_DestSpeciesType = pmacc::_1,
             typename T_SrcFilter = filter::All>
         struct ManipulateDerive
         {
@@ -146,9 +146,9 @@ namespace picongpu
             using SrcSpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SrcSpeciesType>;
             using SrcFrameType = typename SrcSpeciesType::FrameType;
 
-            using DestFunctor = typename boost::mpl::apply1<T_Manipulator, DestSpeciesType>::type;
+            using DestFunctor = pmacc::Apply<T_Manipulator, DestSpeciesType>;
 
-            using SrcFilter = typename boost::mpl::apply1<T_SrcFilter, SrcSpeciesType>::type;
+            using SrcFilter = pmacc::Apply<T_SrcFilter, SrcSpeciesType>;
 
             /* note: this is a FilteredManipulator with filter::All for
              * destination species, users can filter the destination directly via if's
@@ -184,10 +184,7 @@ namespace picongpu
          * @tparam T_Filter picongpu::particles::filter,
          *                  particle filter type to select source particles to derive
          */
-        template<
-            typename T_SrcSpeciesType,
-            typename T_DestSpeciesType = boost::mpl::_1,
-            typename T_Filter = filter::All>
+        template<typename T_SrcSpeciesType, typename T_DestSpeciesType = pmacc::_1, typename T_Filter = filter::All>
         struct Derive : ManipulateDerive<manipulators::generic::None, T_SrcSpeciesType, T_DestSpeciesType, T_Filter>
         {
         };
@@ -208,7 +205,7 @@ namespace picongpu
          * @tparam T_SpeciesType type or name as PMACC_CSTRING of the particle species
          *                       to fill gaps in memory
          */
-        template<typename T_SpeciesType = boost::mpl::_1>
+        template<typename T_SpeciesType = pmacc::_1>
         struct FillAllGaps
         {
             using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -213,7 +213,7 @@ namespace picongpu
                 /* push all species */
                 using VectorSpeciesWithPusher =
                     typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, particlePusher<>>::type;
-                meta::ForEach<VectorSpeciesWithPusher, PushSpecies<boost::mpl::_1>> pushSpecies;
+                meta::ForEach<VectorSpeciesWithPusher, PushSpecies<pmacc::_1>> pushSpecies;
                 pushSpecies(currentStep, eventInt, updateEventList);
 
                 /* join all push events */
@@ -223,8 +223,7 @@ namespace picongpu
                 }
 
                 /* call communication for all species */
-                meta::ForEach<VectorSpeciesWithPusher, particles::CommunicateSpecies<boost::mpl::_1>>
-                    communicateSpecies;
+                meta::ForEach<VectorSpeciesWithPusher, particles::CommunicateSpecies<pmacc::_1>> communicateSpecies;
                 communicateSpecies(updateEventList, commEventList);
 
                 /* join all communication events */
@@ -246,7 +245,7 @@ namespace picongpu
             {
                 using VectorSpeciesWithPusher =
                     typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, particlePusher<>>::type;
-                meta::ForEach<VectorSpeciesWithPusher, RemoveOuterParticles<boost::mpl::_1>> removeOuterParticles;
+                meta::ForEach<VectorSpeciesWithPusher, RemoveOuterParticles<pmacc::_1>> removeOuterParticles;
                 removeOuterParticles(currentStep);
             }
         };
@@ -326,8 +325,7 @@ namespace picongpu
                 using hasIonizers = typename HasFlag<FrameType, ionizers<>>::type;
                 if(hasIonizers::value)
                 {
-                    meta::ForEach<SelectIonizerList, CallIonizationScheme<SpeciesType, boost::mpl::_1>>
-                        particleIonization;
+                    meta::ForEach<SelectIonizerList, CallIonizationScheme<SpeciesType, pmacc::_1>> particleIonization;
                     particleIonization(cellDesc, currentStep);
                 }
             }

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -205,8 +205,7 @@ namespace picongpu
                                 using ParticleCleanedAttrList =
                                     typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type;
 
-                                meta::ForEach<ParticleCleanedAttrList, SetAttributeToDefault<boost::mpl::_1>>
-                                    setToDefault;
+                                meta::ForEach<ParticleCleanedAttrList, SetAttributeToDefault<pmacc::_1>> setToDefault;
                                 setToDefault(particle);
                             }
                             particle[multiMask_] = 1;

--- a/include/picongpu/particles/collision/WithPeer.hpp
+++ b/include/picongpu/particles/collision/WithPeer.hpp
@@ -24,9 +24,8 @@
 #include "picongpu/particles/collision/InterCollision.hpp"
 #include "picongpu/particles/collision/IntraCollision.hpp"
 
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
-
-#include <boost/mpl/apply.hpp>
 
 #include <cstdio>
 
@@ -106,8 +105,7 @@ namespace picongpu
 
                     using PeerSpecies = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_PeerSpecies>;
 
-                    using CollisionFunctor =
-                        typename boost::mpl::apply2<T_CollisionFunctor, BaseSpecies, PeerSpecies>::type;
+                    using CollisionFunctor = pmacc::Apply<T_CollisionFunctor, BaseSpecies, PeerSpecies>;
 
                     detail::WithPeer<CollisionFunctor, T_FilterPair, BaseSpecies, PeerSpecies, colliderId, pairId>{}(
                         deviceHeap,

--- a/include/picongpu/particles/debyeLength/Check.hpp
+++ b/include/picongpu/particles/debyeLength/Check.hpp
@@ -97,7 +97,7 @@ namespace picongpu
                 HINLINE std::uint32_t countElectronLikeSpecies()
                 {
                     Counter::value() = 0u;
-                    meta::ForEach<T_SpeciesSeq, ElectonLikeSpeciesCounter<boost::mpl::_1>> count;
+                    meta::ForEach<T_SpeciesSeq, ElectonLikeSpeciesCounter<pmacc::_1>> count;
                     count();
                     return Counter::value();
                 }
@@ -203,7 +203,7 @@ namespace picongpu
                 }
                 else
                 {
-                    meta::ForEach<AllSpeciesWithCurrent, detail::CheckDebyeLength<boost::mpl::_1>> checkDebyeLength;
+                    meta::ForEach<AllSpeciesWithCurrent, detail::CheckDebyeLength<pmacc::_1>> checkDebyeLength;
                     checkDebyeLength(cellDescription, isPrinting);
                 }
             }

--- a/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/EveryNthCellImpl.hpp
@@ -37,10 +37,7 @@ namespace picongpu
             using SkipCells = typename pmacc::math::CT::shrinkTo<OrgSkipCells, simDim>::type;
 
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = EveryNthCellImpl<OrgSkipCells>;
-            };
+            using fn = EveryNthCellImpl;
 
             HINLINE
             EveryNthCellImpl(uint32_t currentStep)

--- a/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FreeFormulaImpl.hpp
@@ -35,10 +35,7 @@ namespace picongpu
             using UserFunctor = particles::functor::User<T_UserFunctor>;
 
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = FreeFormulaImpl<UserFunctor>;
-            };
+            using fn = FreeFormulaImpl<UserFunctor>;
 
             HINLINE FreeFormulaImpl(uint32_t currentStep) : UserFunctor(currentStep)
             {

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -306,13 +306,12 @@ namespace picongpu
 
         /** Wrapper to be used in density.param, compatible with other density definitions
          *
-         * Hooks internal implementation in detail:: to boost::mpl::apply
-         *
          * @tparam T_ParamClass parameter type
          */
         template<typename T_ParamClass>
         struct FromOpenPMDImpl : public T_ParamClass
         {
+            // TODO(bgruber): is this supposed to hook into MPL? I cannot find where this is used.
             template<typename T_SpeciesType>
             struct apply
             {

--- a/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
@@ -34,10 +34,7 @@ namespace picongpu
             using ParamClass = T_ParamClass;
 
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = GaussianCloudImpl<ParamClass>;
-            };
+            using fn = GaussianCloudImpl;
 
             HINLINE GaussianCloudImpl(uint32_t currentStep)
             {

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -34,10 +34,7 @@ namespace picongpu
             using ParamClass = T_ParamClass;
 
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = GaussianImpl<ParamClass>;
-            };
+            using fn = GaussianImpl;
 
             HINLINE GaussianImpl(uint32_t currentStep)
             {

--- a/include/picongpu/particles/densityProfiles/HomogenousImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/HomogenousImpl.hpp
@@ -29,10 +29,7 @@ namespace picongpu
         struct HomogenousImpl
         {
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = HomogenousImpl;
-            };
+            using fn = HomogenousImpl;
 
             HINLINE HomogenousImpl(uint32_t currentStep)
             {

--- a/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/LinearExponentialImpl.hpp
@@ -32,10 +32,7 @@ namespace picongpu
             using ParamClass = T_ParamClass;
 
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = LinearExponentialImpl<ParamClass>;
-            };
+            using fn = LinearExponentialImpl;
 
             HINLINE LinearExponentialImpl(uint32_t currentStep)
             {

--- a/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
@@ -33,10 +33,7 @@ namespace picongpu
             using ParamClass = T_ParamClass;
 
             template<typename T_SpeciesType>
-            struct apply
-            {
-                using type = SphereFlanksImpl<ParamClass>;
-            };
+            using fn = SphereFlanksImpl;
 
             HINLINE SphereFlanksImpl(uint32_t currentStep)
             {

--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -54,10 +54,7 @@ namespace picongpu
             struct All
             {
                 template<typename T_SpeciesType>
-                struct apply
-                {
-                    using type = All;
-                };
+                using fn = All;
 
                 /** create filter for the accelerator
                  *

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -102,10 +102,7 @@ namespace picongpu
                 using Params = T_Params;
 
                 template<typename T_SpeciesType>
-                struct apply
-                {
-                    using type = RelativeGlobalDomainPosition;
-                };
+                using fn = RelativeGlobalDomainPosition;
 
                 HINLINE RelativeGlobalDomainPosition()
                 {

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -74,10 +74,7 @@ namespace picongpu
                     using Functor = functor::User<T_Functor>;
 
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = Free;
-                    };
+                    using fn = Free;
 
                     /** constructor
                      *

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -79,10 +79,7 @@ namespace picongpu
                     , private picongpu::particles::functor::misc::Rng<T_Distribution>
                 {
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = FreeRng;
-                    };
+                    using fn = FreeRng;
 
                     using RngGenerator = picongpu::particles::functor::misc::Rng<T_Distribution>;
 

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
@@ -21,9 +21,6 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include <boost/mpl/placeholders.hpp>
-
-
 namespace picongpu
 {
     namespace particles

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -91,10 +91,7 @@ namespace picongpu
                     using Functor = functor::User<T_Functor>;
 
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = FreeTotalCellOffset;
-                    };
+                    using fn = FreeTotalCellOffset;
 
                     /** constructor
                      *

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi.def
@@ -31,7 +31,7 @@ namespace picongpu
              *
              * @tparam T_DestSpecies electron species to be created
              * @tparam T_SrcSpecies particle species that is ionized
-             *         default is boost::mpl placeholder because specialization
+             *         default is placeholder because specialization
              *         cannot be known in list of particle species' flags
              *         @see speciesDefinition.param
              */

--- a/include/picongpu/particles/ionization/byField/ADK/ADK.def
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK.def
@@ -34,7 +34,7 @@ namespace picongpu
              * @tparam T_DestSpecies electron species to be created
              * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              * @tparam T_SrcSpecies ion species to be ionized
-             *         default is boost::mpl placeholder because specialization
+             *         default is placeholder because specialization
              *         cannot be known in list of particle species' flags
              *         @see speciesDefinition.param
              */
@@ -42,7 +42,7 @@ namespace picongpu
                 typename T_IonizationAlgorithm,
                 typename T_DestSpecies,
                 typename T_IonizationCurrent,
-                typename T_SrcSpecies = boost::mpl::_1>
+                typename T_SrcSpecies = pmacc::_1>
             struct ADK_Impl;
 
             /** Ammosov-Delone-Krainov tunneling model - linear laser polarization

--- a/include/picongpu/particles/ionization/byField/BSI/BSI.def
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI.def
@@ -34,7 +34,7 @@ namespace picongpu
              * @tparam T_DestSpecies electron species to be created
              * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              * @tparam T_SrcSpecies particle species that is ionized
-             *         default is boost::mpl placeholder because specialization
+             *         default is placeholder because specialization
              *         cannot be known in list of particle species' flags
              *         @see speciesDefinition.param
              */
@@ -42,7 +42,7 @@ namespace picongpu
                 typename T_IonizationAlgorithm,
                 typename T_DestSpecies,
                 typename T_IonizationCurrent,
-                typename T_SrcSpecies = boost::mpl::_1>
+                typename T_SrcSpecies = pmacc::_1>
             struct BSI_Impl;
 
             /** Barrier Suppression Ionization - Hydrogen-Like

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh.def
@@ -34,7 +34,7 @@ namespace picongpu
              * @tparam T_DestSpecies electron species to be created
              * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              * @tparam T_SrcSpecies ion species to be ionized
-             *         default is boost::mpl placeholder because specialization
+             *         default is placeholder because specialization
              *         cannot be known in list of particle species' flags
              *         @see speciesDefinition.param
              */
@@ -42,7 +42,7 @@ namespace picongpu
                 typename T_IonizationAlgorithm,
                 typename T_DestSpecies,
                 typename T_IonizationCurrent,
-                typename T_SrcSpecies = boost::mpl::_1>
+                typename T_SrcSpecies = pmacc::_1>
             struct Keldysh_Impl;
 
             /** Keldysh ionization model

--- a/include/picongpu/particles/manipulators/generic/Free.hpp
+++ b/include/picongpu/particles/manipulators/generic/Free.hpp
@@ -72,10 +72,7 @@ namespace picongpu
                     using Functor = functor::User<T_Functor>;
 
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = Free;
-                    };
+                    using fn = Free;
 
                     /** constructor
                      *

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -79,10 +79,7 @@ namespace picongpu
                     , private picongpu::particles::functor::misc::Rng<T_Distribution>
                 {
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = FreeRng;
-                    };
+                    using fn = FreeRng;
 
                     using RngGenerator = picongpu::particles::functor::misc::Rng<T_Distribution>;
 

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
@@ -84,10 +84,7 @@ namespace picongpu
                     using Functor = functor::User<T_Functor>;
 
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = FreeTotalCellOffset;
-                    };
+                    using fn = FreeTotalCellOffset;
 
                     /** constructor
                      *

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp
@@ -93,10 +93,7 @@ namespace picongpu
                     using Distribution = T_Distribution;
 
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = FreeTotalCellOffsetRng;
-                    };
+                    using fn = FreeTotalCellOffsetRng;
 
                     /** constructor
                      *

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -43,8 +43,6 @@
 
 #include <pmacc/meta/conversion/ToSeq.hpp>
 
-#include <boost/mpl/placeholders.hpp>
-
 #include <vector>
 
 
@@ -197,7 +195,7 @@ namespace picongpu
                 using FilteredAttribute = FilteredDerivedAttribute<T_DerivedAttribute, T_Filter>;
 
                 using type = typename traits::GenerateSolversIfSpeciesEligible<
-                    CreateFieldTmpOperation<boost::mpl::_1, T_DerivedAttribute, T_Filter>,
+                    CreateFieldTmpOperation<pmacc::_1, T_DerivedAttribute, T_Filter>,
                     SeqSpecies,
                     FilteredAttribute>::type;
             };

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def
@@ -25,9 +25,6 @@
 
 #include <pmacc/random/distributions/Uniform.hpp>
 
-#include <boost/mpl/integral_c.hpp>
-
-
 namespace picongpu
 {
     namespace particles

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
@@ -25,9 +25,6 @@
 #include "picongpu/particles/startPosition/detail/WeightMacroParticles.hpp"
 #include "picongpu/particles/startPosition/generic/FreeRng.def"
 
-#include <boost/mpl/integral_c.hpp>
-
-
 namespace picongpu
 {
     namespace particles

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -79,10 +79,7 @@ namespace picongpu
                     using Functor = T_Functor;
 
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = Free;
-                    };
+                    using fn = Free;
 
                     /** constructor
                      *

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -84,10 +84,7 @@ namespace picongpu
                     , private picongpu::particles::functor::misc::Rng<T_Distribution>
                 {
                     template<typename T_SpeciesType>
-                    struct apply
-                    {
-                        using type = FreeRng;
-                    };
+                    using fn = FreeRng;
 
                     using RngGenerator = picongpu::particles::functor::misc::Rng<T_Distribution>;
 

--- a/include/picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp
+++ b/include/picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp
@@ -21,9 +21,8 @@
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/meta/conversion/ToSeq.hpp>
-
-#include <boost/mpl/apply.hpp>
 
 namespace picongpu
 {
@@ -64,7 +63,7 @@ namespace picongpu
                 using SeqEligibleSpecies = pmacc::mp_copy_if<SeqSpecies, Predicate>;
 
                 template<typename T>
-                using Op = typename boost::mpl::apply1<Solver, T>::type;
+                using Op = pmacc::Apply<Solver, T>;
                 using type = pmacc::mp_transform<Op, SeqEligibleSpecies>;
             };
         } // namespace traits

--- a/include/picongpu/particles/traits/GetIonizerList.hpp
+++ b/include/picongpu/particles/traits/GetIonizerList.hpp
@@ -21,12 +21,11 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/meta/accessors/Type.hpp>
 #include <pmacc/meta/conversion/OperateOnSeq.hpp>
 #include <pmacc/traits/GetFlagType.hpp>
 #include <pmacc/traits/Resolve.hpp>
-
-#include <boost/mpl/apply.hpp>
 
 
 namespace picongpu
@@ -57,7 +56,7 @@ namespace picongpu
 
                 using type = typename pmacc::OperateOnSeq<
                     FoundIonizerList,
-                    boost::mpl::apply1<boost::mpl::_1, SpeciesType>,
+                    pmacc::Apply<pmacc::_1, SpeciesType>,
                     pmacc::meta::accessors::Type<>>::type;
             };
 

--- a/include/picongpu/particles/traits/GetMarginPusher.hpp
+++ b/include/picongpu/particles/traits/GetMarginPusher.hpp
@@ -36,29 +36,17 @@ namespace picongpu
          * @tparam T_GetLowerMargin lower margin for pusher getter type
          * @tparam T_GetUpperMargin upper margin for pusher getter type
          */
-        template<
-            typename T_Species,
-            typename T_GetLowerMargin = GetLowerMargin<GetPusher<boost::mpl::_1>>,
-            typename T_GetUpperMargin = GetUpperMargin<GetPusher<boost::mpl::_1>>>
+        template<typename T_Species, typename T_GetLowerMargin, typename T_GetUpperMargin>
         struct GetMarginPusher
         {
-            using AddLowerMargins
-                = pmacc::math::CT::add<GetLowerMargin<GetInterpolation<boost::mpl::_1>>, T_GetLowerMargin>;
-            using LowerMargin = typename boost::mpl::apply<AddLowerMargins, T_Species>::type;
+        private:
+            using Interpolation = typename GetInterpolation<T_Species>::type;
 
-            using AddUpperMargins
-                = pmacc::math::CT::add<GetUpperMargin<GetInterpolation<boost::mpl::_1>>, T_GetUpperMargin>;
-            using UpperMargin = typename boost::mpl::apply<AddUpperMargins, T_Species>::type;
-        };
-
-        /** Get lower margin of a pusher for species
-         *
-         * @tparam T_Species particle species type
-         */
-        template<typename T_Species>
-        struct GetLowerMarginPusher
-        {
-            using type = typename traits::GetMarginPusher<T_Species>::LowerMargin;
+        public:
+            using LowerMargin =
+                typename pmacc::math::CT::add<typename GetLowerMargin<Interpolation>::type, T_GetLowerMargin>::type;
+            using UpperMargin =
+                typename pmacc::math::CT::add<typename GetUpperMargin<Interpolation>::type, T_GetUpperMargin>::type;
         };
 
         /** Get lower margin of the given pusher for species
@@ -78,14 +66,13 @@ namespace picongpu
                 typename GetUpperMargin<T_Pusher>::type>::LowerMargin;
         };
 
-        /** Get upper margin of a pusher for species
+        /** Get lower margin of a pusher for species
          *
          * @tparam T_Species particle species type
          */
         template<typename T_Species>
-        struct GetUpperMarginPusher
+        struct GetLowerMarginPusher : GetLowerMarginForPusher<T_Species, typename GetPusher<T_Species>::type>
         {
-            using type = typename traits::GetMarginPusher<T_Species>::UpperMargin;
         };
 
         /** Get upper margin of the given pusher for species
@@ -103,6 +90,15 @@ namespace picongpu
                 T_Species,
                 typename GetLowerMargin<T_Pusher>::type,
                 typename GetUpperMargin<T_Pusher>::type>::UpperMargin;
+        };
+
+        /** Get upper margin of a pusher for species
+         *
+         * @tparam T_Species particle species type
+         */
+        template<typename T_Species>
+        struct GetUpperMarginPusher : GetUpperMarginForPusher<T_Species, typename GetPusher<T_Species>::type>
+        {
         };
 
     } // namespace traits

--- a/include/picongpu/particles/traits/GetShape.hpp
+++ b/include/picongpu/particles/traits/GetShape.hpp
@@ -33,6 +33,7 @@ namespace picongpu
         {
             using type = typename pmacc::traits::Resolve<
                 typename GetFlagType<typename T_Species::FrameType, shape<>>::type>::type;
+            static_assert(!std::is_void_v<type>);
         };
 
     } // namespace traits

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -230,7 +230,7 @@ namespace picongpu
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{}) override
             {
-                meta::ForEach<EligibleFilters, plugins::misc::AppendName<boost::mpl::_1>> getEligibleFilterNames;
+                meta::ForEach<EligibleFilters, plugins::misc::AppendName<pmacc::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
 
                 concatenatedFilterNames = plugins::misc::concatenateToString(allowedFilters, ", ");
@@ -448,7 +448,7 @@ namespace picongpu
                 mapper,
                 std::placeholders::_1);
 
-            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(
+            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<pmacc::_1>>{}(
                 m_help->filter.get(m_id),
                 currentStep,
                 bindKernel);

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -197,8 +197,8 @@ namespace picongpu
         /* calculate and add the charge density values from all species in FieldTmp */
         meta::ForEach<
             EligibleSpecies,
-            picongpu::detail::ComputeChargeDensity<boost::mpl::_1, pmacc::mp_int<CORE + BORDER>>,
-            boost::mpl::_1>
+            picongpu::detail::ComputeChargeDensity<pmacc::_1, pmacc::mp_int<CORE + BORDER>>,
+            pmacc::_1>
             computeChargeDensity;
         computeChargeDensity(fieldTmp.get(), currentStep);
 

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -237,7 +237,7 @@ namespace picongpu
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{}) override
             {
-                meta::ForEach<EligibleFilters, plugins::misc::AppendName<boost::mpl::_1>> getEligibleFilterNames;
+                meta::ForEach<EligibleFilters, plugins::misc::AppendName<pmacc::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
 
                 concatenatedFilterNames = plugins::misc::concatenateToString(allowedFilters, ", ");
@@ -489,7 +489,7 @@ namespace picongpu
                 mapper,
                 std::placeholders::_1);
 
-            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(
+            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<pmacc::_1>>{}(
                 m_help->filter.get(m_id),
                 currentStep,
                 binaryKernel);

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -195,7 +195,7 @@ namespace picongpu
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{}) override
             {
-                meta::ForEach<EligibleFilters, plugins::misc::AppendName<boost::mpl::_1>> getEligibleFilterNames;
+                meta::ForEach<EligibleFilters, plugins::misc::AppendName<pmacc::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
 
                 concatenatedFilterNames = plugins::misc::concatenateToString(allowedFilters, ", ");
@@ -360,7 +360,7 @@ namespace picongpu
                 mapper,
                 std::placeholders::_1);
 
-            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(
+            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<pmacc::_1>>{}(
                 m_help->filter.get(m_id),
                 currentStep,
                 binaryKernel);

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -100,7 +100,7 @@ namespace picongpu
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{}) override
             {
-                meta::ForEach<EligibleFilters, plugins::misc::AppendName<boost::mpl::_1>> getEligibleFilterNames;
+                meta::ForEach<EligibleFilters, plugins::misc::AppendName<pmacc::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
 
                 concatenatedFilterNames = plugins::misc::concatenateToString(allowedFilters, ", ");

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -186,7 +186,7 @@ namespace picongpu
             // particle filter
             std::placeholders::_1);
 
-        meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(
+        meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<pmacc::_1>>{}(
             m_help->filter.get(m_id),
             currentStep,
             bindFunctor);

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -112,8 +112,7 @@ namespace picongpu
              *                       with two components
              */
             template<typename T_TupleVector>
-            using Apply = typename boost::mpl::
-                apply1<pmacc::mp_at_c<T_TupleVector, plugin>, pmacc::mp_at_c<T_TupleVector, species>>::type;
+            using Apply = pmacc::Apply<pmacc::mp_at_c<T_TupleVector, plugin>, pmacc::mp_at_c<T_TupleVector, species>>;
 
             /** Check the combination Species+Plugin in the Tuple
              *
@@ -151,24 +150,24 @@ namespace picongpu
 
         /* define species plugins */
         using UnspecializedSpeciesPlugins = pmacc::mp_list<
-            plugins::multi::Master<EnergyParticles<boost::mpl::_1>>,
-            plugins::multi::Master<CalcEmittance<boost::mpl::_1>>,
-            plugins::multi::Master<BinEnergyParticles<boost::mpl::_1>>,
-            CountParticles<boost::mpl::_1>,
-            PngPlugin<Visualisation<boost::mpl::_1, PngCreator>>,
-            plugins::transitionRadiation::TransitionRadiation<boost::mpl::_1>
+            plugins::multi::Master<EnergyParticles<pmacc::_1>>,
+            plugins::multi::Master<CalcEmittance<pmacc::_1>>,
+            plugins::multi::Master<BinEnergyParticles<pmacc::_1>>,
+            CountParticles<pmacc::_1>,
+            PngPlugin<Visualisation<pmacc::_1, PngCreator>>,
+            plugins::transitionRadiation::TransitionRadiation<pmacc::_1>
 #if ENABLE_OPENPMD
             ,
-            plugins::radiation::Radiation<boost::mpl::_1>
+            plugins::radiation::Radiation<pmacc::_1>
 #endif
 #if(ENABLE_OPENPMD == 1)
             ,
-            plugins::multi::Master<ParticleCalorimeter<boost::mpl::_1>>,
-            plugins::multi::Master<PhaseSpace<particles::shapes::Counter::ChargeAssignment, boost::mpl::_1>>
+            plugins::multi::Master<ParticleCalorimeter<pmacc::_1>>,
+            plugins::multi::Master<PhaseSpace<particles::shapes::Counter::ChargeAssignment, pmacc::_1>>
 #endif
 #if(ENABLE_OPENPMD == 1)
             ,
-            PerSuperCell<boost::mpl::_1>
+            PerSuperCell<pmacc::_1>
 #endif
             >;
 
@@ -189,7 +188,7 @@ namespace picongpu
          */
         virtual void init()
         {
-            meta::ForEach<AllPlugins, PushBack<boost::mpl::_1>> pushBack;
+            meta::ForEach<AllPlugins, PushBack<pmacc::_1>> pushBack;
             pushBack(plugins);
         }
 

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -43,8 +43,6 @@
 #include <pmacc/particles/particleFilter/FilterFactory.hpp>
 #include <pmacc/particles/particleFilter/PositionFilter.hpp>
 
-#include <boost/mpl/placeholders.hpp>
-
 #include <algorithm>
 #include <type_traits> // std::remove_reference_t
 
@@ -107,14 +105,14 @@ namespace picongpu
             {
                 /* malloc host memory */
                 log<picLog::INPUT_OUTPUT>("openPMD:   (begin) malloc host memory: %1%") % name;
-                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, MallocHostMemory<boost::mpl::_1>> mallocMem;
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, MallocHostMemory<pmacc::_1>> mallocMem;
                 mallocMem(hostFrame, myNumParticles);
                 log<picLog::INPUT_OUTPUT>("openPMD:   ( end ) malloc host memory: %1%") % name;
             }
 
             void free(openPMDFrameType& hostFrame) override
             {
-                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, FreeHostMemory<boost::mpl::_1>> freeMem;
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, FreeHostMemory<pmacc::_1>> freeMem;
                 freeMem(hostFrame);
             }
 
@@ -177,14 +175,14 @@ namespace picongpu
             {
                 log<picLog::INPUT_OUTPUT>("openPMD:  (begin) malloc mapped memory: %1%") % name;
                 /*malloc mapped memory*/
-                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, MallocMappedMemory<boost::mpl::_1>> mallocMem;
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, MallocMappedMemory<pmacc::_1>> mallocMem;
                 mallocMem(mappedFrame, myNumParticles);
                 log<picLog::INPUT_OUTPUT>("openPMD:  ( end ) malloc mapped memory: %1%") % name;
             }
 
             void free(openPMDFrameType& mappedFrame) override
             {
-                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, FreeMappedMemory<boost::mpl::_1>> freeMem;
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, FreeMappedMemory<pmacc::_1>> freeMem;
                 freeMem(mappedFrame);
             }
 
@@ -418,7 +416,7 @@ namespace picongpu
                 log<picLog::INPUT_OUTPUT>("openPMD:  (begin) write particle records for %1%")
                     % T_SpeciesFilter::getName();
 
-                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, openPMD::ParticleAttribute<boost::mpl::_1>>
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, openPMD::ParticleAttribute<pmacc::_1>>
                     writeToOpenPMD;
                 writeToOpenPMD(
                     params,

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -70,8 +70,6 @@
 #include <pmacc/static_assert.hpp>
 #include <pmacc/traits/Limits.hpp>
 
-#include <boost/mpl/placeholders.hpp>
-
 #include <openPMD/openPMD.hpp>
 
 #if !defined(_WIN32)
@@ -274,11 +272,11 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{}) override
             {
-                meta::ForEach<AllEligibleSpeciesSources, plugins::misc::AppendName<boost::mpl::_1>>
+                meta::ForEach<AllEligibleSpeciesSources, plugins::misc::AppendName<pmacc::_1>>
                     getEligibleDataSourceNames;
                 getEligibleDataSourceNames(allowedDataSources);
 
-                meta::ForEach<AllFieldSources, plugins::misc::AppendName<boost::mpl::_1>> appendFieldSourceNames;
+                meta::ForEach<AllFieldSources, plugins::misc::AppendName<pmacc::_1>> appendFieldSourceNames;
                 appendFieldSourceNames(allowedDataSources);
 
                 // string list with all possible particle sources
@@ -1109,11 +1107,11 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 mThreadParams.localWindowToDomainOffset = DataSpace<simDim>::create(0);
 
                 /* load all fields */
-                meta::ForEach<FileCheckpointFields, LoadFields<boost::mpl::_1>> ForEachLoadFields;
+                meta::ForEach<FileCheckpointFields, LoadFields<pmacc::_1>> ForEachLoadFields;
                 ForEachLoadFields(&mThreadParams);
 
                 /* load all particles */
-                meta::ForEach<FileCheckpointParticles, LoadSpecies<boost::mpl::_1>> ForEachLoadSpecies;
+                meta::ForEach<FileCheckpointParticles, LoadSpecies<pmacc::_1>> ForEachLoadSpecies;
                 ForEachLoadSpecies(&mThreadParams, restartChunkSize);
 
                 loadRngStates(&mThreadParams);
@@ -1201,7 +1199,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                      * them for sure (checkpoint) or just some user-defined species
                      * (dump)
                      */
-                    meta::ForEach<FileCheckpointParticles, CopySpeciesToHost<boost::mpl::_1>> copySpeciesToHost;
+                    meta::ForEach<FileCheckpointParticles, CopySpeciesToHost<pmacc::_1>> copySpeciesToHost;
                     copySpeciesToHost();
                     lastSpeciesSyncStep = currentStep;
                 }
@@ -1537,19 +1535,19 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 log<picLog::INPUT_OUTPUT>("openPMD: (begin) writing fields.");
                 if(threadParams->isCheckpoint)
                 {
-                    meta::ForEach<FileCheckpointFields, GetFields<boost::mpl::_1>> ForEachGetFields;
+                    meta::ForEach<FileCheckpointFields, GetFields<pmacc::_1>> ForEachGetFields;
                     ForEachGetFields(threadParams);
                 }
                 else
                 {
                     if(dumpFields)
                     {
-                        meta::ForEach<FileOutputFields, GetFields<boost::mpl::_1>> ForEachGetFields;
+                        meta::ForEach<FileOutputFields, GetFields<pmacc::_1>> ForEachGetFields;
                         ForEachGetFields(threadParams);
                     }
 
                     // move over all field data sources
-                    meta::ForEach<typename Help::AllFieldSources, CallGetFields<boost::mpl::_1>>{}(
+                    meta::ForEach<typename Help::AllFieldSources, CallGetFields<pmacc::_1>>{}(
                         vectorOfDataSourceNames,
                         threadParams);
                 }
@@ -1563,8 +1561,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     meta::ForEach<
                         FileCheckpointParticles,
                         WriteSpecies<
-                            plugins::misc::SpeciesFilter<boost::mpl::_1>,
-                            plugins::misc::UnfilteredSpecies<boost::mpl::_1>>>
+                            plugins::misc::SpeciesFilter<pmacc::_1>,
+                            plugins::misc::UnfilteredSpecies<pmacc::_1>>>
                         writeSpecies;
                     writeSpecies(threadParams, particleToTotalDomainOffset);
                 }
@@ -1574,15 +1572,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     if(dumpAllParticles)
                     {
                         // move over all species defined in FileOutputParticles
-                        meta::ForEach<
-                            FileOutputParticles,
-                            WriteSpecies<plugins::misc::UnfilteredSpecies<boost::mpl::_1>>>
+                        meta::ForEach<FileOutputParticles, WriteSpecies<plugins::misc::UnfilteredSpecies<pmacc::_1>>>
                             writeSpecies;
                         writeSpecies(threadParams, particleToTotalDomainOffset);
                     }
 
                     // move over all species data sources
-                    meta::ForEach<typename Help::AllEligibleSpeciesSources, CallWriteSpecies<boost::mpl::_1>>{}(
+                    meta::ForEach<typename Help::AllEligibleSpeciesSources, CallWriteSpecies<pmacc::_1>>{}(
                         vectorOfDataSourceNames,
                         threadParams,
                         particleToTotalDomainOffset);

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -32,8 +32,6 @@
 #include <pmacc/particles/ParticleDescription.hpp>
 #include <pmacc/particles/operations/splitIntoListOfFrames.kernel>
 
-#include <boost/mpl/placeholders.hpp>
-
 #include <cassert>
 #include <stdexcept>
 
@@ -134,12 +132,11 @@ namespace picongpu
                 openPMDFrameType mappedFrame;
                 log<picLog::INPUT_OUTPUT>("openPMD: malloc mapped memory: %1%") % speciesName;
                 /*malloc mapped memory*/
-                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, MallocMappedMemory<boost::mpl::_1>> mallocMem;
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, MallocMappedMemory<pmacc::_1>> mallocMem;
                 mallocMem(mappedFrame, totalNumParticles);
 
-                meta::
-                    ForEach<typename openPMDFrameType::ValueTypeSeq, LoadParticleAttributesFromOpenPMD<boost::mpl::_1>>
-                        loadAttributes;
+                meta::ForEach<typename openPMDFrameType::ValueTypeSeq, LoadParticleAttributesFromOpenPMD<pmacc::_1>>
+                    loadAttributes;
                 loadAttributes(params, mappedFrame, particleSpecies, particleOffset, totalNumParticles);
 
                 if(totalNumParticles != 0)
@@ -155,7 +152,7 @@ namespace picongpu
                         picLog::INPUT_OUTPUT());
 
                     /*free host memory*/
-                    meta::ForEach<typename openPMDFrameType::ValueTypeSeq, FreeMappedMemory<boost::mpl::_1>> freeMem;
+                    meta::ForEach<typename openPMDFrameType::ValueTypeSeq, FreeMappedMemory<pmacc::_1>> freeMem;
                     freeMem(mappedFrame);
                 }
                 log<picLog::INPUT_OUTPUT>("openPMD: ( end ) load species: %1%") % speciesName;

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -124,11 +124,8 @@ namespace picongpu
     struct OperatorCreateVectorBox
     {
         template<typename InType>
-        struct apply
-        {
-            using type
-                = pmacc::meta::Pair<InType, pmacc::VectorDataBox<typename pmacc::traits::Resolve<InType>::type::type>>;
-        };
+        using fn
+            = pmacc::meta::Pair<InType, pmacc::VectorDataBox<typename pmacc::traits::Resolve<InType>::type::type>>;
     };
 
 } // namespace picongpu

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -49,6 +49,7 @@
 #include <pmacc/memory/boxes/SharedBox.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/meta/Apply.hpp>
 #include <pmacc/meta/ForEach.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
@@ -164,7 +165,7 @@ namespace picongpu
         HDINLINE static float_X getAmplitude()
         {
             using Profiles = fields::incidentField::UniqueEnabledProfiles;
-            meta::ForEach<Profiles, CalculateMaxAmplitude<boost::mpl::_1>> calculateMaxAmplitude;
+            meta::ForEach<Profiles, CalculateMaxAmplitude<pmacc::_1>> calculateMaxAmplitude;
             auto maxAmplitude = 0.0_X;
             calculateMaxAmplitude(maxAmplitude);
             return maxAmplitude;

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -438,7 +438,7 @@ namespace picongpu
                 boost::program_options::options_description& desc,
                 std::string const& masterPrefix = std::string{}) override
             {
-                meta::ForEach<EligibleFilters, plugins::misc::AppendName<boost::mpl::_1>> getEligibleFilterNames;
+                meta::ForEach<EligibleFilters, plugins::misc::AppendName<pmacc::_1>> getEligibleFilterNames;
                 getEligibleFilterNames(allowedFilters);
 
                 concatenatedFilterNames = plugins::misc::concatenateToString(allowedFilters, ", ");
@@ -578,7 +578,7 @@ namespace picongpu
                 endInternalCellsLocal,
                 std::placeholders::_1);
 
-            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(
+            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<pmacc::_1>>{}(
                 m_help->filter.get(m_id),
                 currentStep,
                 unaryKernel);
@@ -644,7 +644,7 @@ namespace picongpu
                 endExternalCellsLocal,
                 std::placeholders::_1);
 
-            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(
+            meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<pmacc::_1>>{}(
                 m_help->filter.get(m_id),
                 Environment<>::get().SimulationDescription().getCurrentStep(),
                 unaryKernel);

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -79,7 +79,6 @@
 #include <pmacc/verify.hpp>
 
 #include <boost/lexical_cast.hpp>
-#include <boost/mpl/placeholders.hpp>
 
 #include <algorithm>
 #include <array>
@@ -354,7 +353,8 @@ namespace picongpu
 #endif
 
             // Allocate and initialize particle species with all left-over memory below
-            meta::ForEach<VectorAllSpecies, particles::CreateSpecies<boost::mpl::_1>> createSpeciesMemory;
+
+            meta::ForEach<VectorAllSpecies, particles::CreateSpecies<pmacc::_1>> createSpeciesMemory;
             createSpeciesMemory(deviceHeap, cellDescription.get());
 
             size_t freeGpuMem = freeDeviceMemory();
@@ -394,7 +394,7 @@ namespace picongpu
 
 #endif
 
-            meta::ForEach<VectorAllSpecies, particles::LogMemoryStatisticsForSpecies<boost::mpl::_1>>
+            meta::ForEach<VectorAllSpecies, particles::LogMemoryStatisticsForSpecies<pmacc::_1>>
                 logMemoryStatisticsForSpecies;
             logMemoryStatisticsForSpecies(deviceHeap);
 
@@ -463,7 +463,7 @@ namespace picongpu
                 else
                 {
                     initialiserController->init();
-                    meta::ForEach<particles::InitPipeline, pmacc::functor::Call<boost::mpl::_1>> initSpecies;
+                    meta::ForEach<particles::InitPipeline, pmacc::functor::Call<pmacc::_1>> initSpecies;
                     initSpecies(0);
                     /* Remove all particles that are outside the respective boundaries
                      * (this can happen if density functor didn't account for it).
@@ -556,7 +556,7 @@ namespace picongpu
         void resetAll(uint32_t currentStep) override
         {
             resetFields(currentStep);
-            meta::ForEach<VectorAllSpecies, particles::CallReset<boost::mpl::_1>> resetParticles;
+            meta::ForEach<VectorAllSpecies, particles::CallReset<pmacc::_1>> resetParticles;
             resetParticles(currentStep);
         }
 
@@ -569,7 +569,7 @@ namespace picongpu
                 log<picLog::SIMULATION_STATE>("slide in step %1%") % currentStep;
                 resetAll(currentStep);
                 initialiserController->slide(currentStep);
-                meta::ForEach<particles::InitPipeline, pmacc::functor::Call<boost::mpl::_1>> initSpecies;
+                meta::ForEach<particles::InitPipeline, pmacc::functor::Call<pmacc::_1>> initSpecies;
                 initSpecies(currentStep);
             }
         }

--- a/include/picongpu/simulation/stage/AtomicPhysics.hpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.hpp
@@ -25,6 +25,7 @@
 // actual call to kernel found here
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/meta/Apply.hpp>
 
 #include <cstdint>
 
@@ -81,9 +82,8 @@ namespace picongpu
                     typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, atomicPhysicsSolver<>>::type;
 
                 //! kernel to be called for each species
-                pmacc::meta::
-                    ForEach<SpeciesWithAtomicPhysics, particles::atomicPhysics::CallAtomicPhysics<boost::mpl::_1>>
-                        callAtomicPhysics;
+                pmacc::meta::ForEach<SpeciesWithAtomicPhysics, particles::atomicPhysics::CallAtomicPhysics<pmacc::_1>>
+                    callAtomicPhysics;
 
                 /** Description of cell structure used for PIC-Simulations.
                  *

--- a/include/picongpu/simulation/stage/CurrentDeposition.hpp
+++ b/include/picongpu/simulation/stage/CurrentDeposition.hpp
@@ -74,7 +74,7 @@ namespace picongpu
                         typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, current<>>::type;
                     meta::ForEach<
                         SpeciesWithCurrentSolver,
-                        detail::CurrentDeposition<boost::mpl::_1, pmacc::mp_int<type::CORE + type::BORDER>>>
+                        detail::CurrentDeposition<pmacc::_1, pmacc::mp_int<type::CORE + type::BORDER>>>
                         depositCurrent;
                     depositCurrent(step, fieldJ, dc);
                 }

--- a/include/picongpu/simulation/stage/IterationStart.hpp
+++ b/include/picongpu/simulation/stage/IterationStart.hpp
@@ -44,7 +44,7 @@ namespace picongpu
                  */
                 void operator()(uint32_t const step) const
                 {
-                    meta::ForEach<IterationStartPipeline, pmacc::functor::Call<boost::mpl::_1>> callFunctors;
+                    meta::ForEach<IterationStartPipeline, pmacc::functor::Call<pmacc::_1>> callFunctors;
                     callFunctors(step);
                 }
             };

--- a/include/picongpu/simulation/stage/ParticleBoundaries.hpp
+++ b/include/picongpu/simulation/stage/ParticleBoundaries.hpp
@@ -231,7 +231,7 @@ namespace picongpu
                 using SpeciesWithPusher =
                     typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, particlePusher<>>::type;
                 //! Functor to process all affected species
-                meta::ForEach<SpeciesWithPusher, detail::ParticleBoundariesCommandLine<boost::mpl::_1>> processSpecies;
+                meta::ForEach<SpeciesWithPusher, detail::ParticleBoundariesCommandLine<pmacc::_1>> processSpecies;
             };
 
         } // namespace stage

--- a/include/picongpu/simulation/stage/ParticleIonization.hpp
+++ b/include/picongpu/simulation/stage/ParticleIonization.hpp
@@ -58,8 +58,7 @@ namespace picongpu
                 {
                     using pmacc::particles::traits::FilterByFlag;
                     using SpeciesWithIonizers = typename FilterByFlag<VectorAllSpecies, ionizers<>>::type;
-                    pmacc::meta::ForEach<SpeciesWithIonizers, particles::CallIonization<boost::mpl::_1>>
-                        particleIonization;
+                    pmacc::meta::ForEach<SpeciesWithIonizers, particles::CallIonization<pmacc::_1>> particleIonization;
                     particleIonization(cellDescription, step);
                 }
 

--- a/include/picongpu/simulation/stage/RuntimeDensityFile.hpp
+++ b/include/picongpu/simulation/stage/RuntimeDensityFile.hpp
@@ -116,7 +116,7 @@ namespace picongpu
 
             private:
                 //! Functor to process all species
-                meta::ForEach<VectorAllSpecies, detail::RuntimeDensityFileCommandLine<boost::mpl::_1>> processSpecies;
+                meta::ForEach<VectorAllSpecies, detail::RuntimeDensityFileCommandLine<pmacc::_1>> processSpecies;
             };
 
         } // namespace stage

--- a/include/pmacc/functor/Call.hpp
+++ b/include/pmacc/functor/Call.hpp
@@ -23,10 +23,7 @@
 
 #include "pmacc/types.hpp"
 
-#include <boost/mpl/placeholders.hpp>
-
 #include <cstdint>
-
 
 namespace pmacc
 {
@@ -37,7 +34,7 @@ namespace pmacc
          * @tparam T_Functor stateless unary functor type, must be default-constructible and
          *         operator() must take the current time step as the only parameter
          */
-        template<typename T_Functor = boost::mpl::_1>
+        template<typename T_Functor = pmacc::_1>
         struct Call
         {
             //! Functor type

--- a/include/pmacc/functor/Filtered.hpp
+++ b/include/pmacc/functor/Filtered.hpp
@@ -95,13 +95,7 @@ namespace pmacc
          * A unary filters means that each argument can only pass the same filter
          * check before its results are combined.
          */
-        template<
-            typename T_FilterOperator,
-            typename T_Filter,
-            typename T_Functor,
-            uint32_t T_numFunctorArguments
-
-            >
+        template<typename T_FilterOperator, typename T_Filter, typename T_Functor, uint32_t T_numFunctorArguments>
         struct Filtered<
             T_FilterOperator,
             filter::Interface<T_Filter, 1u>,
@@ -109,14 +103,8 @@ namespace pmacc
             : private filter::Interface<T_Filter, 1u>
             , Interface<T_Functor, T_numFunctorArguments, void>
         {
-            template<typename... T_Params>
-            struct apply
-            {
-                using type = Filtered<
-                    T_FilterOperator,
-                    typename boost::mpl::apply<T_Filter, T_Params...>::type,
-                    typename boost::mpl::apply<T_Functor, T_Params...>::type>;
-            };
+            // template<typename... T_Params>
+            // using fn = Filtered<T_FilterOperator, Apply<T_Filter, T_Params...>, Apply<T_Functor, T_Params...>>;
 
             using Filter = filter::Interface<T_Filter, 1u>;
             using Functor = Interface<T_Functor, T_numFunctorArguments, void>;

--- a/include/pmacc/mappings/simulation/ResourceMonitor.tpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.tpp
@@ -70,7 +70,7 @@ namespace pmacc
     {
         using dim = std::integral_constant<unsigned int, T_DIM>;
         std::vector<size_t> particleCounts;
-        meta::ForEach<T_Species, MyCountParticles<dim, boost::mpl::_1>> countParticles;
+        meta::ForEach<T_Species, MyCountParticles<dim, pmacc::_1>> countParticles;
         countParticles(particleCounts, cellDescription, parFilter);
         return particleCounts;
     }

--- a/include/pmacc/math/MapTuple.hpp
+++ b/include/pmacc/math/MapTuple.hpp
@@ -28,8 +28,6 @@ namespace pmacc
 {
     namespace math
     {
-        namespace bmpl = boost::mpl;
-
         /** wrap a datum
          *
          * @tparam T_Pair mp_list< key, type of the value >

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -24,8 +24,6 @@
 #include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/types.hpp"
 
-#include <boost/mpl/aux_/na.hpp>
-
 #include <cstdint>
 
 namespace pmacc

--- a/include/pmacc/meta/Apply.hpp
+++ b/include/pmacc/meta/Apply.hpp
@@ -1,0 +1,82 @@
+/* Copyright 2022 Bernhard Manfred Gruber
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Mp11.hpp"
+
+namespace pmacc
+{
+    namespace detail
+    {
+        template<typename E, typename... Args>
+        struct ReplacePlaceholdersImpl
+        {
+            using type = E;
+        };
+        template<std::size_t I, typename... Args>
+        struct ReplacePlaceholdersImpl<mp_arg<I>, Args...>
+        {
+            using type = mp_at_c<mp_list<Args...>, I>;
+        };
+
+        template<template<typename...> typename E, typename... Ts, typename... Args>
+        struct ReplacePlaceholdersImpl<E<Ts...>, Args...>
+        {
+            using type = E<typename ReplacePlaceholdersImpl<Ts, Args...>::type...>;
+            // nested ::type of E to mimic mpl::apply
+            // using type = typename E<typename ReplacePlaceholdersImpl<Ts, Args...>::type...>::type;
+        };
+    } // namespace detail
+
+    template<typename Expression, typename... Args>
+    using ReplacePlaceholders = typename detail::ReplacePlaceholdersImpl<Expression, Args...>::type;
+
+    namespace detail
+    {
+        template<typename T>
+        inline constexpr bool isPlaceholderExpression = false;
+
+        template<std::size_t I>
+        inline constexpr bool isPlaceholderExpression<mp_arg<I>> = true;
+
+        template<template<typename...> typename L, typename... Ts>
+        inline constexpr bool isPlaceholderExpression<L<Ts...>> = (isPlaceholderExpression<Ts> || ... || false);
+
+        template<typename Expression, bool IsPlaceholderExpression = isPlaceholderExpression<Expression>>
+        struct ApplyImpl : Expression
+        {
+        };
+
+        template<typename Expression>
+        struct ApplyImpl<Expression, true>
+        {
+            template<typename... Args>
+            using fn = ReplacePlaceholders<Expression, Args...>;
+        };
+    } // namespace detail
+
+    /// Equivalent of boost::mpl::apply. If Expression contains placeholders (such as _1 etc.), the placeholders are
+    /// replaced by Args via pmacc::ReplacePlaceholders. If there are no placeholders, Expression is treated as a
+    /// quoted meta function and the Expression::fn<Args...> is returned.
+    template<typename Expression, typename... Args>
+    using Apply = typename detail::ApplyImpl<Expression>::template fn<Args...>;
+} // namespace pmacc

--- a/include/pmacc/meta/accessors/Identity.hpp
+++ b/include/pmacc/meta/accessors/Identity.hpp
@@ -24,8 +24,6 @@
 
 #include "pmacc/types.hpp"
 
-#include <boost/mpl/placeholders.hpp>
-
 namespace pmacc
 {
     namespace meta
@@ -37,12 +35,11 @@ namespace pmacc
              * @tparam T in type
              *
              */
-            template<typename T = boost::mpl::_1>
+            template<typename T = pmacc::_1>
             struct Identity
             {
                 using type = T;
             };
-
         } // namespace accessors
 
     } // namespace meta

--- a/include/pmacc/meta/accessors/Type.hpp
+++ b/include/pmacc/meta/accessors/Type.hpp
@@ -23,9 +23,6 @@
 
 #include "pmacc/types.hpp"
 
-#include <boost/mpl/placeholders.hpp>
-
-
 namespace pmacc
 {
     namespace meta
@@ -38,7 +35,7 @@ namespace pmacc
              *
              * T must have defined ::type
              */
-            template<typename T = boost::mpl::_1>
+            template<typename T = pmacc::_1>
             struct Type
             {
                 using type = typename T::type;

--- a/include/pmacc/meta/conversion/ApplyGuard.hpp
+++ b/include/pmacc/meta/conversion/ApplyGuard.hpp
@@ -51,10 +51,7 @@ namespace pmacc
     struct ApplyGuard
     {
         template<typename... T_Args>
-        struct apply
-        {
-            using type = T_LockedType;
-        };
+        using fn = T_LockedType;
     };
 
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/OperateOnSeq.hpp
+++ b/include/pmacc/meta/conversion/OperateOnSeq.hpp
@@ -21,11 +21,10 @@
 
 #pragma once
 
+#include "pmacc/meta/Apply.hpp"
 #include "pmacc/meta/Mp11.hpp"
 #include "pmacc/meta/accessors/Identity.hpp"
 #include "pmacc/types.hpp"
-
-#include <boost/mpl/apply.hpp>
 
 namespace pmacc
 {
@@ -38,12 +37,13 @@ namespace pmacc
      * from the sequence is passed to T_UnaryOperator
      * @return ::type mp_list
      */
-    template<typename T_MPLSeq, typename T_UnaryOperator, typename T_Accessor = meta::accessors::Identity<>>
+    template<typename T_MPLSeq, typename T_UnaryOperator, typename T_Accessor = _1>
     struct OperateOnSeq
     {
-        template<typename X>
-        using Op =
-            typename boost::mpl::apply1<T_UnaryOperator, typename boost::mpl::apply1<T_Accessor, X>::type>::type;
+        static_assert(detail::isPlaceholderExpression<T_UnaryOperator>);
+
+        template<typename T>
+        using Op = Apply<T_UnaryOperator, Apply<T_Accessor, T>>;
 
         using type = mp_transform<Op, T_MPLSeq>;
     };

--- a/include/pmacc/meta/conversion/SeqToMap.hpp
+++ b/include/pmacc/meta/conversion/SeqToMap.hpp
@@ -21,10 +21,7 @@
 
 #pragma once
 
-#include "pmacc/meta/accessors/Identity.hpp"
 #include "pmacc/types.hpp"
-
-#include <boost/mpl/apply.hpp>
 
 namespace pmacc
 {
@@ -32,19 +29,19 @@ namespace pmacc
      *
      * @tparam T_List an mp_list.
      * @tparam T_UnaryOperator unary operator to translate type from the sequence
-     * to a mpl pair
+     * to a mp_list pair
      * @tparam T_Accessor An unary lambda operator which is used before the type
      * from the sequence is passed to T_UnaryOperator
      * @return ::type mpl map
      */
-    template<typename T_List, typename T_UnaryOperator, typename T_Accessor = meta::accessors::Identity<>>
+    template<typename T_List, typename T_UnaryOperator, typename T_Accessor = _1>
     struct SeqToMap
     {
         template<typename X>
-        using Op =
-            typename boost::mpl::apply1<T_UnaryOperator, typename boost::mpl::apply1<T_Accessor, X>::type>::type;
+        using Op = Apply<T_UnaryOperator, Apply<T_Accessor, X>>;
 
-        using ListOfTuples = mp_transform<Op, T_List>;
-        using type = mp_fold<ListOfTuples, mp_list<>, mp_map_insert>;
+        using ListOfPairs = mp_transform<Op, T_List>;
+
+        using type = mp_fold<ListOfPairs, mp_list<>, mp_map_insert>;
     };
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/ToSeq.hpp
+++ b/include/pmacc/meta/conversion/ToSeq.hpp
@@ -28,13 +28,13 @@ namespace pmacc
     namespace detail
     {
         template<typename T_Type>
-        struct ToSeq
+        struct ToSeqImpl
         {
             using type = mp_list<T_Type>;
         };
 
         template<typename... Ts>
-        struct ToSeq<mp_list<Ts...>>
+        struct ToSeqImpl<mp_list<Ts...>>
         {
             using type = mp_list<Ts...>;
         };
@@ -43,5 +43,5 @@ namespace pmacc
     /** If T_Type is an mp_list, return it. Otherwise wrap it in an mp_list.
      */
     template<typename T_Type>
-    using ToSeq = typename detail::ToSeq<T_Type>::type;
+    using ToSeq = typename detail::ToSeqImpl<T_Type>::type;
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/TypeToAliasPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToAliasPair.hpp
@@ -28,6 +28,23 @@
 
 namespace pmacc
 {
+    namespace detail
+    {
+        template<typename T_Type>
+        struct TypeToAliasPairImpl
+        {
+            using type = TypeToPair<T_Type>;
+        };
+
+        /** specialisation if T_Type is a pmacc alias*/
+        template<template<typename, typename> class T_Alias, typename T_Type>
+        struct TypeToAliasPairImpl<T_Alias<T_Type, pmacc::pmacc_isAlias>>
+        {
+            using type
+                = pmacc::meta::Pair<T_Alias<pmacc_void, pmacc::pmacc_isAlias>, T_Alias<T_Type, pmacc::pmacc_isAlias>>;
+        };
+    } // namespace detail
+
     /** create pmacc::meta::Pair
      *
      * If T_Type is a pmacc alias than first is set to anonym alias name
@@ -38,18 +55,5 @@ namespace pmacc
      * @resturn ::type
      */
     template<typename T_Type>
-    struct TypeToAliasPair
-    {
-        using type = typename TypeToPair<T_Type>::type;
-    };
-
-    /** specialisation if T_Type is a pmacc alias*/
-    template<template<typename, typename> class T_Alias, typename T_Type>
-    struct TypeToAliasPair<T_Alias<T_Type, pmacc::pmacc_isAlias>>
-    {
-        using type
-            = pmacc::meta::Pair<T_Alias<pmacc_void, pmacc::pmacc_isAlias>, T_Alias<T_Type, pmacc::pmacc_isAlias>>;
-    };
-
-
+    using TypeToAliasPair = typename detail::TypeToAliasPairImpl<T_Type>::type;
 } // namespace pmacc

--- a/include/pmacc/meta/conversion/TypeToPair.hpp
+++ b/include/pmacc/meta/conversion/TypeToPair.hpp
@@ -32,10 +32,5 @@ namespace pmacc
      * @resturn ::type pmacc::meta::Pair where first and second is set to T_Type
      */
     template<typename T_Type>
-    struct TypeToPair
-    {
-        using type = pmacc::meta::Pair<T_Type, T_Type>;
-    };
-
-
+    using TypeToPair = pmacc::meta::Pair<T_Type, T_Type>;
 } // namespace pmacc

--- a/include/pmacc/meta/errorHandlerPolicies/ReturnType.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ReturnType.hpp
@@ -34,10 +34,7 @@ namespace pmacc
         struct ReturnType
         {
             template<typename T_MPLSeq, typename T_Value>
-            struct apply
-            {
-                using type = T_ReturnType;
-            };
+            using fn = T_ReturnType;
         };
 
     } // namespace errorHandlerPolicies

--- a/include/pmacc/meta/errorHandlerPolicies/ReturnValue.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ReturnValue.hpp
@@ -33,10 +33,7 @@ namespace pmacc
         struct ReturnValue
         {
             template<typename T_MPLSeq, typename T_Value>
-            struct apply
-            {
-                using type = T_Value;
-            };
+            using fn = T_Value;
         };
 
     } // namespace errorHandlerPolicies

--- a/include/pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp
+++ b/include/pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp
@@ -34,7 +34,7 @@ namespace pmacc
         struct ThrowValueNotFound
         {
             template<typename T_MPLSeq, typename T_Value>
-            struct apply
+            struct fn
             {
                 /* The compiler is allowed to evaluate an expression that does not depend on a template parameter
                  * even if the class is never instantiated. In that case static assert is always
@@ -45,7 +45,6 @@ namespace pmacc
                  * `sizeof(ANY_TYPE) != 0` is always true and defers the evaluation.
                  */
                 PMACC_CASSERT_MSG_TYPE(value_not_found_in_seq, T_Value, false && (sizeof(T_MPLSeq) != 0));
-                using type = boost::mpl::void_;
             };
         };
 

--- a/include/pmacc/particles/ParticleDescription.hpp
+++ b/include/pmacc/particles/ParticleDescription.hpp
@@ -44,7 +44,7 @@ namespace pmacc
      *                       (e.g. calculate mass, gamma, ...)
      *                       (e.g. useSolverXY, calcRadiation, ...)
      * @tparam T_FrameExtensionList sequence or single class with frame extensions
-     *                    - extension must be an unary template class that supports boost::mpl::apply1<>
+     *                    - extension must be an unary template class that supports Apply<>
      *                    - type of the final frame is applied to each extension class
      *                      (this allows pointers and references to a frame itself)
      *                    - the final frame that uses ParticleDescription inherits from all

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -50,13 +50,10 @@ namespace pmacc
         template<uint32_t T_size>
         struct OperatorCreatePairStaticArray
         {
-            template<typename X>
-            struct apply
-            {
-                using type = meta::Pair<
-                    X,
-                    StaticArray<typename traits::Resolve<X>::type::type, std::integral_constant<uint32_t, T_size>>>;
-            };
+            template<typename T>
+            using fn = meta::Pair<
+                T,
+                StaticArray<typename traits::Resolve<T>::type::type, std::integral_constant<uint32_t, T_size>>>;
         };
     } // namespace detail
 

--- a/include/pmacc/particles/memory/dataTypes/ListPointer.hpp
+++ b/include/pmacc/particles/memory/dataTypes/ListPointer.hpp
@@ -27,13 +27,13 @@
 
 namespace pmacc
 {
-    template<typename T_Type = boost::mpl::_1>
+    template<typename T_Type = pmacc::_1>
     struct PreviousFramePtr
     {
         PMACC_ALIGN(previousFrame, Pointer<T_Type>);
     };
 
-    template<typename T_Type = boost::mpl::_1>
+    template<typename T_Type = pmacc::_1>
     struct NextFramePtr
     {
         PMACC_ALIGN(nextFrame, Pointer<T_Type>);

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -37,8 +37,6 @@
 #include "pmacc/traits/HasIdentifier.hpp"
 #include "pmacc/types.hpp"
 
-#include <boost/mpl/placeholders.hpp>
-
 #include <type_traits>
 
 namespace pmacc
@@ -226,11 +224,11 @@ namespace pmacc
                     {
                         using pmacc::meta::ForEach;
                         /* assign attributes from src to dest*/
-                        ForEach<CommonTypeSeq, CopyIdentifier<boost::mpl::_1>> copy;
+                        ForEach<CommonTypeSeq, CopyIdentifier<pmacc::_1>> copy;
                         copy(dest, src);
 
                         /* set all attributes which are not in src to their default value*/
-                        ForEach<UniqueInDestTypeSeq, SetAttributeToDefault<boost::mpl::_1>> setAttributeToDefault;
+                        ForEach<UniqueInDestTypeSeq, SetAttributeToDefault<pmacc::_1>> setAttributeToDefault;
                         setAttributeToDefault(dest);
                     };
                 };

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/math/MapTuple.hpp"
+#include "pmacc/meta/Apply.hpp"
 #include "pmacc/meta/GetKeyFromAlias.hpp"
 #include "pmacc/meta/conversion/OperateOnSeq.hpp"
 #include "pmacc/meta/conversion/SeqToMap.hpp"
@@ -33,8 +34,6 @@
 #include "pmacc/traits/HasFlag.hpp"
 #include "pmacc/traits/HasIdentifier.hpp"
 #include "pmacc/types.hpp"
-
-#include <boost/mpl/apply.hpp>
 
 namespace pmacc
 {
@@ -60,9 +59,9 @@ namespace pmacc
               typename SeqToMap<typename T_ParticleDescription::ValueTypeSeq, T_CreatePairOperator>::type>
         , public InheritLinearly<mp_append<
               typename T_ParticleDescription::MethodsList,
-              typename OperateOnSeq<
-                  typename T_ParticleDescription::FrameExtensionList,
-                  boost::mpl::apply1<boost::mpl::_1, Frame<T_CreatePairOperator, T_ParticleDescription>>>::type>>
+              mp_transform_q<
+                  mp_bind<Apply, _1, Frame<T_CreatePairOperator, T_ParticleDescription>>,
+                  typename T_ParticleDescription::FrameExtensionList>>>
     {
         using ParticleDescription = T_ParticleDescription;
         using Name = typename ParticleDescription::Name;

--- a/include/pmacc/particles/meta/FindByNameOrType.hpp
+++ b/include/pmacc/particles/meta/FindByNameOrType.hpp
@@ -21,10 +21,9 @@
 
 #pragma once
 
+#include "pmacc/meta/Apply.hpp"
 #include "pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp"
 #include "pmacc/traits/GetCTName.hpp"
-
-#include <boost/mpl/apply.hpp>
 
 #include <type_traits>
 
@@ -63,7 +62,7 @@ namespace pmacc
 
                 using type = typename mp_if<
                     mp_empty<FilteredSeq>,
-                    boost::mpl::apply<KeyNotFoundPolicy, T_MPLSeq, T_Identifier>,
+                    mp_defer<Apply, KeyNotFoundPolicy, T_MPLSeq, T_Identifier>,
                     mp_defer<mp_front, FilteredSeq>>::type;
             };
 

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -50,6 +50,7 @@
 #include "pmacc/dimensions/Definition.hpp"
 #include "pmacc/eventSystem/EventType.hpp"
 #include "pmacc/memory/Align.hpp"
+#include "pmacc/meta/Apply.hpp"
 #include "pmacc/meta/Mp11.hpp"
 #include "pmacc/ppFunctions.hpp"
 #include "pmacc/type/Area.hpp"

--- a/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/fileOutput.param
@@ -28,9 +28,6 @@
 #include "picongpu/particles/particleToGrid/CombinedDerive.def"
 #include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
 
-#include <boost/mpl/vector.hpp>
-
-
 namespace picongpu
 {
     /** FieldTmp output (calculated at runtime) *******************************


### PR DESCRIPTION
This is a continuation of the epic saga started in #3834. It continues by refactoring the seqence meta algorithms and replaces `boost::mpl::apply`.

- [x] Merge after #3834
- [x] Merge after #4516 