### PR TITLE
fix HIP CI tests

### DIFF
--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -8,8 +8,7 @@
     GIT_SUBMODULE_STRATEGY: normal
     # -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0 workaround for CMake issue
     #  "Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND)"
-    #  gfx900 is the VEGA64 GPU in the CI node
-    PIC_CMAKE_ARGS: "-DGPU_TARGETS=gfx900 -DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
+    PIC_CMAKE_ARGS: "-DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
     # ISAAC is not working with HIP
     DISABLE_ISAAC: "yes"
   script:


### PR DESCRIPTION
The CI for HIP changes, the changes are nessesary to perform runtime tests.

- select the architecture of the GPU via the CI provided variable CI_GPU_ARCH
- select the used GPU randomly depending on the number of GPUs CI_GPUS