### PR TITLE
fix out of memory access in incident field

### DIFF
--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -237,7 +237,7 @@ namespace picongpu
                     const DataSpace<DIM3> periodic
                         = Environment<simDim>::get().EnvironmentController().getCommunicator().getPeriodic();
 
-                    for(uint32_t d = 0u; d < DIM3; ++d)
+                    for(uint32_t d = 0u; d < simDim; ++d)
                     {
                         bool isLaserAxisDirection = d == T_axis;
 


### PR DESCRIPTION
The fix #4457 is introducing a bug that in a 2D simulation some vectors will be accessed with an index that is outside of the allowed range.