### PR TITLE
Add and enable UCX_RC_TIMEOUT workaround

### DIFF
--- a/etc/picongpu/juwels-jsc/booster.tpl
+++ b/etc/picongpu/juwels-jsc/booster.tpl
@@ -39,6 +39,9 @@
 #SBATCH -o stdout
 #SBATCH -e stderr
 
+# Workaround for Infinibands' "Transport retry count exceeded"-error:
+# https://apps.fz-juelich.de/jsc/hps/juwels/faq.html#my-job-failed-with-transport-retry-count-exceeded
+export UCX_RC_TIMEOUT=3000000.00us # 3s instead of 1s
 
 ## calculations will be performed by tbg ##
 .TBG_queue="booster"


### PR DESCRIPTION
This adds the workaround to the Infiniband error ["Transport retry count exceeded"](https://apps.fz-juelich.de/jsc/hps/juwels/faq.html#my-job-failed-with-transport-retry-count-exceeded) that may happen on the JUWELS Booster system during times of a heavy network load.

The documentation of the system suggests to simply restart the simulation and up the `UCX_RC_TIMEOUT` value if the problem persists. Here the default timeout value is increased from 1 [s] to 3 [s].