### PR TITLE
Install dependencies for memoryPerDevice example

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+build:
+    os: ubuntu-20.04
+    tools:
+        python: "3.9"
+    apt_packages:
+      - graphviz
+    
+python:
+   install:
+   - requirements: docs/requirements.txt
+
+formats:
+    - htmlzip
+    - pdf
+    - epub

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,0 @@
-requirements_file: docs/requirements.txt
-
-formats:
-    - htmlzip
-    - pdf
-    - epub

--- a/docs/source/usage/workflows/memoryPerDevice.rst
+++ b/docs/source/usage/workflows/memoryPerDevice.rst
@@ -27,6 +27,6 @@ between devices.
 
 This will give the following output:
 
-.. program-output:: bash -c "PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH ./usage/workflows/memoryPerDevice.py"
+.. program-output:: bash -c "PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH /usr/bin/env python -m pip install -r ../../lib/python/picongpu/requirements.txt >> /dev/null; PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH ./usage/workflows/memoryPerDevice.py"
 
 If you have a machine or cluster node with NVIDIA GPUs you can find out the available memory size by typing ``nvidia-smi`` on a shell.


### PR DESCRIPTION
The example is executed during build time of sphinx doc. The example has indirect dependencies to external libraries, which needs to be installed.

Addresses issue: #4311 