### PR TITLE
use `if constexpr()` to check for simulation/object dimension

### DIFF
--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -124,7 +124,7 @@ namespace picongpu
                     // Note: since this should compile for 2d, .z( ) can't be used
                     using detail::makeIdx;
                     int layerIdx = 0;
-                    if(simDim == 3)
+                    if constexpr(simDim == 3)
                     {
                         auto const negativeZLayer
                             = Layer{makeIdx(0, 0, 0), makeIdx(gridSize[0], gridSize[1], negativeSize[2])};

--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
@@ -169,11 +169,11 @@ namespace picongpu
             std::vector<int> totalDomainSize{&totalDomain.size[0], &totalDomain.size[0] + simDim};
             std::vector<int> totalDomainOffset{&totalDomain.offset[0], &totalDomain.offset[0] + simDim};
             std::vector<std::string> globalDomainAxisLabels;
-            if(simDim == DIM2)
+            if constexpr(simDim == DIM2)
             {
                 globalDomainAxisLabels = {"y", "x"}; // 2D: F[y][x]
             }
-            if(simDim == DIM3)
+            if constexpr(simDim == DIM3)
             {
                 globalDomainAxisLabels = {"z", "y", "x"}; // 3D: F[z][y][x]
             }

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -81,12 +81,13 @@ namespace picongpu
 
         bool activatePlugin = true;
 
-        if(simDim == DIM2 && el_space == AxisDescription::z)
-        {
-            std::cerr << "[Plugin] [" + m_help->getOptionPrefix() + "] Skip requested output for "
-                      << m_help->element_space.get(id) << m_help->element_momentum.get(id) << std::endl;
-            activatePlugin = false;
-        }
+        if constexpr(simDim == DIM2)
+            if(el_space == AxisDescription::z)
+            {
+                std::cerr << "[Plugin] [" + m_help->getOptionPrefix() + "] Skip requested output for "
+                          << m_help->element_space.get(id) << m_help->element_momentum.get(id) << std::endl;
+                activatePlugin = false;
+            }
 
         if(activatePlugin)
         {

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1157,12 +1157,12 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 mesh.setGeometry(::openPMD::Mesh::Geometry::cartesian);
                 mesh.setDataOrder(::openPMD::Mesh::DataOrder::C);
 
-                if(simDim == DIM2)
+                if constexpr(simDim == DIM2)
                 {
                     std::vector<std::string> axisLabels = {"y", "x"}; // 2D: F[y][x]
                     mesh.setAxisLabels(axisLabels);
                 }
-                if(simDim == DIM3)
+                if constexpr(simDim == DIM3)
                 {
                     std::vector<std::string> axisLabels = {"z", "y", "x"}; // 3D: F[z][y][x]
                     mesh.setAxisLabels(axisLabels);

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -713,7 +713,7 @@ namespace picongpu
             m_output.join();
 
             uint32_t localDomainOffset = 0;
-            if(simDim == DIM3)
+            if constexpr(simDim == DIM3)
                 localDomainOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset[sliceDim];
 
             constexpr uint32_t cellsPerSupercell = pmacc::math::CT::volume<SuperCellSize>::type::value;

--- a/include/picongpu/simulation/stage/ParticleBoundaries.hpp
+++ b/include/picongpu/simulation/stage/ParticleBoundaries.hpp
@@ -63,7 +63,7 @@ namespace picongpu
                     void operator()(po::options_description& desc)
                     {
                         auto example = std::string{"example: --" + prefix + "_boundary absorbing periodic"};
-                        if(simDim == 3)
+                        if constexpr(simDim == 3)
                             example += " reflecting";
                         desc.add_options()(
                             (prefix + "_boundary").c_str(),

--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -237,7 +237,7 @@ namespace pmacc
         bool slide() override
         {
             // we can only slide in y direction right now
-            if(DIM < DIM2)
+            if constexpr(DIM < DIM2)
                 return false;
 
             // MPI_Barrier(topology);
@@ -257,7 +257,7 @@ namespace pmacc
                 return false;
 
             // we can only slide in y direction right now
-            if(DIM < DIM2)
+            if constexpr(DIM < DIM2)
                 return false;
 
             bool result = false;
@@ -399,7 +399,7 @@ namespace pmacc
                 if(m.containsExchangeType(RIGHT))
                     mcoords[0]++;
 
-                if(DIM >= DIM2)
+                if constexpr(DIM >= DIM2)
                 {
                     if(m.containsExchangeType(TOP))
                         mcoords[1]--;
@@ -407,7 +407,7 @@ namespace pmacc
                         mcoords[1]++;
                 }
 
-                if(DIM == DIM3)
+                if constexpr(DIM == DIM3)
                 {
                     if(m.containsExchangeType(BACK))
                         mcoords[2]++;

--- a/include/pmacc/cuSTL/container/DeviceBuffer.hpp
+++ b/include/pmacc/cuSTL/container/DeviceBuffer.hpp
@@ -105,9 +105,9 @@ namespace pmacc
                 this->sharedPtr = ptr;
                 this->shiftedPtr = ptr.get();
                 this->_size = size;
-                if(T_dim >= 2)
+                if constexpr(T_dim >= 2)
                     this->pitch[0] = (pitch[0]) ? pitch[0] : size.x() * sizeof(Type);
-                if(T_dim == 3)
+                if constexpr(T_dim == 3)
                     this->pitch[1] = (pitch[1]) ? pitch[1] : this->pitch[0] * size.y();
             }
             HINLINE DeviceBuffer(const Base& base) : Base(base)

--- a/include/pmacc/cuSTL/container/IndexBuffer.hpp
+++ b/include/pmacc/cuSTL/container/IndexBuffer.hpp
@@ -61,7 +61,7 @@ namespace pmacc
                 math::Int<dim> factor;
                 factor[0] = 1;
                 factor[1] = this->_size.x();
-                if(dim == 3)
+                if constexpr(dim == 3)
                     factor[2] = this->_size.x() * this->_size.y();
 
                 return cursor::
@@ -76,7 +76,7 @@ namespace pmacc
                 math::Int<dim> factor;
                 factor[0] = 1;
                 factor[1] = this->_size.x();
-                if(dim == 3)
+                if constexpr(dim == 3)
                     factor[2] = this->_size.x() * this->_size.y();
                 math::Int<dim> customFactor;
                 for(uint32_t i = 0; i < dim; i++)

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemAllocator.tpp
@@ -38,7 +38,7 @@ namespace pmacc
             cuplaData.xsize = size[0] * sizeof(Type);
             cuplaData.ysize = 1;
 
-            if(dim == 2u)
+            if constexpr(dim == 2u)
             {
                 cuplaData.xsize = size[0] * sizeof(Type);
                 cuplaData.ysize = size[1];
@@ -46,7 +46,7 @@ namespace pmacc
                     CUDA_CHECK(cuplaMallocPitch(&cuplaData.ptr, &cuplaData.pitch, cuplaData.xsize, cuplaData.ysize));
                 pitch[0] = cuplaData.pitch;
             }
-            else if(dim == 3u)
+            else if constexpr(dim == 3u)
             {
                 cuplaExtent extent;
                 extent.width = size[0] * sizeof(Type);

--- a/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/DeviceMemEvenPitchAllocator.tpp
@@ -34,11 +34,11 @@ namespace pmacc
             if(size.productOfComponents())
                 CUDA_CHECK(cuplaMalloc((void**) &dataPointer, sizeof(Type) * size.productOfComponents()));
 
-            if(dim == 2u)
+            if constexpr(dim == 2u)
             {
                 pitch[0] = sizeof(Type) * size[0];
             }
-            else if(dim == 3u)
+            else if constexpr(dim == 3u)
             {
                 pitch[0] = sizeof(Type) * size[0];
                 pitch[1] = pitch[0] * size[1];

--- a/include/pmacc/cuSTL/container/allocator/HostMemAllocator.tpp
+++ b/include/pmacc/cuSTL/container/allocator/HostMemAllocator.tpp
@@ -34,11 +34,11 @@ namespace pmacc
 
             if(size.productOfComponents())
                 CUDA_CHECK(cuplaMallocHost((void**) &dataPointer, sizeof(Type) * size.productOfComponents()));
-            if(dim == 2u)
+            if constexpr(dim == 2u)
             {
                 pitch[0] = size[0] * sizeof(Type);
             }
-            else if(dim == 3u)
+            else if constexpr(dim == 3u)
             {
                 pitch[0] = size[0] * sizeof(Type);
                 pitch[1] = pitch[0] * size[1];

--- a/include/pmacc/mappings/simulation/GridController.hpp
+++ b/include/pmacc/mappings/simulation/GridController.hpp
@@ -63,7 +63,7 @@ namespace pmacc
                 DataSpace<DIM3> periodicTmp;
                 tmp[0] = nodes[0];
                 periodicTmp[0] = periodic[0];
-                if(DIM < DIM2)
+                if constexpr(DIM < DIM2)
                 {
                     tmp[1] = 1;
                     periodicTmp[1] = 1;
@@ -74,7 +74,7 @@ namespace pmacc
                     periodicTmp[1] = periodic[1];
                 }
 
-                if(DIM < DIM3)
+                if constexpr(DIM < DIM3)
                 {
                     tmp[2] = 1;
                     periodicTmp[2] = 1;

--- a/include/pmacc/memory/buffers/Buffer.hpp
+++ b/include/pmacc/memory/buffers/Buffer.hpp
@@ -113,11 +113,11 @@ namespace pmacc
             //!\todo: current size can be changed if it is a DeviceBuffer and current size is on device
             // call first get current size (but const not allow this)
 
-            if(DIM == DIM1)
+            if constexpr(DIM == DIM1)
             {
                 tmp[0] = current_size;
             }
-            if(DIM == DIM2)
+            if constexpr(DIM == DIM2)
             {
                 if(current_size <= data_space[0])
                 {
@@ -130,7 +130,7 @@ namespace pmacc
                     tmp[1] = (current_size + data_space[0] - 1) / data_space[0];
                 }
             }
-            if(DIM == DIM3)
+            if constexpr(DIM == DIM3)
             {
                 if(current_size <= data_space[0])
                 {

--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -84,9 +84,9 @@ namespace pmacc
         {
             cuplaPitchedPtr cuplaData = this->getCudaPitched();
             math::Size_t<DIM - 1> pitch;
-            if(DIM >= 2)
+            if constexpr(DIM >= 2)
                 pitch[0] = cuplaData.pitch;
-            if(DIM == 3)
+            if constexpr(DIM == 3)
                 pitch[1] = pitch[0] * this->getPhysicalMemorySize()[1];
             // pass data pointer without deletion policy
             container::DeviceBuffer<TYPE, DIM> result(

--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -126,11 +126,11 @@ namespace pmacc
         {
             __startOperation(ITask::TASK_DEVICE);
 
-            if(DIM == DIM1)
+            if constexpr(DIM == DIM1)
             {
                 return (TYPE*) (data.ptr) + this->offset[0];
             }
-            else if(DIM == DIM2)
+            else if constexpr(DIM == DIM2)
             {
                 return (TYPE*) ((char*) data.ptr + this->offset[1] * this->data.pitch) + this->offset[0];
             }
@@ -238,18 +238,18 @@ namespace pmacc
             data.xsize = this->getDataSpace()[0] * sizeof(TYPE);
             data.ysize = 1;
 
-            if(DIM == DIM1)
+            if constexpr(DIM == DIM1)
             {
                 log<ggLog::MEMORY>("Create device 1D data: %1% MiB") % (data.xsize / 1024 / 1024);
                 CUDA_CHECK(cuplaMallocPitch(&data.ptr, &data.pitch, data.xsize, 1));
             }
-            if(DIM == DIM2)
+            if constexpr(DIM == DIM2)
             {
                 data.ysize = this->getDataSpace()[1];
                 log<ggLog::MEMORY>("Create device 2D data: %1% MiB") % (data.xsize * data.ysize / 1024 / 1024);
                 CUDA_CHECK(cuplaMallocPitch(&data.ptr, &data.pitch, data.xsize, data.ysize));
             }
-            if(DIM == DIM3)
+            if constexpr(DIM == DIM3)
             {
                 cuplaExtent extent;
                 extent.width = this->getDataSpace()[0] * sizeof(TYPE);
@@ -285,7 +285,7 @@ namespace pmacc
             // fake the pitch, thus we can use this 1D Buffer as 2D or 3D
             data.pitch = this->getDataSpace()[0] * sizeof(TYPE);
 
-            if(DIM > DIM1)
+            if constexpr(DIM > DIM1)
             {
                 data.ysize = this->getDataSpace()[1];
             }

--- a/include/pmacc/memory/buffers/ExchangeIntern.hpp
+++ b/include/pmacc/memory/buffers/ExchangeIntern.hpp
@@ -80,7 +80,7 @@ namespace pmacc
                 tmp_size,
                 exchangeTypeToOffset(exchange, memoryLayout, guardingCells, area),
                 sizeOnDevice);
-            if(DIM > DIM1)
+            if constexpr(DIM > DIM1)
             {
                 /*create double buffer on gpu for faster memory transfers*/
                 deviceDoubleBuffer = std::make_unique<DeviceBuffer>(tmp_size, false, true);
@@ -105,7 +105,7 @@ namespace pmacc
             using DeviceBuffer = DeviceBufferIntern<TYPE, DIM>;
             deviceBuffer = std::make_unique<DeviceBuffer>(exchangeDataSpace, sizeOnDevice);
             //  this->deviceBuffer = new DeviceBufferIntern<TYPE, DIM > (exchangeDataSpace, sizeOnDevice,true);
-            if(DIM > DIM1)
+            if constexpr(DIM > DIM1)
             {
                 /*create double buffer on gpu for faster memory transfers*/
                 deviceDoubleBuffer = std::make_unique<DeviceBuffer>(exchangeDataSpace, false, true);
@@ -132,11 +132,13 @@ namespace pmacc
             if(exchangeMask.containsExchangeType(LEFT) || exchangeMask.containsExchangeType(RIGHT))
                 result[0] = 1;
 
-            if(DIM > DIM1 && (exchangeMask.containsExchangeType(TOP) || exchangeMask.containsExchangeType(BOTTOM)))
-                result[1] = 1;
+            if constexpr(DIM > DIM1)
+                if(exchangeMask.containsExchangeType(TOP) || exchangeMask.containsExchangeType(BOTTOM))
+                    result[1] = 1;
 
-            if(DIM > DIM2 && (exchangeMask.containsExchangeType(FRONT) || exchangeMask.containsExchangeType(BACK)))
-                result[2] = 1;
+            if constexpr(DIM > DIM2)
+                if(exchangeMask.containsExchangeType(FRONT) || exchangeMask.containsExchangeType(BACK))
+                    result[2] = 1;
 
             return result;
         }
@@ -153,7 +155,7 @@ namespace pmacc
             DataSpace<DIM> border = memoryLayout.getGuard();
             Mask mask(exchange);
             DataSpace<DIM> tmp_offset;
-            if(DIM >= DIM1)
+            if constexpr(DIM >= DIM1)
             {
                 if(mask.containsExchangeType(RIGHT))
                 {
@@ -173,7 +175,7 @@ namespace pmacc
                     }
                 }
             }
-            if(DIM >= DIM2)
+            if constexpr(DIM >= DIM2)
             {
                 if(mask.containsExchangeType(BOTTOM))
                 {
@@ -192,7 +194,7 @@ namespace pmacc
                     }
                 }
             }
-            if(DIM == DIM3)
+            if constexpr(DIM == DIM3)
             {
                 if(mask.containsExchangeType(BACK))
                 {


### PR DESCRIPTION
Use `if constexpr()` instead of runtime check for special code passed for 2 or 3-dimensional cases.


I have not touched the laser implementation even if there are cases that can use `if constexpr()` too. This avoids merging conflicts with the work @sbastrakov is currently doing.