### PR TITLE
adjust modules for old kepler architecture

### DIFF
--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -19,7 +19,7 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.20.2
-module load cuda/11.2
+module load cuda/11.2-kepler
 module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -19,7 +19,7 @@ module purge
 module load git
 module load gcc/7.3.0
 module load cmake/3.20.2
-module load cuda/11.2
+module load cuda/11.2-kepler
 module load openmpi/4.0.4-cuda112
 module load boost/1.68.0
 


### PR DESCRIPTION
On the HZDR hemera cluster, the CUDA drives were updated rendering the old kepler GPUs k20 and k80 unusable. The IT provided new modules that support older drivers and thus the kepler architecture. 

This pull request adjust the modules in the example profiles. The setup has been testes. PIConGPU runs. 

(OpenMPI, HDF5, ADIOS, openPMD work when selecting the correct CUDA module too.) 