### PR TITLE
introduce switch to dev in hemera in 5min tutorial

### DIFF
--- a/docs/source/tutorials/hemeraIn5min.rst
+++ b/docs/source/tutorials/hemeraIn5min.rst
@@ -51,6 +51,8 @@ Use :command:`git` to obtain the source and use the current ``dev`` branch and p
 
 .. note::
    If you get the error ``git: command not found`` load git by invoking ``module load git`` and try again.
+   Attention: the example uses the ``dev`` branch instead of the latest stable release ``master``.
+   Due to driver changes on hemera the master branch modules configuration is outdated.
 
 Setup
 -----


### PR DESCRIPTION
Since the `master` bunch setup does not work with k80 hemera GPUs out of the box due to a CUDA driver update in early 2022, the "5 min tutorial on hemera" creates `device not found` errors. To avoid these errors, this pull request introduces a switch to the `dev` branch. 

Thanks to @SergeyKonstantinErmakov for finding this error. 