### PR TITLE
Add a new particle attribute for weighting damping factor 

### DIFF
--- a/docs/source/usage/workflows/boundaryConditions.rst
+++ b/docs/source/usage/workflows/boundaryConditions.rst
@@ -22,8 +22,6 @@ When fields are periodic along an axis, boundaries for all species must be perio
 When fields are absorbing (non-periodic), species must be absorbing, reflecting, or thermal.
 
 By default, the particle boundaries are applied at the global domain boundaries.
-For absorbing boundaries it means that particles will exist in the field absorbing area.
-This may be undesired for simulations with Perfectly Matched Layers (see below).
 A user can change the boundary application area by setting an offset with the
 option `--<prefix>_boundaryOffset <x> <y> <z>`.
 The `boundaryOffset` is in terms of whole cells, so integers are expected.
@@ -55,9 +53,7 @@ The rest of the section concerns absorbing boundaries.
 For the absorbing boundaries, there is a virtual field absorber layer inside the global simulation area near its boundaries.
 Field values in the layer are treated differently from the rest, by a combination of a field solver and a field absorber.
 It causes field dynamics inside the absorber layer to differ from that in a vacuum.
-Otherwise, the affected cells are a normal part of a simulation in terms of indexing, particle handling, and output.
-It is recommended to avoid, as possible, having particles in the field absorber layer.
-Ideally, only particles leaving the simulation area are present there, on their way to be absorbed.
+Otherwise, the affected cells are a normal part of a simulation in terms of indexing and output.
 Note that particle absorption happens at the external surface of the field absorber layer, matching the global simulation area border.
 
 The field absorber mechanism and user-controlled parameters depend on the field absorber kind enabled.
@@ -68,5 +64,8 @@ By default, the Perfectly Matched Layer (PML) absorber is used.
 For this absorber, thickness of 8 to 12 cells is recommended.
 Other absorber parameters can generally be used with default values.
 PML generally provides much better absorber qualities than the exponential damping absorber.
+
+In case PML field absorber is used together with absorbing particle boundaries, a special damping is applied for current density values in the PML area.
+This treatment is to smooth effects of charges leaving the simulation volume and thus to better represent open boundaries.
 
 For the exponential absorber, thickness of about 32 cells is recommended.

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -26,6 +26,7 @@
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/fields/currentDeposition/Cache.hpp"
 #include "picongpu/fields/currentDeposition/Strategy.def"
+#include "picongpu/traits/attribute/DampedWeighting.hpp"
 
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/lockstep.hpp>
@@ -131,12 +132,17 @@ namespace picongpu
             template<typename T_Particle, typename BoxJ, typename T_Acc>
             DINLINE void operator()(T_Acc const& acc, T_Particle& particle, BoxJ& jBox)
             {
-                const float_X weighting = particle[weighting_];
+                /* Use (potentially) damped weighting for charge calculation.
+                 * @see particles::boundary::DampWeightsInPml for details.
+                 */
+                const auto dampedWeighting = attribute::getDampedWeighting(particle);
+                const float_X charge = attribute::getCharge(dampedWeighting, particle);
                 const floatD_X pos = particle[position_];
                 const int particleCellIdx = particle[localCellIdx_];
-                const float_X charge = attribute::getCharge(weighting, particle);
                 const DataSpace<simDim> localCell(DataSpaceOperations<simDim>::template map<TVec>(particleCellIdx));
 
+                // The rest uses normal weighting
+                const float_X weighting = particle[weighting_];
                 Velocity velocity;
                 const float3_X vel = velocity(particle[momentum_], attribute::getMass(weighting, particle));
                 auto fieldJShiftToParticle = jBox.shift(localCell);

--- a/include/picongpu/fields/absorber/pml/Parameters.hpp
+++ b/include/picongpu/fields/absorber/pml/Parameters.hpp
@@ -41,6 +41,19 @@ namespace picongpu
                  */
                 struct Parameters
                 {
+                    /** Default constructor setting all members to 0
+                     *
+                     * This constructor only exists for deferred initialization on the host side.
+                     */
+                    Parameters()
+                        : normalizedSigmaMax(floatD_X::create(0.0_X))
+                        , sigmaKappaGradingOrder(0.0_X)
+                        , kappaMax(floatD_X::create(0.0_X))
+                        , normalizedAlphaMax(floatD_X::create(0.0_X))
+                        , alphaGradingOrder(0.0_X)
+                    {
+                    }
+
                     /** Max value of artificial electric conductivity
                      *
                      * Components correspond to directions. Normalized, so that

--- a/include/picongpu/fields/absorber/pml/Pml.hpp
+++ b/include/picongpu/fields/absorber/pml/Pml.hpp
@@ -99,6 +99,21 @@ namespace picongpu
                             updatePsiB};
                     }
 
+                    /** Get parameters for the local domain
+                     *
+                     * @param currentStep index of the current time iteration
+                     */
+                    LocalParameters getLocalParameters(float_X const currentStep) const
+                    {
+                        Thickness localThickness = getLocalThickness(currentStep);
+                        checkLocalThickness(localThickness);
+                        return LocalParameters(
+                            parameters,
+                            localThickness,
+                            cellDescription.getGridSuperCells() * SuperCellSize::toRT(),
+                            cellDescription.getGuardingSuperCells() * SuperCellSize::toRT());
+                    }
+
                 private:
                     //! Read parameters from fieldAbsorber.param
                     void initParameters()
@@ -111,18 +126,6 @@ namespace picongpu
                             parameters.kappaMax[dim] = KAPPA_MAX[dim];
                             parameters.normalizedAlphaMax[dim] = NORMALIZED_ALPHA_MAX[dim];
                         }
-                    }
-
-                    //! Get parameters for the local domain
-                    LocalParameters getLocalParameters(float_X const currentStep) const
-                    {
-                        Thickness localThickness = getLocalThickness(currentStep);
-                        checkLocalThickness(localThickness);
-                        return LocalParameters(
-                            parameters,
-                            localThickness,
-                            cellDescription.getGridSuperCells() * SuperCellSize::toRT(),
-                            cellDescription.getGuardingSuperCells() * SuperCellSize::toRT());
                     }
 
                     /** Get PML thickness for the local domain at the current time step.

--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -45,14 +45,40 @@ namespace picongpu
                 {
                     /** PML size in cells, stored as floats to avoid type casts later,
                      *  negative and positive borders defined the same way as for Thickness
+                     *
+                     * @{
                      */
