### PR TITLE
Fix single particle test example

### DIFF
--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/fieldBackground.param
@@ -49,7 +49,7 @@ namespace picongpu
         ) const
         {
             /* specify your E-Field in V/m and convert to PIConGPU units */
-            return float3_X(0.0, 0.0, -10.0e6 / m_unitField[1]);
+            return float3_X(0.0, 0.0, -10.0e6 / m_unitField[2]);
         }
     };
 
@@ -78,7 +78,7 @@ namespace picongpu
         ) const
         {
             /* specify your B-Field in T and convert to PIConGPU units */
-            return float3_X(0.0, 0.0, 50.0 / m_unitField[1]);
+            return float3_X(0.0, 0.0, 50.0 / m_unitField[2]);
         }
     };
 

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/speciesDefinition.param
@@ -60,7 +60,6 @@ namespace picongpu
 #endif
         shape<UsedParticleShape>,
         interpolation<UsedField2Particle>,
-        current<UsedParticleCurrentSolver>,
         massRatio<MassRatioElectrons>,
         chargeRatio<ChargeRatioElectrons>>;
 


### PR DESCRIPTION
The single particle test has a few (minor) errors. This pull request fixes:
 - particles (electrons) should not have current to follow analytical trajectory (and not interact with its own current) 
 - field background unit conversion used y-unit-SI not z-unit-SI despite using fields in z direction (they are the same however, thus no problem and thus **no bug label**) 