### PR TITLE
fix typo

### DIFF
--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -21,7 +21,7 @@
 /** @file
  *
  * Configurations for particle manipulators. Set up and declare functors that
- * can be used in speciesInitalization.param for particle species
+ * can be used in speciesInitialization.param for particle species
  * initialization and manipulation, such as temperature distributions, drifts,
  * pre-ionization and in-cell position.
  */

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particle.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particle.param
@@ -21,7 +21,7 @@
 /** @file
  *
  * Configurations for particle manipulators. Set up and declare functors that
- * can be used in speciesInitalization.param for particle species
+ * can be used in speciesInitialization.param for particle species
  * initialization and manipulation, such as temperature distributions, drifts,
  * pre-ionization and in-cell position.
  */

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
@@ -21,7 +21,7 @@
 /** @file
  *
  * Configurations for particle manipulators. Set up and declare functors that
- * can be used in speciesInitalization.param for particle species
+ * can be used in speciesInitialization.param for particle species
  * initialization and manipulation, such as temperature distributions, drifts,
  * pre-ionization and in-cell position.
  */

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
@@ -21,7 +21,7 @@
 /** @file
  *
  * Configurations for particle manipulators. Set up and declare functors that
- * can be used in speciesInitalization.param for particle species
+ * can be used in speciesInitialization.param for particle species
  * initialization and manipulation, such as temperature distributions, drifts,
  * pre-ionization and in-cell position.
  */

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
@@ -21,7 +21,7 @@
 /** @file
  *
  * Configurations for particle manipulators. Set up and declare functors that
- * can be used in speciesInitalization.param for particle species
+ * can be used in speciesInitialization.param for particle species
  * initialization and manipulation, such as temperature distributions, drifts,
  * pre-ionization and in-cell position.
  */

--- a/share/picongpu/tests/XrayScattering/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/XrayScattering/include/picongpu/param/particle.param
@@ -21,7 +21,7 @@
 /** @file
  *
  * Configurations for particle manipulators. Set up and declare functors that
- * can be used in speciesInitalization.param for particle species
+ * can be used in speciesInitialization.param for particle species
  * initialization and manipulation, such as temperature distributions, drifts,
  * pre-ionization and in-cell position.
  */


### PR DESCRIPTION
Fix a typo in `particle.param`
This doesn't need the CI to run, @ComputationalRadiationPhysics/picongpu-maintainers can someone set a no-ci flag?