### PR TITLE
PMacc: DataConnector change `get()` interface

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/AddCurrentDensity.hpp
+++ b/include/picongpu/fields/MaxwellSolver/AddCurrentDensity.hpp
@@ -67,8 +67,8 @@ namespace picongpu::fields::maxwellSolver
             float_X coeff) const
         {
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-            auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
+            auto fieldE = dc.get<FieldE>(FieldE::getName());
+            auto fieldB = dc.get<FieldB>(FieldB::getName());
             auto const mapper = makeAreaMapper<T_area>(cellDescription);
             auto const workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
             PMACC_LOCKSTEP_KERNEL(KernelAddCurrentDensity{}, workerCfg)

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -79,7 +79,7 @@ namespace picongpu
                 void addCurrent()
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
                     // Coefficient in front of J in Ampere's law
                     constexpr float_X coeff = -(1.0_X / EPS0) * DELTA_T;
                     this->template addCurrentImpl<T_area>(fieldJ.getDeviceDataBox(), coeff);

--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTDBase.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTDBase.hpp
@@ -78,8 +78,8 @@ namespace picongpu
                         absorberImpl(fields::absorber::AbsorberImpl::getImpl(cellDescription))
                     {
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        fieldE = dc.get<FieldE>(FieldE::getName(), true);
-                        fieldB = dc.get<FieldB>(FieldB::getName(), true);
+                        fieldE = dc.get<FieldE>(FieldE::getName());
+                        fieldB = dc.get<FieldB>(FieldB::getName());
                     }
 
                 protected:

--- a/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Substepping/Substepping.hpp
@@ -120,7 +120,7 @@ namespace picongpu
                     if(existsCurrent)
                     {
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                        auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
                         auto const& gridBuffer = fieldJ.getGridBuffer();
                         previousJ = pmacc::makeDeepCopy(gridBuffer.getDeviceBuffer());
                     }
@@ -158,7 +158,7 @@ namespace picongpu
 
                     // J values in the middle of the current PIC time iteration
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
 
                     /* Initialize previousJ if necessary so that we can process everything uniformly.
                      * The condition can only be true at the very first time step or just after a restart.

--- a/include/picongpu/fields/incidentField/Solver.hpp
+++ b/include/picongpu/fields/incidentField/Solver.hpp
@@ -213,9 +213,9 @@ namespace picongpu
 
                     // Prepare update functor type
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto& updatedField = *dc.get<T_UpdatedField>(T_UpdatedField::getName(), true);
+                    auto& updatedField = *dc.get<T_UpdatedField>(T_UpdatedField::getName());
                     auto dataBox = updatedField.getDeviceDataBox();
-                    auto const& incidentField = *dc.get<T_IncidentField>(T_IncidentField::getName(), true);
+                    auto const& incidentField = *dc.get<T_IncidentField>(T_IncidentField::getName());
                     using Functor
                         = UpdateFunctor<decltype(dataBox), T_CurlIncidentField, T_FunctorIncidentField, T_axis>;
                     auto functor = Functor{

--- a/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/laserProfiles/ExpRampWithPrepulse.hpp
@@ -278,7 +278,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/laserProfiles/GaussianBeam.hpp
@@ -290,7 +290,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/fields/laserProfiles/PlaneWave.hpp
+++ b/include/picongpu/fields/laserProfiles/PlaneWave.hpp
@@ -121,7 +121,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/fields/laserProfiles/Polynom.hpp
+++ b/include/picongpu/fields/laserProfiles/Polynom.hpp
@@ -148,7 +148,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/fields/laserProfiles/PulseFromSpectrum.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFromSpectrum.hpp
@@ -255,7 +255,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
+++ b/include/picongpu/fields/laserProfiles/PulseFrontTilt.hpp
@@ -208,7 +208,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/fields/laserProfiles/Wavepacket.hpp
+++ b/include/picongpu/fields/laserProfiles/Wavepacket.hpp
@@ -144,7 +144,7 @@ namespace picongpu
                 {
                     // get data
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    dataBoxE = dc.get<FieldE>(FieldE::getName(), true)->getDeviceDataBox();
+                    dataBoxE = dc.get<FieldE>(FieldE::getName())->getDeviceDataBox();
 
                     // get meta data for offsets
                     SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/initialization/SimStartInitialiser.hpp
+++ b/include/picongpu/initialization/SimStartInitialiser.hpp
@@ -21,10 +21,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include <pmacc/dataManagement/AbstractInitialiser.hpp>
-//#include <pmacc/dataManagement/DataConnector.hpp>
-
 #include <pmacc/Environment.hpp>
+#include <pmacc/dataManagement/AbstractInitialiser.hpp>
 
 namespace picongpu
 {

--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -108,7 +108,7 @@ namespace picongpu
             HINLINE void operator()(const uint32_t currentStep)
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto speciesPtr = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto speciesPtr = dc.get<SpeciesType>(FrameType::getName());
 
                 DensityFunctor densityFunctor(currentStep);
                 PositionFunctor positionFunctor(currentStep);
@@ -165,8 +165,8 @@ namespace picongpu
             HINLINE void operator()(const uint32_t currentStep)
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto speciesPtr = dc.get<DestSpeciesType>(DestFrameType::getName(), true);
-                auto srcSpeciesPtr = dc.get<SrcSpeciesType>(SrcFrameType::getName(), true);
+                auto speciesPtr = dc.get<DestSpeciesType>(DestFrameType::getName());
+                auto srcSpeciesPtr = dc.get<SrcSpeciesType>(SrcFrameType::getName());
 
                 FilteredManipulator filteredManipulator(currentStep);
                 SrcFilterInterfaced srcFilter(currentStep);
@@ -219,7 +219,7 @@ namespace picongpu
             HINLINE void operator()(const uint32_t currentStep)
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto speciesPtr = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto speciesPtr = dc.get<SpeciesType>(FrameType::getName());
                 speciesPtr->fillAllGaps();
             }
         };

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -340,8 +340,8 @@ namespace picongpu
         using FrameSolver = PushParticlePerFrame<T_Pusher, MappingDesc::SuperCellSize, InterpolationScheme>;
 
         DataConnector& dc = Environment<>::get().DataConnector();
-        auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-        auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
+        auto fieldE = dc.get<FieldE>(FieldE::getName());
+        auto fieldB = dc.get<FieldB>(FieldB::getName());
 
         /* Adjust interpolation area in particle pusher to allow sub-stepping pushes.
          * Here were provide an actual pusher and use its actual margins

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -57,7 +57,7 @@ namespace picongpu
             void operator()()
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto species = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto species = dc.get<SpeciesType>(FrameType::getName());
                 species = nullptr;
             }
         };
@@ -117,7 +117,7 @@ namespace picongpu
             HINLINE void operator()(const uint32_t currentStep)
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto species = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto species = dc.get<SpeciesType>(FrameType::getName());
                 species->reset(currentStep);
             }
         };
@@ -139,7 +139,7 @@ namespace picongpu
                 const
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto species = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto species = dc.get<SpeciesType>(FrameType::getName());
 
                 eventSystem::startTransaction(eventInt);
                 species->update(currentStep);
@@ -165,7 +165,7 @@ namespace picongpu
             HINLINE void operator()(const uint32_t currentStep) const
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto species = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto species = dc.get<SpeciesType>(FrameType::getName());
                 boundary::removeOuterParticles(*species, currentStep);
             }
         };
@@ -186,7 +186,7 @@ namespace picongpu
             HINLINE void operator()(T_EventList& updateEventList, T_EventList& commEventList) const
             {
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto species = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto species = dc.get<SpeciesType>(FrameType::getName());
 
                 EventTask updateEvent(*(updateEventList.begin()));
 
@@ -285,9 +285,9 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
 
                 // alias for pointer on source species
-                auto srcSpeciesPtr = dc.get<SpeciesType>(FrameType::getName(), true);
+                auto srcSpeciesPtr = dc.get<SpeciesType>(FrameType::getName());
                 // alias for pointer on destination species
-                auto electronsPtr = dc.get<DestSpecies>(DestFrameType::getName(), true);
+                auto electronsPtr = dc.get<DestSpecies>(DestFrameType::getName());
 
                 SelectIonizer selectIonizer(currentStep);
 

--- a/include/picongpu/particles/atomicPhysics/CallAtomicPhysics.hpp
+++ b/include/picongpu/particles/atomicPhysics/CallAtomicPhysics.hpp
@@ -336,10 +336,10 @@ namespace picongpu
                     DataConnector& dc = Environment<>::get().DataConnector();
 
                     // ions
-                    auto& ions = *dc.get<IonSpecies>(IonFrameType::getName(), true);
+                    auto& ions = *dc.get<IonSpecies>(IonFrameType::getName());
 
                     // electrons
-                    auto& electrons = *dc.get<ElectronSpecies>(ElectronFrameType::getName(), true);
+                    auto& electrons = *dc.get<ElectronSpecies>(ElectronFrameType::getName());
 
                     // area to apply kernel to
                     AreaMapping<

--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -56,7 +56,7 @@ namespace picongpu
                     {
                         constexpr uint32_t slot = screeningLengthSlot;
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto field = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot), true);
+                        auto field = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot));
                         screeningLengthSquared = (field->getGridBuffer().getDeviceBuffer().getDataBox());
                     }
                 }
@@ -410,8 +410,8 @@ namespace picongpu
 
                     // Access particle data:
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto species0 = dc.get<Species0>(FrameType0::getName(), true);
-                    auto species1 = dc.get<Species1>(FrameType1::getName(), true);
+                    auto species0 = dc.get<Species0>(FrameType0::getName());
+                    auto species1 = dc.get<Species1>(FrameType1::getName());
 
                     // Use mapping information from the first species:
                     auto const mapper = makeAreaMapper<CORE + BORDER>(species0->getCellDescription());

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -50,7 +50,7 @@ namespace picongpu
                     {
                         constexpr uint32_t slot = screeningLengthSlot;
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto field = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot), true);
+                        auto field = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot));
                         screeningLengthSquared = field->getGridBuffer().getDeviceBuffer().getDataBox();
                     }
                 }
@@ -309,7 +309,7 @@ namespace picongpu
                     using CollisionFunctor = T_CollisionFunctor;
 
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto species = dc.get<Species>(FrameType::getName(), true);
+                    auto species = dc.get<Species>(FrameType::getName());
 
                     auto const mapper = makeAreaMapper<CORE + BORDER>(species->getCellDescription());
 

--- a/include/picongpu/particles/debyeLength/Estimate.hpp
+++ b/include/picongpu/particles/debyeLength/Estimate.hpp
@@ -52,7 +52,7 @@ namespace picongpu
             {
                 using Frame = typename T_ElectronSpecies::FrameType;
                 DataConnector& dc = Environment<>::get().DataConnector();
-                auto& electrons = *(dc.get<T_ElectronSpecies>(Frame::getName(), true));
+                auto& electrons = *(dc.get<T_ElectronSpecies>(Frame::getName()));
 
                 auto const mapper = pmacc::makeAreaMapper<CORE + BORDER>(cellDescription);
 

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -110,7 +110,7 @@ namespace picongpu
                 {
                     auto& dc = Environment<>::get().DataConnector();
                     PMACC_CASSERT_MSG(_please_allocate_at_least_one_FieldTmp_in_memory_param, fieldTmpNumSlots > 0);
-                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
+                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0));
                     auto& fieldBuffer = fieldTmp->getGridBuffer();
                     // Set all values to the default values, the values present in the file will be overwritten
                     fieldBuffer.getHostBuffer().setValue(ParamClass::defaultDensity);

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -126,15 +126,15 @@ namespace picongpu
                         _please_allocate_at_least_two_FieldTmp_slots_in_memory_param,
                         (fieldTmpNumSlots >= 2) && (sizeof(T_IonizationAlgorithm) != 0));
                     /* initialize pointers on host-side density-/energy density field databoxes */
-                    auto density = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
-                    auto eneKinDens = dc.get<FieldTmp>(FieldTmp::getUniqueId(1), true);
+                    auto density = dc.get<FieldTmp>(FieldTmp::getUniqueId(0));
+                    auto eneKinDens = dc.get<FieldTmp>(FieldTmp::getUniqueId(1));
 
                     /* reset density and kinetic energy values to zero */
                     density->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.));
                     eneKinDens->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.));
 
                     /* load species without copying the particle data to the host */
