### PR TITLE
Add a helper type for unique typelist of enabled incident field profiles

### DIFF
--- a/include/picongpu/fields/incidentField/Traits.hpp
+++ b/include/picongpu/fields/incidentField/Traits.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/meta/conversion/Unique.hpp>
 
 #include <cstdint>
 #include <type_traits>
@@ -125,6 +126,9 @@ namespace picongpu
                 YMin,
                 YMax,
                 std::conditional_t<simDim == 3, pmacc::MakeSeq_t<ZMin, ZMax>, pmacc::MakeSeq_t<>>>;
+
+            //! Typelist of all unique enabled profiles, can contain duplicates
+            using UniqueEnabledProfiles = pmacc::Unique_t<EnabledProfiles>;
 
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -202,7 +202,7 @@ namespace picongpu
         //! Get laser E amplitude in internal units
         HDINLINE static float_X getAmplitude()
         {
-            using Profiles = fields::incidentField::EnabledProfiles;
+            using Profiles = fields::incidentField::UniqueEnabledProfiles;
             meta::ForEach<Profiles, CalculateMaxAmplitude<bmpl::_1>> calculateMaxAmplitude;
             auto maxAmplitude = 0.0_X;
             calculateMaxAmplitude(maxAmplitude);


### PR DESCRIPTION
Use the new unique incident fields typelist for PNG normalization.

This typelist will also be needed for incident field phase velocity output, coming soon.

- [x] Merge after #4176, this implementation depends on new semantics of `pmacc::Unique` introduced there (syntax didn't change)