### PR TITLE
refactor PMacc plugin slicing

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -124,6 +124,7 @@ PIConGPU command line option          description
 ``--openPMD.source``                  Select data sources and filters to dump. Default is ``species_all,fields_all``, which dumps all fields and particle species.
 ``--openPMD.range``                   Define a contiguous range of cells per dimension to dump. Each dimension is separated by a comma.
                                       A range is defined as ``[BEGIN:END)`` where out of range indices will be clipped.
+                                      A single value e.g. ``10,:,:`` for a dimension will only dump a slice.
                                       Default is ``:,:,:``, which dumps all cells.
 ``--openPMD.file``                    Relative or absolute openPMD file prefix for simulation data. If relative, files are stored under ``simOutput``.
 ``--openPMD.ext``                     openPMD filename extension (this controls thebackend picked by the openPMD API).

--- a/include/picongpu/plugins/misc/intersectRangeWithWindow.hpp
+++ b/include/picongpu/plugins/misc/intersectRangeWithWindow.hpp
@@ -22,7 +22,7 @@
 #include "picongpu/simulation/control/Window.hpp"
 
 #include <pmacc/mappings/simulation/SubGrid.hpp>
-#include <pmacc/pluginSystem/toTimeSlice.hpp>
+#include <pmacc/pluginSystem/toSlice.hpp>
 
 #include <algorithm>
 #include <string>
@@ -54,7 +54,7 @@ namespace picongpu
             {
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
 
-                auto parsedSlice = pmacc::pluginSystem::toTimeSlice(selectedRange);
+                auto parsedSlice = pmacc::pluginSystem::toRangeSlice(selectedRange);
 
                 Window resultWindow = inputWindow;
                 // Parse the ranges only for dimensions the user is providing.

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -63,7 +63,7 @@
 #include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
 #include <pmacc/particles/operations/CountParticles.hpp>
 #include <pmacc/pluginSystem/PluginConnector.hpp>
-#include <pmacc/pluginSystem/toTimeSlice.hpp>
+#include <pmacc/pluginSystem/toSlice.hpp>
 #include <pmacc/simulationControl/TimeInterval.hpp>
 #include <pmacc/static_assert.hpp>
 #include <pmacc/traits/Limits.hpp>
@@ -1671,7 +1671,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 parsed.begin(),
                 parsed.end(),
                 std::back_inserter(res),
-                [](pmacc::pluginSystem::TimeSlice timeSlice) -> TimeSlice {
+                [](pmacc::pluginSystem::Slice timeSlice) -> TimeSlice {
                     return {timeSlice.values[0], timeSlice.values[1], timeSlice.values[2]};
                 });
             return res;

--- a/include/picongpu/plugins/openPMD/toml.hpp
+++ b/include/picongpu/plugins/openPMD/toml.hpp
@@ -54,7 +54,7 @@ namespace picongpu
             }
         };
 
