### PR TITLE
refactor lockstep programming

### DIFF
--- a/docs/source/prgpatterns/lockstep.rst
+++ b/docs/source/prgpatterns/lockstep.rst
@@ -62,11 +62,9 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
 
 .. code-block:: cpp
 
-    // assume one dimensional indexing of threads within a block
-    uint32_t const workerIdx = cupla::threadIdx(acc).x;
+    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
-    constexpr uint32_t numWorkers = 42;
-    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto vIdx = forEachParticleSlotInFrame(
         [](lockstep::Idx const idx) -> int32_t
         {
@@ -77,10 +75,8 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
     // is equal to
 
     // assume one dimensional indexing of threads within a block
-    uint32_t const workerIdx = cupla::threadIdx(acc).x;
     constexpr uint32_t frameSize = 256;
-    constexpr uint32_t numWorkers = 42;
-    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     // variable will be uninitialized
     auto vIdx = lockstep::makeVar<int32_t>(forEachParticleSlotInFrame);
     forEachParticleSlotInFrame(
@@ -94,11 +90,9 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
 
 .. code-block:: cpp
 
-    // assume one dimensional indexing of threads within a block
-    uint32_t const workerIdx = cupla::threadIdx(acc).x;
+    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
-    constexpr uint32_t numWorkers = 42;
-    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto var = lockstep::makeVar<int32_t>(forEachParticleSlotInFrame, 23);
 
 
@@ -107,11 +101,9 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
 
 .. code-block:: cpp
 
-    // assume one dimensional indexing of threads within a block
-    uint32_t const workerIdx = cupla::threadIdx(acc).x;
+    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
-    constexpr uint32_t numWorkers = 42;
-    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto vIdx = forEachParticleSlotInFrame(
         [](lockstep::Idx const idx) -> int32_t
         {
@@ -146,14 +138,13 @@ Collective Loop
 
 .. code-block:: bash
 
+    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     // `frame` is a list which must be traversed collectively
     while( frame.isValid() )
     {
         // assume one dimensional indexing of threads within a block
-        uint32_t const workerIdx = cupla::threadIdx(acc).x;
         constexpr uint32_t frameSize = 256;
-        constexpr uint32_t numWorkers = 42;
-        auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+        auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
         forEachParticleSlotInFrame(
            [&](lockstep::Idx const idx)
            {
@@ -175,11 +166,9 @@ Non-Collective Loop
 
 .. code-block:: cpp
 
-    // assume one dimensional indexing of threads within a block
-    uint32_t const workerIdx = cupla::threadIdx(acc).x;
+    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
-    constexpr uint32_t numWorkers = 42;
-    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+    auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto vWorkerIdx = lockstep::makeVar<int32_t>(forEachParticleSlotInFrame, 0);
     forEachParticleSlotInFrame(
         [&](auto const idx)
@@ -205,9 +194,8 @@ Using a Master Worker
         bool
     );
 
-    // assume one dimensional indexing of threads within a block
-    uint32_t const workerIdx = cupla::threadIdx(acc).x;
-    auto onlyMaster = lockstep::makeMaster(workerIdx);
+    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    auto onlyMaster = lockstep::makeMaster(worker);
 
     // manipulate shared memory
     onlyMaster(
@@ -220,4 +208,4 @@ Using a Master Worker
     /* important: synchronize now, in case upcoming operations (with
      * other workers) access that manipulated shared memory section
      */
-    cupla::__syncthreads(acc);
+    worker.sync();

--- a/docs/source/prgpatterns/lockstep.rst
+++ b/docs/source/prgpatterns/lockstep.rst
@@ -62,7 +62,7 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
 
 .. code-block:: cpp
 
-    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    // variable 'worker' is provided by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
     auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto vIdx = forEachParticleSlotInFrame(
@@ -90,7 +90,7 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
 
 .. code-block:: cpp
 
-    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    // variable 'worker' is provided by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
     auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto var = lockstep::makeVar<int32_t>(forEachParticleSlotInFrame, 23);
@@ -101,7 +101,7 @@ A context variable must be defined outside of ``ForEach`` and should be accessed
 
 .. code-block:: cpp
 
-    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    // variable 'worker' is provided by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
     auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto vIdx = forEachParticleSlotInFrame(
@@ -138,7 +138,7 @@ Collective Loop
 
 .. code-block:: bash
 
-    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    // variable 'worker' is provided by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     // `frame` is a list which must be traversed collectively
     while( frame.isValid() )
     {
@@ -166,7 +166,7 @@ Non-Collective Loop
 
 .. code-block:: cpp
 
-    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    // variable 'worker' is provided by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     constexpr uint32_t frameSize = 256;
     auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
     auto vWorkerIdx = lockstep::makeVar<int32_t>(forEachParticleSlotInFrame, 0);
@@ -194,7 +194,7 @@ Using a Master Worker
         bool
     );
 
-    // variable 'worker' is provides by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
+    // variable 'worker' is provided by pmacc if the kernel launch macro `PMACC_LOCKSTEP_KERNEL()` is used.
     auto onlyMaster = lockstep::makeMaster(worker);
 
     // manipulate shared memory

--- a/include/picongpu/algorithms/Set.hpp
+++ b/include/picongpu/algorithms/Set.hpp
@@ -32,8 +32,8 @@ namespace picongpu
         {
         }
 
-        template<typename Dst, typename T_Acc>
-        HDINLINE void operator()(T_Acc const&, Dst& dst) const
+        template<typename Dst, typename T_Worker>
+        HDINLINE void operator()(T_Worker const&, Dst& dst) const
         {
             dst = value;
         }

--- a/include/picongpu/fields/FieldJ.kernel
+++ b/include/picongpu/fields/FieldJ.kernel
@@ -45,11 +45,10 @@ namespace picongpu
     {
         /** compute current
          *
-         * @tparam T_numWorkers number of workers
          * @tparam T_BlockDescription current field domain description needed for the
          *                            collective stencil
          */
-        template<uint32_t T_numWorkers, typename T_BlockDescription>
+        template<typename T_BlockDescription>
         struct KernelComputeCurrent
         {
             /** scatter particle current of particles located in a supercell
@@ -61,17 +60,17 @@ namespace picongpu
              * @tparam ParBox pmacc::ParticlesBox, particle box type
              * @tparam Mapping mapper functor type
              * @tparam FrameSolver frame solver functor type
-             * @param T_Acc alpaka accelerator type
+             * @tparam T_Worker lockstep worker type
              *
-             * @param alpaka accelerator
+             * @param worker lockstep worker
              * @param fieldJ field with particle current
              * @param boxPar particle memory
              * @param frameSolver functor to calculate the current for a frame
              * @param mapper functor to map a block to a supercell
              */
-            template<typename JBox, typename ParBox, typename FrameSolver, typename Mapping, typename T_Acc>
+            template<typename JBox, typename ParBox, typename FrameSolver, typename Mapping, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 JBox fieldJ,
                 ParBox boxPar,
                 FrameSolver frameSolver,
@@ -79,14 +78,10 @@ namespace picongpu
             {
                 using SuperCellSize = typename Mapping::SuperCellSize;
 
-                constexpr uint32_t numWorkers = T_numWorkers;
-
                 const DataSpace<simDim> superCellIdx(
-                    mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
-                uint32_t const workerIdx = cupla::threadIdx(acc).x;
+                    mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
-                auto forEachParticle
-                    = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, boxPar, superCellIdx);
+                auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach(worker, boxPar, superCellIdx);
 
                 // end kernel if we have no particles
                 if(!forEachParticle.hasParticles())
@@ -96,27 +91,19 @@ namespace picongpu
                 using Strategy = currentSolver::traits::GetStrategy_t<FrameSolver>;
 
                 /* this memory is used by all virtual blocks */
-                auto cachedJ = detail::Cache<Strategy>::template create<numWorkers, T_BlockDescription>(
-                    acc,
-                    fieldJ.shift(blockCell),
-                    workerIdx);
+                auto cachedJ
+                    = detail::Cache<Strategy>::template create<T_BlockDescription>(worker, fieldJ.shift(blockCell));
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
-                forEachParticle(
-                    acc,
-                    [&cachedJ, &frameSolver](auto const& accelerator, auto& particle)
-                    { frameSolver(accelerator, particle, cachedJ); });
+                forEachParticle([&cachedJ, &frameSolver](auto const& lockstepWorker, auto& particle)
+                                { frameSolver(lockstepWorker, particle, cachedJ); });
 
                 /* we wait that all workers finish the loop */
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 /* this memory is used by all virtual blocks */
-                detail::Cache<Strategy>::template flush<numWorkers, T_BlockDescription>(
-                    acc,
-                    fieldJ.shift(blockCell),
-                    cachedJ,
-                    workerIdx);
+                detail::Cache<Strategy>::template flush<T_BlockDescription>(worker, fieldJ.shift(blockCell), cachedJ);
             }
         };
 
@@ -129,8 +116,8 @@ namespace picongpu
             {
             }
 
-            template<typename T_Particle, typename BoxJ, typename T_Acc>
-            DINLINE void operator()(T_Acc const& acc, T_Particle& particle, BoxJ& jBox)
+            template<typename T_Particle, typename BoxJ, typename T_Worker>
+            DINLINE void operator()(T_Worker const& worker, T_Particle& particle, BoxJ& jBox)
             {
                 /* Use (potentially) damped weighting for charge calculation.
                  * @see particles::boundary::DampWeightsInPml for details.
@@ -147,7 +134,7 @@ namespace picongpu
                 const float3_X vel = velocity(particle[momentum_], attribute::getMass(weighting, particle));
                 auto fieldJShiftToParticle = jBox.shift(localCell);
                 ParticleAlgo perParticle;
-                perParticle(acc, fieldJShiftToParticle, pos, vel, charge, m_deltaTime);
+                perParticle(worker, fieldJShiftToParticle, pos, vel, charge, m_deltaTime);
             }
 
         private:

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -36,7 +36,6 @@
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/particles/memory/boxes/ParticlesBox.hpp>
-#include <pmacc/traits/GetNumWorkers.hpp>
 #include <pmacc/traits/GetUniqueTypeId.hpp>
 #include <pmacc/traits/Resolve.hpp>
 
@@ -249,17 +248,14 @@ namespace picongpu
 
         using Strategy = currentSolver::traits::GetStrategy_t<FrameSolver>;
 
-        constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
-            pmacc::math::CT::volume<SuperCellSize>::type::value * Strategy::workerMultiplier>::value;
-
-        auto const depositionKernel = currentSolver::KernelComputeCurrent<numWorkers, BlockArea>{};
+        auto const depositionKernel = currentSolver::KernelComputeCurrent<BlockArea>{};
 
         typename T_Species::ParticlesBoxType pBox = species.getDeviceParticlesBox();
         FieldJ::DataBoxType jBox = buffer.getDeviceBuffer().getDataBox();
         FrameSolver solver(DELTA_T);
 
         auto const deposit = currentSolver::Deposit<Strategy>{};
-        deposit.template execute<T_area, numWorkers>(cellDescription, depositionKernel, solver, jBox, pBox);
+        deposit.template execute<T_area>(cellDescription, depositionKernel, solver, jBox, pBox);
     }
 
     void FieldJ::bashField(uint32_t exchangeType)

--- a/include/picongpu/fields/FieldTmp.kernel
+++ b/include/picongpu/fields/FieldTmp.kernel
@@ -45,10 +45,9 @@ namespace picongpu
      * the species' shape to the field grid and reduced of all contributing
      * particles.
      *
-     * @tparam T_numWorkers number of workers
      * @tparam T_BlockDescription stance area description of the user functor
      */
-    template<uint32_t T_numWorkers, typename T_BlockDescription>
+    template<typename T_BlockDescription>
     struct KernelComputeSupercells
     {
         /** derive species property
@@ -70,10 +69,10 @@ namespace picongpu
             typename T_ParBox,
             typename T_FrameSolver,
             typename T_Mapping,
-            typename T_Acc,
+            typename T_Worker,
             typename T_ParticleFilter>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_TmpBox fieldTmp,
             T_ParBox boxPar,
             T_FrameSolver frameSolver,
@@ -83,84 +82,72 @@ namespace picongpu
             using FramePtr = typename T_ParBox::FramePtr;
             using SuperCellSize = typename T_BlockDescription::SuperCellSize;
 
-            constexpr uint32_t numWorkers = T_numWorkers;
-
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
-            auto accFilter = particleFilter(
-                acc,
-                superCellIdx - mapper.getGuardingSuperCells(),
-                lockstep::Worker<numWorkers>{workerIdx});
+            DataSpace<simDim> const superCellIdx(
+                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
+            auto accFilter = particleFilter(worker, superCellIdx - mapper.getGuardingSuperCells());
 
             namespace particleAccAlgos = pmacc::particles::algorithm::acc;
-            auto forEachParticle = particleAccAlgos::makeForEach<numWorkers, particleAccAlgos::Forward>(
-                workerIdx,
-                boxPar,
-                superCellIdx);
+            auto forEachParticle
+                = particleAccAlgos::makeForEach<particleAccAlgos::Forward>(worker, boxPar, superCellIdx);
 
             // end kernel if we have no particles
             if(!forEachParticle.hasParticles())
                 return;
 
-            auto cachedVal = CachedBox::create<0, typename T_TmpBox::ValueType>(acc, T_BlockDescription{});
+            auto cachedVal = CachedBox::create<0, typename T_TmpBox::ValueType>(worker, T_BlockDescription{});
             Set<typename T_TmpBox::ValueType> set(float_X(0.0));
 
-            ThreadCollective<T_BlockDescription, numWorkers> collective(workerIdx);
-            collective(acc, set, cachedVal);
+            auto collective = makeThreadCollective<T_BlockDescription>();
+            collective(worker, set, cachedVal);
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
-            forEachParticle(
-                acc,
-                [&accFilter, &cachedVal, &frameSolver](auto const& accelerator, auto& particle)
-                { frameSolver(accelerator, particle, SuperCellSize::toRT(), accFilter, cachedVal); });
+            forEachParticle([&accFilter, &cachedVal, &frameSolver](auto const& lockstepWorker, auto& particle)
+                            { frameSolver(lockstepWorker, particle, SuperCellSize::toRT(), accFilter, cachedVal); });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             pmacc::math::operation::Add add;
             DataSpace<simDim> const superCellCellOffset = superCellIdx * SuperCellSize::toRT();
             auto fieldTmpBlock = fieldTmp.shift(superCellCellOffset);
-            collective(acc, add, fieldTmpBlock, cachedVal);
+            collective(worker, add, fieldTmpBlock, cachedVal);
         }
     };
 
     /** Kernel used in the modifyField method
      *
-     * @tparam T_numWorkers number of workers
      * @tparam T_ModifyingOperation a binary operation used to modify one field by another one
      * @tparam T_SuperCellSize compile-time  supercell size vector
      */
-    template<uint32_t T_numWorkers, typename T_ModifyingOperation, typename T_SuperCellSize>
+    template<typename T_ModifyingOperation, typename T_SuperCellSize>
     struct ModifyByFieldKernel
     {
         /** Kernel implementation
          *
-         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          * @tparam T_Mapper mapper type
          * @tparam T_Box1 1st data box type
          * @tparam T_Box2 2nd data box type
-         * @param acc alpaka accelerator
+         * @param worker lockstep worker
          * @param mapper functor to map a block to a supercell
          * @param box1 data box of the first field
          * @param box2 data box of the second field
          */
-        template<typename T_Acc, typename T_Mapper, typename T_Box1, typename T_Box2>
-        DINLINE void operator()(T_Acc const& acc, T_Mapper const mapper, T_Box1 box1, T_Box2 const& box2) const
+        template<typename T_Worker, typename T_Mapper, typename T_Box1, typename T_Box2>
+        DINLINE void operator()(T_Worker const& worker, T_Mapper const mapper, T_Box1 box1, T_Box2 const& box2) const
         {
             // Shift the fields to the supercell processed by current block.
-            DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const block(
+                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
             DataSpace<simDim> const blockCell = block * T_SuperCellSize::toRT();
             auto box1Block = box1.shift(blockCell);
             auto box2Block = box2.shift(blockCell);
 
             // Call the binary operation for a pair of field values for each cell in the supercell.
-            constexpr uint32_t numWorkers = T_numWorkers;
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
             using BlockAreaConfiguration = pmacc::SuperCellDescription<T_SuperCellSize>;
-            ThreadCollective<BlockAreaConfiguration, numWorkers> applyOperationToCells(workerIdx);
+            auto applyOperationToCells = makeThreadCollective<BlockAreaConfiguration>();
             T_ModifyingOperation binaryOperation;
-            applyOperationToCells(acc, binaryOperation, box1Block, box2Block);
+            applyOperationToCells(worker, binaryOperation, box1Block, box2Block);
         }
     };
 

--- a/include/picongpu/fields/MaxwellSolver/AddCurrentDensity.kernel
+++ b/include/picongpu/fields/MaxwellSolver/AddCurrentDensity.kernel
@@ -33,19 +33,16 @@
 namespace picongpu::fields::maxwellSolver
 {
     /** Kernel adding current density to electric and magnetic field
-     *
-     * @tparam T_numWorkers number of workers
      */
-    template<uint32_t T_numWorkers>
     struct KernelAddCurrentDensity
     {
         /** Add current density with the given interpolation functor and coefficient
          *
          * @tparam T_CurrentInterpolationFunctor current interpolation functor type
          * @tparam T_Mapping mapper functor type
-         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          *
-         * @param acc alpaka accelerator
+         * @param worker lockstep worker
          * @param fieldE electric field box
          * @param fieldB magnetic field box
          * @param fieldJ current density box
@@ -53,9 +50,9 @@ namespace picongpu::fields::maxwellSolver
          * @param coeff coefficient to be used in the current interpolation functor
          * @param mapper functor to map a block to a supercell
          */
-        template<typename T_CurrentInterpolationFunctor, typename T_Mapping, typename T_Acc>
+        template<typename T_CurrentInterpolationFunctor, typename T_Mapping, typename T_Worker>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             typename FieldE::DataBoxType fieldE,
             typename FieldB::DataBoxType fieldB,
             typename FieldJ::DataBoxType fieldJ,
@@ -70,25 +67,23 @@ namespace picongpu::fields::maxwellSolver
                 typename T_CurrentInterpolationFunctor::UpperMargin>;
 
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-            auto cachedJ = CachedBox::create<0, typename FieldJ::DataBoxType::ValueType>(acc, BlockArea());
+            auto cachedJ = CachedBox::create<0, typename FieldJ::DataBoxType::ValueType>(worker, BlockArea());
 
             pmacc::math::operation::Assign assign;
-            DataSpace<simDim> const block(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const block(
+                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
             DataSpace<simDim> const blockCell = block * MappingDesc::SuperCellSize::toRT();
 
             auto fieldJBlock = fieldJ.shift(blockCell);
 
-            ThreadCollective<BlockArea, numWorkers> collective(workerIdx);
+            auto collective = makeThreadCollective<BlockArea>();
 
-            collective(acc, assign, cachedJ, fieldJBlock);
+            collective(worker, assign, cachedJ, fieldJBlock);
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
-            lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)(
+            lockstep::makeForEach<cellsPerSuperCell>(worker)(
                 [&](uint32_t const linearIdx)
                 {
                     /* cell index within the superCell */

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTDBase.kernel
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTDBase.kernel
@@ -123,11 +123,7 @@ namespace picongpu
                     T_CurlE const curl = T_CurlE{};
                 };
 
-                /** Kernel to update each cell
-                 *
-                 * @tparam T_numWorkers number of workers
-                 */
-                template<uint32_t T_numWorkers>
+                //! Kernel to update each cell
                 struct KernelUpdateField
                 {
                     HDINLINE KernelUpdateField() = default;
@@ -138,27 +134,27 @@ namespace picongpu
 
                     /** Update the yee field using the given functor
                      *
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      * @tparam T_Mapping mapper functor type
                      * @tparam T_StencilFunctor stencil functor type to update a cell,
                      *         adheres the StencilFunctor concept
                      * @tparam T_SrcBox pmacc::DataBox, source field box type
                      * @tparam T_DestBox pmacc::DataBox, destination field box type
                      *
-                     * @param acc alpaka accelerator
+                     * @param worker lockstep worker
                      * @param mapper functor to map a block to a supercell
                      * @param stencilFunctor stencil functor
                      * @param srcField source field iterator (is not allowed to be an alias of destField data)
                      * @param destField destination field iterator
                      */
                     template<
-                        typename T_Acc,
+                        typename T_Worker,
                         typename T_Mapping,
                         typename T_StencilFunctor,
                         typename T_SrcBox,
                         typename T_DestBox>
                     DINLINE void operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         T_Mapping const mapper,
                         T_StencilFunctor stencilFunctor,
                         T_SrcBox const srcField,
@@ -167,11 +163,9 @@ namespace picongpu
                         /* Each block processes all cells of a supercell,
                          * the index includes guards, same as all indices in this kernel
                          */
-                        auto const beginCellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)))
+                        auto const beginCellIdx
+                            = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())))
                             * MappingDesc::SuperCellSize::toRT();
-
-                        constexpr auto numWorkers = T_numWorkers;
-                        auto const workerIdx = cupla::threadIdx(acc).x;
 
                         // Description of the area and guards where the stencil is performed.
                         using StencilCfg = pmacc::SuperCellDescription<
@@ -183,15 +177,16 @@ namespace picongpu
                          */
                         pmacc::math::operation::Assign assign;
                         auto srcFieldBlock = srcField.shift(beginCellIdx);
-                        ThreadCollective<StencilCfg, numWorkers> cacheStencilArea(workerIdx);
-                        auto cachedSrcField = CachedBox::create<0u, typename T_SrcBox::ValueType>(acc, StencilCfg{});
-                        cacheStencilArea(acc, assign, cachedSrcField, srcFieldBlock);
+                        auto cacheStencilArea = makeThreadCollective<StencilCfg>();
+                        auto cachedSrcField
+                            = CachedBox::create<0u, typename T_SrcBox::ValueType>(worker, StencilCfg{});
+                        cacheStencilArea(worker, assign, cachedSrcField, srcFieldBlock);
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
                         // Execute the stencil functor for each cell in the supercell.
-                        lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)(
+                        lockstep::makeForEach<cellsPerSuperCell>(worker)(
                             [&](uint32_t const linearIdx)
                             {
                                 auto const idxInSuperCell

--- a/include/picongpu/fields/absorber/exponential/Exponential.kernel
+++ b/include/picongpu/fields/absorber/exponential/Exponential.kernel
@@ -41,11 +41,10 @@ namespace picongpu
                 {
                     /** damp each field component at exchange the border
                      *
-                     * @tparam T_NumWorkers, boost::mpl::integral_c number of workers
                      * @tparam T_Axis, boost::mpl::integral_c axis of the coordinate system
                      *                 (0 = x, 1 = y, 2 = z)
                      */
-                    template<typename T_NumWorkers, typename T_Axis>
+                    template<typename T_Axis>
                     struct AbsorbInOneDirection
                     {
                         /** absorb one direction
@@ -62,9 +61,9 @@ namespace picongpu
                          * @param relExchangeDir relative direction for each dimension
                          *        (-1 = negative; +1 = positive direction; 0 = direction not selected)
                          */
-                        template<typename T_BoxedMemory, typename T_Mapping, typename T_Acc>
+                        template<typename T_BoxedMemory, typename T_Mapping, typename T_Worker>
                         DINLINE void operator()(
-                            T_Acc const& acc,
+                            T_Worker const& worker,
                             T_BoxedMemory& field,
                             uint32_t const thickness,
                             float_X const absorberStrength,
@@ -79,12 +78,9 @@ namespace picongpu
 
                             using SuperCellSize = typename T_Mapping::SuperCellSize;
                             DataSpace<simDim> const superCellIdx(
-                                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+                                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
-                            constexpr uint32_t numWorkers = T_NumWorkers::value;
                             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-
-                            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
                             auto const numGuardSuperCells = mapper.getGuardingSuperCells();
                             DataSpace<simDim> guardCells(numGuardSuperCells * SuperCellSize::toRT());
@@ -93,8 +89,7 @@ namespace picongpu
                             DataSpace<simDim> const localDomainCells
                                 = mapper.getGridSuperCells() * SuperCellSize::toRT();
 
-                            auto forEachParticleInFrame
-                                = lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx);
+                            auto forEachParticleInFrame = lockstep::makeForEach<cellsPerSuperCell>(worker);
 
                             forEachParticleInFrame(
                                 [&](uint32_t const linearIdx)
@@ -140,10 +135,7 @@ namespace picongpu
                 /** damp each field's components at the outer cells of the global domain
                  *
                  * Done for one direction per call.
-                 *
-                 * @tparam T_numWorkers number of workers
                  */
-                template<uint32_t T_numWorkers>
                 struct KernelAbsorbBorder
                 {
                     /** damp a field at the border
@@ -157,9 +149,9 @@ namespace picongpu
                      * @param mapper functor to map a block to a supercell,
                      *               selects the direction of damping by the exchange type
                      */
-                    template<typename T_BoxedMemory, typename T_Mapping, typename T_Acc>
+                    template<typename T_BoxedMemory, typename T_Mapping, typename T_Worker>
                     DINLINE void operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         T_BoxedMemory field,
                         uint32_t const thickness,
                         float_X const absorberStrength,
@@ -174,13 +166,10 @@ namespace picongpu
                          */
                         using SimulationDimensions = MakeSeq_t<boost::mpl::range_c<int, 0, int(simDim)>>;
 
-                        meta::ForEach<
-                            SimulationDimensions,
-                            detail::
-                                AbsorbInOneDirection<boost::mpl::integral_c<uint32_t, T_numWorkers>, boost::mpl::_1>>
+                        meta::ForEach<SimulationDimensions, detail::AbsorbInOneDirection<boost::mpl::_1>>
                             absorbInAllDirections;
 
-                        absorbInAllDirections(acc, field, thickness, absorberStrength, mapper, relExchangeDir);
+                        absorbInAllDirections(worker, field, thickness, absorberStrength, mapper, relExchangeDir);
                     }
                 };
 

--- a/include/picongpu/fields/currentDeposition/Cache.hpp
+++ b/include/picongpu/fields/currentDeposition/Cache.hpp
@@ -74,10 +74,10 @@ namespace picongpu
                 DINLINE static void flush(T_Worker const& worker, T_FieldBox fieldBox, T_FieldCache const& cachedBox)
                 {
                     typename T_Strategy::GridReductionOp const op;
-                    auto collectiveAdd = makeThreadCollective<T_BlockDescription>();
+                    auto collectiveFlush = makeThreadCollective<T_BlockDescription>();
 
                     /* write scatter results back to the global memory */
-                    collectiveAdd(worker, op, fieldBox, cachedBox);
+                    collectiveFlush(worker, op, fieldBox, cachedBox);
                 }
             };
 

--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -36,9 +36,9 @@ namespace picongpu
             template<typename T_Strategy, typename T_ParticleAssign, int T_begin, int T_end>
             struct DepositCurrent<T_Strategy, T_ParticleAssign, T_begin, T_end, DIM3>
             {
-                template<typename T_Cursor, typename T_Acc>
+                template<typename T_Cursor, typename T_Worker>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const T_Cursor& cursorJ,
                     const Line<float3_X>& line,
                     const float_X chargeDensity) const
@@ -51,16 +51,16 @@ namespace picongpu
                      */
                     using namespace cursor::tools;
                     cptCurrent1D(
-                        acc,
+                        worker,
                         twistVectorFieldAxes<pmacc::math::CT::Int<1, 2, 0>>(cursorJ),
                         rotateOrigin<1, 2, 0>(line),
                         cellSize.x() * chargeDensity / DELTA_T);
                     cptCurrent1D(
-                        acc,
+                        worker,
                         twistVectorFieldAxes<pmacc::math::CT::Int<2, 0, 1>>(cursorJ),
                         rotateOrigin<2, 0, 1>(line),
                         cellSize.y() * chargeDensity / DELTA_T);
-                    cptCurrent1D(acc, cursorJ, line, cellSize.z() * chargeDensity / DELTA_T);
+                    cptCurrent1D(worker, cursorJ, line, cellSize.z() * chargeDensity / DELTA_T);
                 }
 
                 /** deposites current in z-direction
@@ -69,9 +69,9 @@ namespace picongpu
                  * @param line trajectory of the virtual particle
                  * @param currentSurfaceDensity surface density
                  */
-                template<typename CursorJ, typename T_Line, typename T_Acc>
+                template<typename CursorJ, typename T_Line, typename T_Worker>
                 DINLINE void cptCurrent1D(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     CursorJ cursorJ,
                     const T_Line& line,
                     const float_X currentSurfaceDensity) const
@@ -117,7 +117,7 @@ namespace picongpu
                                 const float_X W = shapeK.DS(k) * tmp;
                                 accumulated_J += W;
                                 auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                                atomicOp(acc, (*cursorJ(i, j, k)).z(), accumulated_J);
+                                atomicOp(worker, (*cursorJ(i, j, k)).z(), accumulated_J);
                             }
                         }
                     }
@@ -133,17 +133,17 @@ namespace picongpu
                  * It is done in computeCurrentZ() which has to be explicitly called by a user.
                  * This it different from 3d, where only calling operator() is needed.
                  */
-                template<typename T_Cursor, typename T_Acc>
+                template<typename T_Cursor, typename T_Worker>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const T_Cursor& cursorJ,
                     const Line<float2_X>& line,
                     const float_X chargeDensity) const
                 {
                     using namespace cursor::tools;
-                    cptCurrent1D(acc, cursorJ, line, cellSize.x() * chargeDensity / DELTA_T);
+                    cptCurrent1D(worker, cursorJ, line, cellSize.x() * chargeDensity / DELTA_T);
                     cptCurrent1D(
-                        acc,
+                        worker,
                         twistVectorFieldAxes<pmacc::math::CT::Int<1, 0>>(cursorJ),
                         rotateOrigin<1, 0>(line),
                         cellSize.y() * chargeDensity / DELTA_T);
@@ -155,9 +155,9 @@ namespace picongpu
                  * @param line trajectory of the virtual particle
                  * @param currentSurfaceDensity surface density
                  */
-                template<typename CursorJ, typename T_Line, typename T_Acc>
+                template<typename CursorJ, typename T_Line, typename T_Worker>
                 DINLINE void cptCurrent1D(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     CursorJ cursorJ,
                     const T_Line& line,
                     const float_X currentSurfaceDensity) const
@@ -190,7 +190,7 @@ namespace picongpu
                             const float_X W = shapeI.DS(i) * tmp;
                             accumulated_J += W;
                             auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                            atomicOp(acc, (*cursorJ(i, j)).x(), accumulated_J);
+                            atomicOp(worker, (*cursorJ(i, j)).x(), accumulated_J);
                         }
                     }
                 }
@@ -208,9 +208,9 @@ namespace picongpu
                  * @param line trajectory of the virtual particle
                  * @param currentSurfaceDensityZ surface density in z direction
                  */
-                template<typename CursorJ, typename T_Line, typename T_Acc>
+                template<typename CursorJ, typename T_Line, typename T_Worker>
                 DINLINE void computeCurrentZ(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     CursorJ cursorJ,
                     const T_Line& line,
                     const float_X currentSurfaceDensityZ) const
@@ -238,7 +238,7 @@ namespace picongpu
 
                             const float_X j_z = W * currentSurfaceDensityZ;
                             auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                            atomicOp(acc, (*cursorJ(i, j)).z(), j_z);
+                            atomicOp(worker, (*cursorJ(i, j)).z(), j_z);
                         }
                     }
                 }

--- a/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/EmZ.hpp
@@ -66,9 +66,9 @@ namespace picongpu
              * @param charge charge of the particle
              * @param deltaTime time of one time step
              */
-            template<typename DataBoxJ, typename T_Acc>
+            template<typename DataBoxJ, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 DataBoxJ dataBoxJ,
                 floatD_X const posEnd,
                 float3_X const velocity,
@@ -107,7 +107,7 @@ namespace picongpu
                     line.m_pos1[d] = relayPoint[d] - shiftStart[d];
                 }
 
-                deposit(acc, dataBoxJ.shift(shiftStart).toCursor(), line, chargeDensity);
+                deposit(worker, dataBoxJ.shift(shiftStart).toCursor(), line, chargeDensity);
 
                 /* detect if there is a second virtual particle */
                 const bool twoParticlesNeeded = (shiftStart != shiftEnd);
@@ -120,7 +120,7 @@ namespace picongpu
                         line.m_pos1[d] = posEnd[d] - shiftEnd[d];
                         line.m_pos0[d] = relayPoint[d] - shiftEnd[d];
                     }
-                    deposit(acc, dataBoxJ.shift(shiftEnd).toCursor(), line, chargeDensity);
+                    deposit(worker, dataBoxJ.shift(shiftEnd).toCursor(), line, chargeDensity);
                 }
 
                 /* 2d case requires special handling of Jz as explained in #3889.
@@ -159,7 +159,7 @@ namespace picongpu
                             DIM2>
                             depositZ;
                         depositZ.computeCurrentZ(
-                            acc,
+                            worker,
                             dataBoxJ.shift(shiftEnd).toCursor(),
                             line,
                             velocity.z() * chargeDensity);

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -63,9 +63,9 @@ namespace picongpu
              *
              * \todo: please fix me that we can use CenteredCell
              */
-            template<typename DataBoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Acc>
+            template<typename DataBoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 DataBoxJ dataBoxJ,
                 const PosType pos,
                 const VelType velocity,
@@ -119,18 +119,18 @@ namespace picongpu
                  */
                 using namespace cursor::tools;
                 cptCurrent1D(
-                    acc,
+                    worker,
                     DataSpace<simDim>(status.y(), status.z(), status.x()),
                     twistVectorFieldAxes<pmacc::math::CT::Int<1, 2, 0>>(cursorJ),
                     rotateOrigin<1, 2, 0>(line),
                     cellSize.x());
                 cptCurrent1D(
-                    acc,
+                    worker,
                     DataSpace<simDim>(status.z(), status.x(), status.y()),
                     twistVectorFieldAxes<pmacc::math::CT::Int<2, 0, 1>>(cursorJ),
                     rotateOrigin<2, 0, 1>(line),
                     cellSize.y());
-                cptCurrent1D(acc, status, cursorJ, line, cellSize.z());
+                cptCurrent1D(worker, status, cursorJ, line, cellSize.z());
             }
 
             /** deposites current in z-direction (rotated PIConGPU coordinate system)
@@ -140,9 +140,9 @@ namespace picongpu
              * @param line trajectory of the particle from to last to the current time step
              * @param cellEdgeLength length of edge of the cell in z-direction
              */
-            template<typename CursorJ, typename T_Acc>
+            template<typename CursorJ, typename T_Worker>
             DINLINE void cptCurrent1D(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 const DataSpace<simDim>& parStatus,
                 CursorJ cursorJ,
                 const Line<float3_X>& line,
@@ -231,7 +231,7 @@ namespace picongpu
                                         const float_X W = shapeK.DS(k) * tmp;
                                         accumulated_J += W;
                                         auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                                        atomicOp(acc, (*cursorJ(i, j, k)).z(), accumulated_J);
+                                        atomicOp(worker, (*cursorJ(i, j, k)).z(), accumulated_J);
                                     }
                             }
                     }

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -70,9 +70,9 @@ namespace picongpu
 
             float_X charge;
 
-            template<typename DataBoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Acc>
+            template<typename DataBoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 DataBoxJ dataBoxJ,
                 const PosType pos,
                 const VelType velocity,
@@ -124,14 +124,14 @@ namespace picongpu
                  */
 
                 using namespace cursor::tools;
-                cptCurrent1D(acc, status, cursorJ, line, cellSize.x());
+                cptCurrent1D(worker, status, cursorJ, line, cellSize.x());
                 cptCurrent1D(
-                    acc,
+                    worker,
                     DataSpace<DIM2>(status[1], status[0]),
                     twistVectorFieldAxes<pmacc::math::CT::Int<1, 0>>(cursorJ),
                     rotateOrigin<1, 0>(line),
                     cellSize.y());
-                cptCurrentZ(acc, status, cursorJ, line, velocity.z());
+                cptCurrentZ(worker, status, cursorJ, line, velocity.z());
             }
 
             /** deposites current in x-direction (rotated PIConGPU coordinate system)
@@ -143,9 +143,9 @@ namespace picongpu
              *
              * @{
              */
-            template<typename CursorJ, typename T_Acc>
+            template<typename CursorJ, typename T_Worker>
             DINLINE void cptCurrent1D(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 const DataSpace<simDim>& parStatus,
                 CursorJ cursorJ,
                 const Line<float2_X>& line,
@@ -200,14 +200,14 @@ namespace picongpu
                                 const float_X W = shapeI.DS(i) * tmp;
                                 accumulated_J += W;
                                 auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                                atomicOp(acc, (*cursorJ(i, j)).x(), accumulated_J);
+                                atomicOp(worker, (*cursorJ(i, j)).x(), accumulated_J);
                             }
                     }
             }
 
