### PR TITLE
remove CUstl from particle push

### DIFF
--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -301,12 +301,10 @@ namespace picongpu
             const traits::FieldPosition<fields::CellType, FieldE> fieldPosE;
             const traits::FieldPosition<fields::CellType, FieldB> fieldPosB;
 
-            auto functorEfield = CreateInterpolationForPusher<Field2ParticleInterpolation>()(
-                eBox.shift(localCell).toCursor(),
-                fieldPosE());
-            auto functorBfield = CreateInterpolationForPusher<Field2ParticleInterpolation>()(
-                bBox.shift(localCell).toCursor(),
-                fieldPosB());
+            auto functorEfield
+                = CreateInterpolationForPusher<Field2ParticleInterpolation>()(eBox.shift(localCell), fieldPosE());
+            auto functorBfield
+                = CreateInterpolationForPusher<Field2ParticleInterpolation>()(bBox.shift(localCell), fieldPosB());
 
             /** @todo this functor should only manipulate the momentum and all changes
              *        in position and cell below need to go into a separate kernel

--- a/include/picongpu/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
+++ b/include/picongpu/particles/interpolationMemoryPolicy/ShiftToValidRange.hpp
@@ -35,7 +35,7 @@ namespace picongpu
                 HDINLINE T_MemoryType memory(const T_MemoryType& mem, const T_PosType& pos) const
                 {
                     const T_PosType pos_floor = math::floor(pos);
-                    return mem(precisionCast<int>(pos_floor));
+                    return mem.shift(precisionCast<int>(pos_floor));
                 }
 
                 template<typename T_PosType>

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -248,11 +248,11 @@ namespace picongpu
                     /* interpolation of density */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldTmp> fieldPosRho;
                     ValueType_Rho densityV
-                        = Field2ParticleInterpolation()(cachedRho.shift(localCell).toCursor(), pos, fieldPosRho());
+                        = Field2ParticleInterpolation()(cachedRho.shift(localCell), pos, fieldPosRho());
                     /*                          and energy density field on the particle position */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldTmp> fieldPosEne;
                     ValueType_Ene kinEnergyV
-                        = Field2ParticleInterpolation()(cachedEne.shift(localCell).toCursor(), pos, fieldPosEne());
+                        = Field2ParticleInterpolation()(cachedEne.shift(localCell), pos, fieldPosEne());
 
                     /* density in sim units */
                     float_X const density = densityV[0];

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -191,12 +191,10 @@ namespace picongpu
                         DataSpaceOperations<TVec::dim>::template map<TVec>(particleCellIdx));
                     /* interpolation of E- */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldE> fieldPosE;
-                    ValueType_E eField
-                        = Field2ParticleInterpolation()(cachedE.shift(localCell).toCursor(), pos, fieldPosE());
+                    ValueType_E eField = Field2ParticleInterpolation()(cachedE.shift(localCell), pos, fieldPosE());
                     /*                     and B-field on the particle position */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldB> fieldPosB;
-                    ValueType_B bField
-                        = Field2ParticleInterpolation()(cachedB.shift(localCell).toCursor(), pos, fieldPosB());
+                    ValueType_B bField = Field2ParticleInterpolation()(cachedB.shift(localCell), pos, fieldPosB());
 
                     IonizationAlgorithm ionizeAlgo;
                     /* determine number of new macro electrons to be created and energy used for ionization */

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -181,8 +181,7 @@ namespace picongpu
                         DataSpaceOperations<TVec::dim>::template map<TVec>(particleCellIdx));
                     /* interpolation of E */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldE> fieldPosE;
-                    ValueType_E eField
-                        = Field2ParticleInterpolation()(cachedE.shift(localCell).toCursor(), pos, fieldPosE());
+                    ValueType_E eField = Field2ParticleInterpolation()(cachedE.shift(localCell), pos, fieldPosE());
 
                     /* this is the point where actual ionization takes place */
                     IonizationAlgorithm ionizeAlgo{};

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -191,12 +191,10 @@ namespace picongpu
                         DataSpaceOperations<TVec::dim>::template map<TVec>(particleCellIdx));
                     /* interpolation of E- */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldE> fieldPosE;
-                    ValueType_E eField
-                        = Field2ParticleInterpolation()(cachedE.shift(localCell).toCursor(), pos, fieldPosE());
+                    ValueType_E eField = Field2ParticleInterpolation()(cachedE.shift(localCell), pos, fieldPosE());
                     /*                     and B-field on the particle position */
                     const picongpu::traits::FieldPosition<fields::CellType, FieldB> fieldPosB;
-                    ValueType_B bField
-                        = Field2ParticleInterpolation()(cachedB.shift(localCell).toCursor(), pos, fieldPosB());
+                    ValueType_B bField = Field2ParticleInterpolation()(cachedB.shift(localCell), pos, fieldPosB());
 
                     IonizationAlgorithm ionizeAlgo;
                     /* determine number of new macro electrons to be created and energy used for ionization */


### PR DESCRIPTION
- remove using CUstl from the pusher
  - refactor filed interpolation and coordinate shift method

I tested LWFA and all looks good. Additionally, I checked that the register footprint for the LWFA example is equal to the register footprint before the refactoring.