### PR TITLE
fix slice parsing bug

### DIFF
--- a/include/pmacc/misc/splitString.cpp
+++ b/include/pmacc/misc/splitString.cpp
@@ -32,9 +32,13 @@ namespace pmacc
     {
         std::vector<std::string> splitString(std::string const& input, std::string const& delimiter)
         {
+            /* Extent the input with one delimiter to get an empty string in cases where the input ends with a
+             * delimiter without any other following characters.
+             */
+            auto inputExtended = input + delimiter;
             std::regex re(delimiter);
             // passing -1 as the submatch index parameter performs splitting
-            std::sregex_token_iterator first{input.begin(), input.end(), re, -1};
+            std::sregex_token_iterator first{inputExtended.begin(), inputExtended.end(), re, -1};
             std::sregex_token_iterator last;
 
             return {first, last};

--- a/include/pmacc/pluginSystem/toSlice.hpp
+++ b/include/pmacc/pluginSystem/toSlice.hpp
@@ -67,10 +67,6 @@ namespace pmacc
             auto const seqOfSlices = misc::splitString(str, ",");
             for(auto const& slice : seqOfSlices)
             {
-                // skip empty slice strings
-                if(slice.empty())
-                    continue;
-
                 auto const sliceComponents = misc::splitString(slice, ":");
                 PMACC_VERIFY_MSG(
                     !sliceComponents.empty(),
@@ -111,10 +107,6 @@ namespace pmacc
             auto const seqOfSlices = misc::splitString(str, ",");
             for(auto const& slice : seqOfSlices)
             {
-                // skip empty slice strings
-                if(slice.empty())
-                    continue;
-
                 auto const sliceComponents = misc::splitString(slice, ":");
                 PMACC_VERIFY_MSG(
                     !sliceComponents.empty(),
@@ -136,11 +128,10 @@ namespace pmacc
                     if(sliceOnly)
                     {
                         // set end to begin + 1 to select only one slice
-                        timeSlice.values[1] = std::stoul(component) + 1;
+                        timeSlice.values[1] = timeSlice.values[0] + 1;
                     }
                     n++;
                 }
-
                 result.push_back(timeSlice);
             }
             return result;


### PR DESCRIPTION
- fix the split string function for cases where the last character is the delimiter
- `toSlice()`
  - remove silend ignore in cases where an empty string is given as a range
  - do not use `std::stoul` to avoid errors if a string is empty

This pr fixes the runtime error: `Unhandled exception of type 'St16invalid_argument' with message 'stoul', terminating` if openPMD output is used.