-            template<typename CursorJ, typename T_Acc>
+            template<typename CursorJ, typename T_Worker>
             DINLINE void cptCurrentZ(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 const DataSpace<simDim>& parStatus,
                 CursorJ cursorJ,
                 const Line<float2_X>& line,
@@ -251,7 +251,7 @@ namespace picongpu
 
                                 const float_X j_z = W * currentSurfaceDensityZ;
                                 auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                                atomicOp(acc, (*cursorJ(i, j)).z(), j_z);
+                                atomicOp(worker, (*cursorJ(i, j)).z(), j_z);
                             }
                     }
             }

--- a/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/EsirkepovNative.hpp
@@ -71,9 +71,9 @@ namespace picongpu
              *
              * \todo: please fix me that we can use CenteredCell
              */
-            template<typename DataBoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Acc>
+            template<typename DataBoxJ, typename PosType, typename VelType, typename ChargeType, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 DataBoxJ dataBoxJ,
                 const PosType pos,
                 const VelType velocity,
@@ -95,16 +95,16 @@ namespace picongpu
 
                 using namespace cursor::tools;
                 cptCurrent1D(
-                    acc,
+                    worker,
                     twistVectorFieldAxes<pmacc::math::CT::Int<1, 2, 0>>(cursorJ),
                     rotateOrigin<1, 2, 0>(line),
                     cellSize.x());
                 cptCurrent1D(
-                    acc,
+                    worker,
                     twistVectorFieldAxes<pmacc::math::CT::Int<2, 0, 1>>(cursorJ),
                     rotateOrigin<2, 0, 1>(line),
                     cellSize.y());
-                cptCurrent1D(acc, cursorJ, line, cellSize.z());
+                cptCurrent1D(worker, cursorJ, line, cellSize.z());
             }
 
             /**
@@ -113,9 +113,9 @@ namespace picongpu
              * @param line trajectory of the particle from to last to the current time step
              * @param cellEdgeLength length of edge of the cell in z-direction
              */
-            template<typename CursorJ, typename T_Acc>
+            template<typename CursorJ, typename T_Worker>
             DINLINE void cptCurrent1D(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 CursorJ cursorJ,
                 const Line<float3_X>& line,
                 const float_X cellEdgeLength)
@@ -141,7 +141,7 @@ namespace picongpu
                             accumulated_J += -this->charge * (float_X(1.0) / float_X(CELL_VOLUME * DELTA_T)) * W
                                 * cellEdgeLength;
                             auto const atomicOp = typename T_Strategy::BlockReductionOp{};
-                            atomicOp(acc, (*cursorJ(i, j, k)).z(), accumulated_J);
+                            atomicOp(worker, (*cursorJ(i, j, k)).z(), accumulated_J);
                         }
                     }
                 }

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -423,17 +423,16 @@ namespace picongpu
 
                 /** Kernel to apply incidentField
                  *
-                 * @tparam T_numWorkers number of workers
                  * @tparam T_BlockDescription domain description
                  */
-                template<uint32_t T_numWorkers, typename T_BlockDescription>
+                template<typename T_BlockDescription>
                 struct ApplyIncidentFieldKernel
                 {
                     /** Run the incidentField kernel
                      *
                      * The kernel must be called for all grid values that need an update.
                      *
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      * @tparam T_UpdateFunctor update functor type
                      *
                      * @param acc alpaka accelerator
@@ -441,21 +440,21 @@ namespace picongpu
                      * @param beginGridIdx begin active grid index, in the local domain with guards
                      * @param endGridIdx end active grid index, in the local domain with guards
                      */
-                    template<typename T_Acc, typename T_UpdateFunctor>
+                    template<typename T_Worker, typename T_UpdateFunctor>
                     HDINLINE void operator()(
-                        T_Acc& acc,
+                        T_Worker const& worker,
                         T_UpdateFunctor const functor,
                         DataSpace<simDim> beginGridIdx,
                         DataSpace<simDim> endGridIdx) const
                     {
                         constexpr uint32_t planeSize = pmacc::math::CT::volume<T_BlockDescription>::type::value;
-                        const uint32_t workerIdx = cupla::threadIdx(acc).x;
+
 
                         // Offset of the superCell (in cells, without any guards) to the origin of the local domain
                         DataSpace<simDim> supercellOffsetCells
-                            = DataSpace<simDim>(cupla::blockIdx(acc)) * SuperCellSize::toRT();
+                            = DataSpace<simDim>(cupla::blockIdx(worker.getAcc())) * SuperCellSize::toRT();
 
-                        lockstep::makeForEach<planeSize, T_numWorkers>(workerIdx)(
+                        lockstep::makeForEach<planeSize>(worker)(
                             [&](uint32_t const linearIdx)
                             {
                                 auto cellIdxInSuperCell

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
@@ -144,12 +144,12 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -321,19 +321,16 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::ExpRampWithPrepulse<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const& /*worker*/,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::ExpRampWithPrepulse<Unitless>(

--- a/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
@@ -122,7 +122,7 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      *
@@ -155,8 +155,8 @@ namespace picongpu
                      * Wikipedia on Gaussian laser beams
                      * https://en.wikipedia.org/wiki/Gaussian_beam
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -364,19 +364,17 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
+                 * @param worker lockstep worker
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::GaussianBeam<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const&,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::GaussianBeam<Unitless>(

--- a/include/picongpu/fields/laserProfiles/None.hpp
+++ b/include/picongpu/fields/laserProfiles/None.hpp
@@ -60,10 +60,10 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const&)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const&)
                     {
                     }
                 };
@@ -82,12 +82,10 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
-                HDINLINE acc::None<Unitless> operator()(T_Acc const&, DataSpace<simDim> const&, T_WorkerCfg const&)
-                    const
+                template<typename T_Worker>
+                HDINLINE acc::None<Unitless> operator()(T_Worker const&, DataSpace<simDim> const&) const
                 {
                     return acc::None<Unitless>();
                 }

--- a/include/picongpu/fields/laserProfiles/PlaneWave.hpp
+++ b/include/picongpu/fields/laserProfiles/PlaneWave.hpp
@@ -88,12 +88,12 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -194,19 +194,17 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
+                 * @param worker lockstep worker
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::PlaneWave<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const&,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::PlaneWave<Unitless>(

--- a/include/picongpu/fields/laserProfiles/Polynom.hpp
+++ b/include/picongpu/fields/laserProfiles/Polynom.hpp
@@ -87,12 +87,12 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -198,19 +198,17 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
+                 * @param worker lockstep worker
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::Polynom<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const&,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::Polynom<Unitless>(

--- a/include/picongpu/fields/laserProfiles/PulseFromSpectrum.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFromSpectrum.hpp
@@ -198,12 +198,12 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -295,19 +295,17 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg pmacc::mappings::threads::WorkerCfg, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
+                 * @param worker lockstep worker
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::PulseFromSpectrum<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const&,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::PulseFromSpectrum<Unitless>(

--- a/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
@@ -95,12 +95,12 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -268,19 +268,17 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
+                 * @param worker lockstep worker
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::PulseFrontTilt<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const&,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::PulseFrontTilt<Unitless>(

--- a/include/picongpu/fields/laserProfiles/Wavepacket.hpp
+++ b/include/picongpu/fields/laserProfiles/Wavepacket.hpp
@@ -94,12 +94,12 @@ namespace picongpu
 
                     /** device side manipulation for init plane (transversal)
                      *
-                     * @tparam T_Args type of the arguments passed to the user manipulator functor
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param cellIndexInSuperCell ND cell index in current supercell
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const&, DataSpace<simDim> const& cellIndexInSuperCell)
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const&, DataSpace<simDim> const& cellIndexInSuperCell)
                     {
                         // coordinate system to global simulation as origin
                         DataSpace<simDim> const localCell(
@@ -211,19 +211,17 @@ namespace picongpu
 
                 /** create device manipulator functor
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param alpaka accelerator
+                 * @param worker lockstep worker
                  * @param localSupercellOffset (in supercells, without guards) to the
                  *        origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::Wavepacket<Unitless> operator()(
-                    T_Acc const&,
-                    DataSpace<simDim> const& localSupercellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const&,
+                    DataSpace<simDim> const& localSupercellOffset) const
                 {
                     auto const superCellToLocalOriginCellOffset = localSupercellOffset * SuperCellSize::toRT();
                     return acc::Wavepacket<Unitless>(

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -52,10 +52,7 @@ namespace picongpu
      * This functor prepares a source and destination particle box to call
      * a user defined functor which allows to derive new particles out of
      * another species.
-     *
-     * @tparam T_numWorkers number of workers
      */
-    template<uint32_t T_numWorkers>
     struct KernelDeriveParticles
     {
         /** frame-wise derive new particles
@@ -79,9 +76,9 @@ namespace picongpu
             typename T_ManipulateFunctor,
             typename T_SrcFilterFunctor,
             typename T_Mapping,
-            typename T_Acc>
+            typename T_Worker>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_DestParBox destBox,
             T_SrcParBox srcBox,
             T_ManipulateFunctor manipulateFunctor,
@@ -94,19 +91,17 @@ namespace picongpu
             using SrcFramePtr = typename T_SrcParBox::FramePtr;
 
             constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
-            constexpr uint32_t numWorker = T_numWorkers;
 
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
+            PMACC_SMEM(worker, srcFrame, SrcFramePtr);
+            PMACC_SMEM(worker, destFrame, DestFramePtr);
 
-            PMACC_SMEM(acc, srcFrame, SrcFramePtr);
-            PMACC_SMEM(acc, destFrame, DestFramePtr);
-
-            DataSpace<simDim> const superCellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)));
+            DataSpace<simDim> const superCellIdx
+                = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())));
 
             // offset of the superCell (in cells, without any guards) to the origin of the local domain
             DataSpace<simDim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             onlyMaster(
                 [&]()
@@ -115,20 +110,20 @@ namespace picongpu
                     if(srcFrame.isValid())
                     {
                         // we have something to clone
-                        destFrame = destBox.getEmptyFrame(acc);
+                        destFrame = destBox.getEmptyFrame(worker);
                     }
                 });
 
-            auto accManipulator = manipulateFunctor(acc, localSuperCellOffset, lockstep::Worker<numWorker>{workerIdx});
-            auto accSrcFilter = srcFilterFunctor(acc, localSuperCellOffset, lockstep::Worker<numWorker>{workerIdx});
+            auto accManipulator = manipulateFunctor(worker, localSuperCellOffset);
+            auto accSrcFilter = srcFilterFunctor(worker, localSuperCellOffset);
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             // move over all Frames
             while(srcFrame.isValid())
             {
                 // loop over all particles in the frame
-                lockstep::makeForEach<frameSize, numWorker>(workerIdx)(
+                lockstep::makeForEach<frameSize>(worker)(
                     [&](uint32_t const linearIdx)
                     {
                         auto parDest = destFrame[linearIdx];
@@ -136,28 +131,28 @@ namespace picongpu
                         if(parSrc[multiMask_] != 1)
                             parSrc.setHandleInvalid();
 
-                        if(accSrcFilter(acc, parSrc))
+                        if(accSrcFilter(worker, parSrc))
                         {
                             assign(parDest, deselect<particleId>(parSrc));
 
-                            accManipulator(acc, parDest, parSrc);
+                            accManipulator(worker, parDest, parSrc);
                         }
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 onlyMaster(
                     [&]()
                     {
-                        destBox.setAsLastFrame(acc, destFrame, superCellIdx);
+                        destBox.setAsLastFrame(worker, destFrame, superCellIdx);
 
                         srcFrame = srcBox.getNextFrame(srcFrame);
                         if(srcFrame.isValid())
                         {
-                            destFrame = destBox.getEmptyFrame(acc);
+                            destFrame = destBox.getEmptyFrame(worker);
                         }
                     });
-                cupla::__syncthreads(acc);
+                worker.sync();
             }
         }
     };
@@ -169,11 +164,10 @@ namespace picongpu
      * special flag `hasLeavingParticle` of the supercell to optimize the kernel shift particles
      * in pmacc.
      *
-     * @tparam T_numWorkers number of workers
      * @tparam T_DataDomain pmacc::SuperCellDescription, compile time data domain
      *                      description with a CORE and GUARD
      */
-    template<uint32_t T_numWorkers, typename T_DataDomain>
+    template<typename T_DataDomain>
     struct KernelMoveAndMarkParticles
     {
         /** update all particles
@@ -183,9 +177,9 @@ namespace picongpu
          * @tparam T_BBox pmacc::DataBox, magnetic field box type
          * @tparam T_ParticleFunctor particle functor type
          * @tparam T_Mapping mapper functor type
-         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          *
-         * @param alpaka accelerator
+         * @param worker lockstep worker
          * @param pb particle memory
          * @param fieldE electric field data
          * @param fieldB magnetic field data
@@ -198,9 +192,9 @@ namespace picongpu
             typename T_BBox,
             typename T_ParticleFunctor,
             typename T_Mapping,
-            typename T_Acc>
+            typename T_Worker>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_ParBox pb,
             T_EBox fieldE,
             T_BBox fieldB,
@@ -208,10 +202,8 @@ namespace picongpu
             T_ParticleFunctor particleFunctor,
             T_Mapping mapper) const
         {
-            constexpr uint32_t numWorkers = T_numWorkers;
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const superCellIdx(
+                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
             // relative offset (in cells) to the supercell (including the guard)
             DataSpace<simDim> const superCellOffset = superCellIdx * SuperCellSize::toRT();
@@ -220,54 +212,53 @@ namespace picongpu
              * 1 if at least one particle is leaving the supercell else 0
              */
             int hasLeavingParticle = 0;
+
             /* shared memory status flag that a particle is leaving the supercell
              * 1 if at least one particle is leaving the supercell else 0
              */
-            PMACC_SMEM(acc, mustShiftSupercell, int);
+            PMACC_SMEM(worker, mustShiftSupercell, int);
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             onlyMaster([&]() { mustShiftSupercell = 0; });
 
-            auto cachedB = CachedBox::create<0, typename T_BBox::ValueType>(acc, T_DataDomain());
-            auto cachedE = CachedBox::create<1, typename T_EBox::ValueType>(acc, T_DataDomain());
+            auto cachedB = CachedBox::create<0, typename T_BBox::ValueType>(worker, T_DataDomain());
+            auto cachedE = CachedBox::create<1, typename T_EBox::ValueType>(worker, T_DataDomain());
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
-            auto forEachParticle
-                = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, pb, superCellIdx);
+            auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach(worker, pb, superCellIdx);
 
             // end kernel if we have no particles
             if(!forEachParticle.hasParticles())
                 return;
 
             pmacc::math::operation::Assign assign;
-            ThreadCollective<T_DataDomain, numWorkers> collective{workerIdx};
+            auto collective = makeThreadCollective<T_DataDomain>();
 
             auto fieldBBlock = fieldB.shift(superCellOffset);
-            collective(acc, assign, cachedB, fieldBBlock);
+            collective(worker, assign, cachedB, fieldBBlock);
 
             auto fieldEBlock = fieldE.shift(superCellOffset);
-            collective(acc, assign, cachedE, fieldEBlock);
+            collective(worker, assign, cachedE, fieldEBlock);
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             forEachParticle(
-                acc,
                 [&cachedB, &cachedE, currentStep, &hasLeavingParticle, &particleFunctor](
-                    auto const& accelerator,
+                    auto const& lockstepWorker,
                     auto& particle)
-                { particleFunctor(accelerator, particle, cachedB, cachedE, currentStep, hasLeavingParticle); });
+                { particleFunctor(lockstepWorker, particle, cachedB, cachedE, currentStep, hasLeavingParticle); });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             // update shared memory marker that particles leaving the supercell
             if(hasLeavingParticle == 1 && mustShiftSupercell == 0)
             {
-                kernel::atomicAllExch(acc, &mustShiftSupercell, 1, ::alpaka::hierarchy::Threads{});
+                kernel::atomicAllExch(worker, &mustShiftSupercell, 1, ::alpaka::hierarchy::Threads{});
             }
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             onlyMaster(
                 [&]()
@@ -277,7 +268,7 @@ namespace picongpu
                      */
                     if(mustShiftSupercell == 1)
                     {
-                        pb.getSuperCell(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))))
+                        pb.getSuperCell(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))))
                             .setMustShift(true);
                     }
                 });
@@ -287,9 +278,9 @@ namespace picongpu
     template<class PushAlgo, class TVec, class T_Field2ParticleInterpolation>
     struct PushParticlePerFrame
     {
-        template<typename T_Acc, typename T_Particle, class BoxB, class BoxE>
+        template<typename T_Worker, typename T_Particle, class BoxB, class BoxE>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_Particle& particle,
             BoxB& bBox,
             BoxE& eBox,

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -63,10 +63,9 @@ namespace picongpu
 
     /** fill supercell grid with particles
      *
-     * @tparam T_numWorkers number of workers
      * @tparam T_Species picongpu::Particles, species type which is initialized
      */
-    template<uint32_t T_numWorkers, typename T_Species>
+    template<typename T_Species>
     struct KernelFillGridWithParticles
     {
         /** fill supercell grid with particles
@@ -75,9 +74,9 @@ namespace picongpu
          * @tparam T_PositionFunctor startPosition::IFunctor, position functor type
          * @tparam T_ParBox pmacc::ParticlesBox, particle box type
          * @tparam T_Mapping supercell mapper functor type
-         * @tparam T_ACC alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          *
-         * @param alpaka accelerator
+         * @param worker lockstep worker
          * @param densityFunctor functor for the density profile
          * @param positionFunctor functor to calculate the in cell position and the number of
          *                        macro particles per cell
@@ -92,9 +91,9 @@ namespace picongpu
             typename T_PositionFunctor,
             typename T_ParBox,
             typename T_Mapping,
-            typename T_Acc>
+            typename T_Worker>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_DensityProfile densityFunctor,
             T_PositionFunctor positionFunctor,
             DataSpace<simDim> const totalGpuCellOffset,
@@ -103,35 +102,33 @@ namespace picongpu
         {
             constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
             PMACC_CONSTEXPR_CAPTURE uint32_t cellsPerSupercell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
-
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             using FramePtr = typename T_ParBox::FramePtr;
             using FrameType = typename T_ParBox::FrameType;
             using ParticleType = typename FrameType::ParticleType;
             DataSpace<simDim> const superCells(mapper.getGridSuperCells());
 
-            PMACC_SMEM(acc, frame, FramePtr);
-            PMACC_SMEM(acc, finished, int);
+            PMACC_SMEM(worker, frame, FramePtr);
+            PMACC_SMEM(worker, finished, int);
 
-            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const superCellIdx(
+                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
             /* offset of the superCell relative to the local domain [in supercells] (without guarding supercells) */
             DataSpace<simDim> const localSuperCellOffset(superCellIdx - mapper.getGuardingSuperCells());
 
-            auto forEachCellInSuperCell = lockstep::makeForEach<cellsPerSupercell, numWorkers>(workerIdx);
+            auto forEachCellInSuperCell = lockstep::makeForEach<cellsPerSupercell>(worker);
 
-            auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+            auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
             /* number of particles to create for each cell (virtual worker) */
             auto numParsPerCellCtx = lockstep::makeVar<uint32_t>(forEachCellInSuperCell, 0u);
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             /* reset shared memory flag if a virtual worker needs to create a particle */
             onlyMaster([&]() { finished = 1; });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             // initialize the position functor for each cell in the supercell
             auto positionFunctorCtx = forEachCellInSuperCell(
@@ -151,8 +148,7 @@ namespace picongpu
                     volatile float_X const realParticlesPerCell = realDensity * CELL_VOLUME;
 
                     // create an independent position functor for each cell in the supercell
-                    auto posFunctor
-                        = positionFunctor(acc, localSuperCellOffset, forEachCellInSuperCell.getWorkerCfg());
+                    auto posFunctor = positionFunctor(forEachCellInSuperCell.getWorker(), localSuperCellOffset);
 
                     if(realParticlesPerCell > 0.0_X)
                         numParsPerCellCtx[idx]
@@ -160,7 +156,7 @@ namespace picongpu
 
                     if(numParsPerCellCtx[idx] > 0)
                         kernel::atomicAllExch(
-                            acc,
+                            worker,
                             &finished,
                             0,
                             ::alpaka::hierarchy::Threads{}); // one or more cells have particles to create
@@ -168,7 +164,7 @@ namespace picongpu
                     return posFunctor;
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             if(finished == 1)
                 return; // if there is no particle which has to be created
@@ -176,19 +172,19 @@ namespace picongpu
             onlyMaster(
                 [&]()
                 {
-                    frame = pb.getEmptyFrame(acc);
-                    pb.setAsLastFrame(acc, frame, superCellIdx);
+                    frame = pb.getEmptyFrame(worker);
+                    pb.setAsLastFrame(worker, frame, superCellIdx);
                 });
 
             // distribute the particles within the cell
             do
             {
                 // wait that master updates the current used frame
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 onlyMaster([&]() { finished = 1; });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 forEachParticle(
                     [&](lockstep::Idx const idx)
@@ -214,27 +210,27 @@ namespace picongpu
                             particle[multiMask_] = 1;
                             particle[localCellIdx_] = idx;
                             // initialize position and weighting
-                            positionFunctorCtx[idx](acc, particle);
+                            positionFunctorCtx[idx](worker, particle);
 
                             numParsPerCellCtx[idx]--;
                             if(numParsPerCellCtx[idx] > 0)
                                 kernel::atomicAllExch(
-                                    acc,
+                                    worker,
                                     &finished,
                                     0,
                                     ::alpaka::hierarchy::Threads{}); // one or more cells have particles to create
                         }
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 onlyMaster(
                     [&]()
                     {
                         if(finished == 0)
                         {
-                            frame = pb.getEmptyFrame(acc);
-                            pb.setAsLastFrame(acc, frame, superCellIdx);
+                            frame = pb.getEmptyFrame(worker);
+                            pb.setAsLastFrame(worker, frame, superCellIdx);
                         }
                     });
             } while(finished == 0);

--- a/include/picongpu/particles/atomicPhysics/AtomicPhysics.kernel
+++ b/include/picongpu/particles/atomicPhysics/AtomicPhysics.kernel
@@ -47,7 +47,6 @@
  *
  * This kernel is called once for every super cell, for every PIC time step.
  *
- * @tparam T_numWorkers ... number of workers used for histogram filling
  * @tparam T_maxNumBins ... maximum number of Bins of the histogram
  */
 
@@ -57,7 +56,7 @@ namespace picongpu
     {
         namespace atomicPhysics
         {
-            template<uint32_t T_numWorkers, uint16_t T_maxNumBins>
+            template<uint16_t T_maxNumBins>
             struct AtomicPhysicsKernel
             {
                 // note: maybe rename variables later
@@ -74,13 +73,13 @@ namespace picongpu
 
                 // template parameters are automatically deduced from input
                 template<
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_ElectronBox,
                     typename T_IonBox,
                     typename T_Mapping,
                     typename T_AtomicDataBox>
                 HDINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ElectronBox electronBox,
                     T_IonBox ionBox,
                     T_Mapping mapper,
@@ -89,10 +88,6 @@ namespace picongpu
                     float_X const relativeErrorTarget, // unit: 1/s /( 1/( m^3 * ATOMIC_UNIT_ENERGY ) )
                     uint32_t const step) const
                 {
-                    // we assume 1d thread indices
-                    // thread index inside a block
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
                     // Create and initialize a histogram on shared memory
                     constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
@@ -116,25 +111,26 @@ namespace picongpu
                     // get new histogram
                     // Histogram histogram;
                     PMACC_SMEM(
-                        acc, // mandatory first parameter
+                        worker, // mandatory first parameter
                         histogram, // variable name
                         Histogram // variable type
                     );
 
                     // init histogram and relative error
-                    if(workerIdx == 0)
-                    {
-                        // pass through parameters of histogram
-                        histogram.init(relativeErrorTarget, initialGridWidth);
-                    }
-                    cupla::__syncthreads(acc);
+                    lockstep::makeMaster(worker)(
+                        [&]()
+                        {
+                            // pass through parameters of histogram
+                            histogram.init(relativeErrorTarget, initialGridWidth);
+                        });
+                    worker.sync();
                     // necessary since all access relativeError and histogram, but both are only valid after init
 
-                    fillHistogram<T_numWorkers>(acc, electronBox, mapper, &histogram, atomicDataBox);
-                    cupla::__syncthreads(acc);
+                    fillHistogram(worker, electronBox, mapper, &histogram, atomicDataBox);
+                    worker.sync();
 
-                    solveRateEquation<T_numWorkers, AtomicRate>(
-                        acc,
+                    solveRateEquation<AtomicRate>(
+                        worker,
                         mapper,
                         rngFactoryInt,
                         rngFactoryFloat,
@@ -142,11 +138,11 @@ namespace picongpu
                         atomicDataBox,
                         &histogram);
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
-                    decelerateElectrons<T_numWorkers>(acc, mapper, electronBox, histogram, atomicDataBox);
+                    decelerateElectrons(worker, mapper, electronBox, histogram, atomicDataBox);
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
                 }
             };
 

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/histogram/Histogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/histogram/Histogram.hpp
@@ -136,8 +136,8 @@ namespace picongpu
                         }
 
                         // add for Argument x, weight to the bin
-                        template<typename T_Acc>
-                        DINLINE void binObject(T_Acc const& acc, float_X const x, float_X const weight)
+                        template<typename T_Worker>
+                        DINLINE void binObject(T_Worker const& worker, float_X const x, float_X const weight)
                         {
                             // compute global bin index
                             uint32_t const binIndex = this->getBinIndex(x);

--- a/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
+++ b/include/picongpu/particles/bremsstrahlung/Bremsstrahlung.hpp
@@ -118,29 +118,23 @@ namespace picongpu
                  * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is
                  * necessary after initializing the ion density field in shared memory.
                  */
-                template<typename T_Acc>
+                template<typename T_Worker>
                 DINLINE void init(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const DataSpace<simDim>& blockCell,
-                    const int& linearThreadIdx,
                     const DataSpace<simDim>& localCellOffset);
 
                 /** cache fields used by this functor
                  *
                  * @warning this is a collective method and calls synchronize
                  *
-                 * @tparam T_Acc alpaka accelerator type
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param acc alpaka accelerator
+                 * @param worker lockstep worker
                  * @param blockCell relative offset (in cells) to the local domain plus the guarding cells
-                 * @param workerCfg configuration of the worker
                  */
-                template<typename T_Acc, typename T_WorkerCfg>
-                DINLINE void collectiveInit(
-                    const T_Acc& acc,
-                    const DataSpace<simDim>& blockCell,
-                    const T_WorkerCfg& workerCfg);
+                template<typename T_Worker>
+                DINLINE void collectiveInit(const T_Worker& worker, const DataSpace<simDim>& blockCell);
 
                 /** Rotates a vector to a given polar angle and a random azimuthal angle.
                  *
@@ -148,8 +142,8 @@ namespace picongpu
                  * @param theta polar angle
                  * @return rotated vector
                  */
-                template<typename T_Acc>
-                DINLINE float3_X scatterByTheta(const T_Acc& acc, const float3_X vec, const float_X theta);
+                template<typename T_Worker>
+                DINLINE float3_X scatterByTheta(const T_Worker& worker, const float3_X vec, const float_X theta);
 
                 /** Return the number of target particles to be created from each source particle.
                  *
@@ -159,8 +153,8 @@ namespace picongpu
                  * @param localIdx Index of the source particle within frame
                  * @return number of particle to be created from each source particle
                  */
-                template<typename T_Acc>
-                DINLINE unsigned int numNewParticles(const T_Acc& acc, FrameType& sourceFrame, int localIdx);
+                template<typename T_Worker>
+                DINLINE unsigned int numNewParticles(const T_Worker& worker, FrameType& sourceFrame, int localIdx);
 
                 /** Functor implementation.
                  *
@@ -169,8 +163,8 @@ namespace picongpu
                  * @tparam Electron type of electron which creates the photon
                  * @tparam Photon type of photon that is created
                  */
-                template<typename Electron, typename Photon, typename T_Acc>
-                DINLINE void operator()(const T_Acc& acc, Electron& electron, Photon& photon);
+                template<typename Electron, typename Photon, typename T_Worker>
+                DINLINE void operator()(const T_Worker& worker, Electron& electron, Photon& photon);
             };
 
         } // namespace bremsstrahlung

--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -42,7 +42,7 @@ namespace picongpu
     {
         namespace collision
         {
-            template<uint32_t T_numWorkers, bool useScreeningLength>
+            template<bool useScreeningLength>
             struct InterCollision
             {
                 HINLINE InterCollision()
@@ -97,7 +97,7 @@ namespace picongpu
                     typename T_ParBox0,
                     typename T_ParBox1,
                     typename T_Mapping,
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_DeviceHeapHandle,
                     typename T_RngHandle,
                     typename T_CollisionFunctor,
@@ -107,7 +107,7 @@ namespace picongpu
                     typename T_SumSParamBox,
                     typename T_TimesCollidedBox>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ParBox0 pb0,
                     T_ParBox1 pb1,
                     T_Mapping const mapper,
@@ -124,39 +124,34 @@ namespace picongpu
 
                     using SuperCellSize = typename T_ParBox0::FrameType::SuperCellSize;
                     constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    constexpr uint32_t numWorkers = T_numWorkers;
 
                     using FramePtr0 = typename T_ParBox0::FramePtr;
                     using FramePtr1 = typename T_ParBox1::FramePtr;
 
-                    PMACC_SMEM(acc, nppc, memory::Array<uint32_t, frameSize>);
+                    PMACC_SMEM(worker, nppc, memory::Array<uint32_t, frameSize>);
 
-                    PMACC_SMEM(acc, parCellList0, memory::Array<detail::ListEntry, frameSize>);
-                    PMACC_SMEM(acc, parCellList1, memory::Array<detail::ListEntry, frameSize>);
-                    PMACC_SMEM(acc, densityArray0, memory::Array<float_X, frameSize>);
-                    PMACC_SMEM(acc, densityArray1, memory::Array<float_X, frameSize>);
-
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
-                    auto onlyMaster = lockstep::makeMaster(workerIdx);
+                    PMACC_SMEM(worker, parCellList0, memory::Array<detail::ListEntry, frameSize>);
+                    PMACC_SMEM(worker, parCellList1, memory::Array<detail::ListEntry, frameSize>);
+                    PMACC_SMEM(worker, densityArray0, memory::Array<float_X, frameSize>);
+                    PMACC_SMEM(worker, densityArray1, memory::Array<float_X, frameSize>);
 
                     constexpr bool ifAverageLog = !std::is_same<T_SumCoulombLogBox, std::nullptr_t>::value;
                     constexpr bool ifAverageSParam = !std::is_same<T_SumSParamBox, std::nullptr_t>::value;
                     constexpr bool ifTimesCollided = !std::is_same<T_TimesCollidedBox, std::nullptr_t>::value;
                     constexpr bool ifDebug = ifAverageLog && ifAverageSParam && ifTimesCollided;
 
-
                     DataSpace<simDim> const superCellIdx
-                        = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)));
+                        = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())));
 
                     // offset of the superCell (in cells, without any guards) to the
                     // origin of the local domain
                     DataSpace<simDim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();
                     rngHandle.init(
                         localSuperCellOffset * SuperCellSize::toRT()
-                        + DataSpaceOperations<simDim>::template map<SuperCellSize>(workerIdx));
+                        + DataSpaceOperations<simDim>::template map<SuperCellSize>(worker.getWorkerIdx()));
 
-                    auto accFilter0 = filter0(acc, localSuperCellOffset, lockstep::Worker<T_numWorkers>{workerIdx});
-                    auto accFilter1 = filter1(acc, localSuperCellOffset, lockstep::Worker<T_numWorkers>{workerIdx});
+                    auto accFilter0 = filter0(worker, localSuperCellOffset);
+                    auto accFilter1 = filter1(worker, localSuperCellOffset);
 
                     auto& superCell0 = pb0.getSuperCell(superCellIdx);
                     uint32_t numParticlesInSupercell0 = superCell0.getNumParticles();
@@ -165,11 +160,11 @@ namespace picongpu
                     uint32_t numParticlesInSupercell1 = superCell1.getNumParticles();
 
                     /* loop over all particles in the frame */
-                    auto forEachFrameElem = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+                    auto forEachFrameElem = lockstep::makeForEach<frameSize>(worker);
 
                     FramePtr0 firstFrame0 = pb0.getFirstFrame(superCellIdx);
                     prepareList(
-                        acc,
+                        worker,
                         forEachFrameElem,
                         deviceHeapHandle,
                         pb0,
@@ -181,7 +176,7 @@ namespace picongpu
 
                     FramePtr1 firstFrame1 = pb1.getFirstFrame(superCellIdx);
                     prepareList(
-                        acc,
+                        worker,
                         forEachFrameElem,
                         deviceHeapHandle,
                         pb1,
@@ -191,9 +186,9 @@ namespace picongpu
                         nppc,
                         accFilter1);
 
-                    cellDensity(acc, forEachFrameElem, firstFrame0, pb0, parCellList0, densityArray0, accFilter0);
-                    cellDensity(acc, forEachFrameElem, firstFrame1, pb1, parCellList1, densityArray1, accFilter1);
-                    cupla::__syncthreads(acc);
+                    cellDensity(worker, forEachFrameElem, firstFrame0, pb0, parCellList0, densityArray0, accFilter0);
+                    cellDensity(worker, forEachFrameElem, firstFrame1, pb1, parCellList1, densityArray1, accFilter1);
+                    worker.sync();
 
                     // shuffle indices list of the longest particle list
                     forEachFrameElem(
@@ -203,16 +198,12 @@ namespace picongpu
                             auto* longParList = parCellList0[linearIdx].size >= parCellList1[linearIdx].size
                                 ? &parCellList0[linearIdx]
                                 : &parCellList1[linearIdx];
-                            (*longParList).shuffle(acc, rngHandle);
+                            (*longParList).shuffle(worker, rngHandle);
                         });
 
                     auto collisionFunctorCtx = lockstep::makeVar<decltype(collisionFunctor(
-                        acc,
+                        worker,
                         alpaka::core::declval<DataSpace<simDim> const>(),
-                        /* frameSize is used because each virtual worker
-                         * is creating **exactly one** functor
-                         */
-                        alpaka::core::declval<lockstep::Worker<frameSize> const>(),
                         alpaka::core::declval<float_X const>(),
                         alpaka::core::declval<float_X const>(),
                         alpaka::core::declval<uint32_t const>()))>(forEachFrameElem);
