### PR TITLE
fix missing return statement

### DIFF
--- a/include/picongpu/fields/currentDeposition/relayPoint.hpp
+++ b/include/picongpu/fields/currentDeposition/relayPoint.hpp
@@ -48,19 +48,18 @@ namespace picongpu::currentSolver
     DINLINE float_X relayPoint(int& i_1, int& i_2, const float_X x_1, const float_X x_2)
     {
         using namespace pmacc;
-        if constexpr(isEvenSupport)
+        constexpr bool value = isEvenSupport;
+        if constexpr(value)
         {
             i_1 = math::floor(x_1);
             i_2 = math::floor(x_2);
 
             return i_1 == i_2 ? x_2 : math::max(i_1, i_2);
         }
-        else
-        {
-            i_1 = pmacc::math::float2int_rd(x_1 + float_X(0.5));
-            i_2 = pmacc::math::float2int_rd(x_2 + float_X(0.5));
 
-            return i_1 == i_2 ? x_2 : float_X(i_1 + i_2) / float_X(2.0);
-        }
+        i_1 = pmacc::math::float2int_rd(x_1 + float_X(0.5));
+        i_2 = pmacc::math::float2int_rd(x_2 + float_X(0.5));
+
+        return i_1 == i_2 ? x_2 : float_X(i_1 + i_2) / float_X(2.0);
     }
 } // namespace picongpu::currentSolver

--- a/include/picongpu/traits/attribute/GetCharge.hpp
+++ b/include/picongpu/traits/attribute/GetCharge.hpp
@@ -62,8 +62,8 @@ namespace picongpu
                      */
                     return ELECTRON_CHARGE * (particle[boundElectrons_] - protonNumber) * weighting;
                 }
-                else
-                    return frame::getCharge<typename T_Particle::FrameType>() * weighting;
+
+                return frame::getCharge<typename T_Particle::FrameType>() * weighting;
             }
 
         } // namespace attribute


### PR DESCRIPTION
With #447 and #4464 the erro is introduced

```
picongpu/fields/currentDeposition/relayPoint.hpp(66): warning #940-D: missing return statement at end of non-void function "picongpu::currentSolver::relayPoint<isEvenSupport>(int &, int &, picongpu::float_X, picongpu::float_X) [with isEvenSupport=false]"
          detected during:
            instantiation of "picongpu::float_X picongpu::currentSolver::relayPoint<isEvenSupport>(int &, int &, picongpu::float_X, picongpu::float_X) [with isEvenSupport=false]"
```

This is a compiler bug because the CI passed and in an `if (bool) ... else` there is always an code path with a return statement.

Software version sued:
- CUDA 11.6.2
- g++ 9.4
- boost 1.75.0