### PR TITLE
fix formating issue

### DIFF
--- a/lib/python/picongpu/utils/param_parser.py
+++ b/lib/python/picongpu/utils/param_parser.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
         elif opt in ("-i", "--ifile"):
             file = arg
 
-    if(type in ["compile", "run"]):
+    if (type in ["compile", "run"]):
         print(parse(file, type))
     else:
         print("-t option not understood! Either choose 'compile' or 'run'!")


### PR DESCRIPTION
`param_parser.py` is not passing flake8 tests. FLake8 got an update and
is now complaining about missing whitespace after the keyword `if`.