### PR TITLE
Allow componentwise calculation of incident field functors

### DIFF
--- a/include/picongpu/fields/background/templates/twtsfast/BField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -143,6 +143,20 @@ namespace picongpu
                 HDINLINE float3_X operator()(floatD_X const& cellIdx, float_X const currentStep) const;
 
                 /** @} */
+
+                /** Calculate the given component of B(r, t)
+                 *
+                 * Result is same as for the fractional version of operator()(cellIdx, currentStep)[T_component].
+                 * This version exists for optimizing usage in incident field where single components are needed.
+                 *
+                 * @tparam T_component field component, 0 = x, 1 = y, 2 = z
+                 *
+                 * @param cellIdx The total fractional cell id counted from the start at t=0
+                 * @param currentStep The current time step for the field to be calculated at
+                 * @return float_X with field component normalized to amplitude in range [-1.:1.]
+                 */
+                template<uint32_t T_component>
+                HDINLINE float_X getComponent(floatD_X const& cellIdx, float_X const currentStep) const;
 
                 /** Calculate B(r, t) for given position, time, and extra in-cell shifts
                  *

--- a/include/picongpu/fields/background/templates/twtsfast/EField.hpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -141,6 +141,20 @@ namespace picongpu
                 HDINLINE float3_X operator()(floatD_X const& cellIdx, float_X const currentStep) const;
 
                 /** @} */
+
+                /** Calculate the given component of E(r, t)
+                 *
+                 * Result is same as for the fractional version of operator()(cellIdx, currentStep)[T_component].
+                 * This version exists for optimizing usage in incident field where single components are needed.
+                 *
+                 * @tparam T_component field component, 0 = x, 1 = y, 2 = z
+                 *
+                 * @param cellIdx The total fractional cell id counted from the start at t=0
+                 * @param currentStep The current time step for the field to be calculated at
+                 * @return float_X with field component normalized to amplitude in range [-1.:1.]
+                 */
+                template<uint32_t T_component>
+                HDINLINE float_X getComponent(floatD_X const& cellIdx, float_X const currentStep) const;
 
                 /** Calculate E(r, t) for given position, time, and extra in-cell shifts
                  *

--- a/include/picongpu/fields/background/templates/twtsfast/EField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/EField.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Alexander Debus, Axel Huebl
+/* Copyright 2014-2022 Alexander Debus, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -217,6 +217,53 @@ namespace picongpu
                     return getTWTSEfield_Normalized_Ey<simDim>(eFieldPositions_SI, time_SI);
                 }
                 return getTWTSEfield_Normalized<simDim>(eFieldPositions_SI, time_SI); // defensive default
+            }
+
+            template<uint32_t T_component>
+            HDINLINE float_X EField::getComponent(floatD_X const& cellIdx, float_X const currentStep) const
+            {
+                // The optimized way is only implemented for 3d, fall back to full field calculation in 2d
+                if constexpr(simDim == DIM3)
+                {
+                    float_64 const time_SI = float_64(currentStep) * dt - tdelay;
+                    pmacc::math::Vector<floatD_X, detail::numComponents> zeroShifts;
+                    for(uint32_t component = 0; component < detail::numComponents; ++component)
+                        zeroShifts[component] = floatD_X::create(0.0);
+                    pmacc::math::Vector<floatD_64, detail::numComponents> const eFieldPositions_SI
+                        = detail::getFieldPositions_SI(cellIdx, halfSimSize, zeroShifts, unit_length, focus_y_SI, phi);
+                    // Explicitly use a 3d vector so that this function compiles for 2d as well
+                    auto const pos = float3_64{
+                        eFieldPositions_SI[T_component][0],
+                        eFieldPositions_SI[T_component][1],
+                        eFieldPositions_SI[T_component][2]};
+                    switch(pol)
+                    {
+                    case LINEAR_X:
+                        if constexpr(T_component == 0)
+                            return static_cast<float_X>(calcTWTSEx(pos, time_SI));
+                        else
+                            return 0.0_X;
+
+                    case LINEAR_YZ:
+                        if constexpr(T_component == 0)
+                            return 0.0_X;
+                        else
+                        {
+                            auto const field = calcTWTSEy(pos, time_SI);
+                            float_X sinPhi;
+                            float_X cosPhi;
+                            pmacc::math::sincos(phi, sinPhi, cosPhi);
+                            if constexpr(T_component == 1)
+                                return -sinPhi * field;
+                            if constexpr(T_component == 2)
+                                return -cosPhi * field;
+                        }
+                    }
+                    // we should never be here
+                    return 0.0_X;
+                }
+                if constexpr(simDim != DIM3)
+                    return (*this)(cellIdx, currentStep)[T_component];
             }
 
             /** Calculate the Ex(r,t) field here

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -66,6 +66,24 @@ namespace picongpu
                  * @return incident field value in internal units
                  */
                 HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const;
