### PR TITLE
DataBox remove method `reduceZ()`

### DIFF
--- a/include/pmacc/memory/boxes/DataBox.hpp
+++ b/include/pmacc/memory/boxes/DataBox.hpp
@@ -70,10 +70,5 @@ namespace pmacc
             result.fixedPointer = &((*this)(offset));
             return result;
         }
-
-        HDINLINE DataBox<typename Base::ReducedType> reduceZ(const int zOffset) const
-        {
-            return Base::reduceZ(zOffset);
-        }
     };
 } // namespace pmacc

--- a/include/pmacc/memory/boxes/PitchedBox.hpp
+++ b/include/pmacc/memory/boxes/PitchedBox.hpp
@@ -174,11 +174,6 @@ namespace pmacc
         }
 
     protected:
-        HDINLINE PitchedBox<TYPE, DIM2> reduceZ(const int zOffset) const
-        {
-            return {(TYPE*) ((char*) (this->fixedPointer) + pitch2D * zOffset), pitch};
-        }
-
         PMACC_ALIGN(pitch, size_t);
         PMACC_ALIGN(pitch2D, size_t);
     };


### PR DESCRIPTION
The removed method is a left over from the past and is no longer used.