### PR TITLE
CUDA: fix false warning

### DIFF
--- a/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
+++ b/include/pmacc/memory/buffers/DeviceBufferIntern.hpp
@@ -134,12 +134,11 @@ namespace pmacc
             {
                 return (TYPE*) ((char*) data.ptr + this->offset[1] * this->data.pitch) + this->offset[0];
             }
-            else
-            {
-                const size_t offsetY = this->offset[1] * this->data.pitch;
-                const size_t sizePlaneXY = this->getPhysicalMemorySize()[1] * this->data.pitch;
-                return (TYPE*) ((char*) data.ptr + this->offset[2] * sizePlaneXY + offsetY) + this->offset[0];
-            }
+
+            // path for the highest supported dimension DIM3
+            const size_t offsetY = this->offset[1] * this->data.pitch;
+            const size_t sizePlaneXY = this->getPhysicalMemorySize()[1] * this->data.pitch;
+            return (TYPE*) ((char*) data.ptr + this->offset[2] * sizePlaneXY + offsetY) + this->offset[0];
         }
 
         DataSpace<DIM> getOffset() const override


### PR DESCRIPTION
follow up of #4107

```
include/pmacc/../pmacc/memory/buffers/DeviceBufferIntern.hpp(143): warning #940-D: missing return statement at end of non-void function "pmacc::DeviceBufferIntern<TYPE, DIM>::getPointer [with TYPE=picongpu::float3_X, DIM=3U]"
          detected during:
            instantiation of "TYPE *pmacc::DeviceBufferIntern<TYPE, DIM>::getPointer() [with TYPE=picongpu::float3_X, DIM=3U]"
```

The warning is a false warning because in any case there will be a
returned value. This PR rewrites the piece of code so that nvcc understands what's going on.