### PR TITLE
Calculate and output laser phase velocity

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/DispersionRelation.def
+++ b/include/picongpu/fields/MaxwellSolver/DispersionRelation.def
@@ -1,0 +1,49 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Calculate dispersion relation for the given field solver
+             *
+             * Dispersion relation is expressed in the following form:
+             * f(absK) = 0, where absK = |k|.
+             * Angular wave vector k = absK * direction, the direction and angular frequency omega are fixed and given
+             * in the constructor.
+             *
+             * Implementor provides functions to calculate f(absK) and df(absK)/d(absK).
+             * These functions will be used to numerically solve the dispersion relation for absK.
+             *
+             * See the general implementation in the .hpp file for interface requirements and more details.
+             * General implementation follows physical dispersion relation in vacuum.
+             *
+             * @tparam T_FieldSolver field solver type
+             */
+            template<typename T_FieldSolver>
+            class DispersionRelation;
+
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/DispersionRelation.hpp
+++ b/include/picongpu/fields/MaxwellSolver/DispersionRelation.hpp
@@ -1,0 +1,119 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            //! Helper class that dispersion relation implementations may (but do not have to) inherit
+            class DispersionRelationBase
+            {
+            public:
+                /** Create an instance with the given parameters
+                 *
+                 * @param omega angular frequency = 2pi * c / lambda
+                 * @param direction normalized propagation direction
+                 */
+                DispersionRelationBase(float_64 const omega, float3_64 const direction)
+                    : omega(omega)
+                    , direction(direction)
+                {
+                }
+
+            protected:
+                //! Field solver time step as float_64
+                float_64 const timeStep = static_cast<float_64>(DELTA_T);
+
+                //! Grid steps as float_64
+                float3_64 const step = precisionCast<float_64>(cellSize);
+
+                //! Angular frequency
+                float_64 const omega;
+
+                //! Normalized propagation direction
+                float3_64 const direction;
+            };
+
+            /** General implementation follows the physical dispersion relation in vacuum
+             *
+             * No finite-difference numerical solver exactly adheres to the physical relation in general case.
+             * This implementation is given as an ideal-case example and to better illustrate the trait.
+             */
+            template<typename T_FieldSolver>
+            class DispersionRelation : public DispersionRelationBase
+            {
+            public:
+                /** Create a functor with the given parameters
+                 *
+                 * @param omega (angular) frequency = 2pi * c / lambda
+                 * @param direction normalized propagation direction
+                 */
+                DispersionRelation(float_64 const omega, float3_64 const direction)
+                    : DispersionRelationBase(omega, direction)
+                {
+                }
+
+                /** Calculate f(absK) in the dispersion relation
+                 *
+                 * @param absK absolute value of the (angular) wave number
+                 */
+                float_64 relation(float_64 const absK) const
+                {
+                    // (4.13) in Taflove-Hagness, expressed as rhs - lhs = 0
+                    auto rhs = 0.0;
+                    for(uint32_t d = 0; d < simDim; d++)
+                    {
+                        auto const term = absK * direction[d];
+                        rhs += term * term;
+                    }
+                    auto const lhsTerm = omega / SPEED_OF_LIGHT;
+                    auto const lhs = lhsTerm * lhsTerm;
+                    return rhs - lhs;
+                }
+
+                /** Calculate df(absK)/d(absK) in the dispersion relation
+                 *
+                 * @param absK absolute value of the (angular) wave number
+                 */
+                float_64 relationDerivative(float_64 const absK) const
+                {
+                    auto result = 0.0;
+                    for(uint32_t d = 0; d < simDim; d++)
+                    {
+                        // Calculate d(term^2(absK))/d(absK), where term is from relation()
+                        auto const term = absK * direction[d];
+                        auto const termDerivative = direction[d];
+                        result += 2.0 * term * termDerivative;
+                    }
+                    return result;
+                }
+            };
+
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/DispersionRelationSolver.hpp
+++ b/include/picongpu/fields/MaxwellSolver/DispersionRelationSolver.hpp
@@ -1,0 +1,73 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/MaxwellSolver/DispersionRelation.hpp"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace maxwellSolver
+        {
+            /** Numerical solver for dispersion relation for the given field solver
+             *
+             * Relies on dispersion properties given by DispersionRelation<T_FieldSolver>.
+             *
+             * @tparam T_FieldSolver field solver type, must have DispersionRelation<> properly specialized
+             */
+            template<typename T_FieldSolver>
+            struct DispersionRelationSolver
+            {
+                /** Numerically solve the dispersion relation with the given parameters
+                 *
+                 * @param omega angular frequency = 2pi * c / lambda
+                 * @param direction normalized propagation direction
+                 * @return absolute value of (angular) wave vector
+                 */
+                float_64 operator()(float_64 omega, float3_64 direction) const
+                {
+                    auto dispersion = DispersionRelation<T_FieldSolver>{omega, direction};
+                    /* Use simple Newton's method to numerically solve equation dispersion.relation(kAbs) = 0.
+                     * We use kAbs corresponding to no dispersion (so matching physical vacuum) as initial
+                     * approximation. Since realistic setups must be quite close to it, we should converge to a
+                     * solution very quickly. So we are not particularly picky wrt numerical solver parameters.
+                     */
+                    auto kAbs = omega * SPEED_OF_LIGHT;
+                    auto const maxNumSteps = 100;
+                    for(uint32_t d = 0; d < maxNumSteps; d++)
+                    {
+                        auto const derivative = dispersion.relationDerivative(kAbs);
+                        // Stop when we are nearly at a stationary point
+                        constexpr auto derivativeMargin = 1e-5;
+                        if(math::abs(derivative) < derivativeMargin)
+                            break;
+                        kAbs = kAbs - dispersion.relation(kAbs) / derivative;
+                    }
+                    return kAbs;
+                }
+            };
+
+        } // namespace maxwellSolver
+    } // namespace fields
+} // namespace picongpu

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
@@ -23,10 +23,12 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/fields/LaserPhysics.hpp"
+#include "picongpu/fields/MaxwellSolver/DispersionRelation.hpp"
 #include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/Lehe/Derivative.hpp"
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.def"
 
