### PR TITLE
remove cupla compatibility marco definition

### DIFF
--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -139,22 +139,11 @@ namespace picongpu
             type* ptr = value.getIdentifier(T_Type()).getPointer();
             if(ptr != nullptr)
             {
+                /* cupla 0.2.0+ does not support the function cudaHostAlloc to create mapped memory.
+                 * Therefore we need to call the native CUDA function cuda/hipFreeHost to free memory.
+                 */
 #if(PMACC_CUDA_ENABLED == 1)
-/* cupla 0.2.0 does not support the function cudaHostAlloc to create mapped memory.
- * Therefore we need to call the native CUDA function cudaFreeHost to free memory.
- * Due to the renaming of cuda functions with cupla via macros we need to remove
- * the renaming to get access to the native cuda function.
- * @todo this is a workaround please fix me. We need to investigate if
- * it is possible to have mapped/unified memory in alpaka.
- *
- * corresponding alpaka issues:
- *   https://github.com/ComputationalRadiationPhysics/alpaka/issues/296
- *   https://github.com/ComputationalRadiationPhysics/alpaka/issues/612
- */
-#    undef cudaFreeHost
                 CUDA_CHECK((cuplaError_t) cudaFreeHost(ptr));
-// re-introduce the cupla macro
-#    define cudaFreeHost(...) cuplaFreeHost(__VA_ARGS__)
 #elif(ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 CUDA_CHECK((cuplaError_t) hipHostFree(ptr));
 #else


### PR DESCRIPTION
Remove a left over macro from the time where PIConGPU used cupla cuda compatibility headers.