### PR TITLE
Fix transversal part of 2d incident field profiles

### DIFF
--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -98,6 +98,7 @@ namespace picongpu
                  * Defines internal coordinate system tied to laser focus position and direction.
                  * Its axes are, in this order: propagation direction, polarization direction,
                  * cross product of propagation direction and polarization direction.
+                 * The internal coordinate system is always 3d, regardless of simDim.
                  *
                  * Provides conversion operations for cooridnate and time transforms to internal system.
                  * Essentially, a client of this class can implement a laser in internal coordinate system and
@@ -169,18 +170,17 @@ namespace picongpu
                         return pmacc::math::cross(getAxis0(), getCircularPolarizationVector1());
                     }
 
-                    /** Transform the given cell index to coordinates (not cell index) in the internal system
+                    /** Transform the given cell index to 3d coordinates (not cell index) in the internal system
                      *
                      * @param totalCellIdx cell index in the total domain
                      */
-                    HDINLINE floatD_X getInternalCoordinates(floatD_X const& totalCellIdx) const
+                    HDINLINE float3_X getInternalCoordinates(floatD_X const& totalCellIdx) const
                     {
                         auto const shiftFromOrigin = totalCellIdx * cellSize.shrink<simDim>() - origin;
-                        floatD_X result;
+                        float3_X result;
                         result[0] = pmacc::math::dot(shiftFromOrigin, getAxis0().shrink<simDim>());
                         result[1] = pmacc::math::dot(shiftFromOrigin, getAxis1().shrink<simDim>());
-                        if constexpr(simDim == 3)
-                            result[2] = pmacc::math::dot(shiftFromOrigin, getAxis2().shrink<simDim>());
+                        result[2] = pmacc::math::dot(shiftFromOrigin, getAxis2().shrink<simDim>());
                         return result;
                     }
 
@@ -399,9 +399,9 @@ namespace picongpu
                      */
                     HDINLINE float_X getTransversal(floatD_X const& totalCellIdx) const
                     {
-                        auto internalPosition = this->getInternalCoordinates(totalCellIdx);
+                        float3_X internalPosition = this->getInternalCoordinates(totalCellIdx);
                         internalPosition[0] = 0.0_X;
-                        auto const w0 = float3_X(1.0_X, Unitless::W0_AXIS_1, Unitless::W0_AXIS_2).shrink<simDim>();
+                        auto const w0 = float3_X(1.0_X, Unitless::W0_AXIS_1, Unitless::W0_AXIS_2);
                         auto const r2 = pmacc::math::abs2(internalPosition / w0);
                         return math::exp(-r2);
                     }

--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
@@ -204,8 +204,8 @@ namespace picongpu
                          */
                         HDINLINE float_X getValue(floatD_X const& totalCellIdx, float_X const phaseShift) const
                         {
-                            // transform to internal coordinate system
-                            floatD_X pos = this->getInternalCoordinates(totalCellIdx);
+                            // transform to 3d internal coordinate system
+                            float3_X pos = this->getInternalCoordinates(totalCellIdx);
                             auto const time = this->getCurrentTime(totalCellIdx);
                             if(time < 0.0_X)
                                 return 0.0_X;
@@ -238,14 +238,11 @@ namespace picongpu
                                     / pmacc::math::dot(this->getDirection(), float3_X{cellSize});
                                 auto const tilt1 = Unitless::TILT_AXIS_1;
                                 pos[1] += math::tan(tilt1) * tiltPositionShift;
-                                if constexpr(simDim == 3)
-                                {
-                                    auto const tilt2 = Unitless::TILT_AXIS_2;
-                                    pos[2] += math::tan(tilt2) * tiltPositionShift;
-                                }
+                                auto const tilt2 = Unitless::TILT_AXIS_2;
+                                pos[2] += math::tan(tilt2) * tiltPositionShift;
                             }
 
-                            auto planeNoNormal = floatD_X::create(1.0_X);
+                            auto planeNoNormal = float3_X::create(1.0_X);
                             planeNoNormal[0] = 0.0_X;
                             auto const transversalDistanceSquared = pmacc::math::abs2(pos * planeNoNormal);
 

--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
@@ -215,7 +215,6 @@ namespace picongpu
                                                                    Unitless::FOCUS_POSITION_X,
                                                                    Unitless::FOCUS_POSITION_Y,
                                                                    Unitless::FOCUS_POSITION_Z)
-                                                                   .shrink<simDim>()
                                 - this->origin;
                             float_X const focusPos = math::sqrt(pmacc::math::abs2(focusRelativeToOrigin)) - pos[0];
                             // beam waist at the generation plane so that at focus we will get W0


### PR DESCRIPTION
Properly convert to the always-3d internal coordinate system.
Fixes https://github.com/ComputationalRadiationPhysics/picongpu/issues/4180.