### PR TITLE
Topic lockstep for each refactoring

### DIFF
--- a/include/picongpu/algorithms/Gamma.hpp
+++ b/include/picongpu/algorithms/Gamma.hpp
@@ -21,8 +21,6 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/algorithms/Gamma.def"
-
 
 namespace picongpu
 {
@@ -30,8 +28,6 @@ namespace picongpu
     template<typename T_MomType, typename T_MassType>
     HDINLINE T_PrecisionType Gamma<T_PrecisionType>::operator()(T_MomType const& mom, T_MassType const mass) const
     {
-        using namespace pmacc;
-
         valueType const fMom2 = pmacc::math::abs2(precisionCast<valueType>(mom));
         constexpr valueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 

--- a/include/picongpu/algorithms/KinEnergy.hpp
+++ b/include/picongpu/algorithms/KinEnergy.hpp
@@ -23,7 +23,6 @@
 
 #include "picongpu/algorithms/Gamma.hpp"
 
-
 namespace picongpu
 {
     using namespace pmacc;

--- a/include/picongpu/algorithms/Velocity.hpp
+++ b/include/picongpu/algorithms/Velocity.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "picongpu/simulation_defines.hpp"
+
 namespace picongpu
 {
     using namespace pmacc;

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -132,7 +132,7 @@ namespace picongpu
 
             // initialize the position functor for each cell in the supercell
             auto positionFunctorCtx = forEachCellInSuperCell(
-                [&](lockstep::Idx const idx)
+                [&](uint32_t const idx, uint32_t& numParsPerCell)
                 {
                     /* cell index within the superCell */
                     DataSpace<simDim> const cellIdx = DataSpaceOperations<simDim>::template map<SuperCellSize>(idx);
@@ -151,10 +151,10 @@ namespace picongpu
                     auto posFunctor = positionFunctor(forEachCellInSuperCell.getWorker(), localSuperCellOffset);
 
                     if(realParticlesPerCell > 0.0_X)
-                        numParsPerCellCtx[idx]
+                        numParsPerCell
                             = posFunctor.template numberOfMacroParticles<ParticleType>(realParticlesPerCell);
 
-                    if(numParsPerCellCtx[idx] > 0)
+                    if(numParsPerCell > 0)
                         kernel::atomicAllExch(
                             worker,
                             &finished,
@@ -162,7 +162,8 @@ namespace picongpu
                             ::alpaka::hierarchy::Threads{}); // one or more cells have particles to create
 
                     return posFunctor;
-                });
+                },
+                numParsPerCellCtx);
 
             worker.sync();
 
@@ -187,9 +188,9 @@ namespace picongpu
                 worker.sync();
 
                 forEachParticle(
-                    [&](lockstep::Idx const idx)
+                    [&](uint32_t const idx, uint32_t& numParsPerCell, auto& positionFunctor)
                     {
-                        if(numParsPerCellCtx[idx] > 0u)
+                        if(numParsPerCell > 0u)
                         {
                             auto particle = frame[idx];
 
@@ -210,17 +211,19 @@ namespace picongpu
                             particle[multiMask_] = 1;
                             particle[localCellIdx_] = idx;
                             // initialize position and weighting
-                            positionFunctorCtx[idx](worker, particle);
+                            positionFunctor(worker, particle);
 
-                            numParsPerCellCtx[idx]--;
-                            if(numParsPerCellCtx[idx] > 0)
+                            numParsPerCell--;
+                            if(numParsPerCell > 0)
                                 kernel::atomicAllExch(
                                     worker,
                                     &finished,
                                     0,
                                     ::alpaka::hierarchy::Threads{}); // one or more cells have particles to create
                         }
-                    });
+                    },
+                    numParsPerCellCtx,
+                    positionFunctorCtx);
 
                 worker.sync();
 

