### PR TITLE
Add polynom incident field profile

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/Polynom.def
+++ b/include/picongpu/fields/incidentField/profiles/Polynom.def
@@ -1,0 +1,113 @@
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace defaults
+                {
+                    struct PolynomParam
+                    {
+                        /** unit: meter */
+                        static constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+                        /** Convert the normalized laser strength parameter a0 to Volt per meter */
+                        static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+                            * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI
+                            * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+                        /** unit: W / m^2 */
+                        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+                        /** unit: none */
+                        // static constexpr float_64 _A0  = 1.5;
+
+                        /** unit: Volt / meter */
+                        // static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+                        /** unit: Volt / meter */
+                        static constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+                        /** Pulse length: sigma of std. gauss for intensity (E^2)
+                         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                         *                                          [    2.354820045     ]
+                         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                         *                      = what a experimentalist calls "pulse duration"
+                         *  unit: seconds (1 sigma) */
+                        static constexpr float_64 PULSE_LENGTH_SI = 4.0e-15;
+
+                        /** beam waist: distance from the axis where the pulse intensity (E^2)
+                         *              decreases to its 1/e^2-th part,
+                         *              at the focus position of the laser
+                         *
+                         * AXIS_1 is next axis after the propagation axis in order (x, y, z) with a periodic
+                         * wrap. LINEAR_AXIS_1 is next after LINEAR_AXIS_2. E.g. for y propagation axis, AXIS_1 = z,
+                         * AXIS_2 = x
+                         *
+                         *  unit: meter
+                         */
+                        static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
+                        static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
+
+                        /** laser phase shift (no shift: 0.0)
+                         *
+                         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+                         *
+                         * unit: rad, periodic in 2*pi
+                         */
+                        static constexpr float_X LASER_PHASE = 0.0;
+
+                        /** Available E polarisation types, B polarization will be calculated automatically
+                         *
+                         * AXIS_1 and AXIS_2 are defined same as for W0_AXIS_1_SI, W0_AXIS_2_SI.
+                         */
+                        enum PolarisationType
+                        {
+                            LINEAR_AXIS_1 = 1u,
+                            LINEAR_AXIS_2 = 2u,
+                            CIRCULAR = 4u
+                        };
+                        /** Polarization selection
+                         */
+                        static constexpr PolarisationType Polarisation = LINEAR_AXIS_2;
+                    };
+                } // namespace defaults
+
+                /** Wavepacket with a polynomial temporal intensity shape laser profiles tag
+                 *
+                 * Based on a wavepacket with Gaussian spatial envelope.
+                 *
+                 * @tparam T_Params class parameter to configure the plane wave profile,
+                 *                  see members of defaults::PolynomParam for
+                 *                  required members
+                 */
+                template<typename T_Params = defaults::PolynomParam>
+                struct Polynom;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/Polynom.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Polynom.hpp
@@ -1,0 +1,197 @@
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/incidentField/profiles/BaseFunctorE.hpp"
+
+#include <cstdint>
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Unitless polynom parameters
+                     *
+                     * @tparam T_Params user (SI) parameters
+                     */
+                    template<typename T_Params>
+                    struct PolynomUnitless : public T_Params
+                    {
+                        using Params = T_Params;
+
+                        static constexpr float_X WAVE_LENGTH
+                            = float_X(Params::WAVE_LENGTH_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X PULSE_LENGTH
+                            = float_X(Params::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (1 sigma)
+                        static constexpr float_X AMPLITUDE
+                            = float_X(Params::AMPLITUDE_SI / UNIT_EFIELD); // unit: Volt /meter
+                        static constexpr float_X W0_AXIS_1
+                            = float_X(Params::W0_AXIS_1_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X W0_AXIS_2
+                            = float_X(Params::W0_AXIS_2_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X INIT_TIME = float_X(
+                            Params::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (full initialization length)
+                        static constexpr float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+                    };
+
+                    /** Polynom incident E functor
+                     *
+                     * @tparam T_Params parameters
+                     * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                     * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from
+                     * the max boundary inwards)
+                     */
+                    template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                    struct PolynomFunctorIncidentE
+                        : public PolynomUnitless<T_Params>
+                        , public BaseFunctorE<T_axis, T_direction>
+                    {
+                        //! Unitless parameters type
+                        using Unitless = PolynomUnitless<T_Params>;
+
+                        //! Base functor type
+                        using Base = BaseFunctorE<T_axis, T_direction>;
+
+                        /** Create a functor on the host side
+                         *
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE PolynomFunctorIncidentE(const float3_64 unitField) : Base(unitField)
+                        {
+                            auto const& subGrid = Environment<simDim>::get().SubGrid();
+                            totalDomainCells = precisionCast<float_X>(subGrid.getTotalDomain().size);
+                        }
+
+                        /** Calculate incident field E value for the given position and time.
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         * @param currentStep current time step index, note that it is fractional
+                         * @return incident field E value in internal units
+                         */
+                        HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
+                        {
+                            return getLongitudinal(currentStep) * getTransversal(totalCellIdx);
+                        }
+
+                    private:
+                        //! Total domain size in cells
+                        floatD_X totalDomainCells;
+
+                        //! Get time-dependent longitudinal vector factor
+                        HDINLINE float3_X getLongitudinal(const float_X currentStep) const
+                        {
+                            auto elong = float3_X::create(0.0_X);
+                            /* a symmetric pulse will be initialized at position z=0
+                             * the laser amplitude rises  for riseTime and falls for riseTime
+                             * making the laser pulse 2*riseTime long
+                             */
+                            float_64 const runTime = DELTA_T * currentStep;
+                            const float_X riseTime = 0.5_X * Unitless::PULSE_LENGTH;
+                            const float_X tau = runTime / riseTime;
+                            const float_X omegaLaser = 2.0_X * PI * Unitless::f;
+                            auto const arg = omegaLaser * (runTime - riseTime) + Unitless::LASER_PHASE;
+                            if(Unitless::Polarisation == Unitless::LINEAR_AXIS_2)
+                                elong[Base::dir2] = math::sin(arg);
+                            else if(Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
+                                elong[Base::dir1] = math::sin(arg);
+                            else if(Unitless::Polarisation == Unitless::CIRCULAR)
+                            {
+                                elong[Base::dir2] = math::sin(arg) / math::sqrt(2.0_X);
+                                elong[Base::dir1] = math::cos(arg) / math::sqrt(2.0_X);
+                            }
+                            auto const amplitude = static_cast<float_X>(Unitless::AMPLITUDE * polynomial(tau));
+                            return elong * amplitude;
+                        }
+
+                        //! Get polynomial value for unitless time variable tau in [0.0, 2.0]
+                        static HDINLINE float_X polynomial(float_X const tau)
+                        {
+                            auto result = 0.0_X;
+                            if(tau >= 0.0_X && tau <= 1.0_X)
+                                result = tau * tau * tau * (10.0_X - 15.0_X * tau + 6.0_X * tau * tau);
+                            else if(tau > 1.0_X && tau <= 2.0_X)
+                                result = (2.0_X - tau) * (2.0_X - tau) * (2.0_X - tau)
+                                    * (4.0_X - 9.0_X * tau + 6.0_X * tau * tau);
+                            return result;
+                        }
+
+                        //! Get position-dependent transversal scalar factor
+                        HDINLINE float_X getTransversal(const floatD_X& totalCellIdx) const
+                        {
+                            floatD_X transversalPosition
+                                = (totalCellIdx - totalDomainCells * 0.5_X) * cellSize.shrink<simDim>();
+                            transversalPosition[Base::dir0] = 0.0_X;
+                            auto w0 = float3_X::create(1.0_X);
+                            w0[Base::dir1] = Unitless::W0_AXIS_1;
+                            w0[Base::dir2] = Unitless::W0_AXIS_2;
+                            float_X const r2 = pmacc::math::abs2(transversalPosition / w0.shrink<simDim>());
+                            return math::exp(-r2);
+                        }
+                    };
+                } // namespace detail
+            } // namespace profiles
+
+            namespace detail
+            {
+                /** Get type of incident field E functor for the polynom profile type
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::Polynom<T_Params>, T_axis, T_direction>
+                {
+                    using type = profiles::detail::PolynomFunctorIncidentE<T_Params, T_axis, T_direction>;
+                };
+
+                /** Get type of incident field B functor for the polynom profile type
+                 *
+                 * Rely on SVEA to calculate value of B from E.
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::Polynom<T_Params>, T_axis, T_direction>
+                {
+                    using type = detail::ApproximateIncidentB<
+                        typename GetFunctorIncidentE<profiles::Polynom<T_Params>, T_axis, T_direction>::type,
+                        T_axis,
+                        T_direction>;
+                };
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -22,3 +22,4 @@
 #include "picongpu/fields/incidentField/profiles/Free.def"
 #include "picongpu/fields/incidentField/profiles/None.def"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
+#include "picongpu/fields/incidentField/profiles/Polynom.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -22,3 +22,4 @@
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
 #include "picongpu/fields/incidentField/profiles/None.hpp"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.hpp"
+#include "picongpu/fields/incidentField/profiles/Polynom.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -25,6 +25,7 @@
  *  - profiles::None        : no incident field
  *  - profiles::Free<>      : custom profile with user-provided functors to calculate incident E and B
  *  - profiles::PlaneWave<> : plane wave profile with given parameters
+ *  - profiles::Polynom<>   : wavepacket with a polynomial temporal intensity shape profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
@@ -35,7 +36,7 @@
  * using XMax = profiles::None;
  * using YMin = profiles::PlaneWave< UserPlaneWaveParams >;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
- * using ZMin = profiles::None;
+ * using ZMin = profiles::Polynom< UserPolynomParams >;
  * using ZMax = profiles::None;
  *
  * constexpr uint32_t OFFSET[3][2] = { {16, 16}, {16, 16}, {16, 16} };

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -25,6 +25,7 @@
  *  - profiles::None        : no incident field
  *  - profiles::Free<>      : custom profile with user-provided functors to calculate incident E and B
  *  - profiles::PlaneWave<> : plane wave profile with given parameters
+ *  - profiles::Polynom<>   : wavepacket with a polynomial temporal intensity shape profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
@@ -35,7 +36,7 @@
  * using XMax = profiles::None;
  * using YMin = profiles::PlaneWave< UserPlaneWaveParams >;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
- * using ZMin = profiles::None;
+ * using ZMin = profiles::Polynom< UserPolynomParams >;
  * using ZMax = profiles::None;
  *
  * constexpr uint32_t OFFSET[3][2] = { {16, 16}, {16, 16}, {16, 16} };


### PR DESCRIPTION
Its parameters mirror ones of the `Polynom` laser profile when possible.

The logic is similar to  #4053 and all explanations there apply to this PR as well. Just here we are porting the `Polynom` laser and not the `PlaneWave` one.

I also made a similar comparison on a test problem that generates at `y_cell = 32`. In this case, it was not possible to perfectly translate the laser `initPlaneY` via only parameters. However, I just hard-coded it inside the incident field for the sake of testing (and removed after). Attaching the problem files and some plots. (also see [my message below](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4064#issuecomment-1105196202))
[polynom_test_problem.zip](https://github.com/ComputationalRadiationPhysics/picongpu/files/8513253/polynom_test_problem.zip)
![laser_vs_incident_300](https://user-images.githubusercontent.com/6825656/164012600-6cdc4bba-0cd2-40f1-b6d4-7cdccb63a1f9.png)
![laser_vs_incident_500](https://user-images.githubusercontent.com/6825656/164012610-889dd863-869e-42b2-b832-6295db2de2ec.png)
![laser_vs_incident_700](https://user-images.githubusercontent.com/6825656/164012623-741eb633-43a0-42fd-847a-5c825c017db7.png)
