### PR TITLE
Add a new functor to sample macroparticles in a cell

### DIFF
--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -64,7 +64,7 @@ namespace picongpu
          *    - Evaluate the amount of real particles in the cell, Nr, using T_DensityFunctor.
          *    - If Nr > 0, decide how to represent it with macroparticles using T_PositionFunctor:
          *        - (For simplicity we describe how all currently used functors but RandomPositionAndWeightingImpl
-         *           operate, see below for customization)
+         *           and RandomBinomialImpl operate, see below for customization)
          *        - Try to have exactly T_PositionFunctor::numParticlesPerCell macroparticles
          *          with same weighting w = Nr / T_PositionFunctor::numParticlesPerCell.
          *        - If such w < MIN_WEIGHTING, instead use fewer macroparticles and higher weighting.

--- a/include/picongpu/particles/startPosition/RandomBinomialImpl.def
+++ b/include/picongpu/particles/startPosition/RandomBinomialImpl.def
@@ -1,0 +1,81 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/startPosition/generic/FreeRng.def"
+
+#include <pmacc/random/distributions/Uniform.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace startPosition
+        {
+            namespace acc
+            {
+                /** Set the in cell position randomly and weights to mimic random sampling in whole domain
+                 *
+                 * @see startPosition::RandomBinomialImpl
+                 *
+                 * @tparam T_ParamClass parameter class, must define ::numParticlesPerCell
+                 */
+                template<typename T_ParamClass>
+                struct RandomBinomialImpl;
+
+            } // namespace acc
+
+            /** Set the in cell position randomly and weights to mimic random sampling in whole domain
+             *
+             * The number of macroparticles in cell will be equal to ::numParticlesPerCell, unless
+             * the weights will get below MIN_WEIGHTING.
+             * Unlike for other sampling functors, the total weighting of macroparticles in a cell will not be exactly
+             * equal to expected number of real particles in the cell.
+             *
+             * Instead, the functor will mimic the process of random sampling in the whole domain as follows.
+             * First, consider a simplified case of uniform density on whole domain and all weightings equal to 1.
+             * Denote m total number of cells and n = T_ParamClass::numParticlesPerCell.
+             * Then the expected number of macroparticles in a cell is distributed as N ~ Binomial(m * n, 1 / m).
+             * So to mimic random sampling we could have changed the number of macroparticles in a cell
+             * from hard-set n to a binomially distributed random value N with expected value n.
+             *
+             * However, we would like to keep computational workload uniform between cells when possible.
+             * (For low n also potentially do some importance sampling, that we also do generally for low density.)
+             * So instead we keep N = n and adjust weightings to result in about the same sampled density in a cell as
+             * the simplistic scheme described above.
+             *
+             * Denote w a weighting calculated for usual PIConGPU sampling in other functors.
+             * The weighting in this method is sampled as W = w * n / N with N ~ Binomial(m * n, 1 / m).
+             * That binomial distribution has parameters E(N) = n, Var(N) = n * (1 - 1/m).
+             * For n > 5 and m >> 1 the we can approximate that distribution with Normal(n, n).
+             * So with this approximation N = n + Z * sqrt(n) with Z ~ Normal(0, 1).
+             * Thus, we sample weighting as follows: W = w * n / (n + Z * sqrt(n)) = W / (1 + Z / sqrt(n)).
+             *
+             * @tparam T_ParamClass parameter class, must define ::numParticlesPerCell
+             */
+            template<typename T_ParamClass>
+            using RandomBinomialImpl = generic::
+                FreeRng<acc::RandomBinomialImpl<T_ParamClass>, pmacc::random::distributions::Uniform<float_X>>;
+        } // namespace startPosition
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/startPosition/RandomBinomialImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomBinomialImpl.hpp
@@ -1,0 +1,107 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/startPosition/RandomImpl.hpp"
+#include "picongpu/particles/startPosition/generic/FreeRng.def"
+
+#include <pmacc/algorithms/math/defines/pi.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace startPosition
+        {
+            namespace acc
+            {
+                template<typename T_ParamClass>
+                struct RandomBinomialImpl : public RandomImpl<T_ParamClass>
+                {
+                    using Base = RandomImpl<T_ParamClass>;
+
+                    /** Set in-cell position and weighting
+                     *
+                     * The scheme is described in the .def file.
+                     *
+                     * @tparam T_Rng functor::misc::RngWrapper, type of the random number generator
+                     * @tparam T_Particle pmacc::Particle, particle type
+                     * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+                     *
+                     * @param rng random number generator
+                     * @param particle particle to be manipulated
+                     * @param ... unused particles
+                     */
+                    template<typename T_Rng, typename T_Particle, typename... T_Args>
+                    HDINLINE void operator()(T_Rng& rng, T_Particle& particle, T_Args&&... args)
+                    {
+                        // Initialize the weighting here as only here we got random number generator
+                        if(!m_isInitialized)
+                        {
+                            /* This is required for normal distribution to be a good approximation to binomial
+                             * (> 5 is minimem, >= 8 is very safe)
+                             */
+                            PMACC_CASSERT_MSG(
+                                __RandomBinomialImpl_numParticlesPerCell_must_be_at_least_8,
+                                T_ParamClass::numParticlesPerCell >= 8);
+                            auto const s = math::sqrt(static_cast<float_X>(T_ParamClass::numParticlesPerCell));
+                            auto const z = getStandardNormal(rng);
+                            this->m_weighting /= (1.0_X + z / s);
+                            auto const minWeighting = MIN_WEIGHTING;
+                            this->m_weighting = math::max(this->m_weighting, minWeighting);
+                            m_isInitialized = true;
+                        }
+                        // The rest is exactly same as for RandomImpl
+                        Base::operator()(rng, particle, args...);
+                    }
+
+                    // If we initialized the weighting in operator()
+                    bool m_isInitialized = false;
+
+                private:
+                    /** Get a standard normally distributed random number from a given uniform distribution generator
+                     *
+                     * For convenience this functor works with uniform distribution, so implement abort
+                     * Box-Muller transform manually for this use case.
+                     *
+                     * @tparam T_UniformRng functor::misc::RngWrapper, type of the uniform random number generator
+                     *
+                     * @param uniformRng uniform random number generator
+                     */
+                    template<typename T_UniformRng>
+                    HDINLINE auto getStandardNormal(T_UniformRng& uniformRng)
+                    {
+                        auto u1 = uniformRng();
+                        while(!u1)
+                            u1 = uniformRng();
+                        auto const u2 = uniformRng();
+                        auto const z = math::sqrt(-2.0_X * math::log(u1))
+                            * math::cos(pmacc::math::Pi<float_X>::doubleValue * u2);
+                        return z;
+                    }
+                };
+
+            } // namespace acc
+        } // namespace startPosition
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/startPosition/functors.def
+++ b/include/picongpu/particles/startPosition/functors.def
@@ -22,6 +22,7 @@
 
 #include "picongpu/particles/startPosition/OnePositionImpl.def"
 #include "picongpu/particles/startPosition/QuietImpl.def"
