### PR TITLE
Check uniqueness of particle attributes

### DIFF
--- a/include/pmacc/meta/conversion/Unique.hpp
+++ b/include/pmacc/meta/conversion/Unique.hpp
@@ -1,0 +1,63 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/meta/conversion/ToSeq.hpp"
+
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/insert.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/set.hpp>
+#include <boost/mpl/size.hpp>
+
+
+namespace pmacc
+{
+    /** Make a sequence out of the input sequence with the duplicate elements removed
+     *
+     * The new sequence may have the elements in different order.
+     *
+     * @tparam T_Seq source sequence
+     */
+    template<typename T_Seq>
+    struct Unique
+    {
+        // Insert all sequence elements to a set, that will remove duplicates.
+        // Note that we cannot simply call bmpl::unique as it only removes duplicates located contiguously.
+        using Set = typename bmpl::fold<T_Seq, bmpl::set0<>, bmpl::insert<bmpl::_1, bmpl::_2>>::type;
+
+        // Convert back to sequence if necessary
+        using type = typename ToSeq<Set>::type;
+    };
+
+    //! Helper alias for @see Unique<>
+    template<typename T_Seq>
+    using Unique_t = typename Unique<T_Seq>::type;
+
+    /** Flag whether the given sequence is unique (has no duplicate elements)
+     *
+     * @tparam T_Seq sequence
+     */
+    template<typename T_Seq>
+    static constexpr bool isUnique = (bmpl::size<T_Seq>::value == bmpl::size<Unique_t<T_Seq>>::value);
+
+} // namespace pmacc

--- a/include/pmacc/particles/ParticleDescription.hpp
+++ b/include/pmacc/particles/ParticleDescription.hpp
@@ -23,10 +23,12 @@
 
 #include "pmacc/HandleGuardRegion.hpp"
 #include "pmacc/meta/conversion/ToSeq.hpp"
+#include "pmacc/meta/conversion/Unique.hpp"
 #include "pmacc/particles/policies/DeleteParticles.hpp"
 #include "pmacc/particles/policies/ExchangeParticles.hpp"
 
 #include <boost/mpl/vector.hpp>
+
 
 namespace pmacc
 {
@@ -39,8 +41,8 @@ namespace pmacc
      * @tparam T_Name name of described particle (e.g. electron, ion)
      *                type must be a boost::mpl::string
      * @tparam T_SuperCellSize compile time size of a super cell
-     * @tparam T_ValueTypeSeq sequence or single type with value_identifier
-     * @tparam T_Flags sequence or single type with identifier to add flags on a frame
+     * @tparam T_ValueTypeSeq sequence or single type with value_identifier, must not have duplicates
+     * @tparam T_Flags sequence or single type with identifier to add flags on a frame, must not have duplicates
      * @tparam T_MethodsList sequence or single class with particle methods
      *                       (e.g. calculate mass, gamma, ...)
      *                       (e.g. useSolverXY, calcRadiation, ...)
@@ -77,6 +79,14 @@ namespace pmacc
             HandleGuardRegion,
             MethodsList,
             FrameExtensionList>;
+
+        // Compile-time check uniqueness of attributes and flags
+        PMACC_CASSERT_MSG(
+            _error_particles_must_not_have_duplicate_attributes____check_your_speciesDefinition_param_file,
+            isUnique<ValueTypeSeq>);
+        PMACC_CASSERT_MSG(
+            _error_particles_must_not_have_duplicate_flags____check_your_speciesDefinition_param_file,
+            isUnique<FlagsList>);
     };
 
 


### PR DESCRIPTION
As pointed out in #4072 we never checked that typelists for particle flags or attributes are unique. And somewhat surprisingly PIConGPU was compiling in that case, but not running.

This PR adds a pmacc meta algorithm to test for uniqueness, and then applies it for the particle-related typelists in question. A build error message for repeated flag looks like that (and similarly for attribute):
`
/home/bastra54/src/picongpu/include/pmacc/../pmacc/particles/ParticleDescription.hpp(87): error #304: no instance of function template "mpl_::assertion_failed" matches the argument list
            argument types are: (mpl_::failed ************(pmacc::ParticleDescription<pmacc::meta::String<'e'>, picongpu::SuperCellSize, boost::mpl::v_item<picongpu::totalCellIdx, boost::mpl::v_item<picongpu::weighting, boost::mpl::v_item<picongpu::momentum, boost::mpl::v_item<picongpu::position<picongpu::position_pic, pmacc::pmacc_isAlias>, boost::mpl::vector0<mpl_::na>, 0>, 0>, 0>, 0>, picongpu::ParticleFlagsElectrons, pmacc::HandleGuardRegion<pmacc::particles::policies::ExchangeParticles, pmacc::particles::policies::DoNothing>, boost::mpl::vector0<mpl_::na>, boost::mpl::v_item<pmacc::NextFramePtr<mpl_::_1>, boost::mpl::v_item<pmacc::PreviousFramePtr<mpl_::_1>, boost::mpl::vector0<mpl_::na>, 0>, 0>>::_error_particles_must_not_have_duplicate_flags____check_your_speciesDefinition_param_file_________94::************)(pmacc::StaticAssertError))
`
