### PR TITLE
Add ExpRampWithPrepulse incident field profile

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -1,0 +1,183 @@
+/* Copyright 2018-2022 Ilja Goethel, Axel Huebl Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace defaults
+                {
+                    struct ExpRampWithPrepulseParam
+                    {
+                        /** Intensities of prepulse and exponential preramp
+                         *
+                         * @{
+                         */
+                        static constexpr float_X INT_RATIO_PREPULSE = 0.;
+                        static constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+                        static constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+                        static constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+                        /** @} */
+
+                        /** Time-positions of prepulse and preramps points
+                         *
+                         * @{
+                         */
+                        static constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+                        static constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+                        static constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+                        static constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+                        static constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+                        /** @} */
+
+                        /** unit: meter */
+                        static constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+                        /** UNITCONV */
+                        static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+                            * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI
+                            * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+                        /** unit: W / m^2 */
+                        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+                        /** unit: none */
+                        static constexpr float_64 _A0 = 20.;
+
+                        /** unit: Volt /meter */
+                        static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+                        /** unit: Volt /meter */
+                        // constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+                        /** Stretch temporal profile by a constant plateau between the up and downramp
+                         *  unit: seconds */
+                        static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI
+                            = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
+
+                        /** Pulse length: sigma of std. gauss for intensity (E^2)
+                         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                         *                                          [    2.354820045     ]
+                         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                         *                      = what a experimentalist calls "pulse duration"
+                         *
+                         *  unit: seconds (1 sigma)
+                         */
+                        static constexpr float_64 PULSE_LENGTH_SI = 3.0e-14
+                            / 2.35482; // half of the time in which E falls to half its initial value (then I falls to
+                                       // half its value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
+
+                        /** beam waist: distance from the axis where the pulse intensity (E^2)
+                         *              decreases to its 1/e^2-th part
+                         *
+                         * AXIS_1 is next axis after the propagation axis in order (x, y, z) with a periodic
+                         * wrap. LINEAR_AXIS_1 is next after LINEAR_AXIS_2. E.g. for y propagation axis, AXIS_1 = z,
+                         * AXIS_2 = x
+                         *
+                         * If both values are equal, the laser has a circular shape in AXIS_1 - AXIS_2
+                         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+                         *                             [   1.17741    ]
+                         *
+                         *  unit: meter
+                         */
+                        static constexpr float_64 W0_AXIS_1_SI = 2.5 * WAVE_LENGTH_SI;
+                        static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
+
+                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before
+                         * plateau and half at the end of the plateau
+                         *
+                         * unit: none
+                         */
+                        static constexpr float_64 RAMP_INIT = 16.0;
+
+                        /** laser phase shift (no shift: 0.0)
+                         *
+                         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+                         *
+                         * unit: rad, periodic in 2*pi
+                         */
+                        static constexpr float_X LASER_PHASE = 0.0;
+
+                        /** Available E polarisation types, B polarization will be calculated automatically
+                         *
+                         * AXIS_1 and AXIS_2 are defined same as for W0_AXIS_1_SI, W0_AXIS_2_SI.
+                         */
+                        enum PolarisationType
+                        {
+                            LINEAR_AXIS_1 = 1u,
+                            LINEAR_AXIS_2 = 2u,
+                            CIRCULAR = 4u
+                        };
+                        /** Polarization selection
+                         */
+                        static constexpr PolarisationType Polarisation = LINEAR_AXIS_2;
+                    };
+                } // namespace defaults
+
+                /** Wavepacket with spatial Gaussian envelope and adjustable temporal shape.
+                 *
+                 * Allows defining a prepulse and two regions of exponential preramp with
+                 * independent slopes. The definition works by specifying three (t, intensity)-
+                 * points, where time is counted from the very beginning in SI and the
+                 * intensity (yes, intensity, not amplitude) is given in multiples of the main
+                 * peak.
+                 *
+                 * Be careful - problematic for few cycle pulses. Thought the rest is cloned
+                 * from laserWavepacket, the correctionFactor is not included (this made a
+                 * correction to the laser phase, which is necessary for very short pulses,
+                 * since otherwise a test particle is, after the laser pulse has passed, not
+                 * returned to immobility, as it should). Since the analytical solution is
+                 * only implemented for the Gaussian regime, and we have mostly exponential
+                 * regimes here, it was not retained here.
+                 *
+                 * A Gaussian peak (optionally lengthened by a plateau) is preceded by
+                 * two pieces of exponential preramps, defined by 3 (time, intensity)-
+                 * -points.
+                 *
+                 * The first two points get connected by an exponential, the 2nd and
+                 * 3rd point are connected by another exponential, which is then
+                 * extrapolated to the peak. The Gaussian is added everywhere, but
+                 * typically contributes significantly only near the peak.
+                 * It is advisable to set the third point far enough from the plateau
+                 * (approx 3*FWHM), then the contribution from the Gaussian is
+                 * negligible there, and the intensity can be set as measured from the
+                 * laser profile.
+                 *
+                 * Optionally a Gaussian prepulse can be added, given by the parameters
+                 * of the relative intensity and time point.
+                 * The time of the prepulse and the three preramp points are given in
+                 * SI, the intensities are given as multiples of the peak intensity.
+                 *
+                 * @tparam T_Params class parameter to configure the beam profile,
+                 *                  see members of defaults::ExpRampWithPrepulseParam
+                 *                  for required members
+                 */
+                template<typename T_Params = defaults::ExpRampWithPrepulseParam>
+                struct ExpRampWithPrepulse;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -1,0 +1,345 @@
+/* Copyright 2018-2022 Ilja Goethel, Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/incidentField/profiles/BaseFunctorE.hpp"
+
+#include <cstdint>
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Unitless exponential ramp with prepulse parameters
+                     *
+                     * @tparam T_Params user (SI) parameters
+                     */
+                    template<typename T_Params>
+                    struct ExpRampWithPrepulseUnitless : public T_Params
+                    {
+                        using Params = T_Params;
+
+                        static constexpr float_X WAVE_LENGTH
+                            = static_cast<float_X>(Params::WAVE_LENGTH_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X PULSE_LENGTH
+                            = static_cast<float_X>(Params::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (1 sigma)
+                        static constexpr float_X LASER_NOFOCUS_CONSTANT
+                            = static_cast<float_X>(Params::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME); // unit: seconds
+                        static constexpr float_X AMPLITUDE
+                            = static_cast<float_X>(Params::AMPLITUDE_SI / UNIT_EFIELD); // unit: Volt /meter
+                        static constexpr float_X W0_AXIS_1
+                            = static_cast<float_X>(Params::W0_AXIS_1_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X W0_AXIS_2
+                            = static_cast<float_X>(Params::W0_AXIS_2_SI / UNIT_LENGTH); // unit: meter
+
+                        static constexpr float_64 TIME_PREPULSE
+                            = static_cast<float_64>(Params::TIME_PREPULSE_SI / UNIT_TIME);
+                        static constexpr float_64 TIME_PEAKPULSE
+                            = static_cast<float_64>(Params::TIME_PEAKPULSE_SI / UNIT_TIME);
+                        static constexpr float_64 TIME_1 = static_cast<float_64>(Params::TIME_POINT_1_SI / UNIT_TIME);
+                        static constexpr float_64 TIME_2 = static_cast<float_64>(Params::TIME_POINT_2_SI / UNIT_TIME);
+                        static constexpr float_64 TIME_3 = static_cast<float_64>(Params::TIME_POINT_3_SI / UNIT_TIME);
+                        static constexpr float_X endUpramp = TIME_PEAKPULSE - 0.5_X * LASER_NOFOCUS_CONSTANT;
+                        static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
+
+                        static constexpr float_X INIT_TIME
+                            = static_cast<float_X>((TIME_PEAKPULSE + Params::RAMP_INIT * PULSE_LENGTH) / UNIT_TIME);
+
+                        // compile-time checks for physical sanity:
+                        static_assert(
+                            (TIME_1 < TIME_2) && (TIME_2 < TIME_3) && (TIME_3 < endUpramp),
+                            "The times in the parameters TIME_POINT_1/2/3 and the beginning of the plateau (which is "
+                            "at "
+                            "TIME_PEAKPULSE - 0.5*RAMP_INIT*PULSE_LENGTH) should be in ascending order");
+
+                        // some prerequisites for check of intensities (approximate check, because I can't use exp and
+                        // log)
+                        static constexpr float_X ratio_dt
+                            = (endUpramp - TIME_3) / (TIME_3 - TIME_2); // ratio of time intervals
+                        static constexpr float_X ri1
+                            = Params::INT_RATIO_POINT_3 / Params::INT_RATIO_POINT_2; // first intensity ratio
+                        static constexpr float_X ri2
+                            = 0.2_X / Params::INT_RATIO_POINT_3; // second intensity ratio (0.2 is an arbitrary upper
+                                                                 // border for the intensity of the exp ramp)
+
+                        /* Approximate check, if ri1 ^ ratio_dt > ri2. That would mean, that the exponential curve
+                         * through (time2, int2) and (time3, int3) lies above (endUpramp, 0.2) the power function is
+                         * emulated by "rounding" the exponent to a rational number and expanding both sides by the
+                         * common denominator, to get integer powers, see below for this, the range for ratio_dt is
+                         * split into parts; the checked condition is "rounded down", i.e. it's weaker in every point
+                         * of those ranges except one.
+                         */
+                        static constexpr bool intensity_too_big = (ratio_dt >= 3._X && ri1 * ri1 * ri1 > ri2)
+                            || (ratio_dt >= 2._X && ri1 * ri1 > ri2)
+                            || (ratio_dt >= 1.5_X && ri1 * ri1 * ri1 > ri2 * ri2) || (ratio_dt >= 1._X && ri1 > ri2)
+                            || (ratio_dt >= 0.8_X && ri1 * ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.75_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.67_X && ri1 * ri1 > ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.6_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.5_X && ri1 > ri2 * ri2)
+                            || (ratio_dt >= 0.4_X && ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.33_X && ri1 > ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.25_X && ri1 > ri2 * ri2 * ri2 * ri2)
+                            || (ratio_dt >= 0.2_X && ri1 > ri2 * ri2 * ri2 * ri2 * ri2);
+                        static_assert(
+                            !intensity_too_big,
+                            "The intensities of the ramp are very large - the extrapolation to the time of the main "
+                            "pulse "
+                            "would give more than half of the pulse amplitude. This is not a Gaussian pulse at all "
+                            "anymore - probably some of the parameters are different from what you think!?");
+
+                        /* a symmetric pulse will be initialized at position z=0 for
+                         * a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+                         * we shift the complete pulse for the half of this time to start with
+                         * the front of the laser pulse.
+                         */
+                        static constexpr float_X time_start_init
+                            = static_cast<float_X>(TIME_1 - (0.5 * Params::RAMP_INIT * PULSE_LENGTH));
+                        static constexpr float_64 f = SPEED_OF_LIGHT / WAVE_LENGTH;
+                        static constexpr float_64 w = 2.0 * PI * f;
+                    };
+
+                    /** Exponential ramp with prepulse incident E functor
+                     *
+                     * @tparam T_Params parameters
+                     * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                     * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from
+                     * the max boundary inwards)
+                     */
+                    template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                    struct ExpRampWithPrepulseFunctorIncidentE
+                        : public ExpRampWithPrepulseUnitless<T_Params>
+                        , public BaseFunctorE<T_axis, T_direction>
+                    {
+                        //! Unitless parameters type
+                        using Unitless = ExpRampWithPrepulseUnitless<T_Params>;
+
+                        //! Base functor type
+                        using Base = BaseFunctorE<T_axis, T_direction>;
+
+                        /** Create a functor on the host side for the given time step
+                         *
+                         * @param currentStep current time step index, note that it is fractional
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE ExpRampWithPrepulseFunctorIncidentE(
+                            float_X const currentStep,
+                            float3_64 const unitField)
+                            : Base(unitField)
+                            , elong(getLongitudinal(currentStep))
+                        {
+                            auto const& subGrid = Environment<simDim>::get().SubGrid();
+                            totalDomainCells = precisionCast<float_X>(subGrid.getTotalDomain().size);
+                        }
+
+                        /** Calculate incident field E value for the given position
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         * @return incident field E value in internal units
+                         */
+                        HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+                        {
+                            return elong * getTransversal(totalCellIdx);
+                        }
+
+                    private:
+                        //! Total domain size in cells
+                        floatD_X totalDomainCells;
+
+                        //! Precalulated time-dependent longitudinal value
+                        float3_X const elong;
+
+                        //! Get time-dependent longitudinal vector factor
+                        HINLINE float3_X getLongitudinal(float_X const currentStep) const
+                        {
+                            /* initialize the laser not in the first cell is equal to a negative shift
+                             * in time
+                             */
+                            float_64 const runTime = Unitless::time_start_init + DELTA_T * currentStep;
+                            float_64 const phase = Unitless::w * runTime + Unitless::LASER_PHASE;
+                            auto result = float3_64::create(0.0);
+                            if(Unitless::Polarisation == Unitless::LINEAR_AXIS_2)
+                            {
+                                result[Base::dir2] = math::sin(phase);
+                            }
+                            else if(Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
+                            {
+                                result[Base::dir1] = math::sin(phase);
+                            }
+                            else if(Unitless::Polarisation == Unitless::CIRCULAR)
+                            {
+                                result[Base::dir2] = math::sin(phase) / math::sqrt(2.0_X);
+                                result[Base::dir1] = math::cos(phase) / math::sqrt(2.0_X);
+                            }
+                            return precisionCast<float_X>(result * getEnvelope(runTime));
+                        }
+
+                        HINLINE float_64 getEnvelope(float_64 const runTime) const
+                        {
+                            /* workaround for clang 5 linker issues
+                             * `undefined reference to
+                             * `picongpu::fields::laserProfiles::ExpRampWithPrepulseParam::INT_RATIO_POINT_1'`
+                             */
+                            constexpr auto int_ratio_prepule = Unitless::INT_RATIO_PREPULSE;
+                            constexpr auto int_ratio_point_1 = Unitless::INT_RATIO_POINT_1;
+                            constexpr auto int_ratio_point_2 = Unitless::INT_RATIO_POINT_2;
+                            constexpr auto int_ratio_point_3 = Unitless::INT_RATIO_POINT_3;
+                            auto const AMP_PREPULSE = math::sqrt(int_ratio_prepule) * Unitless::AMPLITUDE;
+                            auto const AMP_1 = math::sqrt(int_ratio_point_1) * Unitless::AMPLITUDE;
+                            auto const AMP_2 = math::sqrt(int_ratio_point_2) * Unitless::AMPLITUDE;
+                            auto const AMP_3 = math::sqrt(int_ratio_point_3) * Unitless::AMPLITUDE;
+
+                            auto env = 0.0;
+                            bool const before_preupramp = runTime < Unitless::time_start_init;
+                            bool const before_start = runTime < Unitless::TIME_1;
+                            bool const before_peakpulse = runTime < Unitless::endUpramp;
+                            bool const during_first_exp = (Unitless::TIME_1 < runTime) && (runTime < Unitless::TIME_2);
+                            bool const after_peakpulse = Unitless::startDownramp <= runTime;
+
+                            if(before_preupramp)
+                                env = 0.;
+                            else if(before_start)
+                            {
+                                env = AMP_1 * gauss(runTime - Unitless::TIME_1);
+                            }
+                            else if(before_peakpulse)
+                            {
+                                float_X const ramp_when_peakpulse = extrapolateExpo(
+                                                                        Unitless::TIME_2,
+                                                                        AMP_2,
+                                                                        Unitless::TIME_3,
+                                                                        AMP_3,
+                                                                        Unitless::endUpramp)
+                                    / Unitless::AMPLITUDE;
+
+                                if(ramp_when_peakpulse > 0.5)
+                                {
+                                    log<picLog::PHYSICS>(
+                                        "Attention, the intensities of the laser upramp are very large! "
+                                        "The extrapolation of the last exponential to the time of "
+                                        "the peakpulse gives more than half of the amplitude of "
+                                        "the peak Gaussian. This is not a Gaussian at all anymore, "
+                                        "and physically very unplausible, check the params for misunderstandings!");
+                                }
+
+                                env += Unitless::AMPLITUDE * (1._X - ramp_when_peakpulse)
+                                    * gauss(runTime - Unitless::endUpramp);
+                                env += AMP_PREPULSE * gauss(runTime - Unitless::TIME_PREPULSE);
+                                if(during_first_exp)
+                                    env += extrapolateExpo(Unitless::TIME_1, AMP_1, Unitless::TIME_2, AMP_2, runTime);
+                                else
+                                    env += extrapolateExpo(Unitless::TIME_2, AMP_2, Unitless::TIME_3, AMP_3, runTime);
+                            }
+                            else if(!after_peakpulse)
+                                env = Unitless::AMPLITUDE;
+                            else // after startDownramp
+                                env = Unitless::AMPLITUDE * gauss(runTime - Unitless::startDownramp);
+                            return env;
+                        }
+
+                        /** takes time t relative to the center of the Gaussian and returns value
+                         * between 0 and 1, i.e. as multiple of the max value.
+                         * use as: amp_t = amp_0 * gauss( t - t_0 )
+                         */
+                        HINLINE float_64 gauss(float_64 const t) const
+                        {
+                            auto const exponent = t / Unitless::PULSE_LENGTH;
+                            return math::exp(-0.25 * exponent * exponent);
+                        }
+
+                        /** get value of exponential curve through two points at given t
+                         * t/t1/t2 given as float_X, since the envelope doesn't need the accuracy
+                         */
+                        HINLINE float_64 extrapolateExpo(
+                            float_64 const t1,
+                            float_64 const a1,
+                            float_64 const t2,
+                            float_64 const a2,
+                            float_64 const t) const
+                        {
+                            auto const log1 = (t2 - t) * math::log(a1);
+                            auto const log2 = (t - t1) * math::log(a2);
+                            return math::exp((log1 + log2) / (t2 - t1));
+                        }
+
+                        //! Get position-dependent transversal scalar factor
+                        HDINLINE float_X getTransversal(const floatD_X& totalCellIdx) const
+                        {
+                            floatD_X transversalPosition
+                                = (totalCellIdx - totalDomainCells * 0.5_X) * cellSize.shrink<simDim>();
+                            transversalPosition[Base::dir0] = 0.0_X;
+                            auto w0 = float3_X::create(1.0_X);
+                            w0[Base::dir1] = Unitless::W0_AXIS_1;
+                            w0[Base::dir2] = Unitless::W0_AXIS_2;
+                            float_X const r2 = pmacc::math::abs2(transversalPosition / w0.shrink<simDim>());
+                            return math::exp(-r2);
+                        }
+                    };
+                } // namespace detail
+            } // namespace profiles
+
+            namespace detail
+            {
+                /** Get type of incident field E functor for the exponential ramp with prepulse profile type
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::ExpRampWithPrepulse<T_Params>, T_axis, T_direction>
+                {
+                    using type = profiles::detail::ExpRampWithPrepulseFunctorIncidentE<T_Params, T_axis, T_direction>;
+                };
+
+                /** Get type of incident field B functor for the exponential ramp with prepulse  profile type
+                 *
+                 * Rely on SVEA to calculate value of B from E.
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::ExpRampWithPrepulse<T_Params>, T_axis, T_direction>
+                {
+                    using type = detail::ApproximateIncidentB<
+                        typename GetFunctorIncidentE<profiles::ExpRampWithPrepulse<T_Params>, T_axis, T_direction>::
+                            type,
+                        T_axis,
+                        T_direction>;
+                };
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.def
@@ -1,0 +1,138 @@
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace defaults
+                {
+                    namespace gaussianBeam
+                    {
+                        //! Use only the 0th Laguerremode for a standard Gaussian
+                        static constexpr uint32_t MODENUMBER = 0;
+                        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+                        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
+                        // This is just an example for a more complicated set of Laguerre modes
+                        // constexpr uint32_t MODENUMBER = 12;
+                        // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461,
+                        // -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038,
+                        // -0.00896321, -0.0160788); PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES,
+                        // 0.0, 1.0344594, -0.9384701, -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303,
+                        // -0.8039839, 3.0055385, -0.1503778, -9.6980362, -2.8122287);
+                    } // namespace gaussianBeam
+
+                    struct GaussianBeamParam
+                    {
+                        /** unit: meter */
+                        static constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+
+                        /** Convert the normalized laser strength parameter a0 to Volt per meter */
+                        static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI
+                            * ::picongpu::SI::ELECTRON_MASS_SI * ::picongpu::SI::SPEED_OF_LIGHT_SI
+                            * ::picongpu::SI::SPEED_OF_LIGHT_SI / ::picongpu::SI::ELECTRON_CHARGE_SI;
+
+                        /** unit: W / m^2 */
+                        // calculate: _A0 = 8.549297e-6 * sqrt( Intensity[W/m^2] ) * wavelength[m] (linearly polarized)
+
+                        /** unit: none */
+                        // static constexpr float_64 _A0  = 1.5;
+
+                        /** unit: Volt / meter */
+                        // static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+
+                        /** unit: Volt / meter */
+                        static constexpr float_64 AMPLITUDE_SI = 1.738e13;
+
+                        /** Pulse length: sigma of std. gauss for intensity (E^2)
+                         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                         *                                          [    2.354820045     ]
+                         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                         *                      = what a experimentalist calls "pulse duration"
+                         *
+                         *  unit: seconds (1 sigma) */
+                        static constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+
+                        /** beam waist: distance from the axis where the pulse intensity (E^2)
+                         *              decreases to its 1/e^2-th part,
+                         *              at the focus position of the laser
+                         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+                         *                             [   1.17741    ]
+                         *
+                         *  unit: meter */
+                        static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
+                        /** the distance to the laser focus in propagation direction
+                         *  unit: meter */
+                        static constexpr float_64 FOCUS_POS_SI = 4.62e-5;
+
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+                         *
+                         *  unit: none */
+                        static constexpr float_64 PULSE_INIT = 20.0;
+
+                        /** laser phase shift (no shift: 0.0)
+                         *
+                         * sin(omega*time + laser_phase): starts with phase=0 at center --> E-field=0 at center
+                         *
+                         * unit: rad, periodic in 2*pi
+                         */
+                        static constexpr float_X LASER_PHASE = 0.0;
+
+                        using LAGUERREMODES_t = gaussianBeam::LAGUERREMODES_t;
+                        using LAGUERREPHASES_t = gaussianBeam::LAGUERREPHASES_t;
+                        static constexpr uint32_t MODENUMBER = gaussianBeam::MODENUMBER;
+
+                        /** Available E polarisation types, B polarization will be calculated automatically
+                         *
+                         * LINEAR_AXIS_1 is next axis after the propagation axis in order (x, y, z) with a periodic
+                         * wrap. LINEAR_AXIS_1 is next after LINEAR_AXIS_2. E.g. for y propagation axis, LINEAR_AXIS_1
+                         * = linear z polalization, LINEAR_AXIS_2 = linear x
+                         */
+                        enum PolarisationType
+                        {
+                            LINEAR_AXIS_1 = 1u,
+                            LINEAR_AXIS_2 = 2u,
+                            CIRCULAR = 4u,
+                        };
+                        /** Polarization selection
+                         */
+                        static constexpr PolarisationType Polarisation = CIRCULAR;
+                    };
+                } // namespace defaults
+
+                /** Gaussian Beam laser profile with finite pulse length tag
+                 *
+                 * @tparam T_Params class parameter to configure the Gaussian Beam profile,
+                 *                  see members of defaults::GaussianBeamParam
+                 *                  for required members
+                 */
+                template<typename T_Params = defaults::GaussianBeamParam>
+                struct GaussianBeam;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
@@ -1,0 +1,335 @@
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/incidentField/Functors.hpp"
+#include "picongpu/fields/incidentField/Traits.hpp"
+#include "picongpu/fields/incidentField/profiles/BaseFunctorE.hpp"
+
+#include <cstdint>
+#include <limits>
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Unitless gaussian beam parameters
+                     *
+                     * @tparam T_Params user (SI) parameters
+                     */
+                    template<typename T_Params>
+                    struct GaussianBeamUnitless : public T_Params
+                    {
+                        using Params = T_Params;
+
+                        static constexpr float_X WAVE_LENGTH
+                            = static_cast<float_X>(Params::WAVE_LENGTH_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X PULSE_LENGTH
+                            = static_cast<float_X>(Params::PULSE_LENGTH_SI / UNIT_TIME); // unit: seconds (1 sigma)
+                        static constexpr float_X AMPLITUDE
+                            = static_cast<float_X>(Params::AMPLITUDE_SI / UNIT_EFIELD); // unit: Volt /meter
+                        static constexpr float_X W0 = float_X(Params::W0_SI / UNIT_LENGTH); // unit: meter
+                        // rayleigh length in propagation direction
+                        static constexpr float_X R = static_cast<float_X>(PI) * W0 * W0 / WAVE_LENGTH;
+                        static constexpr float_X FOCUS_POS
+                            = static_cast<float_X>(Params::FOCUS_POS_SI / UNIT_LENGTH); // unit: meter
+                        static constexpr float_X INIT_TIME = static_cast<float_X>(
+                            (Params::PULSE_INIT * Params::PULSE_LENGTH_SI)
+                            / UNIT_TIME); // unit: seconds (full initialization length)
+
+                        static constexpr float_X f = static_cast<float_X>(SPEED_OF_LIGHT / WAVE_LENGTH);
+                    };
+
+                    /** Gaussian beam incident E functor
+                     *
+                     * @tparam T_Params parameters
+                     * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                     * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from
+                     * the max boundary inwards)
+                     */
+                    template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                    struct GaussianBeamFunctorIncidentE
+                        : public GaussianBeamUnitless<T_Params>
+                        , public BaseFunctorE<T_axis, T_direction>
+                    {
+                        //! Unitless parameters type
+                        using Unitless = GaussianBeamUnitless<T_Params>;
+
+                        //! Base functor type
+                        using Base = BaseFunctorE<T_axis, T_direction>;
+
+                        /** Create a functor on the host side for the given time step
+                         *
+                         * @param currentStep current time step index, note that it is fractional
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE GaussianBeamFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
+                            : Base(unitField)
+                            , runTime(DELTA_T * currentStep)
+                        {
+                            auto const& subGrid = Environment<simDim>::get().SubGrid();
+                            totalDomainCells = precisionCast<float_X>(subGrid.getTotalDomain().size);
+
+                            // This check is done here on HOST, since std::numeric_limits<float_X>::epsilon() does not
+                            // compile on laserTransversal(), which is on DEVICE.
+                            auto etrans_norm = 0.0_X;
+                            PMACC_CASSERT_MSG(
+                                MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector,
+                                Unitless::MODENUMBER < Unitless::LAGUERREMODES_t::dim);
+                            for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
+                                etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
+                            PMACC_VERIFY_MSG(
+                                math::abs(etrans_norm) > std::numeric_limits<float_X>::epsilon(),
+                                "Sum of LAGUERREMODES can not be 0.");
+                        }
+
+                        /** Calculate incident field E value for the given position
+                         *
+                         * The transverse spatial laser modes are given as a decomposition of Gauss-Laguerre modes
+                         * GLM(m,r,z) : Sum_{m=0}^{m_max} := Snorm * a_m * GLM(m,r,z)
+                         * with a_m being complex-valued coefficients: a_m := |a_m| * exp(I Arg(a_m) )
+                         * |a_m| are equivalent to the LAGUERREMODES vector entries.
+                         * Arg(a_m) are equivalent to the LAGUERREPHASES vector entries.
+                         * The implicit beam properties w0, lambda0, etc... equally apply to all GLM-modes.
+                         * The on-axis, in-focus field value of the mode decomposition is normalized to unity:
+                         * Snorm := 1 / ( Sum_{m=0}^{m_max}GLM(m,0,0) )
+                         *
+                         * Spatial mode: Arg(a_m) * GLM(m,r,z) := w0/w(zeta) * L_m( 2*r^2/(w(zeta))^2 ) \
+                         *     * exp( I*k*z - I*(2*m+1)*ArcTan(zeta) - r^2 / ( w0^2*(1+I*zeta) ) + I*Arg(a_m) ) )
+                         * with w(zeta) = w0*sqrt(1+zeta^2)
+                         * with zeta = z / zR
+                         * with zR = PI * w0^2 / lambda0
+                         *
+                         * Uses only radial modes (m) of Laguerre-Polynomials: L_m(x)=L_m^n=0(x)
+                         * z is the direction of laser propagation. In PIConGPU, the direction of propagation is y.
+                         *
+                         * References:
+                         * F. Pampaloni et al. (2004), Gaussian, Hermite-Gaussian, and Laguerre-Gaussian beams: A
+                         * primer https://arxiv.org/pdf/physics/0410021
+                         *
+                         * Allen, L. (June 1, 1992). "Orbital angular momentum of light
+                         *      and the transformation of Laguerre-Gaussian laser modes"
+                         * https://doi.org/10.1103/physreva.45.8185
+                         *
+                         * Wikipedia on Gaussian laser beams
+                         * https://en.wikipedia.org/wiki/Gaussian_beam
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         * @return incident field E value in internal units
+                         */
+                        HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+                        {
+                            // transform coordinate system to center of x-z plane of initialization
+                            floatD_X pos = (totalCellIdx - totalDomainCells * 0.5_X) * cellSize.shrink<simDim>();
+                            if(T_direction > 0)
+                                pos[Base::dir0] = totalCellIdx[Base::dir0] * cellSize[Base::dir0];
+                            else
+                                pos[Base::dir0]
+                                    = (totalDomainCells[Base::dir0] - totalCellIdx[Base::dir0]) * cellSize[Base::dir0];
+                            floatD_X planeNoNormal = floatD_X::create(1.0_X);
+                            planeNoNormal[Base::dir0] = 0.0_X;
+                            float_X const transversalDistanceSquared = pmacc::math::abs2(pos * planeNoNormal);
+
+                            // calculate focus position relative to the current point in the propagation direction
+                            float_X const focusPos = Unitless::FOCUS_POS - pos[Base::dir0];
+                            // beam waist at the generation plane so that at focus we will get W0
+                            float_X const w = Unitless::W0
+                                * math::sqrt(1.0_X + (focusPos / Unitless::R) * (focusPos / Unitless::R));
+
+                            auto result = getEnvelope(w);
+                            // a symmetric pulse will be initialized at position z=0 for
+                            // a time of PULSE_INIT * PULSE_LENGTH = INIT_TIME.
+                            // we shift the complete pulse for the half of this time to start with
+                            // the front of the laser pulse.
+                            constexpr auto mue = 0.5_X * Unitless::INIT_TIME;
+                            auto const phase = 2.0_X * static_cast<float_X>(PI) * Unitless::f
+                                    * (runTime - mue - focusPos / SPEED_OF_LIGHT)
+                                + Unitless::LASER_PHASE;
+                            if(Unitless::Polarisation == Unitless::LINEAR_AXIS_2
+                               || Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
+                            {
+                                result *= getValue(phase, focusPos, w, transversalDistanceSquared);
+                            }
+                            else if(Unitless::Polarisation == Unitless::CIRCULAR)
+                            {
+                                result[Base::dir2] *= getValue(phase, focusPos, w, transversalDistanceSquared);
+                                result[Base::dir1]
+                                    *= getValue(phase + float_X(PI / 2.0), focusPos, w, transversalDistanceSquared);
+                            }
+                            return result;
+                        }
+
+                    private:
+                        //! Total domain size in cells
+                        floatD_X totalDomainCells;
+
+                        //! Current time
+                        float_X const runTime;
+
+                        /** Get vector field with waist-dependent envelope in components according to the polarization
+                         *
+                         * This function merely applies envelope and polarization, most calculations to produce a_m
+                         * Gaussian pulse happen elsewhere.
+                         *
+                         * @param w unitless beam waist
+                         */
+                        HDINLINE float3_X getEnvelope(float_X const w) const
+                        {
+                            auto envelope = Unitless::AMPLITUDE;
+                            if(simDim == DIM2)
+                                envelope *= math::sqrt(Unitless::W0 / w);
+                            else if(simDim == DIM3)
+                                envelope *= Unitless::W0 / w;
+
+                            auto result = float3_X::create(0.0_X);
+                            if(Unitless::Polarisation == Unitless::LINEAR_AXIS_2)
+                            {
+                                result[Base::dir2] = envelope;
+                            }
+                            else if(Unitless::Polarisation == Unitless::LINEAR_AXIS_1)
+                            {
+                                result[Base::dir1] = envelope;
+                            }
+                            else if(Unitless::Polarisation == Unitless::CIRCULAR)
+                            {
+                                result[Base::dir1] = envelope / math::sqrt(2.0_X);
+                                result[Base::dir2] = envelope / math::sqrt(2.0_X);
+                            }
+                            return result;
+                        }
+
+                        /** Get scalar multiplier to the envelope
+                         *
+                         * Does most calculations to produce a Gaussian pulse.
+                         *
+                         * @param phase phase value
+                         * @param focusPos distance to focus position in the propagation direction
+                         * @param w unitless beam waist
+                         * @param transversalDistanceSquared squared distance from beam center in the transversal plane
+                         */
+                        HDINLINE float_X getValue(
+                            float_X const phase,
+                            float_X const focusPos,
+                            float_X const w,
+                            float_X const transversalDistanceSquared) const
+                        {
+                            // inverse radius of curvature of the beam's  wavefronts
+                            float_X const R_inv = -focusPos / (Unitless::R * Unitless::R + focusPos * focusPos);
+                            // the Gouy phase shift
+                            float_X const xi = math::atan(-focusPos / Unitless::R);
+                            auto etrans = 0.0_X;
+                            auto const r2OverW2 = transversalDistanceSquared / w / w;
+                            auto const r = 0.5_X * transversalDistanceSquared * R_inv;
+                            for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
+                            {
+                                etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre(m, 2.0_X * r2OverW2)
+                                    * math::exp(-r2OverW2)
+                                    * math::cos(
+                                              2.0_X * float_X(PI) / Unitless::WAVE_LENGTH * focusPos
+                                              - 2.0_X * float_X(PI) / Unitless::WAVE_LENGTH * r
+                                              + (2._X * float_X(m) + 1._X) * xi + phase +
+                                              typename Unitless::LAGUERREPHASES_t{}[m]);
+                            }
+                            auto const exponent = (r - focusPos - phase / 2.0_X / float_X(PI) * Unitless::WAVE_LENGTH)
+                                / (SPEED_OF_LIGHT * 2.0_X * Unitless::PULSE_LENGTH);
+                            etrans *= math::exp(-exponent * exponent);
+                            auto etrans_norm = 0.0_X;
+                            for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
+                                etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
+                            return etrans / etrans_norm;
+                        }
+
+                        /** Simple iteration algorithm to implement Laguerre polynomials for GPUs.
+                         *
+                         *  @param n order of the Laguerre polynomial
+                         *  @param x coordinate at which the polynomial is evaluated
+                         */
+                        HDINLINE float_X simpleLaguerre(uint32_t const n, float_X const x) const
+                        {
+                            // Result for special case n == 0
+                            if(n == 0)
+                                return 1.0_X;
+                            uint32_t currentN = 1;
+                            float_X laguerreNMinus1 = 1.0_X;
+                            float_X laguerreN = 1.0_X - x;
+                            float_X laguerreNPlus1(0.0_X);
+                            while(currentN < n)
+                            {
+                                // Core statement of the algorithm
+                                laguerreNPlus1 = ((2.0_X * float_X(currentN) + 1.0_X - x) * laguerreN
+                                                  - float_X(currentN) * laguerreNMinus1)
+                                    / float_X(currentN + 1u);
+                                // Advance by one order
+                                laguerreNMinus1 = laguerreN;
+                                laguerreN = laguerreNPlus1;
+                                currentN++;
+                            }
+                            return laguerreN;
+                        }
+                    };
+                } // namespace detail
+            } // namespace profiles
+
+            namespace detail
+            {
+                /** Get type of incident field E functor for the gaussian beam profile type
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentE<profiles::GaussianBeam<T_Params>, T_axis, T_direction>
+                {
+                    using type = profiles::detail::GaussianBeamFunctorIncidentE<T_Params, T_axis, T_direction>;
+                };
+
+                /** Get type of incident field B functor for the gaussiam beam profile type
+                 *
+                 * Rely on SVEA to calculate value of B from E.
+                 *
+                 * @tparam T_Params parameters
+                 * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
+                 * @tparam T_direction direction, 1 = positive (from the min boundary inwards), -1 = negative (from the
+                 * max boundary inwards)
+                 */
+                template<typename T_Params, uint32_t T_axis, int32_t T_direction>
+                struct GetFunctorIncidentB<profiles::GaussianBeam<T_Params>, T_axis, T_direction>
+                {
+                    using type = detail::ApproximateIncidentB<
+                        typename GetFunctorIncidentE<profiles::GaussianBeam<T_Params>, T_axis, T_direction>::type,
+                        T_axis,
+                        T_direction>;
+                };
+            } // namespace detail
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/fields/incidentField/profiles/Free.def"
+#include "picongpu/fields/incidentField/profiles/GaussianBeam.def"
 #include "picongpu/fields/incidentField/profiles/None.def"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
 #include "picongpu/fields/incidentField/profiles/Polynom.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def"
 #include "picongpu/fields/incidentField/profiles/Free.def"
 #include "picongpu/fields/incidentField/profiles/GaussianBeam.def"
 #include "picongpu/fields/incidentField/profiles/None.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp"
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
 #include "picongpu/fields/incidentField/profiles/GaussianBeam.hpp"
 #include "picongpu/fields/incidentField/profiles/None.hpp"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
+#include "picongpu/fields/incidentField/profiles/GaussianBeam.hpp"
 #include "picongpu/fields/incidentField/profiles/None.hpp"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.hpp"
 #include "picongpu/fields/incidentField/profiles/Polynom.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -22,12 +22,15 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None           : no incident field
- *  - profiles::Free<>         : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<> : Gaussian beam with given parameters
- *  - profiles::PlaneWave<>    : plane wave profile with given parameters
- *  - profiles::Polynom<>      : wavepacket with a polynomial temporal intensity shape profile with given parameters
- *  - profiles::Wavepacket<>   : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
+ *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
+ *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::None                  : no incident field
+ *  - profiles::PlaneWave<>           : plane wave profile with given parameters
+ *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
+ * parameters
+ *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
+ * parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -22,11 +22,12 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None         : no incident field
- *  - profiles::Free<>       : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::PlaneWave<>  : plane wave profile with given parameters
- *  - profiles::Polynom<>    : wavepacket with a polynomial temporal intensity shape profile with given parameters
- *  - profiles::Wavepacket<> : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
+ *  - profiles::None           : no incident field
+ *  - profiles::Free<>         : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::GaussianBeam<> : Gaussian beam with given parameters
+ *  - profiles::PlaneWave<>    : plane wave profile with given parameters
+ *  - profiles::Polynom<>      : wavepacket with a polynomial temporal intensity shape profile with given parameters
+ *  - profiles::Wavepacket<>   : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
@@ -38,7 +39,7 @@
  * using YMin = profiles::PlaneWave< UserPlaneWaveParams >;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
  * using ZMin = profiles::Polynom< UserPolynomParams >;
- * using ZMax = profiles::None;
+ * using ZMax = profiles::GaussianBeam< UserGaussianBeamParams >;
  *
  * constexpr uint32_t OFFSET[3][2] = { {16, 16}, {16, 16}, {16, 16} };
  * @endcode

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -22,12 +22,15 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None           : no incident field
- *  - profiles::Free<>         : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<> : Gaussian beam with given parameters
- *  - profiles::PlaneWave<>    : plane wave profile with given parameters
- *  - profiles::Polynom<>      : wavepacket with a polynomial temporal intensity shape profile with given parameters
- *  - profiles::Wavepacket<>   : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
+ *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
+ *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::None                  : no incident field
+ *  - profiles::PlaneWave<>           : plane wave profile with given parameters
+ *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
+ * parameters
+ *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
+ * parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -22,11 +22,12 @@
  * Configure incident field profile and gap between Huygence surface and absorber for each boundary.
  *
  * Available profiles:
- *  - profiles::None         : no incident field
- *  - profiles::Free<>       : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::PlaneWave<>  : plane wave profile with given parameters
- *  - profiles::Polynom<>    : wavepacket with a polynomial temporal intensity shape profile with given parameters
- *  - profiles::Wavepacket<> : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
+ *  - profiles::None           : no incident field
+ *  - profiles::Free<>         : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::GaussianBeam<> : Gaussian beam with given parameters
+ *  - profiles::PlaneWave<>    : plane wave profile with given parameters
+ *  - profiles::Polynom<>      : wavepacket with a polynomial temporal intensity shape profile with given parameters
+ *  - profiles::Wavepacket<>   : wavepacket with Gaussian spatial and temporal envelope profile with given parameters
  *
  * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. It also has to define constexpr array
@@ -38,7 +39,7 @@
  * using YMin = profiles::PlaneWave< UserPlaneWaveParams >;
  * using YMax = profiles::Free< AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB >;
  * using ZMin = profiles::Polynom< UserPolynomParams >;
- * using ZMax = profiles::None;
+ * using ZMax = profiles::GaussianBeam< UserGaussianBeamParams >;
  *
  * constexpr uint32_t OFFSET[3][2] = { {16, 16}, {16, 16}, {16, 16} };
  * @endcode


### PR DESCRIPTION
- [x] Based on  #4076

Its parameters mirror ones of the `ExpRampWithPrepulse` laser profile when possible.

As for other profiles, here is a test problem and some comparison to the corresponding laser profile.

[expramp_test_problem.zip](https://github.com/ComputationalRadiationPhysics/picongpu/files/8555345/expramp_test_problem.zip)

![laser_vs_incident_300](https://user-images.githubusercontent.com/6825656/165108851-5750464d-4c75-4c88-847f-f49c43fd7950.png)
![laser_vs_incident_500](https://user-images.githubusercontent.com/6825656/165108865-48be4483-8c6d-4c7f-b0b0-57998a7d865f.png)
![laser_vs_incident_700](https://user-images.githubusercontent.com/6825656/165108872-81fbf0a0-5f28-4067-bc25-00f0ecd87b99.png)
