### PR TITLE
Add plane wave incident field profile

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/BaseFunctorE.hpp
+++ b/include/picongpu/fields/incidentField/profiles/BaseFunctorE.hpp
@@ -1,0 +1,96 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Base functor for calculating incident E functors
+                     *
+                     * Defines internal coordinate system tied to given axis and direction.
+                     * Checks unit matching.
+                     *
+                     * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                     * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from
+                     * the max boundary inwards)
+                     */
+                    template<uint32_t T_axis, int32_t T_direction>
+                    struct BaseFunctorE
+                    {
+                    public:
+                        //! Propagation axis
+                        constexpr static uint32_t axis = T_axis;
+
+                        //! Propagation direction
+                        constexpr static uint32_t direction = T_direction;
+
+                        /** Internal right-side coordinate system (dir0, dir1, dir2) with dir0 being propagation axis,
+                         * dir1 being orthogonal to dir0 and dir2 = cross(dir0, dir1).
+                         * @{
+                         */
+                        constexpr static uint32_t dir0 = axis;
+                        constexpr static uint32_t dir1 = (dir0 + 1) % 3;
+                        constexpr static uint32_t dir2 = (dir0 + 2) % 3;
+                        /** @} */
+
+                        /** Create a functor on the host side, check that unit matches the internal E unit
+                         *
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE BaseFunctorE(const float3_64 unitField)
+                        {
+                            // Ensure that we always get unitField = (UNIT_EFIELD, UNIT_EFIELD, UNIT_EFIELD) so that
+                            // we can always calculate in internal units and avoid conversions in child types.
+                            // We can afford it each time, as this is done on host before kernel
+                            for(uint32_t axis = 0; axis < 3; axis++)
+                            {
+                                constexpr double ulp = 1.0;
+                                constexpr double eps = std::numeric_limits<double>::epsilon();
+                                bool const isMatchingUnit = (std::fabs(unitField[axis] - UNIT_EFIELD) <= eps * ulp);
+                                if(!isMatchingUnit)
+                                    throw std::runtime_error(
+                                        "Incident field BaseFunctorE created with wrong unit: expected "
+                                        + std::to_string(UNIT_EFIELD) + ", got " + std::to_string(unitField[axis]));
+                            }
+                        }
+                    };
+                } // namespace detail
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.def
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.def
@@ -1,0 +1,115 @@
+/* Copyright 2013-2022 Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace defaults
+                {
+                    struct PlaneWaveParam
+                    {
+                        /** unit: meter */
+                        static constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+                        /** Convert the normalized laser strength parameter a0 to Volt per meter */
+                        static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+                            * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI
+                            * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+                        /** unit: W / m^2 */
+                        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+                        /** unit: none */
+                        static constexpr float_64 _A0 = 1.5;
+
+                        /** unit: Volt / meter */
+                        static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+                        /** unit: Volt / meter */
+                        // static constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+                        /** Stretch temporal profile by a constant plateau between the up and downramp
+                         *  unit: seconds */
+                        static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
+
+                        /** Pulse length: sigma of std. gauss for intensity (E^2)
+                         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                         *                                          [    2.354820045     ]
+                         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                         *                      = what a experimentalist calls "pulse duration"
+                         *  unit: seconds (1 sigma) */
+                        static constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+
+                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and
+                         * after the plateau unit: none */
+                        static constexpr float_64 RAMP_INIT = 20.6146;
+
+                        /** laser phase shift (no shift: 0.0)
+                         *
+                         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+                         *
+                         * unit: rad, periodic in 2*pi
+                         */
+                        static constexpr float_X LASER_PHASE = 0.0;
+
+                        /** Available E polarisation types, B polarization will be calculated automatically
+                         *
+                         * LINEAR_AXIS_1 is next axis after the propagation axis in order (x, y, z) with a periodic
+                         * wrap. LINEAR_AXIS_1 is next after LINEAR_AXIS_2. E.g. for y propagation axis, LINEAR_AXIS_1
+                         * = linear z polalization, LINEAR_AXIS_2 = linear x
+                         */
+                        enum PolarisationType
+                        {
+                            LINEAR_AXIS_1 = 1u,
+                            LINEAR_AXIS_2 = 2u,
+                            CIRCULAR = 4u
+                        };
+                        /** Polarization selection
+                         */
+                        static constexpr PolarisationType Polarisation = LINEAR_AXIS_2;
+                    };
+                } // namespace defaults
+
+                /** Plane wave laser profile tag
+                 *
+                 * Defines a plane wave with temporally Gaussian envelope.
+                 * Note that the resulting field values will be constant in transversal directions only along the
+                 * generating surface.
+                 * In order to achieve this constness on the whole domain, additional conditions have to be fulfulled:
+                 * no absorber, no incident field sources and zero Huygens surface gap along the transversal
+                 * directions.
+                 *
+                 * @tparam T_Params class parameter to configure the plane wave profile,
+                 *                  see members of defaults::PlaneWaveParam for
+                 *                  required members
+                 */
+                template<typename T_Params = defaults::PlaneWaveParam>
+                struct PlaneWave;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
@@ -1,0 +1,185 @@
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/incidentField/profiles/BaseFunctorE.hpp"
+
+#include <cstdint>
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Unitless plane wave parameters
+                     *
+                     * @tparam T_Params user (SI) parameters
+                     */
+                    template<typename T_Params>
+                    struct PlaneWaveUnitless : public T_Params
+                    {
+                        using Params = T_Params;
+
+                        static constexpr float_X WAVE_LENGTH
+                            = float_X(Params::WAVE_LENGTH_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X PULSE_LENGTH
+                            = float_X(Params::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (1 sigma)
+                        static constexpr float_X LASER_NOFOCUS_CONSTANT
+                            = float_X(Params::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); // unit: seconds
+                        static constexpr float_X AMPLITUDE
+                            = float_X(Params::AMPLITUDE_SI / UNIT_EFIELD); // unit: Volt /meter
+                        static constexpr float_X INIT_TIME = float_X(
+                            (Params::RAMP_INIT * Params::PULSE_LENGTH_SI + Params::LASER_NOFOCUS_CONSTANT_SI)
+                            / UNIT_TIME); // unit: seconds (full inizialisation length)
+                        static constexpr float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+                    };
+
+                    /** Plane wave incident E functor
+                     *
+                     * @tparam T_Params parameters
+                     * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                     * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from
+                     * the max boundary inwards)
+                     */
+                    template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                    struct PlaneWaveFunctorIncidentE
+                        : public PlaneWaveUnitless<T_Params>
+                        , public BaseFunctorE<T_axis, T_direction>
+                    {
+                        //! Unitless parameters type
+                        using Unitless = PlaneWaveUnitless<T_Params>;
+
+                        //! Base functor type
+                        using Base = BaseFunctorE<T_axis, T_direction>;
+
+                        /** Create a functor on the host side
+                         *
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE PlaneWaveFunctorIncidentE(const float3_64 unitField) : Base(unitField)
+                        {
+                        }
+
+                        /** Calculate incident field E value for the given position and time.
+                         *
+                         * Since it is a plane wave parallel to the generating surface, the value only depends on time.
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         * @param currentStep current time step index, note that it is fractional
+                         * @return incident field E value in internal units
+                         */
+                        HDINLINE float3_X operator()(const floatD_X& /*totalCellIdx*/, const float_X currentStep) const
+                        {
+                            float_64 const runTime = DELTA_T * currentStep;
+                            float_64 envelope = float_64(Unitless::AMPLITUDE);
+                            float_64 const mue = 0.5 * Unitless::RAMP_INIT * Unitless::PULSE_LENGTH;
+                            float_64 const w = 2.0 * PI * Unitless::f;
+                            float_64 const tau = Unitless::PULSE_LENGTH * math::sqrt(2.0);
+                            float_64 const endUpramp = mue;
+                            float_64 const startDownramp = mue + Unitless::LASER_NOFOCUS_CONSTANT;
+                            float_64 integrationCorrectionFactor = 0.0;
+                            if(runTime > startDownramp)
+                            {
+                                // downramp = end
+                                float_64 const exponent = (runTime - startDownramp) / tau;
+                                envelope *= exp(-0.5 * exponent * exponent);
+                                integrationCorrectionFactor = (runTime - startDownramp) / (w * tau * tau);
+                            }
+                            else if(runTime < endUpramp)
+                            {
+                                // upramp = start
+                                float_64 const exponent = (runTime - endUpramp) / tau;
+                                envelope *= exp(-0.5 * exponent * exponent);
+                                integrationCorrectionFactor = (runTime - endUpramp) / (w * tau * tau);
+                            }
+
+                            float_64 const timeOszi = runTime - endUpramp;
+                            float_64 const t_and_phase = w * timeOszi + Unitless::LASER_PHASE;
+                            // to understand both components [sin(...) + t/tau^2 * cos(...)] see description above
+                            auto const baseValue = static_cast<float_X>(
+                                envelope
+                                * (math::sin(t_and_phase) + math::cos(t_and_phase) * integrationCorrectionFactor));
+                            auto elong = float3_X::create(0.0_X);
+                            if(Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
+                            {
+                                elong[Base::dir1] = baseValue;
+                            }
+                            else if(Unitless::Polarisation == Unitless::LINEAR_AXIS_2)
+                            {
+                                elong[Base::dir2] = baseValue;
+                            }
+                            else if(Unitless::Polarisation == Unitless::CIRCULAR)
+                            {
+                                elong[Base::dir1] = baseValue / math::sqrt(2.0_X);
+                                elong[Base::dir2] = baseValue / math::sqrt(2.0_X);
+                            }
+                            return elong;
+                        }
+                    };
+                } // namespace detail
+            } // namespace profiles
+
+            namespace detail
+            {
+                /** Get type of incident field E functor for the plane wave profile type
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::PlaneWave<T_Params>, T_axis, T_direction>
+                {
+                    using type = profiles::detail::PlaneWaveFunctorIncidentE<T_Params, T_axis, T_direction>;
+                };
+
+                /** Get type of incident field E functor for the plane wave profile type
+                 *
+                 * For plane wave there is no difference between directly- and SVEA-calculating B, so reuse SVEA for
+                 * brevity.
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::PlaneWave<T_Params>, T_axis, T_direction>
+                {
+                    using type = detail::ApproximateIncidentB<
+                        typename GetFunctorIncidentE<profiles::PlaneWave<T_Params>, T_axis, T_direction>::type,
+                        T_axis,
+                        T_direction>;
+                };
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -21,3 +21,4 @@
 
 #include "picongpu/fields/incidentField/profiles/Free.def"
 #include "picongpu/fields/incidentField/profiles/None.def"
+#include "picongpu/fields/incidentField/profiles/PlaneWave.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -21,3 +21,4 @@
 
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
 #include "picongpu/fields/incidentField/profiles/None.hpp"
+#include "picongpu/fields/incidentField/profiles/PlaneWave.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -22,8 +22,9 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None   : no incident field
- *  - profiles::Free<> : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::None        : no incident field
+ *  - profiles::Free<>      : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::PlaneWave<> : plane wave profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
@@ -32,7 +33,7 @@
  * @code{.cpp}
  * using XMin = profiles::Free< UserFunctorIncidentE >;
  * using XMax = profiles::None;
- * using YMin = profiles::None;
+ * using YMin = profiles::PlaneWave< UserPlaneWaveParams >;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
  * using ZMin = profiles::None;
  * using ZMax = profiles::None;

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -22,8 +22,9 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None   : no incident field
- *  - profiles::Free<> : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::None        : no incident field
+ *  - profiles::Free<>      : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::PlaneWave<> : plane wave profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
@@ -32,7 +33,7 @@
  * @code{.cpp}
  * using XMin = profiles::Free< UserFunctorIncidentE >;
  * using XMax = profiles::None;
- * using YMin = profiles::None;
+ * using YMin = profiles::PlaneWave< UserPlaneWaveParams >;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
  * using ZMin = profiles::None;
  * using ZMax = profiles::None;


### PR DESCRIPTION
This is the first non-trivial preset incident field profile, others will follow in a similar fashion.

The idea is to make the user side of incident field very close to existing lasers. So that a user has a very similar `struct PlaneWaveParams` in a `.param` file and then makes a profile out of that with e.g. `using XMin = profiles::PlaneWave<PlaneWaveParam>;`. Neither parameter structures (like `PlaneWaveParams`) nor the profiles themselves (like `profiles::PlaneWave<>`) know which side they are applied to. The binding happens only by a user putting those as aliases like `XMin`, and the other 5. So that in principle one could write smth like

```cpp
using XMin = profiles::PlaneWave<PlaneWaveParam>;
using XMax= profiles::PlaneWave<PlaneWaveParam>;
...
using ZMax = profiles::PlaneWave<PlaneWaveParam>;
```
and all those lasers would point inwards from the respective boundary.

Thus, the naming has to be generalized a little bit. Polarization is not hard-set to "linear X / linearZ" as in the existing laser. Instead, the laser define an internal coordinate system and polarizations are expressed using it. Focusing shifts will also be expressed as inward-shifts in this coordinate system (not applicable to plane wave). There is no `initPlaneY` member since the incident field generation positioning is controlled externally with `GAP_FROM_ABSORBER`. I also removed the time shift related to that `initPlaneY` as it doesn't make sense now; it could be compensated with other parameters when necessary. 

- [x] depends on #4050
- [x] check that all axes and directions work
- [x] add comparison plots of `YMin` incident field vs. laser 

Here is a comparison result. Only for the sake of this comparison I derived a formula of how to adjust the incident field functor to "represent" the `initPlaneY` in laser: in incident field, `PlaneWaveParam::RAMP_INIT` should be increased by `((laserInitPlaneY + 1.0) * SI::CELL_HEIGHT_SI / SI::SPEED_OF_LIGHT_SI) / (0.5 * PULSE_LENGTH_SI)`. Note that this is only to make it match the logic of the laser, is not relevant for "normal" incident field use. I will document this difference in approach in a separate PR.

Attaching comparison plots for laser with `initPlaneY = 32` vs. incident field with adjustment above, and other parameters as attached. Laser makes a two-sided pulse (as it should due to its implementation), so for the difference plot only use cells after y=37. The difference could probably have been made smaller if the `initPlaneY` is chosen so that analytical laser is 0 there, but I think the existing setup is sufficient proof the new profile works.
[planewave_test_problem.zip](https://github.com/ComputationalRadiationPhysics/picongpu/files/8474105/planewave_test_problem.zip)

![laser_vs_incident_300](https://user-images.githubusercontent.com/6825656/163133212-9b1dcedb-310b-4305-8717-e4dad88bd7c3.png)
![laser_vs_incident_500](https://user-images.githubusercontent.com/6825656/163133232-5150e607-f8cd-42c2-a468-5cc5c31f7088.png)
![laser_vs_incident_700](https://user-images.githubusercontent.com/6825656/163133249-c01bcfd1-a807-4fdd-a8f1-17ea9215a037.png)
