### PR TITLE
Fix fieldBackground constructors to be HINLINE

### DIFF
--- a/include/picongpu/param/fieldBackground.param
+++ b/include/picongpu/param/fieldBackground.param
@@ -36,7 +36,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundE(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundE(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 
@@ -68,7 +68,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundB(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundB(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 
@@ -100,7 +100,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
@@ -209,7 +209,7 @@ namespace picongpu
         /** We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/fieldBackground.param
@@ -35,7 +35,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundE(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundE(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 
@@ -62,7 +62,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundB(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundB(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 
@@ -112,7 +112,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
@@ -33,7 +33,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundE(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundE(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 
@@ -60,7 +60,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundB(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundB(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 
@@ -87,7 +87,7 @@ namespace picongpu
         /* We use this to calculate your SI input back to our unit system */
         PMACC_ALIGN(m_unitField, const float3_64);
 
-        HDINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
+        HINLINE FieldBackgroundJ(const float3_64 unitField) : m_unitField(unitField)
         {
         }
 


### PR DESCRIPTION
fieldBackground constructors are instantiated on the host. Using `HDINLINE` produces compiler warnings.