### PR TITLE
Fix of radiation window for moving simulation.

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -344,7 +344,7 @@ namespace picongpu
                                                 for(uint32_t d = 0; d < simDim; ++d)
                                                 {
                                                     windowFactor *= winFkt(
-                                                        particle_locationNow[d],
+                                                        particle_locationNow[d] - globalOffset[d] * cellSize[d],
                                                         simBoxSize[d] * cellSize[d]);
                                                 }
 


### PR DESCRIPTION
This introduces a shift of the radiation window `winFkt`
by `globalOffset * cellSize` to shift the radiation window
to the moving window.

This should fix #4239.