-                    auto srcSpecies = dc.get<SrcSpecies>(SrcSpecies::FrameType::getName(), true);
+                    auto srcSpecies = dc.get<SrcSpecies>(SrcSpecies::FrameType::getName());
 
                     /** Calculate weighted ion density
                      *
@@ -149,7 +149,7 @@ namespace picongpu
                     densityEvent += density->asyncCommunicationGather(densityEvent);
 
                     /* load species without copying the particle data to the host */
-                    auto destSpecies = dc.get<DestSpecies>(DestSpecies::FrameType::getName(), true);
+                    auto destSpecies = dc.get<DestSpecies>(DestSpecies::FrameType::getName());
 
                     /** Calculate energy density of the electron species with maximum energy cutoff
                      *

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -111,9 +111,9 @@ namespace picongpu
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
                     /* initialize pointers on host-side E-(B-)field and current density databoxes */
-                    auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-                    auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
-                    auto fieldJ = dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto fieldE = dc.get<FieldE>(FieldE::getName());
+                    auto fieldB = dc.get<FieldB>(FieldB::getName());
+                    auto fieldJ = dc.get<FieldJ>(FieldJ::getName());
                     /* initialize device-side E-(B-)field and current density databoxes */
                     eBox = fieldE->getDeviceDataBox();
                     bBox = fieldB->getDeviceDataBox();

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -101,8 +101,8 @@ namespace picongpu
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
                     /* initialize pointers on host-side E-field and current density databoxes */
