### PR TITLE
add device side `ForEachParticle`

### DIFF
--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -32,6 +32,7 @@
 #include <pmacc/mappings/threads/ThreadCollective.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/CachedBox.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/particles/frame_types.hpp>
 #include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
 #include <pmacc/types.hpp>
@@ -77,63 +78,22 @@ namespace picongpu
                 FrameSolver frameSolver,
                 Mapping mapper) const
             {
-                using FrameType = typename ParBox::FrameType;
-                using FramePtr = typename ParBox::FramePtr;
                 using SuperCellSize = typename Mapping::SuperCellSize;
 
-                /** @todo numParticlesPerFrame should be max number of particles within a frame
-                 * and not a magic number derived from SuperCellSize
-                 */
-                constexpr uint32_t numParticlesPerFrame = pmacc::math::CT::volume<SuperCellSize>::type::value;
                 constexpr uint32_t numWorkers = T_numWorkers;
 
-                /* We work with virtual CUDA blocks if we have more workers than particles.
-                 * Each virtual CUDA block is working on a frame, if we have 2 blocks each block processes
-                 * every second frame until all frames are processed.
-                 */
-                constexpr uint32_t numVirtualBlocks = (numWorkers + numParticlesPerFrame - 1u) / numParticlesPerFrame;
-
-
-                const DataSpace<simDim> block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+                const DataSpace<simDim> superCellIdx(
+                    mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
                 uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-                auto forEachParticleInFrame
-                    = lockstep::makeForEach<numParticlesPerFrame * numVirtualBlocks, numWorkers>(workerIdx);
+                auto forEachParticle
+                    = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, boxPar, superCellIdx);
 
-                /* each virtual worker is part of one virtual block */
-                auto virtualBlockIdCtx = forEachParticleInFrame(
-                    [&](uint32_t const linearIdx) -> uint32_t { return linearIdx / numParticlesPerFrame; });
+                // end kernel if we have no particles
+                if(!forEachParticle.hasParticles())
+                    return;
 
-                /* linear virtual worker index in the virtual block*/
-                auto virtualLinearIdCtx = forEachParticleInFrame(
-                    [&](lockstep::Idx const idx) -> uint32_t
-                    {
-                        /* map virtualLinearIdCtx to the range [0;numParticlesPerFrame) */
-                        return idx - (virtualBlockIdCtx[idx] * numParticlesPerFrame);
-                    });
-
-                /* each virtual worker stores the currently used frame */
-                // auto frameCtx = lockstep::makeVar<FramePtr>(forEachParticleInFrame);
-
-                auto particlesInSuperCellCtx = lockstep::makeVar<lcellId_t>(forEachParticleInFrame, lcellId_t(0u));
-                /* each virtual worker stores the currently used frame */
-                auto frameCtx = forEachParticleInFrame(
-                    [&](lockstep::Idx const idx)
-                    {
-                        auto frame = boxPar.getLastFrame(block);
-                        if(frame.isValid() && virtualBlockIdCtx[idx] == 0u)
-                            particlesInSuperCellCtx[idx] = boxPar.getSuperCell(block).getSizeLastFrame();
-
-                        /* select N-th (N=virtualBlockId) frame from the end of the list */
-                        for(uint32_t i = 1; i <= virtualBlockIdCtx[idx] && frame.isValid(); ++i)
-                        {
-                            particlesInSuperCellCtx[idx] = numParticlesPerFrame;
-                            frame = boxPar.getPreviousFrame(frame);
-                        }
-                        return frame;
-                    });
-
-                DataSpace<simDim> const blockCell = block * SuperCellSize::toRT();
+                DataSpace<simDim> const blockCell = superCellIdx * SuperCellSize::toRT();
                 using Strategy = currentSolver::traits::GetStrategy_t<FrameSolver>;
 
                 /* this memory is used by all virtual blocks */
@@ -144,40 +104,10 @@ namespace picongpu
 
                 cupla::__syncthreads(acc);
 
-                while(true)
-                {
-                    bool isOneFrameValid = false;
-                    forEachParticleInFrame([&](lockstep::Idx const idx)
-                                           { isOneFrameValid = isOneFrameValid || frameCtx[idx].isValid(); });
-
-                    if(!isOneFrameValid)
-                        break;
-
-                    forEachParticleInFrame(
-                        [&](lockstep::Idx const idx)
-                        {
-                            /* this test is only important for the last frame
-                             * if the frame is not the last one then: `particlesInSuperCell == numParticlesPerFrame`
-                             */
-                            if(frameCtx[idx].isValid() && virtualLinearIdCtx[idx] < particlesInSuperCellCtx[idx])
-                            {
-                                frameSolver(acc, *frameCtx[idx], virtualLinearIdCtx[idx], cachedJ);
-                            }
-                        });
-
-                    forEachParticleInFrame(
-                        [&](lockstep::Idx const idx)
-                        {
-                            if(frameCtx[idx].isValid())
-                            {
-                                particlesInSuperCellCtx[idx] = numParticlesPerFrame;
-                                for(uint32_t i = 0; i < numVirtualBlocks && frameCtx[idx].isValid(); ++i)
-                                {
-                                    frameCtx[idx] = boxPar.getPreviousFrame(frameCtx[idx]);
-                                }
-                            }
-                        });
-                }
+                forEachParticle(
+                    acc,
+                    [&cachedJ, &frameSolver](auto const& accelerator, auto& particle)
+                    { frameSolver(accelerator, particle, cachedJ); });
 
                 /* we wait that all workers finish the loop */
                 cupla::__syncthreads(acc);
@@ -200,10 +130,9 @@ namespace picongpu
             {
             }
 
-            template<typename FrameType, typename BoxJ, typename T_Acc>
-            DINLINE void operator()(T_Acc const& acc, FrameType& frame, const int localIdx, BoxJ& jBox)
+            template<typename T_Particle, typename BoxJ, typename T_Acc>
+            DINLINE void operator()(T_Acc const& acc, T_Particle& particle, BoxJ& jBox)
             {
-                auto particle = frame[localIdx];
                 const float_X weighting = particle[weighting_];
                 const floatD_X pos = particle[position_];
                 const int particleCellIdx = particle[localCellIdx_];

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -30,6 +30,7 @@
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/CachedBox.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/particles/frame_types.hpp>
 #include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
 
@@ -82,22 +83,25 @@ namespace picongpu
             using FramePtr = typename T_ParBox::FramePtr;
             using SuperCellSize = typename T_BlockDescription::SuperCellSize;
 
-            constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
 
             uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-            DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
-            auto accFilter
-                = particleFilter(acc, block - mapper.getGuardingSuperCells(), lockstep::Worker<numWorkers>{workerIdx});
-            FramePtr frame;
-            lcellId_t particlesInSuperCell;
+            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            auto accFilter = particleFilter(
+                acc,
+                superCellIdx - mapper.getGuardingSuperCells(),
+                lockstep::Worker<numWorkers>{workerIdx});
 
-            frame = boxPar.getLastFrame(block);
-            particlesInSuperCell = boxPar.getSuperCell(block).getSizeLastFrame();
+            namespace particleAccAlgos = pmacc::particles::algorithm::acc;
+            auto forEachParticle = particleAccAlgos::makeForEach<numWorkers, particleAccAlgos::Forward>(
+                workerIdx,
+                boxPar,
+                superCellIdx);
 
-            if(!frame.isValid())
-                return; // end kernel if we have no frames
+            // end kernel if we have no particles
+            if(!forEachParticle.hasParticles())
+                return;
 
             auto cachedVal = CachedBox::create<0, typename T_TmpBox::ValueType>(acc, T_BlockDescription{});
             Set<typename T_TmpBox::ValueType> set(float_X(0.0));
@@ -107,26 +111,16 @@ namespace picongpu
 
             cupla::__syncthreads(acc);
 
-            while(frame.isValid())
-            {
-                lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)(
-                    [&](uint32_t const linearIdx)
-                    {
-                        if(linearIdx < particlesInSuperCell)
-                        {
-                            frameSolver(acc, *frame, linearIdx, SuperCellSize::toRT(), accFilter, cachedVal);
-                        }
-                    });
-
-                frame = boxPar.getPreviousFrame(frame);
-                particlesInSuperCell = cellsPerSuperCell;
-            }
+            forEachParticle(
+                acc,
+                [&accFilter, &cachedVal, &frameSolver](auto const& accelerator, auto& particle)
+                { frameSolver(accelerator, particle, SuperCellSize::toRT(), accFilter, cachedVal); });
 
             cupla::__syncthreads(acc);
 
             pmacc::math::operation::Add add;
-            DataSpace<simDim> const blockCell = block * SuperCellSize::toRT();
-            auto fieldTmpBlock = fieldTmp.shift(blockCell);
+            DataSpace<simDim> const superCellCellOffset = superCellIdx * SuperCellSize::toRT();
+            auto fieldTmpBlock = fieldTmp.shift(superCellCellOffset);
             collective(acc, add, fieldTmpBlock, cachedVal);
         }
     };

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -36,6 +36,7 @@
 #include <pmacc/memory/boxes/CachedBox.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/particles/frame_types.hpp>
 #include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
 #include <pmacc/particles/memory/boxes/TileDataBox.hpp>