--- a/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
@@ -137,7 +137,7 @@ namespace picongpu
                 {
                     // parallel loop over all particles in the frame
                     forEachParticleSlotInFrame(
-                        [&](lockstep::Idx const linearIdx)
+                        [&](uint32_t const linearIdx)
                         {
                             if(linearIdx < particlesInSuperCell)
                             {

--- a/include/picongpu/particles/atomicPhysics/FillHistogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/FillHistogram.hpp
@@ -70,7 +70,7 @@ namespace picongpu
                 {
                     // parallel loop over all particles in the frame
                     forEachParticleSlotInFrame(
-                        [&](lockstep::Idx const linearIdx)
+                        [&](uint32_t const linearIdx)
                         {
                             if(linearIdx < particlesInSuperCell)
                             {

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -115,7 +115,7 @@ namespace picongpu
                     auto particleCreatorCtx = lockstep::makeVar<T_ParticleCreator>(forEachParticle);
 
                     forEachParticle(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const idx, auto& particleCreator)
                         {
                             // cell index within the superCell
                             DataSpace<simDim> const cellIdx
@@ -125,11 +125,12 @@ namespace picongpu
                             pmacc::math::Int<simDim> const localCellIndex = simDomainSupercellCellOffset + cellIdx;
 
                             // create a copy of the functor for each virtual worker
-                            particleCreatorCtx[idx] = particleCreator;
+                            particleCreator = particleCreator;
 
                             // init particle creator functor for each virtual worker
-                            particleCreatorCtx[idx].init(worker, supercellCellOffset, localCellIndex);
-                        });
+                            particleCreator.init(worker, supercellCellOffset, localCellIndex);
+                        },
+                        particleCreatorCtx);
 
                     /* Declare counter in shared memory that will later tell the current fill level or
                      * occupation of the newly created target frames.
@@ -167,15 +168,16 @@ namespace picongpu
                     while(sourceFrame.isValid())
                     {
                         forEachParticle(
-                            [&](lockstep::Idx const idx)
+                            [&](uint32_t const idx, auto& particleCreator, uint32_t& numNewParticles)
                             {
                                 auto const isParticle = static_cast<bool>(sourceFrame[idx][multiMask_]);
-                                numNewParticlesCtx[idx] = 0u;
+                                numNewParticles = 0u;
                                 if(isParticle)
                                     /* ask the particle creator functor how many new particles to create. */
-                                    numNewParticlesCtx[idx]
-                                        = particleCreatorCtx[idx].numNewParticles(worker, *sourceFrame, idx);
-                            });
+                                    numNewParticles = particleCreator.numNewParticles(worker, *sourceFrame, idx);
+                            },
+                            particleCreatorCtx,
+                            numNewParticlesCtx);
 
                         worker.sync();
 
@@ -212,14 +214,16 @@ namespace picongpu
                              * value as targetParId in the new frame
                              */
                             forEachParticle(
-                                [&](lockstep::Idx const idx)
+                                [&](uint32_t const idx, uint32_t const numNewParticles, int& targetParId)
                                 {
-                                    if(numNewParticlesCtx[idx] > 0u)
-                                        targetParIdCtx[idx] = kernel::atomicAllInc(
+                                    if(numNewParticles > 0u)
+                                        targetParId = kernel::atomicAllInc(
                                             worker,
                                             &newFrameFillLvl,
                                             ::alpaka::hierarchy::Threads{});
-                                });
+                                },
+                                numNewParticlesCtx,
+                                targetParIdCtx);
 
                             worker.sync();
 
