### PR TITLE
Add missing year 2022 in a few copyright headers

### DIFF
--- a/include/picongpu/particles/particleToGrid/CombinedDerive.def
+++ b/include/picongpu/particles/particleToGrid/CombinedDerive.def
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/CombinedDerive.hpp
+++ b/include/picongpu/particles/particleToGrid/CombinedDerive.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/CombinedDerivedAttribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.def
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/CombinedAttributes.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.def
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/MPIHelpers.cpp
+++ b/include/picongpu/plugins/common/MPIHelpers.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/common/MPIHelpers.hpp
+++ b/include/picongpu/plugins/common/MPIHelpers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/plugins/openPMD/toml.hpp
+++ b/include/picongpu/plugins/openPMD/toml.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Franz Poeschel
+/* Copyright 2021-2022 Franz Poeschel
  *
  * This file is part of PIConGPU.
  *


### PR DESCRIPTION
Those were missed as they were not part of the main repo when the general update happened in #3953.