### PR TITLE
Clarify approximation order of J in AOFDTD docs

### DIFF
--- a/docs/source/models/AOFDTD.rst
+++ b/docs/source/models/AOFDTD.rst
@@ -3,7 +3,7 @@
 Finite-Difference Time-Domain Method
 ====================================
 
-.. sectionauthor:: Klaus Steiniger, Jakob Trojok
+.. sectionauthor:: Klaus Steiniger, Jakob Trojok, Sergei Bastrakov
 
 
 For the discretization of Maxwell's equations on a mesh in PIConGPU, only the equations
@@ -28,8 +28,8 @@ Starting simulations in an initially charge free and magnetic-divergence-free sp
 
    \nabla \cdot \vec B &= 0
 
-is standard.
-
+is standard in PIConGPU.
+Alternatively, one could use non-charge-free initialization and solve the Poisson equation for initial values of :math:`\vec{E}`.
 
 Discretization on a staggered mesh
 ----------------------------------
@@ -54,11 +54,13 @@ between positions where the field quantities are known.
 
 The above discretization uses one neighbor to each side from the point where the derivative is calculated yielding a
 second order accurate approximation of the derivative.
-Using more neighbors for the approximation of the spatial derivative is possible in PIConGPU and reduces the
-discretization error.
-Which is to say that the order of the method is increased.
-The error order scales with twice the number of neighbors :math:`M` used to approximate the derivative.
-The arbitrary order finite difference of order :math:`2M` reads
+Using more neighbors for finite difference calculation of the spatial derivatives is possible in PIConGPU and increases the approximation order of these derivatives.
+Note, however, that the order of the whole Maxwell's solver also depends on accuracy of :math:`\vec{J}` calculation on the grid.
+For those values PIConGPU provides only second-order accuracy in terms of time and spatial grid steps (as the underlying discretized continuity equation is of that order) regardless of the chosen field solver.
+Thus, in the general case the arbitrary order finite difference solver as a whole still has second order accuracy in space, and only provides arbitrary order in finite difference approximation of curls.
+
+For the latter, the accuracy order scales with twice the number of neighbors :math:`M` used to approximate the derivative.
+The arbitrary order finite difference derivative approximation of order :math:`2M` reads
 
 .. math::
 

--- a/docs/source/models/AOFDTD.rst
+++ b/docs/source/models/AOFDTD.rst
@@ -57,7 +57,7 @@ second order accurate approximation of the derivative.
 Using more neighbors for finite difference calculation of the spatial derivatives is possible in PIConGPU and increases the approximation order of these derivatives.
 Note, however, that the order of the whole Maxwell's solver also depends on accuracy of :math:`\vec{J}` calculation on the grid.
 For those values PIConGPU provides only second-order accuracy in terms of time and spatial grid steps (as the underlying discretized continuity equation is of that order) regardless of the chosen field solver.
-Thus, in the general case the arbitrary order finite difference solver as a whole still has second order accuracy in space, and only provides arbitrary order in finite difference approximation of curls.
+Thus, in the general case the Maxwell's solver as a whole still has second order accuracy in space, and only provides arbitrary order in finite difference approximation of curls.
 
 For the latter, the accuracy order scales with twice the number of neighbors :math:`M` used to approximate the derivative.
 The arbitrary order finite difference derivative approximation of order :math:`2M` reads


### PR DESCRIPTION
Previously it was somewhat misleading and left a wrong impression that AOFDTD had arbitrary order as a whole Maxwell's solver. While in reality it only approximated curls with that order, and for non-zero `J` the overall scheme is still (2, 2), same as Yee. In this PR I tried to more clearly distinguish between those and explain it.

Note that we could in principle calculate grid `J` values more precisely in space and so raise the AOFDTD order as a whole to honest (2, 2*M). But that would mean going away from standard Esirkepov and EmZ as-is. Since the second order comes from their discretized version of the continuity equation. And a change would be to instead apply same AOFDTD finite difference operators to calculate divergence of `J` in the continuity equation and then derive the solution to it. I am not sure how hard it would be to change (or if there are papers which already solved it? - no idea), could turn out relatively straightforward, could be very hard - needs further investigation if there is interest to that.