### PR TITLE
[WIP] NERSC Perlmutter system profile

### DIFF
--- a/etc/picongpu/perlmutter-nersc/gpu.profile
+++ b/etc/picongpu/perlmutter-nersc/gpu.profile
@@ -1,0 +1,136 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Project Information ######################################## (edit this line)
+#   - project account for computing time
+export proj="mXXXX"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="nano"
+
+# General modules #############################################################
+#
+module purge
+module load PrgEnv-gnu/8.3.3
+module load cmake/3.22.0
+module load zlib/1.2.11
+module load cudatoolkit/11.5
+module load craype-accel-nvidia80
+module load cray-hdf5-parallel/1.12.1.1
+
+# Additional libraries
+#
+export PARTITION_LIB=$CFS/$proj/picongpu_libraries
+
+# HDF5
+HDF5_VERSION=1.12.1
+export HDF5_ROOT=$PARTITION_LIB/HDF5/$HDF5_VERSION
+export PATH=$HDF5_ROOT/bin:$PATH
+export CPATH=$HDF5_ROOT/include:$CPATH
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+# BOOST (to include TR1)
+BOOST_VERSION=1.74.0
+export BOOST_ROOT=$PARTITION_LIB/BOOST/$BOOST_VERSION
+export CPATH=$BOOST_ROOT/include:$CPATH
+export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=$BOST_ROOT/lib/cmake:$CMAKE_PREFIX_PATH
+
+# PNGwriter
+PNGWRITER_VERSION=0.7.0
+PNGwriter_ROOT=$PARTITION_LIB/PNGWRITER/$PNGWRITER_VERSION
+export CMAKE_PREFIX_PATH=$PNGWRITER_ROOT:$CMAKE_PREFIX_PATH
+
+# C-BLOSC
+BLOSC_VERSION=1.21.1
+BLOSC_ROOT=$PARTITION_LIB/BLOSC/$BLOSC_VERSION
+export CMAKE_PREFIX_PATH=$BLOSC_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
+
+# ADIOS2 with HDF5 and BLOSC support
+ADIOS2_VERSION=2.7.1.436
+ADIOS2_ROOT=$PARTITION_LIB/ADIOS2/$ADIOS2_VERSION
+export PATH=$ADIOS2_ROOT/bin:$PATH
+export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
+export PYTHONPATH=$ADIOS2_ROOT/lib/python3.9:$PYTHONPATH
+
+# openPMD API with ADIOS2, HDF5 support
+OPENPMD_VERSION=0.14.4
+OPENPMD_ROOT=$PARTITION_LIB/OPENPMD/$OPENPMD_VERSION
+export PATH=$OPENPMD_ROOT/bin:$PATH
+export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
+export PYTHONPATH=$OPENPMD_ROOT/lib64/python3.9:$PYTHONPATH
+
+# Environment #################################################################
+#
+export CC="$(which gcc)"
+export CXX="$(which g++)"
+export CUDACXX=$(which nvcc)
+export CUDAHOSTCXX=$(which g++)
+
+export PICSRC=$HOME/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:80"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "defq" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/perlmutter-nersc/gpu.tpl"
+# allocate an interactive node for one hour to execute a mpi parallel application
+#   getNode 2  # allocates two interactive A100 GPUs (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node 4 --gpus 4 --cpus-per-task=32 -A $proj -C gpu -q shared
+}
+
+# allocate an interactive device for one hour to execute a mpi parallel application
+#   getDevice 2  # allocates two interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        if [ "$1" -gt 8 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
+    fi
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+    salloc --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gpus=$numGPUs --mem=$((230000 / 4) * $numGPUs) -A $proj -C gpu -q shared
+}
+
+# allocate an interactive shell for compilation (without gpus)
+function getShell() {
+    srun --time=1:00:00 --nodes=1 --ntasks 1 --cpus-per-task=32 -A $proj -C gpu -q shared --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi

--- a/etc/picongpu/perlmutter-nersc/gpu.tpl
+++ b/etc/picongpu/perlmutter-nersc/gpu.tpl
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Copyright 2021 Axel Huebl
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for Perlmutter's SLURM batch system
+
+#SBATCH -p !TBG_queue
+#SBATCH --constraint=gpu
+#SBATCH --gpus=!TBG_tasks
+#SBATCH --time=!TBG_wallTime
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem=!TBG_memPerNode
+#SBATCH --chdir=!TBG_dstPath
+
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --account=!TBG_nameProject
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="gpu"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}"_g"
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+
+# number of cores to block per A100 - per node, we got 1 Epyc CPU with
+# 64 cores a 2 threads per core. We utilise only physical cores
+.TBG_coresPerGPU=32
+
+.TBG_totalHostMemory=230000
+# host memory per gpu
+.TBG_memPerGPU="$(( $TBG_totalHostMemory / $TBG_numHostedGPUPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+# note: no need to source profile as environment is cloned from submit environment
+# source !TBG_profile
+echo "profile cloned at submit time: !TBG_profile"
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+  # Run CUDA memtest to check GPU's health
+  srun !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+fi
+
+export OMP_NUM_THREADS=!TBG_coresPerGPU
+
+# In accordance with the example at
+# https://docs.nersc.gov/systems/perlmutter/running-jobs/#4-nodes-16-tasks-16-gpus-1-gpu-visible-to-each-task
+
+export SLURM_CPU_BIND="cores"
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun --cpu_bind=cores                 \
+       !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+fi


### PR DESCRIPTION
Introduces a profile and batch script template for the Perlmutter system at NERSC.

**CAVEATS**:
At the moment the compilation of the dependencies (Boost, HDF5, ADIOS2, openPMD, PNGwriter) and PIC requires the following variables to be defined for CMake:
`MPI_CXX_COMPILER, MPI_C_COMPILER, MPI_CXX_HEADER_DIR, MPI_C_HEADER_DIR, MPI_mpi_gnu_91_LIBRARY` as:

`MPI_CXX_COMPILER=/opt/cray/pe/craype/2.7.15/bin/CC`
`MPI_C_COMPILER=/opt/cray/pe/craype/2.7.15/bin/cc`
`MPI_CXX_HEADER_DIR=/opt/cray/pe/mpich/8.1.15/ofi/gnu/9.1/include`
`MPI_C_HEADER_DIR=/opt/cray/pe/mpich/8.1.15/ofi/gnu/9.1/include`
`MPI_mpi_gnu_91_LIBRARY=/opt/cray/pe/mpich/8.1.15/ofi/gnu/9.1/lib/libmpi_gnu_91.so`

alternatively `MPI_CXX_COMPILER=$(which CC)` and `MPI_C_COMPILER=$(which cc)`.

And specifically for PIC: `ALPAKA_CXX_STANDARD=17` otherwise, using the Cray compiler, the compilation will fail due to an incompatibility with openPMD.