### PR TITLE
HIP: use compute current strategy `strategy::CachedSupercellsScaled<2>`

### DIFF
--- a/include/picongpu/fields/currentDeposition/Strategy.def
+++ b/include/picongpu/fields/currentDeposition/Strategy.def
@@ -42,12 +42,7 @@ namespace picongpu
                  */
                 constexpr int validateAndAdjustWorkerMultiplier(int const multiplicator)
                 {
-#if BOOST_COMP_HIP && PIC_COMPUTE_CURRENT_THREAD_LIMITER
-                    // HIP-clang creates wrong results if more threads than particles in a frame will be used
-                    return 1;
-#else
                     return multiplicator >= 1 ? multiplicator : 1;
-#endif
                 }
 
                 struct ShapeStrategy
@@ -225,7 +220,7 @@ namespace picongpu
             struct GetDefaultStrategy<alpaka::AccGpuUniformCudaHipRt<alpaka::ApiHipRt, T_Args...>>
             {
                 // GPU Utilization is higher compared to `StridedCachedSupercells`
-                using type = strategy::CachedSupercells;
+                using type = strategy::CachedSupercellsScaled<2>;
             };
 #endif
 


### PR DESCRIPTION
`strategy::CachedSupercellsScaled<2>` is showing ~13% better performance on crusher for the FOM benchmark (`pic-build -t 2`).

An old workaround for a compiler bug that avoids using the scaling factor 2 for HIP is removed. 
It looks like the compiler bug is now fixed (tested with ROCM 5.1)