### PR TITLE
fix function `toTimeSlice`

### DIFF
--- a/include/pmacc/pluginSystem/toTimeSlice.hpp
+++ b/include/pmacc/pluginSystem/toTimeSlice.hpp
@@ -64,6 +64,10 @@ namespace pmacc
             auto const seqOfSlices = misc::splitString(str, ",");
             for(auto const& slice : seqOfSlices)
             {
+                // skip empty slice strings
+                if(slice.empty())
+                    continue;
+
                 auto const sliceComponents = misc::splitString(slice, ":");
                 PMACC_VERIFY_MSG(
                     !sliceComponents.empty(),


### PR DESCRIPTION
The translation from strings into time slices processed empty strings e.g. `100,,200` or fully empty slice strings `` into
periods `0::1`.
So it could accedently registering plugins to dump each time step from the begin of the simulation up to the end.