### PR TITLE
Add incident field normalization option to PNG output 

### DIFF
--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -108,7 +108,9 @@ Since an adequate color scaling is essential, there several option the user can 
    // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
    // regime causes a bubble with radius of approx. the laser's
    // beam waist (use for bubble fields)
-   // 6: Custom:  user-provided normalization factors via customNormalizationSI
+   // 6: Custom: user-provided normalization factors via customNormalizationSI
+   // 7: Incident: typical fields calculated out of the incident field amplitude,
+   // uses max amplitude from all enabled incident field profile types ignoring Free
    #define EM_FIELD_SCALE_CHANNEL1 -1
    #define EM_FIELD_SCALE_CHANNEL2 -1
    #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -21,7 +21,11 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
 #include <cstdint>
+#include <type_traits>
+
 
 namespace picongpu
 {
@@ -113,6 +117,14 @@ namespace picongpu
              */
             template<typename T_Profile>
             constexpr float_X amplitude = GetAmplitude<T_Profile>::value;
+
+            //! Typelist of all enabled profiles, can contain duplicates
+            using EnabledProfiles = pmacc::MakeSeq_t<
+                XMin,
+                XMax,
+                YMin,
+                YMax,
+                std::conditional_t<simDim == 3, pmacc::MakeSeq_t<ZMin, ZMax>, pmacc::MakeSeq_t<>>>;
 
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -72,6 +72,48 @@ namespace picongpu
                 /** @} */
 
             } // namespace detail
+
+            /** Get max E field amplitude for the given profile type
+             *
+             * The resulting value is set as ::value, in internal units.
+             * This trait has to be specialized by all profiles.
+             *
+             * @tparam T_Profile profile type
+             *
+             * @{
+             */
+
+            //! Generic implementation for all profiles with parameter structs
+            template<typename T_Profile>
+            struct GetAmplitude
+            {
+                using FunctorE = detail::FunctorIncidentE<T_Profile>;
+                static constexpr float_X value = FunctorE::Unitless::AMPLITUDE;
+            };
+
+            //! Specialization for None profile which has no amplitude
+            template<>
+            struct GetAmplitude<profiles::None>
+            {
+                static constexpr float_X value = 0.0_X;
+            };
+
+            //! Specialization for Free profile which has unknown amplitude
+            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+            struct GetAmplitude<profiles::Free<T_FunctorIncidentE, T_FunctorIncidentB>>
+            {
+                static constexpr float_X value = 0.0_X;
+            };
+
+            /** @} */
+
+            /** Max E field amplitude in internal units for the given profile type
+             *
+             * @tparam T_Profile profile type
+             */
+            template<typename T_Profile>
+            constexpr float_X amplitude = GetAmplitude<T_Profile>::value;
+
         } // namespace incidentField
     } // namespace fields
 } // namespace picongpu

--- a/include/picongpu/param/png.param
+++ b/include/picongpu/param/png.param
@@ -37,16 +37,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 -1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/share/picongpu/benchmarks/Thermal/include/picongpu/param/png.param
+++ b/share/picongpu/benchmarks/Thermal/include/picongpu/param/png.param
@@ -36,16 +36,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 -1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/share/picongpu/examples/Bunch/include/picongpu/param/png.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/png.param
@@ -36,16 +36,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 1
 #define EM_FIELD_SCALE_CHANNEL2 1
 #define EM_FIELD_SCALE_CHANNEL3 1

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/png.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/png.param
@@ -37,16 +37,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 -1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/png.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/png.param
@@ -36,16 +36,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 -1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/png.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/png.param
@@ -36,16 +36,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/png.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/png.param
@@ -36,16 +36,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 -1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/png.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/png.param
@@ -36,16 +36,18 @@ namespace picongpu
     namespace visPreview
     {
         // normalize EM fields to typical laser or plasma quantities
-        //-1: Auto:    enable adaptive scaling for each output
-        // 1: Laser:   typical fields calculated out of the laser amplitude
-        // 2: Drift:   [outdated]
-        // 3: PlWave:  typical fields calculated out of the plasma freq.,
-        //             assuming the wave moves approx. with c
-        // 4: Thermal: [outdated]
-        // 5: BlowOut: typical fields, assuming that a LWFA in the blowout
-        //             regime causes a bubble with radius of approx. the laser's
-        //             beam waist (use for bubble fields)
-        // 6: Custom:  user-provided normalization factors via customNormalizationSI
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    typical fields calculated out of the laser amplitude
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  typical fields, assuming that a LWFA in the blowout
+        //              regime causes a bubble with radius of approx. the laser's
+        //              beam waist (use for bubble fields)
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
 #define EM_FIELD_SCALE_CHANNEL1 -1
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1


### PR DESCRIPTION
For that also add some incident field traits that may be helpful elsewhere as well. Update docs and `png.param` in all examples.

Solves https://github.com/ComputationalRadiationPhysics/picongpu/issues/4158.