### PR TITLE
Radiation plugin: Workaround BP5 bug

### DIFF
--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -774,6 +774,13 @@ namespace picongpu
                     ::openPMD::Series& openPMDdataFile = series.value();
                     ::openPMD::Iteration openPMDdataFileIteration = openPMDdataFile.writeIterations()[currentStep];
 
+                    /* begin required openPMD global attributes */
+                    openPMDdataFileIteration.setDt<float_X>(DELTA_T);
+                    const float_X time = float_X(currentStep) * DELTA_T;
+                    openPMDdataFileIteration.setTime(time);
+                    openPMDdataFileIteration.setTimeUnitSI(UNIT_TIME);
+                    /* end required openPMD global attributes */
+
                     // begin: write amplitude data
                     ::openPMD::Mesh mesh_amp = openPMDdataFileIteration.meshes[dataLabels(-1)];
 
@@ -938,15 +945,6 @@ namespace picongpu
                      */
                     omega_mrc.storeChunk(detectorFrequencies, offset_omega, extent_omega);
                     // end: write frequencies
-
-                    /* begin openPMD attributes */
-                    /* begin required openPMD global attributes */
-
-                    openPMDdataFileIteration.setDt<float_X>(DELTA_T);
-                    const float_X time = float_X(currentStep) * DELTA_T;
-                    openPMDdataFileIteration.setTime(time);
-                    openPMDdataFileIteration.setTimeUnitSI(UNIT_TIME);
-                    /* end required openPMD global attributes */
 
                     openPMDdataFileIteration.close();
                     openPMDdataFile.flush();


### PR DESCRIPTION
With the BP5 engine, the Radiation plugin currently creates unreadable files:

```
$ bpls radiationOpenPMD_/e_radAmplitudes.bp5
Failed to open with BPFile engine: [Thu Dec 15 10:31:43 2022] [ADIOS2 EXCEPTION] <Core> <IO> <DefineAttribute> : modifiable attribute /data/0/dt has been defined with type double. Type cannot be changed to float

Failed to open with HDF5 engine: [Thu Dec 15 10:31:43 2022] [ADIOS2 EXCEPTION] <Engine> <HDF5ReaderP> <HDF5ReaderP> : Invalid HDF5 file found


Error: Could not open this file with any ADIOS2 file reading engines
```

The Radiation plugin sets some attributes quite late. This is normally supported by the openPMD-api, but can become a bit tricky, when the attribute is a default attribute with a default value. The Radiation plugin uncovers a bug in (depending on your point of view) either openPMD-api or in ADIOS2 with this procedure in the BP5 engine. Realistically the best fix for this would be to set defaults in the openPMD-api as late as possible, and not as early as possible (see the corresponding item in https://github.com/openPMD/openPMD-api/issues/1332). For now, defining these attributes as early as possible in the Radiation plugin is a sensible workaround.

TODO:
- [x] Merge #4401 first