### PR TITLE
Fix outdated clang-format version in code formatting docs

### DIFF
--- a/docs/COMMIT.md
+++ b/docs/COMMIT.md
@@ -11,7 +11,7 @@ We agree on the following simple rules to make our lives easier :)
 Format Code
 -----------
 
-- Install *ClangFormat 11*
+- Install *ClangFormat 12* from LLVM 12.0.1
 - To format all files in your working copy, you can run this command in bash from the root folder of PIConGPU:
   ```bash
   find include/ share/picongpu/ share/pmacc -iname "*.def" \


### PR DESCRIPTION
@BrianMarre thanks for pointing out, I believe this is [what you meant](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3464#issuecomment-1157550861)? (I also edited the head message in that issue)