### PR TITLE
fix `positionOffset` for openPMD IO

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -36,17 +36,17 @@ namespace picongpu
          * A change in the major version points to a new feature/fix that cannot be handled by an older PIConGPU IO
          * implementations. Newer PIConGPU IO implementations can optionally support old major versions.
          *
-         * @attention If the version is changed please update openPMDWriter::checkIOFileVersionCompatibility().
+         * @attention If the version is changed please update openPMDWriter::checkIOFileVersionRestartCompatibility().
          */
-        static constexpr int picongpuIOVersionMajor = 1;
+        static constexpr int picongpuIOVersionMajor = 2;
 
         /** PIConGPU's IO minor file version.
          *
          * A change in the minor version means that the new introduced feature/fix can be loaded by all PIConGPU IO
          * implementations with the same major IO file version.
          *
-         * @attention If the version is changed please update openPMDWriter::checkIOFileVersionCompatibility() if
-         * needed.
+         * @attention If the version is changed please update openPMDWriter::checkIOFileVersionRestartCompatibility()
+         * if needed.
          */
         static constexpr int picongpuIOVersionMinor = 0;
         /*

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -60,7 +60,7 @@ namespace picongpu
     {
         using namespace pmacc;
 
-        template<typename SpeciesTmp, typename Filter, typename ParticleFilter, typename T_WindowOffset>
+        template<typename SpeciesTmp, typename Filter, typename ParticleFilter, typename T_ParticleOffset>
         struct StrategyRunParameters
         {
             pmacc::DataConnector& dc;
@@ -68,7 +68,7 @@ namespace picongpu
             SpeciesTmp& speciesTmp;
             Filter& filter;
             ParticleFilter& particleFilter;
-            T_WindowOffset& windowCellOffsetToTotalDomain;
+            T_ParticleOffset& particleToTotalDomainOffset;
             uint64_t myNumParticles, globalNumParticles;
             StrategyRunParameters(
                 pmacc::DataConnector& c_dc,
@@ -76,7 +76,7 @@ namespace picongpu
                 SpeciesTmp& c_speciesTmp,
                 Filter& c_filter,
                 ParticleFilter& c_particleFilter,
-                T_WindowOffset& c_windowCellOffsetToTotalDomain,
+                T_ParticleOffset& c_particleToTotalDomainOffset,
                 uint64_t c_myNumParticles,
                 uint64_t c_globalNumParticles)
                 : dc(c_dc)
@@ -84,7 +84,7 @@ namespace picongpu
                 , speciesTmp(c_speciesTmp)
                 , filter(c_filter)
                 , particleFilter(c_particleFilter)
-                , windowCellOffsetToTotalDomain(c_windowCellOffsetToTotalDomain)
+                , particleToTotalDomainOffset(c_particleToTotalDomainOffset)
                 , myNumParticles(c_myNumParticles)
                 , globalNumParticles(c_globalNumParticles)
             {
@@ -161,7 +161,7 @@ namespace picongpu
                     hostFrame,
                     particlesBox,
                     rp.filter,
-                    rp.windowCellOffsetToTotalDomain,
+                    rp.particleToTotalDomainOffset,
                     totalCellIdx_,
                     mapper,
                     rp.particleFilter);
@@ -219,7 +219,7 @@ namespace picongpu
                     deviceFrame,
                     rp.speciesTmp->getDeviceParticlesBox(),
                     rp.filter,
-                    rp.windowCellOffsetToTotalDomain,
+                    rp.particleToTotalDomainOffset,
                     totalCellIdx_,
                     mapper,
                     rp.particleFilter);
@@ -329,7 +329,7 @@ namespace picongpu
                 }
             }
 
-            HINLINE void operator()(ThreadParams* params, const DataSpace<simDim> windowCellOffsetToTotalDomain)
+            HINLINE void operator()(ThreadParams* params, const DataSpace<simDim> particleToTotalDomainOffset)
             {
                 log<picLog::INPUT_OUTPUT>("openPMD: (begin) write species: %1%") % T_SpeciesFilter::getName();
                 DataConnector& dc = Environment<>::get().DataConnector();
@@ -427,7 +427,7 @@ namespace picongpu
                     speciesTmp,
                     filter,
                     particleFilter,
-                    windowCellOffsetToTotalDomain,
+                    particleToTotalDomainOffset,
                     myNumParticles,
                     globalNumParticles);
                 if(globalNumParticles > 0)
@@ -494,7 +494,9 @@ namespace picongpu
                         ds.options = params->jsonMatcher->get(basename + "/particlePatches/extent/" + name_lookup[d]);
                         extent_x.resetDataset(ds);
 
-                        offset_x.store<index_t>(mpiRank, windowCellOffsetToTotalDomain[d]);
+                        auto const totalPatchOffset
+                            = particleToTotalDomainOffset[d] + params->localWindowToDomainOffset[d];
+                        offset_x.store<index_t>(mpiRank, totalPatchOffset);
                         extent_x.store<index_t>(mpiRank, patchExtent[d]);
                     }
 

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -209,12 +209,19 @@ namespace picongpu
                 }
 
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
-                auto globalDOmainOffset = subGrid.getGlobalDomain().offset;
-                /* window.localDimensions.offset is in PIConGPU for a restart zero but to stay generic we take
+                const pmacc::Selection<simDim> localDomain = subGrid.getLocalDomain();
+                const pmacc::Selection<simDim> globalDomain = subGrid.getGlobalDomain();
+                /* Offset to transform local particle offsets into total offsets for all particles within the
+                 * current local domain.
+                 * @attention A window can be the full simulation domain or the moving window.
+                 */
+                DataSpace<simDim> localToTotalDomainOffset(localDomain.offset + globalDomain.offset);
+
+                /* params->localWindowToDomainOffset is in PIConGPU for a restart zero but to stay generic we take
                  * the variable into account.
                  */
-                DataSpace<simDim> const patchTotalOffset = globalDOmainOffset + params->window.globalDimensions.offset
-                    + params->window.localDimensions.offset;
+                DataSpace<simDim> const patchTotalOffset
+                    = localToTotalDomainOffset + params->localWindowToDomainOffset;
                 DataSpace<simDim> const patchExtent = params->window.localDimensions.size;
 
                 // search the patch index based on the offset and extents of local domain size


### PR DESCRIPTION
fix #4319

Fix that the wrong window offset was used for restarting and wrong offsets where used for writing.

This commit is a breaking change for the IO format, therefore the major IO version is increased to 2.0.