+#include "picongpu/particles/startPosition/RandomBinomialImpl.def"
 #include "picongpu/particles/startPosition/RandomImpl.def"
 #include "picongpu/particles/startPosition/RandomPositionAndWeightingImpl.def"
 #include "picongpu/particles/startPosition/generic/Free.def"

--- a/include/picongpu/particles/startPosition/functors.hpp
+++ b/include/picongpu/particles/startPosition/functors.hpp
@@ -22,6 +22,7 @@
 
 #include "picongpu/particles/startPosition/OnePositionImpl.hpp"
 #include "picongpu/particles/startPosition/QuietImpl.hpp"
+#include "picongpu/particles/startPosition/RandomBinomialImpl.hpp"
 #include "picongpu/particles/startPosition/RandomImpl.hpp"
 #include "picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp"
 #include "picongpu/particles/startPosition/generic/Free.hpp"

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/particle.param
@@ -32,14 +32,14 @@ namespace picongpu
     {
         namespace startPosition
         {
-            struct QuietParam25ppc
+            struct Param25ppc
             {
-                /** Count of particles per cell per direction at initial state
+                /** Count of particles per cell at initial state
                  *  unit: none
                  */
-                using numParticlesPerDimension = typename mCT::shrinkTo<mCT::Int<5, 5, 1>, simDim>::type;
+                static constexpr uint32_t numParticlesPerCell = 25;
             };
-            using Quiet25ppc = QuietImpl<QuietParam25ppc>;
+            using RandomBinomial25ppc = RandomBinomialImpl<Param25ppc>;
 
         } // namespace startPosition
 
@@ -53,8 +53,7 @@ namespace picongpu
          *  number of particles per cell for normalization of weighted
          *  particle attributes.
          */
-        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL
-            = mCT::volume<startPosition::QuietParam25ppc::numParticlesPerDimension>::type::value;
+        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = startPosition::Param25ppc::numParticlesPerCell;
 
         namespace manipulators
         {

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/speciesInitialization.param
@@ -40,7 +40,7 @@ namespace picongpu
          * the functors are called in order (from first to last functor)
          */
         using InitPipeline = bmpl::vector<
-            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet25ppc, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::RandomBinomial25ppc, PIC_Electrons>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::LowerQuarterYPosition>,
             Manipulate<manipulators::AddTemperature, PIC_Electrons>>;
 


### PR DESCRIPTION
It samples positions randomly uniformly inside a cell. The weights are sampled to somewhat mimic a true global sampling vs. cell-based sampling we do in other functors. That yields internal binomial distribution, hence the name as I didn't manage to come up with anything better.

I did some math derivation for that, as described in the `.def` file and was earlier posted in a mattermost channel.

Tbh I am not sure how it should perform. In theory it appears to be a more "statistically honest" sampling than what we normally do. However, perhaps what we normally do is actually better for our use case. This sampling may have more fidelity wrt mixing and natural irregularities. So perhaps it can e.g. more faithfully reproduce KHI growth rate. However, I did not check it yet, and honestly have no time for this side-task. Perhaps after #4106 is merged, we can more simply test it, or if @PrometheusPi has time for it.

- [x] Add to compile-time tests somewhere