### PR TITLE
Workaround NVCC 11.6 compile bug

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -561,6 +561,12 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             private:
                 using UnitType = typename FieldTmp::UnitValueType;
                 using ValueType = typename FieldTmp::ValueType;
+                /*
+                 * Do not change the following lines.
+                 * NVCC 11.6 seems to have a parser bug and it does not understand the short form:
+                 * `using ComponentType = typename GetComponentsType<ValueType>`
+                 * more info: https://github.com/ComputationalRadiationPhysics/picongpu/pull/4006
+                 */
                 using GetComponentsTypeValueType = GetComponentsType<ValueType>;
                 using ComponentType = typename GetComponentsTypeValueType::type;
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -561,7 +561,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             private:
                 using UnitType = typename FieldTmp::UnitValueType;
                 using ValueType = typename FieldTmp::ValueType;
-                using ComponentType = typename GetComponentsType<ValueType>::type;
+                using GetComponentsTypeValueType = GetComponentsType<ValueType>;
+                using ComponentType = typename GetComponentsTypeValueType::type;
 
                 /** Get the unit for the result from the solver*/
                 static std::vector<float_64> getUnit()


### PR DESCRIPTION
Without this change:

```
[ 71%] Building CUDA object CMakeFiles/picongpu.dir/main.cpp.o
/usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/usr/bin/mpic++ -DADIOS2_USE_MPI -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY_MODE -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -DALPAKA_DEBUG=0 -DALPAKA_DEBUG_OFFLOAD_ASSUME_HOST -DALPAKA_OFFLOAD_MAX_BLOCK_SIZE=256 -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_MATH_TR1_DYN_LINK -DBOOST_NO_AUTO_PTR -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_ID=GNU -DCMAKE_CXX_COMPILER_VERSION=11.1.0 -DCMAKE_SYSTEM=Linux-5.4.0-99-generic -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_VERSION=3.21.3 -DCUPLA_STREAM_ASYNC_ENABLED=1 -DENABLE_OPENPMD=1 -DNO_FREETYPE -DPIC_ENABLE_PNG=1 -DPIC_VERBOSE_LVL=63 -DPMACC_VERBOSE_LVL=0 -I/home/franzpoeschel/singularity_build/PIC_build/include -I/home/franzpoeschel/git-repos/picongpu/thirdParty/mallocMC/src/include -I/home/franzpoeschel/git-repos/picongpu/include/pmacc/.. -I/home/franzpoeschel/git-repos/picongpu/include/picongpu/.. -I/home/franzpoeschel/git-repos/picongpu/thirdParty/cupla/include -isystem=/usr/local/cuda/targets/x86_64-linux/include -isystem=/home/franzpoeschel/git-repos/picongpu/thirdParty/cupla/alpaka/include -isystem=/usr/local/cuda/include -isystem=/home/franzpoeschel/singularity_build/local/include -O3 -DNDEBUG --generate-code=arch=compute_35,code=[compute_35,sm_35] --expt-extended-lambda --expt-relaxed-constexpr -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=esa_on_defaulted_function_ignored -std=c++17 -MD -MT CMakeFiles/picongpu.dir/main.cpp.o -MF CMakeFiles/picongpu.dir/main.cpp.o.d -x cu -c /home/franzpoeschel/git-repos/picongpu/include/picongpu/main.cpp -o CMakeFiles/picongpu.dir/main.cpp.o
nvcc warning : The 'compute_35', 'compute_37', 'sm_35', and 'sm_37' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
/home/franzpoeschel/git-repos/picongpu/include/pmacc/../picongpu/plugins/openPMD/openPMDWriter.hpp:564:23: error: need 'typename' before 'pmacc::traits::GetComponentsType<pmacc::math::Vector<float, 1>, is_fundamental_v<pmacc::math::Vector<float, 1, pmacc::math::StandardAccessor, pmacc::math::StandardNavigator, pmacc::math::detail::Vector_components<float, 1> > > >::type' because 'pmacc::traits::GetComponentsType<pmacc::math::Vector<float, 1>, is_fundamental_v<pmacc::math::Vector<float, 1, pmacc::math::StandardAccessor, pmacc::math::StandardNavigator, pmacc::math::detail::Vector_components<float, 1> > > >' is a dependent scope
  564 |                 using ComponentType = typename GetComponentsType<ValueType>::type;
      |                       ^~~~~
      |                       typename
```

I think this is a Parser bug in NVCC. Splitting up the statement makes NVCC understand it again at least for me.