### PR TITLE
Add basic support for laser profiles in incident field

### DIFF
--- a/docs/source/usage/workflows/addLaser.rst
+++ b/docs/source/usage/workflows/addLaser.rst
@@ -8,13 +8,13 @@ Adding Laser
 There are several alternative ways of adding an incoming laser (or any source of electromagnetic field) to a PIConGPU simulation:
 
 #. selecting a laser profile in :ref:`laser.param <usage-params-core>`
-#. enabling an incident field source in :ref:`incidentField.param <usage-params-core>`
+#. selecting non-none incident field profiles for respective boundaries in :ref:`incidentField.param <usage-params-core>`
 #. using field or current background in :ref:`fieldBackground.param <usage-params-core>`
 
 These ways operate independently of one another, each has its features and limitations.
 Beware that the laser is fully accurate only for the standard Yee field solver.
 For other field solver types, a user should evaluate the inaccuracies introduced.
-Incident field, field and current background should be fully accurate for all field solvers.
+Incident field, field- and current background should be fully accurate for all field solvers.
 
 Incident field is applied using the total field/scattered field formulation described :ref:`here <model-TFSF>`.
 

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -21,8 +21,6 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/incidentField/Profiles.def"
-
 
 namespace picongpu
 {
@@ -53,15 +51,31 @@ namespace picongpu
                 HDINLINE float3_X operator()(floatD_X const& totalCellIdx, float_X currentStep) const;
             };
 
-            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
-            struct Source
+            //! Helper incident field functor always returning 0
+            struct ZeroFunctor
             {
-                //! Incident E field functor
-                using FunctorIncidentE = T_FunctorIncidentE;
+                /** Create a functor
+                 *
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  field_internal = field_SI / unitField
+                 */
+                HDINLINE ZeroFunctor(float3_64 unitField)
+                {
+                }
 
-                //! Incident B field functor
-                using FunctorIncidentB = T_FunctorIncidentB;
+                /** Return zero incident field for any given position and time.
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
+                 * @param currentStep current time step index, note that it is fractional
+                 * @return incident field value in internal units
+                 */
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx, float_X currentStep) const
+                {
+                    return float3_X::create(0.0_X);
+                }
             };
+
 
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -24,9 +24,10 @@
 #include "picongpu/fields/Fields.hpp"
 #include "picongpu/fields/MaxwellSolver/FDTD/FDTD.def"
 #include "picongpu/fields/absorber/Absorber.hpp"
-#include "picongpu/fields/incidentField/Profiles.hpp"
+#include "picongpu/fields/incidentField/Functors.hpp"
 #include "picongpu/fields/incidentField/Solver.kernel"
 #include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/incidentField/profiles/profiles.hpp"
 #include "picongpu/traits/GetCurl.hpp"
 
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
@@ -125,7 +126,7 @@ namespace picongpu
                     auto const exPosition = traits::FieldPosition<cellType::Yee, FieldE>{}()[0];
                     PMACC_VERIFY_MSG(
                         exPosition[0] == 0.5_X,
-                        "incident field source does not support the used Yee grid layout");
+                        "incident field profile does not support the used Yee grid layout");
 
                     // Ensure gap along the current axis is large enough that we don't touch the absorber area
                     auto const margin = static_cast<int32_t>(updateFunctor.margin);
@@ -318,7 +319,7 @@ namespace picongpu
                     (gridBlocks, numWorkers)(functor, beginGridIdx, endGridIdx);
                 }
 
