### PR TITLE
fix precision cast is returning a reference

### DIFF
--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -227,9 +227,9 @@ namespace pmacc
             template<typename CastToType>
             struct TypeCast<CastToType, picongpu::plugins::radiation::Amplitude<CastToType>>
             {
-                using result = const picongpu::plugins::radiation::Amplitude<CastToType>&;
+                using result = const picongpu::plugins::radiation::Amplitude<CastToType>;
 
-                HDINLINE result operator()(result amplitude) const
+                HDINLINE result operator()(result const& amplitude) const
                 {
                     return amplitude;
                 }

--- a/include/pmacc/dimensions/DataSpace.tpp
+++ b/include/pmacc/dimensions/DataSpace.tpp
@@ -55,7 +55,7 @@ namespace pmacc
             template<unsigned T_Dim>
             struct TypeCast<int, pmacc::DataSpace<T_Dim>>
             {
-                using result = const pmacc::DataSpace<T_Dim>&;
+                using result = const pmacc::DataSpace<T_Dim>;
 
                 HDINLINE result operator()(const pmacc::DataSpace<T_Dim>& vector) const
                 {

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -101,7 +101,7 @@ namespace pmacc
             template<typename T_CastToType>
             struct TypeCast<T_CastToType, alpaka::Complex<T_CastToType>>
             {
-                using result = const alpaka::Complex<T_CastToType>&;
+                using result = const alpaka::Complex<T_CastToType>;
 
                 HDINLINE result operator()(const alpaka::Complex<T_CastToType>& complexNumber) const
                 {

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -256,9 +256,10 @@ namespace pmacc
             template<typename CastToType, int dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
             struct TypeCast<CastToType, ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>>
             {
-                using result = const ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>&;
+                using result = ::pmacc::math::Vector<CastToType, dim>;
+                using ParamType = ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>;
 
-                HDINLINE result operator()(result vector) const
+                HDINLINE result operator()(ParamType const& vector) const
                 {
                     return vector;
                 }


### PR DESCRIPTION
Returning a reference in case the source and destination type of a precision cast can be dangerous depending on how the result type is used.

fix error:

```bash
/home/rwidera/workspace/picongpu/include/picongpu/../pmacc/memory/boxes/DataBoxDim1Access.hpp: In member function ‘pmacc::DataBoxDim1Access<T_Base>::RefValueType pmacc::DataBoxDim1Access<T_Base>::operator[](int) const [with T_Base = pmacc::DataBoxUnaryTransform<pmacc::DataBoxUnaryTransform<pmacc::DataBox<pmacc::PitchedBox<pmacc::math::Vector<double, 3>, 3> >, picongpu::energyFields::squareComponentWise>, picongpu::energyFields::cast64Bit>]’:
/home/rwidera/workspace/picongpu/include/picongpu/../pmacc/memory/boxes/DataBoxDim1Access.hpp:59:85: error: function returns address of local variable [-Werror=return-local-addr]
   59 |             return Base::operator()(DataSpaceOperations<Dim>::map(originalSize, idx));
      |                                                                                     ^

```

The error was the first time shown in PR #4321 even if the PR is not changing parts of the code that should trigger such an error.
The reason for the compile error is that the result of 

https://github.com/ComputationalRadiationPhysics/picongpu/blob/f7140e37b263851a5df2cbb7d78c114ea4de5047/include/picongpu/plugins/EnergyFields.hpp#L63-L72

is used in the functor

https://github.com/ComputationalRadiationPhysics/picongpu/blob/f7140e37b263851a5df2cbb7d78c114ea4de5047/include/picongpu/plugins/EnergyFields.hpp#L52-L61

In the case that the precision cast is casting at the same type then the input parameter is PMacc returning a reference 

https://github.com/ComputationalRadiationPhysics/picongpu/blob/f7140e37b263851a5df2cbb7d78c114ea4de5047/include/pmacc/math/vector/Vector.tpp#L256-L265

to the local value of `squareComponentWise`.


There are two ways to fix the issue. The developer needs to take care of the member type `result` used and call `ALPAKA_DECAY_T` or we do not return a reference. I choose the second way because bug hunting for the case where an `ALPAKA_DECAY_T` is missing is very hard and the second way does not show any register footprint increase on CUDA devices.


This BUG affects all older releases. It is not clear why the CI has not shown the error before and it is not clear if the bug has any critical side effects because we potentially accessed already freed memory/registers.