### PR TITLE
Switch to std::void_t

### DIFF
--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -46,6 +46,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 namespace picongpu
@@ -54,15 +55,6 @@ namespace picongpu
 
     namespace detail
     {
-        /* Helper to check if a member exists
-         *
-         * Derived from C++17 std::void_t.
-         * This implementation will be removed with Void provided by alpaka 0.6.0 release (not included in the 0.6.0rc3
-         * we currently using).
-         */
-        template<class...>
-        using Void = void;
-
         /** Calculate the scaling factor for each direction.
          *
          * The scaling factor is derived from the reference size of the local domain and a scaling factor provided by
@@ -95,7 +87,7 @@ namespace picongpu
         template<typename T_ExchangeMemCfg>
         struct DirScalingFactor<
             T_ExchangeMemCfg,
-            Void<
+            std::void_t<
                 decltype(std::declval<T_ExchangeMemCfg>().DIR_SCALING_FACTOR),
                 typename T_ExchangeMemCfg::REF_LOCAL_DOM_SIZE>>
         {

--- a/include/pmacc/lockstep/ForEach.hpp
+++ b/include/pmacc/lockstep/ForEach.hpp
@@ -51,15 +51,6 @@ namespace pmacc
             : Config<T_domainSize, T_numWorkers, T_simdSize>
             , Worker<T_numWorkers>
         {
-            /* Helper to check if a member exists
-             *
-             * Derived from C++17 std::void_t.
-             * This implementation will be removed with Void provided by alpaka 0.6.0 release (not included in the
-             * 0.6.0rc3 we currently using).
-             */
-            template<class...>
-            using Void = void;
-
             /** Get the result of a functor invocation.
              *
              * @attention The behavior is undefined for ill-formed invocations.
@@ -83,11 +74,11 @@ namespace pmacc
             /** Expression will result in a well formed type if the functor can be invoked with Idx as argument */
             template<typename T_Functor>
             using IsCallableWithIndex
-                = Void<decltype(alpaka::core::declval<T_Functor>()(alpaka::core::declval<Idx const>()))>;
+                = std::void_t<decltype(alpaka::core::declval<T_Functor>()(alpaka::core::declval<Idx const>()))>;
 
             /** Expression will result in a well formed type if the functor can be invoked without an argument */
             template<typename T_Functor>
-            using IsCallableWithoutArguments = Void<decltype(alpaka::core::declval<T_Functor>()())>;
+            using IsCallableWithoutArguments = std::void_t<decltype(alpaka::core::declval<T_Functor>()())>;
 
         public:
             using BaseConfig = Config<T_domainSize, T_numWorkers, T_simdSize>;


### PR DESCRIPTION
Remove old custom-made `Void<>` doing the same.

@psychocoderHPC in case this conflicts with your ongoing work in #4173 , we can keep this open for now. I just accidentally noticed that while working on other things and needing `std::void_t` for that.