@@ -224,12 +215,11 @@ namespace picongpu
                             if(parCellList0[linearIdx].size >= parCellList1[linearIdx].size)
                             {
                                 inCellCollisions(
-                                    acc,
+                                    worker,
                                     rngHandle,
                                     collisionFunctor,
                                     localSuperCellOffset,
                                     superCellIdx,
-                                    workerIdx,
                                     densityArray0[linearIdx],
                                     densityArray1[linearIdx],
                                     parCellList0[linearIdx].ptrToIndicies,
@@ -246,12 +236,11 @@ namespace picongpu
                             else
                             {
                                 inCellCollisions(
-                                    acc,
+                                    worker,
                                     rngHandle,
                                     collisionFunctor,
                                     localSuperCellOffset,
                                     superCellIdx,
-                                    workerIdx,
                                     densityArray1[linearIdx],
                                     densityArray0[linearIdx],
                                     parCellList1[linearIdx].ptrToIndicies,
@@ -267,20 +256,22 @@ namespace picongpu
                             }
                         });
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     forEachFrameElem(
                         [&](uint32_t const linearIdx)
                         {
-                            parCellList0[linearIdx].finalize(acc, deviceHeapHandle);
-                            parCellList1[linearIdx].finalize(acc, deviceHeapHandle);
+                            parCellList0[linearIdx].finalize(worker, deviceHeapHandle);
+                            parCellList1[linearIdx].finalize(worker, deviceHeapHandle);
                         });
 
                     if constexpr(ifDebug)
                     {
-                        PMACC_SMEM(acc, sumCoulombLogBlock, float_X);
-                        PMACC_SMEM(acc, sumSParamBlock, float_X);
-                        PMACC_SMEM(acc, timesCollidedBlock, uint64_t);
+                        auto onlyMaster = lockstep::makeMaster(worker);
+
+                        PMACC_SMEM(worker, sumCoulombLogBlock, float_X);
+                        PMACC_SMEM(worker, sumSParamBlock, float_X);
+                        PMACC_SMEM(worker, timesCollidedBlock, uint64_t);
                         onlyMaster(
                             [&]()
                             {
@@ -288,7 +279,7 @@ namespace picongpu
                                 sumSParamBlock = 0.0_X;
                                 timesCollidedBlock = 0.0_X;
                             });
-                        cupla::__syncthreads(acc);
+                        worker.sync();
                         forEachFrameElem(
                             [&](lockstep::Idx const idx)
                             {
@@ -296,40 +287,40 @@ namespace picongpu
                                 if(timesUsed > 0u)
                                 {
                                     cupla::atomicAdd(
-                                        acc,
+                                        worker.getAcc(),
                                         &sumCoulombLogBlock,
                                         static_cast<float_X>(collisionFunctorCtx[idx].sumCoulombLog),
                                         ::alpaka::hierarchy::Threads{});
                                     cupla::atomicAdd(
-                                        acc,
+                                        worker.getAcc(),
                                         &sumSParamBlock,
                                         static_cast<float_X>(collisionFunctorCtx[idx].sumSParam),
                                         ::alpaka::hierarchy::Threads{});
                                     cupla::atomicAdd(
-                                        acc,
+                                        worker.getAcc(),
                                         &timesCollidedBlock,
                                         timesUsed,
                                         ::alpaka::hierarchy::Threads{});
                                 }
                             });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         onlyMaster(
                             [&]()
                             {
                                 cupla::atomicAdd(
-                                    acc,
+                                    worker.getAcc(),
                                     &(sumCoulombLogBox[0]),
                                     sumCoulombLogBlock,
                                     ::alpaka::hierarchy::Blocks{});
                                 cupla::atomicAdd(
-                                    acc,
+                                    worker.getAcc(),
                                     &(sumSParamBox[0]),
                                     sumSParamBlock,
                                     ::alpaka::hierarchy::Blocks{});
                                 cupla::atomicAdd(
-                                    acc,
+                                    worker.getAcc(),
                                     &(timesCollidedBox[0]),
                                     timesCollidedBlock,
                                     ::alpaka::hierarchy::Blocks{});
@@ -339,7 +330,7 @@ namespace picongpu
 
 
                 template<
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_RngHandle,
                     typename T_CollisionFunctor,
                     typename T_ListLong,
@@ -352,12 +343,11 @@ namespace picongpu
                     typename T_FrameShort,
                     typename T_CollisionFunctorCtx>
                 DINLINE void inCellCollisions(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_RngHandle& rngHandle,
                     T_CollisionFunctor const& collisionFunctor,
                     DataSpace<simDim> const& localSuperCellOffset,
                     DataSpace<simDim> const& superCellIdx,
-                    uint32_t const& workerIdx,
                     float_X const& densityLong,
                     float_X const& densityShort,
                     T_ListLong& listLong,
@@ -373,13 +363,8 @@ namespace picongpu
 
                 ) const
                 {
-                    collisionFunctorCtx[idx] = collisionFunctor(
-                        acc,
-                        localSuperCellOffset,
-                        lockstep::Worker<T_numWorkers>{workerIdx},
-                        densityLong,
-                        densityShort,
-                        sizeLong);
+                    collisionFunctorCtx[idx]
+                        = collisionFunctor(worker, localSuperCellOffset, densityLong, densityShort, sizeLong);
 
 
                     if constexpr(useScreeningLength)
@@ -397,7 +382,7 @@ namespace picongpu
                         auto parLong = detail::getParticle(pBoxLong, frameLong, listLong[i]);
                         auto parShort = detail::getParticle(pBoxShort, frameShort, listShort[i % sizeShort]);
                         collisionFunctorCtx[idx].duplicationCorrection = duplicationCorrection(i, sizeShort, sizeLong);
-                        (collisionFunctorCtx[idx])(detail::makeCollisionContext(acc, rngHandle), parLong, parShort);
+                        (collisionFunctorCtx[idx])(detail::makeCollisionContext(worker, rngHandle), parLong, parShort);
                     }
                 }
             };
@@ -445,12 +430,10 @@ namespace picongpu
                     // Use mapping information from the first species:
                     auto const mapper = makeAreaMapper<CORE + BORDER>(species0->getCellDescription());
 
-                    constexpr uint32_t numWorkers
-                        = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
-
                     //! random number generator
                     using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
-                    using Kernel = typename CollisionFunctor::template CallingInterKernel<numWorkers>;
+                    using Kernel = typename CollisionFunctor::CallingInterKernel;
+                    auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
 
                     constexpr bool ifDebug = CollisionFunctor::ifDebug_m;
                     if constexpr(ifDebug)
@@ -461,9 +444,8 @@ namespace picongpu
                         sumSParam.getDeviceBuffer().setValue(0.0_X);
                         GridBuffer<uint64_t, DIM1> timesCollided(DataSpace<DIM1>(1));
                         timesCollided.getDeviceBuffer().setValue(0u);
-
-                        PMACC_KERNEL(Kernel{})
-                        (mapper.getGridDim(), numWorkers)(
+                        PMACC_LOCKSTEP_KERNEL(Kernel{}, workerCfg)
+                        (mapper.getGridDim())(
                             species0->getDeviceParticlesBox(),
                             species1->getDeviceParticlesBox(),
                             mapper,
@@ -518,8 +500,8 @@ namespace picongpu
                     }
                     else
                     {
-                        PMACC_KERNEL(Kernel{})
-                        (mapper.getGridDim(), numWorkers)(
+                        PMACC_LOCKSTEP_KERNEL(Kernel{}, workerCfg)
+                        (mapper.getGridDim())(
                             species0->getDeviceParticlesBox(),
                             species1->getDeviceParticlesBox(),
                             mapper,

--- a/include/picongpu/particles/collision/detail/CollisionContext.hpp
+++ b/include/picongpu/particles/collision/detail/CollisionContext.hpp
@@ -29,21 +29,23 @@ namespace picongpu
         {
             namespace detail
             {
-                template<typename T_Acc, typename T_RngHandle>
+                template<typename T_Worker, typename T_RngHandle>
                 struct CollisionContext
                 {
-                    T_Acc const* m_acc;
+                    T_Worker const* m_worker;
                     mutable T_RngHandle* m_hRng;
 
-                    DINLINE CollisionContext(T_Acc const& acc, T_RngHandle& hRng) : m_acc(&acc), m_hRng(&hRng)
+                    DINLINE CollisionContext(T_Worker const& worker, T_RngHandle& hRng)
+                        : m_worker(&worker)
+                        , m_hRng(&hRng)
                     {
                     }
                 };
 
-                template<typename T_Acc, typename T_RngHandle>
-                DINLINE CollisionContext<T_Acc, T_RngHandle> makeCollisionContext(T_Acc const& acc, T_RngHandle& hRng)
+                template<typename T_Worker, typename T_RngHandle>
+                DINLINE auto makeCollisionContext(T_Worker const& worker, T_RngHandle& hRng)
                 {
-                    return CollisionContext<T_Acc, T_RngHandle>(acc, hRng);
+                    return CollisionContext<T_Worker, T_RngHandle>(worker, hRng);
                 }
 
             } // namespace detail

--- a/include/picongpu/particles/collision/detail/cellDensity.hpp
+++ b/include/picongpu/particles/collision/detail/cellDensity.hpp
@@ -32,7 +32,7 @@ namespace picongpu
             namespace detail
             {
                 template<
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_ForEach,
                     typename T_FramePtr,
                     typename T_ParBox,
@@ -40,7 +40,7 @@ namespace picongpu
                     typename T_Array,
                     typename T_Filter>
                 DINLINE void cellDensity(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ForEach forEach,
                     T_FramePtr firstFrame,
                     T_ParBox parBox,
@@ -57,7 +57,7 @@ namespace picongpu
                             for(uint32_t ii = 0; ii < numParInCell; ii++)
                             {
                                 auto particle = getParticle(parBox, firstFrame, parListStart[ii]);
-                                if(filter(acc, particle))
+                                if(filter(worker, particle))
                                 {
                                     density += particle[weighting_];
                                 }

--- a/include/picongpu/particles/collision/kernels.def
+++ b/include/picongpu/particles/collision/kernels.def
@@ -24,9 +24,9 @@ namespace picongpu
     {
         namespace collision
         {
-            template<uint32_t T_numWorkers, bool screeningLength>
+            template<bool screeningLength>
             struct InterCollision;
-            template<uint32_t T_numWorkers, bool screeningLength>
+            template<bool screeningLength>
             struct IntraCollision;
         } // namespace collision
     } // namespace particles

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollision.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollision.hpp
@@ -397,15 +397,15 @@ namespace picongpu
                             float_COLL const& s12) const
                         {
                             // Get a random float value from 0,1
-                            auto const& acc = *ctx.m_acc;
+                            auto const& worker = *ctx.m_worker;
                             auto& rngHandle = *ctx.m_hRng;
                             using UniformFloat = pmacc::random::distributions::Uniform<
                                 pmacc::random::distributions::uniform::ExcludeZero<float_COLL>>;
                             auto rng = rngHandle.template applyDistribution<UniformFloat>();
-                            float_COLL rngValue = rng(acc);
+                            float_COLL rngValue = rng(worker);
 
                             float_COLL const cosXi = calcCosXi(s12, rngValue);
-                            float_COLL const phi = 2.0_COLL * PI * rng(acc);
+                            float_COLL const phi = 2.0_COLL * PI * rng(worker);
                             float3_COLL const finalComs0 = calcFinalComsMomentum(v.comsMomentum0, cosXi, phi);
 
                             float3_COLL finalLab0, finalLab1;
@@ -421,7 +421,7 @@ namespace picongpu
 
 
                                 par1[momentum_] = precisionCast<float_X>(finalLab1 * v.normalizedWeight1);
-                                if((v.normalizedWeight1 / v.normalizedWeight0) - rng(acc) > 0)
+                                if((v.normalizedWeight1 / v.normalizedWeight0) - rng(worker) > 0)
                                 {
                                     finalLab0 = comsToLab(
                                         finalComs0,
@@ -438,7 +438,7 @@ namespace picongpu
                                 finalLab0
                                     = comsToLab(finalComs0, v.mass0, v.coeff0, v.gammaComs, v.factorA, v.comsVelocity);
                                 par0[momentum_] = precisionCast<float_X>(finalLab0 * v.normalizedWeight0);
-                                if((v.normalizedWeight0 / v.normalizedWeight1) - rng(acc) >= 0.0_COLL)
+                                if((v.normalizedWeight0 / v.normalizedWeight1) - rng(worker) >= 0.0_COLL)
                                 {
                                     finalLab1 = comsToLab(
                                         -1.0_COLL * finalComs0,

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollisionConstLog.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollisionConstLog.hpp
@@ -61,27 +61,23 @@ namespace picongpu
                     using AccFunctorImpl = acc::RelativisticCollision<acc::ConstCoulombLog<T_Param>, ifDebug>;
                     using AccFunctor = collision::acc::IBinary<AccFunctorImpl>;
                     // define kernel that should be used to call this functor
-                    template<uint32_t T_numWorkers>
-                    using CallingInterKernel = InterCollision<T_numWorkers, false>;
-                    template<uint32_t T_numWorkers>
-                    using CallingIntraKernel = IntraCollision<T_numWorkers, false>;
+                    using CallingInterKernel = InterCollision<false>;
+                    using CallingIntraKernel = IntraCollision<false>;
 
                     /** create device manipulator functor
                      *
-                     * @param acc alpaka accelerator
+                     * @param worker lockstep worker
                      * @param offset (in supercells, without any guards) to the origin of the local domain
-                     * @param workerCfg configuration of the worker
                      * @param density0 cell density of the 1st species
                      * @param density1 cell density of the 2nd species
                      * @param potentialPartners number of potential collision partners for a macro particle in
                      *   the cell.
                      * @param coulombLog Coulomb logarithm
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE auto operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         DataSpace<simDim> const& offset,
-                        T_WorkerCfg const& workerCfg,
                         float_X const& density0,
                         float_X const& density1,
                         uint32_t const& potentialPartners) const

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
@@ -85,10 +85,8 @@ namespace picongpu
                     };
 
                     // set the kernel to provide the Debye length to the acc functor
-                    template<uint32_t T_numWorkers>
-                    using CallingInterKernel = InterCollision<T_numWorkers, true>;
-                    template<uint32_t T_numWorkers>
-                    using CallingIntraKernel = IntraCollision<T_numWorkers, true>;
+                    using CallingInterKernel = InterCollision<true>;
+                    using CallingIntraKernel = IntraCollision<true>;
 
                     static constexpr bool ifDebug_m = ifDebug;
                     HINLINE RelativisticCollisionDynamicLogImpl(uint32_t currentStep){};
@@ -98,20 +96,18 @@ namespace picongpu
 
                     /** create device manipulator functor
                      *
-                     * @param acc alpaka accelerator
+                     * @param worker lockstep worker
                      * @param offset (in supercells, without any guards) to the origin of the local domain
-                     * @param workerCfg configuration of the worker
                      * @param density0 cell density of the 1st species
                      * @param density1 cell density of the 2nd species
                      * @param potentialPartners number of potential collision partners for a macro particle in
                      *   the cell.
                      * @param coulombLog Coulomb logarithm
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE auto operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         DataSpace<simDim> const& offset,
-                        T_WorkerCfg const& workerCfg,
                         float_X const& density0,
                         float_X const& density1,
                         uint32_t const& potentialPartners) const

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -48,16 +48,11 @@ namespace picongpu
              * - maps the frame dimensions and gathers the particle boxes
              * - contains / calls the Creator
              *
-             * @tparam T_numWorkers number of workers
              * @tparam T_ParBoxSource container of the source species
              * @tparam T_ParBoxTarget container of the target species
              * @tparam T_ParticleCreator type of the particle creation functor
              */
-            template<
-                uint32_t T_numWorkers,
-                typename T_ParBoxSource,
-                typename T_ParBoxTarget,
-                typename T_ParticleCreator>
+            template<typename T_ParBoxSource, typename T_ParBoxTarget, typename T_ParticleCreator>
             struct CreateParticlesKernel
             {
                 using ParBoxSource = T_ParBoxSource;
@@ -85,18 +80,14 @@ namespace picongpu
 
                 /** Goes over all frames and calls `ParticleCreator`
                  *
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
                  * @param blockCell n-dim. block offset (in cells) relative to the origin
                  *                  of the local domain plus guarding cells
                  */
-                template<typename T_Acc>
-                DINLINE void operator()(T_Acc const& acc, pmacc::math::Int<simDim> const& blockCell)
+                template<typename T_Worker>
+                DINLINE void operator()(T_Worker const& worker, pmacc::math::Int<simDim> const& blockCell)
                 {
-                    constexpr uint32_t numWorkers = T_numWorkers;
-
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
                     /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
                     pmacc::math::Int<simDim> const block = blockCell / SuperCellSize::toRT();
 
@@ -120,7 +111,7 @@ namespace picongpu
                      */
                     using FrameArray = memory::Array<TargetFramePtr, 2>;
 
-                    PMACC_SMEM(acc, targetFrames, FrameArray);
+                    PMACC_SMEM(worker, targetFrames, FrameArray);
 
                     // find last frame in super cell
                     SourceFramePtr sourceFrame(sourceBox.getLastFrame(block));
@@ -129,10 +120,10 @@ namespace picongpu
                     if(!sourceFrame.isValid())
                         return;
 
-                    auto forEachParticle = lockstep::makeForEach<maxParticlesInFrame, numWorkers>(workerIdx);
+                    auto forEachParticle = lockstep::makeForEach<maxParticlesInFrame>(worker);
 
                     // initialize the collective part of the functor (e.g. field caching)
-                    particleCreator.collectiveInit(acc, blockCell, lockstep::Worker<numWorkers>{workerIdx});
+                    particleCreator.collectiveInit(worker, blockCell);
 
                     auto particleCreatorCtx = lockstep::makeVar<ParticleCreator>(forEachParticle);
 
@@ -150,16 +141,16 @@ namespace picongpu
                             particleCreatorCtx[idx] = particleCreator;
 
                             // init particle creator functor for each virtual worker
-                            particleCreatorCtx[idx].init(acc, blockCell, idx, localCellIndex);
+                            particleCreatorCtx[idx].init(worker, blockCell, localCellIndex);
                         });
 
                     /* Declare counter in shared memory that will later tell the current fill level or
                      * occupation of the newly created target frames.
                      */
-                    PMACC_SMEM(acc, newFrameFillLvl, int);
+                    PMACC_SMEM(worker, newFrameFillLvl, int);
 
                     // used to maintain the frame double buffer
-                    auto frameMasters = lockstep::makeForEach<2, numWorkers>(workerIdx);
+                    auto frameMasters = lockstep::makeForEach<2>(worker);
 
                     // Declare local variable oldFrameFillLvl for each thread
                     int oldFrameFillLvl;
@@ -178,7 +169,7 @@ namespace picongpu
                             targetFrames[linearIdx] = nullptr;
                         });
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     /* move over source species frames and call particleCreator
                      * frames are worked on in backwards order to avoid asking if there is another frame
@@ -196,10 +187,10 @@ namespace picongpu
                                 if(isParticle)
                                     /* ask the particle creator functor how many new particles to create. */
                                     numNewParticlesCtx[idx]
-                                        = particleCreatorCtx[idx].numNewParticles(acc, *sourceFrame, idx);
+                                        = particleCreatorCtx[idx].numNewParticles(worker, *sourceFrame, idx);
                             });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         /* always true while-loop over all particles inside source frame until each thread breaks out
                          * individually
@@ -226,7 +217,7 @@ namespace picongpu
 
                             oldFrameFillLvl = newFrameFillLvl;
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             /* < CHECK & ADD >
                              * - if a thread wants to create target particles in each cycle it can do that only once
@@ -238,12 +229,12 @@ namespace picongpu
                                 {
                                     if(numNewParticlesCtx[idx] > 0u)
                                         targetParIdCtx[idx] = kernel::atomicAllInc(
-                                            acc,
+                                            worker,
                                             &newFrameFillLvl,
                                             ::alpaka::hierarchy::Threads{});
                                 });
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             /* < EXIT? >
                              * - if the counter hasn't changed all threads break out of the loop
@@ -251,7 +242,7 @@ namespace picongpu
                             if(oldFrameFillLvl == newFrameFillLvl)
                                 break;
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             /* < NEW FRAME >
                              * - if there is no frame, yet, the master will create a new target particle frame
@@ -264,12 +255,12 @@ namespace picongpu
                                         = (newFrameFillLvl + maxParticlesInFrame - 1u) / maxParticlesInFrame;
                                     if(linearIdx < numFramesNeeded && !targetFrames[linearIdx].isValid())
                                     {
-                                        targetFrames[linearIdx] = targetBox.getEmptyFrame(acc);
-                                        targetBox.setAsLastFrame(acc, targetFrames[linearIdx], block);
+                                        targetFrames[linearIdx] = targetBox.getEmptyFrame(worker);
+                                        targetBox.setAsLastFrame(worker, targetFrames[linearIdx], block);
                                     }
                                 });
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             /* < CREATE >
                              * - all target particles were created
@@ -292,13 +283,13 @@ namespace picongpu
                                         auto targetParticle = targetFrames[targetFrameIdx][targetParIdCtx[idx]];
 
                                         // create a target particle in the new target particle frame:
-                                        particleCreatorCtx[idx](acc, sourceParticle, targetParticle);
+                                        particleCreatorCtx[idx](worker, sourceParticle, targetParticle);
 
                                         numNewParticlesCtx[idx] -= 1;
                                     }
                                 });
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             frameMasters(
                                 [&](uint32_t const linearIdx)
@@ -313,10 +304,10 @@ namespace picongpu
                                     }
                                 });
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
                         }
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         sourceFrame = sourceBox.getPreviousFrame(sourceFrame);
                     }
@@ -325,27 +316,20 @@ namespace picongpu
 
             /** Convenient function to create a `CreateParticlesKernel` instance
              *
-             * @tparam T_numWorkers number of workers
-             *
              * @param parBoxSource particle box of the source species
              * @param parBoxTarget particle box of the target species
              * @param particleCreator particle creation functor
              * @param guardSuperCells number of guard cells per dimension
              * @return new `CreateParticlesKernel` instance
              */
-            template<
-                uint32_t T_numWorkers,
-                typename T_ParBoxSource,
-                typename T_ParBoxTarget,
-                typename T_ParticleCreator>
-            CreateParticlesKernel<T_numWorkers, T_ParBoxSource, T_ParBoxTarget, T_ParticleCreator>
-            make_CreateParticlesKernel(
+            template<typename T_ParBoxSource, typename T_ParBoxTarget, typename T_ParticleCreator>
+            CreateParticlesKernel<T_ParBoxSource, T_ParBoxTarget, T_ParticleCreator> make_CreateParticlesKernel(
                 T_ParBoxSource const& parBoxSource,
                 T_ParBoxTarget const& parBoxTarget,
                 T_ParticleCreator const& particleCreator,
                 DataSpace<simDim> const& guardSuperCells)
             {
-                return CreateParticlesKernel<T_numWorkers, T_ParBoxSource, T_ParBoxTarget, T_ParticleCreator>(
+                return CreateParticlesKernel<T_ParBoxSource, T_ParBoxTarget, T_ParticleCreator>(
                     parBoxSource,
                     parBoxTarget,
                     particleCreator,

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -54,16 +54,12 @@ namespace picongpu
                 float_64 sumDebyeLength = 0.0;
             };
 
-            /** Kernel to estimate Debye length for electrons
-             *
-             * @tparam T_numWorkers number of threads per block
-             */
-            template<uint32_t T_numWorkers>
+            //! Kernel to estimate Debye length for electrons
             struct DebyeLengthEstimateKernel
             {
                 /** Kernel to estimate Debye length for electrons
                  *
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  * @tparam T_ElectronBox electron storage type
                  * @tparam T_Mapping mapping type
                  * @tparam T_EstimateBox result storage type, device box for Estimate
@@ -74,18 +70,19 @@ namespace picongpu
                  * @param minMacroparticlesPerSupercell only use supercells with at least this many macroparticles
                  * @param estimateBox device box with a single element to write kernel result to
                  */
-                template<typename T_Acc, typename T_ElectronBox, typename T_Mapping, typename T_EstimateBox>
+                template<typename T_Worker, typename T_ElectronBox, typename T_Mapping, typename T_EstimateBox>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ElectronBox const electronBox,
                     T_Mapping mapper,
                     uint32_t const minMacroparticlesPerSupercell,
                     T_EstimateBox estimateBox) const
                 {
-                    auto const supercellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)));
+                    auto const supercellIdx
+                        = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())));
                     auto& supercell = electronBox.getSuperCell(supercellIdx);
                     if(supercell.getNumParticles() >= minMacroparticlesPerSupercell)
-                        process(acc, electronBox, supercellIdx, estimateBox);
+                        process(worker, electronBox, supercellIdx, estimateBox);
                 }
 
             private:
@@ -93,23 +90,22 @@ namespace picongpu
                  *
                  * The supercell is required to have macroparticles
                  *
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  * @tparam T_ElectronBox electron storage type
                  * @tparam T_EstimateBox result storage type, device box for Estimate
                  *
-                 * @param acc alpaka accelerator
+                 * @param worker lockstep worker
                  * @param electronBox electron storage
                  * @param supercellIdx supercell index, including guards
                  * @param estimate device box with a single element to write kernel result to
                  */
-                template<typename T_Acc, typename T_ElectronBox, typename T_EstimateBox>
+                template<typename T_Worker, typename T_ElectronBox, typename T_EstimateBox>
                 DINLINE void process(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ElectronBox const electronBox,
                     pmacc::DataSpace<simDim> const supercellIdx,
                     T_EstimateBox estimateBox) const
                 {
-                    constexpr uint32_t numWorkers = T_numWorkers;
                     /* Estimate variance in momentum of macroparticles in the supercell.
                      * Each thread processes its particles, then the master thread performs reduction.
                      * Sums are weighted and operate with single- (not macro-) particle momenta.
@@ -119,14 +115,10 @@ namespace picongpu
                     auto sumMomentum = float3_64::create(0.0);
                     auto sumMomentumSquared = float3_64::create(0.0);
 
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
-                    auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
-                        workerIdx,
-                        electronBox,
-                        supercellIdx);
+                    auto forEachParticle
+                        = pmacc::particles::algorithm::acc::makeForEach(worker, electronBox, supercellIdx);
 
                     forEachParticle(
-                        acc,
                         [&sumWeighting, &sumMomentum, &sumMomentumSquared](auto const& /*accelerator*/, auto& particle)
                         {
                             auto const weighting = float_64{particle[weighting_]};
@@ -138,10 +130,10 @@ namespace picongpu
                         });
 
                     // Reduce for supercell in shared memory
-                    PMACC_SMEM(acc, supercellSumWeighting, float_64);
-                    PMACC_SMEM(acc, supercellSumMomentum, float3_64);
-                    PMACC_SMEM(acc, supercellSumMomentumSquared, float3_64);
-                    auto onlyMaster = lockstep::makeMaster(workerIdx);
+                    PMACC_SMEM(worker, supercellSumWeighting, float_64);
+                    PMACC_SMEM(worker, supercellSumMomentum, float3_64);
+                    PMACC_SMEM(worker, supercellSumMomentumSquared, float3_64);
+                    auto onlyMaster = lockstep::makeMaster(worker);
                     onlyMaster(
                         [&]()
                         {
@@ -149,22 +141,26 @@ namespace picongpu
                             supercellSumMomentum = float3_64::create(0.0);
                             supercellSumMomentumSquared = float3_64::create(0.0);
                         });
-                    cupla::__syncthreads(acc);
-                    cupla::atomicAdd(acc, &supercellSumWeighting, sumWeighting, ::alpaka::hierarchy::Threads{});
+                    worker.sync();
+                    cupla::atomicAdd(
+                        worker.getAcc(),
+                        &supercellSumWeighting,
+                        sumWeighting,
+                        ::alpaka::hierarchy::Threads{});
                     for(uint32_t d = 0; d < 3; d++)
                     {
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &(supercellSumMomentum[d]),
                             sumMomentum[d],
                             ::alpaka::hierarchy::Threads{});
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &(supercellSumMomentumSquared[d]),
                             sumMomentumSquared[d],
                             ::alpaka::hierarchy::Threads{});
                     }
-                    cupla::__syncthreads(acc);
+                    worker.sync();
                     onlyMaster(
                         [&]()
                         {
@@ -173,7 +169,7 @@ namespace picongpu
                             auto const variance = pmacc::math::max(
                                 float3_64::create(0.0),
                                 supercellSumMomentumSquared / supercellSumWeighting - mean * mean);
-                            check(acc, electronBox, supercellIdx, supercellSumWeighting, variance, estimateBox);
+                            check(worker, electronBox, supercellIdx, supercellSumWeighting, variance, estimateBox);
                         });
                 }
 
@@ -186,7 +182,7 @@ namespace picongpu
                  * This is according to page 32 of R.W. Hockney, J.W. Eastwood. Computer Simulation Using Particles,
                  * CRC Press (1988).
                  *
-                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Worker lockstep worker type
                  * @tparam T_ElectronBox electron storage type
                  * @tparam T_ResultBox result storage type, device box for Result
                  *
@@ -197,9 +193,9 @@ namespace picongpu
                  * @param result device box of type Result with a single element
                  *        to write kernel result to
                  */
-                template<typename T_Acc, typename T_ElectronBox, typename T_EstimateBox>
+                template<typename T_Worker, typename T_ElectronBox, typename T_EstimateBox>
                 DINLINE void check(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ElectronBox const electronBox,
                     pmacc::DataSpace<simDim> const supercellIdx,
                     float_64 const sumWeighting,
@@ -227,21 +223,29 @@ namespace picongpu
                         maxCellSize = math::max(maxCellSize, cellSize[d]);
                     bool const isDebyeLengthUnderOneCell = (debyeLength < maxCellSize);
 
-                    cupla::atomicAdd(acc, &(estimateBox(0).numUsedSupercells), 1u, ::alpaka::hierarchy::Blocks{});
+                    cupla::atomicAdd(
+                        worker.getAcc(),
+                        &(estimateBox(0).numUsedSupercells),
+                        1u,
+                        ::alpaka::hierarchy::Blocks{});
                     if(isDebyeLengthUnderOneCell)
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &(estimateBox(0).numFailingSupercells),
                             1u,
                             ::alpaka::hierarchy::Blocks{});
-                    cupla::atomicAdd(acc, &(estimateBox(0).sumWeighting), sumWeighting, ::alpaka::hierarchy::Blocks{});
                     cupla::atomicAdd(
-                        acc,
+                        worker.getAcc(),
+                        &(estimateBox(0).sumWeighting),
+                        sumWeighting,
+                        ::alpaka::hierarchy::Blocks{});
+                    cupla::atomicAdd(
+                        worker.getAcc(),
                         &(estimateBox(0).sumTemperatureKeV),
                         sumWeighting * temperatureKeV,
                         ::alpaka::hierarchy::Blocks{});
                     cupla::atomicAdd(
-                        acc,
+                        worker.getAcc(),
                         &(estimateBox(0).sumDebyeLength),
                         sumWeighting * debyeLength,
                         ::alpaka::hierarchy::Blocks{});

--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -38,12 +38,12 @@ namespace picongpu
                      * @tparam T_Particle pmacc::Particles, type of the particle
                      * @tparam alpaka accelerator type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param particle  particle which is checked
                      * @return true if particle handle is valid, else false
                      */
-                    template<typename T_Particle, typename T_Acc>
-                    HDINLINE bool operator()(T_Acc const&, T_Particle const& particle)
+                    template<typename T_Particle, typename T_Worker>
+                    HDINLINE bool operator()(T_Worker const&, T_Particle const& particle)
                     {
                         return particle.isHandleValid();
                     }
@@ -61,13 +61,13 @@ namespace picongpu
 
                 /** create filter for the accelerator
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
+                 * @tparam T_Worker lockstep::Worker, configuration of the worker
                  * @param offset (in superCells, without any guards) relative
                  *                        to the origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
-                HDINLINE acc::All operator()(T_Acc const& acc, DataSpace<simDim> const&, T_WorkerCfg const&) const
+                template<typename T_Worker>
+                HDINLINE acc::All operator()(T_Worker const& worker, DataSpace<simDim> const&) const
                 {
                     return acc::All{};
                 }

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -48,8 +48,8 @@ namespace picongpu
                     {
                     }
 
-                    template<typename T_Acc, typename T_Particle>
-                    HDINLINE bool operator()(T_Acc const&, T_Particle const& particle)
+                    template<typename T_Worker, typename T_Particle>
+                    HDINLINE bool operator()(T_Worker const&, T_Particle const& particle)
                     {
                         if(particle.isHandleValid())
                         {
@@ -116,16 +116,15 @@ namespace picongpu
 
                 /** create filter for the accelerator
                  *
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
+                 * @tparam T_Worker lockstep::Worker, lockstep worker
                  * @param localSupercellOffset offset (in superCells, without any guards) relative
                  *                        to the origin of the local domain
                  * @param configuration of the worker
                  */
-                template<typename T_WorkerCfg, typename T_Acc>
+                template<typename T_Worker>
                 HDINLINE acc::RelativeGlobalDomainPosition<Params> operator()(
-                    T_Acc const& acc,
-                    DataSpace<simDim> const& localSuperCellOffset,
-                    T_WorkerCfg const&) const
+                    T_Worker const& worker,
+                    DataSpace<simDim> const& localSuperCellOffset) const
                 {
                     return acc::RelativeGlobalDomainPosition<Params>(
                         localDomainOffset,

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -58,8 +58,8 @@ namespace picongpu
                          *
                          * @param particle particle to use for the filtering
                          */
-                        template<typename T_Acc, typename T_Particle>
-                        HDINLINE bool operator()(T_Acc const&, T_Particle const& particle)
+                        template<typename T_Worker, typename T_Particle>
+                        HDINLINE bool operator()(T_Worker const&, T_Particle const& particle)
                         {
                             bool const isValid = particle.isHandleValid();
 
@@ -89,17 +89,15 @@ namespace picongpu
 
                     /** create device filter
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param offset (in supercells, without any guards) to the
                      *         origin of the local domain
                      * @param configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE acc::Free<Functor> operator()(T_Acc const&, DataSpace<simDim> const&, T_WorkerCfg const&)
-                        const
+                    template<typename T_Worker>
+                    HDINLINE acc::Free<Functor> operator()(T_Worker const&, DataSpace<simDim> const&) const
                     {
                         return acc::Free<Functor>(*static_cast<Functor const*>(this));
                     }

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -54,14 +54,14 @@ namespace picongpu
                          *
                          * @tparam T_Particle type of the particle to manipulate
                          * @tparam T_Args type of the arguments passed to the user functor
-                         * @tparam T_Acc alpaka accelerator type
+                         * @tparam T_Worker lockstep worker type
                          *
-                         * @param alpaka accelerator
+                         * @param worker lockstep worker
                          * @param particle particle which is given to the user functor
                          * @return void is used to enable the operator if the user functor except two arguments
                          */
-                        template<typename T_Particle, typename... T_Args, typename T_Acc>
-                        HDINLINE bool operator()(T_Acc const&, T_Particle const& particle)
+                        template<typename T_Particle, typename... T_Args, typename T_Worker>
+                        HDINLINE bool operator()(T_Worker const&, T_Particle const& particle)
                         {
                             bool const isValid = particle.isHandleValid();
 
@@ -101,22 +101,18 @@ namespace picongpu
 
                     /** create functor for the accelerator
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param localSupercellOffset offset (in superCells, without any guards) relative
                      *                        to the origin of the local domain
                      * @param workerCfg configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE auto operator()(
-                        T_Acc const& acc,
-                        DataSpace<simDim> const& localSupercellOffset,
-                        T_WorkerCfg const& workerCfg) const -> acc::FreeRng<Functor, RngType>
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const -> acc::FreeRng<Functor, RngType>
                     {
-                        RngType const rng
-                            = (*static_cast<RngGenerator const*>(this))(acc, localSupercellOffset, workerCfg);
+                        RngType const rng = (*static_cast<RngGenerator const*>(this))(worker, localSupercellOffset);
 
                         return acc::FreeRng<Functor, RngType>(*static_cast<Functor const*>(this), rng);
                     }

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -56,14 +56,14 @@ namespace picongpu
                          *
                          * @tparam T_Particle type of the particle to manipulate
                          * @tparam T_Args type of the arguments passed to the user functor
-                         * @tparam T_Acc alpaka accelerator type
+                         * @tparam T_Worker lockstep worker type
                          *
-                         * @param alpaka accelerator
+                         * @param worker lockstep worker
                          * @param particle particle which is given to the user functor
                          * @return void is used to enable the operator if the user functor except two arguments
                          */
-                        template<typename T_Particle, typename T_Acc>
-                        HDINLINE bool operator()(T_Acc const&, T_Particle const& particle)
+                        template<typename T_Particle, typename T_Worker>
+                        HDINLINE bool operator()(T_Worker const&, T_Particle const& particle)
                         {
                             bool filterResult = false;
                             if(particle.isHandleValid())
@@ -108,24 +108,21 @@ namespace picongpu
 
                     /** create functor for the accelerator
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param localSupercellOffset offset (in superCells, without any guards) relative
                      *                        to the origin of the local domain
                      * @param workerCfg configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE auto operator()(
-                        T_Acc const& acc,
-                        DataSpace<simDim> const& localSupercellOffset,
-                        T_WorkerCfg const& workerCfg) const -> acc::FreeTotalCellOffset<Functor>
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const -> acc::FreeTotalCellOffset<Functor>
                     {
                         auto& cellOffsetFunctor = *static_cast<CellOffsetFunctor const*>(this);
                         return acc::FreeTotalCellOffset<Functor>(
                             *static_cast<Functor const*>(this),
-                            cellOffsetFunctor(acc, localSupercellOffset, workerCfg));
+                            cellOffsetFunctor(worker, localSupercellOffset));
                     }
 
                     static HINLINE std::string getName()

--- a/include/picongpu/particles/flylite/NonLTE.tpp
+++ b/include/picongpu/particles/flylite/NonLTE.tpp
@@ -29,7 +29,6 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/ISimulationData.hpp>
-#include <pmacc/lockstep/lockstep.hpp>
 
 #include <memory>
 

--- a/include/picongpu/particles/flylite/NonLTE.tpp
+++ b/include/picongpu/particles/flylite/NonLTE.tpp
@@ -29,7 +29,7 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/ISimulationData.hpp>
-#include <pmacc/traits/GetNumWorkers.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
 
 #include <memory>
 

--- a/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensity.kernel
@@ -25,7 +25,7 @@
 #include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/device/Reduce.hpp>
 #include <pmacc/dimensions/GridLayout.hpp>
-#include <pmacc/lockstep/Worker.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/Array.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
@@ -44,12 +44,7 @@ namespace picongpu
                  *
                  * Average a FieldTmp density to a smaller (per-supercell) resolution and
                  * add it to a local density field.
-                 *
-                 * @tparam T_numWorkers number of workers for lockstep execution per block,
-                 *                      arbitrary for reduce since it will loop over the
-                 *                      source size when necessary
                  */
-                template<uint32_t T_numWorkers>
                 struct KernelAverageDensity
                 {
                     /** Functor
@@ -57,53 +52,53 @@ namespace picongpu
                      * @tparam T_TmpBox pmacc::DataBox with full-resolution density
                      * @tparam T_LocalDensityBox pmacc::DataBox local density with less
                      *                           resolution
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param fieldTmp pmacc::DataBox with FieldTmp density scalar field
                      * @param localDensity pmacc::DataBox with global memory, e.g. for each
                      *                     supercell's density
                      */
-                    template<typename T_TmpBox, typename T_LocalDensityBox, typename T_Acc>
-                    DINLINE void operator()(T_Acc const& acc, T_TmpBox fieldTmp, T_LocalDensityBox localDensity) const
+                    template<typename T_TmpBox, typename T_LocalDensityBox, typename T_Worker>
+                    DINLINE void operator()(T_Worker const& worker, T_TmpBox fieldTmp, T_LocalDensityBox localDensity)
+                        const
                     {
                         using picongpu::flylite::spatialAverageBox;
                         using ValueType = typename T_TmpBox::ValueType;
-                        constexpr uint32_t numWorkers = T_numWorkers;
+                        constexpr uint32_t numWorkers = T_Worker::getNumWorkers();
 
                         // cell index in the average box in reduced resolution
-                        DataSpace<simDim> const avgBoxCell(cupla::blockIdx(acc));
+                        DataSpace<simDim> const avgBoxCell(cupla::blockIdx(worker.getAcc()));
                         // first cell index inside FieldTmp (originating from BORDER) for block
                         DataSpace<simDim> const fieldTmpBlockOriginCell = avgBoxCell * spatialAverageBox::toRT();
-                        // our workers per block are started 1D
-                        uint32_t const linearThreadIdx(cupla::threadIdx(acc).x);
 
                         // shift the fieldTmp to the start of average box
                         auto fieldTmpBlock = fieldTmp.shift(fieldTmpBlockOriginCell);
 
                         // shared memory for reduce
-                        PMACC_SMEM(acc, shReduceBuffer, memory::Array<ValueType, numWorkers>);
+                        PMACC_SMEM(worker, shReduceBuffer, memory::Array<ValueType, numWorkers>);
 
                         // re-map access indices to local average view
                         using D1Box = DataBoxDim1Access<T_TmpBox>;
                         D1Box d1access(fieldTmpBlock, spatialAverageBox::toRT());
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         uint32_t const numAvgCells = pmacc::math::CT::volume<spatialAverageBox>::type::value;
 
-                        pmacc::device::reduce::Kernel<ValueType, numAvgCells, numWorkers> reduce{};
+                        pmacc::device::reduce::Kernel<ValueType, numAvgCells> reduce{};
 
 
                         reduce(
-                            acc,
-                            lockstep::Worker<numWorkers>(linearThreadIdx),
+                            worker,
                             numAvgCells,
                             /* access inside local average view */
                             d1access,
                             numAvgCells,
                             pmacc::math::operation::Add(),
                             shReduceBuffer);
+
+                        worker.sync();
 
                         /* continue with master
                          *
@@ -114,15 +109,16 @@ namespace picongpu
                          *
                          * - change those lines if you want to re-use this kernel for a vector field
                          */
-                        if(linearThreadIdx == 0)
-                        {
-                            ValueType localAverageResult = shReduceBuffer[0]
-                                * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE)
-                                / float_X(numAvgCells);
+                        lockstep::makeMaster(worker)(
+                            [&]()
+                            {
+                                ValueType localAverageResult = shReduceBuffer[0]
+                                    * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE)
+                                    / float_X(numAvgCells);
 
-                            localDensity(avgBoxCell)
-                                = static_cast<typename T_LocalDensityBox::ValueType>(localAverageResult);
-                        }
+                                localDensity(avgBoxCell)
+                                    = static_cast<typename T_LocalDensityBox::ValueType>(localAverageResult);
+                            });
                     }
                 };
 

--- a/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalDensityFunctors.hpp
@@ -121,13 +121,12 @@ namespace picongpu
                          * write in new field
                          */
                         auto nlocal = dc.get<LocalDensity>(helperFields::LocalDensity::getName(speciesGroup), true);
-                        constexpr uint32_t numWorkers
-                            = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
-                        PMACC_KERNEL(helperFields::KernelAverageDensity<numWorkers>{})
+
+                        auto workerCfg = pmacc::lockstep::makeWorkerCfg(SuperCellSize{});
+                        PMACC_LOCKSTEP_KERNEL(helperFields::KernelAverageDensity{}, workerCfg)
                         (
                             // one block per averaged density value
-                            nlocal->getGridBuffer().getGridLayout().getDataSpaceWithoutGuarding(),
-                            numWorkers)(
+                            nlocal->getGridBuffer().getGridLayout().getDataSpaceWithoutGuarding())(
                             // start in border (jump over GUARD area)
                             fieldTmp->getDeviceDataBox().shift(SuperCellSize::toRT() * GuardSize::toRT()),
                             // start in border (has no GUARD area)

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogram.kernel
@@ -42,12 +42,8 @@ namespace picongpu
                 /** Generate and add a local energy histogram
                  *
                  * Generate a (per-supercell) energy histogram and add it to global memory.
-                 *
-                 * @tparam T_numWorkers number of workers for lockstep execution per block,
-                 *                      usually equal to the number of particles per frame
-                 *                      (which is equal to the supercell size)
                  */
-                template<uint32_t T_numWorkers>
+
                 struct KernelAddLocalEnergyHistogram
                 {
                     /** Functor
@@ -63,17 +59,21 @@ namespace picongpu
                      * @tparam T_ParBox pmacc::ParticlesBox, particle box type
                      * @tparam T_LocalEnergyHistogramBox pmacc::DataBox, local energy histograms,
                      *                                   e.g. for each supercell
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param acc alpaka accelerator
+                     * @param worker lockstep worker
                      * @param pb particles of a species
                      * @param energyHistogramBox box with global memory for each supercell's histogram
                      * @param minEnergy minimum energy to account for (eV)
                      * @param maxEnergy maximum energy to account for (eV)
                      */
-                    template<typename T_ParBox, typename T_LocalEnergyHistogramBox, typename T_Mapping, typename T_Acc>
+                    template<
+                        typename T_ParBox,
+                        typename T_LocalEnergyHistogramBox,
+                        typename T_Mapping,
+                        typename T_Worker>
                     DINLINE void operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         T_ParBox pb,
                         T_LocalEnergyHistogramBox energyHistogramBox,
                         float_X const minEnergy,
@@ -82,16 +82,12 @@ namespace picongpu
                     {
                         using picongpu::flylite::spatialAverageBox;
                         constexpr uint16_t numBins = picongpu::flylite::energies;
-                        constexpr uint32_t numWorkers = T_numWorkers;
 
                         using SuperCellSize = typename MappingDesc::SuperCellSize;
 
-                        // our workers per block are started 1D
-                        uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
                         // supercell index of current (frame-wise) supercell including GUARD
                         DataSpace<simDim> const superCellIdx(
-                            mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+                            mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
                         /* index inside local energy histogram in averaged space (has no GUARD)
                          * integer division: we average over multiples of supercells;
@@ -107,11 +103,12 @@ namespace picongpu
                         auto& localEnergyHistogram = *energyHistogramBox.shift(localEnergyBlock);
 
                         // shared memory for local energy histogram
-                        PMACC_SMEM(acc, shLocalEnergyHistogram, memory::Array<float_X, numBins>);
+                        PMACC_SMEM(worker, shLocalEnergyHistogram, memory::Array<float_X, numBins>);
 
 
+                        constexpr uint32_t numWorkers = T_Worker::getNumWorkers();
                         // empty the histogram to contain only zeroes
-                        lockstep::makeForEach<numWorkers, numWorkers>(workerIdx)(
+                        lockstep::makeForEach<numWorkers>(worker)(
                             [&](uint32_t const linearIdx)
                             {
                                 /* set all bins to 0 */
@@ -119,19 +116,17 @@ namespace picongpu
                                     shLocalEnergyHistogram[i] = float_X(0.);
                             });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
-                        auto forEachParticle
-                            = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, pb, superCellIdx);
+                        auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach(worker, pb, superCellIdx);
 
                         // end kernel if we have no particles
                         if(!forEachParticle.hasParticles())
                             return;
 
                         forEachParticle(
-                            acc,
                             [minEnergy, maxEnergy, numBins, &shLocalEnergyHistogram](
-                                auto const& accelerator,
+                                auto const& lockstepWorker,
                                 auto& particle)
                             {
                                 /* kinetic Energy for Particles: E^2 = p^2*c^2 + m^2*c^4
@@ -161,21 +156,22 @@ namespace picongpu
                                         = weighting / float_X(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);
 
                                     cupla::atomicAdd(
-                                        accelerator,
+                                        lockstepWorker.getAcc(),
                                         &(shLocalEnergyHistogram[binNumber]),
                                         normedWeighting,
                                         ::alpaka::hierarchy::Threads{});
                                 }
                             });
-                        cupla::__syncthreads(acc);
+
+                        worker.sync();
 
                         // write histogram back to global memory (add)
-                        lockstep::makeForEach<numWorkers, numWorkers>(workerIdx)(
+                        lockstep::makeForEach<T_Worker::getNumWorkers()>(worker)(
                             [&](uint32_t const linearIdx)
                             {
                                 for(int i = linearIdx; i < numBins; i += numWorkers)
                                     cupla::atomicAdd(
-                                        acc,
+                                        worker.getAcc(),
                                         &(localEnergyHistogram[i]),
                                         shLocalEnergyHistogram[i],
                                         ::alpaka::hierarchy::Blocks{});

--- a/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
+++ b/include/picongpu/particles/flylite/helperFields/LocalEnergyHistogramFunctors.hpp
@@ -79,14 +79,12 @@ namespace picongpu
                                 GuardSize::toRT());
                             auto const mapper = makeAreaMapper<CORE + BORDER>(cellDescription);
 
+                            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
                             // add energy histogram on top of existing data
-                            constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<
-                                pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
-                            PMACC_KERNEL(helperFields::KernelAddLocalEnergyHistogram<numWorkers>{})
+                            PMACC_LOCKSTEP_KERNEL(helperFields::KernelAddLocalEnergyHistogram{}, workerCfg)
                             (
                                 // one block per local energy histogram
-                                mapper.getGridDim(),
-                                numWorkers)(
+                                mapper.getGridDim())(
                                 // start in border (jump over GUARD area)
                                 speciesTmp->getDeviceParticlesBox(),
                                 // start in border (has no GUARD area)

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -52,7 +52,6 @@ namespace picongpu
                     using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
                     using RngHandle = typename RNGFactory::Handle;
 
-
                     /** constructor
                      *
                      * @param currentStep current simulation time step

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -51,7 +51,7 @@ namespace picongpu
                     using Distribution = T_Distribution;
                     using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
                     using RngHandle = typename RNGFactory::Handle;
-                    using RandomGen = RngWrapper<cupla::Acc, typename RngHandle::GetRandomType<Distribution>::type>;
+
 
                     /** constructor
                      *
@@ -64,25 +64,22 @@ namespace picongpu
 
                     /** create functor a random number generator
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep::Worker, lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param localSupercellOffset offset (in superCells, without any guards) relative
-                     *                        to the origin of the local domain
-                     * @param workerCfg configuration of the worker
+                     *                        to the origin of the local domainrker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE RandomGen operator()(
-                        T_Acc const& acc,
-                        DataSpace<simDim> const& localSupercellOffset,
-                        T_WorkerCfg const& workerCfg) const
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const
                     {
                         RngHandle tmp(rngHandle);
                         tmp.init(
                             localSupercellOffset * SuperCellSize::toRT()
-                            + DataSpaceOperations<simDim>::template map<SuperCellSize>(workerCfg.getWorkerIdx()));
-                        return RandomGen(acc, tmp.applyDistribution<Distribution>());
+                            + DataSpaceOperations<simDim>::template map<SuperCellSize>(worker.getWorkerIdx()));
+                        using RandomGen = RngWrapper<T_Worker, typename RngHandle::GetRandomType<Distribution>::type>;
+                        return RandomGen(worker, tmp.applyDistribution<Distribution>());
                     }
 
                 private:

--- a/include/picongpu/particles/functor/misc/RngWrapper.hpp
+++ b/include/picongpu/particles/functor/misc/RngWrapper.hpp
@@ -37,30 +37,30 @@ namespace picongpu
                  * This class allows to generate random numbers without passing the accelerator
                  * to each functor call.
                  *
-                 * @tparam T_Acc type of the alpaka accelerator
+                 * @tparam T_Worker type of the alpaka accelerator
                  * @tparam T_Rng type of the random number generator
                  */
-                template<typename T_Acc, typename T_Rng>
+                template<typename T_Worker, typename T_Rng>
                 struct RngWrapper
                 {
                     DINLINE RngWrapper(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         T_Rng const& rng
 
                         )
-                        : m_acc(&acc)
+                        : m_worker(&worker)
                         , m_rng(rng)
                     {
                     }
 
                     //! generate a random number
                     DINLINE
-                    typename T_Rng::result_type operator()()
+                    typename T_Rng::result_type operator()() const
                     {
-                        return m_rng(*m_acc);
+                        return m_rng(*m_worker);
                     }
 
-                    T_Acc const* m_acc;
+                    T_Worker const* m_worker;
                     mutable T_Rng m_rng;
                 };
 

--- a/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
+++ b/include/picongpu/particles/functor/misc/TotalCellOffset.hpp
@@ -49,19 +49,16 @@ namespace picongpu
 
                     /** get cell offset of the supercell
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
-                     * @param offset (in supercells, without any guards) to the
+                     * @param worker lockstep worker
+                     * @param localSupercellOffset (in supercells, without any guards) to the
                      *         origin of the local domain
-                     * @param configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE DataSpace<simDim> operator()(
-                        T_Acc const& acc,
-                        DataSpace<simDim> const& localSupercellOffset,
-                        T_WorkerCfg const&) const
+                        T_Worker const& worker,
+                        DataSpace<simDim> const& localSupercellOffset) const
                     {
                         DataSpace<simDim> const superCellToLocalOriginCellOffset(
                             localSupercellOffset * SuperCellSize::toRT());

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.def
@@ -43,12 +43,11 @@ namespace picongpu
              *            Modeling field ionization in an energy conserving form and resulting nonstandard fluid
              * dynamcis, Physics of Plasmas 5, 4466 (1998) https://doi.org/10.1063/1.873184
              *
-             * @tparam T_Acc alpaka accelerator type
              * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
              * @tparam T_Dim dimension of simulation
              * @tparam T_IonizationCurrent select type of ionization current (None or EnergyConservation)
              */
-            template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim, typename T_IonizationCurrent>
+            template<typename T_DestSpecies, unsigned T_Dim, typename T_IonizationCurrent>
             struct IonizationCurrent;
         } // namespace ionization
     } // namespace particles

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
@@ -37,12 +37,11 @@ namespace picongpu
             /**@{*/
             /** Implementation of actual ionization current
              *
-             * @tparam T_Acc alpaka accelerator type
              * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
              * @tparam T_Dim dimension of simulation
              */
-            template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim>
-            struct IonizationCurrent<T_Acc, T_DestSpecies, T_Dim, current::EnergyConservation>
+            template<typename T_DestSpecies, unsigned T_Dim>
+            struct IonizationCurrent<T_DestSpecies, T_Dim, current::EnergyConservation>
             {
                 using ValueType_E = FieldE::ValueType;
 
@@ -50,13 +49,13 @@ namespace picongpu
                  *
                  * @tparam T_JBox type of current density data box
                  */
-                template<typename T_JBox>
+                template<typename T_Worker, typename T_JBox>
                 HDINLINE void operator()(
                     IonizerReturn retValue,
                     float_X const weighting,
                     T_JBox jBoxPar,
                     ValueType_E eField,
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     floatD_X const pos)
                 {
                     /* If there is no ionization, the ionization energy is zero. In that case, there is no need for an
@@ -68,27 +67,27 @@ namespace picongpu
                         /* calculate ionization current at particle position */
                         float3_X jIonizationPar = JIonizationCalc{}(ionizationEnergy, eField);
                         /* assign ionization current to grid points */
-                        JIonizationAssignment<T_Acc, T_DestSpecies, simDim>{}(acc, jIonizationPar, pos, jBoxPar);
+                        JIonizationAssignment<T_DestSpecies, simDim>{}(worker, jIonizationPar, pos, jBoxPar);
                     }
                 }
             };
 
             /** Ionization current deactivated
              */
-            template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim>
-            struct IonizationCurrent<T_Acc, T_DestSpecies, T_Dim, current::None>
+            template<typename T_DestSpecies, unsigned T_Dim>
+            struct IonizationCurrent<T_DestSpecies, T_Dim, current::None>
             {
                 using ValueType_E = FieldE::ValueType;
 
                 /** no ionization current
                  */
-                template<typename T_JBox>
+                template<typename T_Worker, typename T_JBox>
                 HDINLINE void operator()(
                     IonizerReturn,
                     float_X const,
                     T_JBox,
                     ValueType_E,
-                    T_Acc const&,
+                    T_Worker const&,
                     floatD_X const)
                 {
                 }

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
@@ -48,26 +48,24 @@ namespace picongpu
             /**@{*/
             /** implementation of current assignment
              *
-             * @tparam T_Acc alpaka accelerator type
              * @tparam T_DestSpecies type or name as boost::mpl::string of the electron species to be created
              * @tparam T_Dim dimension of simulation
              */
-            template<typename T_Acc, typename T_DestSpecies, unsigned T_Dim>
+            template<typename T_DestSpecies, unsigned T_Dim>
             struct JIonizationAssignment;
 
             /** 3d case
              */
-            template<typename T_Acc, typename T_DestSpecies>
-            struct JIonizationAssignment<T_Acc, T_DestSpecies, DIM3>
-                : public JIonizationAssignmentParent<T_DestSpecies>
+            template<typename T_DestSpecies>
+            struct JIonizationAssignment<T_DestSpecies, DIM3> : public JIonizationAssignmentParent<T_DestSpecies>
             {
                 /** functor for  assigning current to databox
                  *
                  * @tparam T_JBox type of current density data box
                  */
-                template<typename T_JBox>
+                template<typename T_Worker, typename T_JBox>
                 HDINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     float3_X const jIonizationPar,
                     float3_X const pos,
                     T_JBox jBoxPar)
@@ -96,7 +94,10 @@ namespace picongpu
                                     float_X(x) - pos.x());
                                 for(int i = 0; i <= 2; i++)
                                 {
-                                    cupla::atomicAdd(acc, &(jBoxPar(DataSpace<DIM3>(x, y, z))[i]), jGridx[i]);
+                                    cupla::atomicAdd(
+                                        worker.getAcc(),
+                                        &(jBoxPar(DataSpace<DIM3>(x, y, z))[i]),
+                                        jGridx[i]);
                                 }
                             }
                         }
@@ -106,15 +107,14 @@ namespace picongpu
 
             /** 2d case
              */
-            template<typename T_Acc, typename T_DestSpecies>
-            struct JIonizationAssignment<T_Acc, T_DestSpecies, DIM2>
-                : public JIonizationAssignmentParent<T_DestSpecies>
+            template<typename T_DestSpecies>
+            struct JIonizationAssignment<T_DestSpecies, DIM2> : public JIonizationAssignmentParent<T_DestSpecies>
             {
                 /** functor for assigning current to databox
                  */
-                template<typename T_JBox>
+                template<typename T_Worker, typename T_JBox>
                 HDINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     float3_X const jIonizationPar,
                     float2_X const pos,
                     T_JBox jBoxPar)
@@ -135,7 +135,7 @@ namespace picongpu
                                 float_X(x) - pos.x());
                             for(int i = 0; i <= 2; i++)
                             {
-                                cupla::atomicAdd(acc, &(jBoxPar(DataSpace<DIM2>(x, y))[i]), jGridx[i]);
+                                cupla::atomicAdd(worker.getAcc(), &(jBoxPar(DataSpace<DIM2>(x, y))[i]), jGridx[i]);
                             }
                         }
                     }

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -32,7 +32,7 @@
 #include "picongpu/traits/FieldPosition.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/lockstep/Worker.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/meta/conversion/TypeToPointerPair.hpp>
