### PR TITLE
Radiation plugin: Save amplitudes additionally per rank

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -314,21 +314,27 @@ Output
 
 Depending on the command line options used, there are different output files.
 
-======================================== ========================================================================================================================
-Command line flag                        Output description
-======================================== ========================================================================================================================
-``--<species>_radiation.totalRadiation`` Contains *ASCII* files that have the total spectral intensity until the timestep specified by the filename.
-                                         Each row gives data for one observation direction (same order as specified in the ``observer.py``).
-                                         The values for each frequency are separated by *tabs* and have the same order as specified in ``radiation.param``.
-                                         The spectral intensity is stored in the units :math:`\mathrm{[Js]}`.
-``--<species>_radiation.lastRadiation``  has the same format as the output of *totalRadiation*.
-                                         The spectral intensity is only summed over the last radiation ``dump`` period.
-``--<species>_radiation.radPerGPU``      Same output as *totalRadiation* but only summed over each GPU.
-                                         Because each GPU specifies a spatial region, the origin of radiation signatures can be distinguished.
-*radiationOpenPMD*                       In the folder  ``radiationOpenPMD``, openPMD files (currently hdf5) for each radiation dump and species are stored.
-                                         These are complex amplitudes in units used by *PIConGPU*.
-                                         These are for restart purposes and for more complex data analysis.
-======================================== ========================================================================================================================
+============================================== ========================================================================================================================
+Command line flag                              Output description
+============================================== ========================================================================================================================
+``--<species>_radiation.totalRadiation``       Contains *ASCII* files that have the total spectral intensity until the timestep specified by the filename.
+                                               Each row gives data for one observation direction (same order as specified in the ``observer.py``).
+                                               The values for each frequency are separated by *tabs* and have the same order as specified in ``radiation.param``.
+                                               The spectral intensity is stored in the units :math:`\mathrm{[Js]}`.
+``--<species>_radiation.lastRadiation``        has the same format as the output of *totalRadiation*.
+                                               The spectral intensity is only summed over the last radiation ``dump`` period.
+``--<species>_radiation.radPerGPU``            Same output as *totalRadiation* but only summed over each GPU.
+                                               Because each GPU specifies a spatial region, the origin of radiation signatures can be distinguished.
+``--<species>_radiation.distributedAmplitude`` By default, the amplitudes are summed up over the MPI ranks.
+                                               Some analyses require the raw distributed output of amplitudes without prior summation.
+                                               Activating this flag will make the Radiation plugin additionally output the amplitudes before summation.
+                                               The first dimension in the dataset output corresponds with the parallel distribution of MPI workers.
+                                               Note that instead of separate datasets for the imaginary and real parts, this output is formatted as datasets of complex
+                                               number types.
+*radiationOpenPMD*                             In the folder  ``radiationOpenPMD``, openPMD files (currently hdf5) for each radiation dump and species are stored.
+                                               These are complex amplitudes in units used by *PIConGPU*.
+                                               These are for restart purposes and for more complex data analysis.
+============================================== ========================================================================================================================
 
 
 Text-based output
@@ -412,6 +418,24 @@ Dataset  Description                                           Dimensions
    This inconsistency will be fixed in the future.
    Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units.
 
+**Amplitude_distributed (Group, opt-in):**
+
+======== ========================================== ============================================
+Dataset  Description                                Dimensions
+======== ========================================== ============================================
+``x``    x-component of the complex amplitude       (``MPI ranks``, ``N_observer``, ``N_omega``)
+``y``    y-component of the complex amplitude       (``MPI ranks``, ``N_observer``, ``N_omega``)
+``z``    z-component of the complex amplitude       (``MPI ranks``, ``N_observer``, ``N_omega``)
+======== ========================================== ============================================
+
+.. note::
+
+   Please be aware, that despite the fact, that the SI-unit of each amplitude entry is :math:`\mathrm{[\sqrt{Js}]}`, the stored ``unitSI`` attribute returns :math:`\mathrm{[Js]}`.
+   This inconsistency will be fixed in the future.
+   Until this inconstincy is resolved, please multiply the datasets with the square root of the ``unitSI`` attribute to convert the amplitudes to SI units.
+
+   Additionally, the representation of complex numbers differs from that in the summed Amplitude output.
+   This inconsistency will be fixed by changing the output format of the summed Amplitudes.
 
 **DetectorDirection (Group):**
 
@@ -559,4 +583,4 @@ References
        *Synthetic radiation diagnostics as a pathway for studying plasma dynamics from advanced accelerators to astrophysical observations*,
        PhD Thesis at Technische Universität Dresden & Helmholtz-Zentrum Dresden - Rossendorf (2019),
        https://doi.org/10.5281/zenodo.3616045
