### PR TITLE
Add Python code formatting guidelines to the docs

### DIFF
--- a/docs/COMMIT.md
+++ b/docs/COMMIT.md
@@ -11,6 +11,9 @@ We agree on the following simple rules to make our lives easier :)
 Format Code
 -----------
 
+Python code must adhere to [PEP 8](https://peps.python.org/pep-0008/) guidelines.
+The following describes formatting of C++ code.
+
 - Install *ClangFormat 12* from LLVM 12.0.1
 - To format all files in your working copy, you can run this command in bash from the root folder of PIConGPU:
   ```bash


### PR DESCRIPTION
Is a very basic fix for #4275 do document the current requirements - this is what our CI checks.

Whether our requirements are reasonable for Python is another question, I am no Python developer and so have no opinion on that.