### PR TITLE
Plugin: CountMacroParticlesPerSupercell and Chargeconservation

### DIFF
--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -49,11 +49,9 @@
 #    include "picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp"
 #endif
 
-#if(PMACC_CUDA_ENABLED == 1)
-#    include "picongpu/plugins/ChargeConservation.hpp"
-#    if(ENABLE_OPENPMD == 1)
-#        include "picongpu/plugins/makroParticleCounter/PerSuperCell.hpp"
-#    endif
+#include "picongpu/plugins/ChargeConservation.hpp"
+#if(ENABLE_OPENPMD == 1)
+#    include "picongpu/plugins/makroParticleCounter/PerSuperCell.hpp"
 #endif
 
 #if(ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
@@ -137,7 +135,8 @@ namespace picongpu
         /* define stand alone plugins */
         using StandAlonePlugins = bmpl::vector<
             Checkpoint,
-            EnergyFields
+            EnergyFields,
+            ChargeConservation
 
 #if(ENABLE_OPENPMD == 1)
             ,
@@ -146,8 +145,7 @@ namespace picongpu
 
 #if(PMACC_CUDA_ENABLED == 1)
             ,
-            SumCurrents,
-            ChargeConservation
+            SumCurrents
 #endif
 
 #if(ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
@@ -175,11 +173,9 @@ namespace picongpu
             plugins::multi::Master<ParticleCalorimeter<bmpl::_1>>,
             plugins::multi::Master<PhaseSpace<particles::shapes::Counter::ChargeAssignment, bmpl::_1>>
 #endif
-#if(PMACC_CUDA_ENABLED == 1)
-#    if(ENABLE_OPENPMD == 1)
+#if(ENABLE_OPENPMD == 1)
             ,
             PerSuperCell<bmpl::_1>
-#    endif
 #endif
             >;
 

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -106,7 +106,6 @@ namespace picongpu
         typedef MappingDesc::SuperCellSize SuperCellSize;
         typedef GridBuffer<size_t, simDim> GridBufferType;
 
-        MappingDesc* cellDescription;
         std::string notifyPeriod;
         std::string m_filenameExtension = openPMD::getDefaultExtension();
         std::string m_filenameInfix = "_%06T";
@@ -114,13 +113,14 @@ namespace picongpu
         std::string pluginName;
         std::string pluginPrefix;
         std::string foldername;
+        MappingDesc* cellDescription;
+
         mpi::MPIReduce reduce;
 
         std::unique_ptr<GridBufferType> localResult;
 
         // @todo upon switching to C++17, use std::option instead
         std::unique_ptr<::openPMD::Series> m_Series;
-        // set attributes for datacollector files
 
         ::openPMD::Offset m_offset;
         ::openPMD::Extent m_extent;


### PR DESCRIPTION
Both plugins can since one of the last refactorings run on CPU and GPU therefore there is no need for guards to avoid the usage of backends other than CUDA.