### PR TITLE
Enable --mpiDirect for crusher-ornl

### DIFF
--- a/etc/picongpu/crusher-ornl/batch.tpl
+++ b/etc/picongpu/crusher-ornl/batch.tpl
@@ -98,5 +98,5 @@ ln -s ../stdout output
 
 
 # Run PIConGPU
-srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+srun -K1 !TBG_dstPath/input/bin/picongpu --mpiDirect !TBG_author !TBG_programParams
 


### PR DESCRIPTION
@psychocoderHPC's short tests showed that MI250X performs slightly better when using
`--mpiDirect`.

fix #3988