### PR TITLE
Fix a bug in plane wave incident field for circular polarization

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
@@ -124,8 +124,7 @@ namespace picongpu
                             float_64 const t_and_phase = w * timeOszi + Unitless::LASER_PHASE;
                             // to understand both components [sin(...) + t/tau^2 * cos(...)] see description above
                             auto const baseValue = static_cast<float_X>(
-                                envelope
-                                * (math::sin(t_and_phase) + math::cos(t_and_phase) * integrationCorrectionFactor));
+                                (math::sin(t_and_phase) + math::cos(t_and_phase) * integrationCorrectionFactor));
                             auto elong = float3_X::create(0.0_X);
                             if(Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
                             {
@@ -137,10 +136,13 @@ namespace picongpu
                             }
                             else if(Unitless::Polarisation == Unitless::CIRCULAR)
                             {
-                                elong[Base::dir1] = baseValue / math::sqrt(2.0_X);
+                                elong[Base::dir1] = static_cast<float_X>(
+                                                        math::cos(t_and_phase)
+                                                        - math::sin(t_and_phase) * integrationCorrectionFactor)
+                                    / math::sqrt(2.0_X);
                                 elong[Base::dir2] = baseValue / math::sqrt(2.0_X);
                             }
-                            return elong;
+                            return elong * envelope;
                         }
                     };
                 } // namespace detail
@@ -161,7 +163,7 @@ namespace picongpu
                     using type = profiles::detail::PlaneWaveFunctorIncidentE<T_Params, T_axis, T_direction>;
                 };
 
-                /** Get type of incident field E functor for the plane wave profile type
+                /** Get type of incident field B functor for the plane wave profile type
                  *
                  * For plane wave there is no difference between directly- and SVEA-calculating B, so reuse SVEA for
                  * brevity.


### PR DESCRIPTION
The bug was introduced as part of #4053 and slipped through the test problem as it only used linear polarization. I didn't run it for the circular polarization as i was testing it during development and it worked fine, just at the end i refactored the implementation and when doing it introduced a mistake. Attaching results for the fixed version, same test problem as in #4053 just with circular polarization.

![laser_vs_incident_300](https://user-images.githubusercontent.com/6825656/164022680-af27ccac-9833-4430-bbbe-f3d36750e2bb.png)
![laser_vs_incident_500](https://user-images.githubusercontent.com/6825656/164022695-833b6410-3d8b-415c-a8a3-c2ae2f570fa6.png)
![laser_vs_incident_700](https://user-images.githubusercontent.com/6825656/164022707-0be13863-0a52-467c-8416-c6568e4eacb2.png)
