### PR TITLE
PIConGPU use RPATH by default

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -256,6 +256,8 @@ set(PIC_VERBOSE "1" CACHE STRING
     "Set verbosity level for PIConGPU (default is only physics output)")
 add_definitions(-DPIC_VERBOSE_LVL=${PIC_VERBOSE})
 
+option(PIC_ADD_RPATH "Add RPATH's to binaries." ON)
+
 
 ################################################################################
 # Additional defines for PIConGPU outputs
@@ -531,6 +533,20 @@ if(PIC_HAVE_openPMD)
     target_link_libraries(picongpu-hostonly PRIVATE toml11::toml11)
 endif()
 
+## annotate with RPATH's
+if(PIC_ADD_RPATH)
+    if(NOT DEFINED CMAKE_INSTALL_RPATH)
+        if(APPLE)
+            set_target_properties(picongpu PROPERTIES INSTALL_RPATH "@loader_path")
+        elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+            set_target_properties(picongpu PROPERTIES INSTALL_RPATH "$ORIGIN")
+        endif()
+    endif()
+    if(NOT DEFINED CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+        set_target_properties(picongpu PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+    endif()
+endif()
+
 
 ################################################################################
 # Clang-Tidy (3.9+) Target for CI
@@ -642,3 +658,4 @@ foreach(dep IN LISTS PIC_DEPENDENCY_LIST)
     endif()
 endforeach()
 message("")
+


### PR DESCRIPTION
Add option `PIC_ADD_RPATH` to control if picongpu is setting the rpath. By default, PIConGPU will now always use RPATH but optionally allow disabling this and falling back to the old behavior.

Using rpath's is motivated by the spack where `LD_LIBRARY_PATH` is not set anymore: https://github.com/spack/spack/pull/28354