### PR TITLE
fix incident field laser and periodic field boundaries

### DIFF
--- a/docs/source/usage/workflows/addLaser.rst
+++ b/docs/source/usage/workflows/addLaser.rst
@@ -54,6 +54,7 @@ It is a combination of profile and particular plane that together will produce a
 For pre-set profiles a proper orientation of the wave will be provided by internal implementation.
 With the ``Free`` profile, it is on a user to provide functors to calculate incident fields and ensure the orientation for the boundaries it is applied to (however, it does not have to work for all boundaries, only the ones in question).
 Please refer to :ref:`the detailed description <model-TFSF>` for setting up ``Free`` profile, also for the case when only one of the external fields is known in explicit form.
+For a laser profile with non zero field amplitudes on the transversal borders of the profile e.g. defined by the profile ``Free`` without a transversal envelop the trait ``MakePeriodicTransversalHuygensSurfaceContiguous`` must be specialized and returning true to handle field periodic boundaries correctly.
 
 Incident field is compatible to all field solvers, however using field solvers other than Yee requires a larger offset of the generating surface from absorber depending on the stencil width along the boundary axis.
 As a rule of thumb, this extra requirement is (order of FDTD solver / 2 - 1) cells.

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -432,6 +432,8 @@ namespace picongpu
                      *
                      * The kernel must be called for all grid values that need an update.
                      *
+                     * The kernel is working on the index interval [beginGridIdx,endGridIdx)
+                     *
                      * @tparam T_Worker lockstep worker type
                      * @tparam T_UpdateFunctor update functor type
                      *

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.def
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.def
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/fields/incidentField/profiles/BaseParam.def"
+#include "picongpu/fields/incidentField/profiles/Traits.hpp"
 
 
 namespace picongpu
@@ -59,6 +60,12 @@ namespace picongpu
                  */
                 template<typename T_Params = defaults::PlaneWaveParam>
                 struct PlaneWave;
+
+                template<typename T_Params>
+                struct MakePeriodicTransversalHuygensSurfaceContiguous<PlaneWave<T_Params>>
+                {
+                    static constexpr bool value = true;
+                };
             } // namespace profiles
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/profiles/Traits.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Traits.hpp
@@ -1,0 +1,44 @@
+/* Copyright 2023 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu::fields::incidentField::profiles
+{
+    /** Express if the Huyhens surface in transversal directions must be extended to the simulation borders in case the
+     * transversal direction is periodic.
+     *
+     * The result of this trait should be true in case you have non zero field amplitudes on the transversal borders
+     * else the field will not be contiguous if periodic boundaries are enabled.
+     *
+     * @tparam T_Profile incident field profile
+     */
+    template<typename T_Profile>
+    struct MakePeriodicTransversalHuygensSurfaceContiguous
+    {
+        static constexpr bool value = false;
+    };
+
+
+    /** short hand notation for @see MakePeriodicTransversalHuygensSurfaceContiguous */
+    template<typename T_Profile>
+    constexpr bool makePeriodicTransversalHuygensSurfaceContiguous
+        = MakePeriodicTransversalHuygensSurfaceContiguous<T_Profile>::value;
+
+} // namespace picongpu::fields::incidentField::profiles

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -27,4 +27,5 @@
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
 #include "picongpu/fields/incidentField/profiles/Polynom.def"
 #include "picongpu/fields/incidentField/profiles/PulseFrontTilt.def"
+#include "picongpu/fields/incidentField/profiles/Traits.hpp"
 #include "picongpu/fields/incidentField/profiles/Wavepacket.def"


### PR DESCRIPTION
fix #4450

Add a trait `MakePeriodicTransversalHuygensSurfaceContiguous` to extend the Huygens surface in transversal direction if they are periodic. If the surface is not extended to the outer boundaries the field will not be contiguous on the periodic boundaries.