### PR TITLE
fix CI

### DIFF
--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -11,6 +11,8 @@
     PIC_CMAKE_ARGS: "-DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
     # ISAAC is not working with HIP
     DISABLE_ISAAC: "yes"
+    # CI_GPU_ARCH architecture of the hosted GPU is provided by the CI
+    GPU_TARGETS: ${CI_GPU_ARCH}
   script:
     - export PATH="$PATH:/opt/rocm/llvm/bin/"
     - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rocm/rocrand/lib/"

--- a/share/ci/install/clang.sh
+++ b/share/ci/install/clang.sh
@@ -12,7 +12,7 @@ echo "Clang-version: $clang_version"
 
 if ! agc-manager -e clang@${clang_version}; then
     apt install -y clang-${clang_version}
-    if [[ "$PIC_BACKEND" =~ "omp2b.*" ]] ; then
+    if [[ "$PIC_BACKEND" =~ omp2b.* ]] ; then
         apt install -y libomp-${clang_version}-dev
     fi
 else

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -21,7 +21,7 @@ else
     echo "No GPU device selected because environment variable CI_GPUS is not set."
 fi
 
-if [[ "$PIC_BACKEND" =~ "hip.*" ]] ; then
+if [[ "$PIC_BACKEND" =~ hip.* ]] ; then
     if [ -z "$CI_GPU_ARCH" ] ; then
         # In case the CI runner is not providing a GPU architecture e.g. a CPU runner set the architecture
         # to Radeon VII or MI50/60.

--- a/share/ci/run_pmacc_tests.sh
+++ b/share/ci/run_pmacc_tests.sh
@@ -110,7 +110,7 @@ else
     echo "No GPU device selected because environment variable CI_GPUS is not set."
 fi
 
-if [[ "$PIC_BACKEND" =~ "hip.*" ]] ; then
+if [[ "$PIC_BACKEND" =~ hip.* ]] ; then
     if [ -z "$CI_GPU_ARCH" ] ; then
         # In case the CI runner is not providing a GPU architecture e.g. a CPU runner set the architecture
         # to Radeon VII or MI50/60.


### PR DESCRIPTION
- Due to a wrong bash syntax the hip architecture was not set correctly. installation of clang OpenMP was not not correct because of the wrong bash syntax for string comparisn.
- The HIP job template missed to forwward the CI system set variable `CI_GPU_ARCH`

OpenMP bug was introduced with #4420 and the HIP architecture bug with #4353