### PR TITLE
Change way of controlling position of the Huygens surface

### DIFF
--- a/docs/source/models/total_field_scattered_field.rst
+++ b/docs/source/models/total_field_scattered_field.rst
@@ -46,7 +46,7 @@ The Huygens surface is chosen so that no Yee grid nodes lay on it.
 So it could be located at an arbitrary position that does not collide with cell- and half-cell boundaries.
 
 In PIConGPU, the position of the Huygens surface is defined relative to the internal boundary of the field absorber.
-The surface is shifted inwards relative to each boundary by a user-defined gap in full cells and an additional 0.75 cells.
+The surface is shifted inwards relative to each boundary by a user-defined offset in full cells and an additional 0.75 cells.
 The equations presented in  this section hold for this 0.75 shift and the Yee grid layout used in PIConGPU.
 In principle, a similar derivation can be done in any case, but the resulting expression would not generally match index-by-index. 
 
@@ -77,7 +77,7 @@ Single Boundary
 ^^^^^^^^^^^^^^^
 
 First we describe application of a field source only at the :math:`x_{min}` boundary.
-For this case, suppose the source is given along a plane :math:`x = x_{min} + gap + 0.75 \Delta x` and acts along the whole domain in :math:`y` and :math:`z`.
+For this case, suppose the source is given along a plane :math:`x = x_{min} + offset + 0.75 \Delta x` and acts along the whole domain in :math:`y` and :math:`z`.
 The source affects transversal field components :math:`E_y`, :math:`E_z`, :math:`B_y`, :math:`B_z`.
 Components :math:`E_x`, :math:`B_x` are not affected by TF/SF and we do not consider them in the following description.
 We also omit the :math:`\vec J` term which is applied as usual in the field solver and is also not affected by TF/SF.
@@ -393,9 +393,13 @@ Usage
 -----
 
 The TF/SF field generation can be configured in :ref:`incidentField.param <usage-params-core>`.
-The position of the Huygens surface is set as a gap relative to the interface of the field absorber and internal area.
-Note that using field solvers other than Yee requires a positive gap along the boundaries with a non-zero source, gap value depending on the stencil width along the boundary axis.
-This is checked at run time.
+The position of the Huygens surface is set as an offset relative to the global domain start.
+The offset must cover at least the field absorber thickness along the boundary so that the Huygens surface is located in the internal area.
+Note that using field solvers other than Yee requires a larger offset depending on the stencil width along the boundary axis.
+As a rule of thumb, this extra requirement is (order of FDTD solver / 2 - 1).
+Additionally, the current implementation requires the offset be located sufficiently far away from local domain boundaries.
+The same rule of a thumb can be used, with offsets being at least that many cells away from domain boundaries.
+Validity of the provided offsets with respect to both conditions is checked at run time.
 
 Consider a case when both :math:`E^{inc}(x, y, z, t)` and  :math:`\vec B^{inc}(x, y, z, t)` are theoretically present, but only one of them is known in explicit form.
 When slowly varying elvelope approximation is applicable, one may employ it to calculate the other field as :math:`\vec B^{inc}(x, y, z, t) = \vec k \cross \vec E^{inc}(x, y, z, t) / c`.

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -27,7 +27,7 @@
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
- * `GAP_FROM_ABSORBER` that controls position of the generating surface relative to field absorber. For example:
+ * `OFFSET` that controls inward offset of the generating surface relative to global domain. For example:
  *
  * @code{.cpp}
  * using XMin = profiles::Free< UserFunctorIncidentE >;
@@ -37,7 +37,7 @@
  * using ZMin = profiles::None;
  * using ZMax = profiles::None;
  *
- * constexpr uint32_t GAP_FROM_ABSORBER[3][2] = { {0, 0}, {0, 0}, {0, 0} };
+ * constexpr uint32_t OFFSET[3][2] = { {16, 16}, {16, 16}, {16, 16} };
  * @endcode
  */
 
@@ -133,15 +133,19 @@ namespace picongpu
             using ZMax = profiles::None;
             /**@}*/
 
-            /** Gap of the Huygence surface from absorber
+            /** Inward offset of the Huygens surface from global domain boundaries
              *
-             * The gap is in cells, counted from the corrresponding boundary in the normal direction pointing inwards.
-             * It is similar to specifying absorber cells, just this layer is further inside.
+             * The offset is in cells, counted from the corrresponding boundary inwards in the normal direction.
+             * This array is logically similar to specifying absorber thickness.
+             * The offset for the boundary must be at least absorber_thickness + (FDTD_spatial_order / 2 - 1).
+             * However beware of setting offset = absorber_thickness + const, as then changing absorber parameters
+             * may also affect laser positioning.
+             * When all used profiles are None, the check for OFFSET validity is skipped.
              */
-            constexpr uint32_t GAP_FROM_ABSORBER[3][2] = {
-                {0, 0}, // x direction [negative, positive]
-                {0, 0}, // y direction [negative, positive]
-                {0, 0} // z direction [negative, positive]
+            constexpr uint32_t OFFSET[3][2] = {
+                {16, 16}, // x direction [negative, positive]
+                {16, 16}, // y direction [negative, positive]
+                {16, 16} // z direction [negative, positive]
             };
 
         } // namespace incidentField

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -27,7 +27,7 @@
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
- * `GAP_FROM_ABSORBER` that controls position of the generating surface relative to field absorber. For example:
+ * `OFFSET` that controls inward offset of the generating surface relative to global domain. For example:
  *
  * @code{.cpp}
  * using XMin = profiles::Free< UserFunctorIncidentE >;
@@ -37,7 +37,7 @@
  * using ZMin = profiles::None;
  * using ZMax = profiles::None;
  *
- * constexpr uint32_t GAP_FROM_ABSORBER[3][2] = { {0, 0}, {0, 0}, {0, 0} };
+ * constexpr uint32_t OFFSET[3][2] = { {16, 16}, {16, 16}, {16, 16} };
  * @endcode
  */
 
@@ -245,15 +245,19 @@ namespace picongpu
             using ZMax = profiles::None;
             /**@}*/
 
-            /** Gap of the Huygence surface from absorber
+            /** Inward offset of the Huygens surface from global domain boundaries
              *
-             * The gap is in cells, counted from the corrresponding boundary in the normal direction pointing inwards.
-             * It is similar to specifying absorber cells, just this layer is further inside.
+             * The offset is in cells, counted from the corrresponding boundary inwards in the normal direction.
+             * This array is logically similar to specifying absorber thickness.
+             * The offset for the boundary must be at least absorber_thickness + (FDTD_spatial_order / 2 - 1).
+             * However beware of setting offset = absorber_thickness + const, as then changing absorber parameters
+             * may also affect laser positioning.
+             * When all used profiles are None, the check for OFFSET validity is skipped.
              */
-            constexpr uint32_t GAP_FROM_ABSORBER[3][2] = {
-                {0, 0}, // x direction [negative, positive]
-                {0, 0}, // y direction [negative, positive]
-                {0, 0} // z direction [negative, positive]
+            constexpr uint32_t OFFSET[3][2] = {
+                {16, 16}, // x direction [negative, positive]
+                {16, 16}, // y direction [negative, positive]
+                {16, 16} // z direction [negative, positive]
             };
 
         } // namespace incidentField


### PR DESCRIPTION
Now it is set by offset from global domain boundary. Updated comments and add a warning about setting it to absorber_size + const. Along the way also refactor validity checking code. Update and slightly extend the docs.

Implements part of #4052, but for now uses global and not total positining. For that issue it's still left to figure out how to properly couple it with moving window.