@@ -124,38 +124,34 @@ namespace picongpu
                  *
                  * @warning this is a collective method and calls synchronize
                  *
-                 * @tparam T_Acc alpaka accelerator type
-                 * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param acc alpaka accelerator
+                 * @param worker lockstep worker
                  * @param blockCell relative offset (in cells) to the local domain plus the guarding cells
                  * @param workerCfg configuration of the worker
                  */
-                template<typename T_Acc, typename T_WorkerCfg>
-                DINLINE void collectiveInit(
-                    const T_Acc& acc,
-                    const DataSpace<simDim>& blockCell,
-                    const T_WorkerCfg& workerCfg)
+                template<typename T_Worker>
+                DINLINE void collectiveInit(const T_Worker& worker, const DataSpace<simDim>& blockCell)
                 {
                     /* shifting origin of jbox to supercell of particle */
                     jBox = jBox.shift(blockCell);
 
                     /* caching of E and B fields */
-                    cachedB = CachedBox::create<0, ValueType_B>(acc, BlockArea());
-                    cachedE = CachedBox::create<1, ValueType_E>(acc, BlockArea());
+                    cachedB = CachedBox::create<0, ValueType_B>(worker, BlockArea());
+                    cachedE = CachedBox::create<1, ValueType_E>(worker, BlockArea());
 
                     /* instance of nvidia assignment operator */
                     pmacc::math::operation::Assign assign;
                     /* copy fields from global to shared */
                     auto fieldBBlock = bBox.shift(blockCell);
-                    ThreadCollective<BlockArea, T_WorkerCfg::numWorkers> collective(workerCfg.getWorkerIdx());
-                    collective(acc, assign, cachedB, fieldBBlock);
+                    auto collective = makeThreadCollective<BlockArea>();
+                    collective(worker, assign, cachedB, fieldBBlock);
                     /* copy fields from global to shared */
                     auto fieldEBlock = eBox.shift(blockCell);
-                    collective(acc, assign, cachedE, fieldEBlock);
+                    collective(worker, assign, cachedE, fieldEBlock);
 
                     /* wait for shared memory to be initialized */
-                    cupla::__syncthreads(acc);
+                    worker.sync();
                 }
 
                 /** Initialization function on device
@@ -167,11 +163,10 @@ namespace picongpu
                  * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is
                  * necessary after initializing the E-/B-field shared boxes in shared memory.
                  */
