### PR TITLE
fix documentation: minimal boost version

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -86,7 +86,7 @@ zlib
 
 boost
 """""
-- 1.66.0+ (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
+- 1.74.0+ (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs, optional: ``fiber`` with ``context``, ``thread``, ``chrono``, ``atomic``, ``date_time``)
 - *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev libboost-atomic-dev libboost-date-time-dev libboost-math-dev libboost-serialization-dev libboost-fiber-dev libboost-context-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``


### PR DESCRIPTION
Set required boost version to 1.74.0.
This change was missed in #4081.

Docu bug was found by @steindev.