### PR TITLE
remove unused methods in radiation plugin

### DIFF
--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -105,20 +105,6 @@ namespace picongpu
                     return calc_gamma(get_momentum<when>());
                 } // get gamma at time when
 
-                template<unsigned int when>
-                HDINLINE picongpu::float_64 get_gamma_inv_square(void) const
-                {
-                    return calc_gamma_inv_square(get_momentum<when>());
-                } // get 1/gamma^2
-
-                template<unsigned int when>
-                HDINLINE picongpu::float_64 get_cos_theta(const vector_64& n) const
-                {
-                    // get cos(theta) at time when
-                    const vector_64 beta = get_beta<when>();
-                    return calc_cos_theta(n, beta);
-                }
-
 
             private:
                 //////////////////////////////////////////////////////////////////
@@ -139,28 +125,6 @@ namespace picongpu
                     return picongpu::math::sqrt(1.0 + x);
                 }
 
-                HDINLINE picongpu::float_64 calc_gamma_inv_square(const vector_X& momentum) const
-                {
-                    // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
-                    const picongpu::float_32 Emass = mass * picongpu::SPEED_OF_LIGHT;
-                    return Emass / (Emass + (util::square<vector_X, picongpu::float_32>(momentum)) / Emass);
-                }
-
-                HDINLINE picongpu::float_64 calc_cos_theta(const vector_64& n, const vector_64& beta) const
-                {
-                    // return cos of angle between looking and flight direction
-                    return (n * beta) / (std::sqrt(beta * beta));
-                }
-
-
-                // setters:
-
-                HDINLINE picongpu::float_64 summand(void) const
-                {
-                    // return \vec n independend summand (next value to add to \vec n independend sum)
-                    const picongpu::float_64 x = get_gamma_inv_square<When::now>();
-                    return Taylor()(x);
-                }
 
             }; // end of Particle definition
 


### PR DESCRIPTION
This pull request removes some not used methods of the radiation plugin to clean up the code base. 
It solves issue #4472. 