### PR TITLE
Update build instruction for Boost

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -99,7 +99,7 @@ boost
   - ``tar -xzf boost_1_66_0.tar.gz``
   - ``cd boost_1_66_0``
   - ``./bootstrap.sh --with-libraries=atomic,chrono,context,date_time,fiber,filesystem,math,program_options,serialization,system,thread --prefix=$HOME/lib/boost``
-  - ``./b2 cxxflags="-std=c++11" -j4 && ./b2 install``
+  - ``./b2 cxxflags="-std=c++14" -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
 
   - ``export BOOST_ROOT=$HOME/lib/boost``


### PR DESCRIPTION
In order to fix a linking error, Boost needs to be built with C++14 (see https://github.com/boostorg/system/issues/26).
A question before merging may be: Should we recommend building boost using C++17 instead of C++14?

```
[ 96%] Linking CXX executable picongpu
libpicongpu-hostonly.a(toml.cpp.o):toml.cpp:function boost::system::error_category::std_category::equivalent(std::error_code const&, int) const: error: undefined reference to 'boost::system::detail::generic_category_instance'
libpicongpu-hostonly.a(toml.cpp.o):toml.cpp:function boost::system::error_category::std_category::equivalent(std::error_code const&, int) const: error: undefined reference to 'boost::system::detail::generic_category_instance'
libpicongpu-hostonly.a(toml.cpp.o):toml.cpp:function boost::system::error_category::std_category::equivalent(std::error_code const&, int) const: error: undefined reference to 'boost::system::detail::generic_category_instance'
libpicongpu-hostonly.a(toml.cpp.o):toml.cpp:function boost::system::error_category::std_category::equivalent(std::error_code const&, int) const: error: undefined reference to 'boost::system::detail::generic_category_instance'
collect2: Fehler: ld gab 1 als Ende-Status zurück
make[2]: *** [picongpu] Fehler 1
make[1]: *** [CMakeFiles/picongpu.dir/all] Fehler 2
make: *** [all] Fehler 2
```