### PR TITLE
fix crusher profiles

### DIFF
--- a/etc/picongpu/crusher-ornl/batch.tpl
+++ b/etc/picongpu/crusher-ornl/batch.tpl
@@ -28,11 +28,10 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
-#SBATCH --ntasks-per-node=!TBG_devicesPerNode
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --cpus-per-task=!TBG_coresPerGPU
 #SBATCH --mem-per-gpu=!TBG_memPerDevice
-#SBATCH --gpus-per-task=1
+#SBATCH --ntasks-per-gpu=1
 #SBATCH --gpu-bind=closest
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress

--- a/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
@@ -100,7 +100,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks=$((numNodes * 8)) --cpus-per-task=8 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -116,7 +116,7 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --cpus-per-task=8 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
@@ -99,7 +99,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks=$((numNodes * 8)) --cpus-per-task=8 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -115,7 +115,7 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=8 --gpus-per-task=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --cpus-per-task=8 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
Fix slurm parameters to avoid the folowing error.

```
srun: fatal: SLURM_GPUS_PER_TASK is mutually exclusive with --ntasks-per-gpu and SLURM_NTASKS_PER_GPU
```