### PR TITLE
Don't install toml11 internally shipped library

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -360,7 +360,8 @@ if(PIC_SEARCH_openPMD)
             if(${PIC_toml11_PROVIDER} STREQUAL "intern")
                 add_subdirectory(
                     "${PIConGPUapp_SOURCE_DIR}/../../thirdParty/toml11"
-                    "${CMAKE_CURRENT_BINARY_DIR}/build_toml11")
+                    "${CMAKE_CURRENT_BINARY_DIR}/build_toml11"
+                    EXCLUDE_FROM_ALL)
             else()
                 find_package(toml11 3.7.0 CONFIG REQUIRED)
                 message(STATUS "toml11: Found version '${toml11_VERSION}'")

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -361,6 +361,12 @@ if(PIC_SEARCH_openPMD)
                 add_subdirectory(
                     "${PIConGPUapp_SOURCE_DIR}/../../thirdParty/toml11"
                     "${CMAKE_CURRENT_BINARY_DIR}/build_toml11"
+                    # EXCLUDE_FROM_ALL ensures that toml11 is not part of
+                    # make install.
+                    # The library is header-only and linking it against
+                    # PIConGPU targets is sufficient.
+                    # It needs not be part of any build or install targets
+                    # explicitly.
                     EXCLUDE_FROM_ALL)
             else()
                 find_package(toml11 3.7.0 CONFIG REQUIRED)


### PR DESCRIPTION
Use `add_subdirectory(... EXCLUDE_FROM_ALL)` to enforce this.
Excluding toml11 from all targets is fine since it is header-only and
needs not be compiled or installed separately.
Linking it against the PIConGPU targets is sufficient.

Before this fix:
```
[100%] Built target picongpu                                                                    
Install the project...                                                                          
-- Install configuration: "Release"                                                             
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/cuda_memtest                     
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/mpiInfo                          
-- Up-to-date: /home/franzpoeschel/singularity_build/local/lib/cmake/toml11/toml11Config.cmake  
-- Up-to-date: /home/franzpoeschel/singularity_build/local/lib/cmake/toml11/toml11ConfigVersion.
cmake                                                                                           
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml.hpp                     
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml                         
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/traits.hpp              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/region.hpp              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/into.hpp                
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/string.hpp              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/value.hpp               
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/serializer.hpp          
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/types.hpp               
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/get.hpp                 
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/source_location.hpp     
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/literal.hpp             
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/combinator.hpp          
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/macros.hpp              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/color.hpp               
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/utility.hpp             
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/exception.hpp           
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/storage.hpp             
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/lexer.hpp               
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/from.hpp                
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/comments.hpp            
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/datetime.hpp            
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/result.hpp              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/include/toml/parser.hpp              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/lib/cmake/toml11/toml11Targets.cmake 
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/picongpu                         
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin                                  
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-compile                      
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-edit                         
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/cuda_memtest.sh                  
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-create                       
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-configure                    
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/picongpu-completion.bash         
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/tbg                              
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/egetopt                          
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-build  
```

After:
```
Install the project...
-- Install configuration: "Release"
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/cuda_memtest
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/mpiInfo
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/picongpu
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-compile
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-edit
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/cuda_memtest.sh
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-create
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-configure
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/picongpu-completion.bash
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/tbg
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/egetopt
-- Up-to-date: /home/franzpoeschel/singularity_build/local/bin/pic-build
```

Notes: We could theoretically do this for other internally shipped libraries such as nlohmann-json as well. 
Currently, we use a convenience option provided by nlohmann-json to disable install, I don't know how we do it for the other libs.