### PR TITLE
openPMD-based plugins: choose default backend depending on what is available

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -97,10 +97,24 @@ namespace picongpu
              * output with old outpu
              */
             plugins::multi::Option<std::string> file_name_extension
-                = {"ext",
-                   "openPMD filename extension (this controls the"
-                   "backend picked by the openPMD API)",
-                   "h5"};
+                = { "ext",
+                    "openPMD filename extension (this controls the"
+                    "backend picked by the openPMD API)",
+#if openPMD_HAVE_HDF5
+                    "h5"
+#elif openPMD_HAVE_ADIOS2
+                    "bp"
+#else
+                    /*
+                     * This branch should never be activated because CMake will
+                     * not enable the openPMD plugin in that case anyway.
+                     */
+                    static_assert(
+                        false,
+                        "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
+                        "openPMD plugin.")
+#endif
+                  };
 
             plugins::multi::Option<std::string> json_config
                 = {"json", "advanced (backend) configuration for openPMD in JSON format", "{}"};

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -116,7 +116,20 @@ namespace picongpu
 
         MappingDesc* cellDescription;
         std::string notifyPeriod;
+#if openPMD_HAVE_HDF5
         std::string m_filenameExtension = "h5";
+#elif openPMD_HAVE_ADIOS2
+        std::string m_filenameExtension = "bp";
+#else
+        /*
+         * This branch should never be activated because CMake will
+         * not enable the openPMD plugin in that case anyway.
+         */
+        static_assert(
+            false,
+            "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
+            "openPMD plugin.");
+#endif
         std::string m_filenameInfix = "_%06T";
 
         std::string pluginName;
