### PR TITLE
fix openPMD outputs negative particle patch offset

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -50,6 +50,8 @@
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/vector.hpp>
 
+#include <algorithm>
+
 
 namespace picongpu
 {
@@ -493,7 +495,10 @@ namespace picongpu
                         ds.options = params->jsonMatcher->get(basename + "/particlePatches/extent/" + name_lookup[d]);
                         extent_x.resetDataset(ds);
 
-                        offset_x.store<index_t>(mpiRank, particleOffset[d]);
+                        // particleOffset[d] is allowed to be negative for the first GPU
+                        using OffsetType = decltype(particleOffset[d]);
+                        auto const patchParticleOffset = std::max(static_cast<OffsetType>(0), particleOffset[d]);
+                        offset_x.store<index_t>(mpiRank, patchParticleOffset);
                         extent_x.store<index_t>(mpiRank, patchExtent[d]);
                     }
 


### PR DESCRIPTION
The patch offset for particles in openPMD output is negative for the top GPU (y-direction) if sliding window is activated.
In openPMD data this offset is stored as unsigned type and therefore underflow happens and stored value is very large.
A tool which is using particle patches to find domains with particles within a special range will not work correctly and so won't find all particle patches.