### PR TITLE
Add utilities for calculating incident B from E using slowly varying envelope approximation

### DIFF
--- a/docs/source/models/total_field_scattered_field.rst
+++ b/docs/source/models/total_field_scattered_field.rst
@@ -398,8 +398,10 @@ Note that using field solvers other than Yee requires a positive gap along the b
 This is checked at run time.
 
 Consider a case when both :math:`E^{inc}(x, y, z, t)` and  :math:`\vec B^{inc}(x, y, z, t)` are theoretically present, but only one of them is known in explicit form.
+When slowly varying elvelope approximation is applicable, one may employ it to calculate the other field as :math:`\vec B^{inc}(x, y, z, t) = \vec k \cross \vec E^{inc}(x, y, z, t) / c`.
+PIConGPU implements this behavior as a default second parameter of the ``Free`` incident field profile.
 
-In this case one can try using TF/SF with only the modified known field set as incident and the other one set to 0.
+Otherwise a user can try using TF/SF with only the modified known field set as incident and the other one set to 0.
 The interpretation of the result is assisted by the equivalence theorem, and in particular Love and Schelkunoff equivalence principles [Harrington2001]_ [Balanis2012]_.
 Having :math:`\vec E^{inc}(x, y, z, t) = \vec 0` means only electric current :math:`\vec J` would be impressed on :math:`S`.
 Taking into account no incident fields in the SF region, the region is effectively a perfect magnetic conductor.
@@ -407,7 +409,8 @@ Likewise, having :math:`\vec B^{inc}(x, y, z, t) = \vec 0` corresponds to only m
 To generate the expected field amplitude inside the area, the only non-zero source field has to be adjusted.
 In the simple plane wave case, the adjustment is to set the amplitude of the present field twice as large, as demonstrated in [Rengarajan2000]_.
 In the general case, it appears unclear how to calculate such an adjustment.