-                /** Update a field with the given incidentField normally to the given axis
+                /** Functor to update a field with the given incidentField normally to the given axis
                  *
                  * After the sliding window started moving, does nothing for the y boundaries.
                  *
@@ -335,48 +336,50 @@ namespace picongpu
                     typename T_UpdatedField,
                     typename T_IncidentField,
                     typename T_Curl,
-                    typename T_FunctorIncidentField,
-                    uint32_t T_axis>
-                inline void callUpdateField(Parameters<T_axis> const& parameters, float_X const curlCoefficient)
+                    typename T_FunctorIncidentField>
+                struct CallUpdateField
                 {
-                    // IncidentField generation at y boundaries cannot be performed once the window started moving
-                    const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(
-                        static_cast<uint32_t>(parameters.sourceTimeIteration));
-                    bool const boxHasSlided = (numSlides != 0);
-                    if(!((T_axis == 1) && boxHasSlided))
-                        updateField<T_UpdatedField, T_IncidentField, T_Curl, T_FunctorIncidentField>(
-                            parameters,
-                            curlCoefficient);
-                }
+                    template<uint32_t T_axis>
+                    void operator()(Parameters<T_axis> const& parameters, float_X const curlCoefficient)
+                    {
+                        // IncidentField generation at y boundaries cannot be performed once the window started moving
+                        const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(
+                            static_cast<uint32_t>(parameters.sourceTimeIteration));
+                        bool const boxHasSlided = (numSlides != 0);
+                        if(!((T_axis == 1) && boxHasSlided))
+                            updateField<T_UpdatedField, T_IncidentField, T_Curl, T_FunctorIncidentField>(
+                                parameters,
+                                curlCoefficient);
+                    }
+                };
 
-                /** Functor to apply contribution of the incidentField functor source to the E field
+                /** Partial specialization of functor to update a field with the given incidentField normally to the
+                 * given axis for zero functor
                  *
-                 * @tparam T_Source source type: Source<...> or None
+                 * The general implementation works in this case and does nothing as it should.
+                 * We provide specialization to avoid compiling and running in this case and short-circuit to doing
+                 * nothing.
+                 *
+                 * @tparam T_UpdatedField updatedField type (FieldE or FieldB)
+                 * @tparam T_IncidentField incidentField type (FieldB or FieldE)
+                 * @tparam T_Curl curl(incidentField) functor type
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
                  */
-                template<typename T_Source>
-                struct UpdateE;
-
-                //! Functor to apply contribution of the None incidentField functor to the E field
-                template<>
-                struct UpdateE<None>
+                template<typename T_UpdatedField, typename T_IncidentField, typename T_Curl>
+                struct CallUpdateField<T_UpdatedField, T_IncidentField, T_Curl, ZeroFunctor>
                 {
-                    /** Apply contribution of the None incidentField functor to the E field
-                     *
-                     * @tparam T_Parameters parameters type
-                     */
-                    template<typename T_Parameters>
-                    void operator()(T_Parameters const&)
+                    template<uint32_t T_axis>
+                    void operator()(Parameters<T_axis> const& /* parameters */, float_X const /* curlCoefficient */)
                     {
                     }
                 };
 
-                /** Functor to apply contribution of the incidentField source functor to the E field
+                /** Functor to apply contribution of the incidentField functor source to the E field
                  *
-                 * @tparam T_FunctorIncidentE functor for the incident E field (not used)
-                 * @tparam T_FunctorIncidentB functor for the incident B field
+                 * @tparam T_FunctorIncidentB incident B source functor type
                  */
