### PR TITLE
update docker container recipe

### DIFF
--- a/share/picongpu/dockerfiles/ubuntu-2004/Dockerfile
+++ b/share/picongpu/dockerfiles/ubuntu-2004/Dockerfile
@@ -1,4 +1,4 @@
-FROM       nvidia/cuda:11.2.0-base-ubuntu20.04
+FROM       nvidia/cuda:11.6.0-base-ubuntu20.04
 MAINTAINER Axel Huebl <a.huebl@hzdr.de>
 LABEL      authors="Axel Huebl, René Widera"
 
@@ -8,7 +8,7 @@ ENV        DEBIAN_FRONTEND=noninteractive \
            SPACK_ROOT=/usr/local \
            SPACK_EXTRA_REPO=/usr/local/share/spack-repo \
            PIC_PACKAGE='picongpu@develop+isaac backend=cuda target=x86_64' \
-           CUDA_PKG_VERSION="11-2"
+           CUDA_PKG_VERSION="11-6"
 
 # install minimal spack dependencies
 #   - adds gfortran for spack's openmpi package

--- a/share/picongpu/dockerfiles/ubuntu-2004/packages.yaml
+++ b/share/picongpu/dockerfiles/ubuntu-2004/packages.yaml
@@ -3,7 +3,7 @@ packages:
     buildable: false
     externals:
       - prefix: /usr/local/cuda
-        spec: cuda@11.2%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64
+        spec: cuda@11.6%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64
   pkg-config:
     buildable: false
     externals:


### PR DESCRIPTION
Use CUDA 11.6 containers to avoid running into the issue that the base
container CUDA keys for apt are wrong because NVIDIA changed these a few weeks ago.

I added the label bug fix because the old recipe is not working because of the key issue.