### PR TITLE
openPMD plugin: JSON parameters for restarting

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -263,6 +263,9 @@ TBG_checkpointTime="--checkpoint.timePeriod 2"
 #   --checkpoint.<IO-backend>.* <value>
 # e.g.:
 #   --checkpoint.openPMD.dataPreparationStrategy doubleBuffer
+# One additional parameter is available for configuring the openPMD-api via JSON
+# for restarting procedures:
+TBG_openPMD_restart="--checkpoint.openPMD.jsonRestart '{\"adios2\": {\"dataset\": {\"operators\": [{\"type\": \"blosc\",\"parameters\": {\"nthreads\": 8}}]}}}'"
 
 # Restart the simulation from checkpoint created using TBG_checkpoint
 TBG_restart="--checkpoint.restart"

--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -101,6 +101,12 @@ A full example:
 
 .. literalinclude:: openPMD_extended_config.json
 
+The extended format is only available for configuration of the writing procedures.
+The reading procedures (i.e. for restarting from a checkpoint) can be configured via ``--checkpoint.openPMD.jsonRestart``, e.g. see the example below for configuring the number of blosc decompression threads in ADIOS2.
+Note that most sensible use cases for this command line option (including this example) require openPMD-api >= 0.15 (or a recent dev version until the 0.15 release).
+
+.. literatlinclude:: openPMD_restart_config.json
+
 Two data preparation strategies are available for downloading particle data off compute devices.
 
 * Set ``--openPMD.dataPreparationStrategy doubleBuffer`` for use of the strategy that has been optimized for use with ADIOS-based backends.
@@ -122,7 +128,8 @@ PIConGPU command line option          description
 ``--openPMD.file``                    Relative or absolute openPMD file prefix for simulation data. If relative, files are stored under ``simOutput``.
 ``--openPMD.ext``                     openPMD filename extension (this controls thebackend picked by the openPMD API).
 ``--openPMD.infix``                   openPMD filename infix (use to pick file- or group-based layout in openPMD). Set to NULL to keep empty (e.g. to pick group-based iteration layout).
-``--openPMD.json``                    Set backend-specific parameters for openPMD backends in JSON format.
+``--openPMD.json``                    Set backend-specific parameters for openPMD backends in JSON format. Used in writing procedures.
+``--checkpoint.openPMD.jsonRestart``  Set backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint.
 ``--openPMD.dataPreparationStrategy`` Strategy for preparation of particle data ('doubleBuffer' or 'mappedMemory'). Aliases 'adios' and 'hdf5' may be used respectively.
 ===================================== ====================================================================================================================================================
 

--- a/docs/source/usage/plugins/openPMD_restart_config.json
+++ b/docs/source/usage/plugins/openPMD_restart_config.json
@@ -1,0 +1,14 @@
+{
+    "adios2": {
+      "dataset": {
+        "operators": [
+          {
+            "type": "blosc",
+            "parameters": {
+              "nthreads": 8
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/docs/source/usage/plugins/openPMD_restart_config.json
+++ b/docs/source/usage/plugins/openPMD_restart_config.json
@@ -1,14 +1,14 @@
 {
-    "adios2": {
-      "dataset": {
-        "operators": [
-          {
-            "type": "blosc",
-            "parameters": {
-              "nthreads": 8
-            }
+  "adios2": {
+    "dataset": {
+      "operators": [
+        {
+          "type": "blosc",
+          "parameters": {
+            "nthreads": 8
           }
-        ]
-      }
+        }
+      ]
     }
   }
+}

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -95,6 +95,7 @@ namespace picongpu
             std::string fileInfix;
 
             std::unique_ptr<AbstractJsonMatcher> jsonMatcher;
+            std::string jsonRestartParams;
 
             std::unique_ptr<toml::DataSources> tomlDataSources;
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -146,8 +146,10 @@ namespace picongpu
                     at,
                     communicator,
                     /*
-                     * The openPMD plugin only supports configuring writing routines via JSON.
-                     * Reading routines get an empty JSON set.
+                     * The writing routines are configured via the JSON set passed
+                     * in --openPMD.json / --checkpoint.openPMD.json, or TOML parameter backend_config.
+                     * The reading routines (for restarting from a checkpoint)
+                     * are configured via --checkpoint.openPMD.jsonRestart.
                      */
                     at == ::openPMD::Access::READ_ONLY ? jsonRestartParams : jsonMatcher->getDefault());
                 if(openPMDSeries->backend() == "MPI_ADIOS1")


### PR DESCRIPTION
Recent ADIOS2 and openPMD-api versions allow configuring the number of threads used for decompression at read time:

```json
{
  "adios2": {
    "dataset": {
      "operators": [
        {
          "type": "blosc",
          "parameters": {
            "nthreads": 8
          }
        }
      ]
    }
  }
}
```

The `--openPMD.json` parameter is only for writing, this introduces a `--checkpoint.openPMD.jsonRestart` parameter that can be used to specify configs as above.

TODO:
- [x] documentation