### PR TITLE
PMacc: refactor kernel en-queuing

### DIFF
--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -44,124 +44,182 @@
 #endif
 
 
-namespace pmacc
+namespace pmacc::exec
 {
-    namespace exec
+    namespace detail
     {
-        /** configured kernel object
+        /** Kernel with dynamic shared memory
          *
-         * this objects contains the functor and the starting parameter
-         *
-         * @tparam T_Kernel pmacc Kernel object
-         * @tparam T_VectorGrid type which defines the grid extents (type must be castable to cupla dim3)
-         * @tparam T_VectorBlock type which defines the block extents (type must be castable to cupla dim3)
+         * This implements the possibility to define dynamic shared memory without
+         * specializing the needed alpaka trait BlockSharedMemDynSizeBytes for each kernel with shared memory.
+         * The trait BlockSharedMemDynSizeBytes is defined by PMacc for all types of KernelWithDynSharedMem.
          */
-        template<typename T_Kernel, typename T_VectorGrid, typename T_VectorBlock>
-        struct KernelStarter;
-
-        /** wrapper for the user kernel functor
-         *
-         * contains debug information like filename and line of the kernel call
-         */
-        template<typename T_KernelFunctor>
-        struct Kernel
+        template<typename T_Kernel>
+        struct KernelWithDynSharedMem : public T_Kernel
         {
-            using KernelType = T_KernelFunctor;
-            /** functor */
-            T_KernelFunctor const m_kernelFunctor;
-            /** file name from where the kernel is called */
+            size_t const m_dynSharedMemBytes;
+
+            KernelWithDynSharedMem(T_Kernel const& kernel, size_t const& dynSharedMemBytes)
+                : T_Kernel(kernel)
+                , m_dynSharedMemBytes(dynSharedMemBytes)
+            {
+            }
+        };
+
+        //! Meta data of a device kernel
+        class KernelMetaData
+        {
+            //! file name
             std::string const m_file;
-            /** line number in the file */
+            //! line number
             size_t const m_line;
 
-            /**
-             *
-             * @param gridExtent grid extent configuration for the kernel
-             * @param blockExtent block extent configuration for the kernel
-             * @param sharedMemByte dynamic shared memory used by the kernel (in byte )
-             * @return
-             */
-            HINLINE Kernel(
+        public:
+            KernelMetaData(std::string const& file, size_t const line) : m_file(file), m_line(line)
+            {
+            }
+
+            //! file name from where the kernel is called
+            std::string getFile() const
+            {
+                return m_file;
+            }
+
+            //! line number in the file where the kernel is called
+            size_t getLine() const
+            {
+                return m_line;
+            }
+        };
+
+
+        /** Object to launch the kernel functor on the device.
+         *
+         * This objects contains the kernel functor, kernel meta information and the launch parameters.
+         * Object is used to enqueue the kernel with user arguments on the device.
+         *
+         * @tparam T_Kernel pmacc Kernel object
+         */
+        template<typename T_Kernel>
+        struct KernelLauncher;
+
+        /** Wraps a user kernel functor to prepare the execution on the device.
+         *
+         * This objects contains the kernel functor, kernel meta information.
+         * Object is used to apply the grid and block extents and optionally the amount of dynamic shared memory to the
+         * kernel.
+         */
+        template<typename T_KernelFunctor>
+        struct KernelPreperationWrapper
+        {
+            T_KernelFunctor const m_kernelFunctor;
+            KernelMetaData const m_metaData;
+
+            HINLINE KernelPreperationWrapper(
                 T_KernelFunctor const& kernelFunctor,
                 std::string const& file = std::string(),
                 size_t const line = 0)
                 : m_kernelFunctor(kernelFunctor)
-                , m_file(file)
-                , m_line(line)
+                , m_metaData(file, line)
             {
             }
 
-            /** configured kernel object
+            /** Apply grid and block extents and optionally dynamic shared memory to the wrapped functor.
              *
-             * this objects contains the functor and the starting parameter
-             *
-             * @tparam T_VectorGrid type which defines the grid extents (type must be castable to cupla dim3)
-             * @tparam T_VectorBlock type which defines the block extents (type must be castable to cupla dim3)
+             * @tparam T_VectorGrid type which defines the grid extents (type must be cast-able to cupla dim3)
+             * @tparam T_VectorBlock type which defines the block extents (type must be cast-able to cupla dim3)
              *
              * @param gridExtent grid extent configuration for the kernel
              * @param blockExtent block extent configuration for the kernel
+             *
+             * @return object with user kernel functor and launch parameters
+             *
+             * @{
+             */
+            template<typename T_VectorGrid, typename T_VectorBlock>
+            HINLINE auto operator()(T_VectorGrid const& gridExtent, T_VectorBlock const& blockExtent) const
+                -> KernelLauncher<T_KernelFunctor>;
+
+            /**
              * @param sharedMemByte dynamic shared memory used by the kernel (in byte)
              */
             template<typename T_VectorGrid, typename T_VectorBlock>
             HINLINE auto operator()(
                 T_VectorGrid const& gridExtent,
                 T_VectorBlock const& blockExtent,
-                size_t const sharedMemByte = 0) const -> KernelStarter<Kernel, T_VectorGrid, T_VectorBlock>;
+                size_t const sharedMemByte) const -> KernelLauncher<KernelWithDynSharedMem<T_KernelFunctor>>;
+            /**@}*/
         };
 
 
-        template<typename T_Kernel, typename T_VectorGrid, typename T_VectorBlock>
-        struct KernelStarter
+        template<typename T_Kernel>
+        struct KernelLauncher
         {
-            /** kernel functor */
+            //! kernel functor
             T_Kernel const m_kernel;
-            /** grid extents for the kernel */
-            T_VectorGrid const m_gridExtent;
-            /** block extents for the kernel */
-            T_VectorBlock const m_blockExtent;
-            /** dynamic shared memory consumed by the kernel (in byte) */
-            size_t const m_sharedMemByte;
+            //! Debug meta data for the kernel functor.
+            KernelMetaData const m_metaData;
+            //! grid extents for the kernel
+            cupla::dim3 const m_gridExtent;
+            //! block extents for the kernel
+            cupla::dim3 const m_blockExtent;
 
             /** kernel starter object
              *
              * @param kernel pmacc Kernel
              */
-            HINLINE KernelStarter(
+            template<typename T_VectorGrid, typename T_VectorBlock>
+            HINLINE KernelLauncher(
                 T_Kernel const& kernel,
+                detail::KernelMetaData const& kernelMetaData,
                 T_VectorGrid const& gridExtent,
-                T_VectorBlock const& blockExtent,
-                size_t const sharedMemByte)
+                T_VectorBlock const& blockExtent)
                 : m_kernel(kernel)
-                , m_gridExtent(gridExtent)
-                , m_blockExtent(blockExtent)
-                , m_sharedMemByte(sharedMemByte)
+                , m_metaData(kernelMetaData)
+                , m_gridExtent(DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toDim3())
+                , m_blockExtent(DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toDim3())
             {
             }
 
-            /** execute the kernel functor
+            /** Enqueue the kernel functor with the given arguments for execution.
+             *
+             * The stream into which the kernel is enqueued is automatically chosen by PMacc's event system.
              *
              * @tparam T_Args types of the arguments
              * @param args arguments for the kernel functor
-             *
-             * @{
              */
             template<typename... T_Args>
-            HINLINE void operator()(T_Args const&... args) const
+            HINLINE void operator()(T_Args&&... args) const
             {
-                std::string const kernelName = typeid(m_kernel.m_kernelFunctor).name();
-                std::string const kernelInfo = kernelName + std::string(" [") + m_kernel.m_file + std::string(":")
-                    + std::to_string(m_kernel.m_line) + std::string(" ]");
+                std::string const kernelName = typeid(m_kernel).name();
+                std::string const kernelInfo = kernelName + std::string(" [") + m_metaData.getFile() + std::string(":")
+                    + std::to_string(m_metaData.getLine()) + std::string(" ]");
 
                 CUDA_CHECK_KERNEL_MSG(cuplaDeviceSynchronize(), std::string("Crash before kernel call ") + kernelInfo);
 
                 pmacc::TaskKernel* taskKernel = pmacc::Environment<>::get().Factory().createTaskKernel(kernelName);
 
-                DataSpace<traits::GetNComponents<T_VectorGrid>::value> gridExtent(m_gridExtent);
+                /* The next 3 lines cast pmacc vectors or integral values used for the execution extents into alpaka
+                 * vectors.
+                 * Note to be cupla compatible we use currently always 3-dimensional kernels.
+                 *
+                 * @todo find a better way to write this part of code, in general alpaka understands PMacc vectors but
+                 * PMacc has no easy way t cast integral numbers to an 3-dimensional vector.
+                 */
+                auto gridExtent = cupla::IdxVec3(m_gridExtent.z, m_gridExtent.y, m_gridExtent.x);
+                auto blockExtent = cupla::IdxVec3(m_blockExtent.z, m_blockExtent.y, m_blockExtent.x);
+                auto elemExtent = cupla::IdxVec3::ones();
+                auto workDiv
+                    = ::alpaka::WorkDivMembers<cupla::KernelDim, cupla::IdxType>(gridExtent, blockExtent, elemExtent);
 
-                DataSpace<traits::GetNComponents<T_VectorBlock>::value> blockExtent(m_blockExtent);
+                auto const kernelTask
+                    = ::alpaka::createTaskKernel<cupla::Acc>(workDiv, m_kernel, std::forward<T_Args>(args)...);
 
-                CUPLA_KERNEL(typename T_Kernel::KernelType)
-                (gridExtent.toDim3(), blockExtent.toDim3(), m_sharedMemByte, taskKernel->getCudaStream())(args...);
+                auto cuplaStream = taskKernel->getCudaStream();
+                auto& stream = cupla::manager::Stream<cupla::AccDev, cupla::AccStream>::get().stream(cuplaStream);
+
+                ::alpaka::enqueue(stream, kernelTask);
+
                 CUDA_CHECK_KERNEL_MSG(
                     cuplaGetLastError(),
                     std::string("Last error after kernel launch ") + kernelInfo);
@@ -173,39 +231,61 @@ namespace pmacc
                     cuplaDeviceSynchronize(),
                     std::string("Crash after kernel activation") + kernelInfo);
             }
-
-            template<typename... T_Args>
-            HINLINE void operator()(T_Args const&... args)
-            {
-                return static_cast<const KernelStarter&>(*this)(args...);
-            }
-
-            /** @} */
         };
 
+    } // namespace detail
 