-                    floatD_X const negativeBorderSize;
-                    floatD_X const positiveBorderSize;
+                    floatD_X negativeBorderSize;
+                    floatD_X positiveBorderSize;
 
-                    //! Local domain characteristics, including guard cells
-                    DataSpace<simDim> const numLocalDomainCells;
-                    DataSpace<simDim> const numGuardCells;
+                    /** @} */
 
+                    //! Number of cells in the local domain including guards
+                    DataSpace<simDim> numLocalDomainCells;
+
+                    //! Number of guard cells
+                    DataSpace<simDim> numGuardCells;
+
+                    /** Default constructor setting all members to 0
+                     *
+                     * This constructor only exists for deferred initialization on the host side.
+                     */
+                    LocalParameters()
+                        : Parameters()
+                        , negativeBorderSize(floatD_X::create(0.0_X))
+                        , positiveBorderSize(floatD_X::create(0.0_X))
+                        , numLocalDomainCells(DataSpace<simDim>::create(0))
+                        , numGuardCells(DataSpace<simDim>::create(0))
+                    {
+                    }
+
+                    /** Constructor with given parameters
+                     *
+                     * @param parameters base parameters instance
+                     * @param localThickness local thickness values
+                     * @param numLocalDomainCells number of cells in the local domain including guards
+                     * @param numGuardCells number of guard cells
+                     */
                     LocalParameters(
                         Parameters const parameters,
                         Thickness const localThickness,
@@ -163,6 +189,33 @@ namespace picongpu
                         }
                     }
 
+                    /** Get normalized sigma value at a given position
+                     *
+                     * Apply polynomial grading, as described in fieldAbsorber.param.
+                     *
+                     * @param cellIdx local cell index without the guard, can be fractional
+                     * @param parameters parameters of PML in the local domain
+                     * @param axis axis index, 0 = x, 1 = y, 2 = z
+                     */
+                    DINLINE float_X
+                    getNormalizedSigma(float_X const& cellIdx, LocalParameters const& parameters, uint32_t const axis)
+                    {
+                        auto const relativeDepth = detail::getRelativeDepth(
+                            cellIdx + parameters.numGuardCells[axis],
+                            parameters.negativeBorderSize[axis],
+                            parameters.positiveBorderSize[axis],
+                            parameters.numLocalDomainCells[axis],
+                            parameters.numGuardCells[axis]);
+                        if(relativeDepth != 0._X)
+                        {
+                            // Same grading as in detail::getAbsorptionParameters()
+                            auto const gradingCoeff = math::pow(relativeDepth, parameters.sigmaKappaGradingOrder);
+                            return parameters.normalizedSigmaMax[axis] * gradingCoeff;
+                        }
+                        else
+                            return 0._X;
+                    }
+
                     //! Coefficients for E or B updates at a particular point
                     struct Coefficients
                     {
@@ -229,6 +282,110 @@ namespace picongpu
                         return coeffs.b.productOfComponents() != 1.0_X;
                     }
                 } // namespace detail
