### PR TITLE
Fix calculation of total current in the SumCurrents plugin for 2d case

### DIFF
--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -106,17 +106,10 @@ namespace picongpu
             // gCurrent is just j
             // j = I/A
 
-            float3_X realCurrent;
-            if constexpr(simDim == DIM3)
-                realCurrent = float3_X(
-                    gCurrent.x() * CELL_HEIGHT * CELL_DEPTH,
-                    gCurrent.y() * CELL_WIDTH * CELL_DEPTH,
-                    gCurrent.z() * CELL_WIDTH * CELL_HEIGHT);
-            if constexpr(simDim == DIM2)
-                realCurrent = float3_X(
-                    gCurrent.x() * CELL_HEIGHT,
-                    gCurrent.y() * CELL_WIDTH,
-                    gCurrent.z() * CELL_WIDTH * CELL_HEIGHT);
+            auto const realCurrent = float3_X(
+                gCurrent.x() * CELL_HEIGHT * CELL_DEPTH,
+                gCurrent.y() * CELL_WIDTH * CELL_DEPTH,
+                gCurrent.z() * CELL_WIDTH * CELL_HEIGHT);
 
             float3_64 realCurrent_SI(
                 float_64(realCurrent.x()) * (UNIT_CHARGE / UNIT_TIME),


### PR DESCRIPTION
The previous implementation relied on `dz == 1` for 2d, which doesn't have to be true. The bug probably existed since forever. The fixed implementation is generic for any parameters. Note that in typical 2d3v fashion, our current density (`FieldJ`) is always in A/m^2, so in previously used formula even units didn't match for `x, y`. The error was noticed during review of #4116

During discussion with @psychocoderHPC we also noticed this plugin has other shortcomings:

- it reduces everything globally in `float_X`, including types of results
- it makes a manual reduction in kernel
- it's written in CUDA-only fashion and thus supported only on GPUs.

 All these can be overcome if the plugin switches to [pmacc device reduction](https://github.com/ComputationalRadiationPhysics/picongpu/blob/ba368ce80b3828ccb6b92f30e701bb601f201a19/include/pmacc/device/Reduce.hpp#L41). That should be relatively straightforward to do in principle. However, we also need to consider if we need this plugin at all.