### PR TITLE
Integer exponent power function

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Weights.hpp
+++ b/include/picongpu/fields/MaxwellSolver/ArbitraryOrderFDTD/Weights.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov
+/* Copyright 2020-2022 Klaus Steiniger, Sergei Bastrakov, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -45,21 +45,21 @@ namespace picongpu
                 {
                     HDINLINE constexpr AOFDTDWeights()
                     {
-                        namespace powSpace = ::picongpu::plugins::radiation::util;
+                        namespace powSpace = pmacc::math;
                         // Set initial value
                         weights[0] = 4.0_X * T_neighbors
-                            * powSpace::pow(
+                            * powSpace::cPow(
                                          (factorial(2 * T_neighbors)
                                           / float_X(
-                                              powSpace::pow(2.0_X, 2 * T_neighbors)
-                                              * powSpace::pow(factorial(T_neighbors), 2))),
-                                         2);
+                                              powSpace::cPow(2.0_X, 2u * T_neighbors)
+                                              * powSpace::cPow(factorial(T_neighbors), 2u))),
+                                         2u);
 
                         // Compute all other values
                         for(uint32_t l = 1u; l < T_neighbors; ++l)
                         {
-                            weights[l] = -1.0_X * powSpace::pow(float_X(l) - 0.5_X, 2) * (T_neighbors - l)
-                                / float_X(T_neighbors + l) / float_X(powSpace::pow(float_X(l) + 0.5_X, 2))
+                            weights[l] = -1.0_X * powSpace::cPow(float_X(l) - 0.5_X, 2u) * (T_neighbors - l)
+                                / float_X(T_neighbors + l) / float_X(powSpace::cPow(float_X(l) + 0.5_X, 2u))
                                 * weights[l - 1];
                         }
                     }

--- a/include/picongpu/particles/atomicPhysics/AtomicRate.hpp
+++ b/include/picongpu/particles/atomicPhysics/AtomicRate.hpp
@@ -17,11 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "picongpu/simulation_defines.hpp"
 
 #include <pmacc/algorithms/math.hpp>
 
-#pragma once
+#include <cstdint>
 
 /** rate calculation from given atomic data, extracted from flylite, based on FLYCHK
  *
@@ -119,7 +121,8 @@ namespace picongpu
                     for(uint8_t i = 0u; i < T_numLevels; i++)
                     {
                         result *= binomialCoefficients(
-                            static_cast<uint8_t>(2u * math::pow(float(i + 1), 2.0f)),
+                            static_cast<uint8_t>(2u)
+                                * pmacc::math::cPow(i + static_cast<uint8_t>(1u), static_cast<uint8_t>(2u)),
                             levelVector[i]); // unitless
                     }
 
@@ -238,7 +241,10 @@ namespace picongpu
                     // physical constants
                     // (unitless * m)^2 / unitless = m^2
                     float_X c0_SI = float_X(
-                        8._X * math::pow(picongpu::PI * picongpu::SI::BOHR_RADIUS, 2.0_X)
+                        8._X
+                        * pmacc::math::cPow(
+                            picongpu::PI * picongpu::SI::BOHR_RADIUS,
+                            static_cast<uint8_t>(2u))
                         / math::sqrt(3._X)); // uint: m^2, SI
 
                     // scaling constants * E_Ry^2/deltaE_Trans^2 * f * deltaE_Trans/E_kin

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2022 Marco Garten, Axel Huebl
+/* Copyright 2016-2022 Marco Garten, Axel Huebl, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -34,6 +34,8 @@
 #include "picongpu/traits/attribute/GetChargeState.hpp"
 
 #include <pmacc/algorithms/math/floatMath/floatingPoint.tpp>
+
+#include <cstdint>
 
 namespace picongpu
 {
@@ -100,7 +102,7 @@ namespace picongpu
 
                     float_64 const B = -math::exp(
                         thomasFermi::TFB0 + thomasFermi::TFB1 * T_F
-                        + thomasFermi::TFB2 * math::pow(T_F, float_64(7.)));
+                        + thomasFermi::TFB2 * pmacc::math::cPow(T_F, static_cast<uint8_t>(7u)));
 
                     float_64 const C = thomasFermi::TFC1 * T_F + thomasFermi::TFC2;
 

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch, Sergei Bastrakov, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -22,6 +22,7 @@
 
 #include "picongpu/plugins/radiation/utilities.hpp"
 
+#include <cstdint>
 
 namespace picongpu
 {
@@ -112,7 +113,7 @@ namespace picongpu
                         for(uint32_t d = 0; d < DIM3; ++d)
                             sincValue *= pmacc::math::sinc(
                                 observerUnitVec[d] * cellSize[d] / (SPEED_OF_LIGHT * 2.0_X) * omega);
-                        return util::pow(sincValue, 2 * T_shapeOrder);
+                        return pmacc::math::cPow(sincValue, static_cast<uint32_t>(2u) * T_shapeOrder);
                     }
                 };
             } // namespace radFormFactor_baseShape_3D

--- a/include/picongpu/plugins/radiation/utilities.hpp
+++ b/include/picongpu/plugins/radiation/utilities.hpp
@@ -71,40 +71,6 @@ namespace picongpu
                     }
                 };
 
-
-                namespace details
-                {
-                    /** power function - with extra const parameter for efficient code
-                     *
-                     * T_type requires cast from int and multiplication
-                     * @tparam T_Type - base type
-                     * @param x - base value
-                     * @param exp - exponent
-                     * @param results (=1) - do not change - workaround to produce efficient code
-                     * @return std::pow(x, exp)
-                     */
-                    template<typename T_Type>
-                    HDINLINE constexpr T_Type pow(T_Type const x, uint32_t const exp, const T_Type result = T_Type(1))
-                    {
-                        return exp == 0 ? result
-                                        : (exp == 1 ? x * result : util::details::pow(x, exp - 1, result * x));
-                    }
-                } // namespace details
-
-                /** power function
-                 *
-                 * T_type requires cast from int and multiplication
-                 * @tparam T_Type - base type
-                 * @param x - base value
-                 * @param exp - exponent
-                 * @return std::pow(x, exp)
-                 */
-                template<typename T_Type>
-                HDINLINE constexpr T_Type pow(T_Type const x, uint32_t const exp)
-                {
-                    return util::details::pow(x, exp);
-                }
-
             } // namespace util
 
         } // namespace radiation