+
+                /** Optional interface to get a given field component
+                 *
+                 * When provided by a functor, this version will be called instead of operator().
+                 * Result of functor.getComponent<T_component>(totalCellIdx) must equal
+                 * functor(totalCellIdx)[T_Component].
+                 *
+                 * This interface exists only for performance optimization purposes for (very) compute-intensive
+                 * functors. Namely, it allows calculation of only components needed by the incident field solver. Note
+                 * however that this is generally not important as incident field is rarely a hot spot.
+                 *
+                 * @tparam T_component field component, 0 = x, 1 = y, 2 = z
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides),
+                 *        note that it is fractional
+                 */
+                template<uint32_t T_component>
+                HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const;
             };
 
             //! Helper incident field functor always returning 0

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -279,24 +279,12 @@ namespace picongpu
 
                     /* Compute which components of the incidentField are used,
                      * which components of the updatedField they contribute to and with which coefficients.
+                     * The sign and cross combination are consistent with implementation of Functor.
                      */
-
-                    // dir0 is boundary normal axis, dir1 and dir2 are two other axes
-                    constexpr auto dir0 = T_axis;
-                    constexpr auto dir1 = (dir0 + 1) % 3;
-                    constexpr auto dir2 = (dir0 + 2) % 3;
-
-                    /* IncidentField components to be used for the two terms.
-                     * Note the intentional cross combination here, the following calculations rely on it
-                     */
-                    functor.incidentComponent1 = dir2;
-                    functor.incidentComponent2 = dir1;
-
-                    // Coefficients for the respective terms
                     float_X const directionSign = (parameters.direction > 0.0_X ? 1.0_X : -1.0_X);
                     float_X const coeffBase = curlCoefficient / cellSize[T_axis] * directionSign;
-                    functor.coeff1[dir1] = coeffBase;
-                    functor.coeff2[dir2] = -coeffBase;
+                    functor.coeff1[functor.incidentComponent2] = coeffBase;
+                    functor.coeff2[functor.incidentComponent1] = -coeffBase;
 
                     /* For the positive direction, the updated total field index was shifted by 1 earlier.
                      * This index shift is translated to in-cell shift for the incidentField here.
@@ -305,9 +293,9 @@ namespace picongpu
                     if(parameters.direction > 0)
                     {
                         if(isUpdatedFieldTotal)
-                            incidentFieldBaseShift[dir0] = -1.0_X;
+                            incidentFieldBaseShift[T_axis] = -1.0_X;
                         else
-                            incidentFieldBaseShift[dir0] = 1.0_X;
+                            incidentFieldBaseShift[T_axis] = 1.0_X;
                     }
                     auto incidentFieldPositions = traits::FieldPosition<cellType::Yee, T_IncidentField>{}();
                     functor.inCellShift1 = incidentFieldBaseShift + incidentFieldPositions[functor.incidentComponent1];

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -25,6 +25,7 @@
 #include "picongpu/fields/incidentField/DerivativeCoefficients.hpp"
 
 #include <cstdint>
+#include <type_traits>
 
 /** @note In this file we use camelCase "updatedField" in both code and comments to denote field E or B that is being
  * updated (i.e. corrected) in the kernel. The other of the two fields is called "incidentField". And for the
@@ -41,6 +42,54 @@ namespace picongpu
         {
             namespace detail
             {
+                /** Helper type to check if T_FunctorIncidentField implements getComponent<T_component>()
+                 *
+                 * Is void for those types, ill-formed otherwise.
+                 *
+                 * @tparam T_FunctorIncidentField incident field source functor type
+                 * @tparam T_component field component, 0 = x, 1 = y, 2 = z
+                 */
+                template<typename T_FunctorIncidentField, uint32_t T_component>
+                using HasGetComponent
+                    = std::void_t<decltype(alpaka::core::declval<T_FunctorIncidentField>()
+                                               .template getComponent<T_component>(floatD_X::create(0.0_X)))>;
+
+                /** Functor to get the chosen component of the given incident field functor at the given position
+                 *
+                 * The general implementation calculates full field and takes the component.
+                 * In case a functor implements getComponent<T_component>(), that will be called.
+                 * @see FunctorIncidentFieldConcept for rationale and interface requirements.
+                 *
+                 * @tparam T_FunctorIncidentField incident field source functor type
+                 * @tparam T_component field component, 0 = x, 1 = y, 2 = z
+                 * @tparam T_Sfinae parameter to SFINAE-switch between the cases
+                 *
+                 * @{
+                 */
+
+                template<typename T_FunctorIncidentField, uint32_t T_component, typename T_Sfinae = void>
+                struct GetComponent
+                {
+                    HDINLINE auto operator()(T_FunctorIncidentField const& functor, floatD_X const& totalCellIdx) const
+                    {
+                        return functor(totalCellIdx)[T_component];
+                    }
+                };
+
+                template<typename T_FunctorIncidentField, uint32_t T_component>
+                struct GetComponent<
+                    T_FunctorIncidentField,
+                    T_component,
+                    HasGetComponent<T_FunctorIncidentField, T_component>>
+                {
+                    HDINLINE auto operator()(T_FunctorIncidentField const& functor, floatD_X const& totalCellIdx) const
+                    {
+                        return functor.template getComponent<T_component>(totalCellIdx);
+                    }
+                };
+
+                /** @} */
+
                 /** Helper functor for in-kernel update of the given field using the given incidentField functor
                  *
                  * Performs update by adding terms with the incidentField.
@@ -159,8 +208,12 @@ namespace picongpu
                      */
                     float3_X coeff1, coeff2;
 
