### PR TITLE
openPMD plugin: Workaround BP5 attribute datatype overriding

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1524,6 +1524,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     threadParams->openSeries(::openPMD::Access::CREATE);
                 }
 
+                /* attributes written here are pure meta data */
+                WriteMeta writeMetaAttributes;
+                writeMetaAttributes(
+                    *threadParams->openPMDSeries,
+                    (*threadParams->openPMDSeries).writeIterations()[threadParams->currentStep],
+                    threadParams->currentStep);
+
                 bool dumpAllParticles = plugins::misc::containsObject(vectorOfDataSourceNames, "species_all");
 
                 /* write fields */
@@ -1601,13 +1608,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 WriteNDScalars<uint64_t, uint64_t> writeIdProviderNextId("picongpu", "idProvider", "nextId");
                 writeIdProviderStartId(*threadParams, idProviderState.startId, idProviderState.maxNumProc);
                 writeIdProviderNextId(*threadParams, idProviderState.nextId);
-
-                /* attributes written here are pure meta data */
-                WriteMeta writeMetaAttributes;
-                writeMetaAttributes(
-                    *threadParams->openPMDSeries,
-                    (*threadParams->openPMDSeries).writeIterations()[threadParams->currentStep],
-                    threadParams->currentStep);
 
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD


### PR DESCRIPTION
Turns out that the openPMD plugin is affected by the same issue fixed already for the Radiation plugin in #4399.

Some further background: The way that the openPMD-api uses part of the ADIOS2 APIs is an edge case that worked so far for the older engines, but works no longer for BP5, see https://github.com/ornladios/ADIOS2/issues/3413.
We'll ultimately have to solve this inside openPMD-api, but we still need to discuss how exactly (several approaches possible).
Until then, overriding the datatype of default attributes (as PIConGPU does with `setDt<float>()`, has to happen before the first flush.