-                    auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-                    auto fieldJ = dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto fieldE = dc.get<FieldE>(FieldE::getName());
+                    auto fieldJ = dc.get<FieldJ>(FieldJ::getName());
                     /* initialize device-side E-(J-)field databoxes */
                     eBox = fieldE->getDeviceDataBox();
                     jBox = fieldJ->getDeviceDataBox();

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -111,9 +111,9 @@ namespace picongpu
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
                     /* initialize pointers on host-side E-(B-)field and current density databoxes */
-                    auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-                    auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
-                    auto fieldJ = dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto fieldE = dc.get<FieldE>(FieldE::getName());
+                    auto fieldB = dc.get<FieldB>(FieldB::getName());
+                    auto fieldJ = dc.get<FieldJ>(FieldJ::getName());
                     /* initialize device-side E-(B-)field and current density databoxes */
                     eBox = fieldE->getDeviceDataBox();
                     bBox = fieldB->getDeviceDataBox();

--- a/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
+++ b/include/picongpu/particles/particleToGrid/ComputeFieldValue.hpp
@@ -83,7 +83,7 @@ namespace picongpu
                     using Solver = ComputeGridValuePerFrame<T...>;
                     DataConnector& dc = Environment<>::get().DataConnector();
                     /*load particle without copy particle data to host*/
