### PR TITLE
refactor `math::Vector`, use unsigned dimension

### DIFF
--- a/include/picongpu/fields/background/templates/TWTS/RotateField.tpp
+++ b/include/picongpu/fields/background/templates/TWTS/RotateField.tpp
@@ -37,9 +37,9 @@ namespace picongpu
                 struct RotateField;
 
                 template<typename T_Type, typename T_AngleType>
-                struct RotateField<pmacc::math::Vector<T_Type, 3>, T_AngleType>
+                struct RotateField<pmacc::math::Vector<T_Type, 3u>, T_AngleType>
                 {
-                    using result = pmacc::math::Vector<T_Type, 3>;
+                    using result = pmacc::math::Vector<T_Type, 3u>;
                     using AngleType = T_AngleType;
                     HDINLINE result operator()(const result& fieldPosVector, const AngleType phi) const
                     {
@@ -60,9 +60,9 @@ namespace picongpu
                 };
 
                 template<typename T_Type, typename T_AngleType>
-                struct RotateField<pmacc::math::Vector<T_Type, 2>, T_AngleType>
+                struct RotateField<pmacc::math::Vector<T_Type, 2u>, T_AngleType>
                 {
-                    using result = pmacc::math::Vector<T_Type, 2>;
+                    using result = pmacc::math::Vector<T_Type, 2u>;
                     using AngleType = T_AngleType;
                     HDINLINE result operator()(const result& fieldPosVector, const AngleType phi) const
                     {

--- a/include/picongpu/fields/background/templates/twtsfast/RotateField.tpp
+++ b/include/picongpu/fields/background/templates/twtsfast/RotateField.tpp
@@ -37,9 +37,9 @@ namespace picongpu
                 struct RotateField;
 
                 template<typename T_Type, typename T_AngleType>
-                struct RotateField<pmacc::math::Vector<T_Type, 3>, T_AngleType>
+                struct RotateField<pmacc::math::Vector<T_Type, 3u>, T_AngleType>
                 {
-                    using result = pmacc::math::Vector<T_Type, 3>;
+                    using result = pmacc::math::Vector<T_Type, 3u>;
                     using AngleType = T_AngleType;
                     HDINLINE result operator()(result const& fieldPosVector, AngleType const phi) const
                     {
@@ -61,9 +61,9 @@ namespace picongpu
                 };
 
                 template<typename T_Type, typename T_AngleType>
-                struct RotateField<pmacc::math::Vector<T_Type, 2>, T_AngleType>
+                struct RotateField<pmacc::math::Vector<T_Type, 2u>, T_AngleType>
                 {
-                    using result = pmacc::math::Vector<T_Type, 2>;
+                    using result = pmacc::math::Vector<T_Type, 2u>;
                     using AngleType = T_AngleType;
                     HDINLINE result operator()(result const& fieldPosVector, AngleType const phi) const
                     {

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -147,7 +147,7 @@ namespace picongpu
                     HDINLINE void operator()(
                         pmacc::DataSpace<simDim> const& beginGridIdx,
                         pmacc::DataSpace<simDim> const& updatedGridIdx,
-                        pmacc::math::Vector<bool, 3> const& isLastUpdatedCell) const
+                        pmacc::math::Vector<bool, 3u> const& isLastUpdatedCell) const
                     {
                         // Determine Huygens surface position for the current updatedField value
                         auto huygensSurfaceIdx = updatedGridIdx;
@@ -298,7 +298,7 @@ namespace picongpu
                         int32_t updatedFieldShift,
                         floatD_X const& incidentFieldShift1,
                         floatD_X const& incidentFieldShift2,
-                        pmacc::math::Vector<bool, 3> const& isLastUpdatedCell) const
+                        pmacc::math::Vector<bool, 3u> const& isLastUpdatedCell) const
                     {
                         auto result = float3_X::create(0.0_X);
                         auto incidentIdxShift = float3_X::create(0.0_X);
@@ -468,7 +468,7 @@ namespace picongpu
                                  * this information here.
                                  */
                                 bool isInside = true;
-                                auto isLastUpdatedCell = pmacc::math::Vector<bool, 3>::create(false);
+                                auto isLastUpdatedCell = pmacc::math::Vector<bool, 3u>::create(false);
                                 for(uint32_t d = 0; d < simDim; d++)
                                 {
                                     isInside = isInside && (updatedGridIdx[d] < endGridIdx[d]);

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -165,7 +165,7 @@ namespace picongpu
         if(relDirType == 1u)
         {
             // x, y, z, edge, corner
-            pmacc::math::Vector<uint32_t, 3> requiredMem(
+            pmacc::math::Vector<uint32_t, 3u> requiredMem(
                 ExchangeMemCfg::BYTES_EXCHANGE_X,
                 ExchangeMemCfg::BYTES_EXCHANGE_Y,
                 ExchangeMemCfg::BYTES_EXCHANGE_Z);

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -115,7 +115,7 @@ namespace picongpu
          *
          * NOTE: This functor uses a Yee-cell stencil.
          */
-        template<int dim, typename ValueType>
+        template<uint32_t dim, typename ValueType>
         struct Div;
 
         template<typename ValueType>

--- a/include/picongpu/unitless/precision.unitless
+++ b/include/picongpu/unitless/precision.unitless
@@ -30,9 +30,9 @@ namespace picongpu
     {
         using float_X = precisionType;
         /* 32 Bit defines */
-        using float1_X = ::pmacc::math::Vector<float_X, 1>;
-        using float2_X = ::pmacc::math::Vector<float_X, 2>;
-        using float3_X = ::pmacc::math::Vector<float_X, 3>;
+        using float1_X = ::pmacc::math::Vector<float_X, 1u>;
+        using float2_X = ::pmacc::math::Vector<float_X, 2u>;
+        using float3_X = ::pmacc::math::Vector<float_X, 3u>;
         using floatD_X = ::pmacc::math::Vector<float_X, simDim>;
     } // namespace precision32Bit
 
@@ -40,9 +40,9 @@ namespace picongpu
     {
         using float_X = precisionType;
         /* 64 Bit defines */
-        using float1_X = ::pmacc::math::Vector<float_X, 1>;
-        using float2_X = ::pmacc::math::Vector<float_X, 2>;
-        using float3_X = ::pmacc::math::Vector<float_X, 3>;
+        using float1_X = ::pmacc::math::Vector<float_X, 1u>;
+        using float2_X = ::pmacc::math::Vector<float_X, 2u>;
+        using float3_X = ::pmacc::math::Vector<float_X, 3u>;
         using floatD_X = ::pmacc::math::Vector<float_X, simDim>;
     } // namespace precision64Bit
 
@@ -50,9 +50,9 @@ namespace picongpu
     using float_64 = precision64Bit::float_X;
 
     /* variable precision defines */
-    using float1_X = ::pmacc::math::Vector<float_X, 1>;
-    using float2_X = ::pmacc::math::Vector<float_X, 2>;
-    using float3_X = ::pmacc::math::Vector<float_X, 3>;
+    using float1_X = ::pmacc::math::Vector<float_X, 1u>;
+    using float2_X = ::pmacc::math::Vector<float_X, 2u>;
+    using float3_X = ::pmacc::math::Vector<float_X, 3u>;
     using floatD_X = ::pmacc::math::Vector<float_X, simDim>;
     /* 32 Bit defines */
     using float1_32 = precision32Bit::float1_X;

--- a/include/picongpu/unitless/speciesAttributes.unitless
+++ b/include/picongpu/unitless/speciesAttributes.unitless
@@ -600,7 +600,7 @@ namespace picongpu
             {
                 // dataType is actual Type of this Object
                 using DataType = typename T_Type::type;
-                constexpr int dim = DataType::dim;
+                constexpr uint32_t dim = DataType::dim;
                 return std::vector<double>(dim, 1.0);
             }
         };

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -28,19 +28,19 @@
 namespace pmacc
 {
     /**
-     * A T_Dim-dimensional data space.
+     * A T_dim-dimensional data space.
      *
-     * DataSpace describes a T_Dim-dimensional data space with a specific size for each dimension.
+     * DataSpace describes a T_dim-dimensional data space with a specific size for each dimension.
      * It only describes the space and does not hold any actual data.
      *
-     * @tparam T_Dim dimension (1-3) of the dataspace
+     * @tparam T_dim dimension (1-3) of the dataspace
      */
-    template<unsigned T_Dim>
-    class DataSpace : public math::Vector<int, T_Dim>
+    template<unsigned T_dim>
+    class DataSpace : public math::Vector<int, T_dim>
     {
     public:
-        static constexpr int Dim = T_Dim;
-        using BaseType = math::Vector<int, T_Dim>;
+        static constexpr uint32_t Dim = T_dim;
+        using BaseType = math::Vector<int, T_dim>;
 
         /**
          * default constructor.
@@ -48,7 +48,7 @@ namespace pmacc
          */
         HDINLINE DataSpace()
         {
-            for(uint32_t i = 0; i < T_Dim; ++i)
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 (*this)[i] = 0;
             }
@@ -64,7 +64,7 @@ namespace pmacc
          */
         HDINLINE explicit DataSpace(cupla::dim3 value)
         {
-            for(uint32_t i = 0; i < T_Dim; ++i)
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 (*this)[i] = *(&(value.x) + i);
             }
@@ -76,7 +76,7 @@ namespace pmacc
          */
         HDINLINE DataSpace(cupla::uint3 value)
         {
-            for(uint32_t i = 0; i < T_Dim; ++i)
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 (*this)[i] = *(&(value.x) + i);
             }
@@ -116,9 +116,9 @@ namespace pmacc
         {
         }
 
-        HDINLINE DataSpace(const math::Size_t<T_Dim>& vec)
+        HDINLINE DataSpace(const math::Size_t<T_dim>& vec)
         {
-            for(uint32_t i = 0; i < T_Dim; ++i)
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 (*this)[i] = vec[i];
             }
@@ -130,10 +130,10 @@ namespace pmacc
          * @param value value which is setfor all dimensions
          * @return the new DataSpace
          */
-        HDINLINE static DataSpace<T_Dim> create(int value = 1)
+        HDINLINE static DataSpace<T_dim> create(int value = 1)
         {
-            DataSpace<T_Dim> tmp;
-            for(uint32_t i = 0; i < T_Dim; ++i)
+            DataSpace<T_dim> tmp;
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 tmp[i] = value;
             }
@@ -141,13 +141,13 @@ namespace pmacc
         }
 
         /**
-         * Returns number of dimensions (T_Dim) of this DataSpace.
+         * Returns number of dimensions (T_dim) of this DataSpace.
          *
          * @return number of dimensions
          */
         HDINLINE int getDim() const
         {
-            return T_Dim;
+            return T_dim;
         }
 
         /**
@@ -156,9 +156,9 @@ namespace pmacc
          * @param other DataSpace to compare with
          * @return true if one dimension is greater, false otherwise
          */
-        HINLINE bool isOneDimensionGreaterThan(const DataSpace<T_Dim>& other) const
+        HINLINE bool isOneDimensionGreaterThan(const DataSpace<T_dim>& other) const
         {
-            for(uint32_t i = 0; i < T_Dim; ++i)
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 if((*this)[i] > other[i])
                     return true;
@@ -166,10 +166,10 @@ namespace pmacc
             return false;
         }
 
-        HDINLINE operator math::Size_t<T_Dim>() const
+        HDINLINE operator math::Size_t<T_dim>() const
         {
-            math::Size_t<T_Dim> result;
-            for(uint32_t i = 0; i < T_Dim; i++)
+            math::Size_t<T_dim> result;
+            for(uint32_t i = 0; i < T_dim; i++)
                 result[i] = static_cast<size_t>((*this)[i]);
             return result;
         }

--- a/include/pmacc/dimensions/DataSpace.tpp
+++ b/include/pmacc/dimensions/DataSpace.tpp
@@ -33,17 +33,17 @@ namespace pmacc
 {
     namespace traits
     {
-        template<unsigned DIM>
-        struct GetComponentsType<DataSpace<DIM>, false>
+        template<unsigned T_dim>
+        struct GetComponentsType<DataSpace<T_dim>, false>
         {
-            using type = typename DataSpace<DIM>::type;
+            using type = typename DataSpace<T_dim>::type;
         };
 
         /** Trait for float_X */
-        template<unsigned DIM>
-        struct GetNComponents<DataSpace<DIM>, false>
+        template<unsigned T_dim>
+        struct GetNComponents<DataSpace<T_dim>, false>
         {
-            static constexpr uint32_t value = DIM;
+            static constexpr uint32_t value = T_dim;
         };
 
     } // namespace traits

--- a/include/pmacc/fields/operations/AddExchangeToBorder.hpp
+++ b/include/pmacc/fields/operations/AddExchangeToBorder.hpp
@@ -76,7 +76,7 @@ namespace pmacc
 
                     // number of cells in a superCell
                     constexpr uint32_t numCells = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    PMACC_CONSTEXPR_CAPTURE int dim = T_Mapping::Dim;
+                    PMACC_CONSTEXPR_CAPTURE uint32_t dim = T_Mapping::Dim;
 
                     DataSpace<dim> const blockCell(
                         mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())))
@@ -160,7 +160,7 @@ namespace pmacc
 
                     using SuperCellSize = T_SuperCellSize;
 
-                    constexpr int dim = T_SuperCellSize::dim;
+                    constexpr uint32_t dim = T_SuperCellSize::dim;
 
                     using MappingDesc = MappingDescription<dim, SuperCellSize>;
 

--- a/include/pmacc/fields/operations/CopyGuardToExchange.hpp
+++ b/include/pmacc/fields/operations/CopyGuardToExchange.hpp
@@ -73,7 +73,7 @@ namespace pmacc
 
                     // number of cells in a superCell
                     constexpr uint32_t numCells = pmacc::math::CT::volume<SuperCellSize>::type::value;
-                    PMACC_CONSTEXPR_CAPTURE int dim = T_Mapping::Dim;
+                    PMACC_CONSTEXPR_CAPTURE uint32_t dim = T_Mapping::Dim;
 
                     DataSpace<dim> const blockCell(
                         mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())))
@@ -151,7 +151,7 @@ namespace pmacc
 
                     using SuperCellSize = T_SuperCellSize;
 
-                    constexpr int dim = T_SuperCellSize::dim;
+                    constexpr uint32_t dim = T_SuperCellSize::dim;
 
                     using MappingDesc = MappingDescription<dim, SuperCellSize>;
 

--- a/include/pmacc/kernel/operation/Atomic.hpp
+++ b/include/pmacc/kernel/operation/Atomic.hpp
@@ -50,7 +50,7 @@ namespace pmacc
                 template<
                     typename T_Worker,
                     typename T_Type,
-                    int T_dim,
+                    uint32_t T_dim,
                     typename T_DstAccessor,
                     typename T_DstNavigator,
                     typename T_DstStorage,
@@ -62,7 +62,7 @@ namespace pmacc
                     pmacc::math::Vector<T_Type, T_dim, T_DstAccessor, T_DstNavigator, T_DstStorage>& dst,
                     pmacc::math::Vector<T_Type, T_dim, T_SrcAccessor, T_SrcNavigator, T_SrcStorage> const& src) const
                 {
-                    for(int i = 0; i < T_dim; ++i)
+                    for(uint32_t i = 0; i < T_dim; ++i)
                         atomicOpNoRet<T_AlpakaOperation>(worker, &dst[i], src[i], T_AlpakaHierarchy{});
                 }
             };

--- a/include/pmacc/math/ConstVector.hpp
+++ b/include/pmacc/math/ConstVector.hpp
@@ -87,7 +87,7 @@
         } /* namespace pmacc_static_const_vector_host + id  */                                                        \
         /* select host or device namespace depending on __CUDA_ARCH__ compiler flag*/                                 \
         PMACC_USING_STATIC_CONST_VECTOR_NAMESPACE(id);                                                                \
-        template<typename T_Type, int T_Dim>                                                                          \
+        template<typename T_Type, uint32_t T_dim>                                                                     \
         struct ConstArrayStorage                                                                                      \
         {                                                                                                             \
             PMACC_CASSERT_MSG(                                                                                        \
@@ -95,7 +95,7 @@
                 Dim <= count);                                                                                        \
             static constexpr bool isConst = true;                                                                     \
             typedef T_Type type;                                                                                      \
-            static constexpr int dim = T_Dim;                                                                         \
+            static constexpr uint32_t dim = T_dim;                                                                    \
                                                                                                                       \
             HDINLINE const type& operator[](const int idx) const                                                      \
             {                                                                                                         \

--- a/include/pmacc/math/vector/Float.hpp
+++ b/include/pmacc/math/vector/Float.hpp
@@ -27,7 +27,7 @@ namespace pmacc
 {
     namespace math
     {
-        template<int dim>
+        template<uint32_t dim>
         using Float = Vector<float, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/Int.hpp
+++ b/include/pmacc/math/vector/Int.hpp
@@ -27,7 +27,7 @@ namespace pmacc
 {
     namespace math
     {
-        template<int dim>
+        template<uint32_t dim>
         using Int = Vector<int, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/Size_t.hpp
+++ b/include/pmacc/math/vector/Size_t.hpp
@@ -27,7 +27,7 @@ namespace pmacc
 {
     namespace math
     {
-        template<int dim>
+        template<uint32_t dim>
         using Size_t = Vector<size_t, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -40,15 +40,15 @@ namespace pmacc
             template<
                 typename T_Axes,
                 typename T_Type,
-                int T_Dim,
+                uint32_t T_dim,
                 typename T_Accessor,
                 typename T_Navigator,
                 typename T_Storage>
-            struct TwistComponents<T_Axes, math::Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>>
+            struct TwistComponents<T_Axes, math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
             {
                 using type = math::Vector<
                     T_Type,
-                    T_Dim,
+                    T_dim,
                     T_Accessor,
                     math::StackedNavigator<T_Navigator, math::PermutedNavigator<T_Axes>>,
                     T_Storage>&;

--- a/include/pmacc/math/vector/UInt32.hpp
+++ b/include/pmacc/math/vector/UInt32.hpp
@@ -27,7 +27,7 @@ namespace pmacc
 {
     namespace math
     {
-        template<int dim>
+        template<uint32_t dim>
         using UInt32 = Vector<uint32_t, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/UInt64.hpp
+++ b/include/pmacc/math/vector/UInt64.hpp
@@ -27,7 +27,7 @@ namespace pmacc
 {
     namespace math
     {
-        template<int dim>
+        template<uint32_t dim>
         using UInt64 = Vector<uint64_t, dim>;
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -41,11 +41,11 @@ namespace pmacc
     {
         namespace detail
         {
-            template<typename T_Type, int T_Dim>
+            template<typename T_Type, uint32_t T_dim>
             struct Vector_components
             {
                 static constexpr bool isConst = false;
-                static constexpr int dim = T_Dim;
+                static constexpr uint32_t dim = T_dim;
                 using type = T_Type;
 
                 HDINLINE
@@ -63,13 +63,13 @@ namespace pmacc
                 PMACC_ALIGN(v[dim], type);
 
                 HDINLINE
-                type& operator[](const int idx)
+                type& operator[](const uint32_t idx)
                 {
                     return v[idx];
                 }
 
                 HDINLINE
-                const type& operator[](const int idx) const
+                const type& operator[](const uint32_t idx) const
                 {
                     return v[idx];
                 }
@@ -84,7 +84,7 @@ namespace pmacc
 
         template<
             typename T_Type,
-            int T_dim,
+            uint32_t T_dim,
             typename T_Accessor = StandardAccessor,
             typename T_Navigator = StandardNavigator,
             typename T_Storage = detail::Vector_components<T_Type, T_dim>>
@@ -95,14 +95,14 @@ namespace pmacc
         {
             using Storage = T_Storage;
             using type = typename Storage::type;
-            static constexpr int dim = Storage::dim;
+            static constexpr uint32_t dim = Storage::dim;
             using tag = tag::Vector;
             using Accessor = T_Accessor;
             using Navigator = T_Navigator;
             using ParamType = typename boost::call_traits<type>::param_type;
 
             /*Vectors without elements are not allowed*/
-            PMACC_CASSERT_MSG(math_Vector__with_DIM_0_is_not_allowed, dim > 0);
+            PMACC_CASSERT_MSG(math_Vector__with_DIM_0_is_not_allowed, dim > 0u);
 
             HDINLINE
             constexpr Vector()
@@ -112,14 +112,14 @@ namespace pmacc
             HDINLINE
             constexpr Vector(const type x)
             {
-                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM1, dim == 1);
+                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM1, dim == 1u);
                 (*this)[0] = x;
             }
 
             HDINLINE
             constexpr Vector(const type x, const type y)
             {
-                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM2, dim == 2);
+                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM2, dim == 2u);
                 (*this)[0] = x;
                 (*this)[1] = y;
             }
@@ -127,7 +127,7 @@ namespace pmacc
             HDINLINE
             constexpr Vector(const type x, const type y, const type z)
             {
-                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM3, dim == 3);
+                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM3, dim == 3u);
                 (*this)[0] = x;
                 (*this)[1] = y;
                 (*this)[2] = z;
@@ -140,7 +140,7 @@ namespace pmacc
             HDINLINE Vector(const Vector<T_Type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
                 : Storage{}
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] = other[i];
             }
 
@@ -152,12 +152,12 @@ namespace pmacc
             HDINLINE explicit Vector(
                 const Vector<T_OtherType, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] = static_cast<type>(other[i]);
             }
 
             /** Allow static_cast / explicit cast to member type for 1D vector */
-            template<int T_deferDim = T_dim, typename = typename std::enable_if<T_deferDim == 1>::type>
+            template<uint32_t T_deferDim = T_dim, typename = typename std::enable_if<T_deferDim == 1u>::type>
             HDINLINE explicit operator type()
             {
                 return (*this)[0];
@@ -173,7 +173,7 @@ namespace pmacc
             static Vector create(ParamType value)
             {
                 Vector result;
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     result[i] = value;
 
                 return result;
@@ -192,7 +192,7 @@ namespace pmacc
             HDINLINE Vector revert()
             {
                 Vector invertedVector;
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     invertedVector[dim - 1 - i] = (*this)[i];
 
                 return invertedVector;
@@ -203,19 +203,19 @@ namespace pmacc
             template<typename T_OtherAccessor, typename T_OtherNavigator, typename T_OtherStorage>
             HDINLINE Vector& operator=(const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] = rhs[i];
                 return *this;
             }
 
             HDINLINE
-            type& operator[](const int idx)
+            type& operator[](const uint32_t idx)
             {
                 return Accessor::operator()(Storage::operator[](Navigator::operator()(idx)));
             }
 
             HDINLINE
-            const type& operator[](const int idx) const
+            const type& operator[](const uint32_t idx) const
             {
                 return Accessor::operator()(Storage::operator[](Navigator::operator()(idx)));
             }
@@ -227,13 +227,13 @@ namespace pmacc
 
             HDINLINE type& y()
             {
-                PMACC_CASSERT_MSG(math_Vector__access_to_y_is_not_allowed_for_DIM_lesser_than_2, dim >= 2);
+                PMACC_CASSERT_MSG(math_Vector__access_to_y_is_not_allowed_for_DIM_lesser_than_2, dim >= 2u);
                 return (*this)[1];
             }
 
             HDINLINE type& z()
             {
-                PMACC_CASSERT_MSG(math_Vector__access_to_z_is_not_allowed_for_DIM_lesser_than_3, dim >= 3);
+                PMACC_CASSERT_MSG(math_Vector__access_to_z_is_not_allowed_for_DIM_lesser_than_3, dim >= 3u);
                 return (*this)[2];
             }
 
@@ -244,24 +244,24 @@ namespace pmacc
 
             HDINLINE const type& y() const
             {
-                PMACC_CASSERT_MSG(math_Vector__access_to_y_is_not_allowed_for_DIM_lesser_than_2, dim >= 2);
+                PMACC_CASSERT_MSG(math_Vector__access_to_y_is_not_allowed_for_DIM_lesser_than_2, dim >= 2u);
                 return (*this)[1];
             }
 
             HDINLINE const type& z() const
             {
-                PMACC_CASSERT_MSG(math_Vector__access_to_z_is_not_allowed_for_DIM_lesser_than_3, dim >= 3);
+                PMACC_CASSERT_MSG(math_Vector__access_to_z_is_not_allowed_for_DIM_lesser_than_3, dim >= 3u);
                 return (*this)[2];
             }
 
-            template<int shrinkedDim>
+            template<uint32_t shrinkedDim>
             HDINLINE Vector<type, shrinkedDim, Accessor, Navigator> shrink(const int startIdx = 0) const
             {
                 PMACC_CASSERT_MSG(
                     math_Vector__shrinkedDim_DIM_must_be_lesser_or_equal_to_Vector_DIM,
                     shrinkedDim <= dim);
                 Vector<type, shrinkedDim, Accessor, Navigator> result;
-                for(int i = 0; i < shrinkedDim; i++)
+                for(uint32_t i = 0u; i < shrinkedDim; i++)
                     result[i] = (*this)[(startIdx + i) % dim];
                 return result;
             }
@@ -273,13 +273,13 @@ namespace pmacc
              * @tparam dimToRemove index which shall be removed; range: [ 0; dim - 1 ]
              * @return vector with `dim - 1` elements
              */
-            template<int dimToRemove>
+            template<uint32_t dimToRemove>
             HDINLINE Vector<type, dim - 1, Accessor, Navigator> remove() const
             {
-                PMACC_CASSERT_MSG(__math_Vector__dim_must_be_greater_than_1__, dim > 1);
+                PMACC_CASSERT_MSG(__math_Vector__dim_must_be_greater_than_1__, dim > 1u);
                 PMACC_CASSERT_MSG(__math_Vector__dimToRemove_must_be_lesser_than_dim__, dimToRemove < dim);
                 Vector<type, dim - 1, Accessor, Navigator> result;
-                for(int i = 0; i < dim - 1; ++i)
+                for(uint32_t i = 0u; i < dim - 1; ++i)
                 {
                     // skip component which must be deleted
                     const int sourceIdx = i >= dimToRemove ? i + 1 : i;
@@ -295,7 +295,7 @@ namespace pmacc
             HDINLINE type productOfComponents() const
             {
                 type result = (*this)[0];
-                for(int i = 1; i < dim; i++)
+                for(uint32_t i = 1u; i < dim; i++)
                     result *= (*this)[i];
                 return result;
             }
@@ -307,7 +307,7 @@ namespace pmacc
             HDINLINE type sumOfComponents() const
             {
                 type result = (*this)[0];
-                for(int i = 1; i < dim; i++)
+                for(uint32_t i = 1u; i < dim; i++)
                     result += (*this)[i];
                 return result;
             }
@@ -320,7 +320,7 @@ namespace pmacc
             HDINLINE Vector& operator+=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] += other[i];
                 return *this;
             }
@@ -333,7 +333,7 @@ namespace pmacc
             HDINLINE Vector& operator-=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] -= other[i];
                 return *this;
             }
@@ -346,7 +346,7 @@ namespace pmacc
             HDINLINE Vector& operator*=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] *= other[i];
                 return *this;
             }
@@ -359,35 +359,35 @@ namespace pmacc
             HDINLINE Vector& operator/=(
                 const Vector<type, dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] /= other[i];
                 return *this;
             }
 
             HDINLINE Vector& operator+=(ParamType other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] += other;
                 return *this;
             }
 
             HDINLINE Vector& operator-=(ParamType other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] -= other;
                 return *this;
             }
 
             HDINLINE Vector& operator*=(ParamType other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] *= other;
                 return *this;
             }
 
             HDINLINE Vector& operator/=(ParamType other)
             {
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     (*this)[i] /= other;
                 return *this;
             }
@@ -403,7 +403,7 @@ namespace pmacc
             HDINLINE bool operator==(const Vector& rhs) const
             {
                 bool result = true;
-                for(int i = 0; i < dim; i++)
+                for(uint32_t i = 0u; i < dim; i++)
                     result = result && ((*this)[i] == rhs[i]);
                 return result;
             }
@@ -450,7 +450,7 @@ namespace pmacc
                 std::stringstream stream;
                 stream << locale_enclosing_begin << (*this)[0];
 
-                for(int i = 1; i < dim; ++i)
+                for(uint32_t i = 1u; i < dim; ++i)
                     stream << separator << (*this)[i];
                 stream << locale_enclosing_end;
                 return stream.str();
@@ -460,7 +460,7 @@ namespace pmacc
             {
                 cupla::dim3 result;
                 unsigned int* ptr = &result.x;
-                for(int d = 0; d < dim; ++d)
+                for(uint32_t d = 0u; d < dim; ++d)
                     ptr[d] = (*this)[d];
                 return result;
             }
@@ -469,7 +469,7 @@ namespace pmacc
         template<
             std::size_t I,
             typename T_Type,
-            int T_dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage>
@@ -481,7 +481,7 @@ namespace pmacc
         template<
             std::size_t I,
             typename T_Type,
-            int T_dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage>
@@ -494,7 +494,7 @@ namespace pmacc
         struct Vector<Type, 0>
         {
             using type = Type;
-            static constexpr int dim = 0;
+            static constexpr uint32_t dim = 0;
 
             template<typename OtherType>
             HDINLINE operator Vector<OtherType, 0>() const
@@ -532,7 +532,7 @@ namespace pmacc
             }
         };
 
-        template<typename Type, int dim, typename Accessor, typename Navigator>
+        template<typename Type, uint32_t dim, typename Accessor, typename Navigator>
         std::ostream& operator<<(std::ostream& s, const Vector<Type, dim, Accessor, Navigator>& vec)
         {
             return s << vec.toString();
@@ -540,173 +540,173 @@ namespace pmacc
 
         template<
             typename T_Type,
-            int T_Dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
             typename T_OtherStorage>
-        HDINLINE Vector<T_Type, T_Dim> operator+(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
+        HDINLINE Vector<T_Type, T_dim> operator+(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            const Vector<T_Type, T_dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result += rhs;
             return result;
         }
 
-        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
-        HDINLINE Vector<T_Type, T_Dim> operator+(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        HDINLINE Vector<T_Type, T_dim> operator+(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            typename Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result += rhs;
             return result;
         }
 
         template<
             typename T_Type,
-            int T_Dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
             typename T_OtherStorage>
-        HDINLINE Vector<T_Type, T_Dim> operator-(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
+        HDINLINE Vector<T_Type, T_dim> operator-(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            const Vector<T_Type, T_dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result -= rhs;
             return result;
         }
 
-        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
-        HDINLINE Vector<T_Type, T_Dim> operator-(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        HDINLINE Vector<T_Type, T_dim> operator-(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            typename Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result -= rhs;
             return result;
         }
 
         template<
             typename T_Type,
-            int T_Dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
             typename T_OtherStorage>
-        HDINLINE Vector<T_Type, T_Dim> operator*(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
+        HDINLINE Vector<T_Type, T_dim> operator*(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            const Vector<T_Type, T_dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result *= rhs;
             return result;
         }
 
         template<
             typename T_Type,
-            int T_Dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
             typename T_OtherStorage>
-        HDINLINE Vector<T_Type, T_Dim> operator/(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
+        HDINLINE Vector<T_Type, T_dim> operator/(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            const Vector<T_Type, T_dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result /= rhs;
             return result;
         }
 
-        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
-        HDINLINE Vector<T_Type, T_Dim> operator*(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        HDINLINE Vector<T_Type, T_dim> operator*(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            typename Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result *= rhs;
             return result;
         }
 
-        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
-        HDINLINE Vector<T_Type, T_Dim> operator*(
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        HDINLINE Vector<T_Type, T_dim> operator*(
             typename boost::call_traits<T_Type>::param_type lhs,
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& rhs)
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(rhs);
+            Vector<T_Type, T_dim> result(rhs);
             result *= lhs;
             return result;
         }
 
-        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
-        HDINLINE Vector<T_Type, T_Dim> operator/(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            typename Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        HDINLINE Vector<T_Type, T_dim> operator/(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            typename Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>::ParamType rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(lhs);
+            Vector<T_Type, T_dim> result(lhs);
             result /= rhs;
             return result;
         }
 
-        template<typename T_Type, int T_Dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
-        HDINLINE Vector<T_Type, T_Dim> operator-(const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& vec)
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        HDINLINE Vector<T_Type, T_dim> operator-(const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& vec)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<T_Type, T_Dim> result(vec);
+            Vector<T_Type, T_dim> result(vec);
 
-            for(int i = 0; i < T_Dim; i++)
+            for(uint32_t i = 0u; i < T_dim; i++)
                 result[i] = -result[i];
             return result;
         }
 
         template<
             typename T_Type,
-            int T_Dim,
+            uint32_t T_dim,
             typename T_Accessor,
             typename T_Navigator,
             typename T_Storage,
             typename T_OtherAccessor,
             typename T_OtherNavigator,
             typename T_OtherStorage>
-        HDINLINE Vector<bool, T_Dim> operator>=(
-            const Vector<T_Type, T_Dim, T_Accessor, T_Navigator, T_Storage>& lhs,
-            const Vector<T_Type, T_Dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
+        HDINLINE Vector<bool, T_dim> operator>=(
+            const Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>& lhs,
+            const Vector<T_Type, T_dim, T_OtherAccessor, T_OtherNavigator, T_OtherStorage>& rhs)
         {
             /* to avoid allocation side effects the result is always a vector
              * with default policies*/
-            Vector<bool, T_Dim> result;
-            for(int i = 0; i < T_Dim; ++i)
+            Vector<bool, T_dim> result;
+            for(uint32_t i = 0u; i < T_dim; ++i)
                 result[i] = (lhs[i] >= rhs[i]);
             return result;
         }
@@ -747,14 +747,14 @@ namespace pmacc
         {
             Lhs result;
 
-            for(int i = 0; i < Lhs::dim; i++)
+            for(uint32_t i = 0u; i < Lhs::dim; i++)
                 result[i] = lhs[i] % rhs[i];
             return result;
         }
 
         struct Abs
         {
-            template<typename Type, int dim>
+            template<typename Type, uint32_t dim>
             HDINLINE Type operator()(const Vector<Type, dim>& vec)
             {
                 return cupla::math::abs(vec);
@@ -778,13 +778,19 @@ namespace pmacc
 
 namespace std
 {
-    template<typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+    template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
     struct tuple_size<pmacc::math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
     {
         static constexpr std::size_t value = T_dim;
     };
 
-    template<std::size_t I, typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+    template<
+        std::size_t I,
+        typename T_Type,
+        uint32_t T_dim,
+        typename T_Accessor,
+        typename T_Navigator,
+        typename T_Storage>
     struct tuple_element<I, pmacc::math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
     {
         using type = T_Type;

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -41,19 +41,19 @@ namespace pmacc
 {
     namespace traits
     {
-        template<typename T_DataType, int T_Dim>
-        struct GetComponentsType<pmacc::math::Vector<T_DataType, T_Dim>, false>
+        template<typename T_DataType, uint32_t T_dim>
+        struct GetComponentsType<pmacc::math::Vector<T_DataType, T_dim>, false>
         {
-            using type = typename pmacc::math::Vector<T_DataType, T_Dim>::type;
+            using type = typename pmacc::math::Vector<T_DataType, T_dim>::type;
         };
 
-        template<typename T_DataType, int T_Dim>
-        struct GetNComponents<pmacc::math::Vector<T_DataType, T_Dim>, false>
+        template<typename T_DataType, uint32_t T_dim>
+        struct GetNComponents<pmacc::math::Vector<T_DataType, T_dim>, false>
         {
-            static constexpr uint32_t value = (uint32_t) pmacc::math::Vector<T_DataType, T_Dim>::dim;
+            static constexpr uint32_t value = (uint32_t) pmacc::math::Vector<T_DataType, T_dim>::dim;
         };
 
-        template<typename T_Type, int T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+        template<typename T_Type, uint32_t T_dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
         struct GetInitializedInstance<math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
         {
             using Type = math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>;
@@ -90,7 +90,7 @@ namespace pmacc
         };
 
         /*! Specialisation of Dot where base is a vector */
-        template<typename Type, int dim>
+        template<typename Type, uint32_t dim>
         struct Dot<::pmacc::math::Vector<Type, dim>, ::pmacc::math::Vector<Type, dim>>
         {
             using myType = ::pmacc::math::Vector<Type, dim>;
@@ -100,14 +100,14 @@ namespace pmacc
             {
                 PMACC_CASSERT(dim > 0);
                 result tmp = a.x() * b.x();
-                for(int i = 1; i < dim; i++)
+                for(uint32_t i = 1; i < dim; i++)
                     tmp += a[i] * b[i];
                 return tmp;
             }
         };
 
         /*specialize abs2 algorithm*/
-        template<typename Type, int dim>
+        template<typename Type, uint32_t dim>
         struct Abs2<::pmacc::math::Vector<Type, dim>>
         {
             using result = typename ::pmacc::math::Vector<Type, dim>::type;
@@ -115,7 +115,7 @@ namespace pmacc
             HDINLINE result operator()(const ::pmacc::math::Vector<Type, dim>& vector)
             {
                 result tmp = pmacc::math::abs2(vector.x());
-                for(int i = 1; i < dim; ++i)
+                for(uint32_t i = 1; i < dim; ++i)
                     tmp += pmacc::math::abs2(vector[i]);
                 return tmp;
             }
@@ -136,7 +136,7 @@ namespace pmacc
  * errors, therefore the alpaka math trait must be used.
  */
 #define PMACC_UNARY_APAKA_MATH_SPECIALIZATION(functionName, alpakaMathTrait)                                          \
-    template<typename T_Ctx, typename T_ScalarType, int T_dim>                                                        \
+    template<typename T_Ctx, typename T_ScalarType, uint32_t T_dim>                                                   \
     struct alpakaMathTrait<T_Ctx, ::pmacc::math::Vector<T_ScalarType, T_dim>, void>                                   \
     {                                                                                                                 \
         using ResultType = ::pmacc::math::Vector<T_ScalarType, T_dim>;                                                \
@@ -148,7 +148,7 @@ namespace pmacc
             PMACC_CASSERT(T_dim > 0);                                                                                 \
                                                                                                                       \
             ResultType tmp;                                                                                           \
-            for(int i = 0; i < T_dim; ++i)                                                                            \
+            for(uint32_t i = 0; i < T_dim; ++i)                                                                       \
                 tmp[i] = alpaka::math::functionName(mathConcept, vector[i]);                                          \
             return tmp;                                                                                               \
         }                                                                                                             \
@@ -164,7 +164,7 @@ namespace alpaka
              *
              * Create pow separately for every component of the vector.
              */
-            template<typename T_Ctx, typename T_ScalarType, int T_dim>
+            template<typename T_Ctx, typename T_ScalarType, uint32_t T_dim>
             struct Pow<T_Ctx, ::pmacc::math::Vector<T_ScalarType, T_dim>, T_ScalarType, void>
             {
                 using ResultType = typename ::pmacc::math::Vector<T_ScalarType, T_dim>::type;
@@ -176,13 +176,13 @@ namespace alpaka
                 {
                     PMACC_CASSERT(T_dim > 0);
                     ResultType tmp;
-                    for(int i = 0; i < T_dim; ++i)
+                    for(uint32_t i = 0; i < T_dim; ++i)
                         tmp[i] = cupla::pow(vector[i], exponent);
                     return tmp;
                 }
             };
 
-            template<typename T_Ctx, typename T_ScalarType1, typename T_ScalarType2, int T_dim>
+            template<typename T_Ctx, typename T_ScalarType1, typename T_ScalarType2, uint32_t T_dim>
             struct Min<
                 T_Ctx,
                 ::pmacc::math::Vector<T_ScalarType1, T_dim>,
@@ -202,13 +202,13 @@ namespace alpaka
                 {
                     PMACC_CASSERT(T_dim > 0);
                     ResultType tmp;
-                    for(int i = 0; i < T_dim; ++i)
+                    for(uint32_t i = 0; i < T_dim; ++i)
                         tmp[i] = alpaka::math::min(mathConcept, vector1[i], vector2[i]);
                     return tmp;
                 }
             };
 
-            template<typename T_Ctx, typename T_ScalarType1, typename T_ScalarType2, int T_dim>
+            template<typename T_Ctx, typename T_ScalarType1, typename T_ScalarType2, uint32_t T_dim>
             struct Max<
                 T_Ctx,
                 ::pmacc::math::Vector<T_ScalarType1, T_dim>,
@@ -228,7 +228,7 @@ namespace alpaka
                 {
                     PMACC_CASSERT(T_dim > 0);
                     ResultType tmp;
-                    for(int i = 0; i < T_dim; ++i)
+                    for(uint32_t i = 0; i < T_dim; ++i)
                         tmp[i] = alpaka::math::max(mathConcept, vector1[i], vector2[i]);
                     return tmp;
                 }
@@ -245,7 +245,7 @@ namespace alpaka
              * Returns the length of the vector to fit the old implementation.
              * @todo implement a math function magnitude instead of using abs to get the length of the vector.
              */
-            template<typename T_Ctx, typename T_ScalarType, int T_dim>
+            template<typename T_Ctx, typename T_ScalarType, uint32_t T_dim>
             struct Abs<T_Ctx, ::pmacc::math::Vector<T_ScalarType, T_dim>, void>
             {
                 using ResultType = typename ::pmacc::math::Vector<T_ScalarType, T_dim>::type;
@@ -271,7 +271,7 @@ namespace pmacc
     {
         namespace precisionCast
         {
-            template<typename CastToType, int dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
+            template<typename CastToType, uint32_t dim, typename T_Accessor, typename T_Navigator, typename T_Storage>
             struct TypeCast<CastToType, ::pmacc::math::Vector<CastToType, dim, T_Accessor, T_Navigator, T_Storage>>
             {
                 using result = ::pmacc::math::Vector<CastToType, dim>;
@@ -286,7 +286,7 @@ namespace pmacc
             template<
                 typename CastToType,
                 typename OldType,
-                int dim,
+                uint32_t dim,
                 typename T_Accessor,
                 typename T_Navigator,
                 typename T_Storage>
@@ -311,7 +311,7 @@ namespace pmacc
     {
         namespace promoteType
         {
-            template<typename PromoteToType, typename OldType, int dim>
+            template<typename PromoteToType, typename OldType, uint32_t dim>
             struct promoteType<PromoteToType, ::pmacc::math::Vector<OldType, dim>>
             {
                 using PartType = typename promoteType<OldType, PromoteToType>::type;
@@ -328,7 +328,7 @@ namespace pmacc
     {
         namespace def
         {
-            template<int T_dim>
+            template<uint32_t T_dim>
             struct GetMPI_StructAsArray<::pmacc::math::Vector<float, T_dim>>
             {
                 MPI_StructAsArray operator()() const
@@ -337,7 +337,7 @@ namespace pmacc
                 }
             };
 
-            template<int T_dim, int T_N>
+            template<uint32_t T_dim, int T_N>
             struct GetMPI_StructAsArray<::pmacc::math::Vector<float, T_dim>[T_N]>
             {
                 MPI_StructAsArray operator()() const
@@ -346,7 +346,7 @@ namespace pmacc
                 }
             };
 
-            template<int T_dim>
+            template<uint32_t T_dim>
             struct GetMPI_StructAsArray<::pmacc::math::Vector<double, T_dim>>
             {
                 MPI_StructAsArray operator()() const
@@ -355,7 +355,7 @@ namespace pmacc
                 }
             };
 
-            template<int T_dim, int T_N>
+            template<uint32_t T_dim, int T_N>
             struct GetMPI_StructAsArray<::pmacc::math::Vector<double, T_dim>[T_N]>
             {
                 MPI_StructAsArray operator()() const

--- a/include/pmacc/math/vector/compile-time/Float.hpp
+++ b/include/pmacc/math/vector/compile-time/Float.hpp
@@ -40,7 +40,7 @@ namespace pmacc
                 using y = Y;
                 using z = Z;
 
-                static constexpr int dim = 3;
+                static constexpr uint32_t dim = 3u;
             };
 
             template<>
@@ -53,7 +53,7 @@ namespace pmacc
             {
                 using x = X;
 
-                static constexpr int dim = 1;
+                static constexpr uint32_t dim = 1u;
             };
 
             template<typename X, typename Y>
@@ -62,7 +62,7 @@ namespace pmacc
                 using x = X;
                 using y = Y;
 
-                static constexpr int dim = 2u;
+                static constexpr uint32_t dim = 2u;
             };
 
         } // namespace CT

--- a/include/pmacc/math/vector/compile-time/Int.hpp
+++ b/include/pmacc/math/vector/compile-time/Int.hpp
@@ -70,23 +70,23 @@ namespace pmacc
             };
 
 
-            template<int dim, int val>
+            template<uint32_t dim, int val>
             struct make_Int;
 
             template<int val>
-            struct make_Int<1, val>
+            struct make_Int<1u, val>
             {
                 using type = Int<val>;
             };
 
             template<int val>
-            struct make_Int<2, val>
+            struct make_Int<2u, val>
             {
                 using type = Int<val, val>;
             };
 
             template<int val>
-            struct make_Int<3, val>
+            struct make_Int<3u, val>
             {
                 using type = Int<val, val, val>;
             };

--- a/include/pmacc/math/vector/compile-time/TwistComponents.hpp
+++ b/include/pmacc/math/vector/compile-time/TwistComponents.hpp
@@ -40,7 +40,7 @@ namespace pmacc
              * using Orientation_Y = pmacc::math::CT::Int<1,2,0>;
              * using TwistedBlockDim = typename pmacc::math::CT::TwistComponents<BlockDim, Orientation_Y>::type;
              */
-            template<typename Vec, typename Axes, int dim = Vec::dim>
+            template<typename Vec, typename Axes, uint32_t dim = Vec::dim>
             struct TwistComponents;
 
             template<typename Vec, typename Axes>

--- a/include/pmacc/math/vector/compile-time/Vector.hpp
+++ b/include/pmacc/math/vector/compile-time/Vector.hpp
@@ -49,42 +49,42 @@ namespace pmacc
 
             namespace detail
             {
-                template<int dim>
+                template<uint32_t dim>
                 struct VectorFromCT;
 
                 template<>
-                struct VectorFromCT<1>
+                struct VectorFromCT<1u>
                 {
                     template<typename Vec, typename CTVec>
                     HDINLINE void operator()(Vec& vec, CTVec) const
                     {
-                        BOOST_STATIC_ASSERT(Vec::dim == 1);
-                        BOOST_STATIC_ASSERT(CTVec::dim == 1);
+                        BOOST_STATIC_ASSERT(Vec::dim == 1u);
+                        BOOST_STATIC_ASSERT(CTVec::dim == 1u);
                         vec[0] = (typename Vec::type) CTVec::x::value;
                     }
                 };
 
                 template<>
-                struct VectorFromCT<2>
+                struct VectorFromCT<2u>
                 {
                     template<typename Vec, typename CTVec>
                     HDINLINE void operator()(Vec& vec, CTVec) const
                     {
-                        BOOST_STATIC_ASSERT(Vec::dim == 2);
-                        BOOST_STATIC_ASSERT(CTVec::dim == 2);
+                        BOOST_STATIC_ASSERT(Vec::dim == 2u);
+                        BOOST_STATIC_ASSERT(CTVec::dim == 2u);
                         vec[0] = (typename Vec::type) CTVec::x::value;
                         vec[1] = (typename Vec::type) CTVec::y::value;
                     }
                 };
 
                 template<>
-                struct VectorFromCT<3>
+                struct VectorFromCT<3u>
                 {
                     template<typename Vec, typename CTVec>
                     HDINLINE void operator()(Vec& vec, CTVec) const
                     {
-                        BOOST_STATIC_ASSERT(Vec::dim == 3);
-                        BOOST_STATIC_ASSERT(CTVec::dim == 3);
+                        BOOST_STATIC_ASSERT(Vec::dim == 3u);
+                        BOOST_STATIC_ASSERT(CTVec::dim == 3u);
                         vec[0] = (typename Vec::type) CTVec::x::value;
                         vec[1] = (typename Vec::type) CTVec::y::value;
                         vec[2] = (typename Vec::type) CTVec::z::value;
@@ -107,7 +107,7 @@ namespace pmacc
                 template<>
                 struct TypeSelector<mpl::na>
                 {
-                    using type = mpl::int_<0>;
+                    using type = mpl::int_<0u>;
                 };
 
             } // namespace detail
@@ -123,13 +123,13 @@ namespace pmacc
 
                 using mplVector = mpl::vector<x, y, z>;
 
-                template<int element>
+                template<uint32_t element>
                 struct at
                 {
                     using type = typename mpl::at_c<mplVector, element>::type;
                 };
 
-                static constexpr int dim = mpl::size<mplVector>::type::value;
+                static constexpr uint32_t dim = mpl::size<mplVector>::type::value;
 
                 using type = typename detail::TypeSelector<x>::type;
                 using This = Vector<x, y, z>;
@@ -436,7 +436,7 @@ namespace pmacc
              * @tparam T_dim count of components
              * @tparam T_Type type which is assigned to all components
              */
-            template<int T_dim, typename T_Type>
+            template<uint32_t T_dim, typename T_Type>
             struct make_Vector;
 
             template<typename T_Type>
@@ -473,7 +473,7 @@ namespace pmacc
             template<uint32_t T_dim, uint32_t T_direction, typename T_ValueType = int>
             struct make_BasisVector
             {
-                using Zeroes = typename make_Vector<T_dim, bmpl::integral_c<T_ValueType, 0>>::type;
+                using Zeroes = typename make_Vector<T_dim, bmpl::integral_c<T_ValueType, 0u>>::type;
                 using type = typename AssignIfInRange<
                     Zeroes,
                     bmpl::integral_c<size_t, T_direction>,


### PR DESCRIPTION
fix #395

Dimensions in PMacc/PIConGPU are always unsigned, only math::Vector, math::CT::Vector and math::ConstVector broke this.

- use `uint32_t` for the number of dimensions

- [x] rebase against #4501 