### PR TITLE
fix PMacc reduce

### DIFF
--- a/include/pmacc/device/reduce/Kernel.hpp
+++ b/include/pmacc/device/reduce/Kernel.hpp
@@ -204,9 +204,9 @@ namespace pmacc
                                     && !(linearIdx != 0u && linearIdx >= active_threads);
                                 if(isActiveCtx[idx])
                                     func(acc, sharedMem[linearIdx], sharedMem[linearIdx + chunk_count]);
-
-                                cupla::__syncthreads(acc);
                             });
+
+                        cupla::__syncthreads(acc);
                     }
                 }
             };


### PR DESCRIPTION
`cupla::__syncthreads()` was used within a lockstep lambda. This is not allowed because `cupla::__syncthreads()` is a collective operation.

- moved `cupla::__syncthreads()` behind the lockstep lambda functor.

For the specific backends we usually use, this should not have an effect, the problem would be the alpaka OMP2 blocks backend.

[update]: luckily it looks like no backend is affected by this bug see https://github.com/ComputationalRadiationPhysics/picongpu/pull/4328#issuecomment-1284989744