### PR TITLE
remove boost workaround

### DIFF
--- a/include/pmacc/boost_workaround.hpp
+++ b/include/pmacc/boost_workaround.hpp
@@ -23,22 +23,9 @@
 // clang-format off
 
 /** @file This file should be included in each `cpp`-file before any other boost include
- * to workaround compiler errors when compiling with clang-cuda and boost <1.69.0
- *
- * https://github.com/ComputationalRadiationPhysics/picongpu/issues/3294
+ * to workaround different compiler errors triggered by boost includes.
  */
-#include <boost/version.hpp>
-#if(BOOST_VERSION < 106900 && defined(__CUDACC__) && defined(__clang__))
-#    if defined(__CUDACC__)
-#        include <boost/config/compiler/nvcc.hpp>
-#    endif
-#    if(!defined(__ibmxl__))
-#        include <boost/config/compiler/clang.hpp>
-#    endif
-#    undef __CUDACC__
-#    include <boost/config/detail/select_compiler_config.hpp>
-#    define __CUDACC__
-#endif
+
 /* workaround for compile error with clang-cuda
  * boost/type_traits/is_base_and_derived.hpp:142:25: error: invalid application of 'sizeof' to an incomplete type
  * 'boost::in_place_factory_base' BOOST_STATIC_ASSERT(sizeof(B) != 0);


### PR DESCRIPTION
The current minimal boost version we support is 1.74.0, therefore the old workaround can be removed.