### PR TITLE
Cached shapes

### DIFF
--- a/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
+++ b/include/picongpu/algorithms/AssignedTrilinearInterpolation.hpp
@@ -49,26 +49,36 @@ namespace picongpu
 {
     struct AssignedTrilinearInterpolation
     {
-        /** Does a 3D trilinear field-to-point interpolation for
+        /** Does a trilinear field-to-point interpolation for
          * arbitrary assignment function and arbitrary field_value types.
          *
-         * @tparam T_AssignmentFunction function for assignment
          * @tparam T_begin lower margin for interpolation
          * @tparam T_end upper margin for interpolation
+         * @tparam T_AssignmentFunction type of shape functors
          *
          * @param cursor cursor pointing to the field
-         * @param pos position of the interpolation point
+         * @param shapeFunctors Array with d shape functors, where d is the dimensionality of the field represented by
+         *                      cursor. The shape functor must have the interface to call
+         *                      `operator()(relative_grid_point)` and return the assignment value for the given grid
+         *                      point.
          * @return sum over: field_value * assignment
          *
          * interpolate on grid points in range [T_begin;T_end]
+         *
+         * @{
          */
-        template<typename T_AssignmentFunction, int T_begin, int T_end, typename T_Cursor>
-        HDINLINE static auto interpolate(const T_Cursor& cursor, const float3_X& pos) ->
-            typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type
+        template<int T_begin, int T_end, typename T_Cursor, typename T_AssignmentFunction>
+        HDINLINE static auto interpolate(
+            const T_Cursor& cursor,
+            const pmacc::memory::Array<T_AssignmentFunction, 3>& shapeFunctors)
         {
-            using type = typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type;
-
             [[maybe_unused]] constexpr auto iterations = T_end - T_begin + 1;
+
+            using type = decltype(*cursor(0, 0, 0) * shapeFunctors[0](0));
+
+            /* The implementation assumes that x is the fastest moving index to iterate over contiguous memory
+             * e.g. a row, to optimize memory fetch operations.
+             */
             auto result_z = type(0.0);
             PMACC_UNROLL(iterations)
             for(int z = T_begin; z <= T_end; ++z)
@@ -83,33 +93,39 @@ namespace picongpu
                         /* a form factor is the "amount of particle" that is affected by this cell
                          * so we have to sum over: cell_value * form_factor
                          */
-                        result_x += *cursor(x, y, z) * T_AssignmentFunction()(float_X(x) - pos.x());
+                        result_x += *cursor(x, y, z) * shapeFunctors[0](x);
 
-                    result_y += result_x * T_AssignmentFunction()(float_X(y) - pos.y());
+                    result_y += result_x * shapeFunctors[1](y);
                 }
-
-                result_z += result_y * T_AssignmentFunction()(float_X(z) - pos.z());
+                result_z += result_y * shapeFunctors[2](z);
             }
             return result_z;
         }
 
         /** Implementation for 2D position*/
-        template<class T_AssignmentFunction, int T_begin, int T_end, class T_Cursor>
-        HDINLINE static auto interpolate(T_Cursor const& cursor, float2_X const& pos) ->
-            typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type
+        template<int T_begin, int T_end, class T_Cursor, class T_AssignmentFunction>
+        HDINLINE static auto interpolate(
+            T_Cursor const& cursor,
+            const pmacc::memory::Array<T_AssignmentFunction, 2>& shapeFunctors)
         {
-            using type = typename ::pmacc::result_of::Functor<AssignedTrilinearInterpolation, T_Cursor>::type;
+            [[maybe_unused]] constexpr int iterations = T_end - T_begin + 1;
 
-            type result_y = type(0.0);
+            using type = decltype(*cursor(0, 0) * shapeFunctors[0](0));
+            /* The implementation assumes that x is the fastest moving index to iterate over contiguous memory
+             * e.g. a row, to optimize memory fetch operations.
+             */
+            auto result_y = type(0.0);
+            PMACC_UNROLL(iterations)
             for(int y = T_begin; y <= T_end; ++y)
             {
-                type result_x = type(0.0);
+                auto result_x = type(0.0);
+                PMACC_UNROLL(iterations)
                 for(int x = T_begin; x <= T_end; ++x)
                     // a form factor is the "amount of particle" that is affected by this cell
                     // so we have to sum over: cell_value * form_factor
-                    result_x += *cursor(x, y) * T_AssignmentFunction()(float_X(x) - pos.x());
+                    result_x += *cursor(x, y) * shapeFunctors[0](x);
 
-                result_y += result_x * T_AssignmentFunction()(float_X(y) - pos.y());
+                result_y += result_x * shapeFunctors[1](y);
             }
             return result_y;
         }