-Also note, that within the plain wave approximation the unknown field could have alternatively been calculated from the known one.
+Note that using this approach in PIConGPU results in generating pulses going both inwards and outwards of the Huygens surface.
+Therefore, it is recommended to have no density outside the surface and use a strong field absorber to negate the effect of the artificial outwards-going pulse.
 
 References
 ----------

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -31,12 +31,19 @@ namespace picongpu
             //! Concept defining interface of incident field functors for E and B
             struct FunctorIncidentFieldConcept
             {
-                /** Create a functor
+                /** Create a functor on the host side
+                 *
+                 * Since it is host-only, one could access global simulation data like Environment<simDim> and objects
+                 * controlled by DataConnector. Note that it is not possible in operator(), but relevant data can be
+                 * saved in members on this class.
                  *
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorIncidentFieldConcept(float3_64 unitField);
+                HINLINE FunctorIncidentFieldConcept(float3_64 unitField);
+
+                //! Functor must be copiable to device by value
+                // HDINLINE FunctorIncidentFieldConcept(const FunctorIncidentFieldConcept& other) = default;
 
                 /** Return incident field for the given position and time.
                  *
@@ -54,12 +61,12 @@ namespace picongpu
             //! Helper incident field functor always returning 0
             struct ZeroFunctor
             {
-                /** Create a functor
+                /** Create a functor on the host side
                  *
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE ZeroFunctor(float3_64 unitField)
+                HINLINE ZeroFunctor(float3_64 unitField)
                 {
                 }
 
@@ -75,7 +82,6 @@ namespace picongpu
                     return float3_X::create(0.0_X);
                 }
             };
-
 
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include <cstdint>
 
 namespace picongpu
 {
@@ -82,7 +83,6 @@ namespace picongpu
                     return float3_X::create(0.0_X);
                 }
             };
-
         } // namespace incidentField
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -21,8 +21,6 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/incidentField/profiles/profiles.hpp"
-
 #include <cstdint>
 
 namespace picongpu
@@ -36,9 +34,8 @@ namespace picongpu
                 /** Get type of incident field functor for the given profile type, axis and direction
                  *
                  * The resulting functor is set as ::type.
-                 * By default forwards internal type FunctorIncidentE/FunctorIncidentB.
-                 *
-                 * These traits have to be specialized by all non-trivial profiles.
+                 * These traits have to be specialized by all profiles.
+                 * The traits essentially constitute applying of profile to a particular boundary.
                  *
                  * @tparam T_Profile profile type
                  * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
@@ -50,17 +47,11 @@ namespace picongpu
 
                 //! Get functor for incident E values
                 template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-                struct GetFunctorIncidentE
-                {
-                    using type = typename T_Profile::FunctorIncidentE;
-                };
+                struct GetFunctorIncidentE;
 
                 //! Get functor for incident B values
                 template<typename T_Profile, uint32_t T_axis, int32_t T_direction>
-                struct GetFunctorIncidentB
-                {
-                    using type = typename T_Profile::FunctorIncidentB;
-                };
+                struct GetFunctorIncidentB;
 
                 /** @} */
 

--- a/include/picongpu/fields/incidentField/profiles/Free.def
+++ b/include/picongpu/fields/incidentField/profiles/Free.def
@@ -30,6 +30,16 @@ namespace picongpu
         {
             namespace profiles
             {
+                /** Calculate incident field B from values of E using slowly varying envelope approximation (SVEA)
+                 *
+                 * It will make orientation consistent with the axis and direction that the Free profile is applied to.
+                 * The calculated B values follow B = cross(k, E) / c, where k is propagation direction vector.
+                 *
+                 * This type does not adhere to FunctorIncidentFieldConcept, however can be used as the second
+                 * (but not first) template parameter of Free<>.
+                 */
+                struct SVEAFunctorIncidentB;
+
                 /** Free profile tag using given functors
                  *
                  * By default translates to source with same functors for any axis and direction.
@@ -38,9 +48,10 @@ namespace picongpu
                  * @tparam T_FunctorIncidentE functor for the incident E field, follows the interface of
                  *                            FunctorIncidentFieldConcept (defined in Functors.hpp)
                  * @tparam T_FunctorIncidentB functor for the incident B field, follows the interface of
-                 *                            FunctorIncidentFieldConcept (defined in Functors.hpp)
+                 *                            FunctorIncidentFieldConcept (defined in Functors.hpp),
+                 *                            or by default a special SVEA functor
                  */
-                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB = SVEAFunctorIncidentB>
                 struct Free;
 
             } // namespace profiles

--- a/include/picongpu/fields/incidentField/profiles/Free.def
+++ b/include/picongpu/fields/incidentField/profiles/Free.def
@@ -30,11 +30,10 @@ namespace picongpu
         {
             namespace profiles
             {
-                /** Free profile using given functors
+                /** Free profile tag using given functors
                  *
                  * By default translates to source with same functors for any axis and direction.
-                 * Thus, a user should either hard-set the functors the required axis and directions or
-                 * provide the mapping by specializing traits GetFunctorIncidentE<> and GetFunctorIncidentB<>.
+                 * Thus, a user should hard-set the functors for the chosen axis and direction.
                  *
                  * @tparam T_FunctorIncidentE functor for the incident E field, follows the interface of
                  *                            FunctorIncidentFieldConcept (defined in Functors.hpp)

--- a/include/picongpu/fields/incidentField/profiles/Free.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Free.hpp
@@ -21,7 +21,10 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/fields/incidentField/Traits.hpp"
 #include "picongpu/fields/incidentField/profiles/Free.def"
+
+#include <cstdint>
 
 
 namespace picongpu
@@ -30,18 +33,45 @@ namespace picongpu
     {
         namespace incidentField
         {
-            namespace profiles
+            namespace detail
             {
-                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
-                struct Free
+                /** Get type of incident field E functor for the free profile type
+                 *
+                 * @tparam T_FunctorIncidentE functor for the incident E field
+                 * @tparam T_FunctorIncidentB functor for the incident B field
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<
+                    typename T_FunctorIncidentE,
+                    typename T_FunctorIncidentB,
+                    uint32_t T_axis,
+                    int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::Free<T_FunctorIncidentE, T_FunctorIncidentB>, T_axis, T_direction>
                 {
-                    // Incident E functor type, hook for FunctorIncidentE trait
-                    using FunctorIncidentE = T_FunctorIncidentE;
-
-                    // Incident B functor type, hook for FunctorIncidentE trait
-                    using FunctorIncidentB = T_FunctorIncidentB;
+                    using type = T_FunctorIncidentE;
                 };
-            } // namespace profiles
+
+                /** Get type of incident field B functor for the free profile type
+                 *
+                 * @tparam T_FunctorIncidentE functor for the incident E field
+                 * @tparam T_FunctorIncidentB functor for the incident B field
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<
+                    typename T_FunctorIncidentE,
+                    typename T_FunctorIncidentB,
+                    uint32_t T_axis,
+                    int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::Free<T_FunctorIncidentE, T_FunctorIncidentB>, T_axis, T_direction>
+                {
+                    using type = T_FunctorIncidentB;
+                };
+
+            } // namespace detail
         } // namespace incidentField
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/Free.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Free.hpp
@@ -71,6 +71,28 @@ namespace picongpu
                     using type = T_FunctorIncidentB;
                 };
 
+                /** Get type of incident field B functor for the free profile type using default parameter
+                 *
+                 * @tparam T_FunctorIncidentE functor for the incident E field
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_FunctorIncidentE, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<
+                    profiles::Free<T_FunctorIncidentE, profiles::SVEAFunctorIncidentB>,
+                    T_axis,
+                    T_direction>
+                {
+                    using type = detail::ApproximateIncidentB<
+                        typename GetFunctorIncidentE<
+                            profiles::Free<T_FunctorIncidentE, profiles::SVEAFunctorIncidentB>,
+                            T_axis,
+                            T_direction>::type,
+                        T_axis,
+                        T_direction>;
+                };
+
             } // namespace detail
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/profiles/None.def
+++ b/include/picongpu/fields/incidentField/profiles/None.def
@@ -28,7 +28,7 @@ namespace picongpu
         {
             namespace profiles
             {
-                //! No incident field profile
+                //! No incident field profile tag
                 struct None;
             } // namespace profiles
         } // namespace incidentField

--- a/include/picongpu/fields/incidentField/profiles/None.hpp
+++ b/include/picongpu/fields/incidentField/profiles/None.hpp
@@ -22,7 +22,10 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
 #include "picongpu/fields/incidentField/profiles/None.def"
+
+#include <cstdint>
 
 
 namespace picongpu
@@ -31,17 +34,32 @@ namespace picongpu
     {
         namespace incidentField
         {
-            namespace profiles
+            namespace detail
             {
-                struct None
+                /** Get type of incident field E functor for the none profile type
+                 *
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::None, T_axis, T_direction>
                 {
-                    // Incident E functor type, hook for FunctorIncidentE trait
-                    using FunctorIncidentE = ZeroFunctor;
-
-                    // Incident B functor type, hook for FunctorIncidentE trait
-                    using FunctorIncidentB = ZeroFunctor;
+                    using type = ZeroFunctor;
                 };
-            } // namespace profiles
+
+                /** Get type of incident field B functor for the none profile type
+                 *
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::None, T_axis, T_direction>
+                {
+                    using type = ZeroFunctor;
+                };
+            } // namespace detail
         } // namespace incidentField
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -30,7 +30,7 @@
  * `GAP_FROM_ABSORBER` that controls position of the generating surface relative to field absorber. For example:
  *
  * @code{.cpp}
- * using XMin = profiles::Free< UserFunctorIncidentE, UserFunctorIncidentB >;
+ * using XMin = profiles::Free< UserFunctorIncidentE >;
  * using XMax = profiles::None;
  * using YMin = profiles::None;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
@@ -118,6 +118,8 @@ namespace picongpu
              *
              * The functors for incident field E and B must be consistent to each other.
              * They also have to take into consideration which boundary the profile is applied to.
+             * The second template parameter may be left with the default value, then B field will be calculated
+             * from E using the slowly varying envelope approximation (SVEA).
              */
             using MyProfile = profiles::Free<UserFunctorIncidentE, UserFunctorIncidentB>;
 

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -30,7 +30,7 @@
  * `GAP_FROM_ABSORBER` that controls position of the generating surface relative to field absorber. For example:
  *
  * @code{.cpp}
- * using XMin = profiles::Free< UserFunctorIncidentE, UserFunctorIncidentB >;
+ * using XMin = profiles::Free< UserFunctorIncidentE >;
  * using XMax = profiles::None;
  * using YMin = profiles::None;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
@@ -155,37 +155,6 @@ namespace picongpu
                 }
             };
 
-            /** Functor to set values of incident B field
-             */
-            class FunctorXMinIncidentB : public FunctorBase
-            {
-            public:
-                /* We use this to calculate your SI input back to our unit system */
-                PMACC_ALIGN(m_unitField, const float3_64);
-
-                /** Create a functor on the host side
-                 *
-                 * @param unitField conversion factor from SI to internal units,
-                 *                  field_internal = field_SI / unitField
-                 */
-                HINLINE FunctorXMinIncidentB(const float3_64 unitField) : m_unitField(unitField)
-                {
-                }
-
-                /** Calculate incident field B_inc(r, t) for a source
-                 *
-                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
-                 *        note that it is fractional
-                 * @param currentStep current time step index, note that it is fractional
-                 */
-                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
-                {
-                    auto const valueSI = getXMinSourceValueSI(totalCellIdx, currentStep);
-                    auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
-                    return fieldSI / precisionCast<float_X>(m_unitField);
-                }
-            };
-
             /** Functor to set values of incident E field
              */
             class FunctorYMaxIncidentE : public FunctorBase
@@ -248,15 +217,18 @@ namespace picongpu
                 }
             };
 