-                template<typename T_Acc>
+                template<typename T_Worker>
                 DINLINE void init(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const DataSpace<simDim>& blockCell,
-                    const int& linearThreadIdx,
                     const DataSpace<simDim>& localCellOffset)
                 {
                     /* initialize random number generator with the local cell index in the simulation */
@@ -183,8 +178,8 @@ namespace picongpu
                  * @param ionFrame reference to frame of the to-be-ionized particles
                  * @param localIdx local (linear) index in super cell / frame
                  */
-                template<typename T_Acc>
-                DINLINE uint32_t numNewParticles(T_Acc const& acc, FrameType& ionFrame, int localIdx)
+                template<typename T_Worker>
+                DINLINE uint32_t numNewParticles(T_Worker const& worker, FrameType& ionFrame, int localIdx)
                 {
                     /* alias for the single macro-particle */
                     auto particle = ionFrame[localIdx];
@@ -205,13 +200,13 @@ namespace picongpu
 
                     IonizationAlgorithm ionizeAlgo;
                     /* determine number of new macro electrons to be created and energy used for ionization */
-                    auto retValue = ionizeAlgo(bField, eField, particle, this->randomGen(acc));
-                    IonizationCurrent<T_Acc, T_DestSpecies, simDim, T_IonizationCurrent>{}(
+                    auto retValue = ionizeAlgo(bField, eField, particle, this->randomGen(worker));
+                    IonizationCurrent<T_DestSpecies, simDim, T_IonizationCurrent>{}(
                         retValue,
                         particle[weighting_],
                         jBox.shift(localCell),
                         eField,
-                        acc,
+                        worker,
                         pos);
 
                     return retValue.newMacroElectrons;
@@ -226,8 +221,8 @@ namespace picongpu
                  * @param parentIon ion instance that is ionized
                  * @param childElectron electron instance that is created
                  */
-                template<typename T_parentIon, typename T_childElectron, typename T_Acc>
-                DINLINE void operator()(T_Acc const& acc, T_parentIon& parentIon, T_childElectron& childElectron)
+                template<typename T_parentIon, typename T_childElectron, typename T_Worker>
+                DINLINE void operator()(T_Worker const& worker, T_parentIon& parentIon, T_childElectron& childElectron)
                 {
                     /* for not mixing operations::assign up with the nvidia functor assign */
                     namespace partOp = pmacc::particles::operations;

--- a/include/picongpu/particles/manipulators/generic/Free.hpp
+++ b/include/picongpu/particles/manipulators/generic/Free.hpp
@@ -54,12 +54,12 @@ namespace picongpu
 
                         /** execute the user manipulator functor
                          *
-                         * @tparam T_Args type of the arguments passed to the user manipulator functor
+                         * @tparam T_Worker lockstep worker type
                          *
                          * @param args arguments passed to the user functor
                          */
-                        template<typename T_Acc, typename... T_Args>
-                        HDINLINE void operator()(T_Acc const&, T_Args&&... args)
+                        template<typename T_Worker, typename... T_Args>
+                        HDINLINE void operator()(T_Worker const&, T_Args&&... args)
                         {
                             Functor::operator()(args...);
                         }
@@ -87,17 +87,15 @@ namespace picongpu
 
                     /** create device manipulator functor
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param offset (in supercells, without any guards) to the
                      *         origin of the local domain
                      * @param configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE acc::Free<Functor> operator()(T_Acc const&, DataSpace<simDim> const&, T_WorkerCfg const&)
-                        const
+                    template<typename T_Worker>
+                    HDINLINE acc::Free<Functor> operator()(T_Worker const&, DataSpace<simDim> const&) const
                     {
                         return acc::Free<Functor>(*static_cast<Functor const*>(this));
                     }

--- a/include/picongpu/particles/manipulators/generic/FreeRng.hpp
+++ b/include/picongpu/particles/manipulators/generic/FreeRng.hpp
@@ -56,14 +56,14 @@ namespace picongpu
                          *
                          * @tparam T_Particle type of the particle to manipulate
                          * @tparam T_Args type of the arguments passed to the user functor
-                         * @tparam T_Acc alpaka accelerator type
+                         * @tparam T_Worker lockstep worker type
                          *
-                         * @param alpaka accelerator
+                         * @param worker lockstep worker
                          * @param particle particle which is given to the user functor
                          * @return void is used to enable the operator if the user functor except two arguments
                          */
-                        template<typename T_Particle, typename... T_Args, typename T_Acc>
-                        HDINLINE void operator()(T_Acc const&, T_Particle& particle, T_Args&&... args)
+                        template<typename T_Particle, typename... T_Args, typename T_Worker>
+                        HDINLINE void operator()(T_Worker const&, T_Particle& particle, T_Args&&... args)
                         {
                             Functor::operator()(m_rng, particle, args...);
                         }
@@ -86,8 +86,6 @@ namespace picongpu
 
                     using RngGenerator = picongpu::particles::functor::misc::Rng<T_Distribution>;
 
-                    using RngType = typename RngGenerator::RandomGen;
-
                     using Functor = functor::User<T_Functor>;
                     using Distribution = T_Distribution;
 
@@ -101,24 +99,22 @@ namespace picongpu
 
                     /** create functor for the accelerator
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param localSupercellOffset offset (in superCells, without any guards) relative
                      *                        to the origin of the local domain
                      * @param workerCfg configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE auto operator()(
-                        T_Acc const& acc,
-                        DataSpace<simDim> const& localSupercellOffset,
-                        T_WorkerCfg const& workerCfg) const -> acc::FreeRng<Functor, RngType>
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const
                     {
-                        RngType const rng
-                            = (*static_cast<RngGenerator const*>(this))(acc, localSupercellOffset, workerCfg);
+                        auto const rng = (*static_cast<RngGenerator const*>(this))(worker, localSupercellOffset);
 
-                        return acc::FreeRng<Functor, RngType>(*static_cast<Functor const*>(this), rng);
+                        return acc::FreeRng<Functor, ALPAKA_DECAY_T(decltype(rng))>(
+                            *static_cast<Functor const*>(this),
+                            rng);
                     }
 
                     static HINLINE std::string getName()

--- a/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp
@@ -56,14 +56,14 @@ namespace picongpu
                          *
                          * @tparam T_Particle type of the particle to manipulate
                          * @tparam T_Args type of the arguments passed to the user functor
-                         * @tparam T_Acc alpaka accelerator type
+                         * @tparam T_Worker lockstep worker type
                          *
-                         * @param alpaka accelerator
+                         * @param worker lockstep worker
                          * @param particle particle which is given to the user functor
                          * @return void is used to enable the operator if the user functor expects two arguments
                          */
-                        template<typename T_Particle, typename T_Acc>
-                        HDINLINE void operator()(T_Acc const&, T_Particle& particle)
+                        template<typename T_Particle, typename T_Worker>
+                        HDINLINE void operator()(T_Worker const&, T_Particle& particle)
                         {
                             DataSpace<simDim> const cellInSuperCell(
                                 DataSpaceOperations<simDim>::template map<SuperCellSize>(particle[localCellIdx_]));
@@ -101,24 +101,21 @@ namespace picongpu
 
                     /** create functor for the accelerator
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param localSupercellOffset offset (in superCells, without any guards) relative
                      *                             to the origin of the local domain
                      * @param workerCfg configuration of the worker
                      */
-                    template<typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE auto operator()(
-                        T_Acc const& acc,
-                        DataSpace<simDim> const& localSupercellOffset,
-                        T_WorkerCfg const& workerCfg) const -> acc::FreeTotalCellOffset<Functor>
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const -> acc::FreeTotalCellOffset<Functor>
                     {
                         auto& cellOffsetFunctor = *static_cast<CellOffsetFunctor const*>(this);
                         return acc::FreeTotalCellOffset<Functor>(
                             *static_cast<Functor const*>(this),
-                            cellOffsetFunctor(acc, localSupercellOffset, workerCfg));
+                            cellOffsetFunctor(worker, localSupercellOffset));
                     }
 
                     static HINLINE std::string getName()

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def
@@ -92,10 +92,10 @@ namespace picongpu
                     typename T_Particle,
                     typename TVecSuperCell,
                     typename BoxTmp,
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_AccFilter>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_Particle& particle,
                     const TVecSuperCell superCell,
                     T_AccFilter& accFilter,

--- a/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp
@@ -61,10 +61,10 @@ namespace picongpu
                 typename T_Particle,
                 typename TVecSuperCell,
                 typename BoxTmp,
-                typename T_Acc,
+                typename T_Worker,
                 typename T_AccFilter>
             DINLINE void ComputeGridValuePerFrame<T_ParticleShape, T_DerivedAttribute>::operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 T_Particle& particle,
                 const TVecSuperCell superCell,
                 T_AccFilter& accFilter,
@@ -74,7 +74,7 @@ namespace picongpu
                 T_DerivedAttribute particleAttribute;
 
                 // Only particles passing the filter contribute
-                if(accFilter(acc, particle))
+                if(accFilter(worker, particle))
                 {
                     /* particle attributes: in-cell position and generic, derived attribute */
                     const floatD_X pos = particle[position_];
@@ -122,7 +122,7 @@ namespace picongpu
                          * one "x" component
                          */
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &(fieldTmpShiftToParticle(offsetParticleCellToCurrentCell).x()),
                             assign * particleAttr,
                             ::alpaka::hierarchy::Threads{});

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.def
@@ -46,13 +46,13 @@ namespace picongpu
                      *
                      * Result overwrites the dst value.
                      *
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      * @param acc alpaka accelerator
                      * @param dst total per cell value and result destination
                      * @param dens number density
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const& acc, float1_X& dst, const float1_X& dens) const;
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const& worker, float1_X& dst, const float1_X& dens) const;
                 };
 
                 //! Provides description for an averaged attribute

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/AverageAttribute.hpp
@@ -37,9 +37,11 @@ namespace picongpu
         {
             namespace combinedAttributes
             {
-                template<typename T_Acc>
-                HDINLINE void AverageDivideOperation::operator()(T_Acc const& acc, float1_X& dst, const float1_X& dens)
-                    const
+                template<typename T_Worker>
+                HDINLINE void AverageDivideOperation::operator()(
+                    T_Worker const& worker,
+                    float1_X& dst,
+                    const float1_X& dens) const
                 {
                     // avoid dividing by zero. Return zero if density is close to zero.
                     if(dens[0] * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE) * CELL_VOLUME

--- a/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
+++ b/include/picongpu/particles/particleToGrid/combinedAttributes/RelativisticDensity.hpp
@@ -41,13 +41,14 @@ namespace picongpu
                      *
                      * Result overwrites the density value.
                      *
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      * @param acc alpaka accelerator
                      * @param density number density value and the result destination
                      * @param energyDensity  energy density value
                      */
-                    template<typename T_Acc>
-                    HDINLINE void operator()(T_Acc const& acc, float1_X& density, const float1_X& energyDensity) const
+                    template<typename T_Worker>
+                    HDINLINE void operator()(T_Worker const& worker, float1_X& density, const float1_X& energyDensity)
+                        const
                     {
                         const float_X densityPICUnits
                             = density[0] * static_cast<float_X>(particles::TYPICAL_NUM_PARTICLES_PER_MACROPARTICLE);

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -54,13 +54,13 @@ namespace picongpu
                         /** execute the user functor
                          *
                          * @tparam T_Args type of the arguments passed to the user functor
-                         * @tparam T_Acc alpaka accelerator type
+                         * @tparam T_Worker lockstep worker type
                          *
-                         * @param alpaka accelerator
+                         * @param worker lockstep worker
                          * @param args arguments passed to the user functor
                          */
-                        template<typename... T_Args, typename T_Acc>
-                        HDINLINE void operator()(T_Acc const&, T_Args&&... args)
+                        template<typename... T_Args, typename T_Worker>
+                        HDINLINE void operator()(T_Worker const&, T_Args&&... args)
                         {
                             Functor::operator()(args...);
                         }
@@ -119,16 +119,15 @@ namespace picongpu
 
                     /** create device functor
                      *
-                     * @tparam T_WorkerCfg lockstep::Worker, configuration of the worker
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
-                     * @param alpaka accelerator
+                     * @param worker lockstep worker
                      * @param offset (in supercells, without any guards) to the
                      *         origin of the local domain
                      * @param configuration of the worker
                      */
-                    template<typename T, typename T_WorkerCfg, typename T_Acc>
-                    HDINLINE acc::Free<Functor> operator()(T_Acc const& acc, T const&, T_WorkerCfg const&) const
+                    template<typename T, typename T_Worker>
+                    HDINLINE acc::Free<Functor> operator()(T_Worker const& worker, T const&) const
                     {
                         return acc::Free<Functor>(*static_cast<Functor const*>(this));
                     }

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -182,8 +182,8 @@ namespace picongpu
 
         struct CalculateAndAssignChargeDeviation
         {
-            template<typename T_Rho, typename T_FieldE, typename T_Acc>
-            HDINLINE void operator()(const T_Acc& acc, T_Rho& rho, const T_FieldE& fieldECursor) const
+            template<typename T_Rho, typename T_FieldE, typename T_Worker>
+            HDINLINE void operator()(const T_Worker& worker, T_Rho& rho, const T_FieldE& fieldECursor) const
             {
                 typedef Div<simDim, typename FieldTmp::ValueType> MyDiv;
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -33,9 +33,9 @@
 #include <pmacc/cuSTL/container/HostBuffer.hpp>
 #include <pmacc/cuSTL/cursor/BufferCursor.hpp>
 #include <pmacc/cuSTL/zone/SphericZone.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/math/Vector.hpp>
 #include <pmacc/pluginSystem/INotify.hpp>
-#include <pmacc/traits/GetNumWorkers.hpp>
 #include <pmacc/traits/HasFlag.hpp>
 #include <pmacc/traits/HasIdentifiers.hpp>
 
@@ -253,11 +253,9 @@ namespace picongpu
             template<typename T_Filter, typename T_Zone, typename... T_Args>
             void operator()(T_Filter const& filter, T_Zone const& zone, T_Args&&... args) const
             {
-                constexpr uint32_t numWorkers
-                    = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
-                algorithm::kernel::ForeachLockstep<numWorkers, SuperCellSize> forEachSuperCell;
+                algorithm::kernel::ForeachLockstep<SuperCellSize> forEachSuperCell;
 
-                FunctorBlock<Species, SuperCellSize, float_PS, num_pbins, r_dir, T_Filter, numWorkers>
+                FunctorBlock<Species, SuperCellSize, float_PS, num_pbins, r_dir, T_Filter>
                     functorBlock(particlesBox, curOriginPhaseSpace, p_element, axis_p_range, filter);
 
                 forEachSuperCell(zone, functorBlock, args...);

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -31,11 +31,7 @@
 
 namespace picongpu
 {
-    /** copy particle from the device to the host frame
-     *
-     * @tparam T_numWorkers number of workers
-     */
-    template<uint32_t T_numWorkers>
+    //! copy particle from the device to the host frame
     struct CopySpecies
     {
         /** copy particle of a species to a host frame
@@ -46,9 +42,9 @@ namespace picongpu
          * @tparam T_Space type of coordinate description
          * @tparam T_Identifier type of identifier for the particle cellIdx
          * @tparam T_Mapping type of the mapper to map cupla idx to supercells
-         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          *
-         * @param acc alpaka accelerator type
+         * @param worker lockstep worker
          * @param counter pointer to a device counter to reserve memory in destFrame
          * @param destFrame frame were we store particles in host memory (no Databox<...>)
          * @param srcBox ParticlesBox with frames
@@ -68,10 +64,10 @@ namespace picongpu
             typename T_Space,
             typename T_Identifier,
             typename T_Mapping,
-            typename T_Acc,
+            typename T_Worker,
             typename T_ParticleFilter>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             int* counter,
             T_DestFrame destFrame,
             T_SrcBox srcBox,
@@ -89,20 +85,18 @@ namespace picongpu
 
             constexpr uint32_t numParticlesPerFrame
                 = pmacc::math::CT::volume<typename SrcFrameType::SuperCellSize>::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-            PMACC_SMEM(acc, srcFramePtr, SrcFramePtr);
-            PMACC_SMEM(acc, localCounter, int);
-            PMACC_SMEM(acc, globalOffset, int);
+            PMACC_SMEM(worker, srcFramePtr, SrcFramePtr);
+            PMACC_SMEM(worker, localCounter, int);
+            PMACC_SMEM(worker, globalOffset, int);
 
             // loop over all particles in a frame
-            auto forEachParticleInFrame = lockstep::makeForEach<numParticlesPerFrame, numWorkers>(workerIdx);
+            auto forEachParticleInFrame = lockstep::makeForEach<numParticlesPerFrame>(worker);
 
             auto storageOffsetCtx = lockstep::makeVar<int>(forEachParticleInFrame);
 
-            DataSpace<simDim> const supcerCellIdx = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc)));
+            DataSpace<simDim> const supcerCellIdx
+                = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())));
             /* offset (in cells) of the supercell relative to the origin of the
              * local domain (without any guards)
              */
@@ -111,12 +105,9 @@ namespace picongpu
 
             // each virtual worker needs only one filter
             filter.setSuperCellPosition(localSuperCellCellOffset);
-            auto accParFilter = parFilter(
-                acc,
-                supcerCellIdx - mapper.getGuardingSuperCells(),
-                lockstep::Worker<numWorkers>{workerIdx});
+            auto accParFilter = parFilter(worker, supcerCellIdx - mapper.getGuardingSuperCells());
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             onlyMaster(
                 [&]()
@@ -125,7 +116,7 @@ namespace picongpu
                     srcFramePtr = srcBox.getFirstFrame(supcerCellIdx);
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             // move over all Frames in the supercell
             while(srcFramePtr.isValid())
@@ -137,20 +128,21 @@ namespace picongpu
                         storageOffsetCtx[idx] = -1;
                         // count particle in frame
                         if(parSrc[multiMask_] == 1 && filter(parSrc))
-                            if(accParFilter(acc, parSrc))
+                            if(accParFilter(worker, parSrc))
                                 storageOffsetCtx[idx]
-                                    = kernel::atomicAllInc(acc, &localCounter, ::alpaka::hierarchy::Threads{});
+                                    = kernel::atomicAllInc(worker, &localCounter, ::alpaka::hierarchy::Threads{});
                     });
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 onlyMaster(
                     [&]()
                     {
                         // reserve host memory for particle
-                        globalOffset = cupla::atomicAdd(acc, counter, localCounter, ::alpaka::hierarchy::Blocks{});
+                        globalOffset
+                            = cupla::atomicAdd(worker.getAcc(), counter, localCounter, ::alpaka::hierarchy::Blocks{});
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 forEachParticleInFrame(
                     [&](lockstep::Idx const idx)
@@ -168,7 +160,7 @@ namespace picongpu
                         }
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 onlyMaster(
                     [&]()
@@ -177,7 +169,7 @@ namespace picongpu
                         srcFramePtr = srcBox.getNextFrame(srcFramePtr);
                         localCounter = 0;
                     });
-                cupla::__syncthreads(acc);
+                worker.sync();
             }
         }
     };

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -208,13 +208,12 @@ namespace picongpu
                 GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
                 auto const mapper = makeAreaMapper<CORE + BORDER>(*(rp.params.cellDescription));
 
-                constexpr uint32_t numWorkers
-                    = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
+                auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
 
                 /* this sanity check costs a little bit of time but hdf5 writing is
                  * slower */
-                PMACC_KERNEL(CopySpecies<numWorkers>{})
-                (mapper.getGridDim(), numWorkers)(
+                PMACC_LOCKSTEP_KERNEL(CopySpecies{}, workerCfg)
+                (mapper.getGridDim())(
                     counterBuffer.getDeviceBuffer().getPointer(),
                     deviceFrame,
                     rp.speciesTmp->getDeviceParticlesBox(),

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.kernel
@@ -28,11 +28,7 @@ namespace picongpu
 {
     using namespace pmacc;
 
-    /** This kernel is only called for guard particles.
-     *
-     * @tparam T_numWorkers number of workers
-     */
-    template<uint32_t T_numWorkers>
+    //! This kernel is only called for guard particles.
     struct KernelParticleCalorimeter
     {
         /** call functor calorimeterFunctor for each particle
@@ -40,9 +36,9 @@ namespace picongpu
          * @tparam T_ParticlesBox pmacc::ParticlesBox, particle box type
          * @tparam T_CalorimeterFunctor type of the functor
          * @tparam T_Mapping supercell mapper functor type
-         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          *
-         * @param alpaka accelerator
+         * @param worker lockstep worker
          * @param particlesBox particle memory
          * @param mapper functor to map a block to a supercell
          * @param beginCellIdxLocal only process particles with local domain cell index >=
@@ -53,10 +49,10 @@ namespace picongpu
             typename T_ParticlesBox,
             typename T_CalorimeterFunctor,
             typename T_Mapper,
-            typename T_Acc,
+            typename T_Worker,
             typename T_Filter>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_ParticlesBox particlesBox,
             T_CalorimeterFunctor calorimeterFunctor,
             T_Mapper mapper,
@@ -64,31 +60,26 @@ namespace picongpu
             pmacc::DataSpace<simDim> endCellIdxLocal,
             T_Filter filter) const
         {
-            constexpr uint32_t numWorkers = T_numWorkers;
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
             /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
-            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(acc))));
+            DataSpace<simDim> const superCellIdx(
+                mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
-            auto forEachParticle
-                = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(workerIdx, particlesBox, superCellIdx);
+            auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
 
             // end kernel if we have no particles
             if(!forEachParticle.hasParticles())
                 return;
 
-            auto accFilter
-                = filter(acc, superCellIdx - mapper.getGuardingSuperCells(), lockstep::Worker<numWorkers>{workerIdx});
+            auto accFilter = filter(worker, superCellIdx - mapper.getGuardingSuperCells());
             auto const superCellCellOffsetNoGuard
                 = (superCellIdx - mapper.getGuardingSuperCells()) * SuperCellSize::toRT();
 
             forEachParticle(
-                acc,
                 [&accFilter, &superCellCellOffsetNoGuard, &beginCellIdxLocal, &endCellIdxLocal, &calorimeterFunctor](
-                    auto const& accelerator,
+                    auto const& lockstepWorker,
                     auto& particle)
                 {
-                    if(accFilter(accelerator, particle))
+                    if(accFilter(lockstepWorker, particle))
                     {
                         // Check if it fits the internal cells range
                         auto const cellInSuperCell
@@ -97,7 +88,7 @@ namespace picongpu
                         for(uint32_t d = 0; d < simDim; d++)
                             if((localCell[d] < beginCellIdxLocal[d]) || (localCell[d] >= endCellIdxLocal[d]))
                                 return;
-                        calorimeterFunctor(accelerator, particle);
+                        calorimeterFunctor(lockstepWorker, particle);
                     }
                 });
         }

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -86,8 +86,8 @@ namespace picongpu
             this->calorimeterCur = calorimeterCur;
         }
 
-        template<typename T_Particle, typename T_Acc>
-        DINLINE void operator()(const T_Acc& acc, T_Particle& particle)
+        template<typename T_Particle, typename T_Worker>
+        DINLINE void operator()(const T_Worker& worker, T_Particle& particle)
         {
             const float3_X mom = particle[momentum_];
             const float_X mom2 = pmacc::math::dot(mom, mom);
@@ -147,7 +147,7 @@ namespace picongpu
                 }
 
                 cupla::atomicAdd(
-                    acc,
+                    worker.getAcc(),
                     &(*this->calorimeterCur(yawBin, pitchBin, energyBin)),
                     energy * normedWeighting,
                     ::alpaka::hierarchy::Threads{});

--- a/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
+++ b/include/picongpu/plugins/particleMerging/ParticleMerger.kernel
@@ -108,22 +108,16 @@ namespace picongpu
                  *
                  * @param cellIdx cell index
                  */
-                template<typename T_Acc>
-                DINLINE void initVoronoiCellIdAttribute(T_Acc const& acc, const pmacc::math::Int<simDim>& cellIdx)
+                template<typename T_Worker>
+                DINLINE void initVoronoiCellIdAttribute(
+                    T_Worker const& worker,
+                    const pmacc::math::Int<simDim>& cellIdx)
                 {
-                    //! \todo change this as soon as the kernel support lock step programming
-                    constexpr uint32_t numWorkers = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    const uint32_t workerIdx
-                        = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
-
                     auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
-                    auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
-                        workerIdx,
-                        particlesBox,
-                        superCellIdx);
+                    auto forEachParticle
+                        = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
 
                     forEachParticle(
-                        acc,
                         [this](auto const&, auto& particle)
                         {
                             const lcellId_t particleCellIdx = particle[localCellIdx_];
@@ -162,26 +156,18 @@ namespace picongpu
                  * @param cellIdx n-dim. cell index, including guard cells
                  * @param listVoronoiCells fixed-sized array of Voronoi cells
                  */
-                template<typename T_Acc>
+                template<typename T_Worker>
                 DINLINE void processParticles(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const pmacc::math::Int<simDim>& cellIdx,
                     ArrayVoronoiCells& listVoronoiCells)
                 {
-                    //! \todo change this as soon as the kernel support lock step programming
-                    constexpr uint32_t numWorkers = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    const uint32_t workerIdx
-                        = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
-
                     auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
-                    auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
-                        workerIdx,
-                        particlesBox,
-                        superCellIdx);
+                    auto forEachParticle
+                        = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
 
                     forEachParticle(
-                        acc,
-                        [&](auto const& accelerator, auto& particle)
+                        [&](auto const& lockstepWorker, auto& particle)
 
                         {
                             const voronoiCellId::type voronoiCellId = particle[voronoiCellId_];
@@ -198,7 +184,7 @@ namespace picongpu
                             switch(voronoiCell.status)
                             {
                             case VoronoiStatus::collecting:
-                                voronoiCell.addParticle(accelerator, position, momentum, weighting);
+                                voronoiCell.addParticle(lockstepWorker, position, momentum, weighting);
 
                                 break;
 
@@ -212,7 +198,7 @@ namespace picongpu
 
                                     /* place particle into one of the two sub-Voronoi cells */
                                     listVoronoiCells[subVoronoiCellId]
-                                        .addParticle(accelerator, position, momentum, weighting);
+                                        .addParticle(lockstepWorker, position, momentum, weighting);
                                 }
 
                                 break;
@@ -225,7 +211,7 @@ namespace picongpu
 
                             case VoronoiStatus::readyForMerging:
                                 /* merge all particles of this Voronoi cell */
-                                if(voronoiCell.isFirstParticle(accelerator))
+                                if(voronoiCell.isFirstParticle(lockstepWorker))
                                 {
                                     /* I am the first particle in the Voronoi cell
                                      * => get dressed with Voronoi cell's attributes */
@@ -353,8 +339,8 @@ namespace picongpu
                  *
                  * @param cellIndex n-dim. cell index from the origin of the local domain
                  */
-                template<typename T_Acc>
-                DINLINE void operator()(T_Acc const& acc, const pmacc::math::Int<simDim>& cellIndex)
+                template<typename T_Worker>
+                DINLINE void operator()(T_Worker const& worker, const pmacc::math::Int<simDim>& cellIndex)
                 {
                     /* multi-dim vector from origin of the super cell to a cell in units of cells */
                     const pmacc::math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
@@ -366,9 +352,9 @@ namespace picongpu
                         threadIndex);
 
                     /* fixed-sized array of Voronoi cells */
-                    PMACC_SMEM(acc, listVoronoiCells, ArrayVoronoiCells);
+                    PMACC_SMEM(worker, listVoronoiCells, ArrayVoronoiCells);
                     /* holds indices of active Voronoi cells within `listVoronoiCells` */
-                    PMACC_SMEM(acc, voronoiIndexPool, VoronoiIndexPool);
+                    PMACC_SMEM(worker, voronoiIndexPool, VoronoiIndexPool);
 
                     /* number of initial Voronoi cells
                      *
@@ -378,39 +364,43 @@ namespace picongpu
                     constexpr uint16_t numInitialVoronoiCells
                         = pmacc::math::CT::volume<SuperCellSize>::type::value / (1u << simDim);
 
-                    if(linearThreadIdx == 0)
-                    {
-                        /* init index pool of Voronoi Cells */
-                        voronoiIndexPool = VoronoiIndexPool(numInitialVoronoiCells);
-                    }
+                    auto mastOnly = lockstep::makeMaster(worker);
+                    mastOnly(
+                        [&]()
+                        {
+                            /* init index pool of Voronoi Cells */
+                            voronoiIndexPool = VoronoiIndexPool(numInitialVoronoiCells);
+                        });
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     /* set initial Voronoi cells into `collecting` state */
-                    if(linearThreadIdx < numInitialVoronoiCells)
-                        listVoronoiCells[linearThreadIdx] = VoronoiCell();
-
-                    cupla::__syncthreads(acc);
+                    auto forEachCell
+                        = lockstep::makeForEach<pmacc::math::CT::volume<SuperCellSize>::type::value>(worker);
+                    forEachCell(
+                        [&](uint32_t const linearIdx)
+                        {
+                            if(linearIdx < numInitialVoronoiCells)
+                                listVoronoiCells[linearThreadIdx] = VoronoiCell();
+                        });
+                    worker.sync();
 
                     /* init the voronoiCellId attribute for each particle */
-                    this->initVoronoiCellIdAttribute(acc, cellIndex);
+                    this->initVoronoiCellIdAttribute(worker, cellIndex);
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     /* main loop of the merging algorithm */
                     while(voronoiIndexPool.size() > 0)
                     {
-                        this->processParticles(acc, cellIndex, listVoronoiCells);
+                        this->processParticles(worker, cellIndex, listVoronoiCells);
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         /* TODO: parallelize */
-                        if(linearThreadIdx == 0)
-                        {
-                            this->processVoronoiCells(listVoronoiCells, voronoiIndexPool);
-                        }
+                        mastOnly([&]() { this->processVoronoiCells(listVoronoiCells, voronoiIndexPool); });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
                     }
                 }
             };

--- a/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
+++ b/include/picongpu/plugins/particleMerging/VoronoiCell.hpp
@@ -117,27 +117,31 @@ namespace picongpu
                 }
 
                 /** check if the current thread is associated to the first particle */
-                template<typename T_Acc>
-                DINLINE bool isFirstParticle(T_Acc const& acc)
+                template<typename T_Worker>
+                DINLINE bool isFirstParticle(T_Worker const& worker)
                 {
-                    return cupla::atomicExch(acc, &this->firstParticleFlag, 1) == 0;
+                    return cupla::atomicExch(worker.getAcc(), &this->firstParticleFlag, 1) == 0;
                 }
 
 
                 /** add a particle to this Voronoi cell */
-                template<typename T_Acc>
+                template<typename T_Worker>
                 DINLINE void addParticle(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const floatD_X position,
                     const float3_X momentum,
                     const float_X weighting)
                 {
                     cupla::atomicAdd(
-                        acc,
+                        worker.getAcc(),
                         &this->numMacroParticles,
                         static_cast<uint32_t>(1),
                         ::alpaka::hierarchy::Threads{});
-                    cupla::atomicAdd(acc, &this->numRealParticles, weighting, ::alpaka::hierarchy::Threads{});
+                    cupla::atomicAdd(
+                        worker.getAcc(),
+                        &this->numRealParticles,
+                        weighting,
+                        ::alpaka::hierarchy::Threads{});
 
                     if(this->splittingStage == VoronoiSplittingStage::position)
                     {
@@ -146,12 +150,12 @@ namespace picongpu
                         for(int i = 0; i < simDim; i++)
                         {
                             cupla::atomicAdd(
-                                acc,
+                                worker.getAcc(),
                                 &this->meanValue[i],
                                 weighting * position[i],
                                 ::alpaka::hierarchy::Threads{});
                             cupla::atomicAdd(
-                                acc,
+                                worker.getAcc(),
                                 &this->meanSquaredValue[i],
                                 weighting * position2[i],
                                 ::alpaka::hierarchy::Threads{});
@@ -164,12 +168,12 @@ namespace picongpu
                         for(int i = 0; i < DIM3; i++)
                         {
                             cupla::atomicAdd(
-                                acc,
+                                worker.getAcc(),
                                 &this->meanValue[i],
                                 weighting * momentum[i],
                                 ::alpaka::hierarchy::Threads{});
                             cupla::atomicAdd(
-                                acc,
+                                worker.getAcc(),
                                 &this->meanSquaredValue[i],
                                 weighting * momentum2[i],
                                 ::alpaka::hierarchy::Threads{});

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -57,10 +57,7 @@ namespace picongpu
             /** calculate the radiation of a species
              *
              * If \p T_dependenciesFulfilled is false a dummy kernel without functionality is created
-             *
-             * @tparam T_numWorkers number of workers
              */
-            template<uint32_t T_numWorkers>
             struct KernelRadiationParticles
             {
                 /**
@@ -90,12 +87,12 @@ namespace picongpu
                  * @param freqFkt
                  * @param simBoxSize
                  */
-                template<typename ParBox, typename DBox, typename Mapping, typename T_Acc>
+                template<typename ParBox, typename DBox, typename Mapping, typename T_Worker>
                 DINLINE
                     /*__launch_bounds__(256, 4)*/
                     void
                     operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         ParBox pb,
                         DBox radiation,
                         DataSpace<simDim> globalOffset,
@@ -107,14 +104,11 @@ namespace picongpu
                     namespace po = boost::program_options;
                     using Amplitude = picongpu::plugins::radiation::Amplitude<>;
                     constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    constexpr uint32_t numWorker = T_numWorkers;
 
                     using FrameType = typename ParBox::FrameType;
                     using FramePtr = typename ParBox::FramePtr;
 
                     using namespace parameters; // parameters of radiation
-
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
                     /// calculate radiated Amplitude
                     /* parallelized in 1 dimensions:
@@ -128,24 +122,24 @@ namespace picongpu
                     constexpr int blockSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
                     // vectorial part of the integrand in the Jackson formula
-                    PMACC_SMEM(acc, real_amplitude_s, memory::Array<vector_64, blockSize>);
+                    PMACC_SMEM(worker, real_amplitude_s, memory::Array<vector_64, blockSize>);
 
                     // retarded time
-                    PMACC_SMEM(acc, t_ret_s, memory::Array<picongpu::float_X, blockSize>);
+                    PMACC_SMEM(worker, t_ret_s, memory::Array<picongpu::float_X, blockSize>);
 
                     // storage for macro particle weighting needed if
                     // the coherent and incoherent radiation of a single
                     // macro-particle needs to be considered
-                    PMACC_SMEM(acc, radWeighting_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, radWeighting_s, memory::Array<float_X, blockSize>);
 
                     // particle counter used if not all particles are considered for
                     // radiation calculation
-                    PMACC_SMEM(acc, counter_s, int);
+                    PMACC_SMEM(worker, counter_s, int);
 
-                    PMACC_SMEM(acc, lowpass_s, memory::Array<NyquistLowPass, blockSize>);
+                    PMACC_SMEM(worker, lowpass_s, memory::Array<NyquistLowPass, blockSize>);
 
 
-                    int const theta_idx = cupla::blockIdx(acc).x; // cupla::blockIdx(acc).x is used to determine theta
+                    int const theta_idx = cupla::blockIdx(worker.getAcc()).x; // determine theta
 
                     // simulation time (needed for retarded time)
                     picongpu::float_64 const t(picongpu::float_64(currentStep) * picongpu::float_64(DELTA_T));
@@ -164,8 +158,8 @@ namespace picongpu
                     // get absolute number of relevant super cells
                     int const numSuperCells = superCellsCount.productOfComponents();
 
-                    int const numJobs = cupla::gridDim(acc).y;
-                    int const jobIdx = cupla::blockIdx(acc).y;
+                    int const numJobs = cupla::gridDim(worker.getAcc()).y;
+                    int const jobIdx = cupla::blockIdx(worker.getAcc()).y;
 
                     /* go over all super cells on GPU with a stride depending on number of temporary results
                      * but ignore all guarding supercells
@@ -197,9 +191,9 @@ namespace picongpu
                              *  all threads must wait for the selection of a new frame
                              *  until all threads have evaluated "isValid"
                              */
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
-                            auto onlyMaster = lockstep::makeMaster(workerIdx);
+                            auto onlyMaster = lockstep::makeMaster(worker);
 
                             /* The Master process (thread 0) in every thread block is in
                              * charge of loading a frame from
@@ -208,10 +202,10 @@ namespace picongpu
                              */
                             onlyMaster([&]() { counter_s = 0; });
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             // loop over all particles in the frame
-                            auto forEachParticle = lockstep::makeForEach<frameSize, numWorker>(workerIdx);
+                            auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
                             forEachParticle(
                                 [&](uint32_t const linearIdx)
@@ -240,7 +234,7 @@ namespace picongpu
                                         {
                                             if(getRadiationMask(par))
                                                 saveParticleAt = kernel::atomicAllInc(
-                                                    acc,
+                                                    worker,
                                                     &counter_s,
                                                     ::alpaka::hierarchy::Threads{});
 
@@ -356,11 +350,12 @@ namespace picongpu
                                     } // END: only threads with particles are running
                                 });
 
-                            cupla::__syncthreads(acc); // wait till every thread has loaded its particle data
+                            worker.sync(); // wait till every thread has loaded its particle data
 
 
                             // run over all  valid omegas for this thread
-                            for(uint32_t o = workerIdx; o < radiation_frequencies::N_omega; o += T_numWorkers)
+                            for(uint32_t o = worker.getWorkerIdx(); o < radiation_frequencies::N_omega;
+                                o += T_Worker::getNumWorkers())
                             {
                                 /* storage for amplitude (complex 3D vector)
                                  * it  is initialized with zeros (  0 +  i 0 )
@@ -410,7 +405,7 @@ namespace picongpu
 
 
                             // wait till all radiation contributions for this super cell are done
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             /* First threads starts loading next frame of the super-cell:
                              *

--- a/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.kernel
+++ b/include/picongpu/plugins/randomizedParticleMerger/RandomizedParticleMerger.kernel
@@ -76,7 +76,6 @@ namespace picongpu
                 float_X momSpreadThreshold;
                 /** factory of gitting random value */
                 RngFactory rngFactory;
-                using RandomGen = RngFactory::RandomGen;
 
             public:
                 RandomizedParticleMergerKernel(
@@ -121,22 +120,16 @@ namespace picongpu
                  *
                  * @param cellIdx cell index, including guard cells
                  */
-                template<typename T_Acc>
-                DINLINE void initVoronoiCellIdAttribute(T_Acc const& acc, const pmacc::math::Int<simDim>& cellIdx)
+                template<typename T_Worker>
+                DINLINE void initVoronoiCellIdAttribute(
+                    T_Worker const& worker,
+                    const pmacc::math::Int<simDim>& cellIdx)
                 {
-                    //! \todo change this as soon as the kernel support lock step programming
-                    constexpr uint32_t numWorkers = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    const uint32_t workerIdx
-                        = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
-
                     auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
-                    auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
-                        workerIdx,
-                        particlesBox,
-                        superCellIdx);
+                    auto forEachParticle
+                        = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
 
                     forEachParticle(
-                        acc,
                         [this](auto const&, auto& particle)
                         {
                             const lcellId_t particleCellIdx = particle[localCellIdx_];
@@ -189,7 +182,8 @@ namespace picongpu
                  * @param randomGen ramdom generator functor
                  * @param voronoiCell voronoi cell
                  */
-                DINLINE bool isNeededSubdivision(RandomGen& randomGen, VoronoiCell const& voronoiCell) const
+                template<typename T_RandomGen>
+                DINLINE bool isNeededSubdivision(T_RandomGen& randomGen, VoronoiCell const& voronoiCell) const
                 {
                     // With large enough number of macroparticles we always subdivide
                     if(voronoiCell.numMacroParticles > maxParticlesToMerge)
@@ -255,10 +249,10 @@ namespace picongpu
                  * @param particle current particle
                  * @param voronoiCell current Voronoi cell
                  */
-                template<typename T_Particle, typename T_Acc>
-                DINLINE void mergeVoronoiCell(T_Acc const& acc, T_Particle& particle, VoronoiCell& voronoiCell)
+                template<typename T_Particle, typename T_Worker>
+                DINLINE void mergeVoronoiCell(T_Worker const& worker, T_Particle& particle, VoronoiCell& voronoiCell)
                 {
-                    if(voronoiCell.isFirstParticle(acc))
+                    if(voronoiCell.isFirstParticle(worker))
                     {
                         /* I am the first particle in the Voronoi cell
                          * => get dressed with Voronoi cell's attributes
@@ -292,32 +286,24 @@ namespace picongpu
                  * Depending on the state of the Voronoi cell where the particle belongs
                  * to the execution is forked into distinct sub-processes.
                  *
-                 * @tparam T_Acc accelerator type
+                 * @tparam T_Worker accelerator type
                  *
-                 * @param acc accelerator
+                 * @param worker lockstep worker
                  * @param cellIdx n-dimensional cell index, including guard cells
                  * @param listVoronoiCells fixed-sized array of Voronoi cells
                  */
-                template<typename T_Acc>
+                template<typename T_Worker>
                 DINLINE void processParticles(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     const pmacc::math::Int<simDim>& cellIdx,
                     ArrayVoronoiCells& listVoronoiCells)
                 {
-                    //! \todo change this as soon as the kernel support lock step programming
-                    constexpr uint32_t numWorkers = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    const uint32_t workerIdx
-                        = DataSpaceOperations<simDim>::template map<SuperCellSize>(cellIdx % SuperCellSize::toRT());
-
                     auto const superCellIdx = pmacc::DataSpace<simDim>{cellIdx / SuperCellSize::toRT()};
-                    auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach<numWorkers>(
-                        workerIdx,
-                        particlesBox,
-                        superCellIdx);
+                    auto forEachParticle
+                        = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
 
                     forEachParticle(
-                        acc,
-                        [&](auto const& accelerator, auto& particle)
+                        [&](auto const& lockstepWorker, auto& particle)
                         {
                             const voronoiCellId::type voronoiCellId = particle[voronoiCellId_];
 
@@ -338,7 +324,7 @@ namespace picongpu
                             switch(voronoiCell.status)
                             {
                             case VoronoiStatus::collecting:
-                                voronoiCell.addParticle(accelerator, position, singleParticleMomentum, weighting);
+                                voronoiCell.addParticle(lockstepWorker, position, singleParticleMomentum, weighting);
                                 break;
 
                             case VoronoiStatus::splitting:
@@ -347,7 +333,7 @@ namespace picongpu
                                         = voronoiCell.getSubVoronoiCell(position, singleParticleMomentum);
                                     particle[voronoiCellId_] = subVoronoiCellId;
                                     listVoronoiCells[subVoronoiCellId]
-                                        .addParticle(accelerator, position, singleParticleMomentum, weighting);
+                                        .addParticle(lockstepWorker, position, singleParticleMomentum, weighting);
 
                                     break;
                                 }
@@ -357,7 +343,7 @@ namespace picongpu
                                 break;
 
                             case VoronoiStatus::readyForMerging:
-                                mergeVoronoiCell(accelerator, particle, voronoiCell);
+                                mergeVoronoiCell(lockstepWorker, particle, voronoiCell);
                                 particle[voronoiCellId_] = -1;
                             }
                         });
@@ -372,10 +358,11 @@ namespace picongpu
                  * @param voronoiIndexPool holds indices of active Voronoi cells within `listVoronoiCells`
                  * @param randomGen random generator functor
                  */
+                template<typename T_RandomGen>
                 DINLINE void processVoronoiCells(
                     ArrayVoronoiCells& listVoronoiCells,
                     VoronoiIndexPool& voronoiIndexPool,
-                    RandomGen& randomGen) const
+                    T_RandomGen& randomGen) const
                 {
                     for(voronoiCellId::type voronoiCellId : voronoiIndexPool)
                     {
@@ -446,13 +433,13 @@ namespace picongpu
 
                 /** Entry point of the particle merging algorithm
                  *
-                 * @tparam T_Acc accelerator type
+                 * @tparam T_Worker lockstep worker type
                  *
-                 * @param acc accelerator
+                 * @param worker lockstep worker
                  * @param cellIndex n-dimensional cell index from the origin of the local domain
                  */
-                template<typename T_Acc>
-                DINLINE void operator()(T_Acc const& acc, const pmacc::math::Int<simDim>& cellIndex)
+                template<typename T_Worker>
+                DINLINE void operator()(T_Worker const& worker, const pmacc::math::Int<simDim>& cellIndex)
                 {
                     // multi-dim vector from origin of the super cell to a cell in units of cells
                     const pmacc::math::Int<simDim> threadIndex = cellIndex % SuperCellSize::toRT();
@@ -461,8 +448,8 @@ namespace picongpu
                         threadIndex);
 
                     // Storage for Voronoi cells in shared memory
-                    PMACC_SMEM(acc, listVoronoiCells, ArrayVoronoiCells);
-                    PMACC_SMEM(acc, voronoiIndexPool, VoronoiIndexPool);
+                    PMACC_SMEM(worker, listVoronoiCells, ArrayVoronoiCells);
+                    PMACC_SMEM(worker, voronoiIndexPool, VoronoiIndexPool);
 
                     /* number of initial Voronoi cells
                      * `1u << simDim` is equivalent to `pow(2, simDim)` but can be
@@ -473,36 +460,34 @@ namespace picongpu
 
 
                     pmacc::math::Int<simDim> localOffset = cellIndex / SuperCellSize::toRT() - guardSuperCells;
-                    constexpr uint32_t numWorkers = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    lockstep::Worker<numWorkers> workerCfg(linearThreadIdx);
 
                     // Thread 0 of each block creates Voronoi cells
                     if(linearThreadIdx == 0)
                     {
                         voronoiIndexPool = VoronoiIndexPool(numInitialVoronoiCells);
                     }
-                    __syncthreads();
+                    worker.sync();
 
                     // Set initial Voronoi cells into `collecting` state
                     if(linearThreadIdx < numInitialVoronoiCells)
                         listVoronoiCells[linearThreadIdx] = VoronoiCell();
-                    __syncthreads();
+                    worker.sync();
 
                     // Distribute particle between original cells
-                    initVoronoiCellIdAttribute(acc, cellIndex);
-                    __syncthreads();
+                    initVoronoiCellIdAttribute(worker, cellIndex);
+                    worker.sync();
 
-                    auto generator = rngFactory(acc, localOffset, workerCfg);
+                    auto generator = rngFactory(worker, localOffset);
                     // Main loop of the algorithm: while there are active cells left
                     while(voronoiIndexPool.size() > 0)
                     {
-                        processParticles(acc, cellIndex, listVoronoiCells);
-                        __syncthreads();
+                        processParticles(worker, cellIndex, listVoronoiCells);
+                        worker.sync();
 
                         // This part is not yet parallelized between blocks of a thread
                         if(linearThreadIdx == 0)
                             processVoronoiCells(listVoronoiCells, voronoiIndexPool, generator);
-                        __syncthreads();
+                        worker.sync();
                     }
                 }
             };

--- a/include/picongpu/plugins/randomizedParticleMerger/VoronoiCell.hpp
+++ b/include/picongpu/plugins/randomizedParticleMerger/VoronoiCell.hpp
@@ -160,39 +160,43 @@ namespace picongpu
                 }
 
                 /** check if the current thread is associated to the first particle */
-                template<typename T_Acc>
-                DINLINE bool isFirstParticle(const T_Acc& acc)
+                template<typename T_Worker>
+                DINLINE bool isFirstParticle(const T_Worker& worker)
                 {
                     return atomicExch(&this->firstParticleFlag, 1) == 0;
                 }
 
 
                 /** add a particle to this Voronoi cell */
-                template<typename T_Acc>
+                template<typename T_Worker>
                 DINLINE void addParticle(
-                    const T_Acc& acc,
+                    const T_Worker& worker,
                     const floatD_X position,
                     const float3_X momentum,
                     const float_X weighting)
                 {
                     cupla::atomicAdd(
-                        acc,
+                        worker.getAcc(),
                         &this->numMacroParticles,
                         static_cast<uint32_t>(1),
                         ::alpaka::hierarchy::Threads{});
-                    cupla::atomicAdd(acc, &this->numRealParticles, weighting, ::alpaka::hierarchy::Threads{});
+                    cupla::atomicAdd(
+                        worker.getAcc(),
+                        &this->numRealParticles,
+                        weighting,
+                        ::alpaka::hierarchy::Threads{});
 
                     const floatD_X position2 = position * position;
 
                     for(int i = 0; i < simDim; i++)
                     {
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &this->meanPositionValue[i],
                             weighting * position[i],
                             ::alpaka::hierarchy::Threads{});
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &this->meanPositionSquaredValue[i],
                             weighting * position2[i],
                             ::alpaka::hierarchy::Threads{});
@@ -203,12 +207,12 @@ namespace picongpu
                     for(int i = 0; i < DIM3; i++)
                     {
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &this->meanMomentumValue[i],
                             weighting * momentum[i],
                             ::alpaka::hierarchy::Threads{});
                         cupla::atomicAdd(
-                            acc,
+                            worker.getAcc(),
                             &this->meanMomentumSquaredValue[i],
                             weighting * momentum2[i],
                             ::alpaka::hierarchy::Threads{});

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -43,35 +43,36 @@ namespace picongpu
     {
         namespace transitionRadiation
         {
-            /** Kernel for computation of transition radiation on GPUs.
-             *
-             * @tparam T_numWorkers maximal CUDA threads
-             * @tparam T_ParBox box with particles
-             * @tparam T_DBox box with float data
-             * @tparam T_DBoxComplex box with complex data
-             * @tparam T_Mapping MappingDescription object
-             * @tparam T_Acc alpaka accelerator
-             * @param acc alpaka accelerator
-             * @param incTransRad output array for storage incoherent transition radiation
-             * @param cohTransRadPara output array for storage of parallel parts of coherent transition radiation
-             * @param cohTransRadPerp output array for storage of perpendicular parts of coherent transition radiation
-             * @param numParticles output array for amount of particles
-             * @param globalOffset offset of simulation
-             * @param mapper MappingDesction object
-             * @param freqFkt frequency functor
-             * @param simBoxSize size of simulation box
-             */
-            template<uint32_t T_numWorkers>
+            //! Kernel for computation of transition radiation on GPUs.
+
             struct KernelTransRadParticles
             {
+                /**
+                 *
+                 * @tparam T_ParBox box with particles
+                 * @tparam T_DBox box with float data
+                 * @tparam T_DBoxComplex box with complex data
+                 * @tparam T_Mapping MappingDescription object
+                 * @tparam T_Worker lockstep worker type
+                 * @param worker lockstep worker
+                 * @param incTransRad output array for storage incoherent transition radiation
+                 * @param cohTransRadPara output array for storage of parallel parts of coherent transition radiation
+                 * @param cohTransRadPerp output array for storage of perpendicular parts of coherent transition
+                 * radiation
+                 * @param numParticles output array for amount of particles
+                 * @param globalOffset offset of simulation
+                 * @param mapper MappingDesction object
+                 * @param freqFkt frequency functor
+                 * @param simBoxSize size of simulation box
+                 */
                 template<
                     typename T_ParBox,
                     typename T_DBox,
                     typename T_DBoxComplex, // Formfactor returns complex values
                     typename T_Mapping,
-                    typename T_Acc>
+                    typename T_Worker>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     T_ParBox pb,
                     T_DBox incTransRad,
                     T_DBoxComplex cohTransRadPara,
@@ -86,12 +87,9 @@ namespace picongpu
                     using complex_64 = alpaka::Complex<float_64>;
 
                     constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    constexpr uint32_t numWorker = T_numWorkers;
 
                     using FrameType = typename T_ParBox::FrameType;
                     using FramePtr = typename T_ParBox::FramePtr;
-
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
                     /* parallelized in 2 dimensions:
                      * looking direction (theta, phi)
@@ -104,25 +102,26 @@ namespace picongpu
                     constexpr int blockSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
                     // perpendicular part of normalized energy
-                    PMACC_SMEM(acc, energyPerp_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, energyPerp_s, memory::Array<float_X, blockSize>);
 
                     // parallel part of normalized energy
-                    PMACC_SMEM(acc, energyPara_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, energyPara_s, memory::Array<float_X, blockSize>);
 
                     // exponent of the form factor
-                    PMACC_SMEM(acc, formfactorExponent_s, memory::Array<complex_X, blockSize>);
+                    PMACC_SMEM(worker, formfactorExponent_s, memory::Array<complex_X, blockSize>);
 
                     // storage for macro particle weighting needed if
                     // the coherent and incoherent radiation of a single
                     // macro-particle needs to be considered
-                    PMACC_SMEM(acc, radWeighting_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, radWeighting_s, memory::Array<float_X, blockSize>);
 
                     // particle counter used if not all particles are considered for
                     // radiation calculation
-                    PMACC_SMEM(acc, counter_s, int);
+                    PMACC_SMEM(worker, counter_s, int);
 
 
-                    int const theta_idx = cupla::blockIdx(acc).x; // cupla::blockIdx(acc).x is used to determine theta
+                    int const theta_idx
+                        = cupla::blockIdx(worker.getAcc()).x; // cupla::blockIdx(acc).x is used to determine theta
 
                     // looking direction (needed for observer) used in the thread
                     float3_X const look = transitionRadiation::observationDirection(theta_idx);
@@ -173,9 +172,9 @@ namespace picongpu
                              *  all threads must wait for the selection of a new frame
                              *  until all threads have evaluated "isValid"
                              */
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
-                            auto onlyMaster = lockstep::makeMaster(workerIdx);
+                            auto onlyMaster = lockstep::makeMaster(worker);
 
                             /* The Master process (thread 0) in every thread block is in
                              * charge of loading a frame from
@@ -184,10 +183,10 @@ namespace picongpu
                              */
                             onlyMaster([&]() { counter_s = 0; });
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             // loop over all particles in the frame
-                            auto forEachParticle = lockstep::makeForEach<frameSize, numWorker>(workerIdx);
+                            auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
                             forEachParticle(
                                 [&](uint32_t const linearIdx)
@@ -213,7 +212,7 @@ namespace picongpu
                                         {
                                             if(transitionRadiation::getTransitionRadiationMask(par))
                                                 saveParticleAt = kernel::atomicAllInc(
-                                                    acc,
+                                                    worker,
                                                     &counter_s,
                                                     ::alpaka::hierarchy::Threads{});
 
@@ -285,11 +284,11 @@ namespace picongpu
                                         } // only moving particles
                                     } // only threads with particle
                                 }); // for each particle
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             // run over all  valid omegas for this thread
-                            for(uint32_t o = workerIdx; o < transitionRadiation::frequencies::nOmega;
-                                o += T_numWorkers)
+                            for(uint32_t o = worker.getWorkerIdx(); o < transitionRadiation::frequencies::nOmega;
+                                o += T_Worker::getNumWorkers())
                             {
                                 float_X itrSum = 0.0;
                                 float_X totalParticles = 0.0;
@@ -325,7 +324,7 @@ namespace picongpu
                                 cohTransRadPerp[index] += ctrSumPerp;
                             }
 
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             /* First threads starts loading next frame of the super-cell:
                              *

--- a/include/picongpu/plugins/xrayScattering/XrayScattering.kernel
+++ b/include/picongpu/plugins/xrayScattering/XrayScattering.kernel
@@ -35,16 +35,12 @@ namespace picongpu
     {
         namespace xrayScattering
         {
-            /** Kernel for xrayScattering calculation.
-             *
-             * @tparam T_numWorkers Number of virtual workers on block.
-             */
-            template<uint32_t T_numWorkers>
+            //! Kernel for xrayScattering calculation.
             struct KernelXrayScattering
             {
                 /** Kernel function.
                  *
-                 * @param acc alpaka accelerator
+                 * @param worker lockstep worker
                  * @param cellsGrid Dimensions of BORDER + CORE in cells, not super
                  *      cells.
                  * @param densityBoxGPU Data box of the density device storage, shifted
@@ -58,7 +54,7 @@ namespace picongpu
                  * @param currentStep Current simulation step.
                  */
                 template<
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_DensityBoxGPU,
                     typename T_FieldPos,
                     typename T_DBox,
@@ -66,7 +62,7 @@ namespace picongpu
                     typename T_ScatteringVectors,
                     typename T_ProbingBeam>
                 DINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     DataSpace<simDim> cellsGrid,
                     T_DensityBoxGPU densityBoxGPU,
                     DataSpace<simDim> globalOffset,
@@ -80,21 +76,18 @@ namespace picongpu
 
                 ) const
                 {
-                    constexpr uint32_t blockSize
-                        = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
-                    constexpr uint32_t numWorkers = T_numWorkers;
-                    uint32_t const workerIdx = cupla::threadIdx(acc).x;
-                    uint32_t const blockIdxLin = cupla::blockIdx(acc).x;
+                    constexpr uint32_t blockSize = T_Worker::getNumWorkers();
+                    uint32_t const blockIdxLin = cupla::blockIdx(worker.getAcc()).x;
 
                     using complex_X = alpaka::Complex<float_X>;
                     // Storage for positions in the beam coordinate system.
-                    PMACC_SMEM(acc, positions, memory::Array<float2_X, blockSize>);
+                    PMACC_SMEM(worker, positions, memory::Array<float2_X, blockSize>);
                     // Storage for (form factor density * beam intensity factor).
-                    PMACC_SMEM(acc, densities, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, densities, memory::Array<float_X, blockSize>);
 
                     uint32_t const linAccessBlockBegin = blockIdxLin * blockSize;
 
-                    lockstep::makeForEach<blockSize, numWorkers>(workerIdx)(
+                    lockstep::makeForEach<blockSize>(worker)(
                         [&](uint32_t const linearIdx)
                         {
                             // Each thread reads one field value and saves it together
@@ -118,12 +111,13 @@ namespace picongpu
                             positions[linearIdx] = position_b.shrink<DIM2>();
 
                             // Wait for all threads on the block to finish.
-                            cupla::__syncthreads(acc);
+                            worker.sync();
 
                             // Calculate the density fourier transform:
                             // Loop over q-vectors in frequency space:
                             // Each worker process every numWorkers vector.
-                            for(uint32_t qLoopIdx = workerIdx; qLoopIdx < totalNumVectors; qLoopIdx += numWorkers)
+                            for(uint32_t qLoopIdx = worker.getWorkerIdx(); qLoopIdx < totalNumVectors;
+                                qLoopIdx += blockSize)
                             {
                                 float2_X q = scatteringVectors[qLoopIdx];
                                 complex_X amplitude(0.0);
@@ -145,8 +139,16 @@ namespace picongpu
                                 // is guaranteed by alpaka::Complex<>.
                                 auto* resultReal = &reinterpret_cast<float_X(&)[2]>(amplitudeBox[qLoopIdx])[0];
                                 auto* resultImag = &reinterpret_cast<float_X(&)[2]>(amplitudeBox[qLoopIdx])[1];
-                                cupla::atomicAdd(acc, resultReal, amplitude.real(), ::alpaka::hierarchy::Blocks{});
-                                cupla::atomicAdd(acc, resultImag, amplitude.imag(), ::alpaka::hierarchy::Blocks{});
+                                cupla::atomicAdd(
+                                    worker.getAcc(),
+                                    resultReal,
+                                    amplitude.real(),
+                                    ::alpaka::hierarchy::Blocks{});
+                                cupla::atomicAdd(
+                                    worker.getAcc(),
+                                    resultImag,
+                                    amplitude.imag(),
+                                    ::alpaka::hierarchy::Blocks{});
                             } // end loop over scattering directions
                         } // end lambda function body
                     );

--- a/include/pmacc/cuSTL/algorithm/functor/Add.hpp
+++ b/include/pmacc/cuSTL/algorithm/functor/Add.hpp
@@ -38,8 +38,8 @@ namespace pmacc
                     return first + second;
                 }
 
-                template<typename T_Type, typename T_Acc>
-                HDINLINE T_Type operator()(T_Acc const&, T_Type const& first, T_Type const& second) const
+                template<typename T_Type, typename T_Worker>
+                HDINLINE T_Type operator()(T_Worker const&, T_Type const& first, T_Type const& second) const
                 {
                     return first + second;
                 }

--- a/include/pmacc/cuSTL/algorithm/functor/AssignValue.hpp
+++ b/include/pmacc/cuSTL/algorithm/functor/AssignValue.hpp
@@ -46,8 +46,8 @@ namespace pmacc
                     arg = m_value;
                 }
 
-                template<typename T_Acc>
-                HDINLINE void operator()(T_Acc const&, Type& arg) const
+                template<typename T_Worker>
+                HDINLINE void operator()(T_Worker const&, Type& arg) const
                 {
                     arg = m_value;
                 }

--- a/include/pmacc/cuSTL/algorithm/functor/GetComponent.hpp
+++ b/include/pmacc/cuSTL/algorithm/functor/GetComponent.hpp
@@ -41,8 +41,8 @@ namespace pmacc
                 {
                 }
 
-                template<typename Array, typename T_Acc>
-                HDINLINE Type& operator()(T_Acc const&, Array& array) const
+                template<typename Array, typename T_Worker>
+                HDINLINE Type& operator()(T_Worker const&, Array& array) const
                 {
                     return array[m_component];
                 }

--- a/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
+++ b/include/pmacc/cuSTL/algorithm/kernel/detail/SphericMapper.hpp
@@ -58,22 +58,22 @@ namespace pmacc
                         return math::Size_t<3>(size.x() / BlockSize::x::value, 1u, 1u);
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE math::Int<1> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const math::Int<1>& _blockIdx,
                         const math::Int<1>& _threadIdx) const
                     {
                         return _blockIdx.x() * BlockSize::x::value + _threadIdx.x();
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE math::Int<1> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const cupla::dim3& _blockIdx,
                         const cupla::dim3& _threadIdx = cupla::dim3(0, 0, 0)) const
                     {
-                        return operator()(acc, math::Int<1>((int) _blockIdx.x), math::Int<1>((int) _threadIdx.x));
+                        return operator()(worker, math::Int<1>((int) _blockIdx.x), math::Int<1>((int) _threadIdx.x));
                     }
                 };
 
@@ -87,9 +87,9 @@ namespace pmacc
                         return math::Size_t<3>(size.x() / BlockSize::x::value, size.y() / BlockSize::y::value, 1u);
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE math::Int<2> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const math::Int<2>& _blockIdx,
                         const math::Int<2>& _threadIdx) const
                     {
@@ -98,14 +98,14 @@ namespace pmacc
                             _blockIdx.y() * BlockSize::y::value + _threadIdx.y());
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE math::Int<2> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const cupla::dim3& _blockIdx,
                         const cupla::dim3& _threadIdx = cupla::dim3(0, 0, 0)) const
                     {
                         return operator()(
-                            acc,
+                            worker,
                             math::Int<2>(_blockIdx.x, _blockIdx.y),
                             math::Int<2>(_threadIdx.x, _threadIdx.y));
                     }
@@ -124,23 +124,23 @@ namespace pmacc
                             size.z() / BlockSize::z::value);
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE math::Int<3> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const math::Int<3>& _blockIdx,
                         const math::Int<3>& _threadIdx) const
                     {
                         return math::Int<3>(_blockIdx * (math::Int<3>) BlockSize().toRT() + _threadIdx);
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     HDINLINE math::Int<3> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const cupla::dim3& _blockIdx,
                         const cupla::dim3& _threadIdx = cupla::dim3(0, 0, 0)) const
                     {
                         return operator()(
-                            acc,
+                            worker,
                             math::Int<3>(_blockIdx.x, _blockIdx.y, _blockIdx.z),
                             math::Int<3>(_threadIdx.x, _threadIdx.y, _threadIdx.z));
                     }
@@ -158,9 +158,9 @@ namespace pmacc
                         return math::Size_t<3>(size.x() / blockSize.x(), 1u, 1u);
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     DINLINE math::Int<1> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const math::Int<1>& _blockDim,
                         const math::Int<1>& _blockIdx,
                         const math::Int<1>& _threadIdx) const
@@ -168,15 +168,15 @@ namespace pmacc
                         return _blockIdx.x() * _blockDim.x() + _threadIdx.x();
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     DINLINE math::Int<1> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const cupla::dim3& _blockDim,
                         const cupla::dim3& _blockIdx,
                         const cupla::dim3& _threadIdx) const
                     {
                         return operator()(
-                            acc,
+                            worker,
                             math::Int<1>((int) _blockDim.x),
                             math::Int<1>((int) _blockIdx.x),
                             math::Int<1>((int) _threadIdx.x));
@@ -193,9 +193,9 @@ namespace pmacc
                         return math::Size_t<3>(size.x() / blockSize.x(), size.y() / blockSize.y(), 1);
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     DINLINE math::Int<2> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const math::Int<2>& _blockDim,
                         const math::Int<2>& _blockIdx,
                         const math::Int<2>& _threadIdx) const
@@ -205,15 +205,15 @@ namespace pmacc
                             _blockIdx.y() * _blockDim.y() + _threadIdx.y()};
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     DINLINE math::Int<2> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const cupla::dim3& _blockDim,
                         const cupla::dim3& _blockIdx,
                         const cupla::dim3& _threadIdx) const
                     {
                         return operator()(
-                            acc,
+                            worker,
                             math::Int<2>(_blockDim.x, _blockDim.y),
                             math::Int<2>(_blockIdx.x, _blockIdx.y),
                             math::Int<2>(_threadIdx.x, _threadIdx.y));
@@ -233,9 +233,9 @@ namespace pmacc
                             size.z() / blockSize.z());
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     DINLINE math::Int<3> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const math::Int<3>& _blockDim,
                         const math::Int<3>& _blockIdx,
                         const math::Int<3>& _threadIdx) const
@@ -246,15 +246,15 @@ namespace pmacc
                             _blockIdx.z() * _blockDim.z() + _threadIdx.z()};
                     }
 
-                    template<typename T_Acc>
+                    template<typename T_Worker>
                     DINLINE math::Int<3> operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         const cupla::dim3& _blockDim,
                         const cupla::dim3& _blockIdx,
                         const cupla::dim3& _threadIdx) const
                     {
                         return operator()(
-                            acc,
+                            worker,
                             math::Int<3>(_blockDim.x, _blockDim.y, _blockDim.z),
                             math::Int<3>(_blockIdx.x, _blockIdx.y, _blockIdx.z),
                             math::Int<3>(_threadIdx.x, _threadIdx.y, _threadIdx.z));

--- a/include/pmacc/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
+++ b/include/pmacc/cuSTL/container/allocator/compile-time/SharedMemAllocator.hpp
@@ -46,11 +46,11 @@ namespace pmacc
                 static constexpr int dim = 1;
                 typedef cursor::CT::BufferCursor<type, math::CT::UInt32<>> Cursor;
 
-                template<typename T_Acc>
-                DINLINE static Cursor allocate(T_Acc const& acc)
+                template<typename T_Worker>
+                DINLINE static Cursor allocate(T_Worker const& worker)
                 {
                     auto& shMem = pmacc::memory::shared::
-                        allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(acc);
+                        allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(worker);
                     return Cursor(shMem.data());
                 }
             };
@@ -63,11 +63,11 @@ namespace pmacc
                 static constexpr int dim = 2;
                 typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
-                template<typename T_Acc>
-                DINLINE static Cursor allocate(T_Acc const& acc)
+                template<typename T_Worker>
+                DINLINE static Cursor allocate(T_Worker const& worker)
                 {
                     auto& shMem = pmacc::memory::shared::
-                        allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(acc);
+                        allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(worker);
                     return Cursor(shMem.data());
                 }
             };
@@ -81,11 +81,11 @@ namespace pmacc
                 static constexpr int dim = 3;
                 typedef cursor::CT::BufferCursor<type, Pitch> Cursor;
 
-                template<typename T_Acc>
-                DINLINE static Cursor allocate(T_Acc const& acc)
+                template<typename T_Worker>
+                DINLINE static Cursor allocate(T_Worker const& worker)
                 {
                     auto& shMem = pmacc::memory::shared::
-                        allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(acc);
+                        allocate<uid, memory::Array<Type, math::CT::volume<Size>::type::value>>(worker);
                     return Cursor(shMem.data());
                 }
             };

--- a/include/pmacc/cuSTL/container/compile-time/CartBuffer.hpp
+++ b/include/pmacc/cuSTL/container/compile-time/CartBuffer.hpp
@@ -53,8 +53,8 @@ namespace pmacc
                 Type* dataPointer;
 
             public:
-                template<typename T_Acc>
-                DINLINE CartBuffer(T_Acc const& acc);
+                template<typename T_Worker>
+                DINLINE CartBuffer(T_Worker const& worker);
                 DINLINE CartBuffer(const CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& other);
 
                 DINLINE CT::CartBuffer<Type, Size, Allocator, Copier, Assigner>& operator=(

--- a/include/pmacc/cuSTL/container/compile-time/CartBuffer.tpp
+++ b/include/pmacc/cuSTL/container/compile-time/CartBuffer.tpp
@@ -28,10 +28,10 @@ namespace pmacc
         namespace CT
         {
             template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>
-            template<typename T_Acc>
-            DINLINE CartBuffer<Type, _Size, Allocator, Copier, Assigner>::CartBuffer(T_Acc const& acc)
+            template<typename T_Worker>
+            DINLINE CartBuffer<Type, _Size, Allocator, Copier, Assigner>::CartBuffer(T_Worker const& worker)
             {
-                this->dataPointer = Allocator::allocate(acc).getMarker();
+                this->dataPointer = Allocator::allocate(worker).getMarker();
             }
 
             template<typename Type, typename _Size, typename Allocator, typename Copier, typename Assigner>

--- a/include/pmacc/device/Reduce.hpp
+++ b/include/pmacc/device/Reduce.hpp
@@ -193,63 +193,63 @@ namespace pmacc
             {
                 if(threads >= 512u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<512u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 512u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<512u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 512u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 256u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<256u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 256u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<256u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 256u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 128u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<128u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 128u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<128u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 128u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 64u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<64u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 64u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<64u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 64u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 32u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<32u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 32u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<32u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 32u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 16u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<16u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 16u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<16u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 16u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 8u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<8u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 8u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<8u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 8u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 4u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<4u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 4u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<4u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 4u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else if(threads >= 2u)
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<2u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 2u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<2u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 2u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
                 else
                 {
-                    constexpr uint32_t numWorkers = traits::GetNumWorkers<1u>::value;
-                    PMACC_KERNEL(reduce::Kernel<Type, 1u, numWorkers>{})
-                    (blocks, numWorkers, sharedMemSize)(args...);
+                    auto workerCfg = lockstep::makeWorkerCfg<1u>();
+                    PMACC_LOCKSTEP_KERNEL(reduce::Kernel<Type, 1u>{}, workerCfg)
+                    (blocks, sharedMemSize)(args...);
                 }
             }
 

--- a/include/pmacc/eventSystem/events/kernelEvents.hpp
+++ b/include/pmacc/eventSystem/events/kernelEvents.hpp
@@ -274,7 +274,7 @@ namespace alpaka
             template<typename... TArgs>
             ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
                 ::pmacc::exec::detail::KernelWithDynSharedMem<T_UserKernel> const& userKernel,
-                TArgs const&...) -> ::alpaka::Idx<T_Acc>
+                TArgs&&...) -> ::alpaka::Idx<T_Acc>
             {
                 return userKernel.m_dynSharedMemBytes;
             }

--- a/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -33,8 +33,8 @@ namespace pmacc
 {
     struct KernelSetValueOnDeviceMemory
     {
-        template<typename T_Acc>
-        DINLINE void operator()(const T_Acc&, size_t* pointer, const size_t size) const
+        template<typename T_Worker>
+        DINLINE void operator()(const T_Worker&, size_t* pointer, const size_t size) const
         {
             *pointer = size;
         }

--- a/include/pmacc/kernel/operation/Atomic.hpp
+++ b/include/pmacc/kernel/operation/Atomic.hpp
@@ -39,15 +39,15 @@ namespace pmacc
             struct Atomic
             {
                 /** Execute generic atomic operation */
-                template<typename T_Acc, typename T_Dst, typename T_Src>
-                HDINLINE void operator()(T_Acc const& acc, T_Dst& dst, T_Src const& src) const
+                template<typename T_Worker, typename T_Dst, typename T_Src>
+                HDINLINE void operator()(T_Worker const& worker, T_Dst& dst, T_Src const& src) const
                 {
-                    atomicOpNoRet<T_AlpakaOperation>(acc, &dst, src, T_AlpakaHierarchy{});
+                    atomicOpNoRet<T_AlpakaOperation>(worker, &dst, src, T_AlpakaHierarchy{});
                 }
 
                 /** Execute atomic operation for pmacc::math::Vector */
                 template<
-                    typename T_Acc,
+                    typename T_Worker,
                     typename T_Type,
                     int T_dim,
                     typename T_DstAccessor,
@@ -57,12 +57,12 @@ namespace pmacc
                     typename T_SrcNavigator,
                     typename T_SrcStorage>
                 HDINLINE void operator()(
-                    T_Acc const& acc,
+                    T_Worker const& worker,
                     pmacc::math::Vector<T_Type, T_dim, T_DstAccessor, T_DstNavigator, T_DstStorage>& dst,
                     pmacc::math::Vector<T_Type, T_dim, T_SrcAccessor, T_SrcNavigator, T_SrcStorage> const& src) const
                 {
                     for(int i = 0; i < T_dim; ++i)
-                        atomicOpNoRet<T_AlpakaOperation>(acc, &dst[i], src[i], T_AlpakaHierarchy{});
+                        atomicOpNoRet<T_AlpakaOperation>(worker, &dst[i], src[i], T_AlpakaHierarchy{});
                 }
             };
 

--- a/include/pmacc/lockstep/Kernel.hpp
+++ b/include/pmacc/lockstep/Kernel.hpp
@@ -1,0 +1,161 @@
+/* Copyright 2017-2022 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/eventSystem/EventSystem.hpp"
+#include "pmacc/lockstep/Worker.hpp"
+#include "pmacc/lockstep/WorkerCfg.hpp"
+#include "pmacc/types.hpp"
+
+
+namespace pmacc::lockstep
+{
+    namespace exec
+    {
+        namespace detail
+        {
+            template<typename T_Kernel, typename T_WorkerCfg>
+            struct LockStepKernel : private T_Kernel
+            {
+                LockStepKernel(T_Kernel const& kernel) : T_Kernel(kernel)
+                {
+                }
+
+                /** Forward arguments to the user kernel.
+                 *
+                 * The alpaka accelerator is replaced by
+                 *
+                 * @tparam T_Acc alpaka accelerator type
+                 * @tparam T_Args user kernel argument types
+                 * @param acc alpaka accelerator
+                 * @param args user kernel arguments
+                 */
+                template<typename T_Acc, typename... T_Args>
+                HDINLINE void operator()(T_Acc const& acc, T_Args&&... args) const
+                {
+                    auto const worker = lockstep::detail::WorkerCfgAssume1DBlock::getWorker<T_WorkerCfg>(acc);
+                    T_Kernel::template operator()(worker, std::forward<T_Args>(args)...);
+                }
+            };
+
+
+            /** Wraps a user kernel functor to prepare the execution on the device.
+             *
+             * This objects contains the kernel functor, kernel meta information.
+             * Object is used to apply the grid and block extents and optionally the amount of dynamic shared memory to
+             * the kernel.
+             */
+            template<typename T_KernelFunctor, typename T_WorkerCfg>
+            struct KernelPreperationWrapper
+            {
+                using KernelFunctor = detail::LockStepKernel<T_KernelFunctor, T_WorkerCfg>;
+                KernelFunctor const m_kernelFunctor;
+                pmacc::exec::detail::KernelMetaData const m_metaData;
+
+                HINLINE KernelPreperationWrapper(
+                    T_KernelFunctor const& kernelFunctor,
+                    std::string const& file = std::string(),
+                    size_t const line = 0)
+                    : m_kernelFunctor(kernelFunctor)
+                    , m_metaData(file, line)
+                {
+                }
+
+                /** Configured kernel object.
+                 *
+                 * This objects contains the functor and the starting parameter.
+                 *
+                 * @tparam T_VectorGrid type which defines the grid extents (type must be castable to cupla dim3)
+                 * @tparam T_VectorBlock type which defines the block extents (type must be castable to cupla dim3)
+                 *
+                 * @param gridExtent grid extent configuration for the kernel
+                 * @param blockExtent block extent configuration for the kernel
+                 *
+                 * @return object to bind arguments to a kernel
+                 *
+                 * @{
+                 */
+                template<typename T_VectorGrid>
+                HINLINE auto operator()(T_VectorGrid const& gridExtent) const
+                    -> pmacc::exec::detail::KernelLauncher<KernelFunctor>
+                {
+                    return {m_kernelFunctor, m_metaData, gridExtent, T_WorkerCfg::getNumWorkers()};
+                }
+
+                /**
+                 * @param sharedMemByte dynamic shared memory used by the kernel (in byte)
+                 */
+                template<typename T_VectorGrid>
+                HINLINE auto operator()(T_VectorGrid const& gridExtent, size_t const sharedMemByte) const
+                    -> pmacc::exec::detail::KernelLauncher<pmacc::exec::detail::KernelWithDynSharedMem<KernelFunctor>>
+                {
+                    return {
+                        pmacc::exec::detail::KernelWithDynSharedMem<KernelFunctor>(m_kernelFunctor, sharedMemByte),
+                        m_metaData,
+                        gridExtent,
+                        T_WorkerCfg::getNumWorkers()};
+                }
+                /**@}*/
+            };
+        } // namespace detail
+
+        /** Creates a kernel object.
+         *
+         * example for lambda usage:
+         *
+         * @code{.cpp}
+         *   pmacc::lockstep::exec::kernel([]ALPAKA_FN_ACC(auto const& acc) -> void{
+         *       printf("Hello World.\n");
+         *   })(1,1)()
+         * @endcode
+         *
+         * @tparam T_KernelFunctor type of the kernel functor
+         * @param kernelFunctor instance of the functor, lambda are supported
+         * @param file file name (for debug)
+         * @param line line number in the file (for debug)
+         */
+        template<typename T_KernelFunctor, uint32_t T_numSuggestedWorkers>
+        inline auto kernel(
+            T_KernelFunctor const& kernelFunctor,
+            WorkerCfg<T_numSuggestedWorkers> const& /*workerCfg*/,
+            std::string const& file = std::string(),
+            size_t const line = 0)
+            -> detail::KernelPreperationWrapper<T_KernelFunctor, WorkerCfg<T_numSuggestedWorkers>>
+        {
+            return detail::KernelPreperationWrapper<T_KernelFunctor, WorkerCfg<T_numSuggestedWorkers>>(
+                kernelFunctor,
+                file,
+                line);
+        }
+
+    } // namespace exec
+} // namespace pmacc::lockstep
+
+/** Create a kernel object out of a functor instance.
+ *
+ * This macro add the current filename and line number to the kernel object.
+ * @see ::pmacc::lockstep::exec::kernel
+ *
+ * @param ... instance of kernel functor
+ */
+#define PMACC_LOCKSTEP_KERNEL(...)                                                                                    \
+    ::pmacc::lockstep::exec::kernel(__VA_ARGS__, __FILE__, static_cast<size_t>(__LINE__))

--- a/include/pmacc/lockstep/Variable.hpp
+++ b/include/pmacc/lockstep/Variable.hpp
@@ -33,7 +33,7 @@ namespace pmacc
 {
     namespace lockstep
     {
-        template<typename T_Config>
+        template<typename T_Worker, typename T_Config>
         class ForEach;
 
         /** Variable used by virtual worker
@@ -115,10 +115,10 @@ namespace pmacc
          * @return Variable usable within a lockstep step. Variable data can not be accessed outside of a lockstep
          * step.
          */
-        template<typename T_Type, typename T_Config>
-        HDINLINE auto makeVar(ForEach<T_Config> const& forEach)
+        template<typename T_Type, typename T_Worker, typename T_Config>
+        HDINLINE auto makeVar(ForEach<T_Worker, T_Config> const& forEach)
         {
-            return Variable<T_Type, typename ForEach<T_Config>::BaseConfig>();
+            return Variable<T_Type, typename ForEach<T_Worker, T_Config>::BaseConfig>();
         }
 
         /** Creates a variable usable within a subsequent locksteps.
@@ -136,10 +136,10 @@ namespace pmacc
          * @return Variable usable within a lockstep step. Variable data can not be accessed outside of a lockstep
          * step.
          */
-        template<typename T_Type, typename T_Config, typename... T_Args>
-        HDINLINE auto makeVar(ForEach<T_Config> const& forEach, T_Args&&... args)
+        template<typename T_Type, typename T_Worker, typename T_Config, typename... T_Args>
+        HDINLINE auto makeVar(ForEach<T_Worker, T_Config> const& forEach, T_Args&&... args)
         {
-            return Variable<T_Type, typename ForEach<T_Config>::BaseConfig>(std::forward<T_Args>(args)...);
+            return Variable<T_Type, typename ForEach<T_Worker, T_Config>::BaseConfig>(std::forward<T_Args>(args)...);
         }
 
     } // namespace lockstep

--- a/include/pmacc/lockstep/Worker.hpp
+++ b/include/pmacc/lockstep/Worker.hpp
@@ -85,8 +85,8 @@ namespace pmacc::lockstep
 
         /** synchronize all workers
          *
-         * @attention It is not allowed to call this method in side of a if branch or a loop if it is not guaranteed
-         * that all worker executing the same code branch.
+         * @attention It is not allowed to call this method inside of an if branch or a loop if it is not guaranteed
+         * that all workers are executing the same code branch.
          */
         HDINLINE void sync() const
         {

--- a/include/pmacc/lockstep/WorkerCfg.hpp
+++ b/include/pmacc/lockstep/WorkerCfg.hpp
@@ -87,6 +87,10 @@ namespace pmacc::lockstep
         {
             auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
             auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+
+            // validate that the kernel is started with the correct number of threads
+            ALPAKA_ASSERT_OFFLOAD(blockExtent.prod() == numWorkers);
+
             auto const linearThreadIdx = alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0];
             return Worker<T_Acc, T_numSuggestedWorkers>(acc, linearThreadIdx);
         }
@@ -110,6 +114,10 @@ namespace pmacc::lockstep
         template<typename T_Acc>
         HDINLINE static auto getWorkerAssume1DThreads(T_Acc const& acc)
         {
+            [[maybe_unused]] auto const blockDim = cupla::blockDim(acc).x;
+            // validate that the kernel is started with the correct number of threads
+            ALPAKA_ASSERT_OFFLOAD(blockDim == numWorkers);
+
             return Worker<T_Acc, T_numSuggestedWorkers>(acc, cupla::threadIdx(acc).x);
         }
     };

--- a/include/pmacc/lockstep/WorkerCfg.hpp
+++ b/include/pmacc/lockstep/WorkerCfg.hpp
@@ -1,0 +1,163 @@
+/* Copyright 2022 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/lockstep/Worker.hpp"
+#include "pmacc/traits/GetNumWorkers.hpp"
+#include "pmacc/types.hpp"
+
+#include "pmacc/math/vector/compile-time/Vector.hpp"
+
+
+namespace pmacc::lockstep
+{
+    namespace detail
+    {
+        /** Helper to manage visibility for methods in WorkerCfg.
+         *
+         * This object provides an optimized access to the one dimensional worker index of WorkerCfg.
+         * This indirection avoids that the user is accessing the optimized method from a kernel which is not
+         * guaranteed launched with a one dimensional block size.
+         */
+        struct WorkerCfgAssume1DBlock
+        {
+            /** Get the lockstep worker index.
+             *
+             * @attention This method should only be called if it is guaranteed that the kernel is started with a one
+             * dimension block size. In general this method should only be used from
+             * lockstep::exec::detail::LockStepKernel.
+             *
+             * @tparam T_WorkerCfg lockstep worker configuration
+             * @tparam T_Acc alpaka accelerator type
+             * @param acc alpaka accelerator
+             * @return worker index
+             */
+            template<typename T_WorkerCfg, typename T_Acc>
+            HDINLINE static auto getWorker(T_Acc const& acc)
+            {
+                return T_WorkerCfg::getWorkerAssume1DThreads(acc);
+            }
+        };
+    } // namespace detail
+    /** Configuration of worker used for a lockstep kernel
+     *
+     * @tparam T_numSuggestedWorkers Suggested number of lockstep workers. Do not assume that the suggested number of
+     *                               workers is used within the kernel. The real used number of worker can be queried
+     *                               with getNumWorkers() or via the member variable numWorkers.
+     *
+     * @attention: The real number of workers used for the lockstep kernel depends on the alpaka backend and will
+     * be adjusted by this class via the trait pmacc::traits::GetNumWorkers.
+     */
+    template<uint32_t T_numSuggestedWorkers>
+    struct WorkerCfg
+    {
+        friend struct detail::WorkerCfgAssume1DBlock;
+
+        /** adjusted number of workers
+         *
+         * This number is taking the block size restriction of the alpaka backend into account.
+         */
+        static constexpr uint32_t numWorkers = pmacc::traits::GetNumWorkers<T_numSuggestedWorkers>::value;
+
+        /** get the worker index
+         *
+         * @return index of the worker
+         */
+        template<typename T_Acc>
+        HDINLINE static auto getWorker(T_Acc const& acc)
+        {
+            auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+            auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+            auto const linearThreadIdx = alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0];
+            return Worker<T_Acc, T_numSuggestedWorkers>(acc, linearThreadIdx);
+        }
+
+        /** get the number of workers
+         *
+         * @return number of workers
+         */
+        HDINLINE static constexpr uint32_t getNumWorkers()
+        {
+            return numWorkers;
+        }
+
+    private:
+        /** Get the lockstep worker index.
+         *
+         * @tparam T_Acc alpaka accelerator type
+         * @param acc alpaka accelerator
+         * @return lockstep worker index
+         */
+        template<typename T_Acc>
+        HDINLINE static auto getWorkerAssume1DThreads(T_Acc const& acc)
+        {
+            return Worker<T_Acc, T_numSuggestedWorkers>(acc, cupla::threadIdx(acc).x);
+        }
+    };
+
+    inline namespace traits
+    {
+        /** Factory to create a worker config from a PMacc compile time vector.
+         *
+         * @tparam T_CTVector PMacc compile time vector
+         * @treturn ::type worker configuration type
+         */
+        template<typename T_CTVector>
+        struct MakeWorkerCfg;
+
+        template<typename T_X, typename T_Y, typename T_Z>
+        struct MakeWorkerCfg<math::CT::Vector<T_X, T_Y, T_Z>>
+        {
+            using Size = math::CT::Vector<T_X, T_Y, T_Z>;
+            using type = WorkerCfg<math::CT::volume<Size>::type::value>;
+        };
+
+        //! Factory alias to get the worker configuration type.
+        template<typename T_CTVector>
+        using MakeWorkerCfg_t = typename MakeWorkerCfg<T_CTVector>::type;
+    } // namespace traits
+
+    /** Creates a lockstep worker configuration.
+     *
+     * @tparam T_numSuggestedWorkers Suggested number of lockstep workers.
+     * @return lockstep worker configuration
+     */
+    template<uint32_t T_numSuggestedWorkers>
+    HDINLINE auto makeWorkerCfg()
+    {
+        return WorkerCfg<T_numSuggestedWorkers>{};
+    }
+
+    /** Specialization to create a lockstep worker configuration out of a PMacc compile time vector.
+     *
+     * @tparam T_X number of elements in X
+     * @tparam T_Y number of elements in Y
+     * @tparam T_Z number of elements in Z
+     * @return lockstep worker configuration
+     */
+    template<typename T_X, typename T_Y, typename T_Z>
+    HDINLINE auto makeWorkerCfg(math::CT::Vector<T_X, T_Y, T_Z> const&)
+    {
+        using Size = math::CT::Vector<T_X, T_Y, T_Z>;
+        return MakeWorkerCfg_t<Size>{};
+    }
+} // namespace pmacc::lockstep

--- a/include/pmacc/lockstep/lockstep.hpp
+++ b/include/pmacc/lockstep/lockstep.hpp
@@ -1,0 +1,29 @@
+/* Copyright 2022 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/lockstep/ForEach.hpp"
+#include "pmacc/lockstep/Idx.hpp"
+#include "pmacc/lockstep/Kernel.hpp"
+#include "pmacc/lockstep/Variable.hpp"
+#include "pmacc/lockstep/Worker.hpp"
+#include "pmacc/lockstep/WorkerCfg.hpp"

--- a/include/pmacc/math/operation/Add.hpp
+++ b/include/pmacc/math/operation/Add.hpp
@@ -38,8 +38,8 @@ namespace pmacc
                     dst += src;
                 }
 
-                template<typename Dst, typename Src, typename T_Acc>
-                HDINLINE void operator()(const T_Acc&, Dst& dst, const Src& src) const
+                template<typename Dst, typename Src, typename T_Worker>
+                HDINLINE void operator()(const T_Worker&, Dst& dst, const Src& src) const
                 {
                     dst += src;
                 }

--- a/include/pmacc/math/operation/Assign.hpp
+++ b/include/pmacc/math/operation/Assign.hpp
@@ -37,8 +37,8 @@ namespace pmacc
                     dst = src;
                 }
 
-                template<typename Dst, typename Src, typename T_Acc>
-                HDINLINE void operator()(const T_Acc&, Dst& dst, const Src& src) const
+                template<typename Dst, typename Src, typename T_Worker>
+                HDINLINE void operator()(const T_Worker&, Dst& dst, const Src& src) const
                 {
                     dst = src;
                 }

--- a/include/pmacc/math/operation/Max.hpp
+++ b/include/pmacc/math/operation/Max.hpp
@@ -39,8 +39,8 @@ namespace pmacc
                     dst = math::max(dst, src);
                 }
 
-                template<typename Dst, typename Src, typename T_Acc>
-                DINLINE void operator()(const T_Acc&, Dst& dst, const Src& src) const
+                template<typename Dst, typename Src, typename T_Worker>
+                DINLINE void operator()(const T_Worker&, Dst& dst, const Src& src) const
                 {
                     dst = math::max(dst, src);
                 }

--- a/include/pmacc/math/operation/Min.hpp
+++ b/include/pmacc/math/operation/Min.hpp
@@ -40,8 +40,8 @@ namespace pmacc
                     dst = math::min(dst, src);
                 }
 
-                template<typename Dst, typename Src, typename T_Acc>
-                DINLINE void operator()(const T_Acc&, Dst& dst, const Src& src) const
+                template<typename Dst, typename Src, typename T_Worker>
+                DINLINE void operator()(const T_Worker&, Dst& dst, const Src& src) const
                 {
                     dst = math::min(dst, src);
                 }

--- a/include/pmacc/math/operation/Mul.hpp
+++ b/include/pmacc/math/operation/Mul.hpp
@@ -38,8 +38,8 @@ namespace pmacc
                     dst *= src;
                 }
 
-                template<typename Dst, typename Src, typename T_Acc>
-                HDINLINE void operator()(const T_Acc&, Dst& dst, const Src& src) const
+                template<typename Dst, typename Src, typename T_Worker>
+                HDINLINE void operator()(const T_Worker&, Dst& dst, const Src& src) const
                 {
                     dst *= src;
                 }

--- a/include/pmacc/math/operation/Sub.hpp
+++ b/include/pmacc/math/operation/Sub.hpp
@@ -37,8 +37,8 @@ namespace pmacc
                     dst -= src;
                 }
 
-                template<typename Dst, typename Src, typename T_Acc>
-                HDINLINE void operator()(const T_Acc&, Dst& dst, const Src& src) const
+                template<typename Dst, typename Src, typename T_Worker>
+                HDINLINE void operator()(const T_Worker&, Dst& dst, const Src& src) const
                 {
                     dst -= src;
                 }

--- a/include/pmacc/memory/boxes/CachedBox.hpp
+++ b/include/pmacc/memory/boxes/CachedBox.hpp
@@ -30,18 +30,18 @@ namespace pmacc
 {
     namespace CachedBox
     {
-        template<uint32_t Id_, typename ValueType_, class BlockDescription_, typename T_Acc>
-        DINLINE auto create(T_Acc const& acc, const BlockDescription_ block)
+        template<uint32_t Id_, typename ValueType_, class BlockDescription_, typename T_Worker>
+        DINLINE auto create(T_Worker const& worker, const BlockDescription_ block)
         {
             using OffsetOrigin = typename BlockDescription_::OffsetOrigin;
             using Type = DataBox<SharedBox<ValueType_, typename BlockDescription_::FullSuperCellSize, Id_>>;
-            return Type{Type::init(acc)}.shift(DataSpace<OffsetOrigin::dim>{OffsetOrigin::toRT()});
+            return Type{Type::init(worker)}.shift(DataSpace<OffsetOrigin::dim>{OffsetOrigin::toRT()});
         }
 
-        template<uint32_t Id_, typename ValueType_, class BlockDescription_, typename T_Acc>
-        DINLINE auto create(T_Acc const& acc, const ValueType_& value, const BlockDescription_ block)
+        template<uint32_t Id_, typename ValueType_, class BlockDescription_, typename T_Worker>
+        DINLINE auto create(T_Worker const& worker, const ValueType_& value, const BlockDescription_ block)
         {
-            return create<Id_, ValueType_, BlockDescription_>(acc);
+            return create<Id_, ValueType_, BlockDescription_>(worker);
         }
     } // namespace CachedBox
 } // namespace pmacc

--- a/include/pmacc/memory/boxes/SharedBox.hpp
+++ b/include/pmacc/memory/boxes/SharedBox.hpp
@@ -122,11 +122,12 @@ namespace pmacc
          * This call synchronizes a block and must be called from all threads and
          * not inside a if clauses
          */
-        template<typename T_Acc>
-        static DINLINE SharedBox init(T_Acc const& acc)
+        template<typename T_Worker>
+        static DINLINE SharedBox init(T_Worker const& worker)
         {
             auto& mem_sh
-                = memory::shared::allocate<T_id, memory::Array<ValueType, math::CT::volume<Size>::type::value>>(acc);
+                = memory::shared::allocate<T_id, memory::Array<ValueType, math::CT::volume<Size>::type::value>>(
+                    worker);
             return {mem_sh.data()};
         }
 

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -40,15 +40,15 @@
 
 namespace pmacc
 {
-    template<typename T_ParticleBox, typename T_SuperCellIdxType, typename T_Acc>
+    template<typename T_ParticleBox, typename T_SuperCellIdxType, typename T_Worker>
     DINLINE typename T_ParticleBox::FramePtr getPreviousFrameAndRemoveLastFrame(
-        const T_Acc& acc,
+        const T_Worker& worker,
         const typename T_ParticleBox::FramePtr& frame,
         T_ParticleBox& pb,
         const T_SuperCellIdxType& superCellIdx)
     {
         typename T_ParticleBox::FramePtr result = pb.getPreviousFrame(frame);
-        pb.removeLastFrame(acc, superCellIdx);
+        pb.removeLastFrame(worker, superCellIdx);
         return result;
     }
 
@@ -57,10 +57,7 @@ namespace pmacc
      * Copy all particles in a frame to the storage places at the frame's beginning.
      * This leaves the frame with a contiguous number of valid particles at
      * the beginning and a subsequent, contiguous gap at the end.
-     *
-     * @tparam T_numWorkers number of workers
      */
-    template<uint32_t T_numWorkers>
     struct KernelFillGapsLastFrame
     {
         /** fill particle gaps
@@ -71,28 +68,26 @@ namespace pmacc
          * @param boxPar particle memory
          * @param mapper functor to map a block to a supercell
          */
-        template<typename T_ParBox, typename T_Mapping, typename T_Acc>
-        DINLINE void operator()(T_Acc const& acc, T_ParBox pb, T_Mapping mapper) const
+        template<typename T_ParBox, typename T_Mapping, typename T_Worker>
+        DINLINE void operator()(T_Worker const& worker, T_ParBox pb, T_Mapping mapper) const
         {
             using namespace particles::operations;
 
             constexpr uint32_t frameSize = math::CT::volume<typename T_Mapping::SuperCellSize>::type::value;
             constexpr uint32_t dim = T_Mapping::Dim;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
             using FramePtr = typename T_ParBox::FramePtr;
 
-            DataSpace<dim> const superCellIdx = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc)));
+            DataSpace<dim> const superCellIdx
+                = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())));
 
-            PMACC_SMEM(acc, lastFrame, FramePtr);
-            PMACC_SMEM(acc, gapIndices_sh, memory::Array<int, frameSize>);
-            PMACC_SMEM(acc, numGaps, int);
-            PMACC_SMEM(acc, numParticles, uint32_t);
-            PMACC_SMEM(acc, srcGap, int);
+            PMACC_SMEM(worker, lastFrame, FramePtr);
+            PMACC_SMEM(worker, gapIndices_sh, memory::Array<int, frameSize>);
+            PMACC_SMEM(worker, numGaps, int);
+            PMACC_SMEM(worker, numParticles, uint32_t);
+            PMACC_SMEM(worker, srcGap, int);
 
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-            lockstep::makeMaster(workerIdx)(
+            lockstep::makeMaster(worker)(
                 [&]()
                 {
                     lastFrame = pb.getLastFrame(superCellIdx);
@@ -101,12 +96,12 @@ namespace pmacc
                     srcGap = 0;
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             if(lastFrame.isValid())
             {
                 /* loop over all particles in the frame */
-                auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+                auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
                 /* context if an element within the frame is a particle */
                 auto isParticleCtx = forEachParticle(
@@ -117,10 +112,10 @@ namespace pmacc
                     [&](lockstep::Idx const idx)
                     {
                         if(isParticleCtx[idx])
-                            kernel::atomicAllInc(acc, &numParticles, ::alpaka::hierarchy::Threads{});
+                            kernel::atomicAllInc(worker, &numParticles, ::alpaka::hierarchy::Threads{});
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 forEachParticle(
                     [&](lockstep::Idx const idx)
@@ -128,18 +123,19 @@ namespace pmacc
                         if(idx < numParticles && isParticleCtx[idx] == false)
                         {
                             int const localGapIdx
-                                = kernel::atomicAllInc(acc, &numGaps, ::alpaka::hierarchy::Threads{});
+                                = kernel::atomicAllInc(worker, &numGaps, ::alpaka::hierarchy::Threads{});
                             gapIndices_sh[localGapIdx] = idx;
                         }
                     });
-                cupla::__syncthreads(acc);
+                worker.sync();
                 forEachParticle(
                     [&](lockstep::Idx const idx)
                     {
                         if(idx >= numParticles && isParticleCtx[idx])
                         {
                             // any particle search a gap
-                            int const srcGapIdx = kernel::atomicAllInc(acc, &srcGap, ::alpaka::hierarchy::Threads{});
+                            int const srcGapIdx
+                                = kernel::atomicAllInc(worker, &srcGap, ::alpaka::hierarchy::Threads{});
                             int const gapIdx = gapIndices_sh[srcGapIdx];
                             auto parDestFull = lastFrame[gapIdx];
                             /* enable particle */
@@ -154,7 +150,7 @@ namespace pmacc
                         }
                     });
             }
-            lockstep::makeMaster(workerIdx)(
+            lockstep::makeMaster(worker)(
                 [&]()
                 {
                     // there is no need to add a zero to the global memory
@@ -168,7 +164,7 @@ namespace pmacc
                         /* The last frame is empty therefore it must be removed.
                          * It is save to call this method even if there is no last frame.
                          */
-                        pb.removeLastFrame(acc, superCellIdx);
+                        pb.removeLastFrame(worker, superCellIdx);
                     }
                 });
         }
@@ -179,10 +175,7 @@ namespace pmacc
      * Copy all particles from the end to the gaps at the beginning of the frame list.
      * The functor fulfills the restriction that the last frame must be hold a contiguous
      * number of valid particles at the beginning and a subsequent, contiguous gap at the end.
-     *
-     * @tparam T_numWorkers number of workers
      */
-    template<uint32_t T_numWorkers>
     struct KernelFillGaps
     {
         /** fill particle gaps
@@ -193,8 +186,8 @@ namespace pmacc
          * @param pb particle memory
          * @param mapper functor to map a block to a supercell
          */
-        template<typename T_ParBox, typename T_Mapping, typename T_Acc>
-        DINLINE void operator()(T_Acc const& acc, T_ParBox pb, T_Mapping const mapper) const
+        template<typename T_ParBox, typename T_Mapping, typename T_Worker>
+        DINLINE void operator()(T_Worker const& worker, T_ParBox pb, T_Mapping const mapper) const
         {
             using namespace particles::operations;
 
@@ -202,25 +195,23 @@ namespace pmacc
 
             constexpr uint32_t frameSize = math::CT::volume<typename T_ParBox::FrameType::SuperCellSize>::type::value;
             constexpr uint32_t dim = T_Mapping::Dim;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
-
-            DataSpace<dim> const superCellIdx(mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc))));
+            DataSpace<dim> const superCellIdx(
+                mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc()))));
 
             // data copied from right (last) to left (first)
-            PMACC_SMEM(acc, firstFrame, FramePtr);
-            PMACC_SMEM(acc, lastFrame, FramePtr);
+            PMACC_SMEM(worker, firstFrame, FramePtr);
+            PMACC_SMEM(worker, lastFrame, FramePtr);
 
-            PMACC_SMEM(acc, particleIndices_sh, memory::Array<int, frameSize>);
+            PMACC_SMEM(worker, particleIndices_sh, memory::Array<int, frameSize>);
             // number of gaps in firstFrame frame
-            PMACC_SMEM(acc, numGaps, int);
+            PMACC_SMEM(worker, numGaps, int);
             // number of particles in the lastFrame
-            PMACC_SMEM(acc, numParticles, int);
+            PMACC_SMEM(worker, numParticles, int);
 
             uint32_t numParticlesPerSuperCell = 0u;
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             onlyMaster(
                 [&]()
@@ -229,7 +220,7 @@ namespace pmacc
                     lastFrame = pb.getLastFrame(superCellIdx);
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             while(firstFrame.isValid() && firstFrame != lastFrame)
             {
@@ -240,10 +231,10 @@ namespace pmacc
                         numParticles = 0;
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 // loop over all particles in the frame
-                auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+                auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
                 // find gaps in firstFrame
                 auto localGapIdxCtx = forEachParticle(
@@ -252,12 +243,12 @@ namespace pmacc
                         int gapIdx = INV_LOC_IDX;
                         if(firstFrame[idx][multiMask_] == 0)
                         {
-                            gapIdx = kernel::atomicAllInc(acc, &numGaps, ::alpaka::hierarchy::Threads{});
+                            gapIdx = kernel::atomicAllInc(worker, &numGaps, ::alpaka::hierarchy::Threads{});
                         }
                         return gapIdx;
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 if(numGaps != 0)
                 {
@@ -269,12 +260,12 @@ namespace pmacc
                             if(lastFrame[linearIdx][multiMask_] == 1)
                             {
                                 int const localParticleIdx
-                                    = kernel::atomicAllInc(acc, &numParticles, ::alpaka::hierarchy::Threads{});
+                                    = kernel::atomicAllInc(worker, &numParticles, ::alpaka::hierarchy::Threads{});
                                 particleIndices_sh[localParticleIdx] = linearIdx;
                             }
                         });
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     // copy particles from lastFrame to the gaps in firstFrame
                     forEachParticle(
@@ -296,7 +287,7 @@ namespace pmacc
                             }
                         });
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     onlyMaster(
                         [&]()
@@ -310,12 +301,12 @@ namespace pmacc
                             else if(numGaps > numParticles)
                             {
                                 // we need more particles
-                                lastFrame = getPreviousFrameAndRemoveLastFrame(acc, lastFrame, pb, superCellIdx);
+                                lastFrame = getPreviousFrameAndRemoveLastFrame(worker, lastFrame, pb, superCellIdx);
                             }
                             else if(numGaps == numParticles)
                             {
                                 // update lastFrame and firstFrame
-                                lastFrame = getPreviousFrameAndRemoveLastFrame(acc, lastFrame, pb, superCellIdx);
+                                lastFrame = getPreviousFrameAndRemoveLastFrame(worker, lastFrame, pb, superCellIdx);
                                 if(lastFrame.isValid() && lastFrame != firstFrame)
                                 {
                                     numParticlesPerSuperCell += frameSize;
@@ -335,7 +326,7 @@ namespace pmacc
                         });
                 }
 
-                cupla::__syncthreads(acc);
+                worker.sync();
             }
 
             onlyMaster(
@@ -349,7 +340,7 @@ namespace pmacc
                 });
 
             // fill all gaps in the last frame of the supercell
