### PR TITLE
remove dependency to `boost::math`

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -71,8 +71,8 @@ MPI 2.3+
 
 Boost
 """""
-- 1.74.0+ (``program_options``, ``filesystem``, ``system``, ``math``, ``serialization`` and header-only libs)
-- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-math-dev libboost-serialization-dev``
+- 1.74.0+ (``program_options``, ``filesystem``, ``system``, ``serialization`` and header-only libs)
+- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-serialization-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*
@@ -82,7 +82,7 @@ Boost
   - ``curl -Lo boost_1_74_0.tar.gz https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz``
   - ``tar -xzf boost_1_74_0.tar.gz``
   - ``cd boost_1_74_0``
-  - ``./bootstrap.sh --with-libraries=filesystem,math,program_options,serialization,system --prefix=$HOME/lib/boost``
+  - ``./bootstrap.sh --with-libraries=filesystem,program_options,serialization,system --prefix=$HOME/lib/boost``
   - ``./b2 cxxflags="-std=c++17" -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -182,11 +182,10 @@ endif()
 ################################################################################
 
 find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options filesystem
-                                              system math_tr1 serialization)
+                                              system serialization)
 if(TARGET Boost::program_options)
     set(HOST_LIBS ${HOST_LIBS} Boost::boost Boost::program_options
-                     Boost::filesystem Boost::system Boost::math_tr1
-                     Boost::serialization)
+                     Boost::filesystem Boost::system Boost::serialization)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     set(HOST_LIBS ${HOST_LIBS} ${Boost_LIBRARIES})

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -287,12 +287,11 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.74 REQUIRED COMPONENTS filesystem system math_tr1 program_options)
+find_package(Boost 1.74 REQUIRED COMPONENTS filesystem system program_options)
 if(TARGET Boost::filesystem)
     target_link_libraries(pmacc PUBLIC Boost::boost)
     target_link_libraries(pmacc PUBLIC Boost::filesystem)
     target_link_libraries(pmacc PUBLIC Boost::system)
-    target_link_libraries(pmacc PUBLIC Boost::math_tr1)
     target_link_libraries(pmacc PUBLIC Boost::program_options)
 else()
     target_include_directories(pmacc PUBLIC ${Boost_INCLUDE_DIRS})

--- a/include/pmacc/algorithms/math/doubleMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/bessel.tpp
@@ -23,7 +23,7 @@
 
 #include "pmacc/types.hpp"
 
-#include <boost/math/special_functions/bessel.hpp>
+#include <cmath>
 
 
 namespace pmacc
@@ -42,7 +42,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::cyl_bessel_i0(x);
 #else
-                    return boost::math::cyl_bessel_i(0, x);
+                    return std::cyl_bessel_i(0, x);
 #endif
                 }
             };
@@ -57,7 +57,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::cyl_bessel_i1(x);
 #else
-                    return boost::math::cyl_bessel_i(1, x);
+                    return std::cyl_bessel_i(1, x);
 #endif
                 }
             };
@@ -72,7 +72,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::j0(x);
 #else
-                    return boost::math::cyl_bessel_j(0, x);
+                    return std::cyl_bessel_j(0, x);
 #endif
                 }
             };
@@ -87,7 +87,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::j1(x);
 #else
-                    return boost::math::cyl_bessel_j(1, x);
+                    return std::cyl_bessel_j(1, x);
 #endif
                 }
             };
@@ -102,7 +102,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::jn(n, x);
 #else
-                    return boost::math::cyl_bessel_j(n, x);
+                    return std::cyl_bessel_j(n, x);
 #endif
                 }
             };
@@ -117,7 +117,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::y0(x);
 #else
-                    return boost::math::cyl_neumann(0, x);
+                    return std::cyl_neumann(0, x);
 #endif
                 }
             };
@@ -132,7 +132,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::y1(x);
 #else
-                    return boost::math::cyl_neumann(1, x);
+                    return std::cyl_neumann(1, x);
 #endif
                 }
             };
@@ -147,7 +147,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::yn(n, x);
 #else
-                    return boost::math::cyl_neumann(n, x);
+                    return std::cyl_neumann(n, x);
 #endif
                 }
             };

--- a/include/pmacc/algorithms/math/floatMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/floatMath/bessel.tpp
@@ -23,7 +23,7 @@
 
 #include "pmacc/types.hpp"
 
-#include <boost/math/special_functions/bessel.hpp>
+#include <cmath>
 
 
 namespace pmacc
@@ -42,7 +42,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::cyl_bessel_i0f(x);
 #else
-                    return boost::math::cyl_bessel_i(0, x);
+                    return std::cyl_bessel_i(0, x);
 #endif
                 }
             };
@@ -57,7 +57,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::cyl_bessel_i1f(x);
 #else
-                    return boost::math::cyl_bessel_i(1, x);
+                    return std::cyl_bessel_i(1, x);
 #endif
                 }
             };
@@ -72,7 +72,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu_
                     return ::j0f(x);
 #else
-                    return boost::math::cyl_bessel_j(0, x);
+                    return std::cyl_bessel_j(0, x);
 #endif
                 }
             };
@@ -87,7 +87,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::j1f(x);
 #else
-                    return boost::math::cyl_bessel_j(1, x);
+                    return std::cyl_bessel_j(1, x);
 #endif
                 }
             };
@@ -102,7 +102,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::jnf(n, x);
 #else
-                    return boost::math::cyl_bessel_j(n, x);
+                    return std::cyl_bessel_j(n, x);
 #endif
                 }
             };
@@ -117,7 +117,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::y0f(x);
 #else
-                    return boost::math::cyl_neumann(0, x);
+                    return std::cyl_neumann(0, x);
 #endif
                 }
             };
@@ -132,7 +132,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::y1f(x);
 #else
-                    return boost::math::cyl_neumann(1, x);
+                    return std::cyl_neumann(1, x);
 #endif
                 }
             };
@@ -147,7 +147,7 @@ namespace pmacc
 #if(CUPLA_DEVICE_COMPILE == 1) // we are on gpu
                     return ::ynf(n, x);
 #else
-                    return boost::math::cyl_neumann(n, x);
+                    return std::cyl_neumann(n, x);
 #endif
                 }
             };


### PR DESCRIPTION
The bessel functions for the host side in pmacc was the last reason to use `boost::math`. This PR is switching to the `std` implementations of the bessel function to remove one depenedency to boost.