--- a/include/pmacc/algorithms/math.hpp
+++ b/include/pmacc/algorithms/math.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Debus
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Debus, Brian Marre
  *
  * This file is part of PMacc.
  *
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/algorithms/math/PowerFunction.hpp"
 #include "pmacc/algorithms/math/defines/abs.hpp"
 #include "pmacc/algorithms/math/defines/bessel.hpp"
 #include "pmacc/algorithms/math/defines/cross.hpp"

--- a/include/pmacc/algorithms/math/PowerFunction.hpp
+++ b/include/pmacc/algorithms/math/PowerFunction.hpp
@@ -1,0 +1,73 @@
+/* Copyright 2022 Brian Marre, Rene Widera, Richard Pausch
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+#include "pmacc/types.hpp"
+#ifndef NDEBUG
+#    include "pmacc/static_assert.hpp"
+#endif
+
+#include <cstdint>
+#include <type_traits>
+
+namespace pmacc::math
+{
+    /** power function for integer exponents, constexpr
+     *
+     * @tparam T_Type return and accumulation data type
+     * @tparam T_Exp exponent data type, must be an integral type, default uint32_t
+     *
+     * @param x base
+     * @param exp exponent
+     */
+    template<typename T_Type, typename T_Exp = uint32_t>
+    HDINLINE constexpr T_Type cPow(T_Type const x, T_Exp const exp)
+    {
+        static_assert(
+            std::is_integral_v<T_Exp>,
+            "This pow() implementation supports only integral types for the exponent.");
+
+        T_Type result = static_cast<T_Type>(1u);
+        for(T_Exp e = static_cast<T_Exp>(0u); e < exp; e++)
+            // for whatever reason "*=" causes the function to return wrong results, do not ask me ...
+            result = result * x;
+        return result;
+    }
+
+    namespace test
+    {
+#ifndef NDEBUG
+        PMACC_CASSERT_MSG(
+            FAIL_unitTest_2_power_0,
+            cPow(static_cast<uint32_t>(2u), static_cast<uint32_t>(0u)) == static_cast<uint32_t>(1u));
+        PMACC_CASSERT_MSG(
+            FAIL_unitTest_2_power_1,
+            cPow(static_cast<uint8_t>(2u), static_cast<uint8_t>(1u)) == static_cast<uint8_t>(2u));
+        PMACC_CASSERT_MSG(
+            FAIL_unitTest_4_power_4,
+            cPow(static_cast<uint32_t>(4u), static_cast<uint8_t>(4u)) == static_cast<uint32_t>(256u));
+        PMACC_CASSERT_MSG(FAIL_unitTest_2_power_2, cPow(2., static_cast<uint8_t>(2u)) == 4.);
+#endif
+    } // namespace test
+
+} // namespace pmacc::math


### PR DESCRIPTION
reimplements the radiation plugin utils integer exponent power(base, exp) implementation directly in pmacc.
- New implementation uses c++ constexpr loop evaluation.
- Switched all pow() calls with integer exponents to the new implementation.
- Removes the old utils implementation
- includes some basic compile time tests for the new implementation