-            KernelFillGapsLastFrame<numWorkers>{}(acc, pb, mapper);
+            KernelFillGapsLastFrame{}(worker, pb, mapper);
         }
     };
 
@@ -362,10 +353,7 @@ namespace pmacc
      * there must be no particles moving towards those directions.
      * So such directions would effectively be skipped.
      * It is required in case the kernel is run in the area including GUARD supercells.
-     *
-     * @tparam T_numWorkers number of workers
      */
-    template<uint32_t T_numWorkers>
     struct KernelShiftParticles
     {
         /** This kernel moves particles to the next supercell
@@ -374,7 +362,7 @@ namespace pmacc
          *
          * @tparam T_ParBox particle data box type
          * @tparam Mapping mapper type, adheres to Mapper concept
-         * @tparam T_Acc alpaka accelerator type
+         * @tparam T_Worker lockstep worker type
          * @tparam T_Idx supercell index type
          *
          * @param acc accelerator
@@ -384,9 +372,9 @@ namespace pmacc
          * @param onlyProcessMustShiftSupercells whether to process only supercells with mustShift set to true
          * (optimization to be used with particle pusher) or process all supercells
          */
-        template<typename T_ParBox, typename Mapping, typename T_Acc, typename T_Idx>
+        template<typename T_ParBox, typename Mapping, typename T_Worker, typename T_Idx>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_ParBox pb,
             Mapping mapper,
             T_Idx numSupercellsWithGuard,
@@ -400,22 +388,21 @@ namespace pmacc
             constexpr uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
             /* number exchanges in 2D=9 and in 3D=27 */
             constexpr uint32_t numExchanges = traits::NumberOfExchanges<dim>::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
             /* define memory for two times Exchanges
              * index range [0,numExchanges-1] are being referred to as `low frames`
              * index range [numExchanges,2*numExchanges-1] are being referred to as `high frames`
              */
-            PMACC_SMEM(acc, destFrames, memory::Array<FramePtr, numExchanges * 2>);
+            PMACC_SMEM(worker, destFrames, memory::Array<FramePtr, numExchanges * 2>);
             // count particles per frame
-            PMACC_SMEM(acc, destFramesCounter, memory::Array<uint32_t, numExchanges>);
+            PMACC_SMEM(worker, destFramesCounter, memory::Array<uint32_t, numExchanges>);
 
-            PMACC_SMEM(acc, isProcessedSupercell, bool);
+            PMACC_SMEM(worker, isProcessedSupercell, bool);
 
-            DataSpace<dim> const superCellIdx = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc)));
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
+            DataSpace<dim> const superCellIdx
+                = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())));
 
