### PR TITLE
fix python code for new flake8 version=3.0.0

### DIFF
--- a/docs/propose_changelog.py
+++ b/docs/propose_changelog.py
@@ -74,7 +74,7 @@ for i in issues:
     # filter out bugs that only appeared in development
     pr_nr = i.number
     pr_labels = i.labels
-    pr_labels_names = list(map(lambda l: l.name, pr_labels))
+    pr_labels_names = list(map(lambda x: x.name, pr_labels))
     pr_url = "https://github.com/ComputationalRadiationPhysics/picongpu/pull/"
     if "bug" in pr_labels_names:
         if "affects latest release" not in pr_labels_names:


### PR DESCRIPTION
Since our CI does not specify we are running into a CI flake8 error since today. 
The existing code does not follow the rule that variables `I` and `l` should be avoided.
See [E741](https://www.flake8rules.com/rules/E741.html) for details. 

This PR fixes that. 