### PR TITLE
docs typo in energy histogram

### DIFF
--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -26,7 +26,7 @@ PIConGPU command line option                description
                                             A value of ``100`` would mean an output at simulation time step *0, 100, 200, ...*.
                                             If set to a non-zero value, the energy histogram of all **electrons** is computed.
                                             By default, the value is ``0`` and no histogram for the electrons is computed.
-``--e_energy.filter``                       Use filtered particles. Available filters are set up in
+``--e_energyHistogram.filter``              Use filtered particles. Available filters are set up in
                                             :ref:`particleFilters.param <usage-params-core>`.
 ``--e_energyHistogram.binCount``            Specifies the number of bins used for the **electron** histogram.
                                             Default is ``1024``.


### PR DESCRIPTION
fixes typo/copy-paste-error

see #3991 