### PR TITLE
Add singleton-like access for AbsorberImpl 

### DIFF
--- a/include/picongpu/fields/absorber/Absorber.hpp
+++ b/include/picongpu/fields/absorber/Absorber.hpp
@@ -190,6 +190,8 @@ namespace picongpu
              * So the base class interface does not offer any common interface but type casts.
              *
              * The reason it is separated from the Absorber class is to better manage lifetime.
+             *
+             * For clients the class behaves in a singleton-like fashion, with getImpl() for instance access.
              */
             class AbsorberImpl : public Absorber
             {
@@ -202,6 +204,16 @@ namespace picongpu
 
                 //! Destructor
                 ~AbsorberImpl() override = default;
+
+                /** Get absorber implementation instance
+                 *
+                 * Must always be called with same cellDescription, this is checked inside.
+                 * This is a bit awkward and ultimately caused by absorbers being stuck in intermediate state
+                 * between compile- and runtime polymorphism.
+                 *
+                 * @param cellDescription mapping for kernels
+                 */
+                static AbsorberImpl& getImpl(MappingDesc cellDescription);
 
                 /** Interpret this as ExponentialImpl instance
                  *

--- a/include/picongpu/fields/absorber/Absorber.tpp
+++ b/include/picongpu/fields/absorber/Absorber.tpp
@@ -182,6 +182,20 @@ namespace picongpu
             {
             }
 
+            AbsorberImpl& AbsorberImpl::getImpl(MappingDesc const cellDescription)
+            {
+                // Delay initialization till the first call since the factory has its parameters set during runtime
+                static std::unique_ptr<AbsorberImpl> pInstance = nullptr;
+                if(!pInstance)
+                {
+                    auto& factory = AbsorberFactory::get();
+                    pInstance = factory.makeImpl(cellDescription);
+                }
+                else if(pInstance->cellDescription != cellDescription)
+                    throw std::runtime_error("AbsorberImpl::getImpl() called with a different mapping description");
+                return *pInstance;
+            }
+
             exponential::ExponentialImpl& AbsorberImpl::asExponentialImpl()
             {
                 auto* result = dynamic_cast<exponential::ExponentialImpl*>(this);

--- a/include/pmacc/mappings/kernel/MappingDescription.hpp
+++ b/include/pmacc/mappings/kernel/MappingDescription.hpp
@@ -125,9 +125,17 @@ namespace pmacc
             return Environment<DIM>::get().GridController().getGpuNodes() * (gridSuperCells - 2 * guardingSuperCells);
         }
 
+        HDINLINE bool operator==(MappingDescription const& other)
+        {
+            return (gridSuperCells == other.gridSuperCells) && (guardingSuperCells == other.guardingSuperCells);
+        }
+
+        HDINLINE bool operator!=(MappingDescription const& other)
+        {
+            return !((*this) == other);
+        }
 
     protected:
-        //\todo: keine Eigenschaft einer Zelle
         PMACC_ALIGN(gridSuperCells, DataSpace<DIM>);
         PMACC_ALIGN(guardingSuperCells, DataSpace<DIM>);
     };


### PR DESCRIPTION
This allows accessing absorber instance from outside a field solver. (Which was not needed before, but a feature I'm working on requires it).