-        /** creates a kernel object
+    /** Creates a kernel object.
+     *
+     * example for lambda usage:
+     *
+     * @code{.cpp}
+     *   pmacc::exec::kernel([]ALPAKA_FN_ACC(auto const& acc) -> void{
+     *       printf("Hello World.\n");
+     *   })(1,1)()
+     * @endcode
+     *
+     * @tparam T_KernelFunctor type of the kernel functor
+     * @param kernelFunctor instance of the functor, lambda are supported
+     * @param file file name (for debug)
+     * @param line line number in the file (for debug)
+     */
+    template<typename T_KernelFunctor>
+    auto kernel(T_KernelFunctor const& kernelFunctor, std::string const& file = std::string(), size_t const line = 0)
+        -> detail::KernelPreperationWrapper<T_KernelFunctor>
+    {
+        return detail::KernelPreperationWrapper<T_KernelFunctor>(kernelFunctor, file, line);
+    }
+} // namespace pmacc::exec
+
+
+namespace alpaka
+{
+    namespace trait
+    {
+        /** alpaka trait specialization to define dynamic shared memory for a kernel.
          *
-         * @tparam T_KernelFunctor type of the kernel functor
-         * @param kernelFunctor instance of the functor
-         * @param file file name (for debug)
-         * @param line line number in the file (for debug)
+         * All PMacc kernel with dynamic shared memory usage are wrapped by KernelWithDynSharedMem where the required
+         * amount of shared memory is available as member variable.
          */
-        template<typename T_KernelFunctor>
-        auto kernel(
-            T_KernelFunctor const& kernelFunctor,
-            std::string const& file = std::string(),
-            size_t const line = 0) -> Kernel<T_KernelFunctor>
+        template<typename T_UserKernel, typename T_Acc>
+        struct BlockSharedMemDynSizeBytes<::pmacc::exec::detail::KernelWithDynSharedMem<T_UserKernel>, T_Acc>
         {
-            return Kernel<T_KernelFunctor>(kernelFunctor, file, line);
-        }
-    } // namespace exec
-} // namespace pmacc
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+                ::pmacc::exec::detail::KernelWithDynSharedMem<T_UserKernel> const& userKernel,
+                TArgs const&...) -> ::alpaka::Idx<T_Acc>
+            {
+                return userKernel.m_dynSharedMemBytes;
+            }
+        };
+    } // namespace trait
+} // namespace alpaka
 
