### PR TITLE
fix/workaround ROCm 5.2.0 compiler bug

### DIFF
--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -83,7 +83,7 @@ namespace picongpu
                     T_EstimateBox estimateBox) const
                 {
                     auto const supercellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)));
-                    auto const& supercell = electronBox.getSuperCell(supercellIdx);
+                    auto& supercell = electronBox.getSuperCell(supercellIdx);
                     if(supercell.getNumParticles() >= minMacroparticlesPerSupercell)
                         process(acc, electronBox, supercellIdx, estimateBox);
                 }

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -342,7 +342,7 @@ namespace picongpu
                     local_grid_coord.x + guarding[0],
                     local_grid_coord.y + guarding[1],
                     local_grid_coord.z + guarding[2]);
-                const auto& superCell = pb[0].getSuperCell(superCellIdx);
+                auto& superCell = pb[0].getSuperCell(superCellIdx);
                 size_t size = superCell.getNumParticles();
                 FramePtr currentFrame = pb[0].getFirstFrame(superCellIdx);
                 return ParticleIterator<featureDim, ParticlesBoxType>(size, pb[0], currentFrame, frameSize);

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -179,7 +179,7 @@ namespace pmacc::particles::algorithm
                 constexpr bool isSupportedOrder = std::is_same_v<Reverse, T_Order> || std::is_same_v<Forward, T_Order>;
                 static_assert(isSupportedOrder, "Unsupported order policy");
 
-                auto const& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
+                auto& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
                 uint32_t const numParticlesInSupercell = superCell.getNumParticles();
 
                 // end kernel if we have no particles
@@ -292,7 +292,7 @@ namespace pmacc::particles::algorithm
 
             DINLINE uint32_t numParticles() const
             {
-                auto const& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
+                auto& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
                 return superCell.getNumParticles();
             }
         };

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -66,13 +66,25 @@ namespace pmacc
             mustShiftVal = value;
         }
 
-        HDINLINE uint32_t getSizeLastFrame() const
+        HDINLINE uint32_t getSizeLastFrame()
+#if(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) == 502)
+            /* ROCm 5.2.0 producing particle loss in KernelShiftParticles if this method is defined as `const`.
+             * see: https://github.com/ComputationalRadiationPhysics/picongpu/issues/4305
+             */
+            volatile
+#endif
         {
             constexpr uint32_t frameSize = math::CT::volume<typename T_FrameType::SuperCellSize>::type::value;
             return numParticles ? ((numParticles - 1u) % frameSize + 1u) : 0u;
         }
 
-        HDINLINE uint32_t getNumParticles() const
+        HDINLINE uint32_t getNumParticles()
+#if(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) == 502)
+            /* ROCm 5.2.0 producing particle loss in KernelShiftParticles if this method is defined as `const`.
+             * see: https://github.com/ComputationalRadiationPhysics/picongpu/issues/4305
+             */
+            volatile
+#endif
         {
             return numParticles;
         }


### PR DESCRIPTION
fix #4305

Fix broken `KernelShiftParticles` most likely produced by a compiler bug.

The workaround is not showing adverse effects on the registered footprint on NVIDIA GPUs (tested sm_70).