### PR TITLE
remove obsolete check in tpl

### DIFF
--- a/etc/picongpu/crusher-ornl/batch.tpl
+++ b/etc/picongpu/crusher-ornl/batch.tpl
@@ -96,8 +96,7 @@ ln -s ../stdout output
 
 # cuda_memtest is available only on CUDA hardware
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
-fi
+
+# Run PIConGPU
+srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 

--- a/etc/picongpu/spock-ornl/caar.tpl
+++ b/etc/picongpu/spock-ornl/caar.tpl
@@ -100,8 +100,6 @@ ln -s ../stdout output
 
 # cuda_memtest is available only on CUDA hardware
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
-fi
+# Run PIConGPU
+srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 


### PR DESCRIPTION
@steindev and I wondered why restarting simulation on crusher never ran but always "crashed". The reason for this error originates from a obsolete check that should only run PIConGPU if `cuda_memtest` ran successfully. 
However, since on AMD GPUs, there is no `cuda_memtest`. The check thus validates the return value of the previous command: creating the symbolic link between `output` and `stderr`, which of course fails if the link already exists. Thus PIConGPU never ran when the link already existed. 
This pull request fixes this issue by removing the check completely. 