### PR TITLE
Expand docs on using incident field

### DIFF
--- a/docs/source/models/total_field_scattered_field.rst
+++ b/docs/source/models/total_field_scattered_field.rst
@@ -392,7 +392,7 @@ Finally, updates of :math:`B_z` are as follows:
 Calculating Incident B from E
 -----------------------------
 
-Consider a case when both :math:`E^{inc}(x, y, z, t)` and  :math:`\vec B^{inc}(x, y, z, t)` are theoretically present, but only :math:`E^{inc}(x, y, z, t)` is known in explicit form.
+Consider a case when both :math:`\vec E^{inc}(x, y, z, t)` and  :math:`\vec B^{inc}(x, y, z, t)` are theoretically present, but only :math:`\vec E^{inc}(x, y, z, t)` is known in explicit form.
 
 When slowly varying elvelope approximation (SVEA) is applicable, one may employ it to calculate the other field as :math:`\vec B^{inc}(x, y, z, t) = \vec k \times \vec E^{inc}(x, y, z, t) / c`.
 PIConGPU implements this approach for all incident field profiles and as a default second parameter of the ``Free`` incident field profile.

--- a/docs/source/models/total_field_scattered_field.rst
+++ b/docs/source/models/total_field_scattered_field.rst
@@ -389,31 +389,22 @@ Finally, updates of :math:`B_z` are as follows:
 
    & B_z\rvert_{i_S + 3/2, j+1/2, k}^{n+3/2} += \frac{\Delta t}{\Delta x} \left( -\frac{1}{24}  E_y^{inc}\left( i_S \Delta x, (j+1/2) \Delta y, k \Delta z, (n+1) \Delta t \right) \right)
 
-Usage
------
+Calculating Incident B from E
+-----------------------------
 
-The TF/SF field generation can be configured in :ref:`incidentField.param <usage-params-core>`.
-The position of the Huygens surface is set as an offset relative to the global domain start.
-The offset must cover at least the field absorber thickness along the boundary so that the Huygens surface is located in the internal area.
-Note that using field solvers other than Yee requires a larger offset depending on the stencil width along the boundary axis.
-As a rule of thumb, this extra requirement is (order of FDTD solver / 2 - 1).
-Additionally, the current implementation requires the offset be located sufficiently far away from local domain boundaries.
-The same rule of a thumb can be used, with offsets being at least that many cells away from domain boundaries.
-Validity of the provided offsets with respect to both conditions is checked at run time.
+Consider a case when both :math:`E^{inc}(x, y, z, t)` and  :math:`\vec B^{inc}(x, y, z, t)` are theoretically present, but only :math:`E^{inc}(x, y, z, t)` is known in explicit form.
 
-Consider a case when both :math:`E^{inc}(x, y, z, t)` and  :math:`\vec B^{inc}(x, y, z, t)` are theoretically present, but only one of them is known in explicit form.
-When slowly varying elvelope approximation is applicable, one may employ it to calculate the other field as :math:`\vec B^{inc}(x, y, z, t) = \vec k \cross \vec E^{inc}(x, y, z, t) / c`.
-PIConGPU implements this behavior as a default second parameter of the ``Free`` incident field profile.
+When slowly varying elvelope approximation (SVEA) is applicable, one may employ it to calculate the other field as :math:`\vec B^{inc}(x, y, z, t) = \vec k \times \vec E^{inc}(x, y, z, t) / c`.
+PIConGPU implements this approach for all incident field profiles and as a default second parameter of the ``Free`` incident field profile.
 
-Otherwise a user can try using TF/SF with only the modified known field set as incident and the other one set to 0.
-The interpretation of the result is assisted by the equivalence theorem, and in particular Love and Schelkunoff equivalence principles [Harrington2001]_ [Balanis2012]_.
+Otherwise one may use TF/SF with only the modified known field set as incident and the other one set to 0.
+Generally, the interpretation of the result is assisted by the equivalence theorem, and in particular Love and Schelkunoff equivalence principles [Harrington2001]_ [Balanis2012]_.
 Having :math:`\vec E^{inc}(x, y, z, t) = \vec 0` means only electric current :math:`\vec J` would be impressed on :math:`S`.
 Taking into account no incident fields in the SF region, the region is effectively a perfect magnetic conductor.
 Likewise, having :math:`\vec B^{inc}(x, y, z, t) = \vec 0` corresponds to only magnetic current and effectively a perfect electric conductor in the SF region.
