### PR TITLE
Fix calls to makeForEach in particle merger plugins

### DIFF
--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -116,10 +116,11 @@ namespace picongpu
                     const uint32_t workerIdx
                         = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
 
+                    auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
                     auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
                         workerIdx,
                         particlesBox,
-                        cellIdx / static_cast<pmacc::math::Int<simDim>>(SuperCellSize::toRT()));
+                        superCellIdx);
 
                     forEachParticle(
                         acc,
@@ -172,10 +173,11 @@ namespace picongpu
                     const uint32_t workerIdx
                         = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
 
+                    auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
                     auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
                         workerIdx,
                         particlesBox,
-                        cellIdx / static_cast<pmacc::math::Int<simDim>>(SuperCellSize::toRT()));
+                        superCellIdx);
 
                     forEachParticle(
                         acc,

--- a/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.kernel
+++ b/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.kernel
@@ -129,10 +129,11 @@ namespace picongpu
                     const uint32_t workerIdx
                         = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
 
+                    auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
                     auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
                         workerIdx,
                         particlesBox,
-                        cellIdx / static_cast<pmacc::math::Int<simDim>>(SuperCellSize::toRT()));
+                        superCellIdx);
 
                     forEachParticle(
                         acc,
@@ -308,10 +309,11 @@ namespace picongpu
                     const uint32_t workerIdx
                         = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
 
+                    auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
                     auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
                         workerIdx,
                         particlesBox,
-                        cellIdx / static_cast<pmacc::math::Int<simDim>>(SuperCellSize::toRT()));
+                        superCellIdx);
 
                     forEachParticle(
                         acc,


### PR DESCRIPTION
The change introduced in #4289 resulted in compile errors at these places. This went unnoticed as we do not compile those plugins in the CI.

Bug reported by @PrometheusPi via the helpline channel.

I will add it to CI in a follow-up PR.