-                    auto speciesTmp = dc.get<T_Species>(T_Species::FrameType::getName(), true);
+                    auto speciesTmp = dc.get<T_Species>(T_Species::FrameType::getName());
 
                     fieldTmp.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType::create(0.0));
                     /*run algorithm*/
@@ -107,9 +107,9 @@ namespace picongpu
 
                     DataConnector& dc = Environment<>::get().DataConnector();
                     // Get the second tmp field for the second function argument.
-                    auto fieldTmp2 = dc.get<FieldTmp>(FieldTmp::getUniqueId(extraSlotNr), true);
+                    auto fieldTmp2 = dc.get<FieldTmp>(FieldTmp::getUniqueId(extraSlotNr));
                     // Load particles without copy particle data to host.
-                    auto speciesTmp = dc.get<T_Species>(T_Species::FrameType::getName(), true);
+                    auto speciesTmp = dc.get<T_Species>(T_Species::FrameType::getName());
                     // initialize both fields with zero
                     fieldTmp1.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType::create(0.0));
                     fieldTmp2->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType::create(0.0));

--- a/include/picongpu/particles/particleToGrid/FoldDeriveFields.hpp
+++ b/include/picongpu/particles/particleToGrid/FoldDeriveFields.hpp
@@ -160,7 +160,7 @@ namespace picongpu
 
                     if constexpr(!bmpl::empty<RemainingFilteredSpecies>::value)
                     {
-                        auto fieldTmp2 = dc.get<FieldTmp>(FieldTmp::getUniqueId(extraSlot), true);
+                        auto fieldTmp2 = dc.get<FieldTmp>(FieldTmp::getUniqueId(extraSlot));
                         pmacc::meta::ForEach<
                             RemainingFilteredSpecies,
                             detail::OpWithNextField<T_Op, bmpl::_1, T_DerivedAttribute>>{}(

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -426,7 +426,7 @@ namespace picongpu
             gBins->getDeviceBuffer().setValue(0);
 
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
             /* convert energy values from keV to PIConGPU units */
             float_X const minEnergy = minEnergy_keV * UNITCONV_keV_to_Joule / UNIT_ENERGY;

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -162,7 +162,7 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
 
                 /* load species without copying the particle data to the host */
-                auto speciesTmp = dc.get<SpeciesType>(SpeciesType::FrameType::getName(), true);
+                auto speciesTmp = dc.get<SpeciesType>(SpeciesType::FrameType::getName());
 
                 /* run algorithm */
                 using ChargeDensitySolver = typename particles::particleToGrid::CreateFieldTmpOperation_t<
@@ -182,7 +182,7 @@ namespace picongpu
 
         /* load FieldTmp without copy data to host */
         PMACC_CASSERT_MSG(_please_allocate_at_least_one_FieldTmp_in_memory_param, fieldTmpNumSlots > 0);
-        auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
+        auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0));
         /* reset density values to zero */
         fieldTmp->getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
 
@@ -203,7 +203,7 @@ namespace picongpu
         EventTask fieldTmpEvent = fieldTmp->asyncCommunication(eventSystem::getTransactionEvent());
         eventSystem::setTransactionEvent(fieldTmpEvent);
 