-
-/** create a kernel object out of a functor instance
+/** Create a kernel object out of a functor instance.
  *
- * this macro add the current filename and line number to the kernel object
+ * This macro add the current filename and line number to the kernel object.
+ * @see ::pmacc::exec::kernel
  *
  * @param ... instance of kernel functor
  */

--- a/include/pmacc/eventSystem/events/kernelEvents.tpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.tpp
@@ -26,18 +26,29 @@
 #include "pmacc/types.hpp"
 
 
-namespace pmacc
+namespace pmacc::exec::detail
 {
-    namespace exec
+    template<typename T_KernelFunctor>
+    template<typename T_VectorGrid, typename T_VectorBlock>
+    HINLINE auto KernelPreperationWrapper<T_KernelFunctor>::operator()(
+        T_VectorGrid const& gridExtent,
+        T_VectorBlock const& blockExtent,
+        size_t const sharedMemByte) const -> KernelLauncher<KernelWithDynSharedMem<T_KernelFunctor>>
     {
-        template<typename T_KernelFunctor>
-        template<typename T_VectorGrid, typename T_VectorBlock>
-        HINLINE auto Kernel<T_KernelFunctor>::operator()(
-            T_VectorGrid const& gridExtent,
-            T_VectorBlock const& blockExtent,
-            size_t const sharedMemByte) const -> KernelStarter<Kernel, T_VectorGrid, T_VectorBlock>
-        {
-            return KernelStarter<Kernel, T_VectorGrid, T_VectorBlock>(*this, gridExtent, blockExtent, sharedMemByte);
-        }
-    } // namespace exec
-} // namespace pmacc
+        return {
+            KernelWithDynSharedMem<T_KernelFunctor>(m_kernelFunctor, sharedMemByte),
+            m_metaData,
+            gridExtent,
+            blockExtent};
+    }
+
+    template<typename T_KernelFunctor>
+    template<typename T_VectorGrid, typename T_VectorBlock>
+    HINLINE auto KernelPreperationWrapper<T_KernelFunctor>::operator()(
+        T_VectorGrid const& gridExtent,
+        T_VectorBlock const& blockExtent) const -> KernelLauncher<T_KernelFunctor>
+    {
+        return {m_kernelFunctor, m_metaData, gridExtent, blockExtent};
+    }
+
+} // namespace pmacc::exec::detail


