### PR TITLE
CMake request boost 1.74.0+

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -184,7 +184,7 @@ endif()
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.66.0 REQUIRED COMPONENTS program_options filesystem
+find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options filesystem
                                               system math_tr1 serialization)
 if(TARGET Boost::program_options)
     set(HOST_LIBS ${HOST_LIBS} Boost::boost Boost::program_options

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -328,7 +328,7 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.66 REQUIRED COMPONENTS filesystem system math_tr1)
+find_package(Boost 1.74 REQUIRED COMPONENTS filesystem system math_tr1)
 if(TARGET Boost::filesystem)
     set(PMacc_LIBRARIES ${PMacc_LIBRARIES} Boost::boost Boost::filesystem
                                            Boost::system Boost::math_tr1)

--- a/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
@@ -104,7 +104,7 @@ endif(GOL_RELEASE)
 # Find Boost
 ###############################################################################
 
-find_package(Boost 1.66.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
cupla/alpaka requires at least boost 1.74.0.
This change was missing in #4104

Thx @steindev for spotting the issue.