### PR TITLE
Change TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE to always be 64-bit

### DIFF
--- a/include/picongpu/param/unit.param
+++ b/include/picongpu/param/unit.param
@@ -36,19 +36,18 @@ namespace picongpu
 
     namespace particles
     {
-        /** Number of particles per makro particle (= macro particle weighting)
+        /** Typical number of particles per macro particle (= typical macro particle weighting)
          *  unit: none */
-        constexpr float_X TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
-            = float_64(SI::BASE_DENSITY_SI * SI::CELL_WIDTH_SI * SI::CELL_HEIGHT_SI * SI::CELL_DEPTH_SI)
+        constexpr float_64 TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
+            = (SI::BASE_DENSITY_SI * SI::CELL_WIDTH_SI * SI::CELL_HEIGHT_SI * SI::CELL_DEPTH_SI)
             / float_64(particles::TYPICAL_PARTICLES_PER_CELL);
     } // namespace particles
 
 
     /** Unit of mass */
-    constexpr float_64 UNIT_MASS = SI::BASE_MASS_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_MASS = SI::BASE_MASS_SI * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
     /** Unit of charge */
-    constexpr float_64 UNIT_CHARGE
-        = -1.0 * SI::BASE_CHARGE_SI * double(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
+    constexpr float_64 UNIT_CHARGE = -1.0 * SI::BASE_CHARGE_SI * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
     /** Unit of energy */
     constexpr float_64 UNIT_ENERGY = (UNIT_MASS * UNIT_LENGTH * UNIT_LENGTH / (UNIT_TIME * UNIT_TIME));
     /** Unit of EField: V/m */

--- a/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
@@ -74,7 +74,9 @@ namespace picongpu
                 float_64 newEnergyPhysicalElectron
                     = energyPhysicalElectron
                     + static_cast<float_64>(
-                          deltaEnergyBin / (picongpu::particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * weightBin));
+                          deltaEnergyBin
+                          / (static_cast<float_X>(picongpu::particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE)
+                             * weightBin));
                 // unit:: ATOMIC_UNIT_ENERGY
 
                 // case: too much energy removed

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/histogram/AdaptiveHistogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/histogram/AdaptiveHistogram.hpp
@@ -610,7 +610,8 @@ namespace picongpu
                         {
                             if((this->binWeight[index] + this->binDeltaWeight[index])
                                        * this->getEnergyBin(acc, index, atomicDataBox)
-                                       * picongpu::particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
+                                       * static_cast<float_X>(
+                                           picongpu::particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE)
                                    + deltaEnergy
                                >= 0.0)
                             {

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.tpp
@@ -165,7 +165,8 @@ namespace picongpu
 
                 /* TODO: obtain the ion density from the molare ion density in order to avoid the rescaling.
                  * So this should be: ionDensity = ionMolDensity / UNIT_AMOUNT_SUBSTANCE */
-                const float_X ionDensity = ionDensity_norm.x() * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+                const float_X ionDensity
+                    = ionDensity_norm.x() * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
 
                 const float_X weighting = particle[weighting_];
 

--- a/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
+++ b/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
@@ -302,18 +302,18 @@ namespace picongpu
                             float3_COLL const labMomentum1
                                 = precisionCast<float_COLL>(par1[momentum_]) / normalizedWeight1;
                             float_COLL const mass0 = precisionCast<float_COLL>(picongpu::traits::attribute::getMass(
-                                particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE,
+                                static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE),
                                 par0));
                             float_COLL const mass1 = precisionCast<float_COLL>(picongpu::traits::attribute::getMass(
-                                particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE,
+                                static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE),
                                 par1));
                             float_COLL const charge0
                                 = precisionCast<float_COLL>(picongpu::traits::attribute::getCharge(
-                                    particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE,
+                                    static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE),
                                     par0));
                             float_COLL const charge1
                                 = precisionCast<float_COLL>(picongpu::traits::attribute::getCharge(
-                                    particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE,
+                                    static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE),
                                     par1));
                             auto const gamma0 = picongpu::gamma<float_COLL>(labMomentum0, mass0);
                             auto const gamma1 = picongpu::gamma<float_COLL>(labMomentum1, mass1);

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
@@ -117,7 +117,8 @@ namespace picongpu
                         if(linearThreadIdx == 0)
                         {
                             ValueType localAverageResult = shReduceBuffer[0]
-                                * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE / float_X(numAvgCells);
+                                * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE)
+                                / float_X(numAvgCells);
 
                             localDensity(avgBoxCell)
                                 = static_cast<typename T_LocalDensityBox::ValueType>(localAverageResult);

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
@@ -42,7 +42,7 @@ namespace picongpu
                     const
                 {
                     // avoid dividing by zero. Return zero if density is close to zero.
-                    if(dens[0] * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME
+                    if(dens[0] * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * CELL_VOLUME
                        <= std::numeric_limits<float_X>::min())
                     {
                         dst = float1_X{0.0};
@@ -51,7 +51,8 @@ namespace picongpu
                     {
                         // average value is total value over number of particles
                         // number of particles is density * CELL_VOLUME
-                        dst /= dens * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME;
+                        dst /= dens * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE)
+                            * CELL_VOLUME;
                     }
                 }
 

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
@@ -50,7 +50,7 @@ namespace picongpu
                     HDINLINE void operator()(T_Acc const& acc, float1_X& density, const float1_X& energyDensity) const
                     {
                         const float_X densityPICUnits
-                            = density[0] * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+                            = density[0] * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
                         // avoid dividing by zero.
                         if(densityPICUnits > std::numeric_limits<float_X>::min())
                         {

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/BoundElectronDensity.hpp
@@ -50,7 +50,7 @@ namespace picongpu
 
                     // calculate new attribute
                     float_X const boundElectronDensity = weighting * boundElectrons
-                        / (particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME);
+                        / (static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * CELL_VOLUME);
 
                     return boundElectronDensity;
                 }

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Counter.hpp
@@ -47,7 +47,8 @@ namespace picongpu
                     const float_X weighting = particle[weighting_];
 
                     /* calculate new attribute */
-                    const float_X particleCounter = weighting / particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE;
+                    const float_X particleCounter
+                        = weighting / static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
 
                     /* return attribute */
                     return particleCounter;

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Density.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Density.hpp
@@ -48,8 +48,8 @@ namespace picongpu
                     const float_X weighting = particle[weighting_];
 
                     /* calculate new attribute */
-                    const float_X particleDensity
-                        = weighting / (particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * CELL_VOLUME);
+                    const float_X particleDensity = weighting
+                        / (static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * CELL_VOLUME);
 
                     /* return attribute */
                     return particleDensity;

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -481,14 +481,14 @@ namespace picongpu
                 for(int i = 0; i < realNumBins; ++i)
                 {
                     count_particles += float_64(binReduced[i]);
-                    outFile << std::scientific
-                            << (binReduced[i]) * float_64(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) << " ";
+                    outFile << std::scientific << (binReduced[i]) * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
+                            << " ";
                 }
                 /* endl: Flush any step to the file.
                  * Thus, we will have data if the program should crash.
                  */
-                outFile << std::scientific
-                        << count_particles * float_64(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) << std::endl;
+                outFile << std::scientific << count_particles * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE
+                        << std::endl;
             }
         }
     };

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -103,7 +103,8 @@ namespace picongpu
 #else
             constexpr auto baseCharge = BASE_CHARGE;
             const float_X tyCurrent = particles::TYPICAL_PARTICLES_PER_CELL
