### PR TITLE
Implement phase-coefficients in Gauss-Laguerre laser modes

### DIFF
--- a/include/picongpu/fields/laserProfiles/GaussianBeam.def
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.def
@@ -36,11 +36,15 @@ namespace picongpu
                     //! Use only the 0th Laguerremode for a standard Gaussian
                     static constexpr uint32_t MODENUMBER = 0;
                     PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+                    PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
                     // This is just an example for a more complicated set of Laguerre modes
                     // constexpr uint32_t MODENUMBER = 12;
                     // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783,
                     // 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321,
                     // -0.0160788);
+                    // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0, 1.0344594, -0.9384701,
+                    // -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303, -0.8039839, 3.0055385, -0.1503778,
+                    // -9.6980362, -2.8122287);
 
                     struct GaussianBeamParam
                     {
@@ -111,6 +115,7 @@ namespace picongpu
                         static constexpr float_X LASER_PHASE = 0.0;
 
                         using LAGUERREMODES_t = defaults::LAGUERREMODES_t;
+                        using LAGUERREPHASES_t = defaults::LAGUERREPHASES_t;
                         static constexpr uint32_t MODENUMBER = defaults::MODENUMBER;
 
                         /** Available polarisation types

--- a/include/picongpu/param/laser.param
+++ b/include/picongpu/param/laser.param
@@ -58,11 +58,15 @@ namespace picongpu
                 //! Use only the 0th Laguerremode for a standard Gaussian
                 static constexpr uint32_t MODENUMBER = 0;
                 PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 1.0);
                 // This is just an example for a more complicated set of Laguerre modes
                 // constexpr uint32_t MODENUMBER = 12;
                 // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783,
                 // 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321,
                 // -0.0160788);
+                // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0, 1.0344594, -0.9384701, -2.7384883,
+                // 0.0016872, 2.4563653, -0.312892, -1.7298303, -0.8039839, 3.0055385, -0.1503778, -9.6980362,
+                // -2.8122287);
 
             } // namespace gaussianBeam
 
@@ -135,6 +139,7 @@ namespace picongpu
                 static constexpr float_X LASER_PHASE = 0.0;
 
                 using LAGUERREMODES_t = gaussianBeam::LAGUERREMODES_t;
+                using LAGUERREPHASES_t = gaussianBeam::LAGUERREPHASES_t;
                 static constexpr uint32_t MODENUMBER = gaussianBeam::MODENUMBER;
 
                 /** Available polarisation types

--- a/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/Bremsstrahlung/include/picongpu/param/laser.param
@@ -57,11 +57,15 @@ namespace picongpu
                 //! Use only the 0th Laguerremode for a standard Gaussian
                 static constexpr uint32_t MODENUMBER = 0;
                 PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 1.0);
                 // This is just an example for a more complicated set of Laguerre modes
                 // constexpr uint32_t MODENUMBER = 12;
                 // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783,
                 // 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321,
                 // -0.0160788);
+                // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0, 1.0344594, -0.9384701, -2.7384883,
+                // 0.0016872, 2.4563653, -0.312892, -1.7298303, -0.8039839, 3.0055385, -0.1503778, -9.6980362,
+                // -2.8122287);
 
             } // namespace gaussianBeam
 
@@ -134,6 +138,7 @@ namespace picongpu
                 static constexpr float_X LASER_PHASE = 0.0;
 
                 using LAGUERREMODES_t = gaussianBeam::LAGUERREMODES_t;
+                using LAGUERREPHASES_t = gaussianBeam::LAGUERREPHASES_t;
                 static constexpr uint32_t MODENUMBER = gaussianBeam::MODENUMBER;
 
                 /** Available polarisation types

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/laser.param
@@ -68,11 +68,15 @@ namespace picongpu
                 //! Use only the 0th Laguerremode for a standard Gaussian
                 static constexpr uint32_t MODENUMBER = 0;
                 PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 1.0);
                 // This is just an example for a more complicated set of Laguerre modes
                 // constexpr uint32_t MODENUMBER = 12;
                 // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461, -0.23783,
                 // 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038, -0.00896321,
                 // -0.0160788);
+                // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0, 1.0344594, -0.9384701, -2.7384883,
+                // 0.0016872, 2.4563653, -0.312892, -1.7298303, -0.8039839, 3.0055385, -0.1503778, -9.6980362,
+                // -2.8122287);
 
             } // namespace gaussianBeam
 
@@ -145,6 +149,7 @@ namespace picongpu
                 static constexpr float_X LASER_PHASE = 0.0;
 
                 using LAGUERREMODES_t = gaussianBeam::LAGUERREMODES_t;
+                using LAGUERREPHASES_t = gaussianBeam::LAGUERREPHASES_t;
                 static constexpr uint32_t MODENUMBER = gaussianBeam::MODENUMBER;
 
                 /** Available polarisation types


### PR DESCRIPTION
This PR extends the functionality of the radial Gauss-Laguerre laser mode decomposition (see #1580) by allowing "complex"-valued series coefficients, that are configured using the added 1D-vector ``LAGUERREPHASES``.