### PR TITLE
allow time dependent checkpointing

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -257,6 +257,8 @@ TBG_openPMD="--openPMD.period 100   \
 # Create a checkpoint that is restartable every --checkpoint.period steps
 #   http://git.io/PToFYg
 TBG_checkpoint="--checkpoint.period 1000"
+# Time periodic checkpoint creation [period in minutes]
+TBG_checkpointTime="--checkpoint.timePeriod 2"
 # Select the backend for the checkpoint, available are openPMD
 #    --checkpoint.backend openPMD
 # Available backend options are exactly as in --openPMD.* and can be set

--- a/docs/source/usage/plugins/checkpoint.rst
+++ b/docs/source/usage/plugins/checkpoint.rst
@@ -31,12 +31,13 @@ The plugin is available as soon as the :ref:`openPMD API library <install-depend
 .cfg file
 ^^^^^^^^^
 
-You can use ``--checkpoint.period`` to specify the output period of the created checkpoints.
+You can use ``--checkpoint.period`` or `--checkpoint.timePeriod` to enable checkpointing.
 
 ============================================= ======================================================================================
 PIConGPU command line option                  Description
 ============================================= ======================================================================================
 ``--checkpoint.period <N>``                   Create checkpoints every N steps.
+``--checkpoint.timePeriod <M>``               Create checkpoints every M minutes.
 ``--checkpoint.backend <IO-backend>``         IO-backend used to create the checkpoint.
 ``--checkpoint.directory <string>``           Directory inside ``simOutput`` for writing checkpoints.
                                               Default is ``checkpoints``.


### PR DESCRIPTION
close: #4023

Add option `--checkpoint.timePeriod` for periodically checkpointing after a user selected time (in minutes).

- [x] merge after #4040 to avoid that each step is checkpointed of ``--checkpoint.period`` is not defined.