@@ -161,7 +174,21 @@ namespace picongpu
             desc.add_options()(
                 (pluginPrefix + ".ext").c_str(),
                 po::value<std::string>(&m_filenameExtension),
-                "openPMD filename extension (default: 'h5')");
+#if openPMD_HAVE_HDF5
+                "openPMD filename extension (default: 'h5')"
+#elif openPMD_HAVE_ADIOS2
+                "openPMD filename extension (default: 'bp')"
+#else
+                /*
+                 * This branch should never be activated because CMake will
+                 * not enable the openPMD plugin in that case anyway.
+                 */
+                static_assert(
+                    false,
+                    "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
+                    "openPMD plugin.")
+#endif
+            );
             desc.add_options()(
                 (pluginPrefix + ".infix").c_str(),
                 po::value<std::string>(&m_filenameInfix),

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -429,7 +429,24 @@ namespace picongpu
             plugins::multi::Option<std::string> notifyPeriod = {"period", "enable plugin [for each n-th step]"};
             plugins::multi::Option<std::string> fileName = {"file", "output filename (prefix)"};
             plugins::multi::Option<std::string> filter = {"filter", "particle filter: "};
-            plugins::multi::Option<std::string> extension = {"ext", "openPMD filename extension", "h5"};
+            plugins::multi::Option<std::string> extension
+                = { "ext",
+                    "openPMD filename extension",
+#if openPMD_HAVE_HDF5
+                    "h5"
+#elif openPMD_HAVE_ADIOS2
+                    "bp"
+#else
+                    /*
+                     * This branch should never be activated because CMake will
+                     * not enable the openPMD plugin in that case anyway.
+                     */
+                    static_assert(
+                        false,
+                        "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
+                        "openPMD plugin.")
+#endif
+                  };
             plugins::multi::Option<uint32_t> numBinsYaw = {"numBinsYaw", "number of bins for angle yaw.", 64};
             plugins::multi::Option<uint32_t> numBinsPitch = {"numBinsPitch", "number of bins for angle pitch.", 64};
             plugins::multi::Option<uint32_t> numBinsEnergy

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.hpp
@@ -197,7 +197,24 @@ namespace picongpu
                         po::value<std::string>(&fileName)->default_value(pluginName + "Output"),
                         "output file name")(
                         (pluginPrefix + ".ext").c_str(),
-                        po::value<std::string>(&fileExtension)->default_value("bp"),
+                        po::value<std::string>(&fileExtension)
+                            ->default_value(
+#if openPMD_HAVE_ADIOS2
+                                "bp"
+#elif openPMD_HAVE_HDF5
+                                "h5"
+#else
+                                /*
+                                 * This branch should never be activated because CMake will
+                                 * not enable the openPMD plugin in that case anyway.
+                                 */
+                                static_assert(
+                                    false,
+                                    "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to "
+                                    "deactivate the "
+                                    "openPMD plugin.")
+#endif
+                                ),
                         "openPMD filename extension (this controls the backend "
                         "picked by the openPMD API)")(
                         (pluginPrefix + ".memoryLayout").c_str(),


### PR DESCRIPTION
Follow-up to #4008
All other openPMD-based plugins have the same issue.

Note: openPMD is also used inside `particles/densityProfiles/FromOpenPMDImpl.hpp`, but I don't really understand where the filename comes from in there. Anyone knows who wrote / who uses that?

After this fix:

**Compiling openPMD without HDF5**
```
> picongpu --help | grep -E '(openPMD\.ext|calorimeter\.ext|phaseSpace\.ext|macroParticlesPerSuperCell\.ext|xrayScattering\.ext)' -C2
                                        frame count blowup
  --checkpoint.openPMD.file arg         openPMD file basename
  --checkpoint.openPMD.ext arg          openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: bp
--
  --openPMD.toml arg                    specify dynamic data sources via TOML
  --openPMD.file arg                    openPMD file basename
  --openPMD.ext arg                     openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: bp
--
  --e_xrayScattering.file arg (=xrayScattering: Calculate the SAXS scattering intensity of a species.Output)
                                        output file name
  --e_xrayScattering.ext arg (=bp)      openPMD filename extension (this 
                                        controls the backend picked by the 
                                        openPMD API)
--
  --e_calorimeter.period arg            enable plugin [for each n-th step]
  --e_calorimeter.file arg              output filename (prefix)
  --e_calorimeter.ext arg               openPMD filename extension | default: 
                                        bp
  --e_calorimeter.filter arg            particle filter: [all, 
--
  --e_phaseSpace.min arg                min range momentum [m_species c]
  --e_phaseSpace.max arg                max range momentum [m_species c]
  --e_phaseSpace.ext arg                openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: bp
--
  --e_macroParticlesPerSuperCell.period arg
                                        enable plugin [for each n-th step]
  --e_macroParticlesPerSuperCell.ext arg
                                        openPMD filename extension (default: 
                                        'bp')
--
  --i_xrayScattering.file arg (=xrayScattering: Calculate the SAXS scattering intensity of a species.Output)
                                        output file name
  --i_xrayScattering.ext arg (=bp)      openPMD filename extension (this 
                                        controls the backend picked by the 
                                        openPMD API)
--
  --i_calorimeter.period arg            enable plugin [for each n-th step]
  --i_calorimeter.file arg              output filename (prefix)
  --i_calorimeter.ext arg               openPMD filename extension | default: 
                                        bp
  --i_calorimeter.filter arg            particle filter: [all, 
--
  --i_phaseSpace.min arg                min range momentum [m_species c]
  --i_phaseSpace.max arg                max range momentum [m_species c]
  --i_phaseSpace.ext arg                openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: bp
--
  --i_macroParticlesPerSuperCell.period arg
                                        enable plugin [for each n-th step]
  --i_macroParticlesPerSuperCell.ext arg
                                        openPMD filename extension (default: 
                                        'bp')

```

**When deactivating ADIOS2**
```
> picongpu --help | grep -E '(openPMD\.ext|calorimeter\.ext|phaseSpace\.ext|macroParticlesPerSuperCell\.ext|xrayScattering\.ext)' -C2
                                        frame count blowup
  --checkpoint.openPMD.file arg         openPMD file basename
  --checkpoint.openPMD.ext arg          openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: h5
--
  --openPMD.toml arg                    specify dynamic data sources via TOML
  --openPMD.file arg                    openPMD file basename
  --openPMD.ext arg                     openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: h5
--
  --e_xrayScattering.file arg (=xrayScattering: Calculate the SAXS scattering intensity of a species.Output)
                                        output file name
  --e_xrayScattering.ext arg (=h5)      openPMD filename extension (this 
                                        controls the backend picked by the 
                                        openPMD API)
--
  --e_calorimeter.period arg            enable plugin [for each n-th step]
  --e_calorimeter.file arg              output filename (prefix)
  --e_calorimeter.ext arg               openPMD filename extension | default: 
                                        h5
  --e_calorimeter.filter arg            particle filter: [all, 
--
  --e_phaseSpace.min arg                min range momentum [m_species c]
  --e_phaseSpace.max arg                max range momentum [m_species c]
  --e_phaseSpace.ext arg                openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: h5
--
  --e_macroParticlesPerSuperCell.period arg
                                        enable plugin [for each n-th step]
  --e_macroParticlesPerSuperCell.ext arg
                                        openPMD filename extension (default: 
                                        'h5')
--
  --i_xrayScattering.file arg (=xrayScattering: Calculate the SAXS scattering intensity of a species.Output)
                                        output file name
  --i_xrayScattering.ext arg (=h5)      openPMD filename extension (this 
                                        controls the backend picked by the 
                                        openPMD API)
--
  --i_calorimeter.period arg            enable plugin [for each n-th step]
  --i_calorimeter.file arg              output filename (prefix)
  --i_calorimeter.ext arg               openPMD filename extension | default: 
                                        h5
  --i_calorimeter.filter arg            particle filter: [all, 
--
  --i_phaseSpace.min arg                min range momentum [m_species c]
  --i_phaseSpace.max arg                max range momentum [m_species c]
  --i_phaseSpace.ext arg                openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: h5
--
  --i_macroParticlesPerSuperCell.period arg
                                        enable plugin [for each n-th step]
  --i_macroParticlesPerSuperCell.ext arg
                                        openPMD filename extension (default: 
                                        'h5')
```

**Both backends activated** (defaults depend on the plugin):
```
> picongpu --help | grep -E '(openPMD\.ext|calorimeter\.ext|phaseSpace\.ext|macroParticlesPerSuperCell\.ext|xrayScattering\.ext)' -C2
                                        frame count blowup
  --checkpoint.openPMD.file arg         openPMD file basename
  --checkpoint.openPMD.ext arg          openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: bp
--
  --openPMD.toml arg                    specify dynamic data sources via TOML
  --openPMD.file arg                    openPMD file basename
  --openPMD.ext arg                     openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: bp
--
  --e_xrayScattering.file arg (=xrayScattering: Calculate the SAXS scattering intensity of a species.Output)
                                        output file name
  --e_xrayScattering.ext arg (=bp)      openPMD filename extension (this 
                                        controls the backend picked by the 
                                        openPMD API)
--
  --e_calorimeter.period arg            enable plugin [for each n-th step]
  --e_calorimeter.file arg              output filename (prefix)
  --e_calorimeter.ext arg               openPMD filename extension | default: 
                                        h5
  --e_calorimeter.filter arg            particle filter: [all, 
--
  --e_phaseSpace.min arg                min range momentum [m_species c]
  --e_phaseSpace.max arg                max range momentum [m_species c]
  --e_phaseSpace.ext arg                openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: h5
--
  --e_macroParticlesPerSuperCell.period arg
                                        enable plugin [for each n-th step]
  --e_macroParticlesPerSuperCell.ext arg
                                        openPMD filename extension (default: 
                                        'h5')
--
  --i_xrayScattering.file arg (=xrayScattering: Calculate the SAXS scattering intensity of a species.Output)
                                        output file name
  --i_xrayScattering.ext arg (=bp)      openPMD filename extension (this 
                                        controls the backend picked by the 
                                        openPMD API)
--
  --i_calorimeter.period arg            enable plugin [for each n-th step]
  --i_calorimeter.file arg              output filename (prefix)
  --i_calorimeter.ext arg               openPMD filename extension | default: 
                                        h5
  --i_calorimeter.filter arg            particle filter: [all, 
--
  --i_phaseSpace.min arg                min range momentum [m_species c]
  --i_phaseSpace.max arg                max range momentum [m_species c]
  --i_phaseSpace.ext arg                openPMD filename extension (this 
                                        controls thebackend picked by the 
                                        openPMD API) | default: h5
--
  --i_macroParticlesPerSuperCell.period arg
                                        enable plugin [for each n-th step]
  --i_macroParticlesPerSuperCell.ext arg
                                        openPMD filename extension (default: 
                                        'h5')
```