### PR TITLE
Do not forceinline recursive functions

### DIFF
--- a/include/pmacc/mappings/kernel/StrideIntervalMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideIntervalMapping.hpp
@@ -126,9 +126,11 @@ namespace pmacc
 
         /** Set mapper to next non-empty subinterval
          *
+         * Note: this function has no HINLINE as it is recursive and so cannot be force-inlined.
+         *
          * @return whether the whole interval was processed
          */
-        HINLINE bool next()
+        bool next()
         {
             int linearOffset = DataSpaceOperations<dim>::map(DataSpace<dim>::create(stride), offset);
             linearOffset++;

--- a/include/pmacc/mappings/kernel/StrideMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapping.hpp
@@ -109,9 +109,11 @@ namespace pmacc
 
         /** Set mapper to next non-empty subarea
          *
+         * Note: this function has no HINLINE as it is recursive and so cannot be force-inlined.
+         *
          * @return whether the whole area was processed
          */
-        HINLINE bool next()
+        bool next()
         {
             int linearOffset = DataSpaceOperations<Dim>::map(DataSpace<DIM>::create(stride), offset);
             linearOffset++;


### PR DESCRIPTION
Fixes #4145

Note: the function is still technically inline, but now as a recommendation and not as a forceinline.