+
+                /** Calculate an integral of normalized sigma along the given axis:
+                 *  I = integral(sigma_axis(pos_axis(t)) / eps0 * dt; t in [startT, startT + durationT])
+                 *
+                 * We only consider the given axis and for brevity omit axis "subscript".
+                 * Same as in the rest of PML implementation, we denote normalizedSigma = sigma / eps0.
+                 *
+                 * The integral is used for procedure to treat J in PML proposed in section II C of
+                 * R. Lehe, A. Blelly, L. Giacomel, R. Jambunathan, J.-L. Vay
+                 * Absorption of charged particles in Perfectly-Matched-Layers by optimal damping of the deposited
+                 * current (2022) - version 2 from arXiv preprint at the time of our implementation.
+                 * We further refer to this paper as [Lehe2022].
+                 *
+                 * Note that it is similar but not exactly same integral as in [Lehe2022].
+                 * Here a time interval is arbitrary and not fixed to a particle crossing the PML interface.
+                 * So this utility function uses the general integral formulation as stated above.
+                 * Our general approach and relation to [Lehe2022] are described at the client side of this function.
+                 *
+                 * For given values of startPos = pos(startT), finishPos = pos(startT + durationT)
+                 * we assume a linear trajectory with constant velocity:
+                 *     vel = (finishPos - startPos) / durationT,
+                 *     pos(t) = startPos + vel * (t - startT).
+                 * This function will be used to integrate over a PIC time step, thus the assumption is harmless.
+                 *
+                 * For |vel| < eps, using the trapezoidal rule (to avoid potential numerical issues) the result is
+                 *     I = durationT * 0.5 * (normalizedSigma(startPos) + normalizedSigma(finishPos)).
+                 * Otherwise, change the variable from t to pos:
+                 *     d(pos) = vel * dt,
+                 *     I = integral(normalizedSigma(pos) * d(pos) / vel; pos in [startPos, finishPos]).
+                 * Note that with the division by velocity due to variable substitution, it becomes more similar to
+                 * eq. (4) in [Lehe2022], which is probably why it was proposed in section II C.
+                 *
+                 * For polynomially graded sigma values, the latter integral is calculated analytically.
+                 * Special care is taken to account for sigma(pos) = 0 when pos is outside of PML.
+                 *
+                 * @param startPos start position, in local domain and without guard [cells]
+                 * @param finishPos finish position, in local domain and without guard [cells]
+                 * @param timeDuration integration time duration (only duration is required as start and finish
+                 *        positions already take into account start time)
+                 * @param parameters parameters of PML in the local domain
+                 * @param axis axis index, 0 = x, 1 = y, 2 = z
+                 */
+                DINLINE float_X getNormalizedSigmaIntegral(
+                    float_X const startPos,
+                    float_X const finishPos,
+                    float_X const timeDuration,
+                    LocalParameters const& parameters,
+                    uint32_t const axis)
+                {
+                    // Note that velocity in units of [cellSize[axis] / time], which is more natural here
+                    auto const vel = (finishPos - startPos) / timeDuration;
+
+                    // For near-zero velocity use an approximate formula
+                    constexpr auto eps = 1e-5;
+                    if(abs(vel) < eps * cellSize[axis])
+                    {
+                        auto const startNormalizedSigma = detail::getNormalizedSigma(startPos, parameters, axis);
+                        auto const finishNormalizedSigma = detail::getNormalizedSigma(finishPos, parameters, axis);
+                        return timeDuration * 0.5_X * (startNormalizedSigma + finishNormalizedSigma);
+                    }
+
+                    /* In case only part of the trajectory is in PML, the result is equal to the integral over only
+                     * that part, since sigma(pos) = 0 for any pos outside of PML.
+                     * In this case adjust the positions and time duration to only represent that part.
+                     * It has no effect when both points are in or both are out of the PML area.
+                     * At most one of the following adjustments will be done as PMLs do not overlap.
+                     */
+                    auto adjustedStartPos = startPos;
+                    auto adjustedFinishPos = finishPos;
+                    // Left-side PML interface end, without guard same as our positions
+                    auto const negativePmlFinishPos = static_cast<float_X>(parameters.negativeBorderSize[axis]);
+                    if((finishPos < negativePmlFinishPos) && (startPos >= negativePmlFinishPos))
+                        adjustedStartPos = negativePmlFinishPos;
+                    if((startPos < negativePmlFinishPos) && (finishPos >= negativePmlFinishPos))
+                        adjustedFinishPos = negativePmlFinishPos;
+                    // Right-side PML interface start, without guard same as our positions
+                    auto const positivePmlStartPos = static_cast<float_X>(
+                        parameters.numLocalDomainCells[axis] - 2 * parameters.numGuardCells[axis]
+                        - parameters.positiveBorderSize[axis]);
+                    if((finishPos > positivePmlStartPos) && (startPos <= positivePmlStartPos))
+                        adjustedStartPos = positivePmlStartPos;
+                    if((startPos > positivePmlStartPos) && (finishPos <= positivePmlStartPos))
+                        adjustedFinishPos = positivePmlStartPos;
+                    auto const adjustedTimeDuration = (adjustedFinishPos - adjustedStartPos) / vel;
+
+                    /* After the adjustment both start and finish position are at the same side from PML interface.
+                     * And the resulting integral is
+                     *     I = integral(normalizedSigma(pos) * d(pos) / vel;
+                     *                  pos in [adjustedStartPosition, adjustedFinishPosition]).
+                     * With normalizedSigma(pos) being a polynomial we calculated it analytically.
+                     * The resulting expression is formulated to reuse the function to calculate normalizedSigma.
+                     */
+                    auto depthCoeff = 0.0_X;
+                    if(adjustedStartPos <= negativePmlFinishPos)
+                        depthCoeff = adjustedStartPos - negativePmlFinishPos;
+                    if(adjustedStartPos >= positivePmlStartPos)
+                        depthCoeff = adjustedStartPos - positivePmlStartPos;
+                    auto const startNormalizedSigma = detail::getNormalizedSigma(adjustedStartPos, parameters, axis);
+                    auto const finishNormalizedSigma = detail::getNormalizedSigma(adjustedFinishPos, parameters, axis);
+                    auto integral = (finishNormalizedSigma * adjustedTimeDuration
+                                     + (finishNormalizedSigma - startNormalizedSigma) * depthCoeff / vel)
+                        / (parameters.sigmaKappaGradingOrder + 1.0_X);
+                    return integral;
+                }
 
                 /** Stencil functor to update electric field by a time step using FDTD with the given curl and PML
                  *

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -70,6 +70,18 @@ namespace picongpu
     //! weighting of the macro particle
     value_identifier(float_X, weighting, 0._X);
 
+    /** optional damping factor for weighting of the macro particle
+     *
+     * This factor is only used for current deposition with absorbing particle boundaries and PML.
+     * In case this attribute is defined, affected particles would have their weightings damped only for that
+     * procedure. Otherwise, the damping would affect weighting directly and so potentially overall properties like
+     * density. It should be generally not a considerable issue, except lots of particles move from PML to internal
+     * area.
+     *
+     * Thus, for efficiency reasons it is recommended to not enable this attribute by default.
+     */
+    value_identifier(float_X, weightingDampingFactor, 1._X);
+
     //! Voronoi cell of the macro particle
     value_identifier(int16_t, voronoiCellId, -1);
 

