### PR TITLE
pmacc::ConstVector: do not use _device namespace for OMP5,OACC

### DIFF
--- a/include/pmacc/math/ConstVector.hpp
+++ b/include/pmacc/math/ConstVector.hpp
@@ -26,7 +26,8 @@
 #include "pmacc/types.hpp"
 
 /* select namespace depending on __CUDA_ARCH__ compiler flag*/
-#if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
+#if(CUPLA_DEVICE_COMPILE == 1 && /* we are on gpu ... and not using an offloading backend: */                         \
+    !(defined ALPAKA_ACC_ANY_BT_OMP5_ENABLED || defined ALPAKA_ACC_ANY_BT_OACC_ENABLED))
 #    define PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id)                                                             \
         using namespace PMACC_JOIN(pmacc_static_const_vector_device, id)
 #else


### PR DESCRIPTION
Directive-based offloading backends (OpenMP5/OpenACC) map constants to the device internally and use the host-symbol to refer to mapped date in device code, thus the `_device` namespace is created for a device vector. This change makes device code of these backends also use the `_host` namespace instead of the, non-existent, '_device' one.