### PR TITLE
auto adjust particle exchange buffers for double precision

### DIFF
--- a/include/picongpu/param/memory.param
+++ b/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -184,8 +184,12 @@ namespace picongpu
         else
             exchangeBytes = ExchangeMemCfg::BYTES_CORNER;
 
+        /* PIConGPU default case is running with 32bit (4byte) precision. In case double precision is used the particle
+         * buffers must be twice as large to avoid that a communication must be split into multiple sends.
+         */
+        double precisionMultiplier = static_cast<double>(sizeof(float_X)) / static_cast<double>(sizeof(float));
         // using double to calculate the memory size is fine, double can precise store integer values up too 2^53
-        return exchangeBytes * exchangeScalingFactor;
+        return exchangeBytes * exchangeScalingFactor * precisionMultiplier;
     }
 
     template<typename T_Name, typename T_Flags, typename T_Attributes>

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/memory.param
@@ -72,14 +72,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 1024 * 1024; // 6 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 3 * 1024 * 1024; // 3 MiB

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 2 * 1024 * 1024; // 2 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 1024 * 1024; // 6 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 2 * 1024 * 1024; // 2 MiB

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species s buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 4 * 1024 * 1024; // 4 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 6 * 1024 * 1024; // 6 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 64 * 1024 * 1024; // 64 MiB

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB

--- a/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/memory.param
@@ -71,14 +71,14 @@ namespace picongpu
 
     /** bytes reserved for species exchange buffer
      *
-     * This is the default configuration for species exchanges buffer sizes.
-     * The default exchange buffer sizes can be changed per species by adding
-     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
-     * to its flag list.
+     * This is the default configuration for species exchanges buffer sizes when performing a simulation with 32bit
+     * precision (default for PIConGPU). For double precision the amount of memory used for exchanges will
+     * be automatically doubled. The default exchange buffer sizes can be changed per species by adding the alias
+     * exchangeMemCfg with similar members like in DefaultExchangeMemCfg to its flag list.
      */
     struct DefaultExchangeMemCfg
     {
-        // memory used for a direction
+        // Memory used for a direction for a simulation performed with 32bit precision.
         static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
         static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB


### PR DESCRIPTION
PIConGPU setups are typically designed for single precision execution.
The memory for particle exchanges defined in `memory.param` is therefore not correct if someone is switching to double precision.

To avoid that users must adjust their setup by hand this PR is automatically adjusting the required buffer sizes by multiplying the size by a factor of 2.

I know that it is not the best way to consume more memory than defined in the param files but this was the only way how to deal with the problem without updating each example and enforcing the example developer to run their initial simulation always in double precision to avoid that we have multiple send because of the buffer size limitation.