-                    //! Indices of the incidentField components for the two terms
-                    uint32_t incidentComponent1, incidentComponent2;
+                    /** Indices of the incidentField components for the two terms
+                     *
+                     * Note the intentional cross combination, this is to match the general vector update stated above.
+                     */
+                    static constexpr uint32_t incidentComponent1 = (T_axis + 2) % 3;
+                    static constexpr uint32_t incidentComponent2 = (T_axis + 1) % 3;
 
                     //! Shifts inside the cell for two functorIncidentField invocations, in cells
                     floatD_X inCellShift1, inCellShift2;
@@ -227,9 +280,10 @@ namespace picongpu
                          * operate as if in 3d.
                          * For 2d the z loop is always for a single iteration.
                          * The resulting 3d indices are shrinked to simDim.
+                         * Note the intentional cross combination here, see declaration of incidentComponent1, 2.
                          */
-                        constexpr auto dir1 = (axis + 1) % 3;
-                        constexpr auto dir2 = (axis + 2) % 3;
+                        constexpr auto dir1 = incidentComponent2;
+                        constexpr auto dir2 = incidentComponent1;
                         constexpr int32_t sizeDir1 = pmacc::math::CT::At_c<NumCoefficients, dir1>::type::value;
                         constexpr int32_t sizeDir2 = pmacc::math::CT::At_c<NumCoefficients, dir2>::type::value;
                         /* Due to indexing of the Yee grid, at the last updated cell we must update only some of the
@@ -261,14 +315,12 @@ namespace picongpu
                                     // coeff1, 2
                                     if(applyIncidentField1)
                                         result += derivativeCoeff * coeff1
-                                            * functorIncidentField(
-                                                      incidentFieldShift1
-                                                      + incidentIdxShift.shrink<simDim>())[incidentComponent1];
+                                            * getIncidentFieldComponent1(
+                                                      incidentFieldShift1 + incidentIdxShift.shrink<simDim>());
                                     if(applyIncidentField2)
                                         result += derivativeCoeff * coeff2
-                                            * functorIncidentField(
-                                                      incidentFieldShift2
-                                                      + incidentIdxShift.shrink<simDim>())[incidentComponent2];
+                                            * getIncidentFieldComponent2(
+                                                      incidentFieldShift2 + incidentIdxShift.shrink<simDim>());
                                     incidentIdxShift[dir2] += 1.0_X;
                                 }
                                 incidentIdxShift[dir1] += 1.0_X;
@@ -314,6 +366,29 @@ namespace picongpu
                             result -= direction;
                         return result;
                     }
+
+                    /** Get individual components of field calculated by the incident field functor
+                     *
+                     * @param totalCellIdx cell index in the total domain
+                     *
+                     * @{
+                     */
+
+                    HDINLINE auto getIncidentFieldComponent1(floatD_X const& totalCellIdx) const
+                    {
+                        return GetComponent<T_FunctorIncidentField, incidentComponent1>{}(
+                            functorIncidentField,
+                            totalCellIdx);
+                    }
+
+                    HDINLINE auto getIncidentFieldComponent2(floatD_X const& totalCellIdx) const
+                    {
+                        return GetComponent<T_FunctorIncidentField, incidentComponent2>{}(
+                            functorIncidentField,
+                            totalCellIdx);
+                    }
+
+                    /** @} */
                 };
 
                 /** Kernel to apply incidentField


### PR DESCRIPTION
This PR adds a new altenative interaface for incident field functors that would provide values for components separately. In case a functor implements the new interface, it would be preferred. All old functors still work, and most of them should not switch to the new interface. The only reason to switch is performance for very computationally intensive incident fields like TWTS. So most functions should not switch as they would gain practically nothing and it will just complicate things for no reason.

Add a hook for component-wise calculation of TWTSfast. This is an alternative to the previously existing interface. It will allow more efficient usage of TWTSfast inside Free incident field functors. (I will add an example in a follow-up PR).