-        auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
+        auto fieldE = dc.get<FieldE>(FieldE::getName());
 
         auto const chargeDeviation = [] ALPAKA_FN_ACC(auto const& worker, auto mapper, auto rohBox, auto fieldEBox)
         {

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -160,7 +160,7 @@ namespace picongpu
             const DataSpace<simDim> localSize(subGrid.getLocalDomain().size);
 
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
             // enforce that the filter interface is fulfilled
             particles::filter::IUnary<particles::filter::All> parFilter{currentStep};

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -459,7 +459,7 @@ namespace picongpu
             DataConnector& dc = Environment<>::get().DataConnector();
 
             // use data connector to get particle data
-            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
             gSumMom2->getDeviceBuffer().setValue(0.0);
             gSumPos2->getDeviceBuffer().setValue(0.0);

--- a/include/picongpu/plugins/EnergyFields.hpp
+++ b/include/picongpu/plugins/EnergyFields.hpp
@@ -187,8 +187,8 @@ namespace picongpu
         {
             DataConnector& dc = Environment<>::get().DataConnector();
 
-            auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-            auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
+            auto fieldE = dc.get<FieldE>(FieldE::getName());
+            auto fieldB = dc.get<FieldB>(FieldB::getName());
 
             /* idx == 0 -> fieldB
              * idx == 1 -> fieldE

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -346,7 +346,7 @@ namespace picongpu
             DataConnector& dc = Environment<>::get().DataConnector();
 
             // use data connector to get particle data
-            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
             // initialize global energies with zero
             gEnergy->getDeviceBuffer().setValue(0.0);

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -81,7 +81,7 @@ namespace picongpu
                 if(enabled)
                 {
                     DataConnector& dc = Environment<simDim>::get().DataConnector();
-                    auto pField = dc.get<FieldType>(FieldType::getName(), true);
+                    auto pField = dc.get<FieldType>(FieldType::getName());
                     DataSpace<simDim> guarding = SuperCellSize::toRT() * cellDescription->getGuardingSuperCells();
 
                     typename FieldType::DataBoxType dataBox = pField->getDeviceDataBox();
@@ -142,7 +142,7 @@ namespace picongpu
                         _please_allocate_at_least_one_FieldTmp_slot_in_memory_param_or_two_when_using_combined_attributes,
                         fieldTmpNumSlots >= 1u + requiredExtraSlots);
 
-                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
+                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0));
                     auto event = particles::particleToGrid::
                         ComputeFieldValue<CORE + BORDER, FrameSolver, ParticleType, ParticleFilter>()(
                             *fieldTmp,
@@ -198,7 +198,7 @@ namespace picongpu
                 if(enabled)
                 {
                     DataConnector& dc = Environment<simDim>::get().DataConnector();
-                    auto pField = dc.get<FieldType>(FieldType::getName(), true);
+                    auto pField = dc.get<FieldType>(FieldType::getName());
                     DataSpace<simDim> guarding = SuperCellSize::toRT() * cellDescription->getGuardingSuperCells();
 
                     typename FieldType::DataBoxType dataBox = pField->getDeviceDataBox();
@@ -325,7 +325,7 @@ namespace picongpu
                 if(enabled)
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+                    auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
                     pb[0] = particles->getDeviceParticlesBox();
 
                     guarding = GuardSize::toRT();

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -172,7 +172,7 @@ namespace picongpu
     {
         /* register particle species observer */
         DataConnector& dc = Environment<>::get().DataConnector();
-        auto particles = dc.get<Species>(Species::FrameType::getName(), true);
+        auto particles = dc.get<Species>(Species::FrameType::getName());
 
         StartBlockFunctor<r_dir> startBlockFunctor(
             particles->getDeviceParticlesBox(),

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -158,7 +158,7 @@ namespace picongpu
         float3_X getSumCurrents()
         {
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto fieldJ = dc.get<FieldJ>(FieldJ::getName(), true);
+            auto fieldJ = dc.get<FieldJ>(FieldJ::getName());
 
             sumcurrents->getDeviceBuffer().setValue(float3_X::create(0.0));
             auto block = MappingDesc::SuperCellSize::toRT();

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -199,7 +199,7 @@ namespace picongpu
 
             DataConnector& dc = Environment<>::get().DataConnector();
 
-            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
             /*############ count particles #######################################*/
             using SuperCellSize = MappingDesc::SuperCellSize;

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -138,7 +138,7 @@ namespace picongpu
 
 #if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 auto mallocMCBuffer
-                    = rp.dc.template get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName(), true);
+                    = rp.dc.template get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName());
                 auto particlesBox = rp.speciesTmp->getHostParticlesBox(mallocMCBuffer->getOffset());
 #else
                 /* This separate code path is only a workaround until
@@ -329,7 +329,7 @@ namespace picongpu
                 uint64_t mpiSize = gc.getGlobalSize();
                 uint64_t mpiRank = gc.getGlobalRank();
                 /* load particle without copy particle data to host */
-                auto speciesTmp = dc.get<ThisSpecies>(ThisSpecies::FrameType::getName(), true);
+                auto speciesTmp = dc.get<ThisSpecies>(ThisSpecies::FrameType::getName());
                 const std::string speciesGroup(T_Species::getName());
 
                 ::openPMD::Series& series = *params->openPMDSeries;

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -545,6 +545,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     if(traits::IsFieldOutputOptional<T_Field>::value && !dc.hasId(T_Field::getName()))
                         return;
                     auto field = dc.get<T_Field>(T_Field::getName());
+                    field->synchronize();
                     bool const isDomainBound = traits::IsFieldDomainBound<T_Field>::value;
 
                     const traits::FieldPosition<fields::CellType, T_Field> fieldPos;
@@ -638,7 +639,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     PMACC_CASSERT_MSG(
                         _please_allocate_at_least_one_or_two_when_using_combined_attributes_FieldTmp_in_memory_param,
                         fieldTmpNumSlots >= 1u + requiredExtraSlots);
-                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0), true);
+                    auto fieldTmp = dc.get<FieldTmp>(FieldTmp::getUniqueId(0));
                     // compute field values
                     auto event
                         = particles::particleToGrid::ComputeFieldValue<CORE + BORDER, Solver, Species, Filter>()(
@@ -1194,7 +1195,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     DataConnector& dc = Environment<>::get().DataConnector();
 
                     /* synchronizes the MallocMCBuffer to the host side */
-                    dc.get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName());
+                    auto mallocMCBuffer = dc.get<MallocMCBuffer<DeviceHeap>>(MallocMCBuffer<DeviceHeap>::getName());
+                    mallocMCBuffer->synchronize();
+
 
                     /* here we are copying all species to the host side since we
                      * can not say at this point if this time step will need all of

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -99,7 +99,7 @@ namespace picongpu
                     = subGrid.getLocalDomain().offset + subGrid.getGlobalDomain().offset;
 
                 /* load particle without copying particle data to host */