-To generate the expected field amplitude inside the area, the only non-zero source field has to be adjusted.
-In the simple plane wave case, the adjustment is to set the amplitude of the present field twice as large, as demonstrated in [Rengarajan2000]_.
-In the general case, it appears unclear how to calculate such an adjustment.
-Note that using this approach in PIConGPU results in generating pulses going both inwards and outwards of the Huygens surface.
+Practically, one may try using the known incident field with twice the amplitude and keeping the other incident field zero, as demonstrated in [Rengarajan2000]_.
+Note that using this approach in PIConGPU results in generating pulses going both inwards and outwards of the Huygens surface
+(similar to laser profiles with ``initPlaneY > 0``).
 Therefore, it is recommended to have no density outside the surface and use a strong field absorber to negate the effect of the artificial outwards-going pulse.
 
 References

--- a/docs/source/usage/workflows/addLaser.rst
+++ b/docs/source/usage/workflows/addLaser.rst
@@ -7,18 +7,55 @@ Adding Laser
 
 There are several alternative ways of adding an incoming laser (or any source of electromagnetic field) to a PIConGPU simulation:
 
+#. selecting incident field profiles for respective boundaries in :ref:`incidentField.param <usage-params-core>`
 #. selecting a laser profile in :ref:`laser.param <usage-params-core>`
-#. selecting non-none incident field profiles for respective boundaries in :ref:`incidentField.param <usage-params-core>`
 #. using field or current background in :ref:`fieldBackground.param <usage-params-core>`
 
 These ways operate independently of one another, each has its features and limitations.