+#include <pmacc/algorithms/math/defines/pi.hpp>
 #include <pmacc/traits/GetStringProperties.hpp>
 
 #include <cstdint>
@@ -38,6 +40,142 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
+            /** Specialization of the dispersion relation for Lehe solver
+             *
+             * @tparam T_CherenkovFreeDir the direction (axis) which should be free of cherenkov radiation
+             *                            0 = x, 1 = y, 2 = z
+             */
+            template<uint32_t T_cherenkovFreeDir>
+            class DispersionRelation<Lehe<T_cherenkovFreeDir>> : public DispersionRelationBase
+            {
+            private:
+                /** Generalized directions: Cherenkov-free along dir0, dir1 and dir2 are the two other directions
+                 *
+                 * @{
+                 */
+
+                static constexpr uint32_t dir0 = T_cherenkovFreeDir;
+                static constexpr uint32_t dir1 = (dir0 + 1) % 3;
+                static constexpr uint32_t dir2 = (dir0 + 2) % 3;
+
+                /** }@ */
+
+                //! Component-wise squared grid steps
+                float3_64 const stepSquared = step * step;
+
+                //! Inverse of Courant factor for the Cherenkov-free direction
+                float_64 const stepRatio = step[dir0] / static_cast<float_64>(SPEED_OF_LIGHT * timeStep);
+
+                //! Helper to calculate delta
+                float_64 const coeff = stepRatio
+                    * math::sin(pmacc::math::Pi<float_64>::halfValue * static_cast<float_64>(SPEED_OF_LIGHT * timeStep)
+                                / step[dir0]);
+
+                /** delta_x0 from eq. (10) in Lehe et al., generalized for any direction
+                 *
+                 * We use delta_x = delta_x0 and the other two deltas = 0 following eq. (11).
+                 */
+                float_64 const delta = 0.25 * (1.0 - coeff * coeff);
+
+                //! Helper to calculate betaDir1 uniformly in 2d and 3d
+                float_64 const stepRatio1 = dir1 < simDim ? step[dir0] / step[dir1] : 0.0;
+
+                //! Helper to calculate betaDir2 uniformly in 2d and 3d
+                float_64 const stepRatio2 = dir2 < simDim ? step[dir0] / step[dir2] : 0.0;
+
+                //! beta_yx = beta_zx from eq. (11), generalized for any direction
+                float_64 const betaDir0 = 0.125;
+
+                //! beta_xy from eq. (11), generalized for any direction
+                float_64 const betaDir1 = 0.125 * stepRatio1 * stepRatio1;
+
+                //! beta_xz from eq. (11), generalized for any direction
+                float_64 const betaDir2 = 0.125 * stepRatio2 * stepRatio2;
+
+            public:
+                /** Create a functor with the given parameters
+                 *
+                 * @param omega angular frequency = 2pi * c / lambda
+                 * @param direction normalized propagation direction
+                 */
+                DispersionRelation(float_64 const omega, float3_64 const direction)
+                    : DispersionRelationBase(omega, direction)
+                {
+                }
+
+                /** Calculate f(absK) in the dispersion relation, see comment to the main template
+                 *
+                 * @param absK absolute value of the (angular) wave number
+                 */
+                float_64 relation(float_64 const absK) const
+                {
+                    /* Eq. (8) in Lehe et al., using coefficients from eq. (11).
+                     * Generalized for arbitrary T_cherenkovFreeDir and expressed as rhs - lhs = 0
+                     */
+                    auto sSquared = sSquaredValues(absK);
+                    auto rhs = 0.0;
+                    for(uint32_t d = 0; d < simDim; d++)
+                        rhs += sSquared[d] / stepSquared[d];
+                    rhs -= 4.0 * delta * sSquared[dir0] * sSquared[dir0] / stepSquared[dir0];
+                    rhs -= 4.0 * (betaDir1 / stepSquared[dir1] + betaDir0 / stepSquared[dir0]) * sSquared[dir0]
+                        * sSquared[dir1];
+                    rhs -= 4.0 * (betaDir2 / stepSquared[dir2] + betaDir0 / stepSquared[dir0]) * sSquared[dir0]
+                        * sSquared[dir2];
+                    auto const lhsTerm = math::sin(0.5 * omega * timeStep) / (SPEED_OF_LIGHT * timeStep);
+                    auto const lhs = lhsTerm * lhsTerm;
+                    return rhs - lhs;
+                }
+
+                /** Calculate df(absK)/d(absK) in the dispersion relation, see comment to the main template
+                 *
+                 * @param absK absolute value of the (angular) wave number
+                 */
+                float_64 relationDerivative(float_64 const absK) const
+                {
+                    /* Due to the structure of the relation, it is more convenient to operate with variables
+                     * sSquared(absK) from function relation() rather than s. So e.g. for calculating d(s^4)/d(absK) we
+                     * use d(sSquared^2)/d(absK). Precalculate d(sSquared(absK))/d(absK) for x, y, z components.
+                     */
+                    auto sSquaredDerivative = float3_64::create(0.0);
+                    for(uint32_t d = 0; d < simDim; d++)
+                    {
+                        auto const arg = 0.5 * absK * direction[d] * step[d];
+                        auto const s = math::sin(arg);
+                        auto const sDerivative = 0.5 * direction[d] * step[d] * math::cos(arg);
+                        sSquaredDerivative[d] = 2.0 * s * sDerivative;
+                    }
+
+                    // Term-wise derivative in same order as in relation()
+                    auto sSquared = sSquaredValues(absK);
+                    auto result = 0.0;
+                    for(uint32_t d = 0; d < simDim; d++)
+                        result += sSquaredDerivative[d] / stepSquared[d];
+                    result -= 4.0 * delta * sSquared[dir0] * sSquaredDerivative[dir0] / stepSquared[dir0];
+                    result -= 4.0 * (betaDir1 / stepSquared[dir1] + betaDir0 / stepSquared[dir0])
+                        * (sSquared[dir0] * sSquaredDerivative[dir1] + sSquaredDerivative[dir0] * sSquared[dir1]);
+                    result -= 4.0 * (betaDir1 / stepSquared[dir1] + betaDir0 / stepSquared[dir0])
+                        * (sSquared[dir0] * sSquaredDerivative[dir2] + sSquaredDerivative[dir0] * sSquared[dir2]);
+                    return result;
+                }
+
+            private:
+                /** Get vector [s_x^2, s_y^2, s_z^2] described under eq. (8) in Lehe et al.
+                 *
+                 * @param absK absolute value of the (angular) wave number
+                 */
+                float3_64 sSquaredValues(float_64 const absK) const
+                {
+                    auto result = float3_64::create(0.0);
+                    for(uint32_t d = 0; d < simDim; d++)
+                    {
+                        auto const arg = 0.5 * absK * direction[d] * step[d];
+                        auto const s = math::sin(arg);
+                        result[d] = s * s;
+                    }
+                    return result;
+                }
+            };
+
             /** Specialization of the laser compatibility checker for for the Lehe solver
              *
              * @tparam T_CherenkovFreeDir the direction (axis) which should be free of cherenkov radiation

--- a/include/picongpu/fields/MaxwellSolver/Solvers.def
+++ b/include/picongpu/fields/MaxwellSolver/Solvers.def
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.def"
+#include "picongpu/fields/MaxwellSolver/DispersionRelation.def"
 #include "picongpu/fields/MaxwellSolver/FDTD/FDTD.def"
 #include "picongpu/fields/MaxwellSolver/Lehe/Lehe.def"
 #include "picongpu/fields/MaxwellSolver/None/None.def"


### PR DESCRIPTION
This PR extends PIConGPU simulation start log output with phase velocity of the laser enabled in `laser.param`. 
It looks like this:
```bash
...
PIConGPUVerbose PHYSICS(1) | Field solver condition: c * dt <= 1.4912 ? (c * dt = 1)
PIConGPUVerbose PHYSICS(1) | Laser numerical dispersion: v_phase = 0.996018 * c
PIConGPUVerbose PHYSICS(1) | Resolving plasma oscillations?
...
```
This part does not perform any check or print a warning when far away from `c`, as it is hard to define reasonable margins. Same as Debye length check, It is information for a user to use their own judgement. (This may be particularly relevant for long simulations, also when using high-order solver and/or time substepping coming in the future).

The calculation is done for the grid parameters and field solver used in a simulation, so matches the current simulation. All our field solvers are supported with their respective numerical dispersion relations used. For now the calculation and output are done only for laser, not for incident field or background field. However, all the internals are general enough to add at least incident field quickly in a follow-up PR (there are some mostly unrelated technical reasons I didn't do it as part of this PR).

Even though our standard lasers always propagate in along `y`, all internal implementation is for general propagation direction (so that we can add incident fields soon). In that general case, the numerical dispersion relation has no explicit form for solution. So the new code always solves it numerically. However, it should  normally be very precise as we know a very good (for a reasonably set up simulation) approximate solution corresponding to `phase_velocity = c`. When I checked against the theoretically known solution for Yee solver and axis-aligned and diagonal propagation directions, the numerical solution had 6 correct digits. This is also why I did not implement these cases as special to fall back. I also checked that the general behavior is reasonable e.g. for Yee diagonal propagation is closer to c than axis-aligned, for Lehe solver our calculated phase velocity is slightly above c in that direction and below it in (substantially) different directions, and that ~~for high-order AOFDTD it could become quite substantially larger than c as also theoretically expected. So basically it all seems to work fine. Edit: for the latter also see my next message~~ edit: I initially implemented wrong dispersion relation for AOFDTD, now fixed and phase velocity is only slightly above c