### PR TITLE
refactor particle filters

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -122,6 +122,7 @@ PIConGPU command line option          description
 ===================================== ====================================================================================================================================================
 ``--openPMD.period``                  Period after which simulation data should be stored on disk.
 ``--openPMD.source``                  Select data sources and filters to dump. Default is ``species_all,fields_all``, which dumps all fields and particle species.
+                                      Only deterministic filters will be shown.
 ``--openPMD.range``                   Define a contiguous range of cells per dimension to dump. Each dimension is separated by a comma.
                                       A range is defined as ``[BEGIN:END)`` where out of range indices will be clipped.
                                       A single value e.g. ``10,:,:`` for a dimension will only dump a slice.

--- a/include/picongpu/particles/filter/All.hpp
+++ b/include/picongpu/particles/filter/All.hpp
@@ -76,6 +76,13 @@ namespace picongpu
                 {
                     return std::string("all");
                 }
+
+                /** A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+                 * variable to true, otherwise to false.
+                 *
+                 * Example: A filter were results depend on a random number generator must return false.
+                 */
+                static constexpr bool isDeterministic = true;
             };
 
         } // namespace filter

--- a/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
+++ b/include/picongpu/particles/filter/RelativeGlobalDomainPosition.hpp
@@ -138,6 +138,13 @@ namespace picongpu
                     return T_Params::name;
                 }
 
+                /** A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+                 * variable to true, otherwise to false.
+                 *
+                 * Example: A filter were results depend on a random number generator must return false.
+                 */
+                static constexpr bool isDeterministic = true;
+
                 DataSpace<simDim> localDomainOffset;
                 DataSpace<simDim> globalDomainSize;
             };

--- a/include/picongpu/particles/filter/generic/Free.def
+++ b/include/picongpu/particles/filter/generic/Free.def
@@ -48,6 +48,8 @@ namespace picongpu
                  *           return result;
                  *       }
                  *       static constexpr char const * name = "eachParticleAboveMiddleOfTheCell";
+                 *
+                 *       static constexpr bool isDeterministic = true;
                  *   };
                  *
                  *   using EachParticleAboveMiddleOfTheCell = generic::Free<

--- a/include/picongpu/particles/filter/generic/Free.hpp
+++ b/include/picongpu/particles/filter/generic/Free.hpp
@@ -107,6 +107,13 @@ namespace picongpu
                         // provide the name from the user functor
                         return Functor::name;
                     }
+
+                    /** A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+                     * variable to true, otherwise to false.
+                     *
+                     * Example: A filter were results depend on a random number generator must return false.
+                     */
+                    static constexpr bool isDeterministic = Functor::isDeterministic;
                 };
 
             } // namespace generic

--- a/include/picongpu/particles/filter/generic/FreeRng.def
+++ b/include/picongpu/particles/filter/generic/FreeRng.def
@@ -57,6 +57,8 @@ namespace picongpu
                  *           return result;
                  *       }
                  *       static constexpr char const * name = "eachSecondParticle";
+                 *
+                 *       static constexpr bool isDeterministic = false;
                  *   };
                  *
                  *   using EachSecondParticle = generic::FreeRng<

--- a/include/picongpu/particles/filter/generic/FreeRng.hpp
+++ b/include/picongpu/particles/filter/generic/FreeRng.hpp
@@ -122,6 +122,13 @@ namespace picongpu
                         // we provide the name from the param class
                         return Functor::name;
                     }
+
+                    /** A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+                     * variable to true, otherwise to false.
+                     *
+                     * Example: A filter were results depend on a random number generator must return false.
+                     */
+                    static constexpr bool isDeterministic = Functor::isDeterministic;
                 };
 
             } // namespace generic

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.def
@@ -58,6 +58,8 @@ namespace picongpu
                  *           return result;
                  *       }
                  *       static constexpr char const * name = "eachParticleInXCell5";
+                 *
+                 *       static constexpr bool isDeterministic = true;
                  *   };
                  *
                  *   using EachParticleInXCell5 = generic::FreeTotalCellOffset<

--- a/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
+++ b/include/picongpu/particles/filter/generic/FreeTotalCellOffset.hpp
@@ -130,6 +130,13 @@ namespace picongpu
                         // we provide the name from the param class
                         return Functor::name;
                     }
+
+                    /** A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+                     * variable to true, otherwise to false.
+                     *
+                     * Example: A filter were results depend on a random number generator must return false.
+                     */
+                    static constexpr bool isDeterministic = Functor::isDeterministic;
                 };
 
             } // namespace generic

--- a/include/picongpu/plugins/misc/SpeciesFilter.hpp
+++ b/include/picongpu/plugins/misc/SpeciesFilter.hpp
@@ -24,6 +24,8 @@
 #include "picongpu/particles/filter/filter.def"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/bool.hpp>
 
 namespace picongpu
 {
@@ -83,9 +85,11 @@ namespace picongpu
                 template<typename T_SpeciesFilter>
                 struct IsEligible
                 {
-                    using type = typename particles::traits::SpeciesEligibleForSolver<
-                        typename T_SpeciesFilter::Species,
-                        typename T_SpeciesFilter::Filter>::type;
+                    using type = boost::mpl::and_<
+                        typename particles::traits::SpeciesEligibleForSolver<
+                            typename T_SpeciesFilter::Species,
+                            typename T_SpeciesFilter::Filter>::type,
+                        boost::mpl::bool_<T_SpeciesFilter::Filter::isDeterministic>>;
                 };
             } // namespace speciesFilter
 

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particleFilters.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particleFilters.param
@@ -49,6 +49,13 @@ namespace picongpu
             {
                 static constexpr char const* name = "forwardPinhole";
 
+                /** A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+                 * variable to true, otherwise to false.
+                 *
+                 * Example: A filter were results depend on a random number generator must return false.
+                 */
+                static constexpr bool isDeterministic = true;
+
                 template<typename T_Particle>
                 HDINLINE bool operator()(T_Particle const& particle)
                 {


### PR DESCRIPTION
- Add `isDeterministic()` to filters to expose if the filter result is always the same result independent of the input data order.
- update documentation for plugin openPMD
- update param files `particleFilters.param`

The openPMD plugin is multiple times executing the counting and serialization kernel with the same filter. If a filter is not deterministic the openPMD plugin will most likely run into segfault issues because the counting kernel result and the number of particles touched in the serialization kernel will not be equal. The result of the counting kernel is used to allocate an intermediate buffer for the serialized particle data, in cases where we use a non-deterministic filter we serialize too many or not enouph particles into this buffer.