### PR TITLE
fix `pic-compile`

### DIFF
--- a/buildsystem/CompileSuite/compileSet.sh
+++ b/buildsystem/CompileSuite/compileSet.sh
@@ -68,7 +68,7 @@ cS_this_dir=$(cd `dirname $0` && pwd)
         caseId=0;
     else
         # cmakeFlags file is available '-t` option can be used
-        $caseOption="-t $caseId"
+        caseOption="-t $caseId"
     fi
 
     param_folder="$cS_tmpRun_path/params/$cS_example_name/cmakePreset_$caseId"


### PR DESCRIPTION
With #4235 a bug was introduces that `pic-compiele` is always using test case zero from `cmakeFlags`.

One side effect is that the CI since #4235 constantly tests case zero and not all other variants.
All users who compile parameter scans with `pic-compile` are affected too.

Thx @steindev for reporting the error.