-                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
-                struct UpdateE<Source<T_FunctorIncidentE, T_FunctorIncidentB>>
+                template<typename T_FunctorIncidentB>
+                struct UpdateE
                 {
                     /** Apply contribution of the incidentField source functor to the E field
                      *
@@ -396,7 +399,7 @@ namespace picongpu
                         using UpdatedField = picongpu::FieldE;
                         using IncidentField = picongpu::FieldB;
                         using Curl = traits::GetCurlB<Solver>::type;
-                        callUpdateField<UpdatedField, IncidentField, Curl, T_FunctorIncidentB>(
+                        CallUpdateField<UpdatedField, IncidentField, Curl, T_FunctorIncidentB>{}(
                             parameters,
                             curlCoefficient);
                     }
@@ -404,32 +407,10 @@ namespace picongpu
 
                 /** Functor to apply contribution of the incidentField source functor to the B field
                  *
-                 * @tparam T_Source source type: Source<...> or None
+                 * @tparam T_FunctorIncidentE incident E source functor type
                  */
-                template<typename T_Source>
-                struct UpdateB;
-
-                //! Functor to apply contribution of the None incidentField functor to the B field
-                template<>
-                struct UpdateB<None>
-                {
-                    /** Apply contribution of the None incidentField functor to the B field
-                     *
-                     * @tparam T_Parameters parameters type
-                     */
-                    template<typename T_Parameters>
-                    void operator()(T_Parameters const&)
-                    {
-                    }
-                };
-
-                /** Functor to apply contribution of the incidentField source functor to the B field
-                 *
-                 * @tparam T_FunctorIncidentE functor for the incident E field
-                 * @tparam T_FunctorIncidentB functor for the incident B field (not used)
-                 */
-                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
-                struct UpdateB<Source<T_FunctorIncidentE, T_FunctorIncidentB>>
+                template<typename T_FunctorIncidentE>
+                struct UpdateB
                 {
                     /** Apply contribution of the incidentField source functor to the B field
                      *
@@ -448,7 +429,7 @@ namespace picongpu
                         using UpdatedField = picongpu::FieldB;
                         using IncidentField = picongpu::FieldE;
                         using Curl = traits::GetCurlE<Solver>::type;
-                        callUpdateField<UpdatedField, IncidentField, Curl, T_FunctorIncidentE>(
+                        CallUpdateField<UpdatedField, IncidentField, Curl, T_FunctorIncidentE>{}(
                             parameters,
                             curlCoefficient);
                     }
@@ -498,10 +479,10 @@ namespace picongpu
                         offsetMinBorder[axis] = absorberThickness(axis, 0) + GAP_FROM_ABSORBER[axis][0];
                         offsetMaxBorder[axis] = absorberThickness(axis, 1) + GAP_FROM_ABSORBER[axis][1];
                     }
-                    hasMinSource[0] = !std::is_same_v<XMin, None>;
-                    hasMinSource[1] = !std::is_same_v<YMin, None>;
+                    hasMinProfile[0] = !std::is_same_v<XMin, profiles::None>;
+                    hasMinProfile[1] = !std::is_same_v<YMin, profiles::None>;
                     if(simDim == 3)
-                        hasMinSource[2] = !std::is_same_v<ZMin, None>;
+                        hasMinProfile[2] = !std::is_same_v<ZMin, profiles::None>;
                 }
 
                 /** Apply contribution of the incident B field to the E field update by one time step
@@ -539,59 +520,63 @@ namespace picongpu
                 /** Apply contribution of the incident B field to the E field update by one time step
                  *
                  * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
-                 * @tparam T_MinSource source type for the min boundary along the axis: Source<...> or None
-                 * @tparam T_MaxSource source type for the max boundary along the axis: Source<...> or None
+                 * @tparam T_MinProfile profile type for the min boundary along the axis
+                 * @tparam T_MaxProfile profile type for the max boundary along the axis
                  *
                  * @param sourceTimeIteration time iteration at which the source incident B field
                  *                            (not the target E field!) values will be calculated
                  */
-                template<uint32_t T_axis, typename T_MinSource, typename T_MaxSource>
+                template<uint32_t T_axis, typename T_MinProfile, typename T_MaxProfile>
                 void updateE(float_X const sourceTimeIteration)
                 {
                     auto parameters = detail::Parameters<T_axis>{cellDescription};
                     parameters.offsetMinBorder = offsetMinBorder;
                     parameters.offsetMaxBorder = offsetMaxBorder;
-                    parameters.hasMinSource = hasMinSource;
+                    parameters.hasMinSource = hasMinProfile;
                     parameters.direction = 1.0_X;
                     parameters.sourceTimeIteration = sourceTimeIteration;
                     parameters.timeIncrementIteration = 1.0_X;
-                    using UpdateMin = typename detail::UpdateE<T_MinSource>;
+                    using FunctorIncidentBMin = FunctorIncidentB<T_MinProfile, T_axis, 1>;
+                    using UpdateMin = typename detail::UpdateE<FunctorIncidentBMin>;
                     UpdateMin{}(parameters);
                     parameters.direction = -1.0_X;
-                    using UpdateMax = typename detail::UpdateE<T_MaxSource>;
+                    using FunctorIncidentBMax = FunctorIncidentB<T_MaxProfile, T_axis, -1>;
+                    using UpdateMax = typename detail::UpdateE<FunctorIncidentBMax>;
                     UpdateMax{}(parameters);
                 }
 
                 /** Apply contribution of the incident E field to the B field update by half a time step
                  *
                  * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
-                 * @tparam T_MinSource source type for the min boundary along the axis: Source<...> or None
-                 * @tparam T_MaxSource source type for the max boundary along the axis: Source<...> or None
+                 * @tparam T_MinProfile profile type for the min boundary along the axis
+                 * @tparam T_MaxProfile profile type for the max boundary along the axis
                  *
                  * @param sourceTimeIteration time iteration at which the source incident E field
                  *                            (not the target B field!) values will be calculated
                  */
-                template<uint32_t T_axis, typename T_MinSource, typename T_MaxSource>
+                template<uint32_t T_axis, typename T_MinProfile, typename T_MaxProfile>
                 void updateBHalf(float_X const sourceTimeIteration)
                 {
                     auto parameters = detail::Parameters<T_axis>{cellDescription};
                     parameters.offsetMinBorder = offsetMinBorder;
                     parameters.offsetMaxBorder = offsetMaxBorder;
-                    parameters.hasMinSource = hasMinSource;
+                    parameters.hasMinSource = hasMinProfile;
                     parameters.direction = 1.0_X;
                     parameters.sourceTimeIteration = sourceTimeIteration;
                     parameters.timeIncrementIteration = 0.5_X;
-                    using UpdateMin = typename detail::UpdateB<T_MinSource>;
+                    using FunctorIncidentEMin = FunctorIncidentE<T_MinProfile, T_axis, 1>;
+                    using UpdateMin = typename detail::UpdateB<FunctorIncidentEMin>;
                     UpdateMin{}(parameters);
                     parameters.direction = -1.0_X;
-                    using UpdateMax = typename detail::UpdateB<T_MaxSource>;
+                    using FunctorIncidentEMax = FunctorIncidentE<T_MaxProfile, T_axis, -1>;
+                    using UpdateMax = typename detail::UpdateB<FunctorIncidentEMax>;
                     UpdateMax{}(parameters);
                 }
 
-                //! ZMin type to be used, shadows ZMin from .param on purpose to handle 2d and 3d uniformly
+                //! ZMin profile to be used, shadows ZMin from .param on purpose to handle 2d and 3d uniformly
                 using ZMin = detail::ZMin;
 
-                //! ZMax type to be used, shadows ZMax from .param on purpose to handle 2d and 3d uniformly
+                //! ZMax profile to be used, shadows ZMax from .param on purpose to handle 2d and 3d uniformly
                 using ZMax = detail::ZMax;
 
                 /** Offset of the Huygens surface from min border of the global domain
@@ -608,8 +593,8 @@ namespace picongpu
                  */
                 pmacc::DataSpace<simDim> offsetMaxBorder;
 
-                //! Whether there is an active (non-none) min source for each axis
-                pmacc::math::Vector<bool, simDim> hasMinSource;
+                //! Whether there is an active (non-none) min profile for each axis
+                pmacc::math::Vector<bool, simDim> hasMinProfile;
 
                 //! Cell description for kernels
                 MappingDesc const cellDescription;

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -21,8 +21,9 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/incidentField/Profiles.hpp"
+#include "picongpu/fields/incidentField/profiles/profiles.hpp"
 
+#include <cstdint>
 
 namespace picongpu
 {
@@ -30,11 +31,45 @@ namespace picongpu
     {
         namespace incidentField
         {
+            // Default implementation of the trait declared in profiles/Free.def
+            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+            struct GetFunctorIncidentE
+            {
+                using type = typename T_Profile::FunctorIncidentE;
+            };
+
+            // Default implementation of the trait declared in profiles/Free.def
+            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+            struct GetFunctorIncidentB
+            {
+                using type = typename T_Profile::FunctorIncidentB;
+            };
+
+            /** Type of incident E functor for the given profile type
+             *
+             * @tparam T_Profile profile type
+             * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+             * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the max
+             * boundary inwards)
+             */
+            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+            using FunctorIncidentE = typename GetFunctorIncidentE<T_Profile, T_axis, T_direction>::type;
+
+            /** Type of incident B functor for the given profile type
+             *
+             * @tparam T_Profile profile type
+             * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+             * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the max
+             * boundary inwards)
+             */
+            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+            using FunctorIncidentB = typename GetFunctorIncidentB<T_Profile, T_axis, T_direction>::type;
+
             namespace detail
             {
-                /** Get ZMin incident field source type
+                /** Get ZMin incident field profile
                  *
-                 * The resulting field source is set as ::type.
+                 * The resulting field profile is set as ::type.
                  * Implementation for 3d returns ZMin from incidentField.param.
                  *
                  * @tparam T_is3d if the simulation is 3d or not
@@ -45,16 +80,16 @@ namespace picongpu
                     using type = ZMin;
                 };
 
-                //! Get None incident field source type as ZMin in the non-3d case
+                //! Get None incident field profile type as ZMin in the non-3d case
                 template<>
                 struct GetZMin<false>
                 {
-                    using type = None;
+                    using type = profiles::None;
                 };
 
-                /** Get ZMax incident field source type
+                /** Get ZMax incident field profile type
                  *
-                 * The resulting field source is set as ::type.
+                 * The resulting field profile is set as ::type.
                  * Implementation for 3d returns ZMax from incidentField.param.
                  *
                  * @tparam T_is3d is the simulation 3d
@@ -65,17 +100,17 @@ namespace picongpu
                     using type = ZMax;
                 };
 
-                //! Get None incident field source type as ZMax in the non-3d case
+                //! Get None incident field profile type as ZMax in the non-3d case
                 template<>
                 struct GetZMax<false>
                 {
-                    using type = None;
+                    using type = profiles::None;
                 };
 
-                //! ZMin incident field type alias adjusted for dimensionality
+                //! ZMin incident field profile type alias adjusted for dimensionality
                 using ZMin = GetZMin<simDim == 3>::type;
 
-                //! ZMax incident field type alias adjusted for dimensionality
+                //! ZMax incident field profile type alias adjusted for dimensionality
                 using ZMax = GetZMax<simDim == 3>::type;
 
             } // namespace detail

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -31,87 +31,61 @@ namespace picongpu
     {
         namespace incidentField
         {
-            // Default implementation of the trait declared in profiles/Free.def
-            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-            struct GetFunctorIncidentE
-            {
-                using type = typename T_Profile::FunctorIncidentE;
-            };
-
-            // Default implementation of the trait declared in profiles/Free.def
-            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-            struct GetFunctorIncidentB
-            {
-                using type = typename T_Profile::FunctorIncidentB;
-            };
-
-            /** Type of incident E functor for the given profile type
-             *
-             * @tparam T_Profile profile type
-             * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
-             * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the max
-             * boundary inwards)
-             */
-            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-            using FunctorIncidentE = typename GetFunctorIncidentE<T_Profile, T_axis, T_direction>::type;
-
-            /** Type of incident B functor for the given profile type
-             *
-             * @tparam T_Profile profile type
-             * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
-             * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the max
-             * boundary inwards)
-             */
-            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-            using FunctorIncidentB = typename GetFunctorIncidentB<T_Profile, T_axis, T_direction>::type;
-
             namespace detail
             {
-                /** Get ZMin incident field profile
+                /** Get type of incident field functor for the given profile type, axis and direction
                  *
-                 * The resulting field profile is set as ::type.
-                 * Implementation for 3d returns ZMin from incidentField.param.
+                 * The resulting functor is set as ::type.
+                 * By default forwards internal type FunctorIncidentE/FunctorIncidentB.
                  *
-                 * @tparam T_is3d if the simulation is 3d or not
+                 * These traits have to be specialized by all non-trivial profiles.
+                 *
+                 * @tparam T_Profile profile type
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 *
+                 * @{
                  */
-                template<bool T_is3d = true>
-                struct GetZMin
+
+                //! Get functor for incident E values
+                template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE
                 {
-                    using type = ZMin;
+                    using type = typename T_Profile::FunctorIncidentE;
                 };
 
-                //! Get None incident field profile type as ZMin in the non-3d case
-                template<>
-                struct GetZMin<false>
+                //! Get functor for incident B values
+                template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB
                 {
-                    using type = profiles::None;
+                    using type = typename T_Profile::FunctorIncidentB;
                 };
 
-                /** Get ZMax incident field profile type
+                /** @} */
+
+                /** Type of incident E/B functor for the given profile type
                  *
-                 * The resulting field profile is set as ::type.
-                 * Implementation for 3d returns ZMax from incidentField.param.
+                 * These are helper aliases to wrap GetFunctorIncidentE/B.
+                 * The latter present customization points.
                  *
-                 * @tparam T_is3d is the simulation 3d
+                 * @tparam T_Profile profile type
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 *
+                 * @{
                  */
-                template<bool T_is3d = true>
-                struct GetZMax
-                {
-                    using type = ZMax;
-                };
 
-                //! Get None incident field profile type as ZMax in the non-3d case
-                template<>
-                struct GetZMax<false>
-                {
-                    using type = profiles::None;
-                };
+                //! Functor for incident E values
+                template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+                using FunctorIncidentE = typename GetFunctorIncidentE<T_Profile, T_axis, T_direction>::type;
 
-                //! ZMin incident field profile type alias adjusted for dimensionality
-                using ZMin = GetZMin<simDim == 3>::type;
+                //! Functor for incident B values
+                template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+                using FunctorIncidentB = typename GetFunctorIncidentB<T_Profile, T_axis, T_direction>::type;
 
-                //! ZMax incident field profile type alias adjusted for dimensionality
-                using ZMax = GetZMax<simDim == 3>::type;
+                /** @} */
 
             } // namespace detail
         } // namespace incidentField

--- a/include/picongpu/fields/incidentField/profiles/Free.def
+++ b/include/picongpu/fields/incidentField/profiles/Free.def
@@ -1,0 +1,78 @@
+/* Copyright 2020-2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                /** Free profile using given functors
+                 *
+                 * By default translates to source with same functors for any axis and direction.
+                 * Thus, a user should either hard-set the functors the required axis and directions or
+                 * provide the mapping by specializing traits GetFunctorIncidentE<> and GetFunctorIncidentB<>.
+                 *
+                 * @tparam T_FunctorIncidentE functor for the incident E field, follows the interface of
+                 *                            FunctorIncidentFieldConcept (defined in Functors.hpp)
+                 * @tparam T_FunctorIncidentB functor for the incident B field, follows the interface of
+                 *                            FunctorIncidentFieldConcept (defined in Functors.hpp)
+                 */
+                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+                struct Free;
+
+            } // namespace profiles
+
+            /** Get type of incident field functor for the given profile type, axis and direction
+             *
+             * The resulting functor is set as ::type.
+             * By default forwards internal type FunctorIncidentE/FunctorIncidentB.
+             *
+             * These traits have to be specialized by a user for profiles::Free<> and particular template arguments
+             * when the same profile is used for multiple boundaries.
+             * Otherwise and for other incident field profiles no specialization is needed.
+             *
+             * @tparam T_Profile profile type
+             * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+             * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the max
+             * boundary inwards)
+             *
+             * @{
+             */
+
+            /** Get functor for incident E values */
+            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+            struct GetFunctorIncidentE;
+
+            /** Get functor for incident B values */
+            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
+            struct GetFunctorIncidentB;
+
+            /** @} */
+
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/Free.def
+++ b/include/picongpu/fields/incidentField/profiles/Free.def
@@ -45,34 +45,6 @@ namespace picongpu
                 struct Free;
 
             } // namespace profiles
-
-            /** Get type of incident field functor for the given profile type, axis and direction
-             *
-             * The resulting functor is set as ::type.
-             * By default forwards internal type FunctorIncidentE/FunctorIncidentB.
-             *
-             * These traits have to be specialized by a user for profiles::Free<> and particular template arguments
-             * when the same profile is used for multiple boundaries.
-             * Otherwise and for other incident field profiles no specialization is needed.
-             *
-             * @tparam T_Profile profile type
-             * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
-             * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the max
-             * boundary inwards)
-             *
-             * @{
-             */
-
-            /** Get functor for incident E values */
-            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-            struct GetFunctorIncidentE;
-
-            /** Get functor for incident B values */
-            template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-            struct GetFunctorIncidentB;
-
-            /** @} */
-
         } // namespace incidentField
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/Free.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Free.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 Sergei Bastrakov
+/* Copyright 2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/profiles/Free.def"
+
 
 namespace picongpu
 {
@@ -26,19 +30,18 @@ namespace picongpu
     {
         namespace incidentField
         {
-            //! No incident field at a boundary
-            struct None;
+            namespace profiles
+            {
+                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+                struct Free
+                {
+                    // Incident E functor type, hook for FunctorIncidentE trait
+                    using FunctorIncidentE = T_FunctorIncidentE;
 
-            /** Incident field source at a boundary
-             *
-             * @tparam T_FunctorIncidentE functor for the incident E field, follows the interface of
-             *                            FunctorIncidentFieldConcept (defined in .hpp file)
-             * @tparam T_FunctorIncidentB functor for the incident B field, follows the interface of
-             *                            FunctorIncidentFieldConcept (defined in .hpp file)
-             */
-            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
-            struct Source;
-
+                    // Incident B functor type, hook for FunctorIncidentE trait
+                    using FunctorIncidentB = T_FunctorIncidentB;
+                };
+            } // namespace profiles
         } // namespace incidentField
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/None.def
+++ b/include/picongpu/fields/incidentField/profiles/None.def
@@ -1,0 +1,36 @@
+/* Copyright 2020-2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                //! No incident field profile
+                struct None;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/None.hpp
+++ b/include/picongpu/fields/incidentField/profiles/None.hpp
@@ -1,0 +1,47 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/profiles/None.def"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                struct None
+                {
+                    // Incident E functor type, hook for FunctorIncidentE trait
+                    using FunctorIncidentE = ZeroFunctor;
+
+                    // Incident B functor type, hook for FunctorIncidentE trait
+                    using FunctorIncidentB = ZeroFunctor;
+                };
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -1,0 +1,23 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/incidentField/profiles/Free.def"
+#include "picongpu/fields/incidentField/profiles/None.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -1,0 +1,23 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/incidentField/profiles/Free.hpp"
+#include "picongpu/fields/incidentField/profiles/None.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -19,12 +19,31 @@
 
 /** @file incidentField.param
  *
- * Load incident field parameters
+ * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
+ *
+ * Available profiles:
+ *  - profiles::None   : no incident field
+ *  - profiles::Free<> : custom profile with user-provided functors to calculate incident E and B
+ *
+ * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
+ * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
+ * `GAP_FROM_ABSORBER` that controls position of the generating surface relative to field absorber. For example:
+ *
+ * @code{.cpp}
+ * using XMin = profiles::Free< UserFunctorIncidentE, UserFunctorIncidentB >;
+ * using XMax = profiles::None;
+ * using YMin = profiles::None;
+ * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
+ * using ZMin = profiles::None;
+ * using ZMax = profiles::None;
+ *
+ * constexpr uint32_t GAP_FROM_ABSORBER[3][2] = { {0, 0}, {0, 0}, {0, 0} };
+ * @endcode
  */
 
 #pragma once
 
