### PR TITLE
Fix copyright years ending in 2021 in some files

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTDBase.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTDBase.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
+/* Copyright 2019-2022 Axel Huebl, Heiko Burau, Rene Widera, Benjamin Worpitz,
  *                     Sergei Bastrakov, Klaus Steiniger
  *
  * This file is part of PIConGPU.

--- a/include/picongpu/fields/MaxwellSolver/GetTimeStep.hpp
+++ b/include/picongpu/fields/MaxwellSolver/GetTimeStep.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.def
+++ b/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.def
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/MaxwellSolver/traits/IsSubstepping.hpp
+++ b/include/picongpu/fields/MaxwellSolver/traits/IsSubstepping.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov
+/* Copyright 2021-2022 Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/laserProfiles/PulseFromSpectrum.def
+++ b/include/picongpu/fields/laserProfiles/PulseFromSpectrum.def
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Nils Prinz,
  *                     Klaus Steiniger
 

--- a/include/picongpu/fields/laserProfiles/PulseFromSpectrum.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFromSpectrum.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
+/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus
  *
  * This file is part of PIConGPU.


### PR DESCRIPTION
Those were from files that were not in our `dev` at start of this year and so were missed.