### PR TITLE
add CMake flag `PMACC_HIP_EMULATE_SHAREDMEM_ATOMICADD_32BIT`

### DIFF
--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -55,6 +55,12 @@ endif()
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${PMACC_BUILD_TYPE}")
 unset(PMACC_BUILD_TYPE)
 
+set(PMACC_HIP_EMULATE_SHAREDMEM_ATOMICADD_32BIT "ON" CACHE STRING "Use atomicCas to emulate atomicAdd(float)")
+set_property(CACHE PMACC_HIP_EMULATE_SHAREDMEM_ATOMICADD_32BIT PROPERTY STRINGS "ON;OFF")
+
+if(PMACC_HIP_EMULATE_SHAREDMEM_ATOMICADD_32BIT STREQUAL ON)
+    set(PMacc_DEFINITIONS ${PMacc_DEFINITIONS} -DPMACC_HIP_EMULATE_SHAREDMEM_ATOMICADD_32BIT=1)
+endif()
 
 ################################################################################
 # CMake policies

--- a/include/pmacc/kernel/atomic.hpp
+++ b/include/pmacc/kernel/atomic.hpp
@@ -84,7 +84,9 @@ namespace pmacc
                     ::atomicAddNoRet(ptr, value);
                 }
             };
-#elif(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) >= 403)
+#elif(                                                                                                                \
+    PMACC_HIP_EMULATE_SHAREDMEM_ATOMICADD_32BIT == 1 && ALPAKA_ACC_GPU_HIP_ENABLED == 1                               \
+    && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) >= 403)
             /** HIP backend specialization for atomic add float
              *
              * atomicAdd(float*,float) into shared memory is very slow for HIP 4.3+.


### PR DESCRIPTION
Allow enabling and disabling the `atomicAdd(float)` workaround for slow HIP atomics into shared memory.