### PR TITLE
run CI down-stream pipes parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,7 @@
 stages:
   - validate
   - generate
-  - test_picongpu
-  - test_pmacc
+  - test
 
 variables:
   CONTAINER_TAG: "3.0"
@@ -71,7 +70,7 @@ picongpu-generate-reduced-matrix:
   extends: ".base_generate-reduced-matrix"
 
 picongpu-compile-reduced-matrix:
-  stage: test_picongpu
+  stage: test
   trigger:
     include:
       - artifact: compile.yml
@@ -85,7 +84,7 @@ pmacc-generate-reduced-matrix:
   extends: ".base_generate-reduced-matrix"
 
 pmacc-compile-reduced-matrix:
-  stage: test_pmacc
+  stage: test
   trigger:
     include:
       - artifact: compile.yml


### PR DESCRIPTION
Due to a bug in the gitlab CI it was in the past not possible to run two down-stream pipes in parallel. 
In this case, the status of the CI could be wrong.
This bug is now fixed in gitlab, therefore we can run now PIConGPU and PMacc tests in parallel.