### PR TITLE
Extend comments in density.param

### DIFF
--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -21,8 +21,30 @@
 /** @file
  *
  * Configure existing or define new normalized density profiles here.
- * During particle species creation in speciesInitialization.param,
+ * During particle species creation in `speciesInitialization.param`,
  * those profiles can be translated to spatial particle distributions.
+ *
+ * This profile is normalized to units of `picongpu::SI::BASE_DENSITY_SI`, also defined in this file.
+ * Note that it only operates with physical density, and does not concern macroparticles.
+ * The number and sampling of macroparticles per cell are defined independently of a density profile.
+ * Please refer to documentation of `picongpu::particles::CreateDensity<>` for further details on this interaction.
+ *
+ * Available profiles:
+ *  - HomogenousImpl          : homogeneous density in whole simulation volume
+ *  - GaussianImpl<>          : Gaussian profile in 'y', optionally with preceeding vacuum
+ *  - GaussianCloudImpl<>     : Gaussian profile in all axes, optionally with preceeding vacuum in 'y'
+ *  - LinearExponentialImpl<> : linear ramping of density in 'y' into exponential slope after
+ *  - SphereFlanksImpl<>      : composition of 1D profiles, each in form of
+ *                              exponential increasing flank, constant sphere, exponential decreasing flank
+ *  - EveryNthCellImpl<>      : checkerboard profile matching the grid, particles are only present in cells
+ *                              with the given stride from one another in all directions
+ *  - FreeFormulaImpl<>       : apply user-defined functor for calculating density,
+ *                              refer to `picongpu::densityProfiles::IProfile` for interface requirements
+ *  - FromOpenPMDImpl<>       : load density values from a given file, requires openPMD API dependency
+ *
+ * In the end, this file typically defines an alias for each density profile to be used.
+ * These aliases do not have to follow any naming convention, but serve as template parameters for
+ * invocations of `picongpu::particles::CreateDensity<>` in `speciesInitialization.param`.
  */
 
 #pragma once
@@ -222,6 +244,9 @@ namespace picongpu
 
         /* definition of sphere profile with flanks */
         using SphereFlanks = SphereFlanksImpl<SphereFlanksParam>;
