### PR TITLE
Make adding J term part of field solver

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/None/None.def
+++ b/include/picongpu/fields/MaxwellSolver/None/None.def
@@ -31,6 +31,10 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
+            /** None solver does nothing and effectively skips integration of Maxwell's equations
+             *
+             * In particular, no J contribution is added to E.
+             */
             class None;
 
         } // namespace maxwellSolver

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -29,6 +29,7 @@
 
 #include <pmacc/types.hpp>
 
+#include <cstdint>
 #include <limits>
 
 
@@ -52,6 +53,11 @@ namespace picongpu
                 }
 
                 void update_beforeCurrent(uint32_t)
+                {
+                }
+
+                template<uint32_t T_area>
+                void addCurrent()
                 {
                 }
 

--- a/include/picongpu/param/fieldSolver.param
+++ b/include/picongpu/param/fieldSolver.param
@@ -49,7 +49,7 @@ namespace picongpu
          * integer number. The order of the solver will be twice the number of neighbors in each direction. Yee's
          * method is a special case of this using one neighbor to each direction.
          *  - Substepping<Solver, 4>: use the given Solver (Yee, etc.) and substep each time step by factor 4
-         *  - None: disable the vacuum update of E and B
+         *  - None: disable the vacuum update of E and B, including no J contribution to E
          */
         using Solver = maxwellSolver::Yee;
 

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -570,7 +570,7 @@ namespace picongpu
             atomicPhysics->runSolver(currentStep);
             CurrentBackground{*cellDescription}(currentStep);
             CurrentDeposition{}(currentStep);
-            currentInterpolationAndAdditionToEMF(currentStep);
+            currentInterpolationAndAdditionToEMF(currentStep, *myFieldSolver);
             myFieldSolver->update_afterCurrent(currentStep);
         }
 

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 
 namespace picongpu
@@ -143,6 +144,10 @@ namespace picongpu
                 template<std::uint32_t T_area>
                 void addCurrentToEMF(FieldJ& fieldJ) const
                 {
+                    // None solver does not integrate Ampere's law, so will not have J added to E
+                    bool isNoneFieldSolver = std::is_same_v<fields::Solver, fields::maxwellSolver::None>;
+                    if(isNoneFieldSolver)
+                        return;
                     using namespace fields::currentInterpolation;
                     auto const kind = CurrentInterpolation::get().kind;
                     if(kind == CurrentInterpolation::Kind::None)


### PR DESCRIPTION
It should logically be part of field solver as the solver defines the way it should be done. This PR does not change the results, but prepares for future changes with PML and substepping. Extend comments to reflect the new logic.

- [x] Depends on #4243.