@@ -207,17 +208,13 @@ namespace picongpu
             T_ParticleFunctor particleFunctor,
             T_Mapping mapper) const
         {
-            constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
             constexpr uint32_t numWorkers = T_numWorkers;
-
             uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
-            using FramePtr = typename T_ParBox::FramePtr;
-
-            DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
 
             // relative offset (in cells) to the supercell (including the guard)
-            DataSpace<simDim> const superCellOffset = block * SuperCellSize::toRT();
+            DataSpace<simDim> const superCellOffset = superCellIdx * SuperCellSize::toRT();
 
             /* worker status flag to mark that a particle is leaving the supercell
              * 1 if at least one particle is leaving the supercell else 0
@@ -228,24 +225,20 @@ namespace picongpu
              */
             PMACC_SMEM(acc, mustShiftSupercell, int);
 
-            // current processed frame
-            FramePtr frame;
-            lcellId_t particlesInSuperCell;
-
             auto onlyMaster = lockstep::makeMaster(workerIdx);
 
             onlyMaster([&]() { mustShiftSupercell = 0; });
-
-            frame = pb.getLastFrame(block);
-            particlesInSuperCell = pb.getSuperCell(block).getSizeLastFrame();
 
             auto cachedB = CachedBox::create<0, typename T_BBox::ValueType>(acc, T_DataDomain());
             auto cachedE = CachedBox::create<1, typename T_EBox::ValueType>(acc, T_DataDomain());
 
             cupla::__syncthreads(acc);
 
-            // end kernel if we have no frames
-            if(!frame.isValid())
+            auto forEachParticle
+                = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, pb, superCellIdx);
+
+            // end kernel if we have no particles
+            if(!forEachParticle.hasParticles())
                 return;
 
             pmacc::math::operation::Assign assign;
@@ -259,22 +252,14 @@ namespace picongpu
 
             cupla::__syncthreads(acc);
 
-            // move over frames and call frame solver
-            while(frame.isValid())
-            {
-                // loop over all particles in the frame
-                lockstep::makeForEach<frameSize, numWorkers>(workerIdx)(
-                    [&](uint32_t const linearIdx)
-                    {
-                        if(linearIdx < particlesInSuperCell)
-                        {
-                            particleFunctor(acc, *frame, linearIdx, cachedB, cachedE, currentStep, hasLeavingParticle);
-                        }
-                    });
-                // independent for each worker
-                frame = pb.getPreviousFrame(frame);
-                particlesInSuperCell = frameSize;
-            }
+            forEachParticle(
+                acc,
+                [&cachedB, &cachedE, currentStep, &hasLeavingParticle, &particleFunctor](
+                    auto const& accelerator,
+                    auto& particle)
+                { particleFunctor(accelerator, particle, cachedB, cachedE, currentStep, hasLeavingParticle); });
+
+            cupla::__syncthreads(acc);
 
             // update shared memory marker that particles leaving the supercell
             if(hasLeavingParticle == 1 && mustShiftSupercell == 0)
@@ -302,23 +287,20 @@ namespace picongpu
     template<class PushAlgo, class TVec, class T_Field2ParticleInterpolation>
     struct PushParticlePerFrame
     {
-        template<class FrameType, class BoxB, class BoxE, typename T_Acc>
+        template<typename T_Acc, typename T_Particle, class BoxB, class BoxE>
         DINLINE void operator()(
             T_Acc const& acc,
-            FrameType& frame,
-            int localIdx,
+            T_Particle& particle,
             BoxB& bBox,
             BoxE& eBox,
             uint32_t const currentStep,
-            int& hasLeavingParticle)
+            int& hasLeavingParticle) const
         {
             using Block = TVec;
             using Field2ParticleInterpolation = T_Field2ParticleInterpolation;
 
             using BType = typename BoxB::ValueType;
             using EType = typename BoxE::ValueType;
-
-            auto particle = frame[localIdx];
 
             floatD_X pos = particle[position_];
             const int particleCellIdx = particle[localCellIdx_];

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -24,6 +24,7 @@
 #include "picongpu/traits/frame/GetMass.hpp"
 
 #include <pmacc/lockstep.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
 
 #include <cstdint>
 
@@ -108,7 +109,6 @@ namespace picongpu
                     pmacc::DataSpace<simDim> const supercellIdx,
                     T_EstimateBox estimateBox) const
                 {
-                    constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
                     constexpr uint32_t numWorkers = T_numWorkers;
                     /* Estimate variance in momentum of macroparticles in the supercell.
                      * Each thread processes its particles, then the master thread performs reduction.
@@ -118,28 +118,24 @@ namespace picongpu
                     auto sumWeighting = float_64{0.0};
                     auto sumMomentum = float3_64::create(0.0);
                     auto sumMomentumSquared = float3_64::create(0.0);
-                    auto frame = electronBox.getLastFrame(supercellIdx);
-                    auto particlesInFrame = electronBox.getSuperCell(supercellIdx).getSizeLastFrame();
+
                     uint32_t const workerIdx = cupla::threadIdx(acc).x;
-                    while(frame.isValid())
-                    {
-                        lockstep::makeForEach<frameSize, numWorkers>(workerIdx)(
-                            [&](uint32_t const linearIdx)
-                            {
-                                if(linearIdx < particlesInFrame)
-                                {
-                                    auto const particle = frame[linearIdx];
-                                    auto const weighting = float_64{particle[weighting_]};
-                                    sumWeighting += weighting;
-                                    auto const singleParticleMomentum
-                                        = precisionCast<float_64>(particle[momentum_]) / weighting;
-                                    sumMomentum += weighting * singleParticleMomentum;
-                                    sumMomentumSquared += weighting * singleParticleMomentum * singleParticleMomentum;
-                                }
-                            });
-                        frame = electronBox.getPreviousFrame(frame);
-                        particlesInFrame = frameSize;
-                    }
+                    auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
+                        workerIdx,
+                        electronBox,
+                        supercellIdx);
+
+                    forEachParticle(
+                        acc,
+                        [&sumWeighting, &sumMomentum, &sumMomentumSquared](auto const& /*accelerator*/, auto& particle)
+                        {
+                            auto const weighting = float_64{particle[weighting_]};
+                            sumWeighting += weighting;
+                            auto const singleParticleMomentum
+                                = precisionCast<float_64>(particle[momentum_]) / weighting;
+                            sumMomentum += weighting * singleParticleMomentum;
+                            sumMomentumSquared += weighting * singleParticleMomentum * singleParticleMomentum;
+                        });
 
                     // Reduce for supercell in shared memory
                     PMACC_SMEM(acc, supercellSumWeighting, float_64);

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -28,6 +28,7 @@
 #include <pmacc/memory/Array.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
 
 
 namespace picongpu
@@ -84,11 +85,6 @@ namespace picongpu
                         constexpr uint32_t numWorkers = T_numWorkers;
 
                         using SuperCellSize = typename MappingDesc::SuperCellSize;
-                        using FramePtr = typename T_ParBox::FramePtr;
-                        constexpr uint32_t maxParticlesPerFrame = pmacc::math::CT::volume<SuperCellSize>::type::value;
-
-                        PMACC_SMEM(acc, frame, FramePtr);
-                        PMACC_SMEM(acc, particlesInSuperCell, lcellId_t);
 
                         // our workers per block are started 1D
                         uint32_t const workerIdx = cupla::threadIdx(acc).x;
