### PR TITLE
Add compilation of particle merger plugins to compile-time tests

### DIFF
--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/speciesDefinition.param
@@ -35,7 +35,8 @@ namespace picongpu
     /*########################### define particle attributes #####################*/
 
     /** describe attributes of a particle*/
-    using DefaultParticleAttributes = MakeSeq_t<position<position_pic>, momentum, weighting, probeE, probeB>;
+    using DefaultParticleAttributes
+        = MakeSeq_t<position<position_pic>, momentum, weighting, probeE, probeB, voronoiCellId>;
 
     /*########################### end particle attributes ########################*/
 


### PR DESCRIPTION
Now these plugins won't accidentally stop compiling again like what happened in #4296. Chose to extend an existing test setup to avoid increasing CI time.

- [x] Merge after #4296 , the CI should fail before it