### PR TITLE
`pic-configure` validate preset selection

### DIFF
--- a/bin/pic-compile
+++ b/bin/pic-compile
@@ -102,15 +102,22 @@ do
         example_name=`basename $examples_path`
     fi
 
-    # the default is 1 to allow examples without the file `cmakeFlags`
-    testFlag_cnt=1
+
+    testFlag_cnt=0
+    # will be set to -1 if `cmakeFlags` file not exists to compile with default parameters
+    testFlagNr=0
     if [ -f "$examples_path/$i/cmakeFlags" ]; then
         testFlag_cnt=`$examples_path/$i/cmakeFlags -l`
+    else
+        testFlagNr=-1
     fi
 
-    testFlagNr=0
     while [ $testFlagNr -lt $testFlag_cnt ] ; do
-        buildDir="$tmpRun_path/build/build_"$example_name"_cmakePreset_$testFlagNr"
+        caseId=$testFlagNr;
+        if [ $caseId -eq -1 ] ; then
+            caseId=0;
+        fi
+        buildDir="$tmpRun_path/build/build_"$example_name"_cmakePreset_$caseId"
         mkdir -p $buildDir
 
         if [ "$num_parallel" -gt "1" ] ; then
@@ -120,7 +127,7 @@ do
                 "$quiet_run" &> $buildDir"/compile.log" &
 
             running="`jobs -p | wc -l`"
-            echo $compileSuite"Spawned $example_name $testFlagNr"
+            echo $compileSuite"Spawned $example_name $caseId"
 
             while [ "$running" -ge "$num_parallel" ]
             do

--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -24,6 +24,12 @@ this_dir=$(cd $(dirname $0) && pwd)
 # PIConGPU prefix path
 picongpu_prefix=$(cd $this_dir/.. && pwd)
 
+function absolute_path()
+{
+    cd $1
+    pwd
+}
+
 help()
 {
     echo "Configure PIConGPU with CMake"
@@ -112,7 +118,7 @@ fi
 
 # configure a specific preset in the cmakeFlags file
 # note: can be overwritten with a command line flag
-cmakeFlagsNr=0
+cmakeFlagsNr=-1
 
 # set a default backend (and architecture) if supplied via environment var
 # note: can be overwritten with a command line flag
@@ -157,7 +163,7 @@ while true ; do
     shift
 done
 
-extension_param="$*"
+extension_param="$(absolute_path $*)"
 
 if [ ! -d "$extension_param" ] ; then
     echo "Path \"$extension_param\" does not exist." >&2
@@ -165,10 +171,24 @@ if [ ! -d "$extension_param" ] ; then
 fi
 # check for cmakeFlags file (interprete with sh)
 if [ -f "$extension_param/cmakeFlags" ] ; then
+    if [ $cmakeFlagsNr -eq -1 ] ; then
+        # if the user has not given this value use zero as default.
+        cmakeFlagsNr=0
+    fi
+    num_cmake_flags=$($extension_param/cmakeFlags -l)
+    if [ $? -ne 0 ] ; then
+        echo "ERROR: Executing '$extension_param/cmakeFlags -l' failed!" >&2
+        echo "       Is the file executable? (chmod u+x cmakeFlags)" >&2
+        exit 2
+    fi
+    if [ $cmakeFlagsNr -ge $num_cmake_flags ] ; then
+        echo "ERROR: Executing '$extension_param/cmakeFlags $cmakeFlagsNr' failed!" >&2
+        echo "       Requested preset '$cmakeFlagsNr' does not exist, '$num_cmake_flags' presets found." >&2
+        exit 2
+    fi
     cmake_flags=$($extension_param/cmakeFlags $cmakeFlagsNr)
     if [ $? -ne 0 ] ; then
         echo "ERROR: Executing '$extension_param/cmakeFlags' failed!" >&2
-        echo "       Is the file executable? (chmod u+x cmakeFlags)" >&2
         exit 2
     fi
     # save the cmakeFlags setup number for future reference
@@ -178,11 +198,14 @@ if [ -f "$extension_param/cmakeFlags" ] ; then
     touch $extension_param/cmakeFlagsSetup
     echo "Last configured cmakeFlags setup was the setup No.: $cmakeFlagsNr" > $extension_param/cmakeFlagsSetup
     echo $cmake_flags >> $extension_param/cmakeFlagsSetup
-
+elif [ $cmakeFlagsNr -ne -1 ] ; then
+    echo "ERROR: '$extension_param/cmakeFlags' not exists!" >&2
+    echo "       Therefore option -t can not be used." >&2
+    exit 2
 fi
 
 # legacy check: we removed simulation_defines/ after PIConGPU 0.3.X
-if [ -d "$extension_param/include/picongpu/simulation_defines" ]; then
+if [ -d "$extension_param/include/picongpu/simulation_defines" ] ; then
     echo "ERROR: simulation_defines/ directory found!" >&2
     echo "       Please update your input directory to the new structure!" >&2
     exit 3

--- a/buildsystem/CompileSuite/compileSet.sh
+++ b/buildsystem/CompileSuite/compileSet.sh
@@ -21,7 +21,7 @@
 # compile a specific set of an example
 #
 # $1: example name ($example_name)
-# $2: cmakePreset number
+# $2: cmakePreset number: -1 means we do not have presets
 # $3: globalCMakeOptions
 # $4: tmp dir we use ($tmpRun_path)
 # $5: build dir in the tmp folder
@@ -62,10 +62,19 @@ cS_this_dir=$(cd `dirname $0` && pwd)
 #
     cd $cS_buildDir
 
-    param_folder="$cS_tmpRun_path/params/$cS_example_name/cmakePreset_$cS_testFlagNr"
+    caseId=$cS_testFlagNr;
+    if [ $caseId -eq -1 ] ; then
+        # cmakeFlags file is not available, do not use '-t' option
+        caseId=0;
+    else
+        # cmakeFlags file is available '-t` option can be used
+        $caseOption="-t $caseId"
+    fi
+
+    param_folder="$cS_tmpRun_path/params/$cS_example_name/cmakePreset_$caseId"
     execute_and_validate $cS_this_dir/../../bin/pic-create -f $cS_examples_path/$cS_example_name $param_folder
 
-    execute_and_validate $cS_this_dir/../../bin/pic-configure $cS_globalCMakeOptions -t $cS_testFlagNr $param_folder
+    execute_and_validate $cS_this_dir/../../bin/pic-configure $cS_globalCMakeOptions $caseOption $param_folder
     execute_and_validate make install
 
     echo "$myError" > ./returnCode


### PR DESCRIPTION
In cases, the user is using `-t` we are checking now if the used preset id is available.

This PR additionally fixes that the path to the file `cmakeFlags` was shown as a relative path instead of an absolut. In cases `pic-build` was used the path was relative to `.build`.