@@ -96,6 +92,7 @@ namespace picongpu
                         // supercell index of current (frame-wise) supercell including GUARD
                         DataSpace<simDim> const superCellIdx(
                             mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+
                         /* index inside local energy histogram in averaged space (has no GUARD)
                          * integer division: we average over multiples of supercells;
                          *                   this index selects the according local energy
@@ -112,15 +109,6 @@ namespace picongpu
                         // shared memory for local energy histogram
                         PMACC_SMEM(acc, shLocalEnergyHistogram, memory::Array<float_X, numBins>);
 
-                        auto onlyMaster = lockstep::makeMaster(workerIdx);
-
-                        // get frame lists of this supercell
-                        onlyMaster(
-                            [&]()
-                            {
-                                frame = pb.getLastFrame(superCellIdx);
-                                particlesInSuperCell = pb.getSuperCell(superCellIdx).getSizeLastFrame();
-                            });
 
                         // empty the histogram to contain only zeroes
                         lockstep::makeForEach<numWorkers, numWorkers>(workerIdx)(
@@ -133,67 +121,53 @@ namespace picongpu
 
                         cupla::__syncthreads(acc);
 
-                        // return if the supercell has no particles
-                        if(!frame.isValid())
+                        auto forEachParticle
+                            = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, pb, superCellIdx);
+
+                        // end kernel if we have no particles
+                        if(!forEachParticle.hasParticles())
                             return;
 
-                        // iterate the frame list
-                        while(frame.isValid())
-                        {
-                            // move over all particles in a frame
-                            lockstep::makeForEach<maxParticlesPerFrame, numWorkers>(workerIdx)(
-                                [&](uint32_t const linearIdx)
+                        forEachParticle(
+                            acc,
+                            [minEnergy, maxEnergy, numBins, &shLocalEnergyHistogram](
+                                auto const& accelerator,
+                                auto& particle)
+                            {
+                                /* kinetic Energy for Particles: E^2 = p^2*c^2 + m^2*c^4
+                                 *                                   = c^2 * [p^2 + m^2*c^2]
+                                 */
+                                float3_X const mom = particle[momentum_];
+                                float_X const weighting = particle[weighting_];
+                                float_X const mass = attribute::getMass(weighting, particle);
+
+                                // calculate kinetic energy of the macro particle
+                                float_X particleEnergy = KinEnergy<>()(mom, mass);
+
+                                particleEnergy /= weighting;
+
+                                // calculate bin number
+                                int binNumber = math::floor(
+                                    (particleEnergy - minEnergy) / (maxEnergy - minEnergy)
+                                    * static_cast<float_X>(numBins));
+
+                                /* all entries larger than maxEnergy or smaller
+                                 * than minEnergy are ignored
+                                 */
+                                if(binNumber >= 0 and binNumber < numBins)
                                 {
-                                    if(linearIdx < particlesInSuperCell)
-                                    {
-                                        auto const particle = frame[linearIdx];
-                                        /* kinetic Energy for Particles: E^2 = p^2*c^2 + m^2*c^4
-                                         *                                   = c^2 * [p^2 + m^2*c^2]
-                                         */
-                                        float3_X const mom = particle[momentum_];
+                                    // artifical norm for reduce
+                                    float_X const normedWeighting
+                                        = weighting / float_X(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
 
-                                        float_X const weighting = particle[weighting_];
-                                        float_X const mass = attribute::getMass(weighting, particle);
-
-                                        // calculate kinetic energy of the macro particle
-                                        float_X particleEnergy = KinEnergy<>()(mom, mass);
-
-                                        particleEnergy /= weighting;
-
-                                        // calculate bin number
-                                        int binNumber = math::floor(
-                                            (particleEnergy - minEnergy) / (maxEnergy - minEnergy)
-                                            * static_cast<float_X>(numBins));
-
-                                        /* all entries larger than maxEnergy or smaller
-                                         * than minEnergy are ignored
-                                         */
-                                        if(binNumber >= 0 and binNumber < numBins)
-                                        {
-                                            // artifical norm for reduce
-                                            float_X const normedWeighting = weighting
-                                                / float_X(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
-
-                                            cupla::atomicAdd(
-                                                acc,
-                                                &(shLocalEnergyHistogram[binNumber]),
-                                                normedWeighting,
-                                                ::alpaka::hierarchy::Threads{});
-                                        }
-                                    }
-                                });
-
-                            cupla::__syncthreads(acc);
-
-                            // go to next frame
-                            onlyMaster(
-                                [&]()
-                                {
-                                    frame = pb.getPreviousFrame(frame);
-                                    particlesInSuperCell = maxParticlesPerFrame;
-                                });
-                            cupla::__syncthreads(acc);
-                        }
+                                    cupla::atomicAdd(
+                                        accelerator,
+                                        &(shLocalEnergyHistogram[binNumber]),
+                                        normedWeighting,
+                                        ::alpaka::hierarchy::Threads{});
+                                }
+                            });
+                        cupla::__syncthreads(acc);
 
                         // write histogram back to global memory (add)
                         lockstep::makeForEach<numWorkers, numWorkers>(workerIdx)(

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -88,15 +88,14 @@ namespace picongpu
                 HINLINE static std::string getName();
 
                 template<
-                    typename FrameType,
+                    typename T_Particle,
                     typename TVecSuperCell,
                     typename BoxTmp,
                     typename T_Acc,
                     typename T_AccFilter>
                 DINLINE void operator()(
                     T_Acc const& acc,
-                    FrameType& frame,
-                    const int localIdx,
+                    T_Particle& particle,
                     const TVecSuperCell superCell,
                     T_AccFilter& accFilter,
                     BoxTmp& tmpBox);

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -57,11 +57,15 @@ namespace picongpu
             }
 
             template<class T_ParticleShape, class T_DerivedAttribute>
-            template<class FrameType, class TVecSuperCell, class BoxTmp, typename T_Acc, typename T_AccFilter>
+            template<
+                typename T_Particle,
+                typename TVecSuperCell,
+                typename BoxTmp,
+                typename T_Acc,
+                typename T_AccFilter>
             DINLINE void ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::operator()(
                 T_Acc const& acc,
-                FrameType& frame,
-                const int localIdx,
+                T_Particle& particle,
                 const TVecSuperCell superCell,
                 T_AccFilter& accFilter,
                 BoxTmp& tmpBox)
@@ -69,7 +73,6 @@ namespace picongpu
                 /* \todo in the future and if useful, the functor can be a parameter */
                 T_DerivedAttribute particleAttribute;
 
-                auto particle = frame[localIdx];
                 // Only particles passing the filter contribute
                 if(accFilter(acc, particle))
                 {

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -22,6 +22,7 @@
 #include <pmacc/lockstep.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
 
 namespace picongpu
 {
@@ -64,61 +65,41 @@ namespace picongpu
             T_Filter filter) const
         {
             constexpr uint32_t numWorkers = T_numWorkers;
-            constexpr lcellId_t maxParticlesInFrame = pmacc::math::CT::volume<SuperCellSize>::type::value;
-
             uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-            DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
 
-            using ParticlesFramePtr = typename T_ParticlesBox::FramePtr;
+            auto forEachParticle
+                = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, particlesBox, superCellIdx);
 
-            ParticlesFramePtr particlesFrame;
-
-            particlesFrame = particlesBox.getLastFrame(block);
-
-            // end kernel if we have no frames within the supercell
-            if(!particlesFrame.isValid())
+            // end kernel if we have no particles
+            if(!forEachParticle.hasParticles())
                 return;
 
             auto accFilter
-                = filter(acc, block - mapper.getGuardingSuperCells(), lockstep::Worker<numWorkers>{workerIdx});
-            auto const blockStartCellLocal = (block - mapper.getGuardingSuperCells()) * SuperCellSize::toRT();
+                = filter(acc, superCellIdx - mapper.getGuardingSuperCells(), lockstep::Worker<numWorkers>{workerIdx});
+            auto const superCellCellOffsetNoGuard
+                = (superCellIdx - mapper.getGuardingSuperCells()) * SuperCellSize::toRT();
 
-            // number of particles in the current frame
-            auto numParticles = particlesBox.getSuperCell(block).getSizeLastFrame();
-
-            while(particlesFrame.isValid())
-            {
-                auto forEachParticleInSuperCell = lockstep::makeForEach<maxParticlesInFrame, numWorkers>(workerIdx);
-
-                // loop over all particles in the frame
-                forEachParticleInSuperCell(
-                    [&](uint32_t const linearIdx)
+            forEachParticle(
+                acc,
+                [&accFilter, &superCellCellOffsetNoGuard, &beginCellIdxLocal, &endCellIdxLocal, &calorimeterFunctor](
+                    auto const& accelerator,
+                    auto& particle)
+                {
+                    if(accFilter(accelerator, particle))
                     {
-                        auto particle = particlesFrame[linearIdx];
-                        if(linearIdx >= numParticles)
-                        {
-                            particle.setHandleInvalid();
-                        }
-
-                        if(accFilter(acc, particle))
-                        {
-                            // Check if it fits the internal cells range
-                            auto const cellInSuperCell
-                                = DataSpaceOperations<simDim>::template map<SuperCellSize>(particle[localCellIdx_]);
-                            auto const localCell = blockStartCellLocal + cellInSuperCell;
-                            for(uint32_t d = 0; d < simDim; d++)
-                                if((localCell[d] < beginCellIdxLocal[d]) || (localCell[d] >= endCellIdxLocal[d]))
-                                    return;
-                            calorimeterFunctor(acc, particlesFrame, linearIdx);
-                        }
-                    });
-
-                // independent for each worker
-                particlesFrame = particlesBox.getPreviousFrame(particlesFrame);
-                numParticles = maxParticlesInFrame;
-            }
+                        // Check if it fits the internal cells range
+                        auto const cellInSuperCell
+                            = DataSpaceOperations<simDim>::template map<SuperCellSize>(particle[localCellIdx_]);
+                        auto const localCell = superCellCellOffsetNoGuard + cellInSuperCell;
+                        for(uint32_t d = 0; d < simDim; d++)
+                            if((localCell[d] < beginCellIdxLocal[d]) || (localCell[d] >= endCellIdxLocal[d]))
+                                return;
+                        calorimeterFunctor(accelerator, particle);
+                    }
+                });
         }
     };
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -86,10 +86,10 @@ namespace picongpu
             this->calorimeterCur = calorimeterCur;
         }
 
