### PR TITLE
Add derived particle attributes for component of momentum and related density

### DIFF
--- a/include/picongpu/param/fileOutput.param
+++ b/include/picongpu/param/fileOutput.param
@@ -51,6 +51,7 @@ namespace picongpu
      *                    particle density
      *       note: this is the same as the sum of kinetic particle energy
      *             divided by a constant for the cell volume
+     *   - Momentum: sum of chosen component of momentum per cell with respect to shape
      *   - MomentumComponent: ratio between a selected momentum component and
      *                        the absolute momentum with respect to shape
      *   - LarmorPower: radiated Larmor power

--- a/include/picongpu/param/fileOutput.param
+++ b/include/picongpu/param/fileOutput.param
@@ -52,6 +52,9 @@ namespace picongpu
      *       note: this is the same as the sum of kinetic particle energy
      *             divided by a constant for the cell volume
      *   - Momentum: sum of chosen component of momentum per cell with respect to shape
+     *   - MomentumDensity: average chosen component of momentum per cell times the particle density
+     *       note: this is the same as the sum of the chosen momentum component
+     *             divided by a constant for the cell volume
      *   - MomentumComponent: ratio between a selected momentum component and
      *                        the absolute momentum with respect to shape
      *   - LarmorPower: radiated Larmor power

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -31,3 +31,4 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/Momentum.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def
@@ -29,4 +29,5 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def"
+#include "picongpu/particles/particleToGrid/derivedAttributes/Momentum.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.def"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -31,3 +31,4 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/Momentum.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.hpp"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.hpp
@@ -29,4 +29,5 @@
 #include "picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MacroCounter.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/Momentum.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/MomentumComponent.hpp"

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.def
@@ -1,0 +1,116 @@
+/* Copyright 2016-2022 Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+
+#include <pmacc/static_assert.hpp>
+#include <pmacc/traits/HasIdentifiers.hpp>
+
+#include <cstdint>
+#include <vector>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace derivedAttributes
+            {
+                /** Chosen component of momentum for particle to grid projections
+                 *
+                 * Derives a scalar field for summed chosen component of particle momentum from a particle
+                 * species at runtime.
+                 * Each value is mapped per cell according to the species' spatial shape.
+                 *
+                 * @param T_direction direction defining the component x=0, y=1, z=2
+                 */
+                template<size_t T_direction>
+                struct Momentum
+                {
+                    PMACC_CASSERT_MSG(
+                        _error_valid_Momentum_directions_are_0_to_2_for_X_to_Z__in_fileOutput_param,
+                        (T_direction >= 0) && (T_direction < 3));
+
+                    //! Get unit
+                    HDINLINE float1_64 getUnit() const;
+
+                    //! Get unit dimension
+                    HINLINE std::vector<float_64> getUnitDimension() const
+                    {
+                        /* L, M, T, I, theta, N, J
+                         *
+                         * momentum is in mass times speed: kg * m / s
+                         *   -> L * M * T^-1
+                         */
+                        std::vector<float_64> unitDimension(7, 0.0);
+                        unitDimension.at(SIBaseUnits::length) = 1.0;
+                        unitDimension.at(SIBaseUnits::mass) = 1.0;
+                        unitDimension.at(SIBaseUnits::time) = -1.0;
+                        return unitDimension;
+                    }
+
+                    //! Get text name
+                    HINLINE static std::string getName()
+                    {
+                        return "particleMomentum";
+                    }
+
+                    /** Calculate value of the derived attribute per particle
+                     *
+                     * Returns an on-the-fly calculated value of a derived particle attribute for the given particle.
+                     * The result can then be mapped to the cells the particle contributes to according to the
+                     * assignment function.
+                     *
+                     * @tparam T_Particle particle type
+                     * @param particle particle handle
+                     *
+                     * @return values of the derived attribute
+                     */
+                    template<typename T_Particle>
+                    DINLINE float_X operator()(T_Particle& particle) const;
+                };
+            } // namespace derivedAttributes
+        } // namespace particleToGrid
+
+        namespace traits
+        {
+            /** Compatibility trait for species and momentum derived attribute
+             *
+             * @tparam T_Species species type
+             * @tparam T_direction direction defining momentum component x=0, y=1, z=2
+             */
+            template<typename T_Species, size_t T_direction>
+            struct SpeciesEligibleForSolver<T_Species, particleToGrid::derivedAttributes::Momentum<T_direction>>
+            {
+                using FrameType = typename T_Species::FrameType;
+
+                using RequiredIdentifiers = MakeSeq_t<position<>, momentum>;
+
+                using type = typename pmacc::traits::HasIdentifiers<FrameType, RequiredIdentifiers>::type;
+            };
+        } // namespace traits
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.hpp
@@ -1,0 +1,60 @@
+/* Copyright 2016-2022 Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/Momentum.def"
+
+#include <type_traits>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace derivedAttributes
+            {
+                template<size_t T_direction>
+                HDINLINE float1_64 Momentum<T_direction>::getUnit() const
+                {
+                    return UNIT_MASS * UNIT_SPEED;
+                }
+
+                template<size_t T_direction>
+                template<typename T_Particle>
+                DINLINE float_X Momentum<T_direction>::operator()(T_Particle& particle) const
+                {
+                    return particle[momentum_][T_direction];
+                }
+
+                //! Component of momentum is weighted
+                template<size_t T_direction>
+                struct IsWeighted<Momentum<T_direction>> : std::true_type
+                {
+                };
+
+            } // namespace derivedAttributes
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def
@@ -1,0 +1,116 @@
+/* Copyright 2016-2022 Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
+
+#include <pmacc/static_assert.hpp>
+#include <pmacc/traits/HasIdentifiers.hpp>
+
+#include <cstdint>
+#include <vector>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace derivedAttributes
+            {
+                /** Density of chosen component of momentum for particle to grid projections
+                 *
+                 * Derives a scalar field for average value of chosen component of momentum in a cell times the
+                 * particle density from a particle species at runtime.
+                 * Each value is mapped per cell according to the species' spatial shape.
+                 *
+                 * @param T_direction direction defining the component x=0, y=1, z=2
+                 */
+                template<size_t T_direction>
+                struct MomentumDensity
+                {
+                    PMACC_CASSERT_MSG(
+                        _error_valid_MomentumDensity_directions_are_0_to_2_for_X_to_Z__in_fileOutput_param,
+                        (T_direction >= 0) && (T_direction < 3));
+
+                    //! Get unit
+                    HDINLINE float1_64 getUnit() const;
+
+                    //! Get unit dimension
+                    HINLINE std::vector<float_64> getUnitDimension() const
+                    {
+                        /* L, M, T, I, theta, N, J
+                         *
+                         * momentum density is in mass times speed per cubic meter: kg * m / s / m^3 = kg / (s * m^2)
+                         *   -> L^-2 * M * T^-1
+                         */
+                        std::vector<float_64> unitDimension(7, 0.0);
+                        unitDimension.at(SIBaseUnits::length) = -2.0;
+                        unitDimension.at(SIBaseUnits::mass) = 1.0;
+                        unitDimension.at(SIBaseUnits::time) = -1.0;
+                        return unitDimension;
+                    }
+
+                    //! Get text name
+                    HINLINE static std::string getName()
+                    {
+                        return "particleMomentumDensity";
+                    }
+
+                    /** Calculate value of the derived attribute per particle
+                     *
+                     * Returns an on-the-fly calculated value of a derived particle attribute for the given particle.
+                     * The result can then be mapped to the cells the particle contributes to according to the
+                     * assignment function.
+                     *
+                     * @tparam T_Particle particle type
+                     * @param particle particle handle
+                     *
+                     * @return values of the derived attribute
+                     */
+                    template<typename T_Particle>
+                    DINLINE float_X operator()(T_Particle& particle) const;
+                };
+            } // namespace derivedAttributes
+        } // namespace particleToGrid
+
+        namespace traits
+        {
+            /** Compatibility trait for species and momentum density derived attribute
+             *
+             * @tparam T_Species species type
+             * @tparam T_direction direction defining momentum component x=0, y=1, z=2
+             */
+            template<typename T_Species, size_t T_direction>
+            struct SpeciesEligibleForSolver<T_Species, particleToGrid::derivedAttributes::MomentumDensity<T_direction>>
+            {
+                using FrameType = typename T_Species::FrameType;
+
+                using RequiredIdentifiers = MakeSeq_t<position<>, momentum>;
+
+                using type = typename pmacc::traits::HasIdentifiers<FrameType, RequiredIdentifiers>::type;
+            };
+        } // namespace traits
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.hpp
@@ -1,0 +1,62 @@
+/* Copyright 2016-2022 Axel Huebl, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/particleToGrid/derivedAttributes/IsWeighted.hpp"
+#include "picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def"
+
+#include <type_traits>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace particleToGrid
+        {
+            namespace derivedAttributes
+            {
+                template<size_t T_direction>
+                HDINLINE float1_64 MomentumDensity<T_direction>::getUnit() const
+                {
+                    constexpr float_64 UNIT_VOLUME = (UNIT_LENGTH * UNIT_LENGTH * UNIT_LENGTH);
+                    return UNIT_MASS * UNIT_SPEED / UNIT_VOLUME;
+                }
+
+                template<size_t T_direction>
+                template<typename T_Particle>
+                DINLINE float_X MomentumDensity<T_direction>::operator()(T_Particle& particle) const
+                {
+                    constexpr float_X INV_CELL_VOLUME = float_X(1.0) / CELL_VOLUME;
+                    return particle[momentum_][T_direction] * INV_CELL_VOLUME;
+                }
+
+                //! Density of component of momentum is weighted
+                template<size_t T_direction>
+                struct IsWeighted<MomentumDensity<T_direction>> : std::true_type
+                {
+                };
+
+            } // namespace derivedAttributes
+        } // namespace particleToGrid
+    } // namespace particles
+} // namespace picongpu


### PR DESCRIPTION
These will allow calculating and outputting integral values of a chosen momentum component as a scalar field. E.g. `deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::Momentum<1>>` will give gridded average value of $p_y$ of macroparticles taking into account their shapes.

Note that `MomentumComponent` seems to not give that. Admittedly, the naming now is confusing. After figuring out #4142 we should improve upon it.