### PR TITLE
PMacc DeviceBuffer: missing override

### DIFF
--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -238,7 +238,7 @@ namespace pmacc
          *
          * @param size count of elements per dimension
          */
-        void setCurrentSize(const size_t size)
+        void setCurrentSize(const size_t size) override
         {
             Buffer<TYPE, DIM>::setCurrentSize(size);
 


### PR DESCRIPTION
Add missing `override` keyword.