### PR TITLE
Typos in laser.param and incident field files

### DIFF
--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -427,7 +427,7 @@ namespace picongpu
                  * profiles::T_BaseTransversalGaussianParam requirements
                  */
                 template<typename T_BaseTransversalGaussianParam>
-                struct BaseSeparableTransveralGaussianFunctorE
+                struct BaseSeparableTransversalGaussianFunctorE
                     : public BaseSeparableFunctorE<T_BaseTransversalGaussianParam>
                 {
                     //! Base class
@@ -443,7 +443,7 @@ namespace picongpu
                      * @param unitField conversion factor from SI to internal units,
                      *                  fieldE_internal = fieldE_SI / unitField
                      */
-                    HINLINE BaseSeparableTransveralGaussianFunctorE(
+                    HINLINE BaseSeparableTransversalGaussianFunctorE(
                         float_X const currentStep,
                         float3_64 const unitField)
                         : Base(currentStep, unitField)

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -76,7 +76,7 @@ namespace picongpu
                         static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
                         static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
 
-                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before
+                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before
                          * plateau and half at the end of the plateau
                          *
                          * unit: none

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -139,13 +139,13 @@ namespace picongpu
                     template<typename T_Params>
                     struct ExpRampWithPrepulseFunctorIncidentE
                         : public ExpRampWithPrepulseUnitless<T_Params>
-                        , public incidentField::detail::BaseSeparableTransveralGaussianFunctorE<T_Params>
+                        , public incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>
                     {
                         //! Unitless parameters type
                         using Unitless = ExpRampWithPrepulseUnitless<T_Params>;
 
                         //! Base functor type
-                        using Base = incidentField::detail::BaseSeparableTransveralGaussianFunctorE<T_Params>;
+                        using Base = incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>;
 
                         /** Create a functor on the host side for the given time step
                          *

--- a/include/picongpu/fields/incidentField/profiles/Polynom.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Polynom.hpp
@@ -72,13 +72,13 @@ namespace picongpu
                     template<typename T_Params>
                     struct PolynomFunctorIncidentE
                         : public PolynomUnitless<T_Params>
-                        , public incidentField::detail::BaseSeparableTransveralGaussianFunctorE<T_Params>
+                        , public incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>
                     {
                         //! Unitless parameters type
                         using Unitless = PolynomUnitless<T_Params>;
 
                         //! Base functor type
-                        using Base = incidentField::detail::BaseSeparableTransveralGaussianFunctorE<T_Params>;
+                        using Base = incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>;
 
                         /** Create a functor on the host side for the given time step
                          *

--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
@@ -82,13 +82,13 @@ namespace picongpu
                     template<typename T_Params>
                     struct WavepacketFunctorIncidentE
                         : public WavepacketUnitless<T_Params>
-                        , public incidentField::detail::BaseSeparableTransveralGaussianFunctorE<T_Params>
+                        , public incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>
                     {
                         //! Unitless parameters type
                         using Unitless = WavepacketUnitless<T_Params>;
 
                         //! Base functor type
-                        using Base = incidentField::detail::BaseSeparableTransveralGaussianFunctorE<T_Params>;
+                        using Base = incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>;
 
                         /** Create a functor on the host side for the given time step
                          *

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.def
@@ -94,7 +94,7 @@ namespace picongpu
                         static constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
                         static constexpr float_64 W0_Z_SI = W0_X_SI;
 
-                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before
+                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before
                          * plateau and half at the end of the plateau unit: none */
                         static constexpr float_64 RAMP_INIT = 16.0;
 

--- a/include/picongpu/fields/laserProfiles/PlaneWave.def
+++ b/include/picongpu/fields/laserProfiles/PlaneWave.def
@@ -78,7 +78,7 @@ namespace picongpu
                          */
                         static constexpr uint32_t initPlaneY = 0;
 
-                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and
+                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before and
                          * after the plateau unit: none */
                         static constexpr float_64 RAMP_INIT = 20.6146;
 

--- a/include/picongpu/fields/laserProfiles/Wavepacket.hpp
+++ b/include/picongpu/fields/laserProfiles/Wavepacket.hpp
@@ -159,7 +159,7 @@ namespace picongpu
                     // offsetToTotalDomain.y() = 0
 
                     // a symmetric pulse will be initialized at position z=0 for
-                    // a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+                    // a time of PULSE_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
                     // we shift the complete pulse for the half of this time to start with
                     // the front of the laser pulse.
                     const float_64 mue = 0.5 * Unitless::INIT_TIME;

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -38,7 +38,7 @@
  * picongpu/fields/incidentField/profiles/. Note that all these parameter structures inherit common base structures
  * from `BaseParam.def`. Thus, a user-provided structure must also define all members according to the base struct.
  *
- * In the end, this file needs to define `XMin`, `XMax`, `YMax`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
+ * In the end, this file needs to define `XMin`, `XMax`, `YMin`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
  * in 2d) type aliases in namespace `picongpu::fields::incidentField`. Each of them could be a single profile or a
  * typelist of profiles created with `MakeSeq_t`. In case a typelist is used, the resulting field is a sum of
  * effects of all profiles in the list. This file also has to define constexpr array `POSITION` that controls

--- a/include/picongpu/param/laser.param
+++ b/include/picongpu/param/laser.param
@@ -410,7 +410,7 @@ namespace picongpu
                 static constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
                 static constexpr float_64 W0_Z_SI = W0_X_SI;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before plateau
                  *  and half at the end of the plateau
                  *  unit: none */
                 static constexpr float_64 RAMP_INIT = 16.0;
@@ -581,7 +581,7 @@ namespace picongpu
                  */
                 static constexpr uint32_t initPlaneY = 0;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before and after
                  * the plateau unit: none */
                 static constexpr float_64 RAMP_INIT = 20.6146;
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/laser.param
@@ -102,7 +102,7 @@ namespace picongpu
                  */
                 static constexpr uint32_t initPlaneY = 0;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before and after
                  * the plateau unit: none */
                 static constexpr float_64 RAMP_INIT = 20.6146;
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/laser.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/laser.param
@@ -96,7 +96,7 @@ namespace picongpu
                  *  unit: seconds (1 sigma) */
                 static constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and after
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before and after
                  * the plateau unit: none */
                 static constexpr float_64 RAMP_INIT = 3. * 2.354820045;
 
@@ -188,7 +188,7 @@ namespace picongpu
                 static constexpr float_64 W0_X_SI = 2.5 * WAVE_LENGTH_SI;
                 static constexpr float_64 W0_Z_SI = W0_X_SI;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before plateau
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before plateau
                 and half at the end of the plateau
                  *  unit: none */
                 static constexpr float_64 RAMP_INIT = 16.0;


### PR DESCRIPTION
Here are some typos I found in the "regular" laser files and in the incident field files.