### PR TITLE
Add string names for incident field profiles

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -27,6 +27,8 @@
 #include <pmacc/algorithms/math/defines/pi.hpp>
 
 #include <cstdint>
+#include <string>
+
 
 namespace picongpu
 {
@@ -36,6 +38,16 @@ namespace picongpu
         {
             namespace profiles
             {
+                template<typename T_Params>
+                struct ExpRampWithPrepulse
+                {
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        return "ExpRampWithPrepulse";
+                    }
+                };
+
                 namespace detail
                 {
                     /** Unitless exponential ramp with prepulse parameters

--- a/include/picongpu/fields/incidentField/profiles/Free.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Free.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/fields/incidentField/profiles/Free.def"
 
 #include <cstdint>
+#include <string>
 
 
 namespace picongpu
@@ -33,6 +34,16 @@ namespace picongpu
     {
         namespace incidentField
         {
+            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+            struct Free
+            {
+                //! Get text name of the incident field profile
+                static HINLINE std::string getName()
+                {
+                    return "Free";
+                }
+            };
+
             namespace detail
             {
                 /** Get type of incident field E functor for the free profile type

--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
@@ -27,9 +27,12 @@
 
 #include <pmacc/algorithms/math/defines/pi.hpp>
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
+#include <string>
 #include <type_traits>
+
 
 namespace picongpu
 {
@@ -311,6 +314,20 @@ namespace picongpu
                         }
                     };
                 } // namespace detail
+
+                template<typename T_Params>
+                struct GaussianBeam
+                {
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        // This template is used for both Gaussian and PulseFrontTilt, distinguish based on tilt value
+                        using TiltParam = detail::TiltParam<T_Params>;
+                        bool isTilted = (std::abs(TiltParam::TILT_AXIS_1) + std::abs(TiltParam::TILT_AXIS_2) > 0);
+                        return isTilted ? "PulseFrontTilt" : "GaussianBeam";
+                    }
+                };
+
             } // namespace profiles
 
             namespace detail

--- a/include/picongpu/fields/incidentField/profiles/None.hpp
+++ b/include/picongpu/fields/incidentField/profiles/None.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/incidentField/profiles/None.def"
 
 #include <cstdint>
+#include <string>
 
 
 namespace picongpu
@@ -34,6 +35,15 @@ namespace picongpu
     {
         namespace incidentField
         {
+            struct None
+            {
+                //! Get text name of the incident field profile
+                static HINLINE std::string getName()
+                {
+                    return "None";
+                }
+            };
+
             namespace detail
             {
                 //! Get type of incident field E functor for the none profile type

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/fields/incidentField/Traits.hpp"
 
 #include <cstdint>
+#include <string>
 
 
 namespace picongpu
@@ -35,6 +36,16 @@ namespace picongpu
         {
             namespace profiles
             {
+                template<typename T_Params>
+                struct PlaneWave
+                {
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        return "PlaneWave";
+                    }
+                };
+
                 namespace detail
                 {
                     /** Unitless plane wave parameters

--- a/include/picongpu/fields/incidentField/profiles/Polynom.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Polynom.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/fields/incidentField/Traits.hpp"
 
 #include <cstdint>
+#include <string>
 
 
 namespace picongpu
@@ -35,6 +36,16 @@ namespace picongpu
         {
             namespace profiles
             {
+                template<typename T_Params>
+                struct Polynom
+                {
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        return "Polynom";
+                    }
+                };
+
                 namespace detail
                 {
                     /** Unitless polynom parameters

--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
@@ -34,6 +34,16 @@ namespace picongpu
         {
             namespace profiles
             {
+                template<typename T_Params>
+                struct Wavepacket
+                {
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        return "Wavepacket";
+                    }
+                };
+
                 namespace detail
                 {
                     /** Unitless wavepacket parameters


### PR DESCRIPTION
The names are not used yet, but will be used soon for phase velocity output (of incident field, to differentiate between them)