### PR TITLE
fix TWTS fast wrong type cast

### DIFF
--- a/include/picongpu/fields/background/templates/twtsfast/BField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/BField.tpp
@@ -491,9 +491,9 @@ namespace picongpu
                        * (complex_T(0, -8) * om0 * y * (cspeed * t - z) * sinPhi2_2 * sinPhi_4
                               * (complex_T(0, 1) * rho0 - z * sinPhi)
                           - om0 * sinPhi_4 * sinPhi
-                              * (-float_t(2.0) * z2 * rho0
+                              * (-float_T(2.0) * z2 * rho0
                                  - cspeed * cspeed
-                                     * (k * tauG2 * x2 + float_t(2.0) * t * (t - complex_T(0, 1) * om0 * tauG2) * rho0)
+                                     * (k * tauG2 * x2 + float_T(2.0) * t * (t - complex_T(0, 1) * om0 * tauG2) * rho0)
                                  + cspeed * (4 * t * z * rho0 - complex_T(0, 2) * om0 * tauG2 * z * rho0)
                                  - complex_T(0, 2) * (cspeed * t - z)
                                      * (cspeed * (t - complex_T(0, 1) * om0 * tauG2) - z) * z * sinPhi)


### PR DESCRIPTION
There is a typo in the TWTS implementation where instead of a cast to `float_T` the value is casted to `float_t`.
Most likly this will not have an negative effect because `float_T` is by default 32bit, so in the worst case `float_t` is defined as `double` which results into an upcast and maybe therefore in a slower code.

This issue was found with ROCM 5.2.X (beta code) where for unknown reason `float_t` is `long double` and therefore the code crashed during compile time.

```
In file included from /ccs/home/widera/workspace/picongpu/include/picongpu/main.cpp:23:
In file included from /ccs/home/widera/workspace/picongpu/include/picongpu/../picongpu/simulation_defines.hpp:52:
In file included from /ccs/home/widera/workspace/picongpu/include/picongpu/../picongpu/_defaultUnitless.loader:42:
In file included from /ccs/home/widera/workspace/picongpu/include/picongpu/../picongpu/unitless/fieldBackground.unitless:25:
In file included from /ccs/home/widera/workspace/picongpu/include/picongpu/../picongpu/fields/background/templates/twtsfast/twtsfast.tpp:23:
/ccs/home/widera/workspace/picongpu/include/picongpu/../picongpu/fields/background/templates/twtsfast/BField.tpp:496:97: error: invalid operands to binary expression ('long double' and 'Complex<float>')
                                     * (static_cast<float_T>(k * tauG2 * x2) + float_t(2.0) * t * (t - complex_T(0, 1) * om0 * tauG2) * rho0)
                                                                               ~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rocm-5.2.0/include/hip/amd_detail/amd_hip_runtime.h:330:15: note: candidate function not viable: no known conversion from 'long double' to '__HIP_Coordinates<__HIP_GridDim>::__X' for 1st argument
std::uint32_t operator*(__HIP_Coordinates<__HIP_GridDim>::__X,
              ^
/opt/rocm-5.2.0/include/hip/amd_detail/amd_hip_runtime.h:336:15: note: candidate function not viable: no known conversion from 'long double' to '__HIP_Coordinates<__HIP_BlockDim>::__X' for 1st argument
std::uint32_t operator*(__HIP_Coordinates<__HIP_BlockDim>::__X,
              ^
/opt/rocm-5.2.0/include/hip/amd_detail/amd_hip_runtime.h:342:15: note: candidate function not viable: no known conversion from 'long double' to '__HIP_Coordinates<__HIP_GridDim>::__Y' for 1st argument
std::uint32_t operator*(__HIP_Coordinates<__HIP_GridDim>::__Y,
              ^
/opt/rocm-5.2.0/include/hip/amd_detail/amd_hip_runtime.h:348:15: note: candidate function not viable: no known conversion from 'long double' to '__HIP_Coordinates<__HIP_BlockDim>::__Y' for 1st argument
std::uint32_t operator*(__HIP_Coordinates<__HIP_BlockDim>::__Y,
              ^
/opt/rocm-5.2.0/include/hip/amd_detail/amd_hip_runtime.h:354:15: note: candidate function not viable: no known conversion from 'long double' to '__HIP_Coordinates<__HIP_GridDim>::__Z' for 1st argument
std::uint32_t operator*(__HIP_Coordinates<__HIP_GridDim>::__Z,
              ^
/opt/rocm-5.2.0/include/hip/amd_detail/amd_hip_runtime.h:360:15: note: candidate function not viable: no known conversion from 'long double' to '__HIP_Coordinates<__HIP_BlockDim>::__Z' for 1st argument
std::uint32_t operator*(__HIP_Coordinates<__HIP_BlockDim>::__Z,
```