-        template<typename ParticlesFrame, typename T_Acc>
-        DINLINE void operator()(const T_Acc& acc, ParticlesFrame& particlesFrame, const uint32_t linearThreadIdx)
+        template<typename T_Particle, typename T_Acc>
+        DINLINE void operator()(const T_Acc& acc, T_Particle& particle)
         {
-            const float3_X mom = particlesFrame[linearThreadIdx][momentum_];
+            const float3_X mom = particle[momentum_];
             const float_X mom2 = pmacc::math::dot(mom, mom);
             float3_X dirVec = mom * math::rsqrt(mom2);
 
@@ -123,10 +123,9 @@ namespace picongpu
                 pitchBin = pitchBin < 0 ? 0 : pitchBin;
 
                 // energy
-                const float_X weighting = particlesFrame[linearThreadIdx][weighting_];
+                const float_X weighting = particle[weighting_];
                 const float_X normedWeighting
                     = weighting / static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
-                const auto particle = particlesFrame[linearThreadIdx];
                 const float_X mass = attribute::getMass(weighting, particle);
                 const float_X energy = KinEnergy<>()(mom, mass) / weighting;
 

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -25,6 +25,7 @@
 #include "pmacc/mappings/kernel/ExchangeMapping.hpp"
 #include "pmacc/memory/Array.hpp"
 #include "pmacc/memory/shared/Allocate.hpp"
+#include "pmacc/particles/algorithm/ForEach.hpp"
 #include "pmacc/particles/memory/boxes/ExchangePopDataBox.hpp"
 #include "pmacc/particles/memory/boxes/ExchangePushDataBox.hpp"
 #include "pmacc/particles/memory/boxes/ParticlesBox.hpp"
@@ -409,7 +410,6 @@ namespace pmacc
             // count particles per frame
             PMACC_SMEM(acc, destFramesCounter, memory::Array<uint32_t, numExchanges>);
 
-            PMACC_SMEM(acc, frame, FramePtr);
             PMACC_SMEM(acc, isProcessedSupercell, bool);
 
             DataSpace<dim> const superCellIdx = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc)));
@@ -423,12 +423,17 @@ namespace pmacc
                     if(isProcessedSupercell)
                     {
                         pb.getSuperCell(superCellIdx).setMustShift(false);
-                        frame = pb.getFirstFrame(superCellIdx);
                     }
                 });
 
+            namespace particleAccAlgos = pmacc::particles::algorithm::acc;
+            auto forEachFrameInSupercell = particleAccAlgos::makeForEachFrame<numWorkers, particleAccAlgos::Forward>(
+                workerIdx,
+                pb,
+                superCellIdx);
+
             cupla::__syncthreads(acc);
-            if(!isProcessedSupercell || !frame.isValid())
+            if(!isProcessedSupercell || !forEachFrameInSupercell.hasParticles())
                 return;
 
             auto forEachExchange = lockstep::makeForEach<numExchanges, numWorkers>(workerIdx);
@@ -470,126 +475,124 @@ namespace pmacc
 
             cupla::__syncthreads(acc);
 