--- a/include/picongpu/particles/boundary/Absorbing.hpp
+++ b/include/picongpu/particles/boundary/Absorbing.hpp
@@ -37,25 +37,52 @@ namespace picongpu
     {
         namespace boundary
         {
-            //! Functor to be applied to all particles in the active area
-            struct AbsorbParticleIfOutside : public functor::misc::Parametrized<Parameters>
+            namespace detail
             {
-                //! Name, required to be wrapped later
-                static constexpr char const* name = "absorbParticleIfOutside";
-
-                /** Process the current particle located in the given cell
-                 *
-                 * @param offsetToTotalOrigin offset of particle cell in the total domain
-                 * @param particle handle of particle to process (can be used to change attribute values)
-                 */
-                template<typename T_Particle>
-                HDINLINE void operator()(DataSpace<simDim> const& offsetToTotalOrigin, T_Particle& particle)
+                //! Functor to be applied to all particles in the active area
+                struct AbsorbParticleIfOutside : public functor::misc::Parametrized<Parameters>
                 {
-                    if((offsetToTotalOrigin[m_parameters.axis] < m_parameters.beginInternalCellsTotal)
-                       || (offsetToTotalOrigin[m_parameters.axis] >= m_parameters.endInternalCellsTotal))
-                        particle[multiMask_] = 0;
+                    //! Name, required to be wrapped later
+                    static constexpr char const* name = "absorbParticleIfOutside";
+
+                    /** Process the current particle located in the given cell
+                     *
+                     * @param offsetToTotalOrigin offset of particle cell in the total domain
+                     * @param particle handle of particle to process (can be used to change attribute values)
+                     */
+                    template<typename T_Particle>
+                    HDINLINE void operator()(DataSpace<simDim> const& offsetToTotalOrigin, T_Particle& particle)
+                    {
+                        if((offsetToTotalOrigin[m_parameters.axis] < m_parameters.beginInternalCellsTotal)
+                           || (offsetToTotalOrigin[m_parameters.axis] >= m_parameters.endInternalCellsTotal))
+                            particle[multiMask_] = 0;
+                    }
+                };
+
+                /** Remove particles of the given species that are outer wrt the given boundary
+                 *
+                 * @tparam T_Species particle species type
+                 *
+                 * @param species particle species
+                 * @param exchangeType exchange describing the active boundary
+                 * @param currentStep current time iteration
+                 */
+                template<typename T_Species>
+                HINLINE void removeOuterParticles(T_Species& species, uint32_t exchangeType, uint32_t currentStep)
+                {
+                    pmacc::DataSpace<simDim> beginInternalCellsTotal, endInternalCellsTotal;
+                    getInternalCellsTotal(species, exchangeType, &beginInternalCellsTotal, &endInternalCellsTotal);
+                    auto const axis = pmacc::boundary::getAxis(exchangeType);
+                    AbsorbParticleIfOutside::parameters().axis = axis;
+                    AbsorbParticleIfOutside::parameters().beginInternalCellsTotal = beginInternalCellsTotal[axis];
+                    AbsorbParticleIfOutside::parameters().endInternalCellsTotal = endInternalCellsTotal[axis];
+                    auto const mapperFactory = getMapperFactory(species, exchangeType);
+                    using Manipulator = manipulators::unary::FreeTotalCellOffset<AbsorbParticleIfOutside>;
+                    particles::manipulate<Manipulator, T_Species>(currentStep, mapperFactory);
+                    species.fillGaps(mapperFactory);
                 }
-            };
+
+            } // namespace detail
 
             //! Functor to apply absorbing boundary to particle species
             template<>
@@ -72,16 +99,7 @@ namespace picongpu
                 template<typename T_Species>
                 void operator()(T_Species& species, uint32_t exchangeType, uint32_t currentStep)
                 {
-                    pmacc::DataSpace<simDim> beginInternalCellsTotal, endInternalCellsTotal;
-                    getInternalCellsTotal(species, exchangeType, &beginInternalCellsTotal, &endInternalCellsTotal);
-                    auto const axis = pmacc::boundary::getAxis(exchangeType);
-                    AbsorbParticleIfOutside::parameters().axis = axis;
-                    AbsorbParticleIfOutside::parameters().beginInternalCellsTotal = beginInternalCellsTotal[axis];
-                    AbsorbParticleIfOutside::parameters().endInternalCellsTotal = endInternalCellsTotal[axis];
-                    auto const mapperFactory = getMapperFactory(species, exchangeType);
-                    using Manipulator = manipulators::unary::FreeTotalCellOffset<AbsorbParticleIfOutside>;
-                    particles::manipulate<Manipulator, T_Species>(currentStep, mapperFactory);
-                    species.fillGaps(mapperFactory);
+                    detail::removeOuterParticles(species, exchangeType, currentStep);
                 }
             };
 

