### PR TITLE
fix soft restart

### DIFF
--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -235,6 +235,10 @@ namespace pmacc
 
             for(uint32_t nthSoftRestart = 0; nthSoftRestart <= softRestarts; ++nthSoftRestart)
             {
+                /* Global offset is updated during the simulation. In case we perform a soft restart we need to reset
+                 * the offset here to be valid for the next simulation run.
+                 */
+                Environment<DIM>::get().SubGrid().setGlobalDomainOffset(DataSpace<DIM>::create(0));
                 resetAll(0);
                 uint32_t currentStep = fillSimulation();
                 Environment<>::get().SimulationDescription().setCurrentStep(currentStep);


### PR DESCRIPTION
The sub-grid structure of PMacc is updated from external classes.
In the case of a soft restart, the global offset must be reset to be valid for the next simulation.

This bug was found with ISAAC where we mostly use the soft restart option. If the moving window is enabled and the simulation restarted all particles in the domain got deleted.

CC-ing: @PrometheusPi 