-            /* iterate over the frame list of the current supercell */
-            while(frame.isValid())
-            {
-                auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+            forEachFrameInSupercell(
+                acc,
+                /* iterate over the frame list of the current supercell */
+                [&](auto const& accelerator, auto& frameIterCtx)
+                {
+                    auto forEachParticleInFrame = forEachFrameInSupercell.lockstepForEach();
 
-                auto destParticleIdxCtx = lockstep::makeVar<lcellId_t>(forEachParticle, lcellId_t(INV_LOC_IDX));
-                // auto directionCtx = lockstep::makeVar<int>(forEachParticle);
+                    auto destParticleIdxCtx
+                        = lockstep::makeVar<lcellId_t>(forEachParticleInFrame, lcellId_t(INV_LOC_IDX));
 
-                auto directionCtx = forEachParticle(
-                    [&](lockstep::Idx const idx)
-                    {
-                        /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
-                         * -2 is no particle
-                         * -1 is particle but it is not shifted (stays in supercell)
-                         * >=0 particle moves in a certain direction
-                         *     (@see ExchangeType in types.h)
-                         */
-                        int direction = frame[idx][multiMask_] - 2;
-                        if(direction >= 0)
+                    auto directionCtx = forEachParticleInFrame(
+                        [&](lockstep::Idx const idx)
                         {
-                            destParticleIdxCtx[idx] = cupla::atomicAdd(
-                                acc,
-                                &(destFramesCounter[direction]),
-                                1u,
-                                ::alpaka::hierarchy::Threads{});
-                        }
-                        return direction;
-                    });
-                cupla::__syncthreads(acc);
-
-                forEachExchange(
-                    [&](lockstep::Idx const idx)
-                    {
-                        uint32_t const linearIdx = idx;
-                        /* If the master thread (responsible for a certain direction) did not
-                         * obtain a `low frame` from the neighboring super cell before the loop,
-                         * it will create one now.
-                         *
-                         * In case not all particles that are shifted to the neighboring
-                         * supercell fit into the `low frame`, a second frame is created to
-                         * contain further particles, the `high frame` (default: invalid).
-                         */
-                        if(destFramesCounter[linearIdx] > 0u)
-                        {
-                            /* neighborSuperCellIdx should not be stored in a context variable.
-                             * Using a context variable results into 16bit reads.
+                            /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
+                             * -2 is no particle
+                             * -1 is particle but it is not shifted (stays in supercell)
+                             * >=0 particle moves in a certain direction
+                             *     (@see ExchangeType in types.h)
                              */
-                            auto const neighborSuperCellIdx
-                                = superCellIdx + Mask::getRelativeDirections<dim>(linearIdx + 1);
-                            if(isValidSupercellIdx(T_Idx{neighborSuperCellIdx}, numSupercellsWithGuard))
+                            int direction = frameIterCtx[idx][idx % frameSize][multiMask_] - 2;
+                            if(direction >= 0)
                             {
-                                /* if we had no `low frame` we load a new empty one */
-                                if(!destFrames[linearIdx].isValid())
+                                destParticleIdxCtx[idx] = cupla::atomicAdd(
+                                    accelerator,
+                                    &(destFramesCounter[direction]),
+                                    1u,
+                                    ::alpaka::hierarchy::Threads{});
+                            }
+                            return direction;
+                        });
+                    cupla::__syncthreads(accelerator);
+
+                    forEachExchange(
+                        [&](lockstep::Idx const idx)
+                        {
+                            uint32_t const linearIdx = idx;
+                            /* If the master thread (responsible for a certain direction) did not
+                             * obtain a `low frame` from the neighboring super cell before the loop,
+                             * it will create one now.
+                             *
+                             * In case not all particles that are shifted to the neighboring
+                             * supercell fit into the `low frame`, a second frame is created to
+                             * contain further particles, the `high frame` (default: invalid).
+                             */
+                            if(destFramesCounter[linearIdx] > 0u)
+                            {
+                                /* neighborSuperCellIdx should not be stored in a context variable.
+                                 * Using a context variable results into 16bit reads.
+                                 */
+                                auto const neighborSuperCellIdx
+                                    = superCellIdx + Mask::getRelativeDirections<dim>(linearIdx + 1);
+                                if(isValidSupercellIdx(T_Idx{neighborSuperCellIdx}, numSupercellsWithGuard))
                                 {
-                                    FramePtr tmpFrame(pb.getEmptyFrame(acc));
-                                    destFrames[linearIdx] = tmpFrame;
-                                    pb.setAsLastFrame(acc, tmpFrame, neighborSuperCellIdx);
-                                }
-                                /* check if a `high frame` is needed */
-                                if(destFramesCounter[linearIdx] > frameSize)
-                                {
-                                    FramePtr tmpFrame(pb.getEmptyFrame(acc));
-                                    destFrames[linearIdx + numExchanges] = tmpFrame;
-                                    pb.setAsLastFrame(acc, tmpFrame, neighborSuperCellIdx);
+                                    /* if we had no `low frame` we load a new empty one */
+                                    if(!destFrames[linearIdx].isValid())
+                                    {
+                                        FramePtr tmpFrame(pb.getEmptyFrame(accelerator));
+                                        destFrames[linearIdx] = tmpFrame;
+                                        pb.setAsLastFrame(accelerator, tmpFrame, neighborSuperCellIdx);
+                                    }
+                                    /* check if a `high frame` is needed */
+                                    if(destFramesCounter[linearIdx] > frameSize)
+                                    {
+                                        FramePtr tmpFrame(pb.getEmptyFrame(accelerator));
+                                        destFrames[linearIdx + numExchanges] = tmpFrame;
+                                        pb.setAsLastFrame(accelerator, tmpFrame, neighborSuperCellIdx);
+                                    }
                                 }
                             }
-                        }
-                    });
-                cupla::__syncthreads(acc);
+                        });
+                    cupla::__syncthreads(accelerator);
 
-                forEachParticle(
-                    [&](lockstep::Idx const idx)
-                    {
-                        /* All threads with a valid index in the neighbor's frame, valid index
-                         * range is [0, frameSize * 2-1], will copy their particle to the new
-                         * frame.
-                         *
-                         * The default value for indexes (in the destination frame) is
-                         * above this range (INV_LOC_IDX) for all particles that are not shifted.
-                         */
-                        if(destParticleIdxCtx[idx] < frameSize * 2)
+                    forEachParticleInFrame(
+                        [&](lockstep::Idx const idx)
                         {
-                            if(destParticleIdxCtx[idx] >= frameSize)
+                            /* All threads with a valid index in the neighbor's frame, valid index
+                             * range is [0, frameSize * 2-1], will copy their particle to the new
+                             * frame.
+                             *
+                             * The default value for indexes (in the destination frame) is
+                             * above this range (INV_LOC_IDX) for all particles that are not shifted.
+                             */
+                            if(destParticleIdxCtx[idx] < frameSize * 2)
                             {
-                                /* use `high frame` */
-                                directionCtx[idx] += numExchanges;
-                                destParticleIdxCtx[idx] -= frameSize;
+                                if(destParticleIdxCtx[idx] >= frameSize)
+                                {
+                                    /* use `high frame` */
+                                    directionCtx[idx] += numExchanges;
+                                    destParticleIdxCtx[idx] -= frameSize;
+                                }
+                                auto dstParticle = destFrames[directionCtx[idx]][destParticleIdxCtx[idx]];
+                                auto srcParticle = frameIterCtx[idx][idx % frameSize];
+                                dstParticle[multiMask_] = 1;
+                                srcParticle[multiMask_] = 0;
+                                auto dstFilteredParticle = particles::operations::deselect<multiMask>(dstParticle);
+                                particles::operations::assign(dstFilteredParticle, srcParticle);
                             }
-                            auto dstParticle = destFrames[directionCtx[idx]][destParticleIdxCtx[idx]];
-                            auto srcParticle = frame[idx];
-                            dstParticle[multiMask_] = 1;
-                            srcParticle[multiMask_] = 0;
-                            auto dstFilteredParticle = particles::operations::deselect<multiMask>(dstParticle);
-                            particles::operations::assign(dstFilteredParticle, srcParticle);
-                        }
-                    });
-                cupla::__syncthreads(acc);
+                        });
+                    cupla::__syncthreads(accelerator);
 
-                forEachExchange(
-                    [&](lockstep::Idx const idx)
-                    {
-                        uint32_t const linearIdx = idx;
-                        /* if the `low frame` is full, each master thread
-                         * uses the `high frame` (is invalid, if still empty) as the next
-                         * `low frame` for the following iteration of the loop
-                         */
-                        if(destFramesCounter[linearIdx] >= frameSize)
+                    forEachExchange(
+                        [&](lockstep::Idx const idx)
                         {
-                            newParticleInFrameCtx[idx] += frameSize;
-                            destFramesCounter[linearIdx] -= frameSize;
-                            destFrames[linearIdx] = destFrames[linearIdx + numExchanges];
-                            destFrames[linearIdx + numExchanges] = FramePtr();
-                        }
-                        if(linearIdx == 0)
-                        {
-                            frame = pb.getNextFrame(frame);
-                        }
-                    });
-                cupla::__syncthreads(acc);
-            }
+                            uint32_t const linearIdx = idx;
+                            /* if the `low frame` is full, each master thread
+                             * uses the `high frame` (is invalid, if still empty) as the next
+                             * `low frame` for the following iteration of the loop
+                             */
+                            if(destFramesCounter[linearIdx] >= frameSize)
+                            {
+                                newParticleInFrameCtx[idx] += frameSize;
+                                destFramesCounter[linearIdx] -= frameSize;
+                                destFrames[linearIdx] = destFrames[linearIdx + numExchanges];
+                                destFrames[linearIdx + numExchanges] = FramePtr();
+                            }
+                        });
+                    cupla::__syncthreads(accelerator);
+                });
 
             forEachExchange(
                 [&](lockstep::Idx const idx)

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -621,9 +621,13 @@ namespace pmacc
             KernelFillGaps<numWorkers>{}(acc, pb, mapper);
         }
 
-        //! Is the given supercell index valid
+        /** Is the given supercell index valid
+         *
+         * This method must be static to workaround an internal compiler bug with g++7 with the OMP2 alpaka
+         * accelerator.
+         */
         template<typename T_Idx>