--- a/include/picongpu/particles/boundary/Absorbing.hpp
+++ b/include/picongpu/particles/boundary/Absorbing.hpp
@@ -30,6 +30,7 @@
 #include "picongpu/particles/boundary/Utility.hpp"
 #include "picongpu/particles/functor/misc/Parametrized.hpp"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp"
+#include "picongpu/traits/attribute/DampedWeighting.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -155,16 +156,9 @@ namespace picongpu
                             m_parameters.localParameters,
                             axis);
 
-                        // Adjust weighting according to [Lehe2022], cap at MIN_WEIGHTING
+                        // Adjust weighting according to [Lehe2022]
                         auto const weightingMultiplier = math::exp(-timeStepIntegral);
-                        auto const dampedWeighting = particle[weighting_] * weightingMultiplier;
-                        auto const minWeighting = MIN_WEIGHTING; // to avoid taking address of constexpr in max()
-                        /* Update macroparticle weighting and values of all weighted attributes.
-                         * We currently have no generic and consistent way to do that #4299.
-                         * So at least update weighted momentums so that particles don't artificially accelerate.
-                         */
-                        particle[weighting_] = math::max(dampedWeighting, minWeighting);
-                        particle[momentum_] *= weightingMultiplier;
+                        attribute::dampWeighting(particle, weightingMultiplier);
                     }
                 };
 