+Incident field- and laser profiles currently match one another.
+
+Incident Field
+""""""""""""""
+
+Incident field is an external field source producing a wave propagating inwards the simulation volume.
+The source is applied at a boundary of an axis-aligned box located inside the simulation area.
+The implementation is based on the total field/scattered field formulation described in detail :ref:`here <model-TFSF>`.
+A user sets offsets of each side of this box from global domain boundary in :ref:`incidentField.param <usage-params-core>`.
+Each offset must cover at least the field absorber thickness along the boundary so that the generating surface is located in the internal area.
+
+For each of the generation planes ``XMin, XMax, YMin, YMax, ZMin, ZMax`` (the latter two for 3d) a user sets incident profile to be applied.
+The configuration is done through parameter structures, depending on the profile type.
+Both profiles and parameter structures generally match their laser counterparts.
+The differences between matching incident field- and laser profiles are:
+
+# positioning of incident field is controlled for the generation plane and not via an internal member ``::initPlaneY``
+# incident field profiles do not have an extra time delay equal to :math:`initPlaneY * \Delta y / c` as lasers do (when needed, other parameters could be adjusted to accomodate for the delay)
+# default initial phase is chosen so that the laser starts smoothly at the generation plane (for laser it is always for plane :math:`y = 0`) 
+# incident field uses generalized coordinate system and treats transversal axes and parameters generically (explained in comments of the profile parameters in question)
+
+Note that the profile itself only controls properties of the laser, but not where it will be applied to.
+It is a combination of profile and particular plane that together will produce an inward-going laser adhering to the profile.
+For pre-set profiles a proper orientation of the wave will be provided by internal implementation.
+With the ``Free`` profile, it is on a user to provide functors to calculate incident fields and ensure the orientation for the boundaries it is applied to (however, it does not have to work for all boundaries, only the ones in question).
+Please refer to :ref:`the detailed description <model-TFSF>` for setting up ``Free`` profile, also for the case when only one of the external fields is known in explicit form.
+
+Incident field is compatible to all field solvers, however using field solvers other than Yee requires a larger offset depending on the stencil width along the boundary axis.
+As a rule of thumb, this extra requirement is (order of FDTD solver / 2 - 1).
+Additionally, the current implementation requires the offset be located sufficiently far away from local domain boundaries.
+The same rule of a thumb can be used, with offsets being at least that many cells away from domain boundaries.
+Validity of the provided offsets with respect to both conditions is checked at run time.
+
+Laser
+"""""
+
+Laser profiles are still supported, but deprecated.
+Consider switching to the incident field counterpart of your laser profile as ``YMin`` source.
+The transition should be straightforward, please refer to the previous section for differences from incident field.
+
 Beware that the laser is fully accurate only for the standard Yee field solver.
 For other field solver types, a user should evaluate the inaccuracies introduced.
-Incident field, field- and current background should be fully accurate for all field solvers.
 
-Incident field is applied using the total field/scattered field formulation described :ref:`here <model-TFSF>`.
-
-The functioning of the laser (the first way) is covered in more detail in the following class:
+The functioning of the laser (the second way) is covered in more detail in the following class:
 
 .. doxygenclass:: picongpu::fields::laserProfiles::acc::BaseFunctor
    :project: PIConGPU

--- a/docs/source/usage/workflows/addLaser.rst
+++ b/docs/source/usage/workflows/addLaser.rst
@@ -20,7 +20,7 @@ Incident Field
 Incident field is an external field source producing a wave propagating inwards the simulation volume.
 The source is applied at a boundary of an axis-aligned box located inside the simulation area.
 The implementation is based on the total field/scattered field formulation described in detail :ref:`here <model-TFSF>`.
-A user sets offsets of each side of this box from global domain boundary in :ref:`incidentField.param <usage-params-core>`.
+A user sets offsets of this box from global domain boundary in :ref:`incidentField.param <usage-params-core>`.
 Each offset must cover at least the field absorber thickness along the boundary so that the generating surface is located in the internal area.
 
 For each of the generation planes ``XMin, XMax, YMin, YMax, ZMin, ZMax`` (the latter two for 3d) a user sets incident profile to be applied.
@@ -28,10 +28,10 @@ The configuration is done through parameter structures, depending on the profile
 Both profiles and parameter structures generally match their laser counterparts.
 The differences between matching incident field- and laser profiles are:
 
-# positioning of incident field is controlled for the generation plane and not via an internal member ``::initPlaneY``
-# incident field profiles do not have an extra time delay equal to :math:`initPlaneY * \Delta y / c` as lasers do (when needed, other parameters could be adjusted to accomodate for the delay)
-# default initial phase is chosen so that the laser starts smoothly at the generation plane (for laser it is always for plane :math:`y = 0`) 
-# incident field uses generalized coordinate system and treats transversal axes and parameters generically (explained in comments of the profile parameters in question)
+#. positioning of incident field is controlled for the generation plane and not via an internal member ``::initPlaneY``
+#. incident field profiles do not have an extra time delay equal to :math:`\mathrm{initPlaneY} * \Delta y / c` as lasers do (when needed, other parameters could be adjusted to accomodate for the delay)
+#. default initial phase is chosen so that the laser starts smoothly at the generation plane (for laser it is always for plane :math:`y = 0`)
+#. incident field uses generalized coordinate system and treats transversal axes and parameters generically (explained in comments of the profile parameters in question)
 
 Note that the profile itself only controls properties of the laser, but not where it will be applied to.
 It is a combination of profile and particular plane that together will produce an inward-going laser adhering to the profile.


### PR DESCRIPTION
Add more information to the `Adding laser` workflow doc page. Explicitly write differences between incident field profiles and laser profiles. Some of this content was taken from the old TF/SF page and extended.

I also positioned incident field as the main way, and laser as deprecated, as we discussed with @psychocoderHPC . The plan is to remove lasers after the next release (so they will still be in the next release 0.7.0, but planned to be removed after).