-        DINLINE bool isValidSupercellIdx(T_Idx const& supercellIdx, T_Idx const& numSupercells) const
+        static DINLINE bool isValidSupercellIdx(T_Idx const& supercellIdx, T_Idx const& numSupercells)
         {
             for(uint32_t d = 0; d < T_Idx::dim; d++)
                 if((supercellIdx[d] < 0) || (supercellIdx[d] >= numSupercells[d]))

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -22,157 +22,445 @@
 #pragma once
 
 #include "pmacc/Environment.hpp"
+#include "pmacc/attribute/Constexpr.hpp"
 #include "pmacc/lockstep.hpp"
+#include "pmacc/lockstep/Config.hpp"
+#include "pmacc/lockstep/ForEach.hpp"
 #include "pmacc/mappings/kernel/AreaMapping.hpp"
+#include "pmacc/particles/algorithm/detail/ForEach.hpp"
 #include "pmacc/particles/frame_types.hpp"
 
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 
 
-namespace pmacc
+namespace pmacc::particles::algorithm
 {
-    namespace particles
+    namespace acc
     {
-        namespace algorithm
+        //! Policy to forward iterate over particles/frames of a supercell.
+        struct Forward
         {
-            namespace acc
+            template<typename T_ParBox>
+            static DINLINE auto getFirst(T_ParBox& pb, DataSpace<T_ParBox::Dim> const& superCellIdx)
             {
-                namespace detail
+                return pb.getFirstFrame(superCellIdx);
+            }
+
+            template<typename T_ParBox>
+            static DINLINE auto next(T_ParBox& pb, typename T_ParBox::FramePtr const& framePtr)
+            {
+                return pb.getNextFrame(framePtr);
+            }
+
+            template<typename T_ForEach>
+            static DINLINE auto createCtx(T_ForEach& forEachParticleInFrame)
+            {
+                return lockstep::makeVar<uint32_t>(forEachParticleInFrame, 0u);
+            }
+        };
+
+        //! Policy to reverse iterate over particles/frames of a supercell.
+        struct Reverse
+        {
+            template<typename T_ParBox>
+            static DINLINE auto getFirst(T_ParBox& pb, DataSpace<T_ParBox::Dim> const& superCellIdx)
+            {
+                return pb.getLastFrame(superCellIdx);
+            }
+
+            template<typename T_ParBox>
+            static DINLINE auto next(T_ParBox& pb, typename T_ParBox::FramePtr const& framePtr)
+            {
+                return pb.getPreviousFrame(framePtr);
+            }
+
+            template<typename T_ForEach>
+            static DINLINE auto createCtx(T_ForEach& forEachParticleInFrame)
+            {
+                return lockstep::makeVar<lcellId_t>(forEachParticleInFrame, lcellId_t(0u));
+            }
+        };
+
+        /** Execute a particle or frame functor for each particle/frame.
+         *
+         * @tparam T_AccessTag Type of the tag to mark if the particle or frame interface will be used.
+         *                     valid options: detail::CallParticleFunctor or detail::CallFrameFunctor
+         * @tparam T_Order Iteration order. valid options: Forward or Reverse
+         * @tparam T_ParBox Type of the particle box to traverse.
+         * @tparam T_numWorkers Number of lockstep workers.
+         */
+        template<typename T_AccessTag, typename T_Order, typename T_ParBox, uint32_t T_numWorkers>
+        class ForEachParticle
+        {
+        private:
+            static constexpr uint32_t dim = T_ParBox::Dim;
+
+            using SuperCellSize = typename T_ParBox::FrameType::SuperCellSize;
+            static constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+            static constexpr uint32_t numWorkers = T_numWorkers;
+
+            /** Number of frames to skip.
+             *
+             * If we have more workers than particles in a frame we skip frames depending on the worker id.
+             */
+            static constexpr uint32_t frameDistance = (numWorkers + frameSize - 1u) / frameSize;
+
+            using ForEachParticleInFrame
+                = lockstep::ForEach<lockstep::Config<frameSize * frameDistance, T_numWorkers, 1>>;
+
+            DataSpace<dim> const m_superCellIdx;
+            ForEachParticleInFrame const forEachParticleInFrame;
+            T_ParBox m_particlesBox;
+
+        public:
+            /** Provide the lockstep foreach executor to execute a functor for each particle within a set of frames.
+             *
+             * Depending of the number of workers used it could be that more than one frame is executed by all workers
+             * in parallel. The frame functor interface is therefore a context with one frame per virtual worker.
+             * It is guaranteed that the executor fits to the frameCtx provided by the frame functor interface. @see
+             * detail::FrameFunctorInterface
+             *
+             * @return Lockstep foreach executor to operate on frames.
+             */
+            DINLINE auto lockstepForEach() const
+            {
+                return forEachParticleInFrame;
+            }
+
+            /** Construct algoritm to operate on particles in a superCell
+             *
+             * @param workerIdx workerIdx index of the worker: range [0;workerSize)
+             * @param particlesBox particles memory
+             *                     It is not allowed concurrently to add or remove particles during the
+             *                     execution of this algorithm.
+             * @param superCellIdx index of the superCell where particles should be processed
+             */
+            DINLINE ForEachParticle(
+                uint32_t const workerIdx,
+                T_ParBox const& particlesBox,
+                DataSpace<dim> const& superCellIdx)
+                : m_superCellIdx(superCellIdx)
+                , forEachParticleInFrame(workerIdx)
+                , m_particlesBox(particlesBox)
+            {
+            }
+
+            /** Execute unary functor for each particle.
+             *
+             * @attention There is no guarantee in which order particles will be executed.
+             *            If the particle functor is used the algorithm assumes that the frame structure is following
+             *            the rule that all frames but the last are fully filled and in the last frame the low indices
+             *            are contiguously filled.
+             *
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_Functor unary particle functor or frame functor following the interface concept
+             *                           detail::FrameFunctorInterface or detail::ParticleFunctorInterface
+             * @param acc alpaka accelerator
+             * @param unaryFunctor Functor executed for each particle/frame.
+             *                     The caller must ensure that calling the functor in parallel with
+             *                     different workers is data race free.
+             *                     - particle functor: 'void operator()(T_Acc const &, ParticleType)'.
+             *                       It is not allowed to call a synchronization function within the functor.
+             *                     - frame functor: 'void operator()(T_Acc const &, FrameCtx)'.
+             *                       Calling synchronization within the functor is allowed.
+             */
+            template<typename T_Acc, typename T_Functor>
+            DINLINE void operator()(T_Acc const& acc, T_Functor&& unaryFunctor) const
+            {
+                if constexpr(numWorkers > frameSize)
                 {
-                    /** operate on particles of a species
-                     *
-                     * @tparam T_numWorkers number of workers
-                     */
-                    template<uint32_t T_numWorkers>
-                    struct ForEachParticle
+                    PMACC_CASSERT_MSG(
+                        __number_of_workers_must_be_either_less_or_a_multiple_of_framesize,
+                        (numWorkers % frameSize) == 0);
+                }
+
+                constexpr bool isSupportedOrder = std::is_same_v<Reverse, T_Order> || std::is_same_v<Forward, T_Order>;
+                static_assert(isSupportedOrder, "Unsupported order policy");
+
+                auto const& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
+                uint32_t const numParticlesInSupercell = superCell.getNumParticles();
+
+                // end kernel if we have no particles
+                if(numParticlesInSupercell == 0)
+                    return;
+
+                // Information used to know if a particle within a frame is active without checking the multiMask.
+                auto frameConditionData = T_Order::createCtx(forEachParticleInFrame);
+
+                // get starting frame
+                auto framePtrCtx = forEachParticleInFrame(
+                    [&](lockstep::Idx const idx)
                     {
-                        /** operate on particles
-                         *
-                         * @tparam T_Acc alpaka accelerator type
-                         * @tparam T_Functor type of the functor to operate on a particle
-                         * @tparam T_Mapping mapping functor type
-                         * @tparam T_ParBox pmacc::ParticlesBox, type of the species box
-                         *
-                         * @param acc alpaka accelerator
-                         * @param functor functor to operate on a particle
-                         *                must fulfill the interface pmacc::functor::Interface<F, 1u, void>
-                         * @param mapper functor to map a block to a supercell
-                         * @param pb particles species box
-                         */
-                        template<typename T_Acc, typename T_Functor, typename T_Mapping, typename T_ParBox>
-                        DINLINE void operator()(
-                            T_Acc const& acc,
-                            T_Functor functor,
-                            T_Mapping const mapper,
-                            T_ParBox pb) const
+                        auto frame = T_Order::getFirst(m_particlesBox, m_superCellIdx);
+
+                        if constexpr(std::is_same_v<Reverse, T_Order>)
                         {
-                            using SuperCellSize = typename T_ParBox::FrameType::SuperCellSize;
-                            constexpr uint32_t dim = SuperCellSize::dim;
-                            constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                            constexpr uint32_t numWorkers = T_numWorkers;
-
-                            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-                            DataSpace<dim> const superCellIdx(
-                                mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc))));
-
-                            auto const& superCell = pb.getSuperCell(superCellIdx);
-                            uint32_t const numPartcilesInSupercell = superCell.getNumParticles();
-
-
-                            // end kernel if we have no particles
-                            if(numPartcilesInSupercell == 0)
-                                return;
-
-                            using FramePtr = typename T_ParBox::FramePtr;
-                            FramePtr frame = pb.getFirstFrame(superCellIdx);
-
-                            // offset of the superCell (in cells, without any guards) to the origin of the local domain
-                            DataSpace<dim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();
-
-                            auto accFunctor
-                                = functor(acc, localSuperCellOffset, lockstep::Worker<T_numWorkers>{workerIdx});
-
-                            for(uint32_t parOffset = 0; parOffset < numPartcilesInSupercell; parOffset += frameSize)
-                            {
-                                auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
-
-                                // loop over all particles in the frame
-                                forEachParticle(
-                                    [&](uint32_t const linearIdx)
-                                    {
-                                        // particle index within the supercell
-                                        uint32_t parIdx = parOffset + linearIdx;
-                                        auto particle = frame[linearIdx];
-
-                                        bool const isPar = parIdx < numPartcilesInSupercell;
-                                        if(isPar)
-                                            accFunctor(acc, particle);
-                                    });
-
-                                frame = pb.getNextFrame(frame);
-                            }
+                            if(frame.isValid())
+                                frameConditionData[idx] = superCell.getSizeLastFrame();
                         }
-                    };
 
-                } // namespace detail
-            } // namespace acc
+                        /* Same as frameDistance, variable is required to workaround an nvcc compiler bug.
+                         * Without redefinition within the lambda the variable will be undefined.
+                         */
+                        constexpr uint32_t frameDist = (numWorkers + frameSize - 1u) / frameSize;
+                        if constexpr(frameDist > 1)
+                        {
+                            uint32_t const skipFrames = idx / frameSize;
+                            /* select N-th (N=frameIdx) frame from the list */
+                            for(uint32_t i = 1; i <= skipFrames && frame.isValid(); ++i)
+                            {
+                                frame = T_Order::next(m_particlesBox, frame);
+                            }
+                            if constexpr(std::is_same_v<Reverse, T_Order>)
+                                frameConditionData[idx] = skipFrames != 0 ? frameSize : frameConditionData[idx];
+                        }
+                        return frame;
+                    });
 