-#include "picongpu/fields/incidentField/Profiles.def"
+#include "picongpu/fields/incidentField/profiles/profiles.def"
 
 
 namespace picongpu
@@ -33,9 +52,9 @@ namespace picongpu
     {
         namespace incidentField
         {
-            /** Functor to set values of incident E field
+            /** User-defined functor to set values of incident E field
              */
-            class FunctorIncidentE
+            class UserFunctorIncidentE
             {
             public:
                 /* We use this to calculate your SI input back to our unit system */
@@ -46,7 +65,7 @@ namespace picongpu
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                HDINLINE UserFunctorIncidentE(const float3_64 unitField) : m_unitField(unitField)
                 {
                 }
 
@@ -64,9 +83,9 @@ namespace picongpu
                 }
             };
 
-            /** Functor to set values of incident B field
+            /** User-defined functor to set values of incident B field
              */
-            class FunctorIncidentB
+            class UserFunctorIncidentB
             {
             public:
                 /* We use this to calculate your SI input back to our unit system */
@@ -77,7 +96,7 @@ namespace picongpu
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                HDINLINE UserFunctorIncidentB(const float3_64 unitField) : m_unitField(unitField)
                 {
                 }
 
@@ -95,23 +114,33 @@ namespace picongpu
                 }
             };
 
