### PR TITLE
move include collision.unitless to the default loader

### DIFF
--- a/include/picongpu/_defaultUnitless.loader
+++ b/include/picongpu/_defaultUnitless.loader
@@ -41,6 +41,7 @@
 #include "picongpu/unitless/speciesInitialization.unitless"
 #include "picongpu/unitless/fieldBackground.unitless"
 #include "picongpu/unitless/synchrotronPhotons.unitless"
+#include "picongpu/unitless/collision.unitless"
 #if(PMACC_CUDA_ENABLED == 1)
 #    include "picongpu/unitless/bremsstrahlung.unitless"
 #endif

--- a/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
+++ b/include/picongpu/particles/collision/binary/RelativisticBinaryCollision.hpp
@@ -22,7 +22,6 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/collision/binary/RelativisticBinaryCollision.def"
-#include "picongpu/unitless/collision.unitless"
 
 #include <pmacc/random/distributions/Uniform.hpp>
 


### PR DESCRIPTION
Puts the `collision.untiless` include where it is supposed to be^^