### PR TITLE
Fix copying of cuSTL device buffers

### DIFF
--- a/include/pmacc/cuSTL/container/copier/D2DCopier.hpp
+++ b/include/pmacc/cuSTL/container/copier/D2DCopier.hpp
@@ -37,27 +37,21 @@ namespace pmacc
         {
             static constexpr int dim = T_dim;
 
-            PMACC_NO_NVCC_HDWARNING /* Handled via CUDA_ARCH */
-                template<typename Type>
-                HINLINE static void copy(
-                    Type* dest,
-                    const math::Size_t<dim - 1>& pitchDest,
-                    Type* source,
-                    const math::Size_t<dim - 1>& pitchSource,
-                    const math::Size_t<dim>& size)
+            template<typename Type>
+            HINLINE static void copy(
+                Type* dest,
+                const math::Size_t<dim - 1>& pitchDest,
+                Type* source,
+                const math::Size_t<dim - 1>& pitchSource,
+                const math::Size_t<dim>& size)
             {
-                typedef cursor::BufferCursor<Type, dim> Cursor;
-                Cursor bufCursorDest(dest, pitchDest);
-                Cursor bufCursorSrc(source, pitchSource);
-                cursor::MapTo1DNavigator<dim> myNavi(size);
-
-                auto srcCursor = cursor::make_Cursor(cursor::CursorAccessor<Cursor>(), myNavi, bufCursorSrc);
-                auto destCursor = cursor::make_Cursor(cursor::CursorAccessor<Cursor>(), myNavi, bufCursorDest);
-                size_t sizeProd = size.productOfComponents();
-                for(size_t i = 0; i < sizeProd; i++)
-                {
-                    destCursor[i] = srcCursor[i];
-                }
+                cuplaWrapper::Memcopy<dim>()(
+                    dest,
+                    pitchDest,
+                    source,
+                    pitchSource,
+                    size,
+                    cuplaWrapper::flags::Memcopy::deviceToDevice);
             }
         };
 


### PR DESCRIPTION
The implementation was trying to directly write to device addresses from a host side. It resulted in a segfault with invalid permissions.

This behavior was introduced accidentally in #3862. That PR kept the wrong of the two pre-existing code paths. As a result, code was written as if in-kernel, while it is host-only. Restore the fitting code path.

I now re-reviewed whole #3862 , there seem to be no other wrong-branch mistakes there.

This error is part of the last release. Which means e.g. particle calorimeter doesn't work on GPU, and maybe some other plugins as well.