-            /** Run a unary functor for each particle of a species in the given area
-             *
-             * Has a version for a fixed area, and for a user-provided mapper factory.
-             * They differ only in how the area is defined.
-             *
-             * @warning Does NOT fill gaps automatically! If the
-             *          operation deactivates particles or creates "gaps" in any
-             *          other way, CallFillAllGaps needs to be called for the
-             *          species manually afterwards!
-             *
-             * @tparam T_Species type of the species
-             * @tparam T_Functor unary particle functor type which follows the interface of
-             *                   pmacc::functor::Interface<F, 1u, void>
-             *
-             * @param species species to operate on
-             * @param functor operation which is applied to each particle of the species
-             *
-             * @{
-             */
+                bool hasMoreWork = true;
+                // iterate over all frames in the supercell
+                do
+                {
+                    if constexpr(std::is_same_v<T_AccessTag, detail::CallParticleFunctor>)
+                    {
+                        // loop over all particles in the frame
+                        forEachParticleInFrame(
+                            [&](lockstep::Idx const linearIdx)
+                            {
+                                auto const particleIdx = linearIdx % frameSize;
 
-            /** Version for a custom area mapper factory
-             *
-             * @tparam T_AreaMapperFactory factory type to construct an area mapper that defines the area to process,
-             *                             adheres to the AreaMapperFactory concept
-             *
-             * @param areaMapperFactory factory to construct an area mapper,
-             *                          the area is defined by the constructed mapper object
-             */
-            template<typename T_Species, typename T_Functor, typename T_AreaMapperFactory>
-            HINLINE void forEach(T_Species&& species, T_Functor functor, T_AreaMapperFactory const& areaMapperFactory)
-            {
-                using MappingDesc = decltype(species.getCellDescription());
-                using SuperCellSize = typename MappingDesc::SuperCellSize;
-                constexpr uint32_t numWorkers
-                    = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
+                                auto particle = framePtrCtx[linearIdx][particleIdx];
+                                if constexpr(std::is_same_v<Reverse, T_Order>)
+                                {
+                                    bool const isParticle = particleIdx < frameConditionData[linearIdx];
+                                    if(!isParticle)
+                                        particle.setHandleInvalid();
+                                }
+                                else if constexpr(std::is_same_v<Forward, T_Order>)
+                                {
+                                    uint32_t const parIdxInSupercell = frameConditionData[linearIdx] + linearIdx;
+                                    bool const isParticle = parIdxInSupercell < numParticlesInSupercell;
+                                    if(!isParticle)
+                                        particle.setHandleInvalid();
+                                }
 
-                auto const mapper = areaMapperFactory(species.getCellDescription());
-                PMACC_KERNEL(acc::detail::ForEachParticle<numWorkers>{})
-                (mapper.getGridDim(), numWorkers)(std::move(functor), mapper, species.getDeviceParticlesBox());
+
+                                PMACC_CASSERT_MSG(
+                                    __unaryParticleFunctor_must_return_void,
+                                    std::is_void_v<decltype(unaryFunctor(acc, particle))>);
+                                if(particle.isHandleValid())
+                                {
+                                    auto particleFunctor
+                                        = detail::makeParticleFunctorInterface(std::forward<T_Functor>(unaryFunctor));
+                                    particleFunctor(acc, particle);
+                                }
+                            });
+                    }
+                    else if constexpr(std::is_same_v<T_AccessTag, detail::CallFrameFunctor>)
+                    {
+                        auto frameFunctor = detail::makeFrameFunctorInterface(std::forward<T_Functor>(unaryFunctor));
+                        frameFunctor(acc, framePtrCtx);
+                    }
+
+                    hasMoreWork = false;
+
+                    // get next frame
+                    forEachParticleInFrame(
+                        [&](lockstep::Idx const idx)
+                        {
+                            if constexpr(std::is_same_v<Reverse, T_Order>)
+                                frameConditionData[idx] = frameSize;
+                            else if constexpr(std::is_same_v<Forward, T_Order>)
+                                frameConditionData[idx] += frameSize * frameDistance;
+
+                            for(uint32_t i = 0; i < frameDistance; ++i)
+                                if(framePtrCtx[idx].isValid())
+                                    framePtrCtx[idx] = T_Order::next(m_particlesBox, framePtrCtx[idx]);
+
+                            hasMoreWork = hasMoreWork || framePtrCtx[idx].isValid();
+                        });
+
+                } while(hasMoreWork);
             }
 
-            /** Version for a fixed area
-             *
-             * @tparam T_area area to process particles in
-             */
-            template<uint32_t T_area, typename T_Species, typename T_Functor>
-            HINLINE void forEach(T_Species&& species, T_Functor functor)
+            DINLINE bool hasParticles() const
             {
-                auto const areaMapperFactory = AreaMapperFactory<T_area>{};
-                forEach(species, functor, areaMapperFactory);
+                return numParticles() != 0u;
             }
 
-            /** @} */
+            DINLINE uint32_t numParticles() const
+            {
+                auto const& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
+                return superCell.getNumParticles();
+            }
+        };
 
-        } // namespace algorithm
-    } // namespace particles
-} // namespace pmacc
+        /** Creates an executor to iterate over all particles in a supercell.
+         *
+         * @return ForEach executor which can be invoked with a particle functor as argument. @see
+         * detail::ParticleFunctorInterface
+         *
+         * @{
+         * @tparam T_numWorkers number of lockstep workers
+         * @tparam T_ParBox Type of the particle box.
+         * @param workerIdx worker index
+         * @param particlesBox particle box
+         * @param superCellIdx supercell index
+         */
+        template<uint32_t T_numWorkers, typename T_ParBox>
+        DINLINE auto makeForEach(
+            uint32_t workerIdx,
+            T_ParBox const& particlesBox,
+            DataSpace<T_ParBox::Dim> const& superCellIdx)
+        {
+            return ForEachParticle<detail::CallParticleFunctor, Reverse, T_ParBox, T_numWorkers>(
+                workerIdx,
+                particlesBox,
+                superCellIdx);
+        }
+
+        /** Creates an executor to iterate over all frames in a supercell.
+         *
+         * @tparam T_Order Iteration order. valid options: Forward or Reverse
+         * @return ForEach executor which can be invoked with a frame functor as argument. @see
+         * detail::FrameFunctorInterface
+         */
+        template<uint32_t T_numWorkers, typename T_Order, typename T_ParBox>
+        DINLINE auto makeForEachFrame(
+            uint32_t workerIdx,
+            T_ParBox const& particlesBox,
+            DataSpace<T_ParBox::Dim> const& superCellIdx)
+        {
+            return ForEachParticle<detail::CallFrameFunctor, T_Order, T_ParBox, T_numWorkers>(
+                workerIdx,
+                particlesBox,
+                superCellIdx);
+        }
+        /** Creates an executor to iterate over all particles in a supercell.
+         *
+         * @tparam T_Order Iteration order. valid options: Forward or Reverse
+         * @return ForEach executor which can be invoked with a particle functor as argument. @see
+         * detail::ParticleFunctorInterface
+         */
+        template<uint32_t T_numWorkers, typename T_Order, typename T_ParBox>
+        DINLINE auto makeForEach(
+            uint32_t workerIdx,
+            T_ParBox const& particlesBox,
+            DataSpace<T_ParBox::Dim> const& superCellIdx)
+        {
+            return ForEachParticle<detail::CallParticleFunctor, T_Order, T_ParBox, T_numWorkers>(
+                workerIdx,
+                particlesBox,
+                superCellIdx);
+        }
+        /** @} */
+
+        namespace detail
+        {
+            /** operate on particles of a species
+             *
+             * @tparam T_numWorkers number of workers
+             */
+            template<uint32_t T_numWorkers>
+            struct KernelForEachParticle
+            {
+                /** operate on particles
+                 *
+                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Functor type of the functor to operate on a particle
+                 * @tparam T_Mapping mapping functor type
+                 * @tparam T_ParBox pmacc::ParticlesBox, type of the species box
+                 *
+                 * @param acc alpaka accelerator
+                 * @param functor functor to operate on a particle
+                 *                must fulfill the interface pmacc::functor::Interface<F, 1u, void>
+                 * @param mapper functor to map a block to a supercell
+                 * @param pb particles species box
+                 */
+                template<typename T_Acc, typename T_Functor, typename T_Mapping, typename T_ParBox>
+                DINLINE void operator()(T_Acc const& acc, T_Functor functor, T_Mapping const mapper, T_ParBox pb) const
+                {
+                    using SuperCellSize = typename T_ParBox::FrameType::SuperCellSize;
+                    constexpr uint32_t dim = SuperCellSize::dim;
+                    constexpr uint32_t numWorkers = T_numWorkers;
+
+                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
+
+                    DataSpace<dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc))));
+
+                    auto forEachParticle = makeForEach<numWorkers>(workerIdx, pb, superCellIdx);
+
+                    // end kernel if we have no particles
+                    if(!forEachParticle.hasParticles())
+                        return;
+
+                    // offset of the superCell (in cells, without any guards) to the origin of the local
+                    // domain
+                    DataSpace<dim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();
+
+                    auto accFunctor = functor(acc, localSuperCellOffset, lockstep::Worker<numWorkers>{workerIdx});
+
+                    forEachParticle(acc, accFunctor);
+                }
+            };
+
+        } // namespace detail
+    } // namespace acc
+
+    /** Run a unary functor for each particle of a species in the given area
+     *
+     * Has a version for a fixed area, and for a user-provided mapper factory.
+     * They differ only in how the area is defined.
+     *
+     * @warning Does NOT fill gaps automatically! If the
+     *          operation deactivates particles or creates "gaps" in any
+     *          other way, CallFillAllGaps needs to be called for the
+     *          species manually afterwards!
+     *
+     * @tparam T_Species type of the species
+     * @tparam T_Functor unary particle functor type which follows the interface of
+     *                   pmacc::functor::Interface<F, 1u, void>
+     *
+     * @param species species to operate on
+     * @param functor operation which is applied to each particle of the species
+     *
+     * @{
+     */
+
+    /** Version for a custom area mapper factory
+     *
+     * @tparam T_AreaMapperFactory factory type to construct an area mapper that defines the area to
+     * process, adheres to the AreaMapperFactory concept
+     *
+     * @param areaMapperFactory factory to construct an area mapper,
+     *                          the area is defined by the constructed mapper object
+     */
+    template<typename T_Species, typename T_Functor, typename T_AreaMapperFactory>
+    HINLINE void forEach(T_Species&& species, T_Functor functor, T_AreaMapperFactory const& areaMapperFactory)
+    {
+        using MappingDesc = decltype(species.getCellDescription());
+        using SuperCellSize = typename MappingDesc::SuperCellSize;
+        constexpr uint32_t numWorkers
+            = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
+
+        auto const mapper = areaMapperFactory(species.getCellDescription());
+        PMACC_KERNEL(acc::detail::KernelForEachParticle<numWorkers>{})
+        (mapper.getGridDim(), numWorkers)(std::move(functor), mapper, species.getDeviceParticlesBox());
+    }
+
+    /** Version for a fixed area
+     *
+     * @tparam T_area area to process particles in
+     */
+    template<uint32_t T_area, typename T_Species, typename T_Functor>
+    HINLINE void forEach(T_Species&& species, T_Functor functor)
+    {
+        auto const areaMapperFactory = AreaMapperFactory<T_area>{};
+        forEach(species, functor, areaMapperFactory);
+    }
+
+    /** @} */
+
+} // namespace pmacc::particles::algorithm

