### PR TITLE
openPMD plugin: Flush data to disk within a step

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -158,10 +158,6 @@ namespace picongpu
                 std::forward<Functor>(createBaseBuffer));
         }
 
-        constexpr char const* jsonConfigBP5TargetBuffer
-            = R"({"adios2": {"engine": {"preferred_flush_target": "disk"}}})";
-        constexpr char const* jsonConfigBP5TargetDisk
-            = R"({"adios2": {"engine": {"preferred_flush_target": "buffer"}}})";
 
         enum class PreferredFlushTarget : bool
         {
@@ -169,17 +165,50 @@ namespace picongpu
             Buffer
         };
 
+        namespace detail
+        {
+            /*
+             * Do some SFINAE tricks to detect whether the openPMD API allows
+             * specifying JSON configs in flush calls or not.
+             */
+            template<typename Series = ::openPMD::Series, typename Dummy = void>
+            struct FlushSeries
+            {
+                static void run(Series& series, PreferredFlushTarget)
+                {
+                    series.flush();
+                }
+            };
+
+            /*
+             * Enable this if Series::flush accepts string parameters.
+             */
+            template<typename Series>
+            struct FlushSeries<Series, decltype(std::declval<Series>().flush(std::declval<std::string>()))>
+            {
+                static constexpr char const* jsonConfigBP5TargetBuffer
+                    = R"({"adios2": {"engine": {"preferred_flush_target": "disk"}}})";
+                static constexpr char const* jsonConfigBP5TargetDisk
+                    = R"({"adios2": {"engine": {"preferred_flush_target": "buffer"}}})";
+
+                static void run(Series& series, PreferredFlushTarget target)
+                {
+                    switch(target)
+                    {
+                    case PreferredFlushTarget::Disk:
+                        series.flush(jsonConfigBP5TargetDisk);
+                        break;
+                    case PreferredFlushTarget::Buffer:
+                        series.flush(jsonConfigBP5TargetBuffer);
+                        break;
+                    }
+                }
+            };
+        } // namespace detail
+
         inline void flushSeries(::openPMD::Series& series, PreferredFlushTarget target)
         {
-            switch(target)
-            {
-            case PreferredFlushTarget::Disk:
-                series.flush(jsonConfigBP5TargetDisk);
-                break;
-            case PreferredFlushTarget::Buffer:
-                series.flush(jsonConfigBP5TargetBuffer);
-                break;
-            }
+            detail::FlushSeries<>::run(series, target);
         }
 
     } // namespace openPMD

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -187,9 +187,9 @@ namespace picongpu
             struct FlushSeries<Series, decltype(std::declval<Series>().flush(std::declval<std::string>()))>
             {
                 static constexpr char const* jsonConfigBP5TargetBuffer
-                    = R"({"adios2": {"engine": {"preferred_flush_target": "disk"}}})";
-                static constexpr char const* jsonConfigBP5TargetDisk
                     = R"({"adios2": {"engine": {"preferred_flush_target": "buffer"}}})";
+                static constexpr char const* jsonConfigBP5TargetDisk
+                    = R"({"adios2": {"engine": {"preferred_flush_target": "disk"}}})";
 
                 static void run(Series& series, PreferredFlushTarget target)
                 {

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -174,6 +174,7 @@ namespace picongpu
             template<typename Series = ::openPMD::Series, typename Dummy = void>
             struct FlushSeries
             {
+                constexpr static bool supportsFlushParameters = false;
                 static void run(Series& series, PreferredFlushTarget)
                 {
                     series.flush();
@@ -186,6 +187,7 @@ namespace picongpu
             template<typename Series>
             struct FlushSeries<Series, decltype(std::declval<Series>().flush(std::declval<std::string>()))>
             {
+                constexpr static bool supportsFlushParameters = true;
                 static constexpr char const* jsonConfigBP5TargetBuffer
                     = R"({"adios2": {"engine": {"preferred_flush_target": "buffer"}}})";
                 static constexpr char const* jsonConfigBP5TargetDisk

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -158,13 +158,28 @@ namespace picongpu
                 std::forward<Functor>(createBaseBuffer));
         }
 
-        inline void flushCollectively(::openPMD::Series& series)
+        constexpr char const* jsonConfigBP5TargetBuffer
+            = R"({"adios2": {"engine": {"preferred_flush_target": "disk"}}})";
+        constexpr char const* jsonConfigBP5TargetDisk
+            = R"({"adios2": {"engine": {"preferred_flush_target": "buffer"}}})";
+
+        enum class PreferredFlushTarget : bool
         {
-            series.flush(
-#if OPENPMDAPI_VERSION_GE(0, 15, 0)
-                ::openPMD::FlushMode::Collective
-#endif
-            );
+            Disk,
+            Buffer
+        };
+
+        inline void flushSeries(::openPMD::Series& series, PreferredFlushTarget target)
+        {
+            switch(target)
+            {
+            case PreferredFlushTarget::Disk:
+                series.flush(jsonConfigBP5TargetDisk);
+                break;
+            case PreferredFlushTarget::Buffer:
+                series.flush(jsonConfigBP5TargetBuffer);
+                break;
+            }
         }
 
     } // namespace openPMD

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -157,5 +157,15 @@ namespace picongpu
                 useSpanAPI,
                 std::forward<Functor>(createBaseBuffer));
         }