### PR DESCRIPTION
Before this PR PMacc used cupla to execute the device kernel, this came with the drawback that it was not possible to execute an instance of a kernel. Cupla is default constructing the kernel even if PMacc was already using an instance for the kernel.
Therefore a kernel was not allowed to have data members.

This PR refactors the kernel execution method of PMacc and is forwarding the device kernel instance directly to alpaka.

ATTENTION: The interface is backward compatible and therefore PMacc and PIConGPU require no code changes.

It is now allowed to execute a device lambda as a kernel.

Example for a lambda hello world (one thread, one block):
```C++
PMACC_KERNEL([]ALPAKA_FN_ACC(auto const& acc) -> void{
    printf("Hello World.\n");
})(1,1)();
```

For example, delete all particles without cleaning the frame list.
```C++
constexpr uint32_t numWorkers
    = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;

auto const mapper = makeAreaMapper<CORE + BORDER>(this->cellDescription);

PMACC_KERNEL(
    [numWorkers] ALPAKA_FN_ACC(auto const& acc, auto particleBox, auto const mapper) -> void
    {
        uint32_t const workerIdx = cupla::threadIdx(acc).x;

        DataSpace<simDim> const superCellIdx(
            mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));

        // relative offset (in cells) to the supercell (including the guard)
        DataSpace<simDim> const superCellOffset = superCellIdx * SuperCellSize::toRT();

        auto forEachParticle
            = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, particleBox, superCellIdx);

        forEachParticle(acc, [](auto const& accelerator, auto& particle) { particle[multiMask_] = 0; });
    })
(mapper.getGridDim(), numWorkers)(this->getDeviceParticlesBox(),mapper);
```