### PR TITLE
Add time interpolation/extrapolation of J in substepping field solver 

### DIFF
--- a/include/picongpu/fields/FieldJ.hpp
+++ b/include/picongpu/fields/FieldJ.hpp
@@ -65,6 +65,9 @@ namespace picongpu
         //! Unit type of field components
         using UnitValueType = promoteType<float_64, ValueType>::type;
 
+        //! Type of host-device buffer for field values
+        using Buffer = pmacc::GridBuffer<ValueType, simDim>;
+
         //! Type of data box for field values on host and device
         using DataBoxType = DataBox<PitchedBox<ValueType, simDim>>;
 
@@ -78,7 +81,7 @@ namespace picongpu
         HINLINE virtual ~FieldJ() = default;
 
         //! Get a reference to the host-device buffer for the field values
-        HINLINE GridBuffer<ValueType, simDim>& getGridBuffer();
+        HINLINE Buffer& getGridBuffer();
 
         //! Get the grid layout
         HINLINE GridLayout<simDim> getGridLayout();
@@ -168,10 +171,10 @@ namespace picongpu
 
     private:
         //! Host-device buffer for current density values
-        GridBuffer<ValueType, simDim> buffer;
+        Buffer buffer;
 
         //! Buffer for receiving near-boundary values
-        std::unique_ptr<GridBuffer<ValueType, simDim>> fieldJrecv;
+        std::unique_ptr<Buffer> fieldJrecv;
     };
 
 } // namespace picongpu

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -123,9 +123,7 @@ namespace picongpu
         const DataSpace<simDim> endRecvGuard = interpolationUpperMargin;
         if(originRecvGuard != DataSpace<simDim>::create(0) || endRecvGuard != DataSpace<simDim>::create(0))
         {
-            fieldJrecv = std::make_unique<GridBuffer<ValueType, simDim>>(
-                buffer.getDeviceBuffer(),
-                cellDescription.getGridLayout());
+            fieldJrecv = std::make_unique<Buffer>(buffer.getDeviceBuffer(), cellDescription.getGridLayout());
 
             /*go over all directions*/
             for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
@@ -146,7 +144,7 @@ namespace picongpu
         }
     }
 
-    GridBuffer<FieldJ::ValueType, simDim>& FieldJ::getGridBuffer()
+    FieldJ::Buffer& FieldJ::getGridBuffer()
     {
         return buffer;
     }

--- a/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.def
+++ b/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.def
@@ -46,6 +46,8 @@ namespace picongpu
              * Thus, it is transparent for the rest of the simulation (except code called inside field solver).
              * This solver is fully equivalent to T_BaseSolver when T_numSubsteps == 1.
              *
+             * This solver uses more memory as it requires a copy of FieldJ at the previous time step.
+             *
              * @tparam T_BaseSolver base field solver, follows requirements of field solvers
              * @tparam T_numSubsteps number of substeps per PIC time iteration
              */


### PR DESCRIPTION
Previous version always used `J` at the middle of the current PIC iteration. That resulted in only first-order approximation of the `J` term. The new scheme yields second-order approximation in this part, same as for other field solvers.

There is a small TODO in the code which is only a minor problem really, I will create an issue once this PR is merged so that it's not forgotten.