### PR TITLE
fix compiling without openPMD-api

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.cpp
@@ -17,11 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <algorithm>
-#include <iterator>
-#include <sstream>
+#if(ENABLE_OPENPMD == 1)
 
-#include <openPMD/openPMD.hpp>
+#    include <algorithm>
+#    include <iterator>
+#    include <sstream>
+
+#    include <openPMD/openPMD.hpp>
 
 namespace picongpu::openPMD
 {
@@ -50,3 +52,5 @@ namespace picongpu::openPMD
         }
     }
 } // namespace picongpu::openPMD
+
+#endif


### PR DESCRIPTION
PR #4234 introduced a bug that avoids compiling PIConGPU with the optional dependency openPMD-api.

I will provide a fix for the CI that we can cover this case in the future.