@@ -254,27 +258,33 @@ namespace picongpu
                              * - internal particle creation counter is decremented by 1
                              */
                             forEachParticle(
-                                [&](lockstep::Idx const idx)
+                                [&](uint32_t const idx,
+                                    int& targetParId,
+                                    uint32_t& numNewParticles,
+                                    auto& particleCreator)
                                 {
                                     uint32_t targetFrameIdx = 0;
-                                    if(targetParIdCtx[idx] >= maxParticlesInFrame)
+                                    if(targetParId >= maxParticlesInFrame)
                                     {
                                         targetFrameIdx = 1;
-                                        targetParIdCtx[idx] -= maxParticlesInFrame;
+                                        targetParId -= maxParticlesInFrame;
                                     }
-                                    if(0 <= targetParIdCtx[idx])
+                                    if(0 <= targetParId)
                                     {
                                         // each virtual worker makes the attributes of its source particle accessible
                                         auto sourceParticle = sourceFrame[idx];
                                         // each virtual worker initializes a target particle if one should be created
-                                        auto targetParticle = targetFrames[targetFrameIdx][targetParIdCtx[idx]];
+                                        auto targetParticle = targetFrames[targetFrameIdx][targetParId];
 
                                         // create a target particle in the new target particle frame:
-                                        particleCreatorCtx[idx](worker, sourceParticle, targetParticle);
+                                        particleCreator(worker, sourceParticle, targetParticle);
 
-                                        numNewParticlesCtx[idx] -= 1;
+                                        numNewParticles -= 1;
                                     }
-                                });
+                                },
+                                targetParIdCtx,
+                                numNewParticlesCtx,
+                                particleCreatorCtx);
 
                             worker.sync();
 

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -122,16 +122,17 @@ namespace picongpu
             while(srcFramePtr.isValid())
             {
                 forEachParticleInFrame(
-                    [&](lockstep::Idx const idx)
+                    [&](uint32_t const idx, int& storageOffset)
                     {
                         auto parSrc = (srcFramePtr[idx]);
-                        storageOffsetCtx[idx] = -1;
+                        storageOffset = -1;
                         // count particle in frame
                         if(parSrc[multiMask_] == 1 && filter(parSrc))
                             if(accParFilter(worker, parSrc))
-                                storageOffsetCtx[idx]
+                                storageOffset
                                     = kernel::atomicAllInc(worker, &localCounter, ::alpaka::hierarchy::Threads{});
-                    });
+                    },
+                    storageOffsetCtx);
                 worker.sync();
 
                 onlyMaster(
@@ -145,11 +146,11 @@ namespace picongpu
                 worker.sync();
 
                 forEachParticleInFrame(
-                    [&](lockstep::Idx const idx)
+                    [&](uint32_t const idx, int const storageOffset)
                     {
-                        if(storageOffsetCtx[idx] != -1)
+                        if(storageOffset != -1)
                         {
-                            auto parDest = destFrame[globalOffset + storageOffsetCtx[idx]];
+                            auto parDest = destFrame[globalOffset + storageOffset];
                             auto parDestNoDomainIdx = deselect<T_Identifier>(parDest);
                             auto parSrc = (srcFramePtr[idx]);
                             assign(parDestNoDomainIdx, parSrc);
@@ -158,7 +159,8 @@ namespace picongpu
                                 DataSpaceOperations<simDim>::template map<SuperCellSize>(parSrc[localCellIdx_]));
                             parDest[domainCellIdxIdentifier] = domainOffset + localSuperCellCellOffset + localCell;
                         }
-                    });
+                    },
+                    storageOffsetCtx);
 
                 worker.sync();
 

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -195,12 +195,12 @@ namespace picongpu
                                 auto forEachParticleInFrame = forEachFrameInSupercell.lockstepForEach();
 
                                 forEachParticleInFrame(
-                                    [&](lockstep::Idx const linearIdx)
+                                    [&](uint32_t const linearIdx, auto& frame)
                                     {
                                         /* modulo is required if the kernel is started with more workers than particle
                                          * in a supercell
                                          */
-                                        auto par = frameCtx[linearIdx][linearIdx % frameSize];
+                                        auto par = frame[linearIdx % frameSize];
                                         /* Not all particle slots in a frame representing an exiting particle.
                                          * Process only real particles and ignore gaps in a frame.
                                          */
@@ -341,7 +341,8 @@ namespace picongpu
 
                                             } // END: if a particle needs to be considered
                                         } // END: check if particle is accelerated
-                                    });
+                                    },
+                                    frameCtx);
 
                                 worker.sync(); // wait till every worker has loaded its particle data
 

--- a/include/picongpu/simulation_types.hpp
+++ b/include/picongpu/simulation_types.hpp
@@ -47,7 +47,13 @@ namespace picongpu
     }
 
     namespace math = cupla::device::math;
-    using namespace pmacc::algorithms::precisionCast;
+    /** g++ 9 creates compile issues when pulling definitions into picongpu namepsace via 'using namespace
+     * pmacc::algorithms::precisionCast;' therefore we pull the class and function separate
+     */
+    using pmacc::algorithms::precisionCast::precisionCast;
+    template<typename CastToType, typename Type>
+    using TypeCast = pmacc::algorithms::precisionCast::TypeCast<CastToType, Type>;
+
     using namespace pmacc::algorithms::promoteType;
     using namespace pmacc::traits;
     using namespace picongpu::traits;