--- a/include/picongpu/particles/boundary/Absorbing.hpp
+++ b/include/picongpu/particles/boundary/Absorbing.hpp
@@ -21,12 +21,21 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/algorithms/Velocity.hpp"
+#include "picongpu/fields/absorber/Absorber.hpp"
+#include "picongpu/fields/absorber/pml/Pml.kernel"
 #include "picongpu/particles/boundary/ApplyImpl.hpp"
 #include "picongpu/particles/boundary/Kind.hpp"
 #include "picongpu/particles/boundary/Parameters.hpp"
 #include "picongpu/particles/boundary/Utility.hpp"
 #include "picongpu/particles/functor/misc/Parametrized.hpp"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp"
+#include "picongpu/traits/attribute/GetMass.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/boundary/Utility.hpp>
+#include <pmacc/mappings/kernel/IntervalMapping.hpp>
+#include <pmacc/traits/HasFlag.hpp>
 
 #include <cstdint>
 
@@ -82,6 +91,146 @@ namespace picongpu
                     species.fillGaps(mapperFactory);
                 }
 
+                //! Parameters to be passed to DampWeightsInPml functor
+                struct DampWeightsInPmlParameters
+                {
+                    //! Axis of the active boundary
+                    uint32_t axis;
+
+                    //! Local PML parameters
+                    fields::absorber::pml::LocalParameters localParameters;
+
+                    //! From local domain start to total domain start, without guards
+                    DataSpace<simDim> localToTotalDomainOffset;
+                };
+
+                /** Functor to be applied to all particles in the active area
+                 *
+                 * Follows approach in section II C of
+                 * R. Lehe, A. Blelly, L. Giacomel, R. Jambunathan, J.-L. Vay
+                 * Absorption of charged particles in Perfectly-Matched-Layers by optimal damping of the deposited
+                 * current (2022) - version 2 from arXiv preprint at the time of our implementation.
+                 * We further refer to this paper as [Lehe2022].
+                 *
+                 * Currently we do not store original (non-damped) weightings and permanently modify particle data.
+                 * Instead, at each time step we calculate a damping multiplier for this time step and apply it.
+                 * This means, using the paper notation, for us the integral is not from t_i to t but each time only
+                 * over the current time step.
+                 * As the particle's weight already has a combined effect from t_i to previous time step.
+                 * If a particle never leaves PML after entering it, these formulations are equivalent.
+                 *
+                 * @TODO add an optional extra particle attribute to store additional weighting if a user chose that -
+                 * then particles leaving PML would have their weights "restored", unlike in the current version.
+                 */
+                struct DampWeightsInPml : public functor::misc::Parametrized<DampWeightsInPmlParameters>
+                {
+                    //! Name, required to be wrapped later
+                    static constexpr char const* name = "dampWeightsInPml";
+
+                    /** Process the current particle located in the given cell
+                     *
+                     * @param offsetToTotalOrigin offset of particle cell in the total domain
+                     * @param particle handle of particle to process (can be used to change attribute values)
+                     */
+                    template<typename T_Particle>
+                    DINLINE void operator()(DataSpace<simDim> const& offsetToTotalOrigin, T_Particle& particle)
+                    {
+                        auto const axis = m_parameters.axis;
+                        // Velocity half time step back relative to the current position
+                        auto velocity = Velocity{};
+                        auto const vel
+                            = velocity(particle[momentum_], attribute::getMass(particle[weighting_], particle))[axis];
+
+                        // Positions in local domain, in units of cells, without guards
+                        auto const localCellIdx = offsetToTotalOrigin - m_parameters.localToTotalDomainOffset;
+                        auto const positionCurrent
+                            = (precisionCast<float_X>(localCellIdx) + particle[position_])[axis];
+                        auto const positionPrevious = positionCurrent - vel * DELTA_T / cellSize[axis];
+
+                        // Integral over the last time step as described in comment of this struct
+                        auto const timeStepIntegral = fields::absorber::pml::getNormalizedSigmaIntegral(
+                            positionPrevious,
+                            positionCurrent,
+                            DELTA_T,
+                            m_parameters.localParameters,
+                            axis);
+
+                        // Adjust weighting according to [Lehe2022], cap at MIN_WEIGHTING
+                        auto const weightingMultiplier = math::exp(-timeStepIntegral);
+                        auto const dampedWeighting = particle[weighting_] * weightingMultiplier;
+                        auto const minWeighting = MIN_WEIGHTING; // to avoid taking address of constexpr in max()
+                        /* Update macroparticle weighting and values of all weighted attributes.
+                         * We currently have no generic and consistent way to do that #4299.
+                         * So at least update weighted momentums so that particles don't artificially accelerate.
+                         */
+                        particle[weighting_] = math::max(dampedWeighting, minWeighting);
+                        particle[momentum_] *= weightingMultiplier;
+                    }
+                };
+
+                /** Damp weights of particles of the given species in PML, modifies weighting_ attribute
+                 *
+                 * @tparam T_Species particle species type
+                 *
+                 * @param species particle species
+                 * @param exchangeType exchange describing the active boundary
+                 * @param currentStep current time iteration
+                 */
+                template<typename T_Species>
+                HINLINE void dampWeightsInPml(
+                    T_Species& species,
+                    uint32_t const exchangeType,
+                    uint32_t const currentStep)
+                {
+                    // Do the procedure only for species with current deposition
+                    using HasCurrentDeposition = typename HasFlag<typename T_Species::FrameType, current<>>::type;
+                    if(!HasCurrentDeposition::value)
+                        return;
+
+                    // Do the procedure only for PML
+                    auto const mappingDescription = species.getCellDescription();
+                    auto& absorberImpl = fields::absorber::AbsorberImpl::getImpl(mappingDescription);
+                    auto const kind = absorberImpl.getKind();
+                    if(kind != fields::absorber::Absorber::Kind::Pml)
+                        return;
+
+                    // Our active area is between particle boundary offset and inner PML boundary
+                    auto const axis = pmacc::boundary::getAxis(exchangeType);
+                    auto const offsetCells = getOffsetCells(species, exchangeType);
+                    auto const isMinSide = pmacc::boundary::isMinSide(exchangeType);
+                    auto const& pmlImpl = absorberImpl.asPmlImpl();
+                    auto const localParameters = pmlImpl.getLocalParameters(currentStep);
+                    auto const pmlThickness = static_cast<uint32_t>(
+                        isMinSide ? localParameters.negativeBorderSize[axis]
+                                  : localParameters.positiveBorderSize[axis]);
+                    if(offsetCells >= pmlThickness)
+                        return;
+
+                    // Create a mapping for the active area, take into account PML is never in guard area
+                    auto const supercellSize = SuperCellSize::toRT()[axis];
+                    auto const offsetFullSupercells = offsetCells / supercellSize;
+                    auto const pmlSupercells = (pmlThickness + supercellSize - 1u) / supercellSize;
+                    auto const guardSupercells = mappingDescription.getGuardingSuperCells();
+                    auto beginSupercell = guardSupercells;
+                    if(isMinSide)
+                        beginSupercell[axis] = guardSupercells[axis] + offsetFullSupercells;
+                    else
+                        beginSupercell[axis]
+                            = mappingDescription.getGridSuperCells()[axis] - guardSupercells[axis] - pmlSupercells;
+                    auto numSupercells = mappingDescription.getGridSuperCells() - 2 * guardSupercells;
+                    numSupercells[axis] = pmlSupercells - offsetFullSupercells;
+                    auto const mapperFactory = pmacc::IntervalMapperFactory<simDim>{beginSupercell, numSupercells};
+
+                    auto const& subGrid = Environment<simDim>::get().SubGrid();
+                    auto const localToTotalDomainOffset
+                        = subGrid.getGlobalDomain().offset + subGrid.getLocalDomain().offset;
+                    DampWeightsInPml::parameters().axis = axis;
+                    DampWeightsInPml::parameters().localParameters = localParameters;
+                    DampWeightsInPml::parameters().localToTotalDomainOffset = localToTotalDomainOffset;
+                    using Manipulator = manipulators::unary::FreeTotalCellOffset<DampWeightsInPml>;
+                    particles::manipulate<Manipulator, T_Species>(currentStep, mapperFactory);
+                }
+
             } // namespace detail
 
             //! Functor to apply absorbing boundary to particle species
