### PR TITLE
fix wrong memory requirment calculation in .tpl files

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -65,7 +65,7 @@
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((378000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((378000 / $TBG_numHostedGPUPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -63,7 +63,7 @@
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((378000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((378000 / $TBG_numHostedGPUPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -65,7 +65,7 @@
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((62000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((62000 / $TBG_numHostedGPUPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -37,7 +37,7 @@
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((62000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((62000 / $TBG_numHostedGPUPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -65,7 +65,7 @@
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((238000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((238000 / $TBG_numHostedGPUPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -37,7 +37,7 @@ TBG_queue=${TBG_partition:-"k80"}
 .TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
 
 # host memory per gpu
-.TBG_memPerGPU="$((238000 / $TBG_gpusPerNode))"
+.TBG_memPerGPU="$((238000 / $TBG_numHostedGPUPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
 

--- a/etc/picongpu/jureca-jsc/gpus.tpl
+++ b/etc/picongpu/jureca-jsc/gpus.tpl
@@ -57,7 +57,7 @@
 .TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
 
 # host memory per device
-.TBG_memPerDevice="$((126000 / $TBG_devicesPerNode))"
+.TBG_memPerDevice="$((126000 / $TBG_numHostedDevicesPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerDevice * TBG_devicesPerNode))"
 

--- a/etc/picongpu/juwels-jsc/booster.tpl
+++ b/etc/picongpu/juwels-jsc/booster.tpl
@@ -60,7 +60,7 @@ export UCX_RC_TIMEOUT=3000000.00us # 3s instead of 1s
 .TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
 
 # host memory per device
-.TBG_memPerDevice="$((499712 / $TBG_devicesPerNode))"
+.TBG_memPerDevice="$((499712 / $TBG_numHostedDevicesPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerDevice * TBG_devicesPerNode))"
 

--- a/etc/picongpu/juwels-jsc/gpus.tpl
+++ b/etc/picongpu/juwels-jsc/gpus.tpl
@@ -57,7 +57,7 @@
 .TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
 
 # host memory per device
-.TBG_memPerDevice="$((180000 / $TBG_devicesPerNode))"
+.TBG_memPerDevice="$((180000 / $TBG_numHostedDevicesPerNode))"
 # host memory per node
 .TBG_memPerNode="$((TBG_memPerDevice * TBG_devicesPerNode))"
 


### PR DESCRIPTION
There was an error in most of our `.tpl` files that made picongpu jobs run almost always exclusive, even when not requiring the full node. Jobs using less than a full node of GPUs were still asking for full node memory.