-                auto speciesTmp = dc.get<ThisSpecies>(FrameType::getName(), true);
+                auto speciesTmp = dc.get<ThisSpecies>(FrameType::getName());
 
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -213,7 +213,7 @@ namespace picongpu
                     return;
 
                 /* load field without copying data to host */
-                auto field = dc.get<T_Field>(T_Field::getName(), true);
+                auto field = dc.get<T_Field>(T_Field::getName());
 
                 /* load from openPMD */
                 bool const isDomainBound = traits::IsFieldDomainBound<T_Field>::value;

--- a/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
+++ b/include/picongpu/plugins/output/WriteSpeciesCommon.hpp
@@ -90,7 +90,8 @@ namespace picongpu
         {
             /* DataConnector copies data to host */
             DataConnector& dc = Environment<>::get().DataConnector();
-            dc.get<SpeciesType>(SpeciesType::FrameType::getName());
+            auto dataSet = dc.get<SpeciesType>(SpeciesType::FrameType::getName());
+            dataSet->synchronize();
         }
     };
 

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -754,10 +754,10 @@ namespace picongpu
             DataConnector& dc = Environment<>::get().DataConnector();
             // Data does not need to be synchronized as visualization is
             // done at the device.
-            auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
-            auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-            auto fieldJ = dc.get<FieldJ>(FieldJ::getName(), true);
-            auto particles = dc.get<ParticlesType>(particleTag, true);
+            auto fieldB = dc.get<FieldB>(FieldB::getName());
+            auto fieldE = dc.get<FieldE>(FieldE::getName());
+            auto fieldJ = dc.get<FieldJ>(FieldJ::getName());
+            auto particles = dc.get<ParticlesType>(particleTag);
 
             /* wait that shared buffers can accessed without conflicts */
             m_output.join();

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -557,7 +557,7 @@ namespace picongpu
 
             /* create kernel functor instance */
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+            auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
             auto const mapper = makeAreaMapper<CORE + BORDER>(*this->m_cellDescription);
             auto const grid = mapper.getGridDim();
@@ -612,7 +612,7 @@ namespace picongpu
             this->calorimeterFunctor->setCalorimeterData(this->dBufLeftParsCalorimeter->getDataBox());
 
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto particles = dc.get<ParticlesType>(speciesName, true);
+            auto particles = dc.get<ParticlesType>(speciesName);
 
             auto mapperFactory = particles::boundary::getMapperFactory(*particles, direction);
             auto const mapper = mapperFactory(*this->m_cellDescription);

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -1086,7 +1086,7 @@ namespace picongpu
                     this->currentStep = currentStep;
 
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName(), true);
+                    auto particles = dc.get<ParticlesType>(ParticlesType::FrameType::getName());
 
                     /* execute the particle filter */
                     radiation::executeParticleFilter(particles, currentStep);

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -459,7 +459,7 @@ namespace picongpu
                 void calculateTransitionRadiation(uint32_t currentStep)
                 {
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto particles = dc.get<T_ParticlesType>(T_ParticlesType::FrameType::getName(), true);
+                    auto particles = dc.get<T_ParticlesType>(T_ParticlesType::FrameType::getName());
 
                     /* execute the particle filter */
                     transitionRadiation::executeParticleFilter(particles, currentStep);

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -487,8 +487,8 @@ namespace picongpu
             }
 
             DataConnector& dc = Environment<>::get().DataConnector();
