### PR TITLE
documentation: mention `CMAKE_BUILD_TYPE`

### DIFF
--- a/docs/source/dev/debugging.rst
+++ b/docs/source/dev/debugging.rst
@@ -17,6 +17,7 @@ The following build options can assist the investigation:
 * ``PMACC_VERBOSE=<N>`` sets log detail level for pmacc, highest level is 127.
 * ``PMACC_BLOCKING_KERNEL=ON`` makes each kernel invocation blocking, which helps to narrow a crash down to a particular kernel.
 * ``CUPLA_STREAM_ASYNC_ENABLE=OFF`` disables asynchronous streams, also helps to narrow a crash down to a particular place.
+* ``CMAKE_BUILD_TYPE=Debug`` compile in debug mode where all assertions are activated. Compiling in debug mode will slowdown your kernels!
 
 These options can be passed when building, or manually modified via cmake.
 An example build command is


### PR DESCRIPTION
Document that `CMAKE_BUILD_TYPE=Debug` can be used to activate all
asserts in the code.

@BrianMarre I added this only for you ^^