### PR TITLE
Fix env variables in install from source docs

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -142,11 +142,11 @@ PIConGPU Source Code
   - *optional:* change to a different branch with ``git branch`` (show) and ``git checkout <BranchName>`` (switch)
 - *environment*:
 
-  - ``export PICSRC=$PICHOME/src/picongpu``
+  - ``export PICSRC=$HOME/src/picongpu``
   - ``export PIC_EXAMPLES=$PICSRC/share/picongpu/examples``
-  - ``export PATH=$PICSRC:$PATH``
-  - ``export PATH=$PICSRC/bin:$PATH``
-  - ``export PATH=$PICSRC/src/tools/bin:$PATH``
+  - ``export PATH=$PATH:$PICSRC``
+  - ``export PATH=$PATH:$PICSRC/bin``
+  - ``export PATH=$PATH:$PICSRC/src/tools/bin``
   - ``export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH``
 
 Optional Libraries


### PR DESCRIPTION
As pointed out by @kimjohn1 , fix outdated ``$PICHOME``.

Also append the `PATH` instead of prepending to be consistent with what we do in existing profiles.