### PR TITLE
Radiation plugin: Enable streaming

### DIFF
--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -62,8 +62,7 @@
 #    include "picongpu/plugins/IsaacPlugin.hpp"
 #endif
 
-#if((ENABLE_OPENPMD == 1) && (openPMD_HAVE_HDF5 == 1))
-// Radiation postprocessing is still native hdf5, so only enable the plugin for this backend
+#if ENABLE_OPENPMD
 #    include "picongpu/plugins/radiation/Radiation.hpp"
 #    include "picongpu/plugins/radiation/VectorTypes.hpp"
 #endif
@@ -169,7 +168,7 @@ namespace picongpu
             CountParticles<bmpl::_1>,
             PngPlugin<Visualisation<bmpl::_1, PngCreator>>,
             plugins::transitionRadiation::TransitionRadiation<bmpl::_1>
-#if((ENABLE_OPENPMD == 1) && (openPMD_HAVE_HDF5 == 1))
+#if ENABLE_OPENPMD
             ,
             plugins::radiation::Radiation<bmpl::_1>
 #endif

--- a/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
+++ b/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
@@ -27,6 +27,12 @@ namespace picongpu
 {
     namespace openPMD
     {
+        enum class ExtensionPreference
+        {
+            ADIOS,
+            HDF5
+        };
+
         /** Get default extension for openPMD files
          *
          * Make a uniform choice when several valid backends are available.
@@ -34,23 +40,36 @@ namespace picongpu
          *
          * This function can only be compiled when openPMD is enabled.
          */
-        inline std::string getDefaultExtension()
+        inline std::string getDefaultExtension(ExtensionPreference ep = ExtensionPreference::ADIOS)
         {
-#if openPMD_HAVE_ADIOS2
-            auto availableExtensions = ::openPMD::getFileExtensions();
-            for(auto const& ext : availableExtensions)
+            using EP = ExtensionPreference;
+            auto getADIOSExtension = []()
             {
-                if(ext == "bp4")
+                auto availableExtensions = ::openPMD::getFileExtensions();
+                for(auto const& ext : availableExtensions)
                 {
-                    return "bp4";
+                    if(ext == "bp4")
+                    {
+                        return "bp4";
+                    }
                 }
+                /*
+                 * BP4 engine is always available in all supported ADIOS2 versions,
+                 * but the bp4 extensions is new in openPMD, so we might need to
+                 * fallback to "bp".
+                 */
+                return "bp";
+            };
+#if openPMD_HAVE_ADIOS2 && openPMD_HAVE_HDF5
+            switch(ep)
+            {
+            case EP::ADIOS:
+                return getADIOSExtension();
+            case EP::HDF5:
+                return "h5";
             }
-            /*
-             * BP4 engine is always available in all supported ADIOS2 versions,
-             * but the bp4 extensions is new in openPMD, so we might need to
-             * fallback to "bp".
-             */
-            return "bp";
+#elif openPMD_HAVE_ADIOS2
+            return getADIOSExtension();
 #elif openPMD_HAVE_HDF5
             return "h5";
 #else

--- a/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
+++ b/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
@@ -68,6 +68,10 @@ namespace picongpu
             case EP::HDF5:
                 return "h5";
             }
+            /*
+             * This silences compiler warnings
+             */
+            return "[openPMD::getDefaultExtension()] Unreachable!";
 #elif openPMD_HAVE_ADIOS2
             return getADIOSExtension();
 #elif openPMD_HAVE_HDF5

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -20,14 +20,15 @@
 
 #pragma once
 
-#if(ENABLE_OPENPMD * openPMD_HAVE_HDF5 != 1)
-#    error The activated radiation plugin (radiation.param) requires openPMD-api with a HDF5 backend
+#if !ENABLE_OPENPMD
+#    error The activated radiation plugin (radiation.param) requires openPMD-api.
 #endif
 
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 #include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/stringHelpers.hpp"
 #include "picongpu/plugins/radiation/ExecuteParticleFilter.hpp"
@@ -142,7 +143,8 @@ namespace picongpu
                 static const int numberMeshRecords = 3;
 
                 std::optional<::openPMD::Series> m_series;
-                std::string openPMDSuffix = "_%T_0_0_0.h5";
+                std::string openPMDSuffix
+                    = "_%T_0_0_0." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
                 std::string openPMDConfig = "{}";
 
             public:
@@ -223,7 +225,9 @@ namespace picongpu
                         po::value<int>(&numJobs)->default_value(2),
                         "Number of independent jobs used for the radiation calculation.")(
                         (pluginPrefix + ".openPMDSuffix").c_str(),
-                        po::value<std::string>(&openPMDSuffix)->default_value("_%T_0_0_0.h5"),
+                        po::value<std::string>(&openPMDSuffix)
+                            ->default_value(
+                                "_%T_0_0_0." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5)),
                         "Suffix for openPMD filename extension and iteration expansion pattern.")(
                         (pluginPrefix + ".openPMDConfig").c_str(),
                         po::value<std::string>(&openPMDConfig)->default_value("{}"),

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -44,6 +44,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <algorithm> // std::any
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -670,7 +671,18 @@ namespace picongpu
                     if(!m_series.has_value())
                     {
                         std::ostringstream filename;
-                        filename << name << openPMDSuffix;
+                        if(std::any_of(
+                               openPMDSuffix.begin(),
+                               openPMDSuffix.end(),
+                               [](char const c) { return c == '.'; }))
+                        {
+                            filename << name << openPMDSuffix;
+                        }
+                        else
+                        {
+                            filename << name << '.' << openPMDSuffix;
+                        }
+
                         m_series = std::make_optional(
                             ::openPMD::Series(filename.str(), ::openPMD::Access::CREATE, openPMDConfig));
 

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -673,10 +673,27 @@ namespace picongpu
                         filename << name << openPMDSuffix;
                         m_series = std::make_optional(
                             ::openPMD::Series(filename.str(), ::openPMD::Access::CREATE, openPMDConfig));
+
+                        /* begin recommended openPMD global attributes */
+                        m_series->setMeshesPath(meshesPathName);
+                        const std::string software("PIConGPU");
+                        std::stringstream softwareVersion;
+                        softwareVersion << PICONGPU_VERSION_MAJOR << "." << PICONGPU_VERSION_MINOR << "."
+                                        << PICONGPU_VERSION_PATCH;
+                        if(!std::string(PICONGPU_VERSION_LABEL).empty())
+                            softwareVersion << "-" << PICONGPU_VERSION_LABEL;
+                        m_series->setSoftware(software, softwareVersion.str());
+
+                        std::string author = Environment<>::get().SimulationDescription().getAuthor();
+                        if(author.length() > 0)
+                            m_series->setAuthor(author);
+
+                        std::string date = helper::getDateString("%F %T %z");
+                        m_series->setDate(date);
+                        /* end recommended openPMD global attributes */
                     }
                     ::openPMD::Series& openPMDdataFile = m_series.value();
                     ::openPMD::Iteration openPMDdataFileIteration = openPMDdataFile.writeIterations()[currentStep];
-                    openPMDdataFile.setMeshesPath(meshesPathName);
 
                     // begin: write amplitude data
                     ::openPMD::Mesh mesh_amp = openPMDdataFileIteration.meshes[dataLabels(-1)];
@@ -851,23 +868,6 @@ namespace picongpu
                     openPMDdataFileIteration.setTime(time);
                     openPMDdataFileIteration.setTimeUnitSI(UNIT_TIME);
                     /* end required openPMD global attributes */
-
-                    /* begin recommended openPMD global attributes */
-                    const std::string software("PIConGPU");
-                    std::stringstream softwareVersion;
-                    softwareVersion << PICONGPU_VERSION_MAJOR << "." << PICONGPU_VERSION_MINOR << "."
-                                    << PICONGPU_VERSION_PATCH;
-                    if(!std::string(PICONGPU_VERSION_LABEL).empty())
-                        softwareVersion << "-" << PICONGPU_VERSION_LABEL;
-                    openPMDdataFile.setSoftware(software, softwareVersion.str());
-
-                    std::string author = Environment<>::get().SimulationDescription().getAuthor();
-                    if(author.length() > 0)
-                        openPMDdataFile.setAuthor(author);
-
-                    std::string date = helper::getDateString("%F %T %z");
-                    openPMDdataFile.setDate(date);
-                    /* end recommended openPMD global attributes */
 
                     openPMDdataFileIteration.close();
                     openPMDdataFile.flush();


### PR DESCRIPTION
The radiation plugin currently hardcodes the HDF5 backend of openPMD, and opens a new instance of openPMD for each output time step.

This PR:
1. keeps one instance of `openPMD::Series` alive, just like the openPMD plugin does
2. adds runtime options to control the filename extension and JSON/TOML configuration for openPMD

TODO
- [x] I haven't actually tested it yet, do so
- [x] The plugin still requires HDF5 to compile at all and hardcodes HDF5 as default. Maybe use a more flexible default, as in other openPMD-based plugins.