### PR TITLE
Fix logging message in openPMD plugin

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -447,10 +447,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 fileName = file.value();
             }
 
-            fileName = boost::filesystem::path(fileName).has_root_path() ? fileName : dir + "/" + fileName;
-            log<picLog::INPUT_OUTPUT>("openPMD: setting file pattern: %1%%2%.%3%") % fileName % fileInfix
-                % fileExtension;
-
             /*
              * Enforce group-based iteration layout for streaming backends
              */
@@ -458,6 +454,10 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             {
                 fileInfix = "";
             }
+
+            fileName = boost::filesystem::path(fileName).has_root_path() ? fileName : dir + "/" + fileName;
+            log<picLog::INPUT_OUTPUT>("openPMD: setting file pattern: %1%%2%.%3%") % fileName % fileInfix
+                % fileExtension;
 
             // Avoid repeatedly parsing the JSON config
             if(!jsonMatcher)


### PR DESCRIPTION
In order to deactivate file-based iteration encoding, users can either specify `--openPMD.infix ''`, or since specifying empty strings is sometimes not possible `--openPMD.infix NULL`. The `NULL` currently leaks into the logs:

Wrong:
```
PIConGPUVerbose INPUT_OUTPUT(32) | openPMD: setting file pattern:
openPMD/streamNULL.bp
```

Correct
```
PIConGPUVerbose INPUT_OUTPUT(32) | openPMD: setting file pattern:
openPMD/stream.bp
```

This is only a logging error, the file is created correctly.