@@ -97,9 +246,10 @@ namespace picongpu
                  * @param currentStep current time iteration
                  */
                 template<typename T_Species>
-                void operator()(T_Species& species, uint32_t exchangeType, uint32_t currentStep)
+                void operator()(T_Species& species, uint32_t const exchangeType, uint32_t const currentStep)
                 {
                     detail::removeOuterParticles(species, exchangeType, currentStep);
+                    detail::dampWeightsInPml(species, exchangeType, currentStep);
                 }
             };
 

--- a/include/picongpu/traits/attribute/DampedWeighting.hpp
+++ b/include/picongpu/traits/attribute/DampedWeighting.hpp
@@ -1,0 +1,92 @@
+/* Copyright 2022 Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/traits/HasIdentifier.hpp>
+
+
+namespace picongpu
+{
+    namespace traits
+    {
+        namespace attribute
+        {
+            /** Get the damped weighting of a macro particle
+             *
+             * For particles with weightingDampingFactor attribute it is a product of that factor and weighting.
+             * Otherwise, damped weighting is equal to weighting.
+             *
+             * @tparam T_Particle particle type, must have weighting attribute
+             *
+             * @param particle a reference to a particle
+             * @return damped weighting of the macro particle
+             */
+            template<typename T_Particle>
+            HDINLINE auto getDampedWeighting(const T_Particle& particle)
+            {
+                using HasWeightingDampingFactor =
+                    typename pmacc::traits::HasIdentifier<T_Particle, weightingDampingFactor>::type;
+                if constexpr(HasWeightingDampingFactor::value)
+                    return particle[weighting_] * particle[weightingDampingFactor_];
+                return particle[weighting_];
+            }
+
+            /** Damp weighting of a macro particle with a given multiplier
+             *
+             * For particles with weightingDampingFactor attribute, affects this attribute.
+             * Otherwise, affects weighting and weighted momentum to keep physical momentum same.
+             *
+             * @warning In case there are other weighted attributes they are not changed by this function and
+             * so will become inconsistent. For now it has to be handled by a caller, see #4299.
+             *
+             * @tparam T_Particle particle type, must have weighting attribute
+             *
+             * @param[in,out] particle a reference to a particle
+             * @param multiplier weighting multiplier, values of < 1 result in damping, > 1 result in boosting
+             */
+            template<typename T_Particle>
+            HDINLINE void dampWeighting(T_Particle& particle, float_X const multiplier)
+            {
+                using HasWeightingDampingFactor =
+                    typename pmacc::traits::HasIdentifier<T_Particle, weightingDampingFactor>::type;
+                if constexpr(HasWeightingDampingFactor::value)
+                    particle[weightingDampingFactor_] *= multiplier;
+                else
+                {
+                    auto const oldWeighting = particle[weighting_];
+                    auto const attemptedWeighting = oldWeighting * multiplier;
+                    // Cap at MIN_WEIGHTING, copy it to avoid taking address of constexpr in max()
+                    auto const minWeighting = particles::MIN_WEIGHTING;
+                    auto const dampedWeighting = math::max(attemptedWeighting, minWeighting);
+                    particle[weighting_] = dampedWeighting;
+                    /* Here we have to update values of all weighted attributes.
+                     * We currently have no generic and consistent way to do that #4299.
+                     * So at least update weighted momentums so that particles don't artificially accelerate.
+                     * This way of updating takes into account the potential capping.
+                     */
+                    particle[momentum_] *= dampedWeighting / oldWeighting;
+                }
+            }
+
+        } // namespace attribute
+    } // namespace traits
+} // namespace picongpu