-            lockstep::makeMaster(workerIdx)(
+            lockstep::makeMaster(worker)(
                 [&]()
                 {
                     isProcessedSupercell
@@ -427,16 +414,14 @@ namespace pmacc
                 });
 
             namespace particleAccAlgos = pmacc::particles::algorithm::acc;
-            auto forEachFrameInSupercell = particleAccAlgos::makeForEachFrame<numWorkers, particleAccAlgos::Forward>(
-                workerIdx,
-                pb,
-                superCellIdx);
+            auto forEachFrameInSupercell
+                = particleAccAlgos::makeForEachFrame<particleAccAlgos::Forward>(worker, pb, superCellIdx);
 
-            cupla::__syncthreads(acc);
+            worker.sync();
             if(!isProcessedSupercell || !forEachFrameInSupercell.hasParticles())
                 return;
 
-            auto forEachExchange = lockstep::makeForEach<numExchanges, numWorkers>(workerIdx);
+            auto forEachExchange = lockstep::makeForEach<numExchanges>(worker);
 
             auto newParticleInFrameCtx = lockstep::makeVar<int32_t>(forEachExchange, 0);
 
@@ -473,12 +458,11 @@ namespace pmacc
                     }
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             forEachFrameInSupercell(
-                acc,
                 /* iterate over the frame list of the current supercell */
-                [&](auto const& accelerator, auto& frameIterCtx)
+                [&](auto const& lockstepWorker, auto& frameIterCtx)
                 {
                     auto forEachParticleInFrame = forEachFrameInSupercell.lockstepForEach();
 
@@ -498,14 +482,14 @@ namespace pmacc
                             if(direction >= 0)
                             {
                                 destParticleIdxCtx[idx] = cupla::atomicAdd(
-                                    accelerator,
+                                    lockstepWorker.getAcc(),
                                     &(destFramesCounter[direction]),
                                     1u,
                                     ::alpaka::hierarchy::Threads{});
                             }
                             return direction;
                         });
-                    cupla::__syncthreads(accelerator);
+                    lockstepWorker.sync();
 
                     forEachExchange(
                         [&](lockstep::Idx const idx)
@@ -531,21 +515,21 @@ namespace pmacc
                                     /* if we had no `low frame` we load a new empty one */
                                     if(!destFrames[linearIdx].isValid())
                                     {
-                                        FramePtr tmpFrame(pb.getEmptyFrame(accelerator));
+                                        FramePtr tmpFrame(pb.getEmptyFrame(lockstepWorker));
                                         destFrames[linearIdx] = tmpFrame;
-                                        pb.setAsLastFrame(accelerator, tmpFrame, neighborSuperCellIdx);
+                                        pb.setAsLastFrame(lockstepWorker, tmpFrame, neighborSuperCellIdx);
                                     }
                                     /* check if a `high frame` is needed */
                                     if(destFramesCounter[linearIdx] > frameSize)
                                     {
-                                        FramePtr tmpFrame(pb.getEmptyFrame(accelerator));
+                                        FramePtr tmpFrame(pb.getEmptyFrame(lockstepWorker));
                                         destFrames[linearIdx + numExchanges] = tmpFrame;
-                                        pb.setAsLastFrame(accelerator, tmpFrame, neighborSuperCellIdx);
+                                        pb.setAsLastFrame(lockstepWorker, tmpFrame, neighborSuperCellIdx);
                                     }
                                 }
                             }
                         });
-                    cupla::__syncthreads(accelerator);
+                    lockstepWorker.sync();
 
                     forEachParticleInFrame(
                         [&](lockstep::Idx const idx)
@@ -573,7 +557,7 @@ namespace pmacc
                                 particles::operations::assign(dstFilteredParticle, srcParticle);
                             }
                         });
-                    cupla::__syncthreads(accelerator);
+                    lockstepWorker.sync();
 
                     forEachExchange(
                         [&](lockstep::Idx const idx)
@@ -591,7 +575,7 @@ namespace pmacc
                                 destFrames[linearIdx + numExchanges] = FramePtr();
                             }
                         });
-                    cupla::__syncthreads(accelerator);
+                    lockstepWorker.sync();
                 });
 
             forEachExchange(
@@ -618,7 +602,7 @@ namespace pmacc
                 });
 
             // fill all gaps in the frame list of the supercell
-            KernelFillGaps<numWorkers>{}(acc, pb, mapper);
+            KernelFillGaps{}(worker, pb, mapper);
         }
 
         /** Is the given supercell index valid
@@ -636,11 +620,7 @@ namespace pmacc
         }
     };
 
-    /** deletes all particles within an AREA
-     *
-     * @tparam T_numWorkers number of workers
-     */
-    template<uint32_t T_numWorkers>
+    //! deletes all particles within an AREA
     struct KernelDeleteParticles
     {
         /** deletes all particles
@@ -653,8 +633,8 @@ namespace pmacc
          * @param pb particle memory
          * @param mapper functor to map a block to a supercell
          */
-        template<typename T_ParticleBox, typename T_Mapping, typename T_Acc>
-        DINLINE void operator()(T_Acc const& acc, T_ParticleBox pb, T_Mapping const mapper) const
+        template<typename T_ParticleBox, typename T_Mapping, typename T_Worker>
+        DINLINE void operator()(T_Worker const& worker, T_ParticleBox pb, T_Mapping const mapper) const
         {
             using namespace particles::operations;
 
@@ -664,23 +644,22 @@ namespace pmacc
 
             constexpr uint32_t dim = T_Mapping::Dim;
             constexpr uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
-            DataSpace<dim> const superCellIdx = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc)));
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
+            DataSpace<dim> const superCellIdx
+                = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())));
 
-            PMACC_SMEM(acc, frame, FramePtr);
+            PMACC_SMEM(worker, frame, FramePtr);
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             onlyMaster([&]() { frame = pb.getLastFrame(superCellIdx); });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             while(frame.isValid())
             {
                 // loop over all particles in the frame
-                auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+                auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
                 forEachParticle(
                     [&](uint32_t const linearIdx)
@@ -689,15 +668,15 @@ namespace pmacc
                         particle[multiMask_] = 0; // delete particle
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
                 onlyMaster(
                     [&]()
                     {
                         // always remove the last frame
-                        frame = getPreviousFrameAndRemoveLastFrame(acc, frame, pb, superCellIdx);
+                        frame = getPreviousFrameAndRemoveLastFrame(worker, frame, pb, superCellIdx);
                     });
-                cupla::__syncthreads(acc);
+                worker.sync();
             }
 
             onlyMaster(
@@ -716,10 +695,7 @@ namespace pmacc
      * contiguous filled.
      * Call KernelFillGaps afterwards if you need a valid number of particles
      * and a contiguously filled last frame.
-     *
-     * @tparam T_numWorkers number of workers
      */
-    template<uint32_t T_numWorkers>
     struct KernelCopyGuardToExchange
     {
         /** copy guard particles to an exchange buffer
@@ -732,9 +708,9 @@ namespace pmacc
          * @param exchangeBox exchange buffer for particles
          * @param mapper functor to map a block to a supercell
          */
-        template<typename T_ParBox, typename T_ExchangeValueType, typename T_Mapping, typename T_Acc>
+        template<typename T_ParBox, typename T_ExchangeValueType, typename T_Mapping, typename T_Worker>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_ParBox pb,
             ExchangePushDataBox<vint_t, T_ExchangeValueType, T_Mapping::Dim - 1> exchangeBox,
             T_Mapping const mapper) const
@@ -743,31 +719,30 @@ namespace pmacc
 
             PMACC_CONSTEXPR_CAPTURE uint32_t dim = T_Mapping::Dim;
             constexpr uint32_t frameSize = math::CT::volume<typename T_ParBox::FrameType::SuperCellSize>::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
 
             using FramePtr = typename T_ParBox::FramePtr;
 
-            DataSpace<dim> const superCellIdx = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(acc)));
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
+            DataSpace<dim> const superCellIdx
+                = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())));
 
             // number of particles in the current handled frame
-            PMACC_SMEM(acc, numParticles, int);
-            PMACC_SMEM(acc, frame, FramePtr);
+            PMACC_SMEM(worker, numParticles, int);
+            PMACC_SMEM(worker, frame, FramePtr);
 
             /* `exchangeChunk` is a view to a chunk of the memory in the exchange-
              * The chunk contains between 0 and `numParticles` particles
              * and is updated for each frame.
              */
-            PMACC_SMEM(acc, exchangeChunk, TileDataBox<T_ExchangeValueType>);
+            PMACC_SMEM(worker, exchangeChunk, TileDataBox<T_ExchangeValueType>);
 
             /* flag: define if all particles from the current frame are copied to the
              * exchange buffer
              *
              * `true` if all particles are copied, else `false`
              */
-            PMACC_SMEM(acc, allParticlesCopied, bool);
+            PMACC_SMEM(worker, allParticlesCopied, bool);
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             onlyMaster(
                 [&]()
@@ -776,16 +751,16 @@ namespace pmacc
                     frame = pb.getLastFrame(superCellIdx);
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             while(frame.isValid() && allParticlesCopied)
             {
                 // loop over all particles in the frame
-                auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+                auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
                 onlyMaster([&]() { numParticles = 0; });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
 
                 /* the index of the gap in the exchange box where the particle
@@ -797,11 +772,12 @@ namespace pmacc
                         lcellId_t gabIdx = INV_LOC_IDX;
                         if(frame[idx][multiMask_] == 1)
                         {
-                            gabIdx = kernel::atomicAllInc(acc, &numParticles, ::alpaka::hierarchy::Threads{});
+                            gabIdx = kernel::atomicAllInc(worker, &numParticles, ::alpaka::hierarchy::Threads{});
                         }
                         return gabIdx;
                     });
-                cupla::__syncthreads(acc);
+
+                worker.sync();
 
                 if(numParticles > 0)
                 {
@@ -810,7 +786,7 @@ namespace pmacc
                         {
                             // try to get as many memory as particles in the current frame
                             exchangeChunk = exchangeBox.pushN(
-                                acc,
+                                worker,
                                 numParticles,
                                 // Compute the target supercell depending on the exchangeType
                                 DataSpaceOperations<dim>::reduce(superCellIdx, mapper.getExchangeType()),
@@ -819,7 +795,7 @@ namespace pmacc
                                 allParticlesCopied = false;
                         });
 
-                    cupla::__syncthreads(acc);
+                    worker.sync();
 
                     forEachParticle(
                         [&](lockstep::Idx const idx)
@@ -833,7 +809,7 @@ namespace pmacc
                                 parSrc[multiMask_] = 0;
                             }
                         });
-                    cupla::__syncthreads(acc);
+                    worker.sync();
                 }
 
                 onlyMaster(
@@ -843,10 +819,10 @@ namespace pmacc
                          * all particles from the current frame to the exchange buffer
                          */
                         if(allParticlesCopied)
-                            frame = getPreviousFrameAndRemoveLastFrame(acc, frame, pb, superCellIdx);
+                            frame = getPreviousFrameAndRemoveLastFrame(worker, frame, pb, superCellIdx);
                     });
 
-                cupla::__syncthreads(acc);
+                worker.sync();
             }
             onlyMaster(
                 [&]()
@@ -859,11 +835,7 @@ namespace pmacc
         }
     };
 
-    /** copy particles from exchange buffer into the border of the simulation
-     *
-     * @tparam T_numWorkers number of workers
-     */
-    template<uint32_t T_numWorkers>
+    //! copy particles from exchange buffer into the border of the simulation
     struct KernelInsertParticles
     {
         /** copy particles from exchange buffer into the border of the simulation
@@ -876,9 +848,9 @@ namespace pmacc
          * @param exchangeBox exchange box for particles
          * @param mapper functor to map a block to a supercell
          */
-        template<typename T_ParBox, typename T_ExchangeValueType, typename T_Mapping, typename T_Acc>
+        template<typename T_ParBox, typename T_ExchangeValueType, typename T_Mapping, typename T_Worker>
         DINLINE void operator()(
-            T_Acc const& acc,
+            T_Worker const& worker,
             T_ParBox pb,
             ExchangePopDataBox<vint_t, T_ExchangeValueType, T_Mapping::Dim - 1> exchangeBox,
             T_Mapping const mapper) const
@@ -887,18 +859,15 @@ namespace pmacc
 
             PMACC_CONSTEXPR_CAPTURE uint32_t dim = T_Mapping::Dim;
             constexpr uint32_t frameSize = math::CT::volume<typename T_ParBox::FrameType::SuperCellSize>::type::value;
-            constexpr uint32_t numWorkers = T_numWorkers;
-
-            uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
             using FramePtr = typename T_ParBox::FramePtr;
 
-            PMACC_SMEM(acc, frame, FramePtr);
-            PMACC_SMEM(acc, elementCount, uint32_t);
-            PMACC_SMEM(acc, exchangeChunk, TileDataBox<T_ExchangeValueType>);
+            PMACC_SMEM(worker, frame, FramePtr);
+            PMACC_SMEM(worker, elementCount, uint32_t);
+            PMACC_SMEM(worker, exchangeChunk, TileDataBox<T_ExchangeValueType>);
 
 
-            auto onlyMaster = lockstep::makeMaster(workerIdx);
+            auto onlyMaster = lockstep::makeMaster(worker);
 
             /* compressed index of the the supercell
              * can be uncompressed with `DataSpaceOperations< >::extend()`
@@ -908,18 +877,19 @@ namespace pmacc
             onlyMaster(
                 [&](lockstep::Idx const idx)
                 {
-                    exchangeChunk = exchangeBox.get(cupla::blockIdx(acc).x, compressedSuperCellIdxCtx[idx]);
+                    exchangeChunk
+                        = exchangeBox.get(cupla::blockIdx(worker.getAcc()).x, compressedSuperCellIdxCtx[idx]);
                     elementCount = exchangeChunk.getSize();
                     if(elementCount > 0u)
                     {
-                        frame = pb.getEmptyFrame(acc);
+                        frame = pb.getEmptyFrame(worker);
                     }
                 });
 
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             // loop over all particles in the frame
-            auto forEachParticle = lockstep::makeForEach<frameSize, numWorkers>(workerIdx);
+            auto forEachParticle = lockstep::makeForEach<frameSize>(worker);
 
             forEachParticle(
                 [&](uint32_t const linearIdx)
@@ -938,7 +908,7 @@ namespace pmacc
             /** @bug This synchronize fixes a kernel crash in special cases,
              * psychocoderHPC: I can't tell why.
              */
-            cupla::__syncthreads(acc);
+            worker.sync();
 
             onlyMaster(
                 [&](lockstep::Idx const idx)
@@ -954,7 +924,7 @@ namespace pmacc
                             mapper.getGridSuperCells(),
                             mapper.getGuardingSuperCells());
 
-                        pb.setAsLastFrame(acc, frame, dstSuperCell);
+                        pb.setAsLastFrame(worker, frame, dstSuperCell);
                     }
                 });
         }

--- a/include/pmacc/particles/ParticlesBase.tpp
+++ b/include/pmacc/particles/ParticlesBase.tpp
@@ -38,11 +38,10 @@ namespace pmacc
     {
         ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
 
-        constexpr uint32_t numWorkers
-            = traits::GetNumWorkers<math::CT::volume<typename FrameType::SuperCellSize>::type::value>::value;
+        auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
 
-        PMACC_KERNEL(KernelDeleteParticles<numWorkers>{})
-        (mapper.getGridDim(), numWorkers)(particlesBuffer->getDeviceParticleBox(), mapper);
+        PMACC_LOCKSTEP_KERNEL(KernelDeleteParticles{}, workerCfg)
+        (mapper.getGridDim())(particlesBuffer->getDeviceParticleBox(), mapper);
     }
 
     template<typename T_ParticleDescription, class MappingDesc, typename T_DeviceHeap>
@@ -51,11 +50,10 @@ namespace pmacc
     {
         auto const mapper = makeAreaMapper<T_area>(this->cellDescription);
 
-        constexpr uint32_t numWorkers
-            = traits::GetNumWorkers<math::CT::volume<typename FrameType::SuperCellSize>::type::value>::value;
+        auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
 
-        PMACC_KERNEL(KernelDeleteParticles<numWorkers>{})
-        (mapper.getGridDim(), numWorkers)(particlesBuffer->getDeviceParticleBox(), mapper);
+        PMACC_LOCKSTEP_KERNEL(KernelDeleteParticles{}, workerCfg)
+        (mapper.getGridDim())(particlesBuffer->getDeviceParticleBox(), mapper);
     }
 
     template<typename T_ParticleDescription, class MappingDesc, typename T_DeviceHeap>
@@ -74,11 +72,10 @@ namespace pmacc
 
             particlesBuffer->getSendExchangeStack(exchangeType).setCurrentSize(0);
 
-            constexpr uint32_t numWorkers
-                = traits::GetNumWorkers<math::CT::volume<typename FrameType::SuperCellSize>::type::value>::value;
+            auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
 