-            /** Source of incident E and B fields.
+            /** Make a profile with the user-provided functors defined above.
              *
-             * Each source type combines functors for incident field E and B, which must be consistent to each other.
+             * The functors for incident field E and B must be consistent to each other.
+             * The profile can be used for XMin, XMax, etc.
              */
-            using MySource = Source<FunctorIncidentE, FunctorIncidentB>;
+            using MyProfile = profiles::Free<UserFunctorIncidentE, UserFunctorIncidentB>;
+
+            /* We can optionally define how to get the functors for MyProfile and given axis and direction.
+             * If we do not make a partial specialization, the template parameters of Free<> would be used.
+             * Note that it assumes the functors are already specialized for a particular direction, and the
+             * profile is used for this direction. This trait allows a more generic implementation when necessary.
+             */
+            template<uint32_t T_axis, int32_t T_direction>
+            struct GetFunctorIncidentE<MyProfile, T_axis, T_direction>
+            {
+                //! Use UserFunctorIncidentE to calculate incident E for any axis and direction
+                using type = UserFunctorIncidentE;
+            };
 
             /**@{*/
-            /** Incident field source types along each boundary, these 6 types (or aliases) are required.
-             *
-             * Each type has to be either Source<> or None.
-             */
-            using XMin = None;
-            using XMax = None;
-            using YMin = None;
-            using YMax = None;
-            using ZMin = None;
-            using ZMax = None;
+            //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
+            using XMin = profiles::None;
+            using XMax = profiles::None;
+            using YMin = profiles::None;
+            using YMax = profiles::None;
+            using ZMin = profiles::None;
+            using ZMax = profiles::None;
             /**@}*/
 
             /** Gap of the Huygence surface from absorber

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -117,21 +117,9 @@ namespace picongpu
             /** Make a profile with the user-provided functors defined above.
              *
              * The functors for incident field E and B must be consistent to each other.
-             * The profile can be used for XMin, XMax, etc.
+             * They also have to take into consideration which boundary the profile is applied to.
              */
             using MyProfile = profiles::Free<UserFunctorIncidentE, UserFunctorIncidentB>;