-            /** Source of incident E and B fields.
+            /** Source of incident E and B fields
              *
-             * Used functors must be consistent to each other.
+             * We use default type for functor B that will calculate it from E values using SVEA according to the
+             * boundary the profile is applied to.
              */
-            using MyXMinProfile = profiles::Free<FunctorXMinIncidentE, FunctorXMinIncidentB>;
+            using MyXMinProfile = profiles::Free<FunctorXMinIncidentE>;
 
-            /** Another source of incident E and B fields.
+            /** Another source of incident E and B fields, this time we provide both E and B functors
              *
-             * Used functors must be consistent to each other.
+             * In this case it is no different since our pulse is plane wave and FunctorYMaxIncidentB results in the
+             * same as what default SVEA would give.
+             * However, in principle a user could implement any behavior in FunctorYMaxIncidentB.
              */
             using MyYMaxProfile = profiles::Free<FunctorYMaxIncidentE, FunctorYMaxIncidentB>;
 

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -132,12 +132,12 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor
+                /** Create a functor on the host side
                  *
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorXMinIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorXMinIncidentE(const float3_64 unitField) : m_unitField(unitField)
                 {
                 }
 
@@ -163,12 +163,12 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor
+                /** Create a functor on the host side
                  *
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorXMinIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorXMinIncidentB(const float3_64 unitField) : m_unitField(unitField)
                 {
                 }
 
@@ -194,12 +194,12 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor
+                /** Create a functor on the host side
                  *
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorYMaxIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorYMaxIncidentE(const float3_64 unitField) : m_unitField(unitField)
                 {
                 }
 
@@ -225,12 +225,12 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor
+                /** Create a functor on the host side
                  *
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HDINLINE FunctorYMaxIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorYMaxIncidentB(const float3_64 unitField) : m_unitField(unitField)
                 {
                 }
 


### PR DESCRIPTION
We will need them for implementing laser profiles, and they also make sense for the `Free` profile as default mode.