--- a/include/picongpu/unitless/speciesDefinition.unitless
+++ b/include/picongpu/unitless/speciesDefinition.unitless
@@ -29,6 +29,9 @@
 #include "picongpu/traits/frame/GetCharge.hpp"
 #include "picongpu/traits/frame/GetMass.hpp"
 
+#include <pmacc/traits/GetFlagType.hpp>
+#include <pmacc/traits/Resolve.hpp>
+
 
 namespace picongpu
 {
@@ -44,8 +47,8 @@ namespace picongpu
             template<typename T_Frame>
             HDINLINE float_X getMass()
             {
-                using MassRatioValue =
-                    typename pmacc::traits::Resolve<typename GetFlagType<T_Frame, massRatio<>>::type>::type;
+                using MassRatioValue = typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<T_Frame, massRatio<>>::type>::type;
 
                 return BASE_MASS * MassRatioValue::getValue();
             }
@@ -59,8 +62,8 @@ namespace picongpu
             template<typename T_Frame>
             HDINLINE float_X getCharge()
             {
-                using ChargeRatioValue =
-                    typename pmacc::traits::Resolve<typename GetFlagType<T_Frame, chargeRatio<>>::type>::type;
+                using ChargeRatioValue = typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<T_Frame, chargeRatio<>>::type>::type;
 
                 return BASE_CHARGE * ChargeRatioValue::getValue();
             }

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -109,29 +109,33 @@ namespace pmacc
 
                 // count particles in last frame
                 forEachParticle(
-                    [&](lockstep::Idx const idx)
+                    [&](bool isParticle)
                     {
-                        if(isParticleCtx[idx])
+                        if(isParticle)
                             kernel::atomicAllInc(worker, &numParticles, ::alpaka::hierarchy::Threads{});
-                    });
+                    },
+                    isParticleCtx);
 
                 worker.sync();
 
                 forEachParticle(
-                    [&](lockstep::Idx const idx)
+                    [&](uint32_t const idx, bool const isParticle)
                     {
-                        if(idx < numParticles && isParticleCtx[idx] == false)
+                        if(idx < numParticles && isParticle == false)
                         {
                             int const localGapIdx
                                 = kernel::atomicAllInc(worker, &numGaps, ::alpaka::hierarchy::Threads{});
                             gapIndices_sh[localGapIdx] = idx;
                         }
-                    });
+                    },
+                    isParticleCtx);
+
                 worker.sync();
+
                 forEachParticle(
-                    [&](lockstep::Idx const idx)
+                    [&](uint32_t const idx, bool const isParticle)
                     {
-                        if(idx >= numParticles && isParticleCtx[idx])
+                        if(idx >= numParticles && isParticle)
                         {
                             // any particle search a gap
                             int const srcGapIdx
@@ -148,7 +152,8 @@ namespace pmacc
                             assign(parDest, parSrc);
                             parSrc[multiMask_] = 0; // delete old particle
                         }
-                    });
+                    },
+                    isParticleCtx);
             }
             lockstep::makeMaster(worker)(
                 [&]()
@@ -238,7 +243,7 @@ namespace pmacc
 
                 // find gaps in firstFrame
                 auto localGapIdxCtx = forEachParticle(
-                    [&](lockstep::Idx const idx)
+                    [&](uint32_t const idx)
                     {
                         int gapIdx = INV_LOC_IDX;
                         if(firstFrame[idx][multiMask_] == 0)
@@ -269,11 +274,11 @@ namespace pmacc
 
                     // copy particles from lastFrame to the gaps in firstFrame
                     forEachParticle(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const idx, int const localGapIdx)
                         {
-                            if(localGapIdxCtx[idx] < numParticles)
+                            if(localGapIdx < numParticles)
                             {
-                                int const parIdx = particleIndices_sh[localGapIdxCtx[idx]];
+                                int const parIdx = particleIndices_sh[localGapIdx];
                                 auto parDestFull = firstFrame[idx];
                                 // enable particle
                                 parDestFull[multiMask_] = 1;
@@ -285,7 +290,8 @@ namespace pmacc
                                 assign(parDest, parSrc);
                                 parSrc[multiMask_] = 0;
                             }
-                        });
+                        },
+                        localGapIdxCtx);
 
                     worker.sync();
 
