### PR TITLE
Fix compile error: decltype(...) somehow returns a reference

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -51,6 +51,7 @@
 #include <boost/mpl/vector.hpp>
 
 #include <algorithm>
+#include <type_traits> // std::remove_reference_t
 
 
 namespace picongpu
@@ -496,7 +497,7 @@ namespace picongpu
                         extent_x.resetDataset(ds);
 
                         // particleOffset[d] is allowed to be negative for the first GPU
-                        using OffsetType = decltype(particleOffset[d]);
+                        using OffsetType = std::remove_reference_t<decltype(particleOffset[d])>;
                         auto const patchParticleOffset = std::max(static_cast<OffsetType>(0), particleOffset[d]);
                         offset_x.store<index_t>(mpiRank, patchParticleOffset);
                         extent_x.store<index_t>(mpiRank, patchExtent[d]);


### PR DESCRIPTION
I cannot compile the current `dev` branch, because in `WriteSpecies.hpp`, `decltype` somehow returns a reference type:

```cpp
                        // particleOffset[d] is allowed to be negative for the first GPU
                        using OffsetType = decltype(particleOffset[d]);
                        auto const patchParticleOffset = std::max(static_cast<OffsetType>(0), particleOffset[d]);
```

Results in error:

```
[ 71%] Building CUDA object CMakeFiles/picongpu.dir/main.cpp.o                                                                      
/usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/usr/bin/mpic++ -DADIOS2_USE_MPI -DALPAKA_ACC_GPU_CUDA_ENABLED -DA
LPAKA_ACC_GPU_CUDA_ONLY_MODE -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -DALPAKA_DEBUG=0 -DALPAKA_DEBUG_OFFLOAD_ASSUME_HOST -DALP
AKA_OFFLOAD_MAX_BLOCK_SIZE=256 -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_MATH_TR1_DYN_LINK -DBOOST_NO_AUTO_PTR -DBOOST_
PROGRAM_OPTIONS_DYN_LINK -DBOOST_RESULT_OF_USE_TR1_WITH_DECLTYPE_FALLBACK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DC
MAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_ID=GNU -DCMAKE_CXX_COMPILER_VERSION=11.1.0 -DCMAKE_SYSTEM=Linux-5.4.0-105-generic -DCMA
KE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_VERSION=3.21.3 -DCUPLA_STREAM_ASYNC_ENABLED=1 -DENABLE_OPENPMD=1 -DNO_FREETYPE -DPIC_ENABLE_PNG=1
 -DPIC_VERBOSE_LVL=63 -DPMACC_VERBOSE_LVL=0 -I/home/franzpoeschel/singularity_build/PIC_build/include -I/home/franzpoeschel/git-repo
s/picongpu/thirdParty/mallocMC/src/include -I/home/franzpoeschel/git-repos/picongpu/include/pmacc/.. -I/home/franzpoeschel/git-repos
/picongpu/include/picongpu/.. -I/home/franzpoeschel/git-repos/picongpu/thirdParty/cupla/include -isystem=/usr/local/cuda/targets/x86
_64-linux/include -isystem=/home/franzpoeschel/git-repos/picongpu/thirdParty/cupla/alpaka/include -isystem=/usr/local/cuda/include -
isystem=/home/franzpoeschel/singularity_build/local/include -O3 -DNDEBUG --generate-code=arch=compute_35,code=[compute_35,sm_35] --e
xpt-extended-lambda --expt-relaxed-constexpr -Xcudafe=--display_error_number -Xcudafe=--diag_suppress=esa_on_defaulted_function_igno
red -std=c++17 -MD -MT CMakeFiles/picongpu.dir/main.cpp.o -MF CMakeFiles/picongpu.dir/main.cpp.o.d -x cu -c /home/franzpoeschel/git-
repos/picongpu/include/picongpu/main.cpp -o CMakeFiles/picongpu.dir/main.cpp.o                                                      
nvcc warning : The 'compute_35', 'compute_37', 'sm_35', and 'sm_37' architectures are deprecated, and may be removed in a future rel
ease (Use -Wno-deprecated-gpu-targets to suppress warning).                                                                         
/home/franzpoeschel/git-repos/picongpu/include/pmacc/../picongpu/plugins/openPMD/WriteSpecies.hpp(500): error: expression must be an
 lvalue
```

Don't really know why `decltype` decides to return a reference here, but who knows what the type of `particleOffset` is..
This PR fixes that