### PR TITLE
OpenPMD plugin: add IO file version

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 Franz Poeschel
+/* Copyright 2020-2022 Franz Poeschel, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -29,6 +29,26 @@ namespace picongpu
 {
     namespace openPMD
     {
+        /** PIConGPU's IO major file version.
+         *
+         * The version can be used to handle incompatibilities between checkpoint files in case breaking changes
+         * within the openPMD checkpoint code are introduced.
+         * A change in the major version points to a new feature/fix that cannot be handled by an older PIConGPU IO
+         * implementations. Newer PIConGPU IO implementations can optionally support old major versions.
+         *
+         * @attention If the version is changed please update openPMDWriter::checkIOFileVersionCompatibility().
+         */
+        static constexpr int picongpuIOVersionMajor = 0;
+
+        /** PIConGPU's IO minor file version.
+         *
+         * A change in the minor version means that the new introduced feature/fix can be loaded by all PIConGPU IO
+         * implementations with the same major IO file version.
+         *
+         * @attention If the version is changed please update openPMDWriter::checkIOFileVersionCompatibility() if
+         * needed.
+         */
+        static constexpr int picongpuIOVersionMinor = 1;
         /*
          * Do some SFINAE tricks to detect whether the openPMD API has
          * dataset-specific configuration or not.

--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -22,6 +22,7 @@
 
 #include "picongpu/fields/absorber/Absorber.hpp"
 #include "picongpu/fields/currentInterpolation/CurrentInterpolation.hpp"
+#include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/stringHelpers.hpp"
 #include "picongpu/plugins/openPMD/openPMDWriter.def"
 #include "picongpu/traits/SIBaseUnits.hpp"
@@ -137,6 +138,10 @@ namespace picongpu
                 if(!std::string(PICONGPU_VERSION_LABEL).empty())
                     softwareVersion << "-" << PICONGPU_VERSION_LABEL;
                 series.setSoftware(software, softwareVersion.str());
+
+                // PIConGPU IO file format version
+                series.setAttribute("picongpuIOVersionMajor", picongpuIOVersionMajor);
+                series.setAttribute("picongpuIOVersionMinor", picongpuIOVersionMinor);
 
                 // don't write this if a previous run already wrote it
                 if(!series.containsAttribute("date"))


### PR DESCRIPTION
Store a PIConGPU specific major and minor IO format version number to handle incompatibilities of new features or bug fixes.

Old files without the openPMD series attribute `picongpuIOVersionMajor` and `picongpuIOVersionMinor` can be loaded and will be handled as version `0.0`.