-   
+

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -492,7 +492,7 @@ namespace picongpu
                     reduce(
                         pmacc::math::operation::Add(),
                         tmp_result.data(),
-                        radiation->getHostBuffer().getBasePointer(), //////////
+                        radiation->getHostBuffer().getBasePointer(),
                         elements_amplitude(),
                         mpi::reduceMethods::Reduce());
                 }

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -568,7 +568,7 @@ namespace picongpu
 
 
                 /** perform all operations to get data from GPU to master */
-                void collectDataGPUToMaster() //////////////
+                void collectDataGPUToMaster()
                 {
                     // collect data GPU -> CPU -> Master
                     copyRadiationDeviceToHost();
@@ -581,7 +581,7 @@ namespace picongpu
                 void writeAllFiles(const DataSpace<simDim> currentGPUpos)
                 {
                     // write data to files
-                    saveRadPerGPU(currentGPUpos); // hier parallele Ausgabe nei
+                    saveRadPerGPU(currentGPUpos);
                     writeLastRadToText();
                     writeTotalRadToText();
                     writeAmplitudesToOpenPMD();
@@ -601,7 +601,7 @@ namespace picongpu
                  */
                 static const std::string dataLabels(int index)
                 {
-                    const std::string path("Amplitude"); // nur amplitude rausschreiben
+                    const std::string path("Amplitude");
 
                     /* return record name if handed -1 */
                     if(index == -1)
@@ -819,6 +819,12 @@ namespace picongpu
 
                         auto srcBuffer = radiation->getHostBuffer().getBasePointer();
 
+                        /*
+                         * numComponents includes the components of a complex number, e.g. in a 3D simulation,
+                         * numComponents is 6.
+                         * Since the distributed output uses native complex types, we don't want this.
+                         * ---> Amplitude::numComponents / 2
+                         */
                         for(uint32_t ampIndex = 0; ampIndex < Amplitude::numComponents / 2; ++ampIndex)
                         {
                             constexpr char const* labels[] = {"x", "y", "z"};

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -291,26 +291,22 @@ namespace picongpu
                     collectRadiationOnMaster();
                     sumAmplitudesOverTime(tmp_result, timeSumArray);
 
-                    // write backup file
-                    if(isMaster)
-                    {
-                        /*
-                         * No need to keep the Series open for checkpointing, so
-                         * just quickly open it here.
-                         */
-                        std::optional<::openPMD::Series> tmp;
-                        writeOpenPMDfile(
-                            tmp_result,
-                            restartDirectory,
-                            speciesName + std::string("_radRestart"),
-                            WriteOpenPMDParams{
-                                tmp,
-                                "_%T_0_0_0"
-                                    + (*openPMDExtensionCheckpointing.begin() == '.'
-                                           ? openPMDExtensionCheckpointing
-                                           : '.' + openPMDExtensionCheckpointing),
-                                openPMDCheckpointConfig});
-                    }
+                    /*
+                     * No need to keep the Series open for checkpointing, so
+                     * just quickly open it here.
+                     */
+                    std::optional<::openPMD::Series> tmp;
+                    writeOpenPMDfile(
+                        tmp_result,
+                        restartDirectory,
+                        speciesName + std::string("_radRestart"),
+                        WriteOpenPMDParams{
+                            tmp,
+                            "_%T_0_0_0"
+                                + (*openPMDExtensionCheckpointing.begin() == '.'
+                                       ? openPMDExtensionCheckpointing
+                                       : '.' + openPMDExtensionCheckpointing),
+                            openPMDCheckpointConfig});
                 }
 
 
@@ -491,7 +487,7 @@ namespace picongpu
                     reduce(
                         pmacc::math::operation::Add(),
                         tmp_result.data(),
-                        radiation->getHostBuffer().getBasePointer(),
+                        radiation->getHostBuffer().getBasePointer(), //////////
                         elements_amplitude(),
                         mpi::reduceMethods::Reduce());
                 }
@@ -558,19 +554,16 @@ namespace picongpu
                 /** write total radiation data as openPMD file */
                 void writeAmplitudesToOpenPMD()
                 {
-                    if(isMaster)
-                    {
-                        writeOpenPMDfile(
-                            timeSumArray,
-                            std::string("radiationOpenPMD/"),
-                            speciesName + std::string("_radAmplitudes"),
-                            WriteOpenPMDParams{m_series, openPMDSuffix, openPMDConfig});
-                    }
+                    writeOpenPMDfile(
+                        timeSumArray,
+                        std::string("radiationOpenPMD/"),
+                        speciesName + std::string("_radAmplitudes"),
+                        WriteOpenPMDParams{m_series, openPMDSuffix, openPMDConfig});
                 }
 
 
                 /** perform all operations to get data from GPU to master */
-                void collectDataGPUToMaster()
+                void collectDataGPUToMaster() //////////////
                 {
                     // collect data GPU -> CPU -> Master
                     copyRadiationDeviceToHost();
@@ -583,7 +576,7 @@ namespace picongpu
                 void writeAllFiles(const DataSpace<simDim> currentGPUpos)
                 {
                     // write data to files
-                    saveRadPerGPU(currentGPUpos);
+                    saveRadPerGPU(currentGPUpos); // hier parallele Ausgabe nei
                     writeLastRadToText();
                     writeTotalRadToText();
                     writeAmplitudesToOpenPMD();
@@ -603,7 +596,7 @@ namespace picongpu
                  */
                 static const std::string dataLabels(int index)
                 {
-                    const std::string path("Amplitude");
+                    const std::string path("Amplitude"); // nur amplitude rausschreiben
 
                     /* return record name if handed -1 */
                     if(index == -1)
@@ -724,8 +717,13 @@ namespace picongpu
 
                     if(!series.has_value())
                     {
-                        series = std::make_optional(
-                            ::openPMD::Series(dir + '/' + filename.str(), ::openPMD::Access::CREATE, jsonConfig));
+                        GridController<simDim>& gc = Environment<simDim>::get().GridController();
+                        auto communicator = gc.getCommunicator().getMPIComm();
+                        series = std::make_optional(::openPMD::Series(
+                            dir + '/' + filename.str(),
+                            ::openPMD::Access::CREATE,
+                            communicator,
+                            jsonConfig));
 
                         /* begin recommended openPMD global attributes */
                         series->setMeshesPath(meshesPathName);
@@ -819,25 +817,29 @@ namespace picongpu
 
                             // ask openPMD to create a buffer for us
                             // in some backends (ADIOS2), this allows avoiding memcopies
-                            auto span
-                                = ::picongpu::openPMD::storeChunkSpan<double>(
-                                      mesh_amp[dir],
-                                      offset_amp,
-                                      extent_amp,
-                                      [&fallbackBuffer](size_t numElements)
-                                      {
-                                          // if there is no special backend support for creating buffers,
-                                          // use the fallback buffer
-                                          fallbackBuffer.resize(numElements);
-                                          return std::shared_ptr<float_64>{fallbackBuffer.data(), [](auto const*) {}};
-                                      })
-                                      .currentBuffer();
-
-                            // select data
-                            for(uint32_t copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
+                            if(isMaster)
                             {
-                                span[copyIndex] = reinterpret_cast<picongpu::float_64*>(
-                                    values.data())[ampIndex + Amplitude::numComponents * copyIndex];
+                                auto span
+                                    = ::picongpu::openPMD::storeChunkSpan<double>(
+                                          mesh_amp[dir],
+                                          offset_amp,
+                                          extent_amp,
+                                          [&fallbackBuffer](size_t numElements)
+                                          {
+                                              // if there is no special backend support for creating buffers,
+                                              // use the fallback buffer
+                                              fallbackBuffer.resize(numElements);
+                                              return std::shared_ptr<float_64>{fallbackBuffer.data(), [](auto const*) {
+                                                                               }};
+                                          })
+                                          .currentBuffer();
+
+                                // select data
+                                for(uint32_t copyIndex = 0; copyIndex < N_tmpBuffer; ++copyIndex)
+                                {
+                                    span[copyIndex] = reinterpret_cast<picongpu::float_64*>(
+                                        values.data())[ampIndex + Amplitude::numComponents * copyIndex];
+                                }
                             }
                             // flush data now
                             // this allows us to reuse the fallbackBuffer in the next iteration
@@ -877,27 +879,30 @@ namespace picongpu
                             ::openPMD::Dataset dataset_n = ::openPMD::Dataset(datatype_n, extent_n);
                             mesh_n[dir].resetDataset(dataset_n);
 
-                            // ask openPMD to create a buffer for us
-                            // in some backends (ADIOS2), this allows avoiding memcopies
-                            auto span
-                                = ::picongpu::openPMD::storeChunkSpan<double>(
-                                      mesh_n[dir],
-                                      offset_n,
-                                      extent_n,
-                                      [&fallbackBuffer](size_t numElements)
-                                      {
-                                          // if there is no special backend support for creating buffers,
-                                          // use the fallback buffer
-                                          fallbackBuffer.resize(numElements);
-                                          return std::shared_ptr<float_64>{fallbackBuffer.data(), [](auto const*) {}};
-                                      })
-                                      .currentBuffer();
-
-                            // select data
-                            for(uint32_t copyIndex = 0u; copyIndex < parameters::N_observer; ++copyIndex)
+                            if(isMaster)
                             {
-                                span[copyIndex] = reinterpret_cast<picongpu::float_64*>(
-                                    detectorPositions.data())[detectorDim + 3u * copyIndex];
+                                // ask openPMD to create a buffer for us
+                                // in some backends (ADIOS2), this allows avoiding memcopies
+                                auto span
+                                    = ::picongpu::openPMD::storeChunkSpan<double>(
+                                        mesh_n[dir],
+                                        offset_n,
+                                        extent_n,
+                                        [&fallbackBuffer](size_t numElements)
+                                        {
+                                            // if there is no special backend support for creating buffers,
+                                            // use the fallback buffer
+                                            fallbackBuffer.resize(numElements);
+                                            return std::shared_ptr<float_64>{fallbackBuffer.data(), [](auto const*) {}};
+                                        })
+                                        .currentBuffer();
+
+                                // select data
+                                for(uint32_t copyIndex = 0u; copyIndex < parameters::N_observer; ++copyIndex)
+                                {
+                                    span[copyIndex] = reinterpret_cast<picongpu::float_64*>(
+                                        detectorPositions.data())[detectorDim + 3u * copyIndex];
+                                }
                             }
 
                             // flush data now
@@ -935,14 +940,17 @@ namespace picongpu
                     ::openPMD::Dataset dataset_omega = ::openPMD::Dataset(datatype_omega, extent_omega);
                     omega_mrc.resetDataset(dataset_omega);
 
-                    // write actual data
-                    ::openPMD::Offset offset_omega = {0, 0, 0};
-                    /*
-                     * Here, we don't use storeChunkSpan, since detectorFrequencies
-                     * is created and filled upon activation of the plugin,
-                     * so it survives beyond the writing of a single dataset.
-                     */
-                    omega_mrc.storeChunk(detectorFrequencies, offset_omega, extent_omega);
+                    if(isMaster)
+                    {
+                        // write actual data
+                        ::openPMD::Offset offset_omega = {0, 0, 0};
+                        /*
+                        * Here, we don't use storeChunkSpan, since detectorFrequencies
+                        * is created and filled upon activation of the plugin,
+                        * so it survives beyond the writing of a single dataset.
+                        */
+                        omega_mrc.storeChunk(detectorFrequencies, offset_omega, extent_omega);
+                    }
                     // end: write frequencies
 
                     openPMDdataFileIteration.close();


### PR DESCRIPTION
Unlike the aggregated amplitudes, this uses std::complex to store the output, making things a bit inconsistent. The goal should be to use std::complex for the aggregated output too, but Richard says that some postprocessing still relies on the current format. (In the same instant, we should remove the useless third dimension there)

Output now looks like (with two ranks):
```
$ bpls radiationOpenPMD/e_radAmplitudes200.bp/   
  double          /data/200/DetectorMesh/Amplitude/x_Im           {128, 1024, 1}
  double          /data/200/DetectorMesh/Amplitude/x_Re           {128, 1024, 1}
  double          /data/200/DetectorMesh/Amplitude/y_Im           {128, 1024, 1}
  double          /data/200/DetectorMesh/Amplitude/y_Re           {128, 1024, 1}
  double          /data/200/DetectorMesh/Amplitude/z_Im           {128, 1024, 1}
  double          /data/200/DetectorMesh/Amplitude/z_Re           {128, 1024, 1}
  double          /data/200/DetectorMesh/DetectorDirection/x      {128, 1, 1}
  double          /data/200/DetectorMesh/DetectorDirection/y      {128, 1, 1}
  double          /data/200/DetectorMesh/DetectorDirection/z      {128, 1, 1}
  double          /data/200/DetectorMesh/DetectorFrequency/omega  {1, 1024, 1}
  double complex  /data/200/DetectorMesh/amplitude_distributed/x  {2, 128, 1024}
  double complex  /data/200/DetectorMesh/amplitude_distributed/y  {2, 128, 1024}
  double complex  /data/200/DetectorMesh/amplitude_distributed/z  {2, 128, 1024}
```

TODO
- [x] Testing, documentation
- [x] mesh naming?
- [x] Command line option to switch this on off