### PR TITLE
Check that averagized derived attributes are weighted

### DIFF
--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
@@ -1,4 +1,4 @@
-/* Copyright 2021-2022 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -61,6 +61,7 @@ namespace picongpu
                 /** Average (per particle) value of a derived attribute
                  *
                  * @tparam T_DerivedAttribute derived attribute class that should be averaged
+                 *                            must have trait derivedAttributes::IsWeighted specialized as true
                  */
                 template<typename T_DerivedAttribute>
                 using AverageAttribute = CombinedDeriveAttribute<

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021-2022 Pawel Ordyna
+/* Copyright 2021-2022 Pawel Ordyna, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -22,10 +22,13 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
 
 #include <limits>
 #include <string>
 #include <vector>
+
+
 namespace picongpu
 {
     namespace particles
@@ -56,6 +59,11 @@ namespace picongpu
                 template<typename T_DerivedAttribute>
                 struct AverageAttributeDescription
                 {
+                    // Check prerequisite on the input type
+                    PMACC_CASSERT_MSG(
+                        _error_average_attribute_only_supports_weighted_derived_attributes_check_trait_IsWeighted,
+                        derivedAttributes::IsWeighted<T_DerivedAttribute>::value);
+
                     HDINLINE float1_64 getUnit() const
                     {
                         // Average quantity has the same unit as the total quantity

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
@@ -22,6 +22,9 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -51,6 +54,12 @@ namespace picongpu
 
                     return boundElectronDensity;
                 }
+
+                //! Bound electron density is weighted
+                template<>
+                struct IsWeighted<BoundElectronDensity> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.hpp
@@ -22,6 +22,9 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -51,6 +54,12 @@ namespace picongpu
                     /* return attribute */
                     return particleChargeDensity;
                 }
+
+                //! Charge density is weighted
+                template<>
+                struct IsWeighted<ChargeDensity> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp
@@ -22,6 +22,9 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/particleToGrid/derivedAttributes/Counter.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -49,6 +52,12 @@ namespace picongpu
                     /* return attribute */
                     return particleCounter;
                 }
+
+                //! Counter is weighted (as it is a count of real particles)
+                template<>
+                struct IsWeighted<Counter> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Density.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Density.hpp
@@ -22,6 +22,9 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/particleToGrid/derivedAttributes/ChargeDensity.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -51,6 +54,12 @@ namespace picongpu
                     /* return attribute */
                     return particleDensity;
                 }
+
+                //! Density is weighted
+                template<>
+                struct IsWeighted<Density> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.hpp
@@ -23,6 +23,9 @@
 
 #include "picongpu/algorithms/KinEnergy.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensity.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -51,6 +54,12 @@ namespace picongpu
 
                     return KinEnergy<>()(mom, mass) * INV_CELL_VOLUME;
                 }
+
+                //! Energy density is weighted
+                template<>
+                struct IsWeighted<EnergyDensity> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.hpp
@@ -23,6 +23,10 @@
 
 #include "picongpu/algorithms/KinEnergy.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/EnergyDensityCutoff.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+
+#include <type_traits>
+
 
 namespace picongpu
 {
@@ -57,6 +61,15 @@ namespace picongpu
 
                     return result;
                 }
+
+                /** Energy density cutoff is weighted
+                 *
+                 * @tparam T_ParamClass parameter class containing the maximum energy cutoff
+                 */
+                template<typename T_ParamClass>
+                struct IsWeighted<EnergyDensityCutoff<T_ParamClass>> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Axel Huebl, Rene Widera
+/* Copyright 2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -19,12 +19,6 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
-
-#include "picongpu/algorithms/KinEnergy.hpp"
-#include "picongpu/particles/particleToGrid/derivedAttributes/Energy.def"
-#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
-
 #include <type_traits>
 
 
@@ -36,25 +30,19 @@ namespace picongpu
         {
             namespace derivedAttributes
             {
-                HDINLINE float1_64 Energy::getUnit() const
-                {
-                    return UNIT_ENERGY;
-                }
-
-                template<class T_Particle>
-                DINLINE float_X Energy::operator()(T_Particle& particle) const
-                {
-                    /* read existing attributes */
-                    const float_X weighting = particle[weighting_];
-                    const float3_X mom = particle[momentum_];
-                    const float_X mass = attribute::getMass(weighting, particle);
-
-                    return KinEnergy<>()(mom, mass);
-                }
-
-                //! Energy is weighted
-                template<>
-                struct IsWeighted<Energy> : std::true_type
+                /** Derive attribute trait whether its value is scaled to macroparticle weight
+                 *
+                 * Note that it describes how the derived attribute itself is calculated, not the eventual field.
+                 * Logically it roughly corresponds to openPMD macroWeighted = true and weightingPower = 1.0
+                 * @see traits::MacroWeighted @see traits::WeightingPower.
+                 * However, as derived attributes are a separate quantity from species we have a separate trait.
+                 *
+                 * Inherits std::true_type, std::false_type or a compatible type.
+                 *
+                 * @tparam T_DerivedAttribute derived attribute type
+                 */
+                template<typename T_DerivedAttribute>
+                struct IsWeighted : public std::false_type
                 {
                 };
             } // namespace derivedAttributes

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -21,9 +21,12 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def"
 
 #include <pmacc/static_assert.hpp>
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -74,6 +77,12 @@ namespace picongpu
                     /* return attribute */
                     return larmorPower;
                 }
+
+                //! Larmor power is weighted
+                template<>
+                struct IsWeighted<LarmorPower> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.hpp
@@ -21,7 +21,10 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -43,6 +46,12 @@ namespace picongpu
                     /* return attribute */
                     return 1.0;
                 }
+
+                //! Macroparticle counter is not weighted
+                template<>
+                struct IsWeighted<MacroCounter> : std::false_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp
@@ -21,7 +21,10 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -61,6 +64,15 @@ namespace picongpu
                     /* return attribute */
                     return particleCurrentDensity;
                 }
+
+                /** Mid current density component is weighted
+                 *
+                 * @param T_direction perpendicular direction x=0, y=1, z=2
+                 */
+                template<size_t T_direction>
+                struct IsWeighted<MidCurrentDensityComponent<T_direction>> : std::true_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp
@@ -21,7 +21,10 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def"
+
+#include <type_traits>
 
 
 namespace picongpu
@@ -56,6 +59,15 @@ namespace picongpu
                     // return attribute
                     return momComOverTotal;
                 }
+
+                /** Momentum component is not weighted as it is a ratio of two weighted quantities
+                 *
+                 * @param T_direction perpendicular direction x=0, y=1, z=2
+                 */
+                template<size_t T_direction>
+                struct IsWeighted<MomentumComponent<T_direction>> : std::false_type
+                {
+                };
             } // namespace derivedAttributes
         } // namespace particleToGrid
     } // namespace particles


### PR DESCRIPTION
The logic of averagizing implementation relied on that, but it was not checked or documented. This PR adds a new trait for weighted attributes, specializes it for all existing attributes, and adds a check and documentation to `AverageAttribute`. With the trait, a user could also specialize it for their custom attributes if they need averagation for them. Having the trait `std::true_type` by default would have saved a few lines of code in this PR, but then averaziging would be on for user-provided attributes automatically, and this is unsafe (wrt getting weird or unexpected results).

Fixes https://github.com/ComputationalRadiationPhysics/picongpu/issues/4143.