@@ -120,5 +136,7 @@ namespace picongpu
             return propList;
         }
     };
+
+    //! @}
 
 } // namespace picongpu

--- a/include/picongpu/particles/shapes.hpp
+++ b/include/picongpu/particles/shapes.hpp
@@ -26,4 +26,5 @@
 #include "picongpu/particles/shapes/NGP.hpp"
 #include "picongpu/particles/shapes/PCS.hpp"
 #include "picongpu/particles/shapes/PQS.hpp"
+#include "picongpu/particles/shapes/ShapeSelector.hpp"
 #include "picongpu/particles/shapes/TSC.hpp"

--- a/include/picongpu/particles/shapes/Counter.hpp
+++ b/include/picongpu/particles/shapes/Counter.hpp
@@ -65,7 +65,7 @@ namespace picongpu
 
                 struct ChargeAssignment : public detail::Counter
                 {
-                    HDINLINE float_X operator()(float_X const x)
+                    HDINLINE float_X operator()(float_X const x) const
                     {
                         /*       -
                          *       | -1               if -1<x<=0
@@ -85,7 +85,7 @@ namespace picongpu
                     /** form factor of this particle shape.
                      * @param x has to be within [0, 1)
                      */
-                    HDINLINE float_X operator()(float_X const x)
+                    HDINLINE float_X operator()(float_X const x) const
                     {
                         bool const in_cell = 0.0_X <= x && x < 1.0_X;
 

--- a/include/picongpu/particles/shapes/ShapeSelector.hpp
+++ b/include/picongpu/particles/shapes/ShapeSelector.hpp
@@ -1,0 +1,107 @@
+/* Copyright 2022 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+    namespace shapes
+    {
+        /** Just in time assignment shape evaluation functor.
+         *
+         * @tparam T_ParticleAssignFunctor functor for assignment
+         */
+        template<typename T_ParticleAssignFunctor>
+        struct Jit
+        {
+            /** Create the Jit shape assignment functor.
+             *
+             * @param position position of the particle
+             * @param isInBaseAssignmentCell If the position given is within the assignment cell.
+             *                               True for event particle shape if position is [-0.5;0.5), else false.
+             *                               True for odd particle shape if position is [0.0;1.0), else false,
+             */
+            float_X const particlePosition;
+            HDINLINE Jit(float_X const position, [[maybe_unused]] bool const isInBaseAssignmentCell)
+                : particlePosition(position)
+            {
+            }
+
+            /** Create the Jit shape assignment functor.
+             *
+             * @param position position of the particle
+             */
+            HDINLINE Jit(float_X const position) : particlePosition(position)
+            {
+            }
+
+            /** Assignment value on the position of the grid point.
+             *
+             * @param gridPointOffset grid offset relative to the cell where the particle is located.
+             * @return Assignment value based on the particle shape.
+             */
+            HDINLINE float_X operator()(int const gridPointOffset) const
+            {
+                return T_ParticleAssignFunctor()(float_X(gridPointOffset) - particlePosition);
+            }
+        };
+
+        /** Cached assignment shape functor.
+         *
+         * The result of the assignment shape evaluation will be cached to avoid duplicated calculations.
+         *
+         * @tparam T_ParticleAssignFunctor functor for assignment
+         */
+        template<typename T_ParticleAssignFunctor>
+        struct Cached
+        {
+            /** Create the Cached shape assignment functor.
+             *
+             * @param position Position of the particle.
+             *                 Range of position for even particles shapes [-0.5;1.5).
+             *                 Range of position for odd particles shapes [0.0;2.0).
+             * @param isInBaseAssignmentCell If the position given is within the assignment cell.
+             *                               True for event particle shape if position is [-0.5;0.5), else false.
+             *                               True for odd particle shape if position is [0.0;1.0), else false,
+             */
+            HDINLINE Cached(float_X const position, bool const isInBaseAssignmentCell)
+                : shapeArray(std::move(T_ParticleAssignFunctor().shapeArray(position, !isInBaseAssignmentCell)))
+            {
+            }
+
+            /** Assignment value on the position of the grid point.
+             *
+             * @param gridPointOffset grid offset relative to the cell where the particle is located.
+             * @return Assignment value based on the particle shape.
+             */
+            HDINLINE float_X operator()(int const gridPointOffset) const
+            {
+                return shapeArray[gridPointOffset - T_ParticleAssignFunctor::begin];
+            }
+
+            using ShapeArrayType = decltype(T_ParticleAssignFunctor().shapeArray(
+                alpaka::core::declval<float_X>(),
+                alpaka::core::declval<bool>()));
+            ShapeArrayType shapeArray;
+        };
+
+    } // namespace shapes
+} // namespace picongpu

--- a/include/picongpu/particles/shapes/TSC.hpp
+++ b/include/picongpu/particles/shapes/TSC.hpp
@@ -60,6 +60,28 @@ namespace picongpu
                         float_X const square_tmp = tmp * tmp;
                         return 0.5_X * square_tmp;
                     }
