### PR TITLE
update crusher ORNL profiles

### DIFF
--- a/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
@@ -37,26 +37,28 @@ export PROJID=<yourProject>
 # There are a lot of required modules already loaded when connecting
 # such as mpi, libfabric and others.
 # The following modules just add to these.
-module load PrgEnv-cray/8.2.0 # Compiling with cray compiler wrapper CC
 
+# Compiling with cray compiler wrapper CC
+module load PrgEnv-cray/8.3.3
 module load craype-accel-amd-gfx90a
-module load rocm/4.5.2
+module load rocm/5.1.0
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-module load cray-mpich/8.1.12
+module load cray-mpich/8.1.16
+PE_MPICH_GTL_DIR_amd_gfx90a="-L${CRAY_MPICH_ROOTDIR}/gtl/lib"
+PE_MPICH_GTL_LIBS_amd_gfx90a="-lmpi_gtl_hsa"
+export CXXFLAGS="$CXXFLAGS -I${ROCM_PATH}/include"
+export LDFLAGS="$LDFLAGS -L${ROCM_PATH}/lib -lamdhip64"
 
-module load cmake/3.21.3
-module load zlib/1.2.11
-
-module load boost/1.77.0-cxx17
-
-module load git/2.31.1
+module load cmake/3.22.2
+module load boost/1.78.0-cxx17
 
 # Other Software ##############################################################
 #
-module load c-blosc/1.21.0 adios2/2.7.1 hdf5/1.12.0
-export CMAKE_PREFIX_PATH="$OLCF_C_BLOSC_ROOT:$OLCF_ADIOS2_ROOT:$HDF5_ROOT:$CMAKE_PREFIX_PATH"
-
+module load zlib/1.2.11
+module load git/2.35.1
+module load c-blosc/1.21.1 adios2/2.7.1 hdf5/1.12.0 openpmd-api/0.14.4
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OLCF_HDF5_ROOT/lib
 module load libpng/1.6.37 freetype/2.11.0
 
 # Self-Build Software #########################################################
@@ -64,13 +66,6 @@ module load libpng/1.6.37 freetype/2.11.0
 #
 # needs to be compiled by the user
 export PIC_LIBS=$HOME/lib/crusher
-
-# (not really) optionally install openPMD-api yourself
-# required when using picongpu > 0.6.0
-#   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#openpmd-api
-export OPENPMD_API_ROOT=$PIC_LIBS/openPMD-api
-export CMAKE_PREFIX_PATH="$OPENPMD_API_ROOT:$CMAKE_PREFIX_PATH"
-export LD_LIBRARY_PATH="$OPENPMD_API_ROOT/lib64:$LD_LIBRARY_PATH"
 
 # optionally install pngwriter yourself:
 #   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#pngwriter
@@ -131,4 +126,3 @@ if [ -f $BASH_COMP_FILE ] ; then
 else
     echo "bash completion file '$BASH_COMP_FILE' not found." >&2
 fi
-

--- a/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
@@ -34,33 +34,30 @@ export PROJID=<yourProject>
 # There are a lot of required modules already loaded when connecting
 # such as mpi, libfabric and others.
 # The following modules just add to these.
-module load PrgEnv-cray/8.2.0 # Compiling with cray compiler wrapper CC
 
+# Compiling with cray compiler wrapper CC
+module load PrgEnv-cray/8.3.3
 module load craype-accel-amd-gfx90a
-module load rocm/4.5.2
+module load rocm/5.1.0
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-module load cray-mpich/8.1.12
+module load cray-mpich/8.1.16
 
-module load cmake/3.21.3
-module load zlib/1.2.11
-
-module load boost/1.77.0-cxx17
-
-module load git/2.31.1
+module load cmake/3.22.2
+module load boost/1.78.0-cxx17
 
 ## set environment variables required for compiling and linking w/ hipcc
 ##   see (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#compiling-with-hipcc)
 export CXX=hipcc
-export HIPCC_COMPILE_FLAGS_APPEND="$HIPCC_COMPILE_FLAGS_APPEND -I${MPICH_DIR}/include"
-export HIPCC_LINK_FLAGS_APPEND="$HIPCC_LINK_FLAGS_APPEND -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa"
-export HIPFLAGS="--amdgpu-target=gfx90a $HIPFLAGS"
+export CXXFLAGS="$CXXFLAGS -I${MPICH_DIR}/include"
+export LDFLAGS="$LDFLAGS -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa"
 
 # Other Software ##############################################################
 #
-module load c-blosc/1.21.0 adios2/2.7.1 hdf5/1.12.0
-export CMAKE_PREFIX_PATH="$OLCF_C_BLOSC_ROOT:$OLCF_ADIOS2_ROOT:$HDF5_ROOT:$CMAKE_PREFIX_PATH"
-
+module load zlib/1.2.11
+module load git/2.35.1
+module load c-blosc/1.21.1 adios2/2.7.1 hdf5/1.12.0 openpmd-api/0.14.4
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OLCF_HDF5_ROOT/lib
 module load libpng/1.6.37 freetype/2.11.0
 
 # Self-Build Software #########################################################
@@ -68,13 +65,6 @@ module load libpng/1.6.37 freetype/2.11.0
 #
 # needs to be compiled by the user
 export PIC_LIBS=$HOME/lib/crusher
-
-# (not really) optionally install openPMD-api yourself
-# required when using picongpu > 0.6.0
-#   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#openpmd-api
-export OPENPMD_API_ROOT=$PIC_LIBS/openPMD-api
-export CMAKE_PREFIX_PATH="$OPENPMD_API_ROOT:$CMAKE_PREFIX_PATH"
-export LD_LIBRARY_PATH="$OPENPMD_API_ROOT/lib64:$LD_LIBRARY_PATH"
 
 # optionally install pngwriter yourself:
 #   https://picongpu.readthedocs.io/en/0.6.0/install/dependencies.html#pngwriter
@@ -135,4 +125,3 @@ if [ -f $BASH_COMP_FILE ] ; then
 else
     echo "bash completion file '$BASH_COMP_FILE' not found." >&2
 fi
-


### PR DESCRIPTION
- switch to rocm/5.1.0
- use the latest openPMD


Currently, I observe issues with the CRAYCC profile. I get runtime issues 
```
:0:rocdevice.cpp            :2614: 1094391689242 us: 124747: [tid:0x7fb14447b700] Device::callbackQueue aborting with error : HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION: The agent attempted to access memory beyond the largest legal address. code: 0x29
:0:rocdevice.cpp            :2614: 1094391689306 us: 124746: [tid:0x7fce53e05700] Device::callbackQueue aborting with error : HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION: The agent attempted to access memory beyond the largest legal address. code: 0x29
```

A support ticket is already opened.