### PR TITLE
Skip J contribution to E for None field solver

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/None/None.def
+++ b/include/picongpu/fields/MaxwellSolver/None/None.def
@@ -31,6 +31,10 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
+            /** None solver does nothing and effectively skips integration of Maxwell's equations
+             *
+             * In particular, no J contribution is added to E.
+             */
             class None;
 
         } // namespace maxwellSolver

--- a/include/picongpu/param/fieldSolver.param
+++ b/include/picongpu/param/fieldSolver.param
@@ -49,7 +49,7 @@ namespace picongpu
          * integer number. The order of the solver will be twice the number of neighbors in each direction. Yee's
          * method is a special case of this using one neighbor to each direction.
          *  - Substepping<Solver, 4>: use the given Solver (Yee, etc.) and substep each time step by factor 4
-         *  - None: disable the vacuum update of E and B
+         *  - None: disable the vacuum update of E and B, including no J contribution to E
          */
         using Solver = maxwellSolver::Yee;
 

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 
 namespace picongpu
@@ -143,6 +144,10 @@ namespace picongpu
                 template<std::uint32_t T_area>
                 void addCurrentToEMF(FieldJ& fieldJ) const
                 {
+                    // None solver does not integrate Ampere's law, so will not have J added to E
+                    bool isNoneFieldSolver = std::is_same_v<fields::Solver, fields::maxwellSolver::None>;
+                    if(isNoneFieldSolver)
+                        return;
                     using namespace fields::currentInterpolation;
                     auto const kind = CurrentInterpolation::get().kind;
                     if(kind == CurrentInterpolation::Kind::None)


### PR DESCRIPTION
The new way is more consistent with meaning of `None` solver. Extend the comments to reflect the new behavior.

There are more changes coming to current deposition and field solver interactions, this bug was noticed along the way.