-        // We can't use pmacc::pluginSystem::TimeSlice in a hostonly file due to PIConGPU include structure
+        // We can't use pmacc::pluginSystem::Slice in a hostonly file due to PIConGPU include structure
         // so reimplement it here
         struct TimeSlice
         {

--- a/include/pmacc/pluginSystem/PluginConnector.cpp
+++ b/include/pmacc/pluginSystem/PluginConnector.cpp
@@ -24,9 +24,9 @@
 
 #include "pmacc/pluginSystem/INotify.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
-#include "pmacc/pluginSystem/TimeSlice.hpp"
+#include "pmacc/pluginSystem/Slice.hpp"
 #include "pmacc/pluginSystem/containsStep.hpp"
-#include "pmacc/pluginSystem/toTimeSlice.hpp"
+#include "pmacc/pluginSystem/toSlice.hpp"
 
 #include <list>
 #include <string>

--- a/include/pmacc/pluginSystem/PluginConnector.hpp
+++ b/include/pmacc/pluginSystem/PluginConnector.hpp
@@ -25,7 +25,7 @@
 #include "pmacc/Environment.def"
 #include "pmacc/pluginSystem/INotify.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
-#include "pmacc/pluginSystem/TimeSlice.hpp"
+#include "pmacc/pluginSystem/Slice.hpp"
 
 #include <list>
 #include <string>
@@ -42,7 +42,7 @@ namespace pmacc
     class PluginConnector
     {
     private:
-        using SeqOfTimeSlices = std::vector<pluginSystem::TimeSlice>;
+        using SeqOfTimeSlices = std::vector<pluginSystem::Slice>;
         using PluginPair = std::pair<INotify*, SeqOfTimeSlices>;
         using NotificationList = std::list<PluginPair>;
 

--- a/include/pmacc/pluginSystem/Slice.hpp
+++ b/include/pmacc/pluginSystem/Slice.hpp
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include "pmacc/types.hpp"
 #include "pmacc/verify.hpp"
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 
@@ -32,7 +32,7 @@ namespace pmacc
 {
     namespace pluginSystem
     {
-        struct TimeSlice
+        struct Slice
         {
             /** time slice configuration
              *
@@ -74,7 +74,7 @@ namespace pmacc
              * @param end last time step taken into account
              * @param period select any period(st) time step between start and end
              */
-            TimeSlice(uint32_t start = 0, uint32_t end = uint32_t(-1), uint32_t period = 1)
+            Slice(uint32_t start = 0, uint32_t end = uint32_t(-1), uint32_t period = 1)
                 : /* default: start:end:period
                    * -1 stored as unsigned is the highest available unsigned integer
                    */

--- a/include/pmacc/pluginSystem/containsStep.hpp
+++ b/include/pmacc/pluginSystem/containsStep.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "pmacc/pluginSystem/TimeSlice.hpp"
+#include "pmacc/pluginSystem/Slice.hpp"
 
 #include <vector>
 
@@ -36,7 +36,7 @@ namespace pmacc
          * @param timeStep simulation time step to check
          * @return true if step is included in the interval list else false
          */
-        HINLINE bool containsStep(std::vector<pluginSystem::TimeSlice> const& seqTimeSlices, uint32_t const timeStep)
+        HINLINE bool containsStep(std::vector<pluginSystem::Slice> const& seqTimeSlices, uint32_t const timeStep)
         {
             for(auto const& timeSlice : seqTimeSlices)
             {

--- a/include/pmacc/pluginSystem/toSlice.hpp
+++ b/include/pmacc/pluginSystem/toSlice.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2022 Rene Widera
+/* Copyright 2022 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -22,12 +22,12 @@
 #pragma once
 
 #include "pmacc/misc/splitString.hpp"
-#include "pmacc/pluginSystem/TimeSlice.hpp"
-#include "pmacc/types.hpp"
+#include "pmacc/pluginSystem/Slice.hpp"
 #include "pmacc/verify.hpp"
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <iostream>
 #include <regex>
 #include <string>
@@ -53,14 +53,17 @@ namespace pmacc
 
         /** create a TimeSlice out of an string
          *
-         * Parse a comma separated list of time slices and creates a vector of TimeSlices.
-         * TimeSlice Syntax:
+         * Parse a comma separated list of time slices and creates a vector of slices.
+         * time slice syntax:
          *   - `start:stop:period`
          *   - a number ``N is equal to `::N`
+         *   - `:` is equal to `0:-1:1`
+         *
+         * If stop is `-1` there is no defined end.
          */
-        HINLINE std::vector<TimeSlice> toTimeSlice(std::string const& str)
+        HINLINE std::vector<Slice> toTimeSlice(std::string const& str)
         {
-            std::vector<TimeSlice> result;
+            std::vector<Slice> result;
             auto const seqOfSlices = misc::splitString(str, ",");
             for(auto const& slice : seqOfSlices)
             {
@@ -76,7 +79,7 @@ namespace pmacc
                 // id of the component
                 size_t n = 0;
                 bool const hasOnlyPeriod = sliceComponents.size() == 1u;
-                TimeSlice timeSlice;
+                Slice timeSlice;
                 for(auto& component : sliceComponents)
                 {
                     // be sure that component it is a number or empty
@@ -87,6 +90,57 @@ namespace pmacc
                     timeSlice.setValue(hasOnlyPeriod ? 2 : n, component);
                     n++;
                 }
+                result.push_back(timeSlice);
+            }
+            return result;
+        }
+
+        /** create a RangeSlice out of an string
+         *
+         * Parse a comma separated list of slices and creates a vector of slices.
+         * range slice syntax:
+         *   - `begin:end:period`
+         *   - a number ``N is equal to `N:N+1,1`
+         *   - `:` is equal to `0:-1:1`
+         *
+         * If end is `-1` there is no defined end if the range.
+         */
+        HINLINE std::vector<Slice> toRangeSlice(std::string const& str)
+        {
+            std::vector<Slice> result;
+            auto const seqOfSlices = misc::splitString(str, ",");
+            for(auto const& slice : seqOfSlices)
+            {
+                // skip empty slice strings
+                if(slice.empty())
+                    continue;
+
+                auto const sliceComponents = misc::splitString(slice, ":");
+                PMACC_VERIFY_MSG(
+                    !sliceComponents.empty(),
+                    std::string("time slice without a defined element is not allowed") + str);
+
+                // id of the component
+                size_t n = 0;
+                bool const sliceOnly = sliceComponents.size() == 1u;
+                Slice timeSlice;
+
+                for(auto& component : sliceComponents)
+                {
+                    // be sure that component it is a number or empty
+                    PMACC_VERIFY_MSG(
+                        component.empty() || detail::is_number(component),
+                        std::string("value") + component + " in " + str + "is not a number");
+
+                    timeSlice.setValue(n, component);
+                    if(sliceOnly)
+                    {
+                        // set end to begin + 1 to select only one slice
+                        timeSlice.values[1] = std::stoul(component) + 1;
+                    }
+                    n++;
+                }
+
                 result.push_back(timeSlice);
             }
             return result;

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -29,7 +29,7 @@
 #include "pmacc/mappings/simulation/GridController.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
 #include "pmacc/pluginSystem/containsStep.hpp"
-#include "pmacc/pluginSystem/toTimeSlice.hpp"
+#include "pmacc/pluginSystem/toSlice.hpp"
 #include "pmacc/simulationControl/signal.hpp"
 #include "pmacc/types.hpp"
 
@@ -400,7 +400,7 @@ namespace pmacc
                 signalCreateCheckpoint = false;
 
                 // add a new checkpoint
-                seqCheckpointPeriod.push_back(pluginSystem::TimeSlice(signalMaxTimestep, signalMaxTimestep));
+                seqCheckpointPeriod.push_back(pluginSystem::Slice(signalMaxTimestep, signalMaxTimestep));
             }
             if(signalStopSimulation)
             {

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -47,7 +47,7 @@ namespace pmacc
     class SimulationHelper : public IPlugin
     {
     public:
-        using SeqOfTimeSlices = std::vector<pluginSystem::TimeSlice>;
+        using SeqOfTimeSlices = std::vector<pluginSystem::Slice>;
 
         /**
          * Constructor


### PR DESCRIPTION
- rename `TimeSlice` into `Slice`
- add method `toRangeSlice` with special handling for the case that only the begin of the range is given


This PR fixes a bug @PrometheusPi found that setting only the begin of a range for the OpenPMD plugin dumped all data, instead of a single slice.