### PR TITLE
optimize CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,18 +63,46 @@ pull-request-validation:
 #                    "examples" starts one gitlab job per directory in `examples/*`
 #                    "examples/" compile all directories in `examples/*` within one gitlab job
 #                    "examples/KelvinHelmholtz" compile all cases within one gitlab job
-picongpu-generate-reduced-matrix:
+picongpu-generate-reduced-matrix_examples:
   variables:
-    PIC_INPUTS: "examples tests benchmarks"
+    PIC_INPUTS: "examples"
     TEST_TUPLE_NUM_ELEM: 1
   extends: ".base_generate-reduced-matrix"
 
-picongpu-compile-reduced-matrix:
+picongpu-compile-reduced-matrix_examples:
   stage: test
   trigger:
     include:
       - artifact: compile.yml
-        job: picongpu-generate-reduced-matrix
+        job: picongpu-generate-reduced-matrix_examples
+    strategy: depend
+
+picongpu-generate-reduced-matrix_tests:
+  variables:
+    PIC_INPUTS: "tests"
+    TEST_TUPLE_NUM_ELEM: 1
+  extends: ".base_generate-reduced-matrix"
+
+picongpu-compile-reduced-matrix_tests:
+  stage: test
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: picongpu-generate-reduced-matrix_tests
+    strategy: depend
+
+picongpu-generate-reduced-matrix_benchmarks:
+  variables:
+    PIC_INPUTS: "benchmarks"
+    TEST_TUPLE_NUM_ELEM: 1
+  extends: ".base_generate-reduced-matrix"
+
+picongpu-compile-reduced-matrix_benchmarks:
+  stage: test
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: picongpu-generate-reduced-matrix_benchmarks
     strategy: depend
 
 pmacc-generate-reduced-matrix:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,7 @@
 stages:
   - validate
   - generate
-  - test_picongpu
-  - test_pmacc
+  - test
 
 variables:
   CONTAINER_TAG: "3.0"
@@ -71,7 +70,7 @@ picongpu-generate-reduced-matrix:
   extends: ".base_generate-reduced-matrix"
 
 picongpu-compile-reduced-matrix:
-  stage: test_picongpu
+  stage: test
   trigger:
     include:
       - artifact: compile.yml
@@ -85,7 +84,7 @@ pmacc-generate-reduced-matrix:
   extends: ".base_generate-reduced-matrix"
 
 pmacc-compile-reduced-matrix:
-  stage: test_pmacc
+  stage: test
   trigger:
     include:
       - artifact: compile.yml

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -7,6 +7,7 @@ from allpairspy import AllPairs
 import argparse
 import sys
 import math
+import random
 
 parser = argparse.ArgumentParser(description='Generate tesing pairs')
 parser.add_argument('-n', dest='n_pairs', default=1, action="store",
@@ -247,6 +248,12 @@ for i in range(rounds):
         AllPairs(parameters,
                  filter_func=is_valid_combination, n=n_pairs)):
         job_list.append(value)
+
+# set seed to be deterministic in each CI run
+random.seed(42)
+# Shuffle the job list to avoid that too many jobs, testing the
+# same backend, run at the same time.
+random.shuffle(job_list)
 
 num_jobs = len(job_list)
 num_jobs_per_stage = int(args.num_jobs_per_stage)


### PR DESCRIPTION
Due to a bug in the gitlab CI it was in the past not possible to run two down-stream pipes in parallel. In this case, the status of the CI could be wrong. This bug is now fixed in gitlab, therefore we can run now PIConGPU and PMacc tests in parallel.

- run examples, tests, and benchmarks in parallel downstream pipes
- run PIConGPU and PMacc pipes in parallel
- shuffle the job list in the generator to avoid all jobs for one
  backends will always be in the first stage
