### PR TITLE
fix png artefacts in particle density

### DIFF
--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -520,10 +520,6 @@ namespace picongpu
             auto forEachParticle
                 = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, pb, suplercellIdx);
 
-            // end kernel if we have no particles
-            if(!forEachParticle.hasParticles())
-                return;
-
             forEachParticle(
                 acc,
                 [&supercellCellOffset, &counter, &transpose, sliceDim, slice, localDomainOffset](


### PR DESCRIPTION
The png plugin is producing artifacts in the output for the particle density.
The issue was introduced with #4173.
An early exit of the calculation within a supercell without particles skipped the mapping of the density value to the correct color.

example:
![e_png_yx_0 5_000780](https://user-images.githubusercontent.com/4037125/188155697-fcf5153d-46c9-4719-99c1-f867e64fa40a.png)
