### PR TITLE
clang: fix early assert evaluation

### DIFF
--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -45,7 +45,8 @@ namespace picongpu
 
             PMACC_CASSERT_MSG(
                 __EmZ_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-                pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
+                sizeof(T_ParticleShape*) // defer assert evaluation
+                    && pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
                         >= currentLowerMargin
                     && pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
                         >= currentUpperMargin);

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -51,7 +51,8 @@ namespace picongpu
 
             PMACC_CASSERT_MSG(
                 __Esirkepov_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-                pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
+                sizeof(T_ParticleShape) // defer assert evaluation
+                    && pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
                         >= currentLowerMargin
                     && pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
                         >= currentUpperMargin);

--- a/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
+++ b/include/picongpu/fields/currentDeposition/VillaBune/CurrentVillaBune.hpp
@@ -276,8 +276,9 @@ namespace picongpu
 
             PMACC_CASSERT_MSG(
                 __VillaBune_supercell_or_number_of_guard_supercells_is_too_small_for_stencil,
-                pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
-                    >= maxMargin);
+                sizeof(T_ParticleShape) // defer assert evaluation
+                    && pmacc::math::CT::min<typename pmacc::math::CT::mul<SuperCellSize, GuardSize>::type>::type::value
+                        >= maxMargin);
         };
 
     } // namespace traits


### PR DESCRIPTION
clang is evaluating static asserts inside of a class/struct even if the object will never be used. Therefore the evaluation must be deferred by using `sizeof(TEMPLATE_PARAM)` or moving the assert into a method of the class.