### PR TITLE
Better separate CFL and pusher/current deposition requirements

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/ArbitraryOrderFDTD.hpp
@@ -72,7 +72,7 @@ namespace picongpu
                         throw std::runtime_error(
                             std::string("Courant-Friedrichs-Lewy condition check failed, check your grid.param file\n")
                             + "Courant Friedrichs Lewy condition: c * dt <= " + std::to_string(maxC_DT)
-                            + " ? (c * dt = " + std::to_string(SPEED_OF_LIGHT * DELTA_T) + ")");
+                            + " ? (c * dt = " + std::to_string(SPEED_OF_LIGHT * dt) + ")");
                     }
 
                     return maxC_DT;

--- a/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
@@ -49,7 +49,10 @@ namespace picongpu
                  */
                 float_X operator()() const
                 {
-                    constexpr auto minCellSize = std::min({CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH});
+                    // For 2d the value of dz does not matter for this check.
+                    // Using dx instead is fine here since we are taking min grid step.
+                    constexpr auto usedDz = (simDim == 3) ? CELL_DEPTH : CELL_WIDTH;
+                    constexpr auto minCellSize = std::min({CELL_WIDTH, CELL_HEIGHT, usedDz});
                     /* Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
                      * (in this case, could have depended on T_FieldSolver as well)
                      */

--- a/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CFLChecker.hpp
@@ -39,29 +39,11 @@ namespace picongpu
             template<typename T_FieldSolver, typename T_Defer = void>
             struct CFLChecker
             {
-                /** Check the CFL condition, doesn't compile when failed
-                 *
-                 * The default implementation checks the basic explicit PIC assumption c * dt <= min(dx, dy, dz).
-                 * Note that generally FDTD-type field solvers have a more strict condition, and have to provide a
-                 * specialization.
+                /** Check the CFL condition
                  *
                  * @return value of 'X' to fulfill the condition 'c * dt <= X`
                  */
-                float_X operator()() const
-                {
-                    // For 2d the value of dz does not matter for this check.
-                    // Using dx instead is fine here since we are taking min grid step.
-                    constexpr auto usedDz = (simDim == 3) ? CELL_DEPTH : CELL_WIDTH;
-                    constexpr auto minCellSize = std::min({CELL_WIDTH, CELL_HEIGHT, usedDz});
-                    /* Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
-                     * (in this case, could have depended on T_FieldSolver as well)
-                     */
-                    PMACC_CASSERT_MSG(
-                        Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
-                        (SPEED_OF_LIGHT * DELTA_T / minCellSize <= 1.0) && sizeof(T_Defer*) != 0);
-
-                    return minCellSize;
-                }
+                float_X operator()() const;
             };
 
         } // namespace maxwellSolver

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -21,12 +21,15 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/LaserChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/None/None.def"
 #include "picongpu/fields/cellType/Yee.hpp"
 #include "picongpu/traits/GetMargin.hpp"
 
 #include <pmacc/types.hpp>
+
+#include <limits>
 
 
 namespace picongpu
@@ -60,6 +63,23 @@ namespace picongpu
                 {
                     pmacc::traits::StringProperty propList("name", "none");
                     return propList;
+                }
+            };
+
+            /** Specialization of the CFL condition checker for the None solver
+             *
+             * @tparam T_Defer technical parameter to defer evaluation
+             */
+            template<typename T_Defer>
+            struct CFLChecker<None, T_Defer>
+            {
+                /** No limitations for this solver, allow any dt
+                 *
+                 * @return value of 'X' to fulfill the condition 'c * dt <= X`
+                 */
+                float_X operator()() const
+                {
+                    return std::numeric_limits<float_X>::infinity();
                 }
             };
 

