### PR TITLE
refactor openPMD plugin

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -100,19 +100,16 @@ namespace picongpu
 
             WriteSpeciesStrategy strategy = WriteSpeciesStrategy::ADIOS;
 
-            pmacc::math::UInt64<simDim> fieldsSizeDims;
-            pmacc::math::UInt64<simDim> fieldsGlobalSizeDims;
-            pmacc::math::UInt64<simDim> fieldsOffsetDims;
-
-            GridLayout<simDim> gridLayout;
             MappingDesc* cellDescription;
 
             std::vector<char> fieldBuffer; /* temp. buffer for fields */
 
             Window window; /* window describing the volume to be dumped */
 
-            DataSpace<simDim> localWindowToDomainOffset; /** offset from local moving
-                                                            window to local domain */
+            /** Offset from local moving window to local domain.
+             *  Value for all components will always be >= 0.
+             */
+            DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
 

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -81,7 +81,7 @@ namespace picongpu
                  */
                 if(!isDomainBound)
                 {
-                    auto const field_layout = params->gridLayout;
+                    auto const field_layout = field.getGridLayout();
                     auto const field_no_guard = field_layout.getDataSpaceWithoutGuarding();
                     auto const elementCount = field_no_guard.productOfComponents();
 
@@ -214,7 +214,6 @@ namespace picongpu
 
                 /* load field without copying data to host */
                 auto field = dc.get<T_Field>(T_Field::getName(), true);
-                tp->gridLayout = field->getGridLayout();
 
                 /* load from openPMD */
                 bool const isDomainBound = traits::IsFieldDomainBound<T_Field>::value;


### PR DESCRIPTION
- Remove field sizes and offsets from the helper collection struct
`ThreadParams` and calculate these values at the place where those are
needed.
- Rename some variables pointing to a buffer, window or openPMD property/size.
buffer

This PR is the base to implement slicing for fields and particles. We already support sliding window, a slide will be an arbitrary window (contiguous area within the global domain)