### PR TITLE
Output numerical phase velocity for enabled incident field profiles

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/Free.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Free.hpp
@@ -34,15 +34,18 @@ namespace picongpu
     {
         namespace incidentField
         {
-            template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
-            struct Free
+            namespace profiles
             {
-                //! Get text name of the incident field profile
-                static HINLINE std::string getName()
+                template<typename T_FunctorIncidentE, typename T_FunctorIncidentB>
+                struct Free
                 {
-                    return "Free";
-                }
-            };
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        return "Free";
+                    }
+                };
+            } // namespace profiles
 
             namespace detail
             {

--- a/include/picongpu/fields/incidentField/profiles/None.hpp
+++ b/include/picongpu/fields/incidentField/profiles/None.hpp
@@ -35,14 +35,17 @@ namespace picongpu
     {
         namespace incidentField
         {
-            struct None
+            namespace profiles
             {
-                //! Get text name of the incident field profile
-                static HINLINE std::string getName()
+                struct None
                 {
-                    return "None";
-                }
-            };
+                    //! Get text name of the incident field profile
+                    static HINLINE std::string getName()
+                    {
+                        return "None";
+                    }
+                };
+            } // namespace profiles
 
             namespace detail
             {


### PR DESCRIPTION
Similarly to how it has recently been added for laser. Each different enabled incident field will be a separale line in the output, the calculation will use its wavelength and propagation direction. That is exept `None` (no phase velocity) and `Free` (no way to automatically calculate phase velocity).

This PR also fixes a mistake in string names in some incident field profiles, that was just introduced in #4175 (with a plan to be used here).