### PR TITLE
introduce a constexpr value identifier

### DIFF
--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Rene Widera
+/* Copyright 2013-2022 Rene Widera, Pawel Ordyna
  *
  * This file is part of PMacc.
  *
@@ -45,8 +45,17 @@
  *
  * to create a instance of this value_identifier you can use:
  *      `length()` or `length_`
+ * @{
  */
 #define value_identifier(in_type, name, in_default)                                                                   \
     identifier(                                                                                                       \
         name, using type = in_type; static HDINLINE type getValue()                                                   \
+        { return in_default; } static std::string getName() { return std::string(#name); })
+
+/** getValue() is defined constexpr
+ * @}
+ */
+#define value_identifier_constexpr(in_type, name, in_default)                                                         \
+    identifier(                                                                                                       \
+        name, using type = in_type; static constexpr HDINLINE type getValue()                                         \
         { return in_default; } static std::string getName() { return std::string(#name); })


### PR DESCRIPTION
Introduce a new macro for defining value identifiers that can be later used in `constexpr` expressions. I use it in radiation transport when defining a species wide wavelength as a species flag. @psychocoderHPC, what do you think, is this the right way to do it?