### PR TITLE
Add profiles for A100 GPUs on Taurus

### DIFF
--- a/etc/picongpu/taurus-tud/A100.tpl
+++ b/etc/picongpu/taurus-tud/A100.tpl
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_gpusPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem=0
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+#SBATCH --exclusive
+
+# disable hyperthreading (default on taurus)
+#SBATCH --hint=nomultithread
+
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --chdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="alpha"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# 6 gpus per node
+# Taurus does not have enough node memory to hold data of all GPUs in node memory during ADIOS output.
+# If you experience crashes with memory allocation errors or get killed by the batch system's
+# resource watch dog, reduce the number of GPUs used per node to four here for debugging.
+# That is, replace in the following line the two appearances of 8 with 4.
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
+
+# number of CPU cores to block per GPU
+# we got 6 CPU cores per GPU (48cores/8gpus ~ 6cores)
+.TBG_coresPerGPU=6
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to calculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
+#   support ticket [Ticket:2014052241001186] srun: mpi mca flags
+#   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
+export OMPI_MCA_mpi_leave_pinned=0
+
+# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
+# fallback ROMIO backend instead.
+#   see bug https://github.com/open-mpi/ompi/issues/6285
+export OMPI_MCA_io=^ompio
+
+# test if cuda_memtest binary is available
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+  # Run CUDA memtest to check GPU's health
+  srun -K1 !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+fi
+

