### PR TITLE
CI: disable all optional dependencies for the Empty test case 

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.cpp
@@ -17,11 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <algorithm>
-#include <iterator>
-#include <sstream>
+#if(ENABLE_OPENPMD == 1)
 
-#include <openPMD/openPMD.hpp>
+#    include <algorithm>
+#    include <iterator>
+#    include <sstream>
+
+#    include <openPMD/openPMD.hpp>
 
 namespace picongpu::openPMD
 {
@@ -50,3 +52,5 @@ namespace picongpu::openPMD
         }
     }
 } // namespace picongpu::openPMD
+
+#endif

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -24,15 +24,21 @@ if [ -n "$CI_CLANG_AS_CUDA_COMPILER" ] ; then
   CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CUDA_COMPILER=${CXX_VERSION}"
 fi
 
-# enforce optional dependencies
-CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON"
+if [[ "$PIC_TEST_CASE_FOLDER" =~ .*Empty.* ]] ; then
+    # For the empty test case (default param files) we disable all optional dependencies to have at least one check
+    # where all dependencies are disabled.
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF -DPIC_USE_openPMD=OFF -DPIC_USE_PNGwriter=OFF"
+else
+    # enforce optional dependencies
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON"
 
-# ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
-if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* || "$PIC_TEST_CASE_FOLDER" =~ .*WarmCopper.* ]] ; then
-    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
-    export CI_CPUS=1
-elif [ -z "$DISABLE_ISAAC" ] ; then
-    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
+    # ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
+    if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* || "$PIC_TEST_CASE_FOLDER" =~ .*WarmCopper.* ]] ; then
+        CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
+        export CI_CPUS=1
+    elif [ -z "$DISABLE_ISAAC" ] ; then
+        CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
+    fi
 fi
 
 # Test is running out of memory, therefore we do not run in parallel.


### PR DESCRIPTION
Enforce that at least one test is compiling without optional dependencies is possible.

- [x] depends on #4253