### PR TITLE
Fix radiation trees.

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -266,14 +266,20 @@ namespace picongpu
                                                     + DataSpaceOperations<simDim>::template map<SuperCellSize>(
                                                         cellIdx));
 
-                                                // add global position of cell with local position of particle in cell
-                                                vector_X particle_locationNow;
+                                                /* add global position of cell with local position of particle in cell
+                                                 *
+                                                 * Info:
+                                                 * Mandatory 64 bit precision to avoid artefacts above betatron
+                                                 * critical frequency.
+                                                 * https://github.com/ComputationalRadiationPhysics/picongpu/issues/4208
+                                                 */
+                                                vector_64 particle_locationNow;
                                                 // set z component to zero in case of simDim==DIM2
                                                 particle_locationNow[2] = 0.0;
                                                 // run over all components and compute gobal position
                                                 for(uint32_t i = 0; i < simDim; ++i)
                                                     particle_locationNow[i]
-                                                        = (float_X(globalPos[i]) + pos[i]) * cellSize[i];
+                                                        = (float_64(globalPos[i]) + pos[i]) * cellSize[i];
 
                                                 /* get macro-particle weighting
                                                  *


### PR DESCRIPTION
This commit fixes the source of a periodic doubling of minima/maxima when computing radiation above the critical betatron frequency of the bunch as described in #4208 

The source are accumulations of rounding errors in `particle_locationNow`. Switching the variable to a default 64 bit precision fixes the problem.