### PR TITLE
fix using uninitilized variable

### DIFF
--- a/include/pmacc/kernel/atomic.hpp
+++ b/include/pmacc/kernel/atomic.hpp
@@ -140,7 +140,7 @@ namespace pmacc
                     const auto mask = alpaka::warp::activemask(acc);
                     const auto leader = alpaka::ffs(acc, static_cast<std::make_signed_t<decltype(mask)>>(mask)) - 1;
 
-                    T_Type result;
+                    auto result = T_Type{};
                     const int laneId = getLaneId();
                     /* Get the start value for this warp */
                     if(laneId == leader)


### PR DESCRIPTION
There was an uninitialized variable in our `AtomicAllInc` method that forced HIP 5.2 to crash during the runtime. The compiler is handling unused conditional variables somehow so that the kernel is failing, even if in the case where we use the variable conditionally uninitialized there should be no problem.
We use warp broadcast to communicate the value of a variable to other threads. In our case, the root value is initialized but the receivers are using an uninitialized variable, which should be no problem.

This PR is default initializing the helper variable to avoid using an uninitialized value.