### PR TITLE
Enable span-based storeChunk() API in openPMD plugin by default in recent versions of openPMD-api

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -146,9 +146,12 @@ Backend-specific notes
 ADIOS2
 ======
 
-The memory usage of some engines in ADIOS2 can be reduced by specifying the environment variable ``openPMD_USE_STORECHUNK_SPAN=1``.
-This makes PIConGPU use the `span-based Put() API <https://adios2.readthedocs.io/en/latest/components/components.html#put-modes-and-memory-contracts>`_ of ADIOS2 which avoids buffer copies, but does not allow for compression.
-Do *not* use this optimization in combination with compression, otherwise the resulting datasets will not be usable.
+* **Only for openPMD-api <= 0.14.3:**
+  The memory usage of some engines in ADIOS2 can be reduced by specifying the environment variable ``openPMD_USE_STORECHUNK_SPAN=1``.
+  This makes PIConGPU use the `span-based Put() API <https://adios2.readthedocs.io/en/latest/components/components.html#put-modes-and-memory-contracts>`_ of ADIOS2 which avoids buffer copies, but does not allow for compression.
+  Do *not* use this optimization in combination with compression, otherwise the resulting datasets will not be usable.
+* **For openPMD-api >= 0.14.4:** The above behavior has been fixed, no user interaction is required. The memory-optimized implementation will be automatically selected if possible.
+* **You don't know the precise settings and versions in your setup?** Then keep everything as it is and use the defaults.
 
 HDF5
 ====

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -97,7 +97,11 @@ namespace picongpu
             ::openPMD::Extent extent,
             Functor&& createBaseBuffer) -> detail::openPMDSpan<ValueType>
         {
-            bool useSpanAPI = false;
+            /*
+             * openPMD-api >= 0.14.4 automatically disables the
+             * span-based Put() API in ADIOS2 if compression is used.
+             */
+            bool useSpanAPI = OPENPMDAPI_VERSION_GE(0, 14, 4);
             {
                 auto value = std::getenv("openPMD_USE_STORECHUNK_SPAN");
                 unsigned long long valueAsLong{};


### PR DESCRIPTION
Follow-up to #3933 

The bug addressed by that PR has been fixed in [openPMD 0.14.4](https://github.com/openPMD/openPMD-api/blob/0.14.4/CHANGELOG.rst). If a recent version of openPMD-api is found, we can avoid the workaround introduced by #3933 and enjoy decreased memory usage again.