-            PMACC_KERNEL(KernelCopyGuardToExchange<numWorkers>{})
-            (mapper.getGridDim(), numWorkers)(
+            PMACC_LOCKSTEP_KERNEL(KernelCopyGuardToExchange{}, workerCfg)
+            (mapper.getGridDim())(
                 particlesBuffer->getDeviceParticleBox(),
                 particlesBuffer->getSendExchangeStack(exchangeType).getDeviceExchangePushDataBox(),
                 mapper);
@@ -100,11 +97,10 @@ namespace pmacc
             {
                 ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
 
-                constexpr uint32_t numWorkers
-                    = traits::GetNumWorkers<math::CT::volume<typename FrameType::SuperCellSize>::type::value>::value;
+                auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
 
-                PMACC_KERNEL(KernelInsertParticles<numWorkers>{})
-                (numParticles, numWorkers)(
+                PMACC_LOCKSTEP_KERNEL(KernelInsertParticles{}, workerCfg)
+                (numParticles)(
                     particlesBuffer->getDeviceParticleBox(),
                     particlesBuffer->getReceiveExchangeStack(exchangeType).getDeviceExchangePopDataBox(),
                     mapper);

--- a/include/pmacc/particles/algorithm/detail/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/detail/ForEach.hpp
@@ -54,7 +54,7 @@ namespace pmacc::particles::algorithm::acc
 
             /** Invokes the user functor with the given parameters.
              *
-             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_Worker lockstep worker type
              * @tparam T_FrameType @see FramePointer
              * @tparam T_Config @see lockstep::Variable
              * @param acc alpaka accelerator
@@ -63,20 +63,20 @@ namespace pmacc::particles::algorithm::acc
              *
              * @{
              */
-            template<typename T_Acc, typename T_FrameType, typename T_Config>
+            template<typename T_Worker, typename T_FrameType, typename T_Config>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 lockstep::Variable<FramePointer<T_FrameType>, T_Config>& frameIterCtx)
             {
-                m_functor(acc, frameIterCtx);
+                m_functor(worker, frameIterCtx);
             }
 
-            template<typename T_Acc, typename T_FrameType, typename T_Config>
+            template<typename T_Worker, typename T_FrameType, typename T_Config>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 lockstep::Variable<FramePointer<T_FrameType>, T_Config>& frameIterCtx) const
             {
-                m_functor(acc, frameIterCtx);
+                m_functor(worker, frameIterCtx);
             }
             /**@}*/
         };
@@ -110,24 +110,24 @@ namespace pmacc::particles::algorithm::acc
 
             /** Invoke the user functor with the given arguments.
              *
-             * @tparam T_Acc alpaka accelerator type
+             * @tparam T_Worker lockstep worker type
              * @tparam T_FrameType @see Particle
              * @tparam T_ValueTypeSeq @see Particle
-             * @param acc alpaka accelerator
+             * @param worker lockstep worker
              * @param particle particle to process
              *
              * @{
              */
-            template<typename T_Acc, typename T_FrameType, typename T_ValueTypeSeq>
-            DINLINE void operator()(T_Acc const& acc, Particle<T_FrameType, T_ValueTypeSeq>& particle)
+            template<typename T_Worker, typename T_FrameType, typename T_ValueTypeSeq>
+            DINLINE void operator()(T_Worker const& worker, Particle<T_FrameType, T_ValueTypeSeq>& particle)
             {
-                m_functor(acc, particle);
+                m_functor(worker, particle);
             }
 
-            template<typename T_Acc, typename T_FrameType, typename T_ValueTypeSeq>
-            DINLINE void operator()(T_Acc const& acc, Particle<T_FrameType, T_ValueTypeSeq>& particle) const
+            template<typename T_Worker, typename T_FrameType, typename T_ValueTypeSeq>
+            DINLINE void operator()(T_Worker const& worker, Particle<T_FrameType, T_ValueTypeSeq>& particle) const
             {
-                m_functor(acc, particle);
+                m_functor(worker, particle);
             }
 
             /**@}*/

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -67,18 +67,18 @@ namespace pmacc
          *
          * @return a TileDataBox of size count pointing to the new stack elements
          */
-        template<typename T_Acc, typename T_Hierarchy>
+        template<typename T_Worker, typename T_Hierarchy>
         HDINLINE TileDataBox<VALUE> pushN(
-            T_Acc const& acc,
+            T_Worker const& worker,
             TYPE count,
             DataSpace<DIM> const& superCell,
             T_Hierarchy const& hierarchy)
         {
-            TYPE oldSize = cupla::atomicAdd(acc, currentSizePointer, count, hierarchy); // get count VALUEs
+            TYPE oldSize = cupla::atomicAdd(worker.getAcc(), currentSizePointer, count, hierarchy); // get count VALUEs
 
             if(oldSize + count > maxSize)
             {
-                cupla::atomicExch(acc, currentSizePointer, maxSize, hierarchy); // reset size to maxsize
+                cupla::atomicExch(worker.getAcc(), currentSizePointer, maxSize, hierarchy); // reset size to maxsize
                 if(oldSize >= maxSize)
                 {
                     return TileDataBox<VALUE>(nullptr, DataSpace<DIM1>(0), 0);
@@ -87,7 +87,7 @@ namespace pmacc
                     count = maxSize - oldSize;
             }
 
-            TileDataBox<PushType> tmp = virtualMemory.pushN(acc, 1, hierarchy);
+            TileDataBox<PushType> tmp = virtualMemory.pushN(worker, 1, hierarchy);
             tmp[0].setSuperCell(superCell);
             tmp[0].setCount(count);
             tmp[0].setStartIndex(oldSize);

--- a/include/pmacc/particles/memory/boxes/PushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/PushDataBox.hpp
@@ -69,10 +69,10 @@ namespace pmacc
          *
          * @return a TileDataBox of size count pointing to the new stack elements
          */
-        template<typename T_Acc, typename T_Hierarchy>
-        HDINLINE TileDataBox<VALUE> pushN(T_Acc const& acc, TYPE count, T_Hierarchy const& hierarchy)
+        template<typename T_Worker, typename T_Hierarchy>
+        HDINLINE TileDataBox<VALUE> pushN(T_Worker const& worker, TYPE count, T_Hierarchy const& hierarchy)
         {
-            TYPE old_addr = cupla::atomicAdd(acc, currentSize, count, hierarchy);
+            TYPE old_addr = cupla::atomicAdd(worker.getAcc(), currentSize, count, hierarchy);
             return TileDataBox<VALUE>(this->fixedPointer, DataSpace<DIM1>(old_addr));
         }
 
@@ -90,10 +90,10 @@ namespace pmacc
          *
          * @return a TileDataBox of size count pointing to the new stack elements
          */
-        template<typename T_Acc, typename T_Hierarchy>
-        HDINLINE void push(T_Acc const& acc, VALUE val, T_Hierarchy const& hierarchy)
+        template<typename T_Worker, typename T_Hierarchy>
+        HDINLINE void push(T_Worker const& worker, VALUE val, T_Hierarchy const& hierarchy)
         {
-            TYPE old_addr = cupla::atomicAdd(acc, currentSize, 1, hierarchy);
+            TYPE old_addr = cupla::atomicAdd(worker.getAcc(), currentSize, 1, hierarchy);
             (*this)[old_addr] = val;
         }
 

--- a/include/pmacc/particles/operations/ConcatListOfFrames.hpp
+++ b/include/pmacc/particles/operations/ConcatListOfFrames.hpp
@@ -110,9 +110,7 @@ namespace pmacc
                         filter.setSuperCellPosition(superCellPosition);
                         auto accParFilter = parFilter(
                             1, /* @todo this is a hack, please add a alpaka accelerator here*/
-                            superCellIdx - mapper.getGuardingSuperCells(),
-                            lockstep::Worker<1>{0} /* @todo this is a workaround because we use no alpaka*/
-                        );
+                            superCellIdx - mapper.getGuardingSuperCells());
 
                         SrcFramePtr srcFramePtr = srcBox.getFirstFrame(superCellIdx);
 

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -41,11 +41,7 @@ namespace pmacc
         {
             namespace detail
             {
-                /** transform a large frame into a list of small frames
-                 *
-                 * @tparam T_numWorkers number of workers
-                 */
-                template<uint32_t T_numWorkers>
+                //! transform a large frame into a list of small frames
                 struct KernelSplitIntoListOfFrames
                 {
                     /** Copy particles from big frame to PMacc frame structure
@@ -60,7 +56,7 @@ namespace pmacc
                      * @tparam T_Space pmacc::DataSpace, type for indicies and offsets within the domain
                      * @tparam T_Identifier Identifier, type of the identifier for the total domain offset
                      * @tparam T_CellDescription pmacc::MappingDescription, type of the domain description
-                     * @tparam T_Acc alpaka accelerator type
+                     * @tparam T_Worker lockstep worker type
                      *
                      * @param acc alpaka accelerator
                      * @param counter box with three integers [sharedSrcParticleOffset, numLoadedParticles,
@@ -81,9 +77,9 @@ namespace pmacc
                         typename T_Space,
                         typename T_Identifier,
                         typename T_CellDescription,
-                        typename T_Acc>
+                        typename T_Worker>
                     DINLINE void operator()(
-                        T_Acc const& acc,
+                        T_Worker const& worker,
                         T_CounterBox counter,
                         T_DestBox destBox,
                         T_SrcFrame srcFrame,
@@ -99,20 +95,17 @@ namespace pmacc
                         using DestFramePtr = typename T_DestBox::FramePtr;
                         using SuperCellSize = typename DestFrameType::SuperCellSize;
 
-                        constexpr uint32_t numWorkers = T_numWorkers;
                         constexpr uint32_t numDims = T_DestBox::Dim;
                         constexpr uint32_t particlesPerFrame = math::CT::volume<SuperCellSize>::type::value;
 
-                        PMACC_SMEM(acc, destFramePtr, memory::Array<DestFramePtr, particlesPerFrame>);
-                        PMACC_SMEM(acc, sharedLinearSuperCellIds, memory::Array<int, particlesPerFrame>);
-                        PMACC_SMEM(acc, sharedSrcParticleOffset, int);
-
-                        uint32_t const workerIdx = cupla::threadIdx(acc).x;
+                        PMACC_SMEM(worker, destFramePtr, memory::Array<DestFramePtr, particlesPerFrame>);
+                        PMACC_SMEM(worker, sharedLinearSuperCellIds, memory::Array<int, particlesPerFrame>);
+                        PMACC_SMEM(worker, sharedSrcParticleOffset, int);
 
                         DataSpace<numDims> const numSuperCells(
                             cellDesc.getGridSuperCells() - cellDesc.getGuardingSuperCells() * 2);
 
-                        auto onlyMaster = lockstep::makeMaster(workerIdx);
+                        auto onlyMaster = lockstep::makeMaster(worker);
 
                         onlyMaster(
                             [&]()
@@ -121,16 +114,16 @@ namespace pmacc
                                  * offset in srcFrame to load N particles
                                  */
                                 sharedSrcParticleOffset = cupla::atomicAdd(
-                                    acc,
+                                    worker.getAcc(),
                                     &(counter[0]),
                                     particlesPerFrame,
                                     ::alpaka::hierarchy::Blocks{});
                             });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         // loop over all particles in the frame
-                        auto forEachParticle = lockstep::makeForEach<particlesPerFrame, numWorkers>(workerIdx);
+                        auto forEachParticle = lockstep::makeForEach<particlesPerFrame>(worker);
 
                         auto srcParticleIdxCtx = lockstep::makeVar<int>(forEachParticle);
                         auto hasValidParticleCtx = lockstep::makeVar<bool>(forEachParticle);
@@ -145,7 +138,7 @@ namespace pmacc
                                 hasValidParticleCtx[idx] = srcParticleIdxCtx[idx] < maxParticles;
                             });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         // linear cell index of the particle within the destination frame
                         auto lCellIdxCtx = lockstep::makeVar<lcellId_t>(forEachParticle, INV_LOC_IDX);
@@ -175,10 +168,7 @@ namespace pmacc
                                 return particlesSuperCellIdx;
                             });
 
-                        cupla::__syncthreads(acc);
-
-                        // auto masterVirtualThreadIdxCtx
-                        //     = forEachParticle([&](uint32_t const linearIdx) -> int { return linearIdx - 1; });
+                        worker.sync();
 
                         auto masterVirtualThreadIdxCtx = forEachParticle(
                             [&](lockstep::Idx const idx) -> int
@@ -202,11 +192,11 @@ namespace pmacc
                                     if(vThreadMasterIdx == static_cast<int32_t>(idx))
                                     {
                                         /* counter[2] -> number of used frames */
-                                        kernel::atomicAllInc(acc, &(counter[2]), ::alpaka::hierarchy::Blocks{});
-                                        DestFramePtr tmpFrame = destBox.getEmptyFrame(acc);
+                                        kernel::atomicAllInc(worker, &(counter[2]), ::alpaka::hierarchy::Blocks{});
+                                        DestFramePtr tmpFrame = destBox.getEmptyFrame(worker);
                                         destFramePtr[idx] = tmpFrame;
                                         destBox.setAsFirstFrame(
-                                            acc,
+                                            worker,
                                             tmpFrame,
                                             particlesSuperCellCtx[idx] + cellDesc.getGuardingSuperCells());
                                     }
@@ -214,7 +204,7 @@ namespace pmacc
                                 return vThreadMasterIdx;
                             });
 
-                        cupla::__syncthreads(acc);
+                        worker.sync();
 
                         forEachParticle(
                             [&](lockstep::Idx const idx)
@@ -232,7 +222,7 @@ namespace pmacc
                                      * this counter is evaluated on host side
                                      * (check that loaded particles by this kernel == loaded particles from HDF5
                                      * file)*/
-                                    kernel::atomicAllInc(acc, &(counter[1]), ::alpaka::hierarchy::Blocks{});
+                                    kernel::atomicAllInc(worker, &(counter[1]), ::alpaka::hierarchy::Blocks{});
                                 }
                             });
                     }
@@ -303,11 +293,10 @@ namespace pmacc
                     log(logLvl, "load particles on device chunk offset=%1%; chunk size=%2%; left particles %3%")
                         % (i * chunkSize) % currentChunkSize % leftOverParticles;
 
-                    constexpr uint32_t numWorkers
-                        = pmacc::traits::GetNumWorkers<pmacc::math::CT::volume<SuperCellSize>::type::value>::value;
+                    auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
 
-                    PMACC_KERNEL(detail::KernelSplitIntoListOfFrames<numWorkers>{})
-                    (math::float2int_ru(double(currentChunkSize) / double(cellsInSuperCell)), numWorkers)(
+                    PMACC_LOCKSTEP_KERNEL(detail::KernelSplitIntoListOfFrames{}, workerCfg)
+                    (math::float2int_ru(double(currentChunkSize) / double(cellsInSuperCell)))(
                         counterBuffer.getDeviceBuffer().getDataBox(),
                         destSpecies.getDeviceParticlesBox(),
                         srcFrame,

--- a/include/pmacc/random/Random.hpp
+++ b/include/pmacc/random/Random.hpp
@@ -67,10 +67,10 @@ namespace pmacc
             }
 
             /** Returns a new random number advancing the state */
-            template<typename T_Acc>
-            DINLINE result_type operator()(T_Acc const& acc)
+            template<typename T_Worker>
+            DINLINE result_type operator()(T_Worker const& worker)
             {
-                return Distribution::operator()(acc, RNGHandle::getState());
+                return Distribution::operator()(worker, RNGHandle::getState());
             }
         };
 
@@ -94,10 +94,10 @@ namespace pmacc
             }
 
             /** Returns a new random number advancing the state */
-            template<typename T_Acc>
-            DINLINE result_type operator()(T_Acc const& acc)
+            template<typename T_Worker>
+            DINLINE result_type operator()(T_Worker const& worker)
             {
-                return Distribution::operator()(acc, *m_rngState);
+                return Distribution::operator()(worker, *m_rngState);
             }
 
         protected:

--- a/include/pmacc/random/distributions/misc/MullerBox.hpp
+++ b/include/pmacc/random/distributions/misc/MullerBox.hpp
@@ -58,13 +58,13 @@ namespace pmacc
                  * @param acc alpaka accelerator
                  * @param state the state of an pmacc random number generator
                  */
-                template<typename T_Acc>
-                DINLINE T_Type getNormal(T_Acc const& acc, StateType& state)
+                template<typename T_Worker>
+                DINLINE T_Type getNormal(T_Worker const& worker, StateType& state)
                 {
                     constexpr T_Type valueTwoPI = 6.2831853071795860;
 
-                    T_Type u1 = UniformRng::operator()(acc, state);
-                    T_Type u2 = UniformRng::operator()(acc, state) * valueTwoPI;
+                    T_Type u1 = UniformRng::operator()(worker, state);
+                    T_Type u2 = UniformRng::operator()(worker, state) * valueTwoPI;
 
                     T_Type s = cupla::math::sqrt(T_Type(-2.0) * cupla::math::log(u1));
 
@@ -89,8 +89,8 @@ namespace pmacc
                  * @param acc alpaka accelerator
                  * @param state the state of an pmacc random number generator
                  */
-                template<typename T_Acc>
-                DINLINE result_type operator()(T_Acc const& acc, StateType& state)
+                template<typename T_Worker>
+                DINLINE result_type operator()(T_Worker const& worker, StateType& state)
                 {
                     T_Type result;
                     if(hasSecondRngNumber)
@@ -100,7 +100,7 @@ namespace pmacc
                     }
                     else
                     {
-                        result = getNormal(acc, state);
+                        result = getNormal(worker, state);
                     }
                     return result;
                 }

--- a/include/pmacc/random/distributions/normal/Normal_generic.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_generic.hpp
@@ -45,10 +45,10 @@ namespace pmacc
                 public:
                     using result_type = T_Type;
 
-                    template<typename T_Acc>
-                    DINLINE result_type operator()(T_Acc const& acc, StateType& state)
+                    template<typename T_Worker>
+                    DINLINE result_type operator()(T_Worker const& worker, StateType& state)
                     {
-                        return ::alpaka::rand::distribution::createNormalReal<T_Type>(acc)(state);
+                        return ::alpaka::rand::distribution::createNormalReal<T_Type>(worker.getAcc())(state);
                     }
                 };
 

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral32Bit.hpp
@@ -49,10 +49,10 @@ namespace pmacc
                 public:
                     using result_type = T_Type;
 
-                    template<typename T_Acc>
-                    DINLINE result_type operator()(T_Acc const& acc, StateType& state)
+                    template<typename T_Worker>
+                    DINLINE result_type operator()(T_Worker const& worker, StateType& state)
                     {
-                        return static_cast<result_type>(RNGMethod().get32Bits(acc, state));
+                        return static_cast<result_type>(RNGMethod().get32Bits(worker, state));
                     }
                 };
 

--- a/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_Integral64Bit.hpp
@@ -50,10 +50,10 @@ namespace pmacc
                 public:
                     using result_type = T_Type;
 
-                    template<typename T_Acc>
-                    DINLINE result_type operator()(T_Acc const& acc, StateType& state)
+                    template<typename T_Worker>
+                    DINLINE result_type operator()(T_Worker const& worker, StateType& state)
                     {
-                        return static_cast<result_type>(RNGMethod().get64Bits(acc, state));
+                        return static_cast<result_type>(RNGMethod().get64Bits(worker, state));
                     }
                 };
 

--- a/include/pmacc/random/distributions/uniform/Uniform_double.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_double.hpp
@@ -45,11 +45,11 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = double;
 
-                    template<typename T_Acc>
-                    DINLINE double operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE double operator()(T_Worker const& worker, StateType& state) const
                     {
                         double const value2pow64Inv = 5.421010862427522e-20;
-                        uint64_t const random = RNGMethod().get64Bits(acc, state);
+                        uint64_t const random = RNGMethod().get64Bits(worker, state);
                         return static_cast<double>(random) * value2pow64Inv + (value2pow64Inv / 2.0);
                     }
                 };
@@ -66,12 +66,12 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = double;
 
-                    template<typename T_Acc>
-                    DINLINE double operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE double operator()(T_Worker const& worker, StateType& state) const
                     {
                         double const randomValue
                             = pmacc::random::distributions::Uniform<uniform::ExcludeZero<double>, RNGMethod>()(
-                                acc,
+                                worker,
                                 state);
                         return randomValue == 1.0 ? 0.0 : randomValue;
                     }
@@ -91,11 +91,11 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = double;
 
-                    template<typename T_Acc>
-                    DINLINE double operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE double operator()(T_Worker const& worker, StateType& state) const
                     {
                         double const value2pow53Inv = 1.1102230246251565e-16;
-                        double const randomValue53Bit = RNGMethod().get64Bits(acc, state) >> 11;
+                        double const randomValue53Bit = RNGMethod().get64Bits(worker, state) >> 11;
                         return randomValue53Bit * value2pow53Inv;
                     }
                 };
@@ -113,14 +113,14 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = double;
 
-                    template<typename T_Acc>
-                    DINLINE result_type operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE result_type operator()(T_Worker const& worker, StateType& state) const
                     {
                         do
                         {
                             const double randomValue
                                 = pmacc::random::distributions::Uniform<uniform::ExcludeZero<double>, RNGMethod>()(
-                                    acc,
+                                    worker,
                                     state);
 
                             if(randomValue != 1.0)

--- a/include/pmacc/random/distributions/uniform/Uniform_float.hpp
+++ b/include/pmacc/random/distributions/uniform/Uniform_float.hpp
@@ -45,11 +45,11 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = float;
 
-                    template<typename T_Acc>
-                    DINLINE float operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE float operator()(T_Worker const& worker, StateType& state) const
                     {
                         const float value2pow32Inv = 2.3283064e-10f;
-                        const uint32_t random = RNGMethod().get32Bits(acc, state);
+                        const uint32_t random = RNGMethod().get32Bits(worker, state);
                         return static_cast<float>(random) * value2pow32Inv + (value2pow32Inv / 2.0f);
                     }
                 };
@@ -66,12 +66,12 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = float;
 
-                    template<typename T_Acc>
-                    DINLINE float operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE float operator()(T_Worker const& worker, StateType& state) const
                     {
                         const float randomValue
                             = pmacc::random::distributions::Uniform<uniform::ExcludeZero<float>, RNGMethod>()(
-                                acc,
+                                worker,
                                 state);
                         return randomValue == 1.0f ? 0.0f : randomValue;
                     }
@@ -91,11 +91,11 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = float;
 
-                    template<typename T_Acc>
-                    DINLINE float operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE float operator()(T_Worker const& worker, StateType& state) const
                     {
                         const float value2pow24Inv = 5.9604645e-08f;
-                        const float randomValue24Bit = RNGMethod().get32Bits(acc, state) >> 8;
+                        const float randomValue24Bit = RNGMethod().get32Bits(worker, state) >> 8;
                         return static_cast<float>(randomValue24Bit) * value2pow24Inv;
                     }
                 };
@@ -113,14 +113,14 @@ namespace pmacc
                     using StateType = typename RNGMethod::StateType;
                     using result_type = float;
 
-                    template<typename T_Acc>
-                    DINLINE float operator()(T_Acc const& acc, StateType& state) const
+                    template<typename T_Worker>
+                    DINLINE float operator()(T_Worker const& worker, StateType& state) const
                     {
                         do
                         {
                             const float randomValue
                                 = pmacc::random::distributions::Uniform<uniform::ExcludeZero<float>, RNGMethod>()(
-                                    acc,
+                                    worker,
                                     state);
 
                             if(randomValue != 1.0f)

--- a/include/pmacc/random/methods/AlpakaRand.hpp
+++ b/include/pmacc/random/methods/AlpakaRand.hpp
@@ -38,24 +38,28 @@ namespace pmacc
                     alpaka::core::declval<uint32_t&>(),
                     alpaka::core::declval<uint32_t&>()));
 
-                DINLINE void init(T_Acc const& acc, StateType& state, uint32_t seed, uint32_t subsequence = 0) const
+                template<typename T_Worker>
+                DINLINE void init(T_Worker const& worker, StateType& state, uint32_t seed, uint32_t subsequence = 0)
+                    const
                 {
-                    state = ::alpaka::rand::engine::createDefault(acc, seed, subsequence);
+                    state = ::alpaka::rand::engine::createDefault(worker.getAcc(), seed, subsequence);
                 }
 
-                DINLINE uint32_t get32Bits(T_Acc const& acc, StateType& state) const
+                template<typename T_Worker>
+                DINLINE uint32_t get32Bits(T_Worker const& worker, StateType& state) const
                 {
-                    return ::alpaka::rand::distribution::createUniformUint<uint32_t>(acc)(state);
+                    return ::alpaka::rand::distribution::createUniformUint<uint32_t>(worker.getAcc())(state);
                 }
 
-                DINLINE uint64_t get64Bits(T_Acc const& acc, StateType& state) const
+                template<typename T_Worker>
+                DINLINE uint64_t get64Bits(T_Worker const& worker, StateType& state) const
                 {
                     /* Two 32bit values are packed into a 64bit value because alpaka is not
                      * supporting 64bit integer random numbers
                      */
-                    uint64_t result = get32Bits(acc, state);
+                    uint64_t result = get32Bits(worker, state);
                     result <<= 32;
-                    result ^= get32Bits(acc, state);
+                    result ^= get32Bits(worker, state);
                     return result;
                 }
 

--- a/include/pmacc/random/methods/MRG32k3aMin.hpp
+++ b/include/pmacc/random/methods/MRG32k3aMin.hpp
@@ -53,14 +53,17 @@ namespace pmacc
                     double s2[3];
                 };
 
-                DINLINE void init(T_Acc const& acc, StateType& state, uint32_t seed, uint32_t subsequence = 0) const
+                template<typename T_Worker>
+                DINLINE void init(T_Worker const& worker, StateType& state, uint32_t seed, uint32_t subsequence = 0)
+                    const
                 {
                     curandStateMRG32k3a tmpState;
                     curand_init(seed, subsequence, 0, &tmpState);
                     AssignState(state, tmpState);
                 }
 
-                DINLINE uint32_t get32Bits(T_Acc const& acc, StateType& state) const
+                template<typename T_Worker>
+                DINLINE uint32_t get32Bits(T_Worker const& worker, StateType& state) const
                 {
                     /* We can do this cast if: 1) Only state data is used and
                      *                         2) Data is aligned and positioned the same way
@@ -68,12 +71,13 @@ namespace pmacc
                     return curand(reinterpret_cast<curandStateMRG32k3a*>(&state));
                 }
 
-                DINLINE uint64_t get64Bits(T_Acc const& acc, StateType& state) const
+                template<typename T_Worker>
+                DINLINE uint64_t get64Bits(T_Worker const& worker, StateType& state) const
                 {
                     // two 32bit values are packed into a 64bit value
-                    uint64_t result = get32Bits(acc, state);
+                    uint64_t result = get32Bits(worker, state);
                     result <<= 32;
-                    result ^= get32Bits(acc, state);
+                    result ^= get32Bits(worker, state);
                     return result;
                 }
 

--- a/include/pmacc/random/methods/XorMin.hpp
+++ b/include/pmacc/random/methods/XorMin.hpp
@@ -80,7 +80,9 @@ namespace pmacc
                     }
                 };
 
-                DINLINE void init(T_Acc const& acc, StateType& state, uint32_t seed, uint32_t subsequence = 0) const
+                template<typename T_Worker>
+                DINLINE void init(T_Worker const& worker, StateType& state, uint32_t seed, uint32_t subsequence = 0)
+                    const
                 {
                     NativeStateType tmpState;
 
@@ -96,8 +98,8 @@ namespace pmacc
 
                     state = tmpState;
                 }
-
-                DINLINE uint32_t get32Bits(T_Acc const& acc, StateType& state) const
+                template<typename T_Worker>
+                DINLINE uint32_t get32Bits(T_Worker const& worker, StateType& state) const
                 {
                     /* This generator uses the xorwow formula of
                      * www.jstatsoft.org/v08/i14/paper page 5
@@ -113,13 +115,13 @@ namespace pmacc
                     state.d += 362437;
                     return state.v[4] + state.d;
                 }
-
-                DINLINE uint64_t get64Bits(T_Acc const& acc, StateType& state) const
+                template<typename T_Worker>
+                DINLINE uint64_t get64Bits(T_Worker const& worker, StateType& state) const
                 {
                     // two 32bit values are packed into a 64bit value
-                    uint64_t result = get32Bits(acc, state);
+                    uint64_t result = get32Bits(worker, state);
                     result <<= 32;
-                    result ^= get32Bits(acc, state);
+                    result ^= get32Bits(worker, state);
                     return result;
                 }
 

--- a/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Evolution.hpp
@@ -24,6 +24,7 @@
 
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
 #include <pmacc/lockstep.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 #include <pmacc/mappings/threads/ThreadCollective.hpp>
 #include <pmacc/math/Vector.hpp>
@@ -33,7 +34,6 @@
 #include <pmacc/random/Random.hpp>
 #include <pmacc/random/distributions/distributions.hpp>
 #include <pmacc/random/methods/methods.hpp>
-#include <pmacc/traits/GetNumWorkers.hpp>
 
 #include <memory>
 
@@ -46,10 +46,7 @@ namespace gol
         /** run game of life stencil
          *
          * evaluate each cell in the supercell
-         *
-         * @tparam T_numWorkers number of workers
          */
-        template<uint32_t T_numWorkers>
         struct Evolution
         {
             /** run stencil for a supercell
@@ -63,9 +60,9 @@ namespace gol
              * @param rule description of the rule as bitmap mask
              * @param mapper functor to map a block to a supercell
              */
-            template<typename T_BoxReadOnly, typename T_BoxWriteOnly, typename T_Mapping, typename T_Acc>
+            template<typename T_BoxReadOnly, typename T_BoxWriteOnly, typename T_Mapping, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 T_BoxReadOnly const& buffRead,
                 T_BoxWriteOnly buffWrite,
                 uint32_t const rule,
@@ -74,25 +71,23 @@ namespace gol
                 using Type = typename T_BoxReadOnly::ValueType;
                 using SuperCellSize = typename T_Mapping::SuperCellSize;
                 using BlockArea = SuperCellDescription<SuperCellSize, math::CT::Int<1, 1>, math::CT::Int<1, 1>>;
-                auto cache = CachedBox::create<0, Type>(acc, BlockArea());
+                auto cache = CachedBox::create<0, Type>(worker, BlockArea());
 
-                Space const block(mapper.getSuperCellIndex(Space(cupla::blockIdx(acc))));
+                Space const block(mapper.getSuperCellIndex(Space(cupla::blockIdx(worker.getAcc()))));
                 Space const blockCell = block * T_Mapping::SuperCellSize::toRT();
 
                 constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                constexpr uint32_t numWorkers = T_numWorkers;
-                uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
                 auto buffRead_shifted = buffRead.shift(blockCell);
 
-                ThreadCollective<BlockArea, numWorkers> collective(workerIdx);
+                auto collective = makeThreadCollective<BlockArea>();
 
                 math::operation::Assign assign;
-                collective(acc, assign, cache, buffRead_shifted);
+                collective(worker, assign, cache, buffRead_shifted);
 
-                cupla::__syncthreads(acc);
+                worker.sync();
 
-                lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)(
+                lockstep::makeForEach<cellsPerSuperCell>(worker)(
                     [&](uint32_t const linearIdx)
                     {
                         // cell index within the superCell
@@ -118,10 +113,8 @@ namespace gol
         /** initialize each cell
          *
          * randomly activate each cell within a supercell
-         *
-         * @tparam T_numWorkers number of workers
          */
-        template<uint32_t T_numWorkers>
+
         struct RandomInit
         {
             /** initialize each cell
@@ -136,9 +129,9 @@ namespace gol
              *                  be activated
              * @param mapper functor to map a block to a supercell
              */
-            template<typename T_BoxWriteOnly, typename T_Mapping, typename T_Acc>
+            template<typename T_BoxWriteOnly, typename T_Mapping, typename T_Worker>
             DINLINE void operator()(
-                T_Acc const& acc,
+                T_Worker const& worker,
                 T_BoxWriteOnly buffWrite,
                 uint32_t const seed,
                 float const threshold,
@@ -146,38 +139,34 @@ namespace gol
             {
                 using SuperCellSize = typename T_Mapping::SuperCellSize;
                 constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                constexpr uint32_t numWorkers = T_numWorkers;
-                uint32_t const workerIdx = cupla::threadIdx(acc).x;
 
                 // get position in grid in units of SuperCells from blockID
-                Space const block(mapper.getSuperCellIndex(Space(cupla::blockIdx(acc))));
+                Space const block(mapper.getSuperCellIndex(Space(cupla::blockIdx(worker.getAcc()))));
                 // convert position in unit of cells
                 Space const blockCell = block * T_Mapping::SuperCellSize::toRT();
-                // convert CUDA dim3 to DataSpace<DIM3>
-                Space const threadIndex(cupla::threadIdx(acc));
 
                 uint32_t const globalUniqueId = DataSpaceOperations<DIM2>::map(
                     mapper.getGridSuperCells() * T_Mapping::SuperCellSize::toRT(),
-                    blockCell + DataSpaceOperations<DIM2>::template map<SuperCellSize>(workerIdx));
+                    blockCell + DataSpaceOperations<DIM2>::template map<SuperCellSize>(worker.getWorkerIdx()));
 
                 // create a random number state and generator
-                using RngMethod = random::methods::XorMin<T_Acc>;
+                using RngMethod = random::methods::XorMin<typename T_Worker::Acc>;
                 using State = typename RngMethod::StateType;
                 State state;
                 RngMethod method;
-                method.init(acc, state, seed, globalUniqueId);
+                method.init(worker, state, seed, globalUniqueId);
                 using Distribution = random::distributions::Uniform<float, RngMethod>;
                 using Random = random::Random<Distribution, RngMethod, State*>;
                 Random rng(&state);
 
-                lockstep::makeForEach<cellsPerSuperCell, numWorkers>(workerIdx)(
+                lockstep::makeForEach<cellsPerSuperCell>(worker)(
                     [&](uint32_t const linearIdx)
                     {
                         // cell index within the superCell
                         DataSpace<DIM2> const cellIdx
                             = DataSpaceOperations<DIM2>::template map<SuperCellSize>(linearIdx);
                         // write 1(white) if uniform random number 0<rng<1 is smaller than 'threshold'
-                        buffWrite(blockCell + cellIdx) = static_cast<bool>(rng(acc) <= threshold);
+                        buffWrite(blockCell + cellIdx) = static_cast<bool>(rng(worker) <= threshold);
                     });
             }
         };
@@ -202,25 +191,22 @@ namespace gol
         void initEvolution(DBox const& writeBox, float const fraction)
         {
             AreaMapping<CORE + BORDER, T_MappingDesc> mapper(*mapping);
-            constexpr uint32_t numWorkers
-                = traits::GetNumWorkers<math::CT::volume<typename T_MappingDesc::SuperCellSize>::type::value>::value;
 
             GridController<DIM2>& gc = Environment<DIM2>::get().GridController();
             uint32_t seed = gc.getGlobalSize() + gc.getGlobalRank();
 
-            PMACC_KERNEL(kernel::RandomInit<numWorkers>{})
-            (mapper.getGridDim(), numWorkers)(writeBox, seed, fraction, mapper);
+            auto workerCfg = lockstep::makeWorkerCfg(typename T_MappingDesc::SuperCellSize{});
+            PMACC_LOCKSTEP_KERNEL(kernel::RandomInit{}, workerCfg)
+            (mapper.getGridDim())(writeBox, seed, fraction, mapper);
         }
 
         template<uint32_t Area, typename DBox>
         void run(DBox const& readBox, DBox const& writeBox)
         {
             AreaMapping<Area, T_MappingDesc> mapper(*mapping);
-            constexpr uint32_t numWorkers
-                = traits::GetNumWorkers<math::CT::volume<typename T_MappingDesc::SuperCellSize>::type::value>::value;
-
-            PMACC_KERNEL(kernel::Evolution<numWorkers>{})
-            (mapper.getGridDim(), numWorkers)(readBox, writeBox, rule, mapper);
+            auto workerCfg = lockstep::makeWorkerCfg(typename T_MappingDesc::SuperCellSize{});
+            PMACC_LOCKSTEP_KERNEL(kernel::Evolution{}, workerCfg)
+            (mapper.getGridDim())(readBox, writeBox, rule, mapper);
         }
     };
 


### PR DESCRIPTION
Entirely rewrite the lockstep programming of PMacc.
The initial implementation requires that the user starts the kernel with the correct number of threads and that the kernel uses the valid number of workers (compile time) and passes the thread index correctly to the lockstep classes.
This was hard to understand and the possibility of mistakes was high.

The new implementation simplifies the usage and avoids typical errors by passing wrong indices to the lockstep classes.

# Review

I split the PR into a few commits to simplifying the review. The most critical part is PMacc cuSTL and kernel/plugins using cuSTL. The reason is that cuSTL is not maintained since years and mostly not able to handle heterogeneous kernel very well.
Many cuSTL plugins can only run on GPU :-( anyway.
NOTE: we are working on removing cuSTL but this will take some time.

- [x] contains #4337 to fix compile issues
- [x] contains #4338 to fix broken game of life

The rewrite is not increasing the register memory footprint!

- [x] update documentation
- [x] perform more runtime tests/validation
- [x] rebase against https://github.com/ComputationalRadiationPhysics/picongpu/pull/4338