### PR TITLE
Ignore VS config and output dir and checkout script line endings as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ docs/build/
 .DS_Store
 .AppleDouble
 .LSOverride
+
+# Visual Studio configuration and output files
+out
+/.vs


### PR DESCRIPTION
This helps a bit working on Windows platforms.