### PR TITLE
provide a pmacc CMake target 

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -148,9 +148,6 @@ unset(IN_SRC_POS)
 ################################################################################
 
 find_package(PMacc REQUIRED CONFIG PATHS "${PIConGPUapp_SOURCE_DIR}/../pmacc")
-include_directories(${PMacc_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${PMacc_LIBRARIES})
-add_definitions(${PMacc_DEFINITIONS})
 
 ################################################################################
 # Find MPI
@@ -515,6 +512,7 @@ cupla_add_executable(picongpu
 )
 
 target_link_libraries(picongpu PUBLIC ${LIBS} ${HOST_LIBS} picongpu-hostonly)
+target_link_libraries(picongpu PRIVATE pmacc::pmacc)
 
 if(PIC_HAVE_openPMD)
     # Including <nlohmann/json.hpp> will throw loads of warnings. Quiet them.

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -72,9 +72,6 @@ get_filename_component(PMACC_ROOT_DIR "${PMACC_ROOT_DIR}" ABSOLUTE)
 ################################################################################
 
 find_package(PMacc REQUIRED CONFIG PATHS ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(SYSTEM ${PMacc_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${PMacc_LIBRARIES})
-add_definitions(${PMacc_DEFINITIONS})
 
 
 ###############################################################################
@@ -85,13 +82,10 @@ add_subdirectory(${PMACC_ROOT_DIR}/../../thirdParty/catch2/catch_main ${CMAKE_BI
 
 
 ################################################################################
-# Find MPI
+# MPI
 ################################################################################
 
-find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
-set(LIBS ${LIBS} ${MPI_C_LIBRARIES})
-
+# MPI is provided by pmacc but to execute the binaries via root additional flags must be given to the execution command
 option(USE_MPI_AS_ROOT_USER "add --allow-run-as-root mpiexec used by ctest" OFF)
 
 if(USE_MPI_AS_ROOT_USER)
@@ -117,8 +111,8 @@ foreach(dim 2 3)
         set(testExe "${PROJECT_NAME}-${testCase}-${dim}D")
         cupla_add_executable(${testExe} ${testCaseFilepath})
         target_compile_definitions(${testExe} PRIVATE TEST_DIM=${dim})
-        target_link_libraries(${testExe} PUBLIC ${LIBS})
         target_link_libraries(${testExe} PUBLIC CatchMain)
+        target_link_libraries(${testExe} PRIVATE pmacc::pmacc)
         add_test(NAME "${testCase}-${dim}D" COMMAND mpiexec ${MPI_RUNTIME_FLAGS} -n 1 ./${testExe})
     endforeach()
     string(REPLACE "-DTEST_DIM=${dim}" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/include/pmacc/dummy.cpp
+++ b/include/pmacc/dummy.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2022 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */

--- a/include/pmacc/test/random/CMakeLists.txt
+++ b/include/pmacc/test/random/CMakeLists.txt
@@ -19,10 +19,19 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.18.0)
 project("TestRandomGenerators")
 
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
+###############################################################################
+# Language Flags
+###############################################################################
+
+# enforce C++17
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
 
 
 ################################################################################
@@ -39,16 +48,13 @@ endif()
 # PMacc
 ################################################################################
 find_package(PMacc REQUIRED CONFIG PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../..")
-include_directories(SYSTEM ${PMacc_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${PMacc_LIBRARIES})
-add_definitions(${PMacc_DEFINITIONS})
 
 ###############################################################################
 # Targets
 ###############################################################################
 
 cupla_add_executable(TestRng 2DDistribution.cpp)
-target_link_libraries(TestRng ${LIBS})
+target_link_libraries(TestRng PRIVATE pmacc::pmacc)
 
 add_custom_target(run
     COMMAND mpiexec -n 1 TestRng

--- a/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
@@ -71,18 +71,6 @@ set(CMAKE_CXX_STANDARD 17)
 ################################################################################
 
 find_package(PMacc REQUIRED CONFIG PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/pmacc")
-include_directories(SYSTEM ${PMacc_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${PMacc_LIBRARIES})
-add_definitions(${PMacc_DEFINITIONS})
-
-
-################################################################################
-# Find MPI
-################################################################################
-
-find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
-set(LIBS ${LIBS} ${MPI_C_LIBRARIES})
 
 
 ################################################################################
@@ -100,15 +88,6 @@ else(GOL_RELEASE)
 endif(GOL_RELEASE)
 
 
-###############################################################################
-# Find Boost
-###############################################################################
-
-find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${Boost_LIBRARIES})
-
-
 ################################################################################
 # PNGwriter
 ################################################################################
@@ -118,17 +97,7 @@ find_package(PNGwriter 0.7.0 REQUIRED CONFIG)
 
 if(PNGwriter_FOUND)
     list(APPEND PNGwriter_DEFINITIONS "-DGOL_ENABLE_PNG=1")
-    set(LIBS ${LIBS} PNGwriter::PNGwriter)
 endif(PNGwriter_FOUND)
-
-################################################################################
-# Math
-################################################################################
-
-if(NOT WIN32)
-    # automatically added on windows
-    set(LIBS ${LIBS} m)
-endif()
 
 
 ################################################################################
@@ -164,7 +133,19 @@ cupla_add_executable(gameOfLife
     ${SRCFILES}
 )
 
-target_link_libraries(gameOfLife PRIVATE ${LIBS})
+target_link_libraries(gameOfLife PRIVATE pmacc::pmacc)
+if(PNGwriter_FOUND)
+    target_link_libraries(PNGwriter::PNGwriter)
+endif()
+
+################################################################################
+# Math
+################################################################################
+
+if(NOT WIN32)
+    # automatically added on windows
+    target_link_libraries(gameOfLife PRIVATE m)
+endif()
 
 
 ################################################################################


### PR DESCRIPTION
- provide a target for pmacc and not expose include path, libraries, and defines via variables
- use the CMake target for PIConGPU, game of life and pmacc tests

I do not want to bring in a CMake interface target for PMacc which must be changed later to a target with real libraries behind, therefore I added a file `dummy.cpp` which will be deleted as soon as first parts of PMacc will contain a cpp file.
Excuse the basic usage of CMake, I am not an expert and assume we will refactor the CMake part in the near future many times.