-            auto fieldE = dc.get<FieldE>(FieldE::getName(), true);
-            auto fieldB = dc.get<FieldB>(FieldB::getName(), true);
+            auto fieldE = dc.get<FieldE>(FieldE::getName());
+            auto fieldB = dc.get<FieldB>(FieldB::getName());
 
             // generate valid GUARDS (overwrite)
             EventTask eRfieldE = fieldE->asyncCommunication(eventSystem::getTransactionEvent());
@@ -742,7 +742,7 @@ namespace picongpu
                 if(fieldExists)
                 {
                     using FieldHelper = SimulationFieldHelper<MappingDesc>;
-                    auto field = std::dynamic_pointer_cast<FieldHelper>(dc.get<ISimulationData>(name, true));
+                    auto field = std::dynamic_pointer_cast<FieldHelper>(dc.get<ISimulationData>(name));
                     if(field)
                         field->reset(currentStep);
                 }

--- a/include/picongpu/simulation/stage/Collision.hpp
+++ b/include/picongpu/simulation/stage/Collision.hpp
@@ -174,7 +174,7 @@ namespace picongpu
                         using SpeciesSeq = picongpu::particles::collision::CollisionScreeningSpecies;
                         constexpr uint32_t slot = picongpu::particles::collision::screeningLengthSlot;
                         // get a FieldTmp for storring the result
-                        auto screeningLengthSquared = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot), true);
+                        auto screeningLengthSquared = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot));
                         // The inverse of the Debye length squared is the sum over ScreeningInvSquared of each
                         // species. Calculate it using the fold algorithm:
                         particles::particleToGrid::FoldDeriveFields<
@@ -189,7 +189,7 @@ namespace picongpu
                         // The Debye length is bound to be greater than the mean inter-atomic distance of the most
                         // dense species ( this definition of the lower cut-off comes from [Perez 2012]).
                         // To find this cut-off we need to find the highest density:
-                        auto maxDensity = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot + 1u), true);
+                        auto maxDensity = dc.get<FieldTmp>(FieldTmp::getUniqueId(slot + 1u));
                         particles::particleToGrid::FoldDeriveFields<
                             CORE + BORDER,
                             SpeciesSeq,

