### PR TITLE
Remove getGlobalSuperCells

### DIFF
--- a/include/pmacc/mappings/kernel/MappingDescription.hpp
+++ b/include/pmacc/mappings/kernel/MappingDescription.hpp
@@ -120,11 +120,6 @@ namespace pmacc
                 SuperCellSize::toRT() * guardingSuperCells);
         }
 
-        HINLINE DataSpace<DIM> getGlobalSuperCells() const
-        {
-            return Environment<DIM>::get().GridController().getGpuNodes() * (gridSuperCells - 2 * guardingSuperCells);
-        }
-
         HDINLINE bool operator==(MappingDescription const& other)
         {
             return (gridSuperCells == other.gridSuperCells) && (guardingSuperCells == other.guardingSuperCells);


### PR DESCRIPTION
This code was wrong and unused. global super cells is not simply the local cells times the nodes, since the cells can be distributed unevenly with `--gridDist`.