### PR TITLE
Bugfix JUWELS Booster profile

### DIFF
--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -69,6 +69,7 @@ export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
 export PATH=$ADIOS2_ROOT/bin:$PATH
 export PATH=$OPENPMD_ROOT/bin:$PATH
 
+export PYTHONPATH=$ADIOS2_ROOT/lib/python3.9/site-packages/adios2:$PYTHONPATH
 export PYTHONPATH=$OPENPMD_ROOT/lib64/python3.9/site-packages/openpmd_api:$PYTHONPATH
 # Environment #################################################################
 #

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -33,12 +33,14 @@ fi
 # General modules #############################################################
 #
 module purge
+module load Stages/2022
 module load GCC/11.2.0
 module load CUDA/11.5
 module load CMake/3.21.1
 module load ParaStationMPI/5.5.0-1
 module load mpi-settings/CUDA
 module load Python/3.9.6
+module load libpng/.1.6.37
 
 module load HDF5/1.12.1
 module load Boost/1.78.0
@@ -54,10 +56,10 @@ module load h5py
 # https://gist.github.com/steindev/5a2ab0c4957a1e57ed671ac198b491c6
 #
 export PIC_LIBS=$PROJECT/lib
-export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.0
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.1
 export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0
-export ADIOS2_ROOT=$PIC_LIBS/adios2-2.7.1
-export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.13.3
+export ADIOS2_ROOT=$PIC_LIBS/adios2-2.7.1.436
+export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.14.4
 
 export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$PNGwriter_DIR/lib:$LD_LIBRARY_PATH
@@ -65,7 +67,9 @@ export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
 
 export PATH=$ADIOS2_ROOT/bin:$PATH
+export PATH=$OPENPMD_ROOT/bin:$PATH
 
+export PYTHONPATH=$OPENPMD_ROOT/lib64/python3.9/site-packages/openpmd_api:$PYTHONPATH
 # Environment #################################################################
 #
 


### PR DESCRIPTION
In my last update of the JUWELS Booster profile I neglected to update the versions of the dependencies (via path names).

Additionally added the default `Stages/2022` module for completenes' sake, as well as the _hidden_ `libpng/.1.6.37` that is not loaded by default but required for PNG writer.

**ToDo**

- [X] Update link to the installation script for the dependencies.