### PR TITLE
Modify incident field functors to take time in constructor instead of operator()

### DIFF
--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -32,53 +32,54 @@ namespace picongpu
             //! Concept defining interface of incident field functors for E and B
             struct FunctorIncidentFieldConcept
             {
-                /** Create a functor on the host side
+                /** Create a functor on the host side for the given time step
                  *
                  * Since it is host-only, one could access global simulation data like Environment<simDim> and objects
                  * controlled by DataConnector. Note that it is not possible in operator(), but relevant data can be
                  * saved in members on this class.
+                 * Time-dependent part of the functor can also be precalculated on host and saved in members.
                  *
+                 * @param currentStep current time step index, note that it is fractional
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HINLINE FunctorIncidentFieldConcept(float3_64 unitField);
+                HINLINE FunctorIncidentFieldConcept(float_X currentStep, float3_64 unitField);
 
                 //! Functor must be copiable to device by value
                 // HDINLINE FunctorIncidentFieldConcept(const FunctorIncidentFieldConcept& other) = default;
 
-                /** Return incident field for the given position and time.
+                /** Return incident field for the given position
                  *
                  * Note that component matching the source boundary (e.g. the y component for YMin and YMax boundaries)
                  * will not be used, and so should be zero.
                  *
                  * @param totalCellIdx cell index in the total domain (including all moving window slides),
                  *        note that it is fractional
-                 * @param currentStep current time step index, note that it is fractional
                  * @return incident field value in internal units
                  */
-                HDINLINE float3_X operator()(floatD_X const& totalCellIdx, float_X currentStep) const;
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const;
             };
 
             //! Helper incident field functor always returning 0
             struct ZeroFunctor
             {
-                /** Create a functor on the host side
+                /** Create a functor on the host side for the given time step
                  *
+                 * @param currentStep current time step index, note that it is fractional
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HINLINE ZeroFunctor(float3_64 unitField)
+                HINLINE ZeroFunctor(float_X const currentStep, float3_64 const unitField)
                 {
                 }
 
-                /** Return zero incident field for any given position and time.
+                /** Return zero incident field for any given position
                  *
                  * @param totalCellIdx cell index in the total domain (including all moving window slides),
                  *        note that it is fractional
-                 * @param currentStep current time step index, note that it is fractional
                  * @return incident field value in internal units
                  */
-                HDINLINE float3_X operator()(floatD_X const& totalCellIdx, float_X currentStep) const
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
                 {
                     return float3_X::create(0.0_X);
                 }
@@ -107,12 +108,14 @@ namespace picongpu
                     //! Relation between unitField for E and B: E = B * unitConversionBtoE
                     static constexpr float_64 unitConversionBtoE = UNIT_EFIELD / UNIT_BFIELD;
 
-                    /** Create a functor on the host side
+                    /** Create a functor on the host side for the given time step
                      *
+                     * @param currentStep current time step index, note that it is fractional
                      * @param unitField conversion factor from SI to internal units,
                      *                  fieldB_internal = fieldB_SI / unitField
                      */
-                    HINLINE ApproximateIncidentB(const float3_64 unitField) : Base(unitField * unitConversionBtoE)
+                    HINLINE ApproximateIncidentB(float_X const currentStep, float3_64 const unitField)
+                        : Base(currentStep, unitField * unitConversionBtoE)
                     {
                     }
 
@@ -123,13 +126,12 @@ namespace picongpu
                      * E is value returned by a base functor at the target location and time of resulting B
                      *
                      * @param totalCellIdx cell index in the total domain (including all moving window slides)
-                     * @param currentStep current time step index, note that it is fractional
                      * @return incident field B value in internal units
                      */
-                    HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
+                    HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
                     {
                         // Get corresponding E value, it is already in internal units
-                        auto const eValue = Base::operator()(totalCellIdx, currentStep);
+                        auto const eValue = Base::operator()(totalCellIdx);
                         // To avoid making awkward type casts and calling cross product, we express it manually as
                         // rotation and sign change
                         constexpr float_X signAndNormalization = static_cast<float_X>(T_direction) / SPEED_OF_LIGHT;

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -267,9 +267,8 @@ namespace picongpu
                     auto endGridIdx = endLocalUserIdx + numGuardCells;
 
                     // Indexing is done, now prepare the update functor
-                    auto functor = Functor{incidentField.getUnit()};
+                    auto functor = Functor{parameters.sourceTimeIteration, incidentField.getUnit()};
                     functor.updatedField = dataBox;
-                    functor.currentStep = parameters.sourceTimeIteration;
                     functor.isUpdatedFieldTotal = isUpdatedFieldTotal;
                     functor.direction = parameters.direction;
                     /* Shift between local grid idx and fractional total cell idx that a user functor needs:

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -58,15 +58,16 @@ namespace picongpu
                     uint32_t T_axis>
                 struct UpdateFunctor
                 {
-                    /** Create an update functor instance on the host side
+                    /** Create an update functor instance on the host side for the given time step
                      *
                      * It should then be passed to the kernel by value
                      *
+                     * @param currentStep current time step index, note that it is fractional
                      * @param unitField conversion factor from SI to internal units,
                      *                  field_internal = field_SI / unitField
                      */
-                    UpdateFunctor(float3_64 const unitField)
-                        : functorIncidentField(unitField)
+                    HINLINE UpdateFunctor(float_X const currentStep, float3_64 const unitField)
+                        : functorIncidentField(currentStep, unitField)
                         , coeff1(float3_X::create(0.0_X))
                         , coeff2(float3_X::create(0.0_X))
                     {
@@ -158,9 +159,6 @@ namespace picongpu
                     //! Index shift: totalCellIdx (that a user functor gets) = gridIdx + gridIdxShirt
                     pmacc::DataSpace<simDim> gridIdxShift;
 
-                    //! Current time step, in iterations; can be fractional
-                    float_X currentStep;
-
                     /** Direction of the incidentField propagation
                      *
                      * +1._X is positive direction (from the min boundary inwards).
@@ -240,12 +238,12 @@ namespace picongpu
                                     result += derivativeCoeff
                                         * (coeff1
                                                * functorIncidentField(
-                                                   incidentFieldShift1 + incidentIdxShift.shrink<simDim>(),
-                                                   currentStep)[incidentComponent1]
+                                                   incidentFieldShift1
+                                                   + incidentIdxShift.shrink<simDim>())[incidentComponent1]
                                            + coeff2
                                                * functorIncidentField(
-                                                   incidentFieldShift2 + incidentIdxShift.shrink<simDim>(),
-                                                   currentStep)[incidentComponent2]);
+                                                   incidentFieldShift2
+                                                   + incidentIdxShift.shrink<simDim>())[incidentComponent2]);
                                     incidentIdxShift[dir2] += 1.0_X;
                                 }
                                 incidentIdxShift[dir1] += 1.0_X;

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -54,7 +54,11 @@ namespace picongpu
     {
         namespace incidentField
         {
-            // This base class is merely to keep all laser-related things together
+            /** Base class with laser parameters and common functionality
+             *
+             * It is not required to have a base class, but in this case convenient to keep all laser-related things
+             * together.
+             */
             class FunctorBase
             {
             public:
@@ -67,7 +71,7 @@ namespace picongpu
                 static constexpr float_64 AMPLITUDE_SI = A0 * UNITCONV_A0_to_Amplitude_SI;
                 static constexpr float_64 DURATION_SI = 0.026e-9; // 0.026 ns
 
-                /// These need to be changed together with grid size
+                // These need to be changed together with grid size
                 static constexpr float_64 LASER_CENTER_X_SI = 80.0e-3; // 80 mm
                 static constexpr float_64 LASER_WIDTH_X_SI = 8.0e-3; // 8 mm
                 static constexpr float_64 LASER_CENTER_Y_SI = 40.0e-3; // 40 mm
@@ -87,17 +91,30 @@ namespace picongpu
                 // Delay at initialization to ensure a smooth start
                 static constexpr float_64 initializationDurationSI = 16.0 * DURATION_SI;
 
-                // Get value to calculate Ey / Bz for the XMin source
-                HDINLINE float_X getXMinSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
+                /** Create base functor on the host side for the given time step
+                 *
+                 * We will precalculate and save time-dependent values in members to avoid recalculating same values
+                 *
+                 * @param currentStep current time step index, note that it is fractional
+                 */
+                HINLINE FunctorBase(float_X const currentStep)
                 {
                     auto const normalizedDuration
                         = (currentStep * SI::DELTA_T_SI - 0.5 * initializationDurationSI) / DURATION_SI;
+                    timeEnvelope = static_cast<float_X>(math::exp(-normalizedDuration * normalizedDuration));
+                    currentTime = currentStep * SI::DELTA_T_SI;
+                }
+
+                /** Get value to calculate Ey / Bz for the XMin source
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
+                 */
+                HDINLINE float_X getXMinSourceValueSI(floatD_X const& totalCellIdx) const
+                {
                     auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
                     auto const x = totalCellIdx.x() * SI::CELL_WIDTH_SI;
-                    auto const t = currentStep * SI::DELTA_T_SI;
-                    // note: one could also add x influence to normalizedDuration under exp
-                    auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
-                        * sin(k * (x - SI::SPEED_OF_LIGHT_SI * t));
+                    auto const longitudinal = timeEnvelope * sin(k * (x - SI::SPEED_OF_LIGHT_SI * currentTime));
                     auto const normalizedY = (totalCellIdx.y() - LASER_CENTER_Y_CELLS) / LASER_WIDTH_Y_CELLS;
                     auto normalizedZ = 0.0;
                     if constexpr(simDim == 3)
@@ -106,17 +123,16 @@ namespace picongpu
                     return AMPLITUDE_SI * longitudinal * transversal;
                 }
 
-                // Get value to calculate Ex / Bz for the XMax source
-                HDINLINE float_X getYMaxSourceValueSI(const floatD_X& totalCellIdx, const float_X currentStep) const
+                /** Get value to calculate Ex / Bz for the XMax source
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
+                 */
+                HDINLINE float_X getYMaxSourceValueSI(floatD_X const& totalCellIdx) const
                 {
-                    auto const normalizedDuration
-                        = (currentStep * SI::DELTA_T_SI - 0.5 * initializationDurationSI) / DURATION_SI;
                     auto const k = 2.0_X * M_PI / WAVE_LENGTH_SI;
                     auto const y = totalCellIdx.y() * SI::CELL_HEIGHT_SI;
-                    auto const t = currentStep * SI::DELTA_T_SI;
-                    // note: one could also add y influence to normalizedDuration under exp
-                    auto const longitudinal = math::exp(-normalizedDuration * normalizedDuration)
-                        * sin(k * (y + SI::SPEED_OF_LIGHT_SI * t));
+                    auto const longitudinal = timeEnvelope * sin(k * (y + SI::SPEED_OF_LIGHT_SI * currentTime));
                     auto const normalizedX = (totalCellIdx.x() - LASER_CENTER_Y_CELLS) / LASER_WIDTH_X_CELLS;
                     auto normalizedZ = 0.0;
                     if constexpr(simDim == 3)
@@ -124,6 +140,13 @@ namespace picongpu
                     auto const transversal = math::exp(-(normalizedX * normalizedX + normalizedZ * normalizedZ));
                     return AMPLITUDE_SI * longitudinal * transversal;
                 }
+
+            private:
+                //! Precalculated time-dependent envelope
+                float_X timeEnvelope;
+
+                //! Current time
+                float_X currentTime;
             };
 
             /** Functor to set values of incident E field
@@ -134,12 +157,15 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor on the host side
+                /** Create a functor on the host side for the given time step
                  *
+                 * @param currentStep current time step index, note that it is fractional
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HINLINE FunctorXMinIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorXMinIncidentE(float_X const currentStep, float3_64 const unitField)
+                    : FunctorBase(currentStep)
+                    , m_unitField(unitField)
                 {
                 }
 
@@ -147,11 +173,10 @@ namespace picongpu
                  *
                  * @param totalCellIdx cell index in the total domain (including all moving window slides),
                  *        note that it is fractional
-                 * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
                 {
-                    auto const valueSI = getXMinSourceValueSI(totalCellIdx, currentStep);
+                    auto const valueSI = getXMinSourceValueSI(totalCellIdx);
                     auto const fieldSI = float3_X(0.0_X, valueSI, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -165,12 +190,15 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor on the host side
+                /** Create a functor on the host side for the given time step
                  *
+                 * @param currentStep current time step index, note that it is fractional
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HINLINE FunctorYMaxIncidentE(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorYMaxIncidentE(float_X const currentStep, float3_64 const unitField)
+                    : FunctorBase(currentStep)
+                    , m_unitField(unitField)
                 {
                 }
 
@@ -178,11 +206,10 @@ namespace picongpu
                  *
                  * @param totalCellIdx cell index in the total domain (including all moving window slides),
                  *        note that it is fractional
-                 * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
                 {
-                    auto const valueSI = getYMaxSourceValueSI(totalCellIdx, currentStep);
+                    auto const valueSI = getYMaxSourceValueSI(totalCellIdx);
                     auto const fieldSI = float3_X(valueSI, 0.0_X, 0.0_X);
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }
@@ -196,12 +223,15 @@ namespace picongpu
                 /* We use this to calculate your SI input back to our unit system */
                 PMACC_ALIGN(m_unitField, const float3_64);
 
-                /** Create a functor on the host side
+                /** Create a functor on the host side for the given time step
                  *
+                 * @param currentStep current time step index, note that it is fractional
                  * @param unitField conversion factor from SI to internal units,
                  *                  field_internal = field_SI / unitField
                  */
-                HINLINE FunctorYMaxIncidentB(const float3_64 unitField) : m_unitField(unitField)
+                HINLINE FunctorYMaxIncidentB(float_X const currentStep, float3_64 const unitField)
+                    : FunctorBase(currentStep)
+                    , m_unitField(unitField)
                 {
                 }
 
@@ -209,11 +239,10 @@ namespace picongpu
                  *
                  * @param totalCellIdx cell index in the total domain (including all moving window slides),
                  *        note that it is fractional
-                 * @param currentStep current time step index, note that it is fractional
                  */
-                HDINLINE float3_X operator()(const floatD_X& totalCellIdx, const float_X currentStep) const
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
                 {
-                    auto const valueSI = getYMaxSourceValueSI(totalCellIdx, currentStep);
+                    auto const valueSI = getYMaxSourceValueSI(totalCellIdx);
                     auto const fieldSI = float3_X(0.0_X, 0.0_X, valueSI) / SI::SPEED_OF_LIGHT_SI;
                     return fieldSI / precisionCast<float_X>(m_unitField);
                 }


### PR DESCRIPTION
Adjust all profiles and example accordingly. The motivation for the change is explained in #4065.
Fixes #4065.

- [x] Based on #4064.