+
+        inline void flushCollectively(::openPMD::Series& series)
+        {
+            series.flush(
+#if OPENPMDAPI_VERSION_GE(0, 15, 0)
+                ::openPMD::FlushMode::Collective
+#endif
+            );
+        }
+
     } // namespace openPMD
 } // namespace picongpu

--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -21,6 +21,7 @@
 
 #    include "picongpu/plugins/openPMD/Json.hpp"
 
+#    include "picongpu/plugins/common/openPMDVersion.def"
 #    include "picongpu/plugins/openPMD/Json_private.hpp"
 
 #    include <algorithm> // std::copy_n, std::find
@@ -332,7 +333,7 @@ The key 'select' must point to either a single string or an array of strings.)EN
                 adios2EngineParams["BufferChunkSize"] = "2147381248";
             }
         }
-#if OPENPMDAPI_VERSION_GE(0,15,0)
+        if constexpr(picongpu::openPMD::detail::FlushSeries<openPMD::Series>::supportsFlushParameters)
         {
             auto& adios2Engine = config["adios2"]["engine"];
             if(!adios2Engine.contains("preferred_flush_target"))
@@ -349,7 +350,6 @@ The key 'select' must point to either a single string or an array of strings.)EN
                 adios2Engine["preferred_flush_target"] = "buffer";
             }
         }
-#endif
     }
 } // namespace
 

--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -26,6 +26,8 @@
 #    include <algorithm> // std::copy_n, std::find
 #    include <cctype> // std::isspace
 
+#    include <openPMD/openPMD.hpp>
+
 /*
  * Note:
  * This is a hostonly .cpp file because CMake will not use -isystem for system
@@ -330,6 +332,24 @@ The key 'select' must point to either a single string or an array of strings.)EN
                 adios2EngineParams["BufferChunkSize"] = "2147381248";
             }
         }
+#if OPENPMDAPI_VERSION_GE(0,15,0)
+        {
+            auto& adios2Engine = config["adios2"]["engine"];
+            if(!adios2Engine.contains("preferred_flush_target"))
+            {
+                /*
+                 * Only relevant for ADIOS2 engines that support this feature,
+                 * ignored otherwise. Currently supported in BP5.
+                 * Small datasets should be written to the internal ADIOS2
+                 * buffer.
+                 * Big datasets should explicitly specify their flush target
+                 * in Series::flush(). Options are "buffer" and "disk".
+                 * Ideally, all flush() calls should specify this explicitly.
+                 */
+                adios2Engine["preferred_flush_target"] = "buffer";
+            }
+        }
+#endif
     }
 } // namespace
 

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -115,7 +115,7 @@ namespace picongpu
                     std::make_shared<T_Scalar>(value),
                     std::move(std::get<1>(tuple)),
                     std::move(std::get<2>(tuple)));
-                params.openPMDSeries->flush();
+                flushCollectively(*params.openPMDSeries);
             }
 
         private:

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -115,7 +115,7 @@ namespace picongpu
                     std::make_shared<T_Scalar>(value),
                     std::move(std::get<1>(tuple)),
                     std::move(std::get<2>(tuple)));
-                flushCollectively(*params.openPMDSeries);
+                flushSeries(*params.openPMDSeries, PreferredFlushTarget::Buffer);
             }
 
         private:

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -504,7 +504,7 @@ namespace picongpu
                         globalNumParticles,
                         *params->jsonMatcher,
                         series.particlesPath() + speciesGroup);
-                    flushCollectively(*params->openPMDSeries);
+                    flushSeries(*params->openPMDSeries, PreferredFlushTarget::Buffer);
                 }
 
                 log<picLog::INPUT_OUTPUT>("openPMD: ( end ) writing particle patches for %1%")

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -504,7 +504,7 @@ namespace picongpu
                         globalNumParticles,
                         *params->jsonMatcher,
                         series.particlesPath() + speciesGroup);
-                    params->openPMDSeries->flush();
+                    flushCollectively(*params->openPMDSeries);
                 }
 
                 log<picLog::INPUT_OUTPUT>("openPMD: ( end ) writing particle patches for %1%")

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -730,7 +730,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     ::openPMD::shareRaw(rawPtr),
                     asStandardVector(recordOffsetDims),
                     asStandardVector(recordLocalSizeDims));