@@ -429,16 +435,15 @@ namespace pmacc
              * each master thread (one master per direction) will load it
              */
             forEachExchange(
-                [&](lockstep::Idx const idx)
+                [&](uint32_t const linearIdx, int32_t& newParticleInFrame)
                 {
-                    uint32_t const linearIdx = idx;
                     destFramesCounter[linearIdx] = 0u;
                     destFrames[linearIdx] = FramePtr();
                     destFrames[linearIdx + numExchanges] = FramePtr();
                     /* neighborSuperCellIdx should not be stored in a context variable.
                      * Using a context variable results into 16bit reads.
                      */
-                    auto const neighborSuperCellIdx = superCellIdx + Mask::getRelativeDirections<dim>(idx + 1);
+                    auto const neighborSuperCellIdx = superCellIdx + Mask::getRelativeDirections<dim>(linearIdx + 1);
                     if(isValidSupercellIdx(T_Idx{neighborSuperCellIdx}, numSupercellsWithGuard))
                     {
                         /* load last frame of neighboring supercell */
@@ -450,13 +455,14 @@ namespace pmacc
                             // do not use the neighbor's last frame if it is full
                             if(particlesInFrame < frameSize)
                             {
-                                newParticleInFrameCtx[idx] = -particlesInFrame;
+                                newParticleInFrame = -particlesInFrame;
                                 destFrames[linearIdx] = tmpFrame;
                                 destFramesCounter[linearIdx] = particlesInFrame;
                             }
                         }
                     }
-                });
+                },
+                newParticleInFrameCtx);
 
             worker.sync();
 
