### PR TITLE
[breaking change] fix openPMD particles `positionOffset`

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -38,7 +38,7 @@ namespace picongpu
          *
          * @attention If the version is changed please update openPMDWriter::checkIOFileVersionCompatibility().
          */
-        static constexpr int picongpuIOVersionMajor = 0;
+        static constexpr int picongpuIOVersionMajor = 1;
 
         /** PIConGPU's IO minor file version.
          *
@@ -48,7 +48,7 @@ namespace picongpu
          * @attention If the version is changed please update openPMDWriter::checkIOFileVersionCompatibility() if
          * needed.
          */
-        static constexpr int picongpuIOVersionMinor = 1;
+        static constexpr int picongpuIOVersionMinor = 0;
         /*
          * Do some SFINAE tricks to detect whether the openPMD API has
          * dataset-specific configuration or not.

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -68,8 +68,7 @@ namespace pmacc
                      * @param destBox particle box where all particles are copied to (destination)
                      * @param srcFrame frame with particles (is used as source)
                      * @param maxParticles number of particles in srcFrame
-                     * @param localDomainCellOffset offset in cells to user-defined domain (@see wiki PIConGPU domain
-                     * definitions)
+                     * @param cellOffsetToTotalDomain offset of the local domain in cells to total domain origin
                      * @param domainCellIdxIdentifier the identifier for the particle domain cellIdx
                      *                                that is calculated back to the local domain
                      *                                with respect to localDomainCellOffset
@@ -89,7 +88,7 @@ namespace pmacc
                         T_DestBox destBox,
                         T_SrcFrame srcFrame,
                         int const maxParticles,
-                        T_Space const localDomainCellOffset,
+                        T_Space const cellOffsetToTotalDomain,
                         T_Identifier const domainCellIdxIdentifier,
                         T_CellDescription const cellDesc) const
                     {
@@ -163,7 +162,7 @@ namespace pmacc
                                     // offset of the particle relative to the origin of the local domain
                                     DataSpace<numDims> const particleCellOffset
                                         = srcFrame[srcParticleIdxCtx[idx]][domainCellIdxIdentifier]
-                                        - localDomainCellOffset;
+                                        - cellOffsetToTotalDomain;
                                     particlesSuperCellIdx = particleCellOffset / SuperCellSize::toRT();
                                     linearParticlesSuperCellCtx[idx]
                                         = DataSpaceOperations<numDims>::map(numSuperCells, particlesSuperCellIdx);
@@ -257,11 +256,10 @@ namespace pmacc
              * @param srcFrame device frame with particles (is used as source)
              * @param numParticles number of particles in srcFrame
              * @param chunkSize number of particles to process in one kernel call
-             * @param localDomainCellOffset offset in cells to user-defined domain (@see wiki PIConGPU domain
-             * definitions)
+             * @param cellOffsetToTotalDomain offset of the local domain in cells to total domain origin
              * @param domainCellIdxIdentifier the identifier for the particle domain cellIdx
              *                                that is calculated back to the local domain
-             *                                with respect to localDomainCellOffset
+             *                                with respect to cellOffsetToTotalDomain
              * @param cellDesc supercell domain description
              * @param logLvl Log level used for information logging
              */
@@ -277,7 +275,7 @@ namespace pmacc
                 T_SrcFrame srcFrame,
                 uint32_t numParticles,
                 uint32_t const chunkSize,
-                T_Space const& localDomainCellOffset,
+                T_Space const& cellOffsetToTotalDomain,
                 T_Identifier const domainCellIdxIdentifier,
                 T_CellDescription const& cellDesc,
                 T_LogLvl const& logLvl = T_LogLvl())
@@ -314,7 +312,7 @@ namespace pmacc
                         destSpecies.getDeviceParticlesBox(),
                         srcFrame,
                         static_cast<int>(numParticles),
-                        localDomainCellOffset,
+                        cellOffsetToTotalDomain,
                         domainCellIdxIdentifier,
                         cellDesc);
                     destSpecies.fillAllGaps();


### PR DESCRIPTION
fix #4276

PIConGPU used offsets relative to the data domain (global domain) instead of total offsets for particles. This aviods performing particle analysis if there are no field data because there was no way to get the total particle position.

**This PR is a breaking change, post-processing tools must be updated, and restarting from checkpoints (IO file version 0.1) created before this PR is no longer possible.**

- [x] rebase against #4287 and introduce a new major file version