### PR TITLE
Fix incorrect doxygen includes in readthedocs

### DIFF
--- a/docs/source/dev/pmacc.rst
+++ b/docs/source/dev/pmacc.rst
@@ -38,7 +38,7 @@ DataSpace
 Vector
 ------
 
-.. doxygenclass:: pmacc::math::Vector
+.. doxygenstruct:: pmacc::math::Vector
    :project: PIConGPU
    :members:
    :protected-members:
@@ -91,7 +91,7 @@ ParticleDescription
 ParticleBox
 -----------
 
-.. doxygenstruct:: pmacc::ParticlesBox
+.. doxygenclass:: pmacc::ParticlesBox
    :project: PIConGPU
    :members:
    :protected-members:
@@ -136,7 +136,7 @@ SimulationHelper
 ForEach
 -------
 
-.. doxygenstruct:: meta::ForEach
+.. doxygenstruct:: pmacc::meta::ForEach
    :project: PIConGPU
    :members:
    :protected-members:

--- a/docs/source/prgpatterns/lockstep.rst
+++ b/docs/source/prgpatterns/lockstep.rst
@@ -45,7 +45,7 @@ pmacc helpers
 .. doxygenstruct:: pmacc::lockstep::Variable
    :project: PIConGPU
 
-.. doxygenstruct:: pmacc::lockstep::ForEach
+.. doxygenclass:: pmacc::lockstep::ForEach
    :project: PIConGPU
 
 Common Patterns

--- a/docs/source/usage/param/particles/current.rst
+++ b/docs/source/usage/param/particles/current.rst
@@ -25,7 +25,7 @@ EmZ
 EZ (alias for EmZ)
 ~~~~~~~~~~~~~~~~~~
 
-.. doxygenstruct:: picongpu::currentSolver::EZ
+.. doxygentypedef:: picongpu::currentSolver::EZ
    :project: PIConGPU
 
 VillaBune


### PR DESCRIPTION
It caused a warning being displayed instead of those contents.