@@ -470,7 +476,7 @@ namespace pmacc
                         = lockstep::makeVar<lcellId_t>(forEachParticleInFrame, lcellId_t(INV_LOC_IDX));
 
                     auto directionCtx = forEachParticleInFrame(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const idx, lcellId_t& destParticleIdx, auto const frameIter)
                         {
                             /* set to value to of multiMask to a value in range [-2, EXCHANGES - 1]
                              * -2 is no particle
@@ -478,23 +484,25 @@ namespace pmacc
                              * >=0 particle moves in a certain direction
                              *     (@see ExchangeType in types.h)
                              */
-                            int direction = frameIterCtx[idx][idx % frameSize][multiMask_] - 2;
+                            int direction = frameIter[idx % frameSize][multiMask_] - 2;
                             if(direction >= 0)
                             {
-                                destParticleIdxCtx[idx] = cupla::atomicAdd(
+                                destParticleIdx = cupla::atomicAdd(
                                     lockstepWorker.getAcc(),
                                     &(destFramesCounter[direction]),
                                     1u,
                                     ::alpaka::hierarchy::Threads{});
                             }
                             return direction;
-                        });
+                        },
+                        destParticleIdxCtx,
+                        frameIterCtx);
+
                     lockstepWorker.sync();
 
                     forEachExchange(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const linearIdx)
                         {
-                            uint32_t const linearIdx = idx;
                             /* If the master thread (responsible for a certain direction) did not
                              * obtain a `low frame` from the neighboring super cell before the loop,
                              * it will create one now.
@@ -532,7 +540,7 @@ namespace pmacc
                     lockstepWorker.sync();
 
                     forEachParticleInFrame(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const idx, auto& direction, auto& destParticleIdx, auto& frameIter)
                         {
                             /* All threads with a valid index in the neighbor's frame, valid index
                              * range is [0, frameSize * 2-1], will copy their particle to the new
@@ -541,48 +549,51 @@ namespace pmacc
                              * The default value for indexes (in the destination frame) is
                              * above this range (INV_LOC_IDX) for all particles that are not shifted.
                              */
-                            if(destParticleIdxCtx[idx] < frameSize * 2)
+                            if(destParticleIdx < frameSize * 2)
                             {
-                                if(destParticleIdxCtx[idx] >= frameSize)
+                                if(destParticleIdx >= frameSize)
                                 {
                                     /* use `high frame` */
-                                    directionCtx[idx] += numExchanges;
-                                    destParticleIdxCtx[idx] -= frameSize;
+                                    direction += numExchanges;
+                                    destParticleIdx -= frameSize;
                                 }
-                                auto dstParticle = destFrames[directionCtx[idx]][destParticleIdxCtx[idx]];
-                                auto srcParticle = frameIterCtx[idx][idx % frameSize];
+                                auto dstParticle = destFrames[direction][destParticleIdx];
+                                auto srcParticle = frameIter[idx % frameSize];
                                 dstParticle[multiMask_] = 1;
                                 srcParticle[multiMask_] = 0;
                                 auto dstFilteredParticle = particles::operations::deselect<multiMask>(dstParticle);
                                 particles::operations::assign(dstFilteredParticle, srcParticle);
                             }
-                        });
+                        },
+                        directionCtx,
+                        destParticleIdxCtx,
+                        frameIterCtx);
                     lockstepWorker.sync();
 
                     forEachExchange(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const linearIdx, auto& newParticleInFrame)
                         {
-                            uint32_t const linearIdx = idx;
                             /* if the `low frame` is full, each master thread
                              * uses the `high frame` (is invalid, if still empty) as the next
                              * `low frame` for the following iteration of the loop
                              */
                             if(destFramesCounter[linearIdx] >= frameSize)
                             {
-                                newParticleInFrameCtx[idx] += frameSize;
+                                newParticleInFrame += frameSize;
                                 destFramesCounter[linearIdx] -= frameSize;
                                 destFrames[linearIdx] = destFrames[linearIdx + numExchanges];
                                 destFrames[linearIdx + numExchanges] = FramePtr();
                             }
-                        });
+                        },
+                        newParticleInFrameCtx);
                     lockstepWorker.sync();
                 });
 
             forEachExchange(
-                [&](lockstep::Idx const idx)
+                [&](uint32_t const idx, auto& newParticleInFrame)
                 {
-                    newParticleInFrameCtx[idx] += destFramesCounter[idx];
-                    if(newParticleInFrameCtx[idx] > 0)
+                    newParticleInFrame += destFramesCounter[idx];
+                    if(newParticleInFrame > 0)
                     {
                         /* neighborSuperCellIdx should not be stored in a context variable.
                          * Using a context variable results into 16bit reads.
@@ -596,10 +607,11 @@ namespace pmacc
                              * current used supercell.
                              */
                             auto& superCell = pb.getSuperCell(neighborSuperCellIdx);
-                            superCell.setNumParticles(superCell.getNumParticles() + newParticleInFrameCtx[idx]);
+                            superCell.setNumParticles(superCell.getNumParticles() + newParticleInFrame);
                         }
                     }
-                });
+                },
+                newParticleInFrameCtx);
 
             // fill all gaps in the frame list of the supercell
             KernelFillGaps{}(worker, pb, mapper);
@@ -798,17 +810,17 @@ namespace pmacc
                     worker.sync();
 
                     forEachParticle(
-                        [&](lockstep::Idx const idx)
+                        [&](uint32_t const idx, auto const exchangeGapIdx)
                         {
-                            if(exchangeGapIdxCtx[idx] != lcellId_t(INV_LOC_IDX)
-                               && exchangeGapIdxCtx[idx] < exchangeChunk.getSize())
+                            if(exchangeGapIdx != lcellId_t(INV_LOC_IDX) && exchangeGapIdx < exchangeChunk.getSize())
                             {
-                                auto parDest = exchangeChunk[exchangeGapIdxCtx[idx]][0];
+                                auto parDest = exchangeChunk[exchangeGapIdx][0];
                                 auto parSrc = frame[idx];
                                 assign(parDest, parSrc);
                                 parSrc[multiMask_] = 0;
                             }
-                        });
+                        },
+                        exchangeGapIdxCtx);
                     worker.sync();
                 }
 