--- a/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.hpp
@@ -64,8 +64,6 @@ namespace picongpu
                      */
                     SubsteppingBase(MappingDesc const cellDescription) : Base(cellDescription)
                     {
-                        // We still have to check the basic PIC condition c * dt < dx as particles need it
-                        CFLChecker<SubsteppingBase>{}();
                         PMACC_CASSERT_MSG(
                             Substepping_field_solver_wrong_number_of_substeps____must_be_at_least_1,
                             numSubsteps >= 1);
@@ -178,6 +176,19 @@ namespace picongpu
                             fieldJ.addCurrentToEMF<area>(currentInterpolation::Binomial{});
                     }
                 }
+            };
+
+            /** Specialization of the CFL condition checker for substepping solver
+             *
+             * Uses CFL of the base solver, those already take care of using the correct time (sub)step.
+             *
+             * @tparam T_BaseSolver base field solver, follows requirements of field solvers
+             * @tparam T_numSubsteps number of substeps per PIC time iteration
+             * @tparam T_Defer technical parameter to defer evaluation
+             */
+            template<typename T_BaseSolver, uint32_t T_numSubsteps, typename T_Defer>
+            struct CFLChecker<Substepping<T_BaseSolver, T_numSubsteps>, T_Defer> : CFLChecker<T_BaseSolver, T_Defer>
+            {
             };
 
         } // namespace maxwellSolver

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/LaserPhysics.hpp"
 #include "picongpu/fields/MaxwellSolver/CFLChecker.hpp"
 #include "picongpu/fields/MaxwellSolver/DispersionRelationSolver.hpp"
+#include "picongpu/fields/MaxwellSolver/traits/IsSubstepping.hpp"
 #include "picongpu/fields/incidentField/Traits.hpp"
 #include "picongpu/fields/incidentField/profiles/profiles.hpp"
 #include "picongpu/fields/laserProfiles/profiles.hpp"
@@ -130,8 +131,11 @@ namespace picongpu
             if(Environment<simDim>::get().GridController().getGlobalRank() == 0)
             {
                 auto maxC_DT = fields::maxwellSolver::CFLChecker<fields::Solver>{}();
-                log<picLog::PHYSICS>("Field solver condition: c * dt <= %1% ? (c * dt = %2%)") % maxC_DT
-                    % (SPEED_OF_LIGHT * DELTA_T);
+                auto const isSubstepping = fields::maxwellSolver::traits::IsSubstepping<fields::Solver>::value;
+                auto const dtName = std::string{isSubstepping ? "substepping_dt" : "dt"};
+                auto const cflMessage
+                    = std::string{"Field solver condition: c * "} + dtName + " <= %1% ? (c * " + dtName + " = %2%)";
+                log<picLog::PHYSICS>(cflMessage.c_str()) % maxC_DT % (SPEED_OF_LIGHT * DELTA_T);
 
                 printDispersionInformation();
 

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -28,7 +28,6 @@
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
 #include "picongpu/fields/MaxwellSolver/Solvers.hpp"
-#include "picongpu/fields/MaxwellSolver/traits/IsSubstepping.hpp"
 #include "picongpu/fields/absorber/pml/Field.hpp"
 #include "picongpu/fields/background/cellwiseOperation.hpp"
 #include "picongpu/initialization/IInitPlugin.hpp"


### PR DESCRIPTION
This PR does a few related things.

It separates CFL which is a property of field solver from PIConGPU condition that particle passes at most 1 cell per time step. Though somewhat similar, these conditions are not actually related. CFL is a mathematical property of field solver. The latter condition is only required due to our organization of particle pusher and current deposition, it is not a principle limitation of the method (but is crucial for PIConGPU). Also clarify output of these checks.

Fix edge case of checking that particles don't pass more than a cell in a time step: for 2d the previous check then required (among other things) `c * dt < dz`, while it is irrelevant in 2d. Instead, `c * dt < min(dx, dy)` should be, and now is, used in this case.

Fix message on failed CFL for arbitrary order solver with substepping. The check was correct, but output used full dt and not field solver `dt`.