### PR TITLE
CI: test game of life example

### DIFF
--- a/share/ci/run_pmacc_tests.sh
+++ b/share/ci/run_pmacc_tests.sh
@@ -154,3 +154,17 @@ cmake $CMAKE_ARGS $code_DIR/include/pmacc
 make
 
 ctest -V
+
+# With HIP we run into MPI linker issues, therefore GoL tests are disabled for now
+# clang+cuda is running into compiler ptx errors when code for sm_60 is generated.
+# @todo analyse and fix MPI linker issues
+if ! [[ "$PIC_BACKEND" =~ hip.* || ($CXX_VERSION =~ ^clang && $PIC_BACKEND =~ ^cuda) ]] ; then
+  ## compile and test game of life
+  export GoL_folder=$HOME/buildGoL
+  mkdir -p $GoL_folder
+  cd $GoL_folder
+  cmake $CMAKE_ARGS $code_DIR/share/pmacc/examples/gameOfLife2D
+  make -j $PMACC_PARALLEL_BUILDS
+  # execute on one device
+  ./gameOfLife -d 1 1 -g 64 64  -s 100 -p 1 1
+fi


### PR DESCRIPTION
fix #4341 

Fix game of life example and add CI coverage.

We tried to add the example already https://github.com/ComputationalRadiationPhysics/picongpu/pull/4338#issuecomment-1305334917 but due to issues, we postponed it.

- [x] rebase after #4434  is merged to hopefully get rid of the MPi linker issue  most likely triggered by cuSTL.
- [x] rebase against #4441
- [x] disable gameOfLife compile for HIP
- [x] rebase against #4493