+
+        /* definition of checkerboard density profile with particles every fourth cell in all directions */
+        using EveryFourthCell = EveryNthCellImpl<mCT::UInt32<4, 4, 4>>;
 
         /** Density values taken from an openPMD file
          *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/density.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/density.param
@@ -21,8 +21,30 @@
 /** @file
  *
  * Configure existing or define new normalized density profiles here.
- * During particle species creation in speciesInitialization.param,
+ * During particle species creation in `speciesInitialization.param`,
  * those profiles can be translated to spatial particle distributions.
+ *
+ * This profile is normalized to units of `picongpu::SI::BASE_DENSITY_SI`, also defined in this file.
+ * Note that it only operates with physical density, and does not concern macroparticles.
+ * The number and sampling of macroparticles per cell are defined independently of a density profile.
+ * Please refer to documentation of `picongpu::particles::CreateDensity<>` for further details on this interaction.
+ *
+ * Available profiles:
+ *  - HomogenousImpl          : homogeneous density in whole simulation volume
+ *  - GaussianImpl<>          : Gaussian profile in 'y', optionally with preceeding vacuum
+ *  - GaussianCloudImpl<>     : Gaussian profile in all axes, optionally with preceeding vacuum in 'y'
+ *  - LinearExponentialImpl<> : linear ramping of density in 'y' into exponential slope after
+ *  - SphereFlanksImpl<>      : composition of 1D profiles, each in form of
+ *                              exponential increasing flank, constant sphere, exponential decreasing flank
+ *  - EveryNthCellImpl<>      : checkerboard profile matching the grid, particles are only present in cells
+ *                              with the given stride from one another in all directions
+ *  - FreeFormulaImpl<>       : apply user-defined functor for calculating density,
+ *                              refer to `picongpu::densityProfiles::IProfile` for interface requirements
+ *  - FromOpenPMDImpl<>       : load density values from a given file, requires openPMD API dependency
+ *
+ * In the end, this file typically defines an alias for each density profile to be used.
+ * These aliases do not have to follow any naming convention, but serve as template parameters for
+ * invocations of `picongpu::particles::CreateDensity<>` in `speciesInitialization.param`.
  */
 
 #pragma once

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/density.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/density.param
@@ -21,8 +21,30 @@
 /** @file
  *
  * Configure existing or define new normalized density profiles here.
- * During particle species creation in speciesInitialization.param,
+ * During particle species creation in `speciesInitialization.param`,
  * those profiles can be translated to spatial particle distributions.
+ *
+ * This profile is normalized to units of `picongpu::SI::BASE_DENSITY_SI`, also defined in this file.
+ * Note that it only operates with physical density, and does not concern macroparticles.
+ * The number and sampling of macroparticles per cell are defined independently of a density profile.
+ * Please refer to documentation of `picongpu::particles::CreateDensity<>` for further details on this interaction.
+ *
+ * Available profiles:
+ *  - HomogenousImpl          : homogeneous density in whole simulation volume
+ *  - GaussianImpl<>          : Gaussian profile in 'y', optionally with preceeding vacuum
+ *  - GaussianCloudImpl<>     : Gaussian profile in all axes, optionally with preceeding vacuum in 'y'
+ *  - LinearExponentialImpl<> : linear ramping of density in 'y' into exponential slope after
+ *  - SphereFlanksImpl<>      : composition of 1D profiles, each in form of
+ *                              exponential increasing flank, constant sphere, exponential decreasing flank
+ *  - EveryNthCellImpl<>      : checkerboard profile matching the grid, particles are only present in cells
+ *                              with the given stride from one another in all directions
+ *  - FreeFormulaImpl<>       : apply user-defined functor for calculating density,
+ *                              refer to `picongpu::densityProfiles::IProfile` for interface requirements
+ *  - FromOpenPMDImpl<>       : load density values from a given file, requires openPMD API dependency
+ *
+ * In the end, this file typically defines an alias for each density profile to be used.
+ * These aliases do not have to follow any naming convention, but serve as template parameters for
+ * invocations of `picongpu::particles::CreateDensity<>` in `speciesInitialization.param`.
  */
 
 #pragma once

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/density.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/density.param
@@ -21,8 +21,30 @@
 /** @file
  *
  * Configure existing or define new normalized density profiles here.
- * During particle species creation in speciesInitialization.param,
+ * During particle species creation in `speciesInitialization.param`,
  * those profiles can be translated to spatial particle distributions.
+ *
+ * This profile is normalized to units of `picongpu::SI::BASE_DENSITY_SI`, also defined in this file.
+ * Note that it only operates with physical density, and does not concern macroparticles.
+ * The number and sampling of macroparticles per cell are defined independently of a density profile.
+ * Please refer to documentation of `picongpu::particles::CreateDensity<>` for further details on this interaction.
+ *
+ * Available profiles:
+ *  - HomogenousImpl          : homogeneous density in whole simulation volume
+ *  - GaussianImpl<>          : Gaussian profile in 'y', optionally with preceeding vacuum
+ *  - GaussianCloudImpl<>     : Gaussian profile in all axes, optionally with preceeding vacuum in 'y'
+ *  - LinearExponentialImpl<> : linear ramping of density in 'y' into exponential slope after
+ *  - SphereFlanksImpl<>      : composition of 1D profiles, each in form of
+ *                              exponential increasing flank, constant sphere, exponential decreasing flank
+ *  - EveryNthCellImpl<>      : checkerboard profile matching the grid, particles are only present in cells
+ *                              with the given stride from one another in all directions
+ *  - FreeFormulaImpl<>       : apply user-defined functor for calculating density,
+ *                              refer to `picongpu::densityProfiles::IProfile` for interface requirements
+ *  - FromOpenPMDImpl<>       : load density values from a given file, requires openPMD API dependency
+ *
+ * In the end, this file typically defines an alias for each density profile to be used.
+ * These aliases do not have to follow any naming convention, but serve as template parameters for
+ * invocations of `picongpu::particles::CreateDensity<>` in `speciesInitialization.param`.
  */
 
 #pragma once

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/density.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/density.param
@@ -21,8 +21,30 @@
 /** @file
  *
  * Configure existing or define new normalized density profiles here.
- * During particle species creation in speciesInitialization.param,
+ * During particle species creation in `speciesInitialization.param`,
  * those profiles can be translated to spatial particle distributions.
+ *
+ * This profile is normalized to units of `picongpu::SI::BASE_DENSITY_SI`, also defined in this file.
+ * Note that it only operates with physical density, and does not concern macroparticles.
+ * The number and sampling of macroparticles per cell are defined independently of a density profile.
+ * Please refer to documentation of `picongpu::particles::CreateDensity<>` for further details on this interaction.
+ *
+ * Available profiles:
+ *  - HomogenousImpl          : homogeneous density in whole simulation volume
+ *  - GaussianImpl<>          : Gaussian profile in 'y', optionally with preceeding vacuum
+ *  - GaussianCloudImpl<>     : Gaussian profile in all axes, optionally with preceeding vacuum in 'y'
+ *  - LinearExponentialImpl<> : linear ramping of density in 'y' into exponential slope after
+ *  - SphereFlanksImpl<>      : composition of 1D profiles, each in form of
+ *                              exponential increasing flank, constant sphere, exponential decreasing flank
+ *  - EveryNthCellImpl<>      : checkerboard profile matching the grid, particles are only present in cells
+ *                              with the given stride from one another in all directions
+ *  - FreeFormulaImpl<>       : apply user-defined functor for calculating density,
+ *                              refer to `picongpu::densityProfiles::IProfile` for interface requirements
+ *  - FromOpenPMDImpl<>       : load density values from a given file, requires openPMD API dependency
+ *
+ * In the end, this file typically defines an alias for each density profile to be used.
+ * These aliases do not have to follow any naming convention, but serve as template parameters for
+ * invocations of `picongpu::particles::CreateDensity<>` in `speciesInitialization.param`.
  */
 
 #pragma once


### PR DESCRIPTION
As pointed out in #4020, documentation of density profiles in `density.param` is lacking. This PR adds the user-facing part as a "header" of the file that's hooked up to readthedocs.
Also added demonstration of every Nth cell density, as it was missing from the file.

Adding documentation to `.def` files and fixing naming of homogenous density will be done elsewhere.