### PR TITLE
Unify default openPMD file extension in plugins

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/PhaseSpace/AxisDescription.hpp"
 #include "picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp"
+#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 
 #include <pmacc/communication/manager_common.hpp>
 #include <pmacc/cuSTL/algorithm/kernel/Foreach.hpp>
@@ -92,29 +93,11 @@ namespace picongpu
             plugins::multi::Option<float_X> momentum_range_min = {"min", "min range momentum [m_species c]"};
             plugins::multi::Option<float_X> momentum_range_max = {"max", "max range momentum [m_species c]"};
 
-            /*
-             * Set to h5 for now at least, to make for easier comparison of
-             * output with old outpu
-             */
             plugins::multi::Option<std::string> file_name_extension
-                = { "ext",
-                    "openPMD filename extension (this controls the"
-                    "backend picked by the openPMD API)",
-#if openPMD_HAVE_HDF5
-                    "h5"
-#elif openPMD_HAVE_ADIOS2
-                    "bp"
-#else
-                    /*
-                     * This branch should never be activated because CMake will
-                     * not enable the openPMD plugin in that case anyway.
-                     */
-                    static_assert(
-                        false,
-                        "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
-                        "openPMD plugin.")
-#endif
-                  };
+                = {"ext",
+                   "openPMD filename extension (this controls the"
+                   "backend picked by the openPMD API)",
+                   openPMD::getDefaultExtension().c_str()};
 
             plugins::multi::Option<std::string> json_config
                 = {"json", "advanced (backend) configuration for openPMD in JSON format", "{}"};

--- a/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
+++ b/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
@@ -1,0 +1,51 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <openPMD/openPMD.hpp>
+
+namespace picongpu
+{
+    namespace openPMD
+    {
+        /** Get default extension for openPMD files
+         *
+         * Make a uniform choice when several valid backends are available.
+         * Check that at least one valid backend is available.
+         *
+         * This function can only be compiled when openPMD is enabled.
+         */
+        inline std::string getDefaultExtension()
+        {
+#if openPMD_HAVE_ADIOS2
+            return "bp";
+#elif openPMD_HAVE_HDF5
+            return "h5";
+#else
+            // Neither ADIOS2 nor HDF5 is not allowed when openPMD is enabled (we can only be here in this case)
+            static_assert(
+                false,
+                "Error: openPMD API dependency is enabled but has neither ADIOS2 nor HDF5 backend available.");
+#endif
+        }
+    } // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -31,6 +31,7 @@
 #include "picongpu/particles/particleToGrid/CombinedDerive.def"
 #include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 #include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/openPMDWriteMeta.hpp"
 #include "picongpu/plugins/misc/ComponentNames.hpp"
@@ -214,24 +215,10 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             plugins::multi::Option<std::string> fileName = {"file", "openPMD file basename"};
 
             plugins::multi::Option<std::string> fileNameExtension
-                = { "ext",
-                    "openPMD filename extension (this controls the"
-                    "backend picked by the openPMD API)",
-#if openPMD_HAVE_ADIOS2
-                    "bp"
-#elif openPMD_HAVE_HDF5
-                    "h5"
-#else
-                    /*
-                     * This branch should never be activated because CMake will
-                     * not enable the openPMD plugin in that case anyway.
-                     */
-                    static_assert(
-                        false,
-                        "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
-                        "openPMD plugin.")
-#endif
-                  };
+                = {"ext",
+                   "openPMD filename extension (this controls the"
+                   "backend picked by the openPMD API)",
+                   openPMD::getDefaultExtension().c_str()};
 
             plugins::multi::Option<std::string> fileNameInfix
                 = {"infix",

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/particles/boundary/Utility.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/common/openPMDAttributes.hpp"
+#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 #include "picongpu/plugins/common/openPMDWriteMeta.hpp"
 #include "picongpu/plugins/misc/misc.hpp"
 #include "picongpu/plugins/multi/multi.hpp"
@@ -430,23 +431,7 @@ namespace picongpu
             plugins::multi::Option<std::string> fileName = {"file", "output filename (prefix)"};
             plugins::multi::Option<std::string> filter = {"filter", "particle filter: "};
             plugins::multi::Option<std::string> extension
-                = { "ext",
-                    "openPMD filename extension",
-#if openPMD_HAVE_HDF5
-                    "h5"
-#elif openPMD_HAVE_ADIOS2
-                    "bp"
-#else
-                    /*
-                     * This branch should never be activated because CMake will
-                     * not enable the openPMD plugin in that case anyway.
-                     */
-                    static_assert(
-                        false,
-                        "openPMD-api has neither ADIOS2 or HDF5 backend available. Use CMake to deactivate the "
-                        "openPMD plugin.")
-#endif
-                  };
+                = {"ext", "openPMD filename extension", openPMD::getDefaultExtension().c_str()};
             plugins::multi::Option<uint32_t> numBinsYaw = {"numBinsYaw", "number of bins for angle yaw.", 64};
             plugins::multi::Option<uint32_t> numBinsPitch = {"numBinsPitch", "number of bins for angle pitch.", 64};
             plugins::multi::Option<uint32_t> numBinsEnergy


### PR DESCRIPTION
It affects which of ADIOS2 and HDF5 is choosen by default when both are available. We were not consistent there before, so with both backends on by default PIConGPU would write files in different formats, which may be confusing. Now I switch all to ADIOS2 when both available, like the openPMD and checkpoints plugin were already doing, but not calorimeter and phase space.

Fixes https://github.com/ComputationalRadiationPhysics/picongpu/issues/4148.