-                * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * math::abs(baseCharge) / DELTA_T;
+                * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * math::abs(baseCharge)
+                / DELTA_T;
             const float_X tyEField = fields::laserProfiles::Selected::Unitless::AMPLITUDE + FLT_MIN;
             const float_X tyBField = tyEField * MUE0_EPS0;
 
@@ -153,7 +154,8 @@ namespace picongpu
             const float_X tyEField = fields::laserProfiles::Selected::Unitless::W0 * BASE_DENSITY / 3.0f / EPS0;
             const float_X tyBField = tyEField * MUE0_EPS0;
             const float_X tyCurrent = particles::TYPICAL_PARTICLES_PER_CELL
-                * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * math::abs(baseCharge) / DELTA_T;
+                * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * math::abs(baseCharge)
+                / DELTA_T;
 
             return float3_X(tyBField, tyEField, tyCurrent);
 #endif
@@ -192,7 +194,8 @@ namespace picongpu
 #else
             constexpr auto baseCharge = BASE_CHARGE;
             const float_X tyCurrent = particles::TYPICAL_PARTICLES_PER_CELL
-                * particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE * math::abs(baseCharge) / DELTA_T;
+                * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * math::abs(baseCharge)
+                / DELTA_T;
             const float_X tyEField = getAmplitude() + FLT_MIN;
             const float_X tyBField = tyEField * MUE0_EPS0;
             return float3_X(tyBField, tyEField, tyCurrent);
@@ -545,7 +548,8 @@ namespace picongpu
                             accelerator,
                             &(counter(reducedCell)),
                             // normalize the value to avoid bad precision for large macro particle weightings
-                            particle[weighting_] / particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE,
+                            particle[weighting_]
+                                / static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE),
                             ::alpaka::hierarchy::Threads{});
                     }
                 });


### PR DESCRIPTION
This variable is used for unit calculations, and so must be `float_64` as other units. Previous usage as `float_X` caused potential unit inconsistencies in order of 32-bit ulp. Now it is raised to 64-bit ulp, as is the idea behind the units.

Thanks to @finnolec for reporting the issue with incident field unit check that led to this investigation and fix.