### PR TITLE
CI: re-enable ISAAC

### DIFF
--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -7,21 +7,20 @@ set -o pipefail
 
 cd $CI_PROJECT_DIR
 
-export GLM_ROOT=/opt/glm/0.9.9.8
-export CMAKE_PREFIX_PATH=$GLM_ROOT/cmake/glm:$CMAKE_PREFIX_PATH
-mkdir -p $GLM_ROOT
-cd $GLM_ROOT
-git clone --branch 0.9.9.8 https://github.com/g-truc/glm.git .
-
-# patch glm to support CUDA compile with clang
-sed -i 's/inline/GLM_FUNC_DECL/g' $GLM_ROOT/glm/gtc/type_ptr.inl
+export GLM_ROOT=/opt/glm/0.9.9.9-dev
+export CMAKE_PREFIX_PATH=$GLM_ROOT:$CMAKE_PREFIX_PATH
+git clone https://github.com/g-truc/glm.git
+cd glm
+git checkout 6ad79aae3eb5bf809c30bf1168171e9e55857e45
+mkdir build
+cd build
+cmake ../ -DCMAKE_INSTALL_PREFIX=$GLM_ROOT -DGLM_TEST_ENABLE=OFF
+make install
 
 cd $CI_PROJECT_DIR
 git clone https://github.com/ComputationalRadiationPhysics/isaac.git
 cd isaac
-# ISAAC version with new LIC kernel https://github.com/ComputationalRadiationPhysics/isaac/pull/143
-# and moving window fix https://github.com/ComputationalRadiationPhysics/isaac/pull/148
-git checkout b8c66ba851e9dfcc48e7bc1ab677828e3adbd22f
+git checkout 195420ca1c43f6148c7f6c3a10ad9cad32e04d6a
 mkdir build_isaac
 cd build_isaac
 cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -28,14 +28,11 @@ fi
 CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON"
 
 # ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
-if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* ]] ; then
+if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* || "$PIC_TEST_CASE_FOLDER" =~ .*WarmCopper.* ]] ; then
     CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
     export CI_CPUS=1
-#elif [ -z "$DISABLE_ISAAC" ] ; then
-#    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
-else
-  # enforce disabling ISACC, there are unsolved CI issues.
-  CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
+elif [ -z "$DISABLE_ISAAC" ] ; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
 fi
 
 # Test is running out of memory, therefore we do not run in parallel.


### PR DESCRIPTION
ISAAC tests was disabled with #4081 because of compatibility issues.
Switch to the latest development version of ISAAC.