-                flushCollectively(*params->openPMDSeries);
+                flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
             }
 
             /** Implementation of loading random number generator states
@@ -1386,7 +1386,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                     if(numDataPoints == 0)
                     {
-                        flushCollectively(*params->openPMDSeries);
+                        flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
                         continue;
                     }
 
@@ -1437,7 +1437,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         }
                     }
 
-                    flushCollectively(*params->openPMDSeries);
+                    flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
                 }
             }
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -730,7 +730,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     ::openPMD::shareRaw(rawPtr),
                     asStandardVector(recordOffsetDims),
                     asStandardVector(recordLocalSizeDims));
-                params->openPMDSeries->flush();
+                flushCollectively(*params->openPMDSeries);
             }
 
             /** Implementation of loading random number generator states
@@ -1386,9 +1386,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                     if(numDataPoints == 0)
                     {
-                        // technically not necessary if we write no dataset,
-                        // but let's keep things uniform
-                        params->openPMDSeries->flush();
+                        flushCollectively(*params->openPMDSeries);
                         continue;
                     }
 
@@ -1439,7 +1437,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         }
                     }
 
-                    params->openPMDSeries->flush();
+                    flushCollectively(*params->openPMDSeries);
                 }
             }
 

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -103,9 +103,7 @@ namespace picongpu
 
                     if(elements == 0)
                     {
-                        // technically not necessary if we write no dataset,
-                        // but let's keep things uniform
-                        params->openPMDSeries->flush();
+                        flushCollectively(*params->openPMDSeries);
                         continue;
                     }
 
@@ -137,7 +135,7 @@ namespace picongpu
                         span[i] = reinterpret_cast<ComponentType*>(dataPtr)[d + i * components];
                     }
 
-                    params->openPMDSeries->flush();
+                    flushCollectively(*params->openPMDSeries);
                 }
 
                 auto unitMap = convertToUnitDimension(unitDimension);

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -103,7 +103,7 @@ namespace picongpu
 
                     if(elements == 0)
                     {
-                        flushCollectively(*params->openPMDSeries);
+                        flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
                         continue;
                     }
 
@@ -135,7 +135,7 @@ namespace picongpu
                         span[i] = reinterpret_cast<ComponentType*>(dataPtr)[d + i * components];
                     }
 
-                    flushCollectively(*params->openPMDSeries);
+                    flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
                 }
 
                 auto unitMap = convertToUnitDimension(unitDimension);


### PR DESCRIPTION
The upcoming BP5 engine in ADIOS2 has some features for saving memory compared to BP4.

BP5 will **not** replace BP4 because these memory optimizations come at a runtime cost, instead users will be able to decide between runtime efficiency and memory efficiency.

One feature that we asked for and is now implemented is the ability to flush data to disk within a single IO step. I'm [currently working on](https://github.com/openPMD/openPMD-api/pull/1207) exposing this functionality in openPMD. Together with that PR, this PR makes the feature available as a preview in PIConGPU.

Pinging @psychocoderHPC because he asked for this feature

TODO:
- [x] Merge https://github.com/openPMD/openPMD-api/pull/1207 in openPMD-api
- [x] Resolve https://github.com/openPMD/openPMD-api/issues/1205 in openPMD-api before starting to use BP5 in production workflows, otherwise there will be too much confusion
- [x] Maybe wait for ADIOS 2.8.0 release which will contain the BP5 engine for the first time
- [x] There might still be API changes in the openPMD-api PR, adapt to them
- [x] Parallel testing

**First results**

I ran 4 tests, each one writing 3 IO steps, bit more than 15Gb per step:

1. BP4 engine without InitialBufferSize 
2. BP4 engine with correctly specified InitialBufferSize
3. BP5 engine without this PR
4. BP5 engine with this PR, aggressively write to disk as often as possible

The memory profiles of each run are seen in the following screenshot line by line, note the different y scales
```
( 1 | 2 )
( 3 | 4 )
```
![Bildschirmfoto vom 2022-02-28 15-30-54](https://user-images.githubusercontent.com/14241876/156002569-eca39c4c-2469-4e56-a1db-c12cff37263e.png)

Further details:
![Bildschirmfoto vom 2022-02-28 15-30-35](https://user-images.githubusercontent.com/14241876/156002684-0c9eacda-bd02-4ff1-a3e6-edadc99aba2d.png)

Interpretation:

1. Known pathological behavior if not specifying InitialBufferSize, don't do this
2. Best speed, but high memory usage and necessity to specify InitialBufferSize beforehand
3. Buffers are allocated as needed, memory usage is equivalent to 2. if InitialBufferSize is specified as the perfect amount
4. Lowest memory usage, but long runtime due to many little write operations. Compared to the current ADIOS2 output, this saves ~15Gb of peak memory usage

As it stands, the runtime duration of BP5 approaches is very long in these benchmarks. The parameters of the BP5 engine are not yet documented, so I have not really had the chance to tune this yet. 