### PR TITLE
Add wavepacket incident field profile 

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.def
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.def
@@ -1,0 +1,122 @@
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Stefan Tietze, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace defaults
+                {
+                    struct WavepacketParam
+                    {
+                        /** unit: meter */
+                        static constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+                        /** Convert the normalized laser strength parameter a0 to Volt per meter */
+                        static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+                            * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI
+                            * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+                        /** unit: W / m^2 */
+                        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+                        /** unit: none */
+                        // static constexpr float_64 _A0  = 1.5;
+
+                        /** unit: Volt / meter */
+                        // static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+                        /** unit: Volt / meter */
+                        static constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+                        /** Stretch temporal profile by a constant plateau between the up and downramp
+                         *  unit: seconds */
+                        static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI
+                            = 7.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+                        /** Pulse length: sigma of std. gauss for intensity (E^2)
+                         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                         *                                          [    2.354820045     ]
+                         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                         *                      = what a experimentalist calls "pulse duration"
+                         *  unit: seconds (1 sigma) */
+                        static constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+
+                        /** beam waist: distance from the axis where the pulse intensity (E^2)
+                         *              decreases to its 1/e^2-th part,
+                         *              at the focus position of the laser
+                         *
+                         * AXIS_1 is next axis after the propagation axis in order (x, y, z) with a periodic
+                         * wrap. LINEAR_AXIS_1 is next after LINEAR_AXIS_2. E.g. for y propagation axis, AXIS_1 = z,
+                         * AXIS_2 = x
+                         *
+                         *  unit: meter
+                         */
+                        static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
+                        static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
+
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+                         *
+                         *  unit: none */
+                        static constexpr float_64 PULSE_INIT = 20.0;
+
+                        /** laser phase shift (no shift: 0.0)
+                         *
+                         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+                         *
+                         * unit: rad, periodic in 2*pi
+                         */
+                        static constexpr float_X LASER_PHASE = 0.0;
+
+                        /** Available E polarisation types, B polarization will be calculated automatically
+                         *
+                         * AXIS_1 and AXIS_2 are defined same as for W0_AXIS_1_SI, W0_AXIS_2_SI.
+                         */
+                        enum PolarisationType
+                        {
+                            LINEAR_AXIS_1 = 1u,
+                            LINEAR_AXIS_2 = 2u,
+                            CIRCULAR = 4u
+                        };
+                        /** Polarization selection
+                         */
+                        static constexpr PolarisationType Polarisation = LINEAR_AXIS_2;
+                    };
+                } // namespace defaults
+
+                /** Wavepacket with Gaussian spatial and temporal envelope tag
+                 *
+                 * @tparam T_Params class parameter to configure the Wavepacket profile,
+                 *                  see members of wavepacket::defaults::WavepacketParam for
+                 *                  required members
+                 */
+                template<typename T_Params = defaults::WavepacketParam>
+                struct Wavepacket;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
@@ -1,0 +1,218 @@
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Stefan Tietze, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/incidentField/profiles/BaseFunctorE.hpp"
+
+#include <cstdint>
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Unitless wavepacket parameters
+                     *
+                     * Only parameters to be used for calculations inside kernel are float_X.
+                     * For others we can use float_64 basically without any overhead.
+                     *
+                     * @tparam T_Params user (SI) parameters
+                     */
+                    template<typename T_Params>
+                    struct WavepacketUnitless : public T_Params
+                    {
+                        using Params = T_Params;
+
+                        static constexpr float_64 WAVE_LENGTH = Params::WAVE_LENGTH_SI / UNIT_LENGTH; // unit: meter
+                        static constexpr float_64 PULSE_LENGTH
+                            = Params::PULSE_LENGTH_SI / UNIT_TIME; // unit: seconds (1 sigma)
+                        static constexpr float_X LASER_NOFOCUS_CONSTANT
+                            = float_X(Params::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); // unit: seconds
+                        static constexpr float_64 AMPLITUDE = Params::AMPLITUDE_SI / UNIT_EFIELD; // unit: Volt /meter
+                        static constexpr float_X W0_AXIS_1
+                            = float_X(Params::W0_AXIS_1_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X W0_AXIS_2
+                            = float_X(Params::W0_AXIS_2_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_64 INIT_TIME = Params::PULSE_INIT * PULSE_LENGTH
+                            + LASER_NOFOCUS_CONSTANT; // unit: seconds (full initialization length)
+                        static constexpr float_64 endUpramp = -0.5_X * LASER_NOFOCUS_CONSTANT; // unit: seconds
+                        static constexpr float_64 startDownramp = 0.5_X * LASER_NOFOCUS_CONSTANT; // unit: seconds
+                        static constexpr float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+                        static constexpr float_64 w = 2.0 * PI * f;
+                    };
+
+                    /** Wavepacket incident E functor
+                     *
+                     * @tparam T_Params parameters
+                     * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                     * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from
+                     * the max boundary inwards)
+                     */
+                    template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                    struct WavepacketFunctorIncidentE
+                        : public WavepacketUnitless<T_Params>
+                        , public BaseFunctorE<T_axis, T_direction>
+                    {
+                        //! Unitless parameters type
+                        using Unitless = WavepacketUnitless<T_Params>;
+
+                        //! Base functor type
+                        using Base = BaseFunctorE<T_axis, T_direction>;
+
+                        /** Create a functor on the host side for the given time step
+                         *
+                         * @param currentStep current time step index, note that it is fractional
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE WavepacketFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
+                            : Base(unitField)
+                            , elong(getLongitudinal(currentStep))
+                        {
+                            auto const& subGrid = Environment<simDim>::get().SubGrid();
+                            totalDomainCells = precisionCast<float_X>(subGrid.getTotalDomain().size);
+                        }
+
+                        /** Calculate incident field E value for the given position
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         * @return incident field E value in internal units
+                         */
+                        HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+                        {
+                            return elong * getTransversal(totalCellIdx);
+                        }
+
+                    private:
+                        //! Total domain size in cells
+                        floatD_X totalDomainCells;
+
+                        //! Precalulated time-dependent longitudinal value
+                        float3_X const elong;
+
+                        //! Get time-dependent longitudinal vector field
+                        HDINLINE float3_X getLongitudinal(float_X const currentStep) const
+                        {
+                            // a symmetric pulse will be initialized at position z=0 for
+                            // a time of PULSE_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+                            // we shift the complete pulse for the half of this time to start with
+                            // the front of the laser pulse.
+                            auto const mue = 0.5 * Unitless::INIT_TIME;
+                            auto const runTime = static_cast<float_64>(DELTA_T * currentStep) - mue;
+                            auto const tau = Unitless::PULSE_LENGTH * math::sqrt(2.0);
+                            auto envelope = Unitless::AMPLITUDE;
+                            auto correctionFactor = 0.0;
+                            if(runTime > Unitless::startDownramp)
+                            {
+                                // downramp = end
+                                auto const exponent
+                                    = ((runTime - Unitless::startDownramp) / Unitless::PULSE_LENGTH / math::sqrt(2.0));
+                                envelope *= math::exp(-0.5 * exponent * exponent);
+                                correctionFactor = (runTime - Unitless::startDownramp) / (tau * tau * Unitless::w);
+                            }
+                            else if(runTime < Unitless::endUpramp)
+                            {
+                                // upramp = start
+                                auto const exponent
+                                    = ((runTime - Unitless::endUpramp) / Unitless::PULSE_LENGTH / math::sqrt(2.0_X));
+                                envelope *= math::exp(-0.5 * exponent * exponent);
+                                correctionFactor = (runTime - Unitless::endUpramp) / (tau * tau * Unitless::w);
+                            }
+
+                            auto result = float3_X::create(0.0_X);
+                            auto const phase = Unitless::w * runTime + Unitless::LASER_PHASE;
+                            auto const baseValue = math::sin(phase) + correctionFactor * math::cos(phase);
+                            if(Unitless::Polarisation == Unitless::LINEAR_AXIS_2)
+                                result[Base::dir2] = baseValue;
+                            else if(Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
+                            {
+                                result[Base::dir1] = baseValue;
+                            }
+                            else if(Unitless::Polarisation == Unitless::CIRCULAR)
+                            {
+                                result[Base::dir2] = baseValue / math::sqrt(2.0);
+                                result[Base::dir1]
+                                    = (math::cos(phase) + correctionFactor * math::sin(phase)) / math::sqrt(2.0);
+                            }
+                            return result * static_cast<float_X>(envelope);
+                        }
+
+                        //! Get position-dependent transversal scalar multiplier
+                        HDINLINE float_X getTransversal(const floatD_X& totalCellIdx) const
+                        {
+                            floatD_X transversalPosition
+                                = (totalCellIdx - totalDomainCells * 0.5_X) * cellSize.shrink<simDim>();
+                            transversalPosition[Base::dir0] = 0.0_X;
+                            auto w0 = float3_X::create(1.0_X);
+                            w0[Base::dir1] = Unitless::W0_AXIS_1;
+                            w0[Base::dir2] = Unitless::W0_AXIS_2;
+                            float_X const r2 = pmacc::math::abs2(transversalPosition / w0.shrink<simDim>());
+                            return math::exp(-r2);
+                        }
+                    };
+                } // namespace detail
+            } // namespace profiles
+
+            namespace detail
+            {
+                /** Get type of incident field E functor for the wavepacket profile type
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::Wavepacket<T_Params>, T_axis, T_direction>
+                {
+                    using type = profiles::detail::WavepacketFunctorIncidentE<T_Params, T_axis, T_direction>;
+                };
+
+                /** Get type of incident field B functor for the wavepacket profile type
+                 *
+                 * Rely on SVEA to calculate value of B from E.
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::Wavepacket<T_Params>, T_axis, T_direction>
+                {
+                    using type = detail::ApproximateIncidentB<
+                        typename GetFunctorIncidentE<profiles::Wavepacket<T_Params>, T_axis, T_direction>::type,
+                        T_axis,
+                        T_direction>;
+                };
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -23,3 +23,4 @@
 #include "picongpu/fields/incidentField/profiles/None.def"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
 #include "picongpu/fields/incidentField/profiles/Polynom.def"
+#include "picongpu/fields/incidentField/profiles/Wavepacket.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -23,3 +23,4 @@
 #include "picongpu/fields/incidentField/profiles/None.hpp"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.hpp"
 #include "picongpu/fields/incidentField/profiles/Polynom.hpp"
+#include "picongpu/fields/incidentField/profiles/Wavepacket.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -22,10 +22,11 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None        : no incident field
- *  - profiles::Free<>      : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::PlaneWave<> : plane wave profile with given parameters
- *  - profiles::Polynom<>   : wavepacket with a polynomial temporal intensity shape profile with given parameters
+ *  - profiles::None         : no incident field
+ *  - profiles::Free<>       : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::PlaneWave<>  : plane wave profile with given parameters
+ *  - profiles::Polynom<>    : wavepacket with a polynomial temporal intensity shape profile with given parameters
+ *  - profiles::Wavepacket<> : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -22,10 +22,11 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None        : no incident field
- *  - profiles::Free<>      : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::PlaneWave<> : plane wave profile with given parameters
- *  - profiles::Polynom<>   : wavepacket with a polynomial temporal intensity shape profile with given parameters
+ *  - profiles::None         : no incident field
+ *  - profiles::Free<>       : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::PlaneWave<>  : plane wave profile with given parameters
+ *  - profiles::Polynom<>    : wavepacket with a polynomial temporal intensity shape profile with given parameters
+ *  - profiles::Wavepacket<> : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array


### PR DESCRIPTION
- [x] Based on #4068

Its parameters mirror ones of the `Wavepacket` laser profile when possible.

Similar to other ported incident feld profiles, I made a comparison on a test problem that generates at `y_cell = 32`. For this test only, I hard-coded a shift equivalent to laser `initPlaneY` into the profile (it's not included in the PR). Attaching the problem files and some plots.

[wavepacket_test_problem.zip](https://github.com/ComputationalRadiationPhysics/picongpu/files/8521576/wavepacket_test_problem.zip)
![laser_vs_incident_300](https://user-images.githubusercontent.com/6825656/164233931-45d01cbc-9aec-45cf-8a43-ab7fc2633477.png)
![laser_vs_incident_500](https://user-images.githubusercontent.com/6825656/164233942-ae6643fe-25a2-43bd-b30f-89a81d7c7e03.png)
![laser_vs_incident_700](https://user-images.githubusercontent.com/6825656/164233951-7bd4428d-d2cd-4c22-a22f-01981a9d308a.png)


