### PR TITLE
fix missing mallocMC includes if HIP is used

### DIFF
--- a/include/picongpu/versionFormat.cpp
+++ b/include/picongpu/versionFormat.cpp
@@ -28,6 +28,11 @@
 
 #ifdef __CUDACC_VER_MAJOR__
 #    include <cuda.h>
+#endif
+#ifdef HIP_VERSION_MAJOR
+#    include <hip/hip_runtime.h>
+#endif
+#if(defined(__CUDACC_VER_MAJOR__) || defined(HIP_VERSION_MAJOR))
 #    include <mallocMC/mallocMC.hpp>
 #endif
 #include <mpi.h>


### PR DESCRIPTION
fix #4152, follow up of https://github.com/ComputationalRadiationPhysics/picongpu/pull/4139

- include malloMC headers if HIP is used