### PR TITLE
Change particle attribute for thermal boundaries to openPMD-conformant name

### DIFF
--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -207,9 +207,9 @@ namespace picongpu
                     propList[directionName]["name"] = "reflecting";
                     break;
                 case particles::boundary::Kind::Thermal:
-                    propList[directionName]["name"] = "thermal";
+                    propList[directionName]["name"] = "reinjecting";
                     propList[directionName]["param"]
-                        = std::string("temperature ") + std::to_string(temperature) + " keV";
+                        = std::string("thermal, T=") + std::to_string(temperature) + "keV";
                     break;
                 default:
                     propList[directionName]["name"] = "unknown";


### PR DESCRIPTION
The change only affects the attribute text in output files.

The conformant name taken from [here](https://github.com/openPMD/openPMD-standard/blob/latest/EXT_ED-PIC.md#additional-attributes-for-the-group-meshespath)