### PR TITLE
Fix index shift in 2d incident field kernel

### DIFF
--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -272,7 +272,7 @@ namespace picongpu
                         pmacc::math::Vector<bool, simDim> const& isLastUpdatedCell) const
                     {
                         auto result = float3_X::create(0.0_X);
-                        auto incidentIdxShift = floatD_X::create(0.0_X);
+                        auto incidentIdxShift = float3_X::create(0.0_X);
                         incidentIdxShift[axis] = getInitialIncidentFieldShift(updatedFieldShift);
                         auto const incidentIdxShiftIncrement = getIncidentFieldShiftIncrement(updatedFieldShift);
 


### PR DESCRIPTION
The index was mistakenly `simDim`-dimensional, but the kernel logically always operates with 3d. As a result, we potentially accessed memory off the allocated vector. Change the index to 3d always as was originally intended.