### PR TITLE
Add doxygen comments to declarations of density profile types

### DIFF
--- a/include/picongpu/particles/densityProfiles/FreeFormulaImpl.def
+++ b/include/picongpu/particles/densityProfiles/FreeFormulaImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -24,7 +24,11 @@ namespace picongpu
 {
     namespace densityProfiles
     {
-        template<typename T_ParamClass>
+        /** Apply user-defined functor for calculating density profile
+         *
+         * @tparam T_UserFunctor functor to calculate density, adheres to IProfile concept
+         */
+        template<typename T_UserFunctor>
         struct FreeFormulaImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.def
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -26,9 +26,22 @@ namespace picongpu
 {
     namespace densityProfiles
     {
+        /** Density values taken from an openPMD file
+         *
+         * The density values must be a scalar dataset of type float_X, type mismatch would cause errors.
+         * This implementation would ignore all openPMD metadata but axisLabels.
+         * Each value in the dataset defines density in the cell with the corresponding total coordinate minus the
+         * given offset. When the functor is instantiated, it will load the part matching the current domain position.
+         * Density in points not present in the file would be set to the given default density.
+         * Dimensionality of the file indexing must match the simulation dimensionality.
+         * Density values are in BASE_DENSITY_SI units.
+         *
+         * @tparam T_ParamClass structure with parameters,
+         *                      requirements are documented by FromOpenPMDParam in density.param
+         */
         template<typename T_ParamClass>
         struct FromOpenPMDImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu
 
 #endif

--- a/include/picongpu/particles/densityProfiles/GaussianCloudImpl.def
+++ b/include/picongpu/particles/densityProfiles/GaussianCloudImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -24,7 +24,16 @@ namespace picongpu
 {
     namespace densityProfiles
     {
+        /** Gaussian density profile in all axes, optionally with preceeding vacuum in 'y'
+         *
+         * Profile Formula:
+         *     exponent = |globalCellPos - center| / sigma
+         *     density = e^[ gasFactor * exponent^gasPower ]
+         *
+         * @tparam T_ParamClass structure with parameters,
+         *                      requirements are documented by GaussianCloudParam in density.param
+         */
         template<typename T_ParamClass>
         struct GaussianCloudImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.def
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -24,7 +24,20 @@ namespace picongpu
 {
     namespace densityProfiles
     {
+        /** Gaussian density profile in 'y', optionally with preceeding vacuum
+         *
+         * Profile formula (parameters defined via the template parameter type):
+         *   `const float_X exponent = abs((y - gasCenter_SI) / gasSigma_SI);`
+         *   `const float_X density = exp(gasFactor * pow(exponent, gasPower));`
+         *
+         *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
+         *         `gasCenterRight_SI     for y > gasCenterRight_SI`,
+         *   and `exponent = 0.0 for gasCenterLeft_SI < y < gasCenterRight_SI`
+         *
+         * @tparam T_ParamClass structure with parameters,
+         *                      requirements are documented by GaussianParam in density.param
+         */
         template<typename T_ParamClass>
         struct GaussianImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/HomogenousImpl.def
+++ b/include/picongpu/particles/densityProfiles/HomogenousImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -24,6 +24,7 @@ namespace picongpu
 {
     namespace densityProfiles
     {
+        //! Homogeneous density in whole simulation volume
         struct HomogenousImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/LinearExponentialImpl.def
+++ b/include/picongpu/particles/densityProfiles/LinearExponentialImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -24,7 +24,12 @@ namespace picongpu
 {
     namespace densityProfiles
     {
+        /** Linear ramping of density in 'y' into exponential slope after
+         *
+         * @tparam T_ParamClass structure with parameters,
+         *                      requirements are documented by LinearExponentialParam in density.param
+         */
         template<typename T_ParamClass>
         struct LinearExponentialImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu

--- a/include/picongpu/particles/densityProfiles/SphereFlanksImpl.def
+++ b/include/picongpu/particles/densityProfiles/SphereFlanksImpl.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2022 Rene Widera, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -24,7 +24,13 @@ namespace picongpu
 {
     namespace densityProfiles
     {
+        /** Density profile that is a composition of 1D profiles, each in form of exponential increasing flank,
+         * constant sphere, exponential decreasing flank
+         *
+         * @tparam T_ParamClass structure with parameters,
+         *                      requirements are documented by SphereFlanksParam in density.param
+         */
         template<typename T_ParamClass>
         struct SphereFlanksImpl;
-    }
+    } // namespace densityProfiles
 } // namespace picongpu


### PR DESCRIPTION
Those were missing before.

I decided to not copy-paste full documentation already present in `density.param`, as then we would have to support two things. Instead, I made a brief description in spirit of what is being added in #4020, and also "linked" the parameter requirements from `density.param` by names of those structs. Those are still not proper concepts, but at least now it should be more readable.

This is logically a continuation of PR #4021 to solve another point raised by #4020. Technically the two PRs are independent from one another.