### PR TITLE
Allow fractional incides in TWTSfast functors

### DIFF
--- a/include/picongpu/fields/background/templates/twtsfast/BField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.hpp
@@ -128,9 +128,32 @@ namespace picongpu
 
                 /** Specify your background field B(r,t) here
                  *
-                 * @param cellIdx The total cell id counted from the start at t=0
-                 * @param currentStep The current time step */
+                 * @param cellIdx The total cell id counted from the start at t=0, note it can be fractional
+                 * @param currentStep The current time step for the field to be calculated at, note it can be
+                 * fractional
+                 * @return float3_X with field normalized to amplitude in range [-1.:1.]
+                 *
+                 * @{
+                 */
+
+                //! Integer index version, adds in-cell shifts according to the grid used; t = currentStep * dt
                 HDINLINE float3_X operator()(DataSpace<simDim> const& cellIdx, uint32_t const currentStep) const;
+
+                //! Floating-point index version, uses fractional cell index as provided; t = currentStep * dt
+                HDINLINE float3_X operator()(floatD_X const& cellIdx, float_X const currentStep) const;
+
+                /** @} */
+
+                /** Calculate B(r, t) for given position, time, and extra in-cell shifts
+                 *
+                 * @param cellIdx The total cell id counted from the start at t=0, note it is fractional
+                 * @param extraShifts The extra in-cell shifts to be added to calculate the position
+                 * @param currentStep The current time step for the field to be calculated at, note it is fractional
+                 */
+                HDINLINE float3_X getValue(
+                    floatD_X const& cellIdx,
+                    pmacc::math::Vector<floatD_X, detail::numComponents> const& extraShifts,
+                    float_X const currentStep) const;
 
                 /** Calculate the By(r,t) field, when electric field vector (Ex,0,0)
                  *  is normal to the pulse-front-tilt plane (y,z)

--- a/include/picongpu/fields/background/templates/twtsfast/BField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.tpp
@@ -289,11 +289,29 @@ namespace picongpu
             HDINLINE
             float3_X BField::operator()(DataSpace<simDim> const& cellIdx, uint32_t const currentStep) const
             {
-                float_64 const time_SI = float_64(currentStep) * dt - tdelay;
                 traits::FieldPosition<fields::CellType, FieldB> const fieldPosB;
+                return getValue(precisionCast<float_X>(cellIdx), fieldPosB(), static_cast<float_X>(currentStep));
+            }
+
+            HDINLINE
+            float3_X BField::operator()(floatD_X const& cellIdx, float_X const currentStep) const
+            {
+                pmacc::math::Vector<floatD_X, detail::numComponents> zeroShifts;
+                for(uint32_t component = 0; component < detail::numComponents; ++component)
+                    zeroShifts[component] = floatD_X::create(0.0);
+                return getValue(cellIdx, zeroShifts, currentStep);
+            }
+
+            HDINLINE
+            float3_X BField::getValue(
+                floatD_X const& cellIdx,
+                pmacc::math::Vector<floatD_X, detail::numComponents> const& extraShifts,
+                float_X const currentStep) const
+            {
+                float_64 const time_SI = float_64(currentStep) * dt - tdelay;
 
                 pmacc::math::Vector<floatD_64, detail::numComponents> const bFieldPositions_SI
-                    = detail::getFieldPositions_SI(cellIdx, halfSimSize, fieldPosB(), unit_length, focus_y_SI, phi);
+                    = detail::getFieldPositions_SI(cellIdx, halfSimSize, extraShifts, unit_length, focus_y_SI, phi);
                 /* Single TWTS-Pulse */
                 switch(pol)
                 {

--- a/include/picongpu/fields/background/templates/twtsfast/EField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.hpp
@@ -126,11 +126,32 @@ namespace picongpu
 
                 /** Specify your background field E(r,t) here
                  *
-                 * @param cellIdx The total cell id counted from the start at timestep 0.
-                 * @param currentStep The current time step
+                 * @param cellIdx The total cell id counted from the start at t=0, note it can be fractional
+                 * @param currentStep The current time step for the field to be calculated at, note it can be
+                 * fractional
                  * @return float3_X with field normalized to amplitude in range [-1.:1.]
+                 *
+                 * @{
                  */
+
+                //! Integer index version, adds in-cell shifts according to the grid used; t = currentStep * dt
                 HDINLINE float3_X operator()(DataSpace<simDim> const& cellIdx, uint32_t const currentStep) const;
+
+                //! Floating-point index version, uses fractional cell index as provided; t = currentStep * dt
+                HDINLINE float3_X operator()(floatD_X const& cellIdx, float_X const currentStep) const;
+
+                /** @} */
+
+                /** Calculate E(r, t) for given position, time, and extra in-cell shifts
+                 *
+                 * @param cellIdx The total cell id counted from the start at t=0, note it is fractional
+                 * @param extraShifts The extra in-cell shifts to be added to calculate the position
+                 * @param currentStep The current time step for the field to be calculated at, note it is fractional
+                 */
+                HDINLINE float3_X getValue(
+                    floatD_X const& cellIdx,
+                    pmacc::math::Vector<floatD_X, detail::numComponents> const& extraShifts,
+                    float_X const currentStep) const;
 
                 /** Calculate the Ex(r,t) field here (electric field vector normal to pulse-front-tilt plane)
                  *

--- a/include/picongpu/fields/background/templates/twtsfast/getFieldPositions_SI.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/getFieldPositions_SI.tpp
@@ -39,7 +39,7 @@ namespace picongpu
                  *  and Bz(r ,t) calculations as r.
                  *  @param cellIdx The total cell id counted from the start at timestep 0. */
                 HDINLINE pmacc::math::Vector<floatD_64, numComponents> getFieldPositions_SI(
-                    DataSpace<simDim> const& cellIdx,
+                    floatD_X const& cellIdx,
                     DataSpace<simDim> const& halfSimSize,
                     pmacc::math::Vector<floatD_X, numComponents> const& fieldOnGridPositions,
                     float_64 const unit_length,
@@ -67,7 +67,7 @@ namespace picongpu
 
                     for(uint32_t i = 0; i < numComponents; ++i) /* cellIdx Ex, Ey and Ez */
                     {
-                        fieldPositions[i] += (precisionCast<float_X>(cellIdx) - laserOrigin);
+                        fieldPositions[i] += (cellIdx - laserOrigin);
                         fieldPositions_SI[i] = precisionCast<float_64>(fieldPositions[i]) * cellDimensions;
 
                         fieldPositions_SI[i] = rotateField(fieldPositions_SI[i], phi);


### PR DESCRIPTION
The pre-existing interface is kept, and can still be used for background fields with its previously existing logic for in-cell shifts according to the Yee grid (so thie PR does not change the results of the `TWEAC_FOM` setup).

The new interface is suited for usage inside a `Free` incident field functor that already gets appropriately space and time-shifted incides. Then no further shifts are applied inside `TWTSfast` and it should all work correctly then.

Note that this PR only changes `TWTSfast`, but not `TWTS`. So only the former is readily available for usage with incident field. In principle, same changes can be also applied for `TWTS` if that is needed.