### PR TITLE
avoid that numerical instabilities trigegring the KHI

### DIFF
--- a/include/picongpu/simulation/stage/IterationStart.hpp
+++ b/include/picongpu/simulation/stage/IterationStart.hpp
@@ -44,8 +44,11 @@ namespace picongpu
                  */
                 void operator()(uint32_t const step) const
                 {
-                    meta::ForEach<IterationStartPipeline, pmacc::functor::Call<bmpl::_1>> callFunctors;
-                    callFunctors(step);
+                    if(step == 500)
+                    {
+                        meta::ForEach<IterationStartPipeline, pmacc::functor::Call<bmpl::_1>> callFunctors;
+                        callFunctors(step);
+                    }
                 }
             };
 

--- a/lib/python/test/KHI_growthRate/TestKHIManager.py
+++ b/lib/python/test/KHI_growthRate/TestKHIManager.py
@@ -377,7 +377,7 @@ class TestKHIManager:
 
         # calculate the growthrate
         keys = list(self.__khiData.getGrowthRate())
-        cut = 0  # Auxiliary variable to slice the data
+        cut = 28  # Auxiliary variable to slice the data
 
         for key in keys:
 
@@ -391,7 +391,7 @@ class TestKHIManager:
                     cut = argrelextrema(value, np.less)[0][0]
 
                 self.__khiData.setGrowthRateByKey(key, value)
-
+        print(cut)
         # cut the field data and the growth rate
         if cut != 0:
 

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/particle.param
@@ -45,6 +45,15 @@ namespace picongpu
             };
             using Quiet25ppc = QuietImpl<QuietParam25ppc>;
 
