### PR TITLE
fix particle position rounding issue

### DIFF
--- a/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
+++ b/include/picongpu/algorithms/FieldToParticleInterpolation.hpp
@@ -100,7 +100,6 @@ namespace picongpu
              * The following calls seperate the vector interpolation into
              * independent scalar interpolations.
              */
-            using Supports = typename pmacc::math::CT::make_Int<simDim, supp>::type;
             using ResultType = typename T_FieldDataBox::ValueType;
 
             ResultType result;
@@ -110,7 +109,7 @@ namespace picongpu
                 // work on a copy to shift the field for each loop round separate
                 auto shiftedField = field;
                 floatD_X particlePosShifted = particlePos;
-                ShiftCoordinateSystem<Supports>()(shiftedField, particlePosShifted, fieldPos[i]);
+                ShiftCoordinateSystem<supp>()(shiftedField, particlePosShifted, fieldPos[i]);
 
                 auto accessFunctor = [&](DataSpace<simDim> const& idx) constexpr
                 {


### PR DESCRIPTION
fix #3910

- Besides fixing #3910 the code for shift coordinate system is simplified. Complicated template constructs get removed by a simple for loop.
- The correction schema in MoveParticles has changed.

The fix is based on the fact that the precision is around 0.0 and is equally distributed, in contrast to the previously used range `[0;1)`.
The new method in `MoveParticles` uses a few more floating point operations and a conditional compare but avoids using floor.

# Tests
- [x] KHI growth rate test TSC
- [x] KHI growth rate test PCS
- [x] KHI growth rate test PQS
- [x] compared register footprint (number of used registers for sm_70 is constant)
- [x] manual compared the PTX code