-
-            /* We can optionally define how to get the functors for MyProfile and given axis and direction.
-             * If we do not make a partial specialization, the template parameters of Free<> would be used.
-             * Note that it assumes the functors are already specialized for a particular direction, and the
-             * profile is used for this direction. This trait allows a more generic implementation when necessary.
-             */
-            template<uint32_t T_axis, int32_t T_direction>
-            struct GetFunctorIncidentE<MyProfile, T_axis, T_direction>
-            {
-                //! Use UserFunctorIncidentE to calculate incident E for any axis and direction
-                using type = UserFunctorIncidentE;
-            };
 
             /**@{*/
             //! Incident field profile types along each boundary, these 6 types (or aliases) are required.

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -19,12 +19,31 @@
 
 /** @file incidentField.param
  *
- * Load incident field parameters
+ * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
+ *
+ * Available profiles:
+ *  - profiles::None   : no incident field
+ *  - profiles::Free<> : custom profile with user-provided functors to calculate incident E and B
+ *
+ * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
+ * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
+ * `GAP_FROM_ABSORBER` that controls position of the generating surface relative to field absorber. For example:
+ *
+ * @code{.cpp}
+ * using XMin = profiles::Free< UserFunctorIncidentE, UserFunctorIncidentB >;
+ * using XMax = profiles::None;
+ * using YMin = profiles::None;
+ * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
+ * using ZMin = profiles::None;
+ * using ZMax = profiles::None;
+ *
+ * constexpr uint32_t GAP_FROM_ABSORBER[3][2] = { {0, 0}, {0, 0}, {0, 0} };
+ * @endcode
  */
 
 #pragma once
 