+            struct RandomParameter25ppc
+            {
+                /** Count of particles per cell at initial state
+                 *  unit: none
+                 */
+                static constexpr uint32_t numParticlesPerCell = 25u;
+            };
+            using Random25ppc = RandomImpl<RandomParameter25ppc>;
+
         } // namespace startPosition
 
         /** a particle with a weighting below MIN_WEIGHTING will not

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/species.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/species.param
@@ -1,0 +1,103 @@
+/* Copyright 2014-2022 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Particle shape, field to particle interpolation, current solver, and particle pusher
+ * can be declared here for usage in `speciesDefinition.param`.
+ *
+ * @see
+ *   **MODELS / Hierarchy of Charge Assignment Schemes**
+ *   in the online documentation for information on particle shapes.
+ *
+ *
+ * \attention
+ * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
+ *     * PQS is the name of the 3rd order assignment function (instead of PCS)
+ *     * PCS is the name of the 4th order assignment function (instead of P4S)
+ *     * P4S does not exist anymore
+ */
+
+#pragma once
+
+#include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
+#include "picongpu/fields/currentDeposition/Solver.def"
+#include "picongpu/particles/shapes.hpp"
+
+
+namespace picongpu
+{
+    /** select macroparticle shape
+     *
+     * **WARNING** the shape names are redefined and diverge from PIConGPU versions before 0.6.0.
+     *
+     *  - particles::shapes::CIC : Assignment function is a piecewise linear spline
+     *  - particles::shapes::TSC : Assignment function is a piecewise quadratic spline
+     *  - particles::shapes::PQS : Assignment function is a piecewise cubic spline
+     *  - particles::shapes::PCS : Assignment function is a piecewise quartic spline
+     */
+    using UsedParticleShape = particles::shapes::TSC;
+
+    /** select interpolation method to be used for interpolation of grid-based field values to particle positions
+     */
+    using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
+
+    /*! select current solver method
+     * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::EZ< SHAPE, STRATEGY >        : same as EmZ (just an alias to match the currently used naming)
+     *
+     * STRATEGY (optional):
+     * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
+     */
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
+
+    /** particle pusher configuration
+     *
+     * Defining a pusher is optional for particles
+     *
+     * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+     * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+     * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
+     * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+     *                                              with classical radiation reaction
+     * - particles::pusher::Composite : composite of two given pushers,
+     *                                  switches between using one (or none) of those
+     *
+     * For diagnostics & modeling: ------------------------------------------------
+     * - particles::pusher::Acceleration : Accelerate particles by applying a constant electric field
+     * - particles::pusher::Free : free propagation, ignore fields
+     *                             (= free stream model)
+     * - particles::pusher::Photon : propagate with c in direction of normalized mom.
+     * - particles::pusher::Probe : Probe particles that interpolate E & B
+     * For development purposes: --------------------------------------------------
+     * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
+     */
+    using UsedParticlePusher = particles::pusher::Composite<
+        particles::pusher::Free,
+        particles::pusher::Boris,
+        particles::pusher::CompositeBinarySwitchActivationFunctor<500>>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,106 @@
+/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/meta/String.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+
+#ifndef PARAM_RADIATION
+/* disable radiation calculation */
+#    define PARAM_RADIATION 0
+#endif
+
+
+namespace picongpu
+{
+    /*########################### define particle attributes #####################*/
+
+    /** describe attributes of a particle*/
+    using DefaultParticleAttributes = MakeSeq_t<
+        position<position_pic>,
+        momentum,
+        weighting
+#if(PARAM_RADIATION == 1)
+        ,
+        momentumPrev1
+#endif
+        >;
+
+    /*########################### end particle attributes ########################*/
+
+    /*########################### define species #################################*/
+
+    /*--------------------------- electrons --------------------------------------*/
+
+    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    value_identifier(float_X, MassRatioElectrons, 1.0);
+    value_identifier(float_X, ChargeRatioElectrons, 1.0);
+
+    using ParticleFlagsElectrons = MakeSeq_t<
+        particlePusher<UsedParticlePusher>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        current<UsedParticleCurrentSolver>,
+        massRatio<MassRatioElectrons>,
+        chargeRatio<ChargeRatioElectrons>>;
+
+    /* define species electrons */
+    using PIC_Electrons = Particles<PMACC_CSTRING("e"), ParticleFlagsElectrons, DefaultParticleAttributes>;
+
+    /*--------------------------- ions -------------------------------------------*/
+
+    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    value_identifier(float_X, MassRatioIons, 1836.152672);
+    value_identifier(float_X, ChargeRatioIons, -1.0);
+
+    /* ratio relative to BASE_DENSITY */
+    value_identifier(float_X, DensityRatioIons, 1.0);
+
+    using ParticleFlagsIons = MakeSeq_t<
+        particlePusher<UsedParticlePusher>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        current<UsedParticleCurrentSolver>,
+        massRatio<MassRatioIons>,
+        chargeRatio<ChargeRatioIons>,
+        densityRatio<DensityRatioIons>,
+        atomicNumbers<ionization::atomicNumbers::Hydrogen_t>>;
+
+    /* define species ions */
+    using PIC_Ions = Particles<PMACC_CSTRING("i"), ParticleFlagsIons, DefaultParticleAttributes>;
+
+    /*########################### end species ####################################*/
+
+    /** All known particle species of the simulation
+     *
+     * List all defined particle species from above in this list
+     * to make them available to the PIC algorithm.
+     */
+    using VectorAllSpecies = MakeSeq_t<PIC_Electrons, PIC_Ions>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/speciesInitialization.param
@@ -40,15 +40,14 @@ namespace picongpu
          * the functors are called in order (from first to last functor)
          */
         using InitPipeline = bmpl::vector<
-            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet25ppc, PIC_Electrons>,
-            Derive<PIC_Electrons, PIC_Ions>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Random25ppc, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Random25ppc, PIC_Ions>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::LowerQuarterYPosition>,
             Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleHalfYPosition>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::UpperQuarterYPosition>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::LowerQuarterYPosition>,
             Manipulate<manipulators::AssignXDriftNegative, PIC_Electrons, filter::MiddleHalfYPosition>,
-            Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::UpperQuarterYPosition>,
-            Manipulate<manipulators::AddTemperature, PIC_Electrons>>;
+            Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::UpperQuarterYPosition>>;
 
     } // namespace particles
 } // namespace picongpu


### PR DESCRIPTION
related to #3234

We observe since long time that our KHi is seeded by nummerical issues instead a well reproducable condition.
I came up with the idea to use the composit pusher to create maxwell conform fields over 500 steps and then start to real KHI simulation. @PrometheusPi suggested to use a random position for electrons and ions and not using the temperature seeding for electrons.

The results look quite good.
The python tool is adjusted to ignore the first 28 outputs.

`./bin/picongpu -d 1 1 1 -g 192 128 128 --periodic 1 1 1 -s 2500 --fields_energy.period 20 --e_png.period 100 --e_png.axis yx --e_png.slicePoint 0.5 --e_png.folder pngElectronsYX --e_macroParticlesCount.period 100 --e_energy.period 20 --e_energy.filter all --i_energy.period 20 --i_energy.filter all`

![result](https://user-images.githubusercontent.com/4037125/219376905-363be69a-7666-4c79-bcce-bae0de616288.png)


- [ ] do not merge this is a work-in-progress PR to provide @PrometheusPi with the setup of my lasts tests