--- a/include/picongpu/simulation/stage/CurrentBackground.hpp
+++ b/include/picongpu/simulation/stage/CurrentBackground.hpp
@@ -62,7 +62,7 @@ namespace picongpu
                     {
                         using namespace pmacc;
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                        auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
                         using CurrentBackground = cellwiseOperation::CellwiseOperation<type::CORE + type::BORDER>;
                         CurrentBackground currentBackground(cellDescription);
                         currentBackground(

--- a/include/picongpu/simulation/stage/CurrentDeposition.hpp
+++ b/include/picongpu/simulation/stage/CurrentDeposition.hpp
@@ -50,7 +50,7 @@ namespace picongpu
 
                     HINLINE void operator()(const uint32_t currentStep, FieldJ& fieldJ, pmacc::DataConnector& dc) const
                     {
-                        auto species = dc.get<SpeciesType>(FrameType::getName(), true);
+                        auto species = dc.get<SpeciesType>(FrameType::getName());
                         fieldJ.computeCurrent<T_Area::value, SpeciesType>(*species, currentStep);
                     }
                 };
@@ -69,7 +69,7 @@ namespace picongpu
                 {
                     using namespace pmacc;
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
                     using SpeciesWithCurrentSolver =
                         typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, current<>>::type;
                     meta::ForEach<

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -106,7 +106,7 @@ namespace picongpu
                     if(existsParticleCurrent)
                     {
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                        auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
                         auto eRecvCurrent = fieldJ.asyncCommunication(eventSystem::getTransactionEvent());
                         auto& interpolation = fields::currentInterpolation::CurrentInterpolation::get();
                         auto const currentRecvLower = interpolation.getLowerMargin();

--- a/include/picongpu/simulation/stage/CurrentReset.hpp
+++ b/include/picongpu/simulation/stage/CurrentReset.hpp
@@ -46,7 +46,7 @@ namespace picongpu
                 {
                     using namespace pmacc;
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName(), true);
+                    auto& fieldJ = *dc.get<FieldJ>(FieldJ::getName());
                     FieldJ::ValueType zeroJ(FieldJ::ValueType::create(0._X));
                     fieldJ.assign(zeroJ);
                 }

--- a/include/picongpu/simulation/stage/FieldBackground.hpp
+++ b/include/picongpu/simulation/stage/FieldBackground.hpp
@@ -77,7 +77,7 @@ namespace picongpu
                         {
                             // Allocate a duplicate field buffer and copy the values
                             DataConnector& dc = Environment<>::get().DataConnector();
-                            auto field = dc.get<Field>(Field::getName(), true);
+                            auto field = dc.get<Field>(Field::getName());
                             auto const& gridBuffer = field->getGridBuffer();
                             duplicateBuffer = pmacc::makeDeepCopy(gridBuffer.getDeviceBuffer());
                         }
@@ -92,7 +92,7 @@ namespace picongpu
                         if(!isEnabled)
                             return;
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto& field = *dc.get<Field>(Field::getName(), true);
+                        auto& field = *dc.get<Field>(Field::getName());
                         // Always add to the field, conditionally make a copy of the old values first
                         if(useDuplicateField)
                         {
@@ -112,7 +112,7 @@ namespace picongpu
                         if(!isEnabled)
                             return;
                         DataConnector& dc = Environment<>::get().DataConnector();
-                        auto& field = *dc.get<Field>(Field::getName(), true);
+                        auto& field = *dc.get<Field>(Field::getName());
                         /* Either restore from the pre-made copy or subtract.
                          * Note that here it is not sufficient to check for useDuplicateField as it
                          * is not necessarily up-to-date, e.g. right after loading from a checkpoint.

--- a/include/pmacc/dataManagement/DataConnector.hpp
+++ b/include/pmacc/dataManagement/DataConnector.hpp
@@ -99,19 +99,14 @@ namespace pmacc
         /** Returns shared pointer to managed data.
          *
          * Reference to data in Dataset with identifier id and type TYPE is returned.
-         * If the Dataset status in invalid, it is automatically synchronized.
          * Increments the reference counter to the dataset specified by id.
          *
          * @tparam TYPE if of the data to load
          * @param id id of the Dataset to load from
-         * @param noSync indicates that no synchronization should be performed, regardless of dataset status
          * @return returns a reference to the data of type TYPE
          */
         template<class TYPE>
-        std::shared_ptr<TYPE> get(
-            SimulationDataId id,
-            bool noSync = false // @todo invert!
-        )
+        std::shared_ptr<TYPE> get(SimulationDataId id)
         {
             auto it = findId(id);
 
@@ -119,12 +114,6 @@ namespace pmacc
                 throw std::runtime_error(getExceptionStringForID("Invalid dataset ID", id));
 
             log<ggLog::MEMORY>("DataConnector: sharing access to '%1%' (%2% uses)") % id % (it->use_count());
-
-            if(!noSync)
-            {
-                (*it)->synchronize();
-            }
-
             return std::static_pointer_cast<TYPE>(*it);
         }
 

--- a/include/pmacc/mappings/simulation/ResourceMonitor.tpp
+++ b/include/pmacc/mappings/simulation/ResourceMonitor.tpp
@@ -44,7 +44,7 @@ namespace pmacc
 
             uint64_cu totalNumParticles = 0;
             totalNumParticles = pmacc::CountParticles::countOnDevice<CORE + BORDER>(
-                *dc.get<T_Species>(T_Species::FrameType::getName(), true),
+                *dc.get<T_Species>(T_Species::FrameType::getName()),
                 cellDescription,
                 DataSpace<T_DIM::value>(),
                 localSize,

--- a/include/pmacc/particles/algorithm/CallForEach.hpp
+++ b/include/pmacc/particles/algorithm/CallForEach.hpp
@@ -62,7 +62,7 @@ namespace pmacc
                     using UnaryFunctor = pmacc::functor::Interface<typename T_FunctorOperator::type, 1u, void>;
 
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto species = dc.get<Species>(FrameType::getName(), true);
+                    auto species = dc.get<Species>(FrameType::getName());
                     forEach<T_area>(*species, UnaryFunctor(currentStep));
                 }
 
@@ -84,7 +84,7 @@ namespace pmacc
                     using UnaryFunctor = pmacc::functor::Interface<typename T_FunctorOperator::type, 1u, void>;
 
                     DataConnector& dc = Environment<>::get().DataConnector();
-                    auto species = dc.get<Species>(FrameType::getName(), true);
+                    auto species = dc.get<Species>(FrameType::getName());
                     forEach(*species, UnaryFunctor(currentStep), areaMapperFactory);
                 }
             };

--- a/include/pmacc/random/RNGProvider.tpp
+++ b/include/pmacc/random/RNGProvider.tpp
@@ -89,7 +89,7 @@ namespace pmacc
         typename RNGProvider<T_dim, T_RNGMethod>::Handle RNGProvider<T_dim, T_RNGMethod>::createHandle(
             const std::string& id)
         {
-            auto provider = Environment<>::get().DataConnector().get<RNGProvider>(id, true);
+            auto provider = Environment<>::get().DataConnector().get<RNGProvider>(id);
             Handle result(provider->getDeviceDataBox());
             return result;
         }


### PR DESCRIPTION
Change the DataConnector interface to get access to a data set. Remove the parameter to synchronize the data. Synchronization must be called explicit by the user, now.
Before the parameter name was a negation of the execution `noSync` which always required thinking and was error-prone.
The default method used in PMacc and PIConGPU is not performing the synchronization which is now always the case.