--- a/etc/picongpu/taurus-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/A100_picongpu.profile.example
@@ -1,0 +1,114 @@
+#Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="vim"
+
+# Modules #####################################################################
+#
+module switch modenv/hiera
+
+# load CUDA/11.1.1, also loads GCC/10.2.0, zlib, OpenMPI/4.0.5 and others
+module load fosscuda/2020b
+module load HDF5/1.10.7
+module load CMake/3.18.4
+module load libpng/1.6.37
+module load freetype/2.10.3
+
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+printf "@ Note: You need to compile picongpu on a node. @\n"
+printf "@       Likewise for building the libraries.    @\n"
+printf "@       Get a node with the getNode command.    @\n"
+printf "@       Then source %s again.@\n" "$(basename $PIC_PROFILE)"
+printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+
+# Self-Build Software #########################################################
+#
+# needs to be compiled by the user
+# Check the install script at
+# https://gist.github.com/BeyondEspresso/c8f9e07224e2844db299b664a32ceab7#file-taurus-a100-build-picongpu-dependencies-sh
+#
+export PIC_LIBS=$HOME/lib/alpha
+export BOOST_ROOT=$PIC_LIBS/boost-1.68.0
+export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.0
+export ADIOS2_ROOT=$PIC_LIBS/adios2-2.7.1
+export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.14.3
+
+export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PNGwriter_DIR/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
+
+export PATH=$ADIOS2_ROOT/bin:$PATH
+
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:80"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+# python not included yet
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# This is necessary in order to make alpaka compile.
+# The workaround is from Axel Huebl according to alpaka PR #702.
+export CXXFLAGS="-Dlinux"
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "alpha" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/A100.tpl"
+
+# allocate an interactive shell for two hours
+#   getNode 2  # allocates 2 interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    export OMP_NUM_THREADS=6
+    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((8 * $numNodes)) --ntasks-per-node=8 --cpus-per-task=6 --mem=0 --exclusive --gres=gpu:8 -p alpha-interactive --pty bash
+}
+
+# allocate an interactive shell for two hours
+#   getDevice 2  # allocates 2 interactive devices on one node (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numDevices=1
+    else
+        if [ "$1" -gt 6 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numDevices=$1
+        fi
+    fi
+    export OMP_NUM_THREADS=6
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha-interactive --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi
+

--- a/etc/picongpu/taurus-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/A100_picongpu.profile.example
@@ -17,12 +17,13 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module switch modenv/hiera
 
-# load CUDA/11.1.1, also loads GCC/10.2.0, zlib, OpenMPI/4.0.5 and others
-module load fosscuda/2020b
+# load GCC/10.3.0, zlib 1.2.11, OpenMPI/4.1.1 and others
+module load foss/2021a
+module load CUDA/11.6.0
 module load HDF5/1.10.7
-module load CMake/3.18.4
+module load CMake/3.20.1
 module load libpng/1.6.37
-module load freetype/2.10.3
+module load freetype/2.10.4
 
 printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
 printf "@ Note: You need to compile picongpu on a node. @\n"

--- a/etc/picongpu/taurus-tud/A100_restart.tpl
+++ b/etc/picongpu/taurus-tud/A100_restart.tpl
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Copyright 2013-2022 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for taurus' SLURM batch system
+# This tpl for automated restarts is older than the actual
+# V100.tpl.
+# It uses a machine file for parallel job execution,
+# which is not necessary anymore.
+# (See comment below, MPI has been fixed)
+# However, it still works and therefore is left unchanged.
+# Klaus, June 2019
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_gpusPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+# Maximum memory setting the SLURM queue "alpha" accepts.
+#SBATCH --mem=0
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+#SBATCH --exclusive
+
+# disable hyperthreading (default on taurus)
+#SBATCH --hint=nomultithread
+
+# send me mails on BEGIN, END, FAIL, REQUEUE, ALL,
+# TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --chdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="alpha"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# 8 gpus per node
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
+
+# number of CPU cores to block per GPU
+# we got 6 CPU cores per GPU (48cores/8gpus ~ 6cores)
+.TBG_coresPerGPU=6
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to calculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+# Due to missing SLURM integration of the current MPI libraries
+# we have to create a suitable machinefile.
+rm -f machinefile.txt
+for i in `seq !TBG_gpusPerNode`
+do
+    scontrol show hostnames $SLURM_JOB_NODELIST >> machinefile.txt
+done
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
+#   support ticket [Ticket:2014052241001186] srun: mpi mca flags
+#   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
+export OMPI_MCA_mpi_leave_pinned=0
+# Use ROMIO for IO
+# according to ComputationalRadiationPhysics/picongpu#2857
+export OMPI_MCA_io=^ompio
+
+sleep 1
+
+echo "----- automated restart routine -----" | tee -a output
+
+#check whether last checkpoint is valid
+file=""
+# ADIOS2 restart files take precedence over HDF5 files
+fileEnding="h5"
+hasADIOS=$(ls ./checkpoints/checkpoint_*.bp 2>/dev/null | wc -w)
+if [ $hasADIOS -gt 0 ]
+then
+    fileEnding="bp"
+fi
+
+for file in `ls -t ./checkpoints/checkpoint_*.$fileEnding`
+do
+    echo -n "validate checkpoint $file: " | tee -a output
+    $fileEnding"ls" $file &> /dev/null
+    if [ $? -eq 0 ]
+    then
+        echo "OK" | tee -a output
+        break
+    else
+        echo "FAILED" | tee -a output
+        file=""
+    fi
+done
+
+#this sed call extracts the final simulation step from the cfg (assuming a standard cfg)
+finalStep=`echo !TBG_programParams | sed 's/.*-s[[:blank:]]\+\([0-9]\+[^\s]\).*/\1/'`
+echo "final step      = " $finalStep | tee -a output
+#this sed call extracts the -s and --checkpoint flags
+programParams=`echo !TBG_programParams | sed 's/-s[[:blank:]]\+[0-9]\+[^\s]//g' | sed 's/--checkpoint\.period[[:blank:]]\+[0-9,:,\,]\+[^\s]//g'`
+#extract restart period
+restartPeriod=`echo !TBG_programParams | sed 's/.*--checkpoint\.period[[:blank:]]\+\([0-9,:,\,]\+[^\s]\).*/\1/'`
+echo  "restart period = " $restartPeriod | tee -a output
+
+
+# ******************************************* #
+# need some magic, if the restart period is in new notation with the ':' and ','
+
+currentStep=`basename $file | sed 's/checkpoint_//g' | sed 's/.'$fileEnding'//g'`
+nextStep=$(nextstep_from_period.sh $restartPeriod $finalStep $currentStep)
+
+if [ -z "$file" ]; then
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod"
+else
+    stepSetup="-s $nextStep --checkpoint.period $restartPeriod --checkpoint.restart --checkpoint.restart.step $currentStep"
+fi
+
+# ******************************************* #
+
+echo "--- end automated restart routine ---" | tee -a output
+
+#wait that all nodes see output folder
+sleep 1
+
+# test if cuda_memtest binary is available
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+  # Run CUDA memtest to check GPU's health
+  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  mpiexec -hostfile ../machinefile.txt !TBG_dstPath/input/bin/picongpu $stepSetup !TBG_author !TBG_programParams | tee output
+fi
+
+mpiexec -hostfile ../machinefile.txt /usr/bin/env bash -c "killall -9 picongpu 2>/dev/null || true"
+
+if [ $nextStep -lt $finalStep ]
+then
+    ssh tauruslogin6 "/usr/bin/sbatch !TBG_dstPath/tbg/submit.start"
+    if [ $? -ne 0 ] ; then
+        echo "error during job submission" | tee -a output
+    else
+        echo "job submitted" | tee -a output
+    fi
+fi
+


### PR DESCRIPTION
Adds the profiles for the `alpha`-queue on the TU Dresden system Taurus. At the moment, **the PR is still a draft**, because these profiles currently only work for the latest PIConGPU release `0.6.0`, but not the latest `dev`-branch, see issue #3997, where PIConGPU fails to compile.