@@ -875,16 +887,16 @@ namespace pmacc
             auto compressedSuperCellIdxCtx = lockstep::makeVar<DataSpace<dim - 1>>(onlyMaster);
 
             onlyMaster(
-                [&](lockstep::Idx const idx)
+                [&](auto& compressedSuperCellIdx)
                 {
-                    exchangeChunk
-                        = exchangeBox.get(cupla::blockIdx(worker.getAcc()).x, compressedSuperCellIdxCtx[idx]);
+                    exchangeChunk = exchangeBox.get(cupla::blockIdx(worker.getAcc()).x, compressedSuperCellIdx);
                     elementCount = exchangeChunk.getSize();
                     if(elementCount > 0u)
                     {
                         frame = pb.getEmptyFrame(worker);
                     }
-                });
+                },
+                compressedSuperCellIdxCtx);
 
             worker.sync();
 
@@ -911,7 +923,7 @@ namespace pmacc
             worker.sync();
 
             onlyMaster(
-                [&](lockstep::Idx const idx)
+                [&](auto const compressedSuperCellIdx)
                 {
                     if(elementCount > 0u)
                     {
@@ -919,14 +931,15 @@ namespace pmacc
                         //! @todo: offset == simulation border should be passed to this func instead of being created
                         //! here
                         DataSpace<dim> dstSuperCell = DataSpaceOperations<dim - 1>::extend(
-                            compressedSuperCellIdxCtx[idx],
+                            compressedSuperCellIdx,
                             mapper.getExchangeType(),
                             mapper.getGridSuperCells(),
                             mapper.getGuardingSuperCells());
 
                         pb.setAsLastFrame(worker, frame, dstSuperCell);
                     }
-                });
+                },
+                compressedSuperCellIdxCtx);
         }
     };
 

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -129,14 +129,16 @@ namespace pmacc
                         auto hasValidParticleCtx = lockstep::makeVar<bool>(forEachParticle);
 
                         forEachParticle(
-                            [&](lockstep::Idx const idx)
+                            [&](uint32_t const idx, int& srcParticleIdx, bool& hasValidParticle)
                             {
                                 destFramePtr[idx] = DestFramePtr{};
                                 sharedLinearSuperCellIds[idx] = -1;
 
-                                srcParticleIdxCtx[idx] = sharedSrcParticleOffset + idx;
-                                hasValidParticleCtx[idx] = srcParticleIdxCtx[idx] < maxParticles;
-                            });
+                                srcParticleIdx = sharedSrcParticleOffset + idx;
+                                hasValidParticle = srcParticleIdx < maxParticles;
+                            },
+                            srcParticleIdxCtx,
+                            hasValidParticleCtx);
 
                         worker.sync();
 