--- a/include/pmacc/particles/algorithm/detail/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/detail/ForEach.hpp
@@ -1,0 +1,149 @@
+/* Copyright 2017-2022 Axel Huebl, Rene Widera, Sergei Bastrakov
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/lockstep/Variable.hpp"
+#include "pmacc/particles/memory/dataTypes/FramePointer.hpp"
+#include "pmacc/particles/memory/dataTypes/Particle.hpp"
+
+#include <utility>
+
+
+namespace pmacc::particles::algorithm::acc
+{
+    namespace detail
+    {
+        //! Tag marks that the particle functor interface must be used
+        struct CallParticleFunctor;
+
+        //! Tag marks that the frame functor interface must be used
+        struct CallFrameFunctor;
+
+        /** Frame functor interface
+         *
+         * Ensure that a functor can be called with the given lockstep frame variable.
+         *
+         * @tparam T_FrameFunctor Type of the user functor to operate on frames.
+         */
+        template<typename T_FrameFunctor>
+        struct FrameFunctorInterface
+        {
+            T_FrameFunctor m_functor;
+            DINLINE FrameFunctorInterface(T_FrameFunctor&& functor) : m_functor(std::forward<T_FrameFunctor>(functor))
+            {
+            }
+
+            /** Invokes the user functor with the given parameters.
+             *
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_FrameType @see FramePointer
+             * @tparam T_Config @see lockstep::Variable
+             * @param acc alpaka accelerator
+             * @param frameIterCtx Lockstep variable containing a frame for each virtual worker. To operate on this
+             *                     parameter @see ForEachParticle::lockstepForEach should be used.
+             *
+             * @{
+             */
+            template<typename T_Acc, typename T_FrameType, typename T_Config>
+            DINLINE void operator()(
+                T_Acc const& acc,
+                lockstep::Variable<FramePointer<T_FrameType>, T_Config>& frameIterCtx)
+            {
+                m_functor(acc, frameIterCtx);
+            }
+
+            template<typename T_Acc, typename T_FrameType, typename T_Config>
+            DINLINE void operator()(
+                T_Acc const& acc,
+                lockstep::Variable<FramePointer<T_FrameType>, T_Config>& frameIterCtx) const
+            {
+                m_functor(acc, frameIterCtx);
+            }
+            /**@}*/
+        };
+
+        /** Factory to create a particle interface functor.
+         *
+         * @tparam T_FrameFunctor Type of the user frame functor.
+         * @param frameFunctor Frame functor which should be wrapped to check the interface.
+         * @return Callable functor which guarantees the frame interface used by forEach.
+         */
+        template<typename T_FrameFunctor>
+        DINLINE auto makeFrameFunctorInterface(T_FrameFunctor&& frameFunctor)
+        {
+            return FrameFunctorInterface<T_FrameFunctor>{std::forward<T_FrameFunctor>(frameFunctor)};
+        }
+
+        /** Particle functor interface
+         *
+         * Ensure that a functor can be called for a particle.
+         *
+         * @tparam T_ParticleFunctor Type of the user particle functor to operate with a single particle.
+         */
+        template<typename T_ParticleFunctor>
+        struct ParticleFunctorInterface
+        {
+            T_ParticleFunctor m_functor;
+            DINLINE ParticleFunctorInterface(T_ParticleFunctor&& functor)
+                : m_functor(std::forward<T_ParticleFunctor>(functor))
+            {
+            }
+
+            /** Invoke the user functor with the given arguments.
+             *
+             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_FrameType @see Particle
+             * @tparam T_ValueTypeSeq @see Particle
+             * @param acc alpaka accelerator
+             * @param particle particle to process
+             *
+             * @{
+             */
+            template<typename T_Acc, typename T_FrameType, typename T_ValueTypeSeq>
+            DINLINE void operator()(T_Acc const& acc, Particle<T_FrameType, T_ValueTypeSeq>& particle)
+            {
+                m_functor(acc, particle);
+            }
+
+            template<typename T_Acc, typename T_FrameType, typename T_ValueTypeSeq>
+            DINLINE void operator()(T_Acc const& acc, Particle<T_FrameType, T_ValueTypeSeq>& particle) const
+            {
+                m_functor(acc, particle);
+            }
+
+            /**@}*/
+        };
+
+        /** Factory to create a particle interface functor.
+         *
+         * @tparam T_ParticleFunctor Type of the user particle functor to operate with a single particle.
+         * @param particleFunctor Particle functor which should be wrapped to check the interface.
+         * @return Callable functor which guarantees the particle interface used by forEach.
+         */
+        template<typename T_ParticleFunctor>
+        DINLINE auto makeParticleFunctorInterface(T_ParticleFunctor&& particleFunctor)
+        {
+            return ParticleFunctorInterface<T_ParticleFunctor>{std::forward<T_ParticleFunctor>(particleFunctor)};
+        }
+
+    } // namespace detail
+} // namespace pmacc::particles::algorithm::acc


### PR DESCRIPTION
Add device-side `ForEachParticle` algorithm.

- add a policy to describe if particle frames should be forward or backward processed
- add factory functions to create the particle forEach executor.
- The particle for each is providing two modes
  - iterate over all particles in a supercell
  - iterate over all frames -> required mostly for pmacc internal algorithms to compress the linked frame data structures.

Depending on the number of worker and the frame size the forach algorithm will work with skip lists to utilize all threads.