-#include "picongpu/fields/incidentField/Profiles.def"
+#include "picongpu/fields/incidentField/profiles/profiles.def"
 
 
 namespace picongpu
@@ -198,29 +217,27 @@ namespace picongpu
 
             /** Source of incident E and B fields.
              *
-             * Each source type combines functors for incident field E and B, which must be consistent to each other.
+             * Used functors must be consistent to each other.
              */
-            using MyXMinSource = Source<FunctorXMinIncidentE, FunctorXMinIncidentB>;
+            using MyXMinProfile = profiles::Free<FunctorXMinIncidentE, FunctorXMinIncidentB>;
 
             /** Another source of incident E and B fields.
              *
-             * Each source type combines functors for incident field E and B, which must be consistent to each other.
+             * Used functors must be consistent to each other.
              */
-            using MyYMaxSource = Source<FunctorYMaxIncidentE, FunctorYMaxIncidentB>;
+            using MyYMaxProfile = profiles::Free<FunctorYMaxIncidentE, FunctorYMaxIncidentB>;
 
             /**@{*/
-            /** Incident field source types along each boundary, these 6 types (or aliases) are required.
-             *
-             * Each type has to be either Source<> or None.
+            /** Incident field profile types along each boundary, these 6 types (or aliases) are required.
              *
              * Here we generate a plane wave from the X min border.
              */
-            using XMin = MyXMinSource;
-            using XMax = None;
-            using YMin = None;
-            using YMax = MyYMaxSource;
-            using ZMin = None;
-            using ZMax = None;
+            using XMin = MyXMinProfile;
+            using XMax = profiles::None;
+            using YMin = profiles::None;
+            using YMax = MyYMaxProfile;
+            using ZMin = profiles::None;
+            using ZMax = profiles::None;
             /**@}*/
 
             /** Gap of the Huygence surface from absorber


### PR DESCRIPTION
It doesn't add any new profiles compared to the current state. But prepares to make this addition more simple. Also improves naming to be more consistent with existing laser and density profiles.

~~Adding current WIP. It is mostly ready, will continue next week.~~
Ready for review. After this PR is merged, I can start transferring the existing laser profiles one by one, with mostly reusing the old parameter structures.