+
+                    /** Creates an array with assignment values assuming that the position of the particle is on
+                     * support.
+                     *
+                     * @tparam T_size Number of elements within the resulting array. Only the first three elements will
+                     * be filled with valid values.
+                     * @param  x particle position relative to the assignment cell range [-0.5;0.5)
+                     * @return array with evaluated shape values
+                     */
+                    template<uint32_t T_size>
+                    HDINLINE auto shapeArray(float_X const x) const
+                    {
+                        static_assert(T_size >= 3);
+                        pmacc::memory::Array<float_X, T_size> shapeValues;
+                        // grid points [-1;1]
+                        shapeValues[0] = ff_2nd_radius(math::abs(-1._X - x));
+                        // note: math::abs(0 - x) == math::abs(x)
+                        shapeValues[1] = ff_1st_radius(math::abs(x));
+                        // equal to ff_2nd_radius(1._X - x); but less compute intensive
+                        shapeValues[2] = 1.0_X - (shapeValues[0] + shapeValues[1]);
+                        return shapeValues;
+                    }
                 };
 
             } // namespace detail
@@ -76,7 +98,12 @@ namespace picongpu
 
                 struct ChargeAssignment : public detail::TSC
                 {
-                    HDINLINE float_X operator()(float_X const x)
+                    // lowest valid grid offsets
+                    static constexpr int begin = -1;
+                    // highest valid grid offsets
+                    static constexpr int end = 2;
+
+                    HDINLINE float_X operator()(float_X const x) const
                     {
                         /*       -
                          *       |  3/4 - x^2                  if |x|<1/2
@@ -100,14 +127,41 @@ namespace picongpu
 
                         return result;
                     }
+
+                    /** Creates an array with assignment values.
+                     *
+                     * @param pos particle position relative to the assignment cell range [-0.5;1.5)
+                     * @param isOutOfRange True if pos in range [-0.5;1.5)
+                     * @return Array with precomputed assignment values.
+                     */
+                    HDINLINE auto shapeArray(float_X const xx, bool const isOutOfRange) const
+                    {
+                        float_X x = isOutOfRange ? xx - 1.0_X : xx;
+
+                        auto shapeValues = detail::TSC::shapeArray<support + 1>(x);
+
+                        // Update value so that a particle can be out of range without using lmem/local memory on GPUs
+                        // because of dynamic indexing into an array located in registers.
+                        shapeValues[3] = isOutOfRange ? shapeValues[2] : 0.0_X;
+                        shapeValues[2] = isOutOfRange ? shapeValues[1] : shapeValues[2];
+                        shapeValues[1] = isOutOfRange ? shapeValues[0] : shapeValues[1];
+                        shapeValues[0] = isOutOfRange ? 0.0_X : shapeValues[0];
+
+                        return shapeValues;
+                    }
                 };
 
                 struct ChargeAssignmentOnSupport : public detail::TSC
                 {
+                    // lowest valid grid offsets
+                    static constexpr int begin = -1;
+                    // highest valid grid offsets
+                    static constexpr int end = 1;
+
                     /** form factor of this particle shape.
                      * @param x has to be within [-support/2, support/2]
                      */
-                    HDINLINE float_X operator()(float_X const x)
+                    HDINLINE float_X operator()(float_X const x) const
                     {
                         /*       -
                          *       |  3/4 - x^2                  if |x|<1/2
@@ -127,6 +181,18 @@ namespace picongpu
                             result = rad1;
 
                         return result;
+                    }
+
+                    /** Creates an array with assignment values.
+                     *
+                     * @param pos particle position relative to the assignment cell range [-0.5;0.5)
+                     * @param isOutOfRange must be false, input will be ignored because the particle shape is always on
+                     *                     support.
+                     * @return Array with precomputed assignment values.
+                     */
+                    HDINLINE auto shapeArray(float_X const x, [[maybe_unused]] bool const isOutOfRange) const
+                    {
+                        return detail::TSC::shapeArray<support>(x);
                     }
                 };
             };


### PR DESCRIPTION
- Implement caching option for each shape which can be used as a particle shape (CIC-PCS)
- Add a wrapper to provide a unified interface to use cached and just in time evaluated shapes.
- Refactor particle assignment algorithm and use assignment shape wrapper.
- Refactor filed interpolation and use shape wrapper.


The new shapes will be used in a separate PR for the current deposition. The wrapper is not increasing the register footprint for the updated algorithms.
The performance will be slightly increased and the number of operations of the interpolation is strongly reduced.