### PR TITLE
System DICC: add a system description and a profile for the GPU queue

### DIFF
--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -353,7 +353,7 @@ V100 GPUs (recommended)
    :language: bash
    
 DICC (UM)
-------------
+---------
 
 **System overview:** `link <https://www.dicc.um.edu.my/>`_
 
@@ -364,7 +364,7 @@ DICC (UM)
 For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>`.
 
 Queue: gpu (8 x NVIDIA Tesla k10 GPUs)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: profiles/dicc-um/gpu_picongpu.profile.example
    :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -351,3 +351,20 @@ V100 GPUs (recommended)
 
 .. literalinclude:: profiles/ascent-ornl/gpu_picongpu.profile.example
    :language: bash
+   
+DICC (UM)
+------------
+
+**System overview:** `link <https://www.dicc.um.edu.my/>`_
+
+**User guide:** `link <https://confluence.dicc.um.edu.my/display/HPCDOCS/HPC+Documentation>`_
+
+**Production directory:** usually ``/lustre/user/<username>`` (`link <https://confluence.dicc.um.edu.my/display/HPCDOCS/Managing+Storage`_)
+
+For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>`.
+
+Queue: gpu (8 x NVIDIA Tesla k10 GPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/dicc-um/gpu_picongpu.profile.example
+   :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -359,7 +359,7 @@ DICC (UM)
 
 **User guide:** `link <https://confluence.dicc.um.edu.my/display/HPCDOCS/HPC+Documentation>`_
 
-**Production directory:** usually ``/lustre/user/<username>`` (`link <https://confluence.dicc.um.edu.my/display/HPCDOCS/Managing+Storage`_)
+**Production directory:** usually ``/lustre/user/<username>`` (`link <https://confluence.dicc.um.edu.my/display/HPCDOCS/Managing+Storage>`_)
 
 For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>`.
 

--- a/etc/picongpu/dicc-um/gpu.tpl
+++ b/etc/picongpu/dicc-um/gpu.tpl
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Copyright 2013-2022 Jian Fuh Ong
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_gpusPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --mem=!TBG_memPerNode
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+## calculations will be performed by tbg ##
+.TBG_queue="gpu-k10"   
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"END"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject='free'
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=8  
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+
+# host memory per node
+.TBG_memPerNode=38000  
+
+# host memory per gpu
+.TBG_memPerGPU=$(( TBG_memPerNode / TBG_numHostedGPUPerNode ))
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+
+# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
+# fallback ROMIO backend instead.
+#   see bug https://github.com/open-mpi/ompi/issues/6285
+export OMPI_MCA_io=^ompio
+
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+  # Run CUDA memtest to check GPU's health
+  srun -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun -n !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+fi

--- a/etc/picongpu/dicc-um/gpu.tpl
+++ b/etc/picongpu/dicc-um/gpu.tpl
@@ -35,23 +35,23 @@
 #SBATCH -e stderr
 
 ## calculations will be performed by tbg ##
-.TBG_queue="gpu-k10"   
+.TBG_queue="gpu-k10"
 
 # settings that can be controlled by environment variables before submit
-.TBG_mailSettings=${MY_MAILNOTIFY:-"END"}
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_nameProject='free'
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 # number of available/hosted GPUs per node in the system
-.TBG_numHostedGPUPerNode=8  
+.TBG_numHostedGPUPerNode=8
 
 # required GPUs per node for the current job
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per node
-.TBG_memPerNode=38000  
+.TBG_memPerNode=38000
 
 # host memory per gpu
 .TBG_memPerGPU=$(( TBG_memPerNode / TBG_numHostedGPUPerNode ))

--- a/etc/picongpu/dicc-um/gpu_picongpu.profile.example
+++ b/etc/picongpu/dicc-um/gpu_picongpu.profile.example
@@ -5,7 +5,7 @@ export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURC
 #   - automatically add your name and contact to output file meta data
 #   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
 #     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
-export MY_MAILNOTIFY="END"
+export MY_MAILNOTIFY="NONE"
 export MY_MAIL="someone@example.com"
 export MY_NAME="$(whoami) <$MY_MAIL>"
 
@@ -27,7 +27,7 @@ module load pngwriter/pngwriter-0.7.0-gcc-8.5.0
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
-export PIC_BACKEND="cuda:30"  
+export PIC_BACKEND="cuda:30"
 export PATH=$PICSRC:$PATH
 export PATH=$PICSRC/bin:$PATH
 export PATH=$PICSRC/src/tools/bin:$PATH
@@ -36,9 +36,9 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export SCRATCH=/lustre/user/$(whoami)
 
 export TBG_SUBMIT="sbatch"
-export TBG_TPLFILE="$HOME/gpu.tpl"
+export TBG_TPLFILE="etc/picongpu/dicc-um/gpu.tpl"
 # use gpu for regular queue and gpu_low for low priority queue
-export TBG_partition="gpu-k10"   
+export TBG_partition="gpu-k10"
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/dicc-um/gpu_picongpu.profile.example
+++ b/etc/picongpu/dicc-um/gpu_picongpu.profile.example
@@ -1,0 +1,49 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="END"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# basic environment ###########################################################
+#
+module load git
+module load openpmd-api/openpmd-api-0.14.4-gcc-8.5.0
+module load boost/boost-1.74.0-gcc-8.5.0
+
+export CC=$(which gcc)
+export CXX=$(which g++)
+
+# plugins (optional) ##########################################################
+module load pngwriter/pngwriter-0.7.0-gcc-8.5.0
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:30"  
+export PATH=$PICSRC:$PATH
+export PATH=$PICSRC/bin:$PATH
+export PATH=$PICSRC/src/tools/bin:$PATH
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+export SCRATCH=/lustre/user/$(whoami)
+
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="$HOME/gpu.tpl"
+# use gpu for regular queue and gpu_low for low priority queue
+export TBG_partition="gpu-k10"   
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi


### PR DESCRIPTION
Add new system documentation, profiles and tbg template for the [DICC cluster at UM](https://www.dicc.um.edu.my/).

The module openpmd-api/openpmd-api-0.14.4 is linked to its dependencies. Loading it will load gcc, cuda, openmpi, adios2, hdf5, etc. The same for loading pngwriter/pngwriter-0.7.0-gcc-8.5.0 will load libpng, etc.