--- a/include/picongpu/unitless/speciesAttributes.unitless
+++ b/include/picongpu/unitless/speciesAttributes.unitless
@@ -334,6 +334,45 @@ namespace picongpu
             }
         };
 
+        template<>
+        struct Unit<weightingDampingFactor>
+        {
+            // unitless and not scaled by a factor: 1.0
+            static std::vector<double> get()
+            {
+                std::vector<double> unit(1, 1.0);
+                return unit;
+            }
+        };
+        template<>
+        struct UnitDimension<weightingDampingFactor>
+        {
+            static std::vector<float_64> get()
+            {
+                // weighting damping factor is unitless
+                std::vector<float_64> unitDimension(NUnitDimension, 0.0);
+
+                return unitDimension;
+            }
+        };
+        template<>
+        struct MacroWeighted<weightingDampingFactor>
+        {
+            // the weighting damping factor is not macro weighted
+            static bool get()
+            {
+                return false;
+            }
+        };
+        template<>
+        struct WeightingPower<weightingDampingFactor>
+        {
+            // flag * weightingDampingFactor^0 == flag: same for real and macro particle
+            static float_64 get()
+            {
+                return 0.0;
+            }
+        };
 
         template<>
         struct Unit<voronoiCellId>


### PR DESCRIPTION
Follow-up to #4293. It adds a new optional particle attribute to more precisely apply that procedure. Namely, the damping itself is exactly the same. The "added value" in this PR is that in case this attribute is defined the density calculations and all other parts of the code will be not affected by damping. And if not, it will all work the same as in #4293 just with [this inaccuracy](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4293#discussion_r977681034) fixed and a more clear expalantion. I believe there should be no reason to enable the new attribute for most simulations. And an exception would be if lots of particles travel from PML to internal area.

- [x] Merge after #4293.
