### PR TITLE
Improve reporting of wrong MPI/devices configuration

### DIFF
--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -186,6 +186,11 @@ namespace picongpu
             else
                 while(devices.size() < 3)
                     devices.push_back(1);
+            // check for request of > 1 device in z for a 2d simulation, this is probably a user's mistake
+            if((simDim == 2) && (devices[2] > 1))
+                std::cerr
+                    << "Warning: " << devices[2] << " devices requested for z in a 2d simulation, this parameter "
+                    << "will be reset to 1. Number of MPI ranks must be equal to the number of devices in x * y\n";
 
             // check on correct grid size. fill with default grid size value 1 for missing 3. dimension
             if(gridSize.size() < 2 || gridSize.size() > 3)

--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -29,6 +29,7 @@
 #include "pmacc/types.hpp"
 
 #include <map>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -139,7 +140,11 @@ namespace pmacc
 
             if(numberProcesses.productOfComponents() != mpiSize)
             {
-                throw std::invalid_argument("wrong parameters or wrong mpirun-call!");
+                throw std::invalid_argument(
+                    "Wrong configuration of processes or wrong MPI launch call: MPI_COMM_WORLD has "
+                    + std::to_string(mpiSize) + " ranks, but process configuration "
+                    + std::to_string(numberProcesses[0]) + "x" + std::to_string(numberProcesses[1]) + "x"
+                    + std::to_string(numberProcesses[2]) + " was requested");
             }
 
             // 1. create Communicator (computing_comm) of computing nodes (ranks 0...n)


### PR DESCRIPTION
Fixes #4121, the motivation is described here.

For example, now if one asks for 2 MPI ranks and 1x1x2 process configuration in a 2d simulation, first a warning will be printed for a user to check their configuration: `Warning: 2 devices requested for z in a 2d simulation, this parameter will be reset to 1. Number of MPI ranks must be equal to the number of devices in x * y`. Then, since the internally used configuration will be `1x1x1` (we reset z to 1 and that is independent from this PR) the MPI configuration check will fail and throw with `Wrong configuration of processes or wrong MPI launch call: MPI_COMM_WORLD has 2 ranks, but process configuration 1x1x1 was requested`
