### PR TITLE
fix CUDA container apt keys

### DIFF
--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -5,6 +5,8 @@
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-${CI_CONTAINER_NAME}-clang-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    # ISAAC is not supporting CPU
+    DISABLE_ISAAC: "yes"
   script:
     - apt update
     - apt install -y curl libjpeg-dev

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -5,6 +5,8 @@
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-${CI_CONTAINER_NAME}-gcc-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    # ISAAC is not supporting CPU
+    DISABLE_ISAAC: "yes"
   script:
     - apt update
     - apt install -y curl libjpeg-dev

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -293,6 +293,11 @@ for stage in range(num_stages):
                 print("    - wget -q -O - "
                       "https://repo.radeon.com/rocm/rocm.gpg.key | "
                       "sudo apt-key add -")
+            if backend == "cuda":
+                print("    - apt-key adv --fetch-keys "
+                      "https://developer.download.nvidia.com/compute"
+                      "/cuda/repos/${CI_CONTAINER_NAME//.}"
+                      "/x86_64/3bf863cc.pub")
             print("    - apt-get update -qq")
             print("    - apt-get install -y -qq libopenmpi-dev "
                   "openmpi-bin openssh-server")


### PR DESCRIPTION
NVIDIA changed there ubuntu apt keys, therefore `apt update` is failing.

I used the suggestion from https://github.com/NVIDIA/nvidia-container-toolkit/issues/258 and updated the keys within each job.