### PR TITLE
Update alpakaCommon.cmake

### DIFF
--- a/thirdParty/cupla/alpaka/cmake/alpakaCommon.cmake
+++ b/thirdParty/cupla/alpaka/cmake/alpakaCommon.cmake
@@ -487,6 +487,9 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE)
     # minimal supported HIP version
     set(_ALPAKA_HIP_MIN_VER 4.0)
     find_package(hip "${_ALPAKA_HIP_MIN_VER}")
+    if(NOT TARGET hip)
+      find_package(hip 5.0)
+    endif()
 
     if(NOT TARGET hip)
         message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")


### PR DESCRIPTION
Fallback to manually checking for hip 5 when hip 4 is not found.

update by @psychocoderHPC: 
- [ ] discuss with @ComputationalRadiationPhysics/picongpu-maintainers if we should merge it before the alpaka update (could make merging issue)