### PR TITLE
refactor CountParticles and particle filters

### DIFF
--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -136,7 +136,7 @@ namespace picongpu
                         auto parSrc = (srcFramePtr[idx]);
                         storageOffsetCtx[idx] = -1;
                         // count particle in frame
-                        if(parSrc[multiMask_] == 1 && filter(*srcFramePtr, idx))
+                        if(parSrc[multiMask_] == 1 && filter(parSrc))
                             if(accParFilter(acc, parSrc))
                                 storageOffsetCtx[idx]
                                     = kernel::atomicAllInc(acc, &localCounter, ::alpaka::hierarchy::Threads{});

--- a/include/pmacc/particles/operations/ConcatListOfFrames.hpp
+++ b/include/pmacc/particles/operations/ConcatListOfFrames.hpp
@@ -126,7 +126,7 @@ namespace pmacc
                                 localIdxs[particleIdx] = -1;
                                 auto parSrc = (srcFramePtr[particleIdx]);
                                 /* Check if particle exists and is not filtered */
-                                if(parSrc[multiMask_] == 1 && filter(*srcFramePtr, particleIdx))
+                                if(parSrc[multiMask_] == 1 && filter(parSrc))
                                     if(accParFilter(
                                            1, /* @todo this is a hack, please add a alpaka accelerator here*/
                                            parSrc))

--- a/include/pmacc/particles/particleFilter/PositionFilter.hpp
+++ b/include/pmacc/particles/particleFilter/PositionFilter.hpp
@@ -61,16 +61,17 @@ namespace pmacc
                 return offset;
             }
 
-            template<class FRAME>
-            HDINLINE bool operator()(FRAME& frame, lcellId_t id)
+            template<class T_Particle>
+            HDINLINE bool operator()(T_Particle const& particle)
             {
-                DataSpace<dim> localCellIdx = DataSpaceOperations<dim>::template map<typename FRAME::SuperCellSize>(
-                    (uint32_t) (frame[id][localCellIdx_]));
+                DataSpace<dim> localCellIdx
+                    = DataSpaceOperations<dim>::template map<typename T_Particle::SuperCellSize>(
+                        (uint32_t) (particle[localCellIdx_]));
                 DataSpace<dim> pos = this->superCellIdx + localCellIdx;
                 bool result = true;
                 for(uint32_t d = 0; d < dim; ++d)
                     result = result && (this->offset[d] <= pos[d]) && (pos[d] < this->max[d]);
-                return Base::operator()(frame, id) && result;
+                return Base::operator()(particle) && result;
             }
         };
 

--- a/include/pmacc/particles/particleFilter/system/DefaultFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/DefaultFilter.hpp
@@ -36,10 +36,10 @@ namespace pmacc
     public:
         HDINLINE DefaultFilter() = default;
 
-        template<class FRAME>
-        HDINLINE bool operator()(FRAME& frame, lcellId_t id)
+        template<class T_Particle>
+        HDINLINE bool operator()(T_Particle const& particle)
         {
-            return (!filterActive) || Base::operator()(frame, id);
+            return (!filterActive) || Base::operator()(particle);
         }
 
         /*disable or enable filter

--- a/include/pmacc/particles/particleFilter/system/FalseFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/FalseFilter.hpp
@@ -38,8 +38,8 @@ namespace pmacc
         {
         }
 
-        template<class FRAME>
-        bool operator()(FRAME& frame, lcellId_t id)
+        template<class T_Particle>
+        bool operator()(T_Particle const& particle)
         {
             return false;
         }

--- a/include/pmacc/particles/particleFilter/system/TrueFilter.hpp
+++ b/include/pmacc/particles/particleFilter/system/TrueFilter.hpp
@@ -32,8 +32,8 @@ namespace pmacc
     public:
         HDINLINE TrueFilter() = default;
 
-        template<class FRAME>
-        HDINLINE bool operator()(FRAME&, lcellId_t)
+        template<class T_Particle>
+        HDINLINE bool operator()(T_Particle const& particle)
         {
             return true;
         }


### PR DESCRIPTION
- Change the interface of filters from using a frame and the index within the frame to accessing particles by using a particle instance instead.
- Use on-device particle forEach.

Note: The way how `workerIdx` was calculated was wrong but luckily ended up in the same value as the correct solution. 
```
DataSpace<dim> const threadIndex(cupla::threadIdx(acc));
auto const workerIdx
    = static_cast<uint32_t>(DataSpaceOperations<dim>::template map<SuperCellSize>(threadIndex));
```
must be

```
uint32_t const workerIdx = cupla::threadIdx(acc).x;
```

because the kernel was always started with one-dimensional block size.