### PR TITLE
remove `boost::filesystem usage`

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -71,8 +71,8 @@ MPI 2.3+
 
 Boost
 """""
-- 1.74.0+ (``program_options``, ``filesystem``, ``system``, ``serialization`` and header-only libs)
-- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-filesystem-dev libboost-system-dev libboost-serialization-dev``
+- 1.74.0+ (``program_options``, ``atomic`` and header-only libs)
+- *Debian/Ubuntu:* ``sudo apt-get install libboost-program-options-dev libboost-atomic-dev``
 - *Arch Linux:* ``sudo pacman --sync boost``
 - *Spack:* ``spack install boost``
 - *from source:*
@@ -82,7 +82,7 @@ Boost
   - ``curl -Lo boost_1_74_0.tar.gz https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz``
   - ``tar -xzf boost_1_74_0.tar.gz``
   - ``cd boost_1_74_0``
-  - ``./bootstrap.sh --with-libraries=filesystem,program_options,serialization,system --prefix=$HOME/lib/boost``
+  - ``./bootstrap.sh --with-libraries=atomic,program_options--prefix=$HOME/lib/boost``
   - ``./b2 cxxflags="-std=c++17" -j4 && ./b2 install``
 - *environment:* (assumes install from source in ``$HOME/lib/boost``)
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -181,11 +181,9 @@ endif()
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options filesystem
-                                              system serialization)
-if(TARGET Boost::program_options)
-    set(HOST_LIBS ${HOST_LIBS} Boost::boost Boost::program_options
-                     Boost::filesystem Boost::system Boost::serialization)
+find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options)
+if(TARGET Boost::boost)
+    set(HOST_LIBS ${HOST_LIBS} Boost::boost Boost::program_options)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     set(HOST_LIBS ${HOST_LIBS} ${Boost_LIBRARIES})

--- a/include/picongpu/plugins/common/txtFileHandling.hpp
+++ b/include/picongpu/plugins/common/txtFileHandling.hpp
@@ -19,8 +19,7 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
-
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -28,8 +27,6 @@
 
 namespace picongpu
 {
-    using namespace boost::filesystem;
-
     /** Restore a txt file from the checkpoint dir
      *
      * Restores a txt file from the checkpoint dir and starts appending to it.
@@ -54,11 +51,11 @@ namespace picongpu
         sStep << restartStep;
 
         /* set location of restart file and output file */
-        path src(restartDirectory + std::string("/") + filename + std::string(".") + sStep.str());
-        path dst(filename);
+        std::filesystem::path src(restartDirectory + std::string("/") + filename + std::string(".") + sStep.str());
+        std::filesystem::path dst(filename);
 
         /* check whether restart file exists */
-        if(!boost::filesystem::exists(src))
+        if(!std::filesystem::exists(src))
         {
             /* restart file does not exists */
             log<picLog::INPUT_OUTPUT>("Plugin restart file: %1% was not found. \
@@ -72,7 +69,7 @@ namespace picongpu
             if(outFile.is_open())
                 outFile.close();
 
-            copy_file(src, dst, copy_option::overwrite_if_exists);
+            std::filesystem::copy_file(src, dst, std::filesystem::copy_options::overwrite_existing);
 
             outFile.open(filename.c_str(), std::ofstream::out | std::ostream::app);
             if(!outFile)
@@ -104,10 +101,10 @@ namespace picongpu
         std::stringstream sStep;
         sStep << currentStep;
 
-        path src(filename);
-        path dst(checkpointDirectory + std::string("/") + filename + std::string(".") + sStep.str());
+        std::filesystem::path src(filename);
+        std::filesystem::path dst(checkpointDirectory + std::string("/") + filename + std::string(".") + sStep.str());
 
-        copy_file(src, dst, copy_option::overwrite_if_exists);
+        std::filesystem::copy_file(src, dst, std::filesystem::copy_options::overwrite_existing);
     }
 
 } /* namespace picongpu */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -68,13 +68,14 @@
 #include <pmacc/static_assert.hpp>
 #include <pmacc/traits/Limits.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/begin_end.hpp>
 #include <boost/mpl/find.hpp>
 #include <boost/mpl/pair.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/vector.hpp>
+
+#include <filesystem>
 
 #include <openPMD/openPMD.hpp>
 
@@ -459,7 +460,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 fileInfix = "";
             }
 
-            fileName = boost::filesystem::path(fileName).has_root_path() ? fileName : dir + "/" + fileName;
+            fileName = std::filesystem::path(fileName).has_root_path() ? fileName : dir + "/" + fileName;
             log<picLog::INPUT_OUTPUT>("openPMD: setting file pattern: %1%%2%.%3%") % fileName % fileInfix
                 % fileExtension;
 

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -28,10 +28,8 @@
 
 #    include <pmacc/communication/manager_common.hpp>
 
-// @todo Use std library function upon switching to C++17
-#    include <boost/filesystem.hpp> // boost::filesystem::exists
-
 #    include <chrono>
+#    include <filesystem>
 #    include <sstream>
 #    include <thread> // std::this_thread::sleep_for
 #    include <utility> // std::forward
@@ -230,7 +228,7 @@ namespace
 
             char const* argsv[] = {path.c_str()};
             ChronoDuration waitedFor = 0s;
-            while(!boost::filesystem::exists(path))
+            while(!std::filesystem::exists(path))
             {
                 picongpu::toml::writeLog("openPMD: Still waiting for TOML file:\n\t%1%", 1, argsv);
                 if(waitedFor > timeout)

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -42,10 +42,9 @@
 #include <pmacc/mpi/reduceMethods/Reduce.hpp>
 #include <pmacc/traits/HasIdentifier.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <algorithm> // std::any
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -969,7 +968,7 @@ namespace picongpu
                     filename << name << timeStep << "_0_0_0" + extension;
 
                     /* check if restart file exists */
-                    if(!boost::filesystem::exists(filename.str()))
+                    if(!std::filesystem::exists(filename.str()))
                     {
                         log<radLog::SIMULATION_STATE>(
                             "Radiation (%1%): restart file not found (%2%) - start with zero values")

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -287,11 +287,9 @@ endif(MPI_CXX_FOUND)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.74 REQUIRED COMPONENTS filesystem system program_options)
-if(TARGET Boost::filesystem)
+find_package(Boost 1.74 REQUIRED COMPONENTS program_options)
+if(TARGET Boost::boost)
     target_link_libraries(pmacc PUBLIC Boost::boost)
-    target_link_libraries(pmacc PUBLIC Boost::filesystem)
-    target_link_libraries(pmacc PUBLIC Boost::system)
     target_link_libraries(pmacc PUBLIC Boost::program_options)
 else()
     target_include_directories(pmacc PUBLIC ${Boost_INCLUDE_DIRS})

--- a/include/pmacc/mappings/simulation/Filesystem.cpp
+++ b/include/pmacc/mappings/simulation/Filesystem.cpp
@@ -19,14 +19,16 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "pmacc/mappings/simulation/Filesystem.hpp"
+#if __cplusplus < 201703L
+#    error "C++17 is required"
+#endif
 
-#include <pmacc/boost_workaround.hpp>
+#include "pmacc/mappings/simulation/Filesystem.hpp"
 
 #include "pmacc/Environment.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace pmacc
 {
@@ -34,14 +36,17 @@ namespace pmacc
     void Filesystem<DIM>::createDirectory(const std::string dir) const
     {
         /* does not throw if the directory exists or has been created */
-        bfs::create_directories(dir);
+        std::filesystem::create_directories(dir);
     }
 
     template<unsigned DIM>
     void Filesystem<DIM>::setDirectoryPermissions(const std::string dir) const
     {
+        using namespace std::filesystem;
         /* set permissions */
-        bfs::permissions(dir, bfs::owner_all | bfs::group_read | bfs::group_exe | bfs::others_read | bfs::others_exe);
+        permissions(
+            dir,
+            perms::owner_all | perms::group_read | perms::group_exec | perms::others_read | perms::others_exec);
     }
 
     template<unsigned DIM>
@@ -62,7 +67,7 @@ namespace pmacc
     template<unsigned DIM>
     std::string Filesystem<DIM>::basename(const std::string pathFilename) const
     {
-        return bfs::path(pathFilename).filename().string();
+        return std::filesystem::path(pathFilename).filename().string();
     }
 
     // Explicit template instantiation to provide symbols for usage together with PMacc

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -34,11 +34,10 @@
 #include "pmacc/simulationControl/signal.hpp"
 #include "pmacc/types.hpp"
 
-#include <boost/filesystem.hpp>
-
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -450,7 +449,7 @@ namespace pmacc
         const std::string checkpointMasterFile
             = this->restartDirectory + std::string("/") + this->CHECKPOINT_MASTER_FILE;
 
-        if(!boost::filesystem::exists(checkpointMasterFile))
+        if(!std::filesystem::exists(checkpointMasterFile))
             return checkpoints;
 
         std::ifstream file(checkpointMasterFile.c_str());

--- a/include/pmacc/types.hpp
+++ b/include/pmacc/types.hpp
@@ -64,6 +64,4 @@
 namespace pmacc
 {
     namespace bmpl = boost::mpl;
-    namespace bfs = boost::filesystem;
-
 } // namespace pmacc

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -84,6 +84,11 @@ def is_valid_combination(row):
         os_name = row[2][0] if n >= 3 else ""
         os_version = get_version(row[2]) if n >= 3 else 0
 
+        # STL of g++ shipped with ubuntu <20.04 does not support full
+        # c++17 standard
+        if os_name == "ubuntu" and is_clang and os_version < 20.04:
+            return False
+
         if is_cuda and os_name == "ubuntu":
             if os_version < 20.04 and v_cuda >= 11.0:
                 return False


### PR DESCRIPTION
Switch from `boost::filesystem` to `std::filesystem` and reduc ethe boost dependencies.

The second commit is dropping clang tests on ubuntu 18.04 do to libstdc++ incompatibilities between OS shipped g++7 and clang if we compile for C++17.