### PR TITLE
scr: add init/finalize and start/complete output

### DIFF
--- a/include/picongpu/plugins/multi/Master.hpp
+++ b/include/picongpu/plugins/multi/Master.hpp
@@ -26,6 +26,8 @@
 #include "picongpu/plugins/multi/IHelp.hpp"
 #include "picongpu/plugins/multi/IInstance.hpp"
 
+#include "scr.h"
+
 #include <list>
 #include <stdexcept>
 #include <vector>
@@ -85,8 +87,11 @@ namespace picongpu
                  */
                 void restart(uint32_t restartStep, std::string const restartDirectory) override
                 {
+                    char scr_dset[SCR_MAX_FILENAME];
+                    SCR_Start_restart(&scr_dset);
                     for(auto& instance : instanceList)
                         instance->restart(restartStep, restartDirectory);
+                    SCR_Complete_restart(1);
                 }
 
                 /** Call the onParticleLeave() method for all instances.
@@ -108,8 +113,10 @@ namespace picongpu
                  */
                 void checkpoint(uint32_t currentStep, std::string const checkpointDirectory) override
                 {
+                    SCR_Start_output(std::to_string(currentStep).c_str(), SCR_FLAG_CHECKPOINT /* | SCR_FLAG_OUTPUT */);
                     for(auto& instance : instanceList)
                         instance->checkpoint(currentStep, checkpointDirectory);
+                    SCR_Complete_output(1);
                 }
 
             private:

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -74,6 +74,8 @@
 
 #include <openPMD/openPMD.hpp>
 
+#include "scr.h"
+
 #if !defined(_WIN32)
 #    include <unistd.h>
 #endif
@@ -135,6 +137,7 @@ namespace picongpu
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 __getTransactionEvent().waitForFinished();
+                //SCR_Start_output(fullName, SCR_FLAG_OUTPUT);
                 openPMDSeries = std::make_unique<::openPMD::Series>(
                     fullName,
                     at,
@@ -175,6 +178,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 log<picLog::INPUT_OUTPUT>("openPMD: close file: %1%") % fileName;
                 openPMDSeries.reset();
                 MPI_Barrier(this->communicator);
+                //SCR_Complete_output(1);
                 log<picLog::INPUT_OUTPUT>("openPMD: successfully closed file: %1%") % fileName;
             }
             else

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -34,6 +34,8 @@
 #include "pmacc/simulationControl/signal.hpp"
 #include "pmacc/types.hpp"
 
+#include "scr.h"
+
 #include <boost/filesystem.hpp>
 
 #include <csignal>
@@ -159,6 +161,8 @@ namespace pmacc
                 // avoid deadlock between not finished PMacc tasks and MPI_Barrier
                 __getTransactionEvent().waitForFinished();
 
+                SCR_Start_output(std::to_string(currentStep), SCR_FLAG_CHECKPOINT /* | SCR_FLAG_OUTPUT */);
+
                 GridController<DIM>& gc = Environment<DIM>::get().GridController();
                 /* can be spared for better scalings, but allows to spare the
                  * time for checkpointing if some ranks died */
@@ -190,6 +194,8 @@ namespace pmacc
                     writeCheckpointStep(currentStep);
                 }
                 numCheckpoints++;
+
+                SCR_Complete_output(1);
             }
         }
 
@@ -229,6 +235,8 @@ namespace pmacc
             signal::activate();
 
             init();
+
+            SCR_Init();
 
             // translate checkpointPeriod string into checkpoint intervals
             seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
@@ -310,6 +318,8 @@ namespace pmacc
                 }
 
             } // softRestarts loop
+
+            SCR_Finalize();
         }
 
         void pluginRegisterHelp(po::options_description& desc) override


### PR DESCRIPTION
@franzpoeschel, @psychocoderHPC 

This is getting ahead of things, since it's not yet apparent that SCR would be needed/useful.  However, I had started the integration work just in case in might be.  I wanted to open this PR, since I thought it'd be easier to discuss things than an email thread.

First, I've got a PR open that adds SCR calls into ADIOS2.  That includes the commands to download and build ADIOS2 with SCR.  I need to work with the ADIOS team to iron things out there, but it does work well enough that we can do testing.

https://github.com/ornladios/ADIOS2/pull/3294

I think there are also spots in PiConGPU where we'll want to add some SCR calls.

First, we'll want to call SCR_Init and SCR_Finalize.  These calls typically are placed near MPI_Init() and MPI_Finalize(), respectively.  Really, I often end up placing SCR_Init after any application option processing that the user might specify.  It's common to configure SCR according to user settings, like the output directory for checkpoints or to allow the user to name a particular checkpoint to read during restart.  Most of those settings need to be applied before one calls SCR_Init.  For now, I've just added it near the MPI_Init().

Second, we need to add SCR_Start_output and SCR_Complete_output calls.  These two calls should bookend the checkpoint logic such that all files belonging to a given checkpoint are created and written in between those two calls.  The SCR_Start_output call also takes a name that is meaningful to the application/user, and some bit flags that the application would set.

All four of these calls are implicitly collective over MPI_COMM_WORLD.

Are there good spots that you'd recommend for adding these?

I've found a few potential spots that look interesting, but I don't know whether I'm headed down the right path.

If you have time, would you please take a look and let me know?

Thanks!