@@ -147,41 +149,48 @@ namespace pmacc
 
                         // supercell index of the particle relative to the origin of the local domain
                         auto particlesSuperCellCtx = forEachParticle(
-                            [&](lockstep::Idx const idx) -> DataSpace<numDims>
+                            [&](uint32_t const idx,
+                                bool const hasValidParticle,
+                                auto& lCellIdx,
+                                int const srcParticleIdx,
+                                int& linearParticlesSuperCell) -> DataSpace<numDims>
                             {
                                 DataSpace<numDims> particlesSuperCellIdx;
-                                if(hasValidParticleCtx[idx])
+                                if(hasValidParticle)
                                 {
                                     // offset of the particle relative to the origin of the local domain
                                     DataSpace<numDims> const particleCellOffset
-                                        = srcFrame[srcParticleIdxCtx[idx]][domainCellIdxIdentifier]
-                                        - cellOffsetToTotalDomain;
+                                        = srcFrame[srcParticleIdx][domainCellIdxIdentifier] - cellOffsetToTotalDomain;
                                     particlesSuperCellIdx = particleCellOffset / SuperCellSize::toRT();
-                                    linearParticlesSuperCellCtx[idx]
+                                    linearParticlesSuperCell
                                         = DataSpaceOperations<numDims>::map(numSuperCells, particlesSuperCellIdx);
-                                    sharedLinearSuperCellIds[idx] = linearParticlesSuperCellCtx[idx];
+                                    sharedLinearSuperCellIds[idx] = linearParticlesSuperCell;
                                     DataSpace<numDims> const localCellIdx(
                                         particleCellOffset - particlesSuperCellIdx * SuperCellSize::toRT());
-                                    lCellIdxCtx[idx]
-                                        = DataSpaceOperations<numDims>::template map<SuperCellSize>(localCellIdx);
+                                    lCellIdx = DataSpaceOperations<numDims>::template map<SuperCellSize>(localCellIdx);
                                 }
                                 return particlesSuperCellIdx;
-                            });
+                            },
+                            hasValidParticleCtx,
+                            lCellIdxCtx,
+                            srcParticleIdxCtx,
+                            linearParticlesSuperCellCtx);
 
                         worker.sync();
 
                         auto masterVirtualThreadIdxCtx = forEachParticle(
-                            [&](lockstep::Idx const idx) -> int
+                            [&](uint32_t const idx,
+                                bool const hasValidParticle,
+                                int const linearParticlesSuperCell,
+                                auto const& particlesSuperCell) -> int
                             {
                                 int vThreadMasterIdx = static_cast<int>(idx) - 1;
-                                if(hasValidParticleCtx[idx])
+                                if(hasValidParticle)
                                 {
-                                    // auto& vThreadMasterIdx = masterVirtualThreadIdxCtx[idx];
                                     /* search master thread index */
                                     while(vThreadMasterIdx >= 0)
                                     {
-                                        if(linearParticlesSuperCellCtx[idx]
-                                           != sharedLinearSuperCellIds[vThreadMasterIdx])
+                                        if(linearParticlesSuperCell != sharedLinearSuperCellIds[vThreadMasterIdx])
                                             break;
 
                                         --vThreadMasterIdx;
@@ -198,25 +207,32 @@ namespace pmacc
                                         destBox.setAsFirstFrame(
                                             worker,
                                             tmpFrame,
-                                            particlesSuperCellCtx[idx] + cellDesc.getGuardingSuperCells());
+                                            particlesSuperCell + cellDesc.getGuardingSuperCells());
                                     }
                                 }
                                 return vThreadMasterIdx;
-                            });
+                            },
+                            hasValidParticleCtx,
+                            linearParticlesSuperCellCtx,
+                            particlesSuperCellCtx);
 
                         worker.sync();
 
                         forEachParticle(
-                            [&](lockstep::Idx const idx)
+                            [&](uint32_t const idx,
+                                bool const hasValidParticle,
+                                auto const masterVirtualThreadIdx,
+                                int const srcParticleIdx,
+                                auto const lCellIdx)
                             {
-                                if(hasValidParticleCtx[idx])
+                                if(hasValidParticle)
                                 {
                                     /* copy attributes and activate particle*/
-                                    auto parDest = destFramePtr[masterVirtualThreadIdxCtx[idx]][idx];
+                                    auto parDest = destFramePtr[masterVirtualThreadIdx][idx];
                                     auto parDestDeselect = deselect<bmpl::vector2<localCellIdx, multiMask>>(parDest);
 
-                                    assign(parDestDeselect, srcFrame[srcParticleIdxCtx[idx]]);
-                                    parDest[localCellIdx_] = lCellIdxCtx[idx];
+                                    assign(parDestDeselect, srcFrame[srcParticleIdx]);
+                                    parDest[localCellIdx_] = lCellIdx;
                                     parDest[multiMask_] = 1;
                                     /* counter[1] -> number of loaded particles
                                      * this counter is evaluated on host side
@@ -224,7 +240,11 @@ namespace pmacc
                                      * file)*/
                                     kernel::atomicAllInc(worker, &(counter[1]), ::alpaka::hierarchy::Blocks{});
                                 }
-                            });
+                            },
+                            hasValidParticleCtx,
+                            masterVirtualThreadIdxCtx,
+                            srcParticleIdxCtx,
+                            lCellIdxCtx);
                     }
                 };
             } // namespace detail


### PR DESCRIPTION
Extend the lockstep foreach algorithm interface with the possibility to forward lockstep context variables to the user functor.
A variable forwarded to the functor can be accessed without any index operations.

- refactor forEach
  - separate the functor execution in hierarchical helper to simplify the     user functor signature detection
- update documentation to reflect the latest changes
- use new interface in PMacc and PIConGPU

I am aware that the new way requires few more lines of code but it eliminates the requirement of fiddling around with indices to access the distributed context variable.
The old way is still supported because I am not fully sure if I should forbid it to favor the new interface.
I will do many more refactorings of the lockstep usage/interface in the near future where the benefits of the current refactoring will be shown step by step.