### PR TITLE
incident laser focus origin

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -40,6 +40,17 @@ namespace picongpu
                 Circular
             };
 
+
+            /** Coordinate system origin
+             */
+            enum class Origin
+            {
+                //! origin of the total domain
+                Zero,
+                //! the center of the global domain
+                Center
+            };
+
             namespace profiles
             {
                 /** Base structure for parameters of all lasers
@@ -102,7 +113,7 @@ namespace picongpu
                     static constexpr float_64 DIRECTION_Z = 0.0;
                     /** @} */
 
-                    /** Focus position in total coordinate system
+                    /** Focus position relative to FOCUS_ORIGIN_*
                      *
                      * "Non-focused" lasers should have it set at or near the generation surface where the laser enters
                      * the domain. The position does not have to be inside the domain.
@@ -110,6 +121,9 @@ namespace picongpu
                      * The focus position and propagation direction together define the entry point of laser to
                      * the generation surface.
                      * So they also control the laser center at the generation plane, not just a shift inwards.
+                     *
+                     * FOCUS_ORIGIN_X, FOCUS_ORIGIN_Y or FOCUS_ORIGIN_Z is not defined the origin will be Origin::Zero
+                     * (total domain).
                      *
                      * For 2d simulations, z component has no effect and is not required.
                      *
@@ -120,6 +134,19 @@ namespace picongpu
                     static constexpr float_64 FOCUS_POSITION_X_SI = 8.0e-5;
                     static constexpr float_64 FOCUS_POSITION_Y_SI = 5.0e-5;
                     static constexpr float_64 FOCUS_POSITION_Z_SI = 8.0e-5;
+                    /** @} */
+
+                    /** Origin of the laser
+                     *
+                     * possible values:
+                     *   - Origin::Center center of the global coordinate system
+                     *   - Origin::Zero total coordinate origin
+                     *
+                     * @attention FOCUS_ORIGIN_X, FOCUS_ORIGIN_y, FOCUS_ORIGIN_Z are optional
+                     */
+                    static constexpr Origin FOCUS_ORIGIN_X = Origin::Zero;
+                    static constexpr Origin FOCUS_ORIGIN_Y = Origin::Zero;
+                    static constexpr Origin FOCUS_ORIGIN_Z = Origin::Zero;
                     /** @} */
 
                     /** E polarization type

--- a/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
+++ b/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
@@ -154,11 +154,7 @@ namespace picongpu
                             float3_X pos = this->getInternalCoordinates(totalCellIdx);
 
                             // calculate focus position relative to the current point in the propagation direction
-                            auto const focusRelativeToOrigin = float3_X(
-                                                                   Unitless::FOCUS_POSITION_X,
-                                                                   Unitless::FOCUS_POSITION_Y,
-                                                                   Unitless::FOCUS_POSITION_Z)
-                                - this->origin;
+                            auto const focusRelativeToOrigin = this->focus - this->origin;
                             // current distance to focus position
                             float_X const focusPos = math::sqrt(pmacc::math::abs2(focusRelativeToOrigin)) - pos[0];
                             // beam waist at the generation plane so that at focus we will get W0
@@ -212,11 +208,7 @@ namespace picongpu
                             float3_X pos = this->getInternalCoordinates(totalCellIdx);
 
                             // calculate focus position relative to the current point in the propagation direction
-                            auto const focusRelativeToOrigin = float3_X(
-                                                                   Unitless::FOCUS_POSITION_X,
-                                                                   Unitless::FOCUS_POSITION_Y,
-                                                                   Unitless::FOCUS_POSITION_Z)
-                                - this->origin;
+                            auto const focusRelativeToOrigin = this->focus - this->origin;
                             float_X const focusPos = math::sqrt(pmacc::math::abs2(focusRelativeToOrigin)) - pos[0];
 
                             // Initial frequency dependent complex phase

--- a/share/picongpu/examples/Bunch/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/incidentField.param
@@ -135,7 +135,7 @@ namespace picongpu
                 static constexpr float_64 DIRECTION_Z = 0.0;
                 /** @} */
 
-                /** Focus position in total coordinate system
+                /** Focus position relative to FOCUS_ORIGIN_*
                  *
                  * "Non-focused" lasers should have it set at or near the generation surface where the laser enters
                  * the domain. The position does not have to be inside the domain.
@@ -143,6 +143,9 @@ namespace picongpu
                  * The focus position and propagation direction together define the entry point of laser to
                  * the generation surface.
                  * So they also control the laser center at the generation plane, not just a shift inwards.
+                 *
+                 * FOCUS_ORIGIN_X, FOCUS_ORIGIN_Y or FOCUS_ORIGIN_Z is not defined the origin will be Origin::Zero
+                 * (total domain).
                  *
                  * For 2d simulations, z component has no effect and is not required.
                  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
@@ -138,7 +138,7 @@ namespace picongpu
                 static constexpr float_64 DIRECTION_Z = 0.0;
                 /** @} */
 
-                /** Focus position in total coordinate system
+                /** Focus position relative to FOCUS_ORIGIN_*
                  *
                  * "Non-focused" lasers should have it set at or near the generation surface where the laser enters
                  * the domain. The position does not have to be inside the domain.
@@ -146,6 +146,9 @@ namespace picongpu
                  * The focus position and propagation direction together define the entry point of laser to
                  * the generation surface.
                  * So they also control the laser center at the generation plane, not just a shift inwards.
+                 *
+                 * FOCUS_ORIGIN_X, FOCUS_ORIGIN_Y or FOCUS_ORIGIN_Z is not defined the origin will be Origin::Zero
+                 * (total domain).
                  *
                  * For 2d simulations, z component has no effect and is not required.
                  *
@@ -158,6 +161,18 @@ namespace picongpu
                 static constexpr float_64 FOCUS_POSITION_X_SI = 0.0;
                 static constexpr float_64 FOCUS_POSITION_Y_SI = 0.0;
                 static constexpr float_64 FOCUS_POSITION_Z_SI = 0.0;
+                /** @} */
+
+                /** Origin of the laser
+                 *
+                 * possible values:
+                 *   - Origin::Center center of the global coordinate system
+                 *   - Origin::Zero total coordinate origin
+                 *
+                 * @attention FOCUS_ORIGIN_X, FOCUS_ORIGIN_y, FOCUS_ORIGIN_Z are optional
+                 */
+                static constexpr Origin FOCUS_ORIGIN_X = Origin::Center;
+                static constexpr Origin FOCUS_ORIGIN_Z = Origin::Center;
                 /** @} */
 
                 /** E polarization type

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -144,7 +144,7 @@ namespace picongpu
                 static constexpr float_64 DIRECTION_Z = 0.0;
                 /** @} */
 
-                /** Focus position in total coordinate system
+                /** Focus position relative to FOCUS_ORIGIN_*
                  *
                  * "Non-focused" lasers should have it set at or near the generation surface where the laser enters
                  * the domain. The position does not have to be inside the domain.
@@ -153,15 +153,29 @@ namespace picongpu
                  * the generation surface.
                  * So they also control the laser center at the generation plane, not just a shift inwards.
                  *
+                 * FOCUS_ORIGIN_X, FOCUS_ORIGIN_Y or FOCUS_ORIGIN_Z is not defined the origin will be Origin::Zero
+                 * (total domain).
+                 *
                  * For 2d simulations, z component has no effect and is not required.
                  *
                  * unit: m
                  *
                  * @{
                  */
-                static constexpr float_64 FOCUS_POSITION_X_SI = 1.70112e-5; // 96 cells
+                static constexpr float_64 FOCUS_POSITION_X_SI = 0.0;
                 static constexpr float_64 FOCUS_POSITION_Y_SI = 4.62e-5;
-                static constexpr float_64 FOCUS_POSITION_Z_SI = 1.70112e-5; // 96 cells
+                static constexpr float_64 FOCUS_POSITION_Z_SI = 0.0;
+
+                /** Origin of the laser
+                 *
+                 * possible values:
+                 *   - Origin::Center center of the global coordinate system
+                 *   - Origin::Zero total coordinate origin
+                 *
+                 * @attention FOCUS_ORIGIN_X, FOCUS_ORIGIN_y, FOCUS_ORIGIN_Z are optional
+                 */
+                static constexpr Origin FOCUS_ORIGIN_X = Origin::Center;
+                static constexpr Origin FOCUS_ORIGIN_Z = Origin::Center;
                 /** @} */
 
                 /** E polarization type


### PR DESCRIPTION
With #4394 where we switched from the old laser profiles to incident field lasers it was required to define the focus position absolute to the origin of the total domain. Because of this absolute focus, it was not possible to in/decrease the simulation volume without adjusting the focus position if the laser should be centered in the domain. The drawback was that the simulation domain was adjustable at runtime and the focus change required recompiling PIConGPU.
For some workflows e.g. visualization the change was a disadvantage.
This PR is solving the issue by introducing a way to bring back the old behavior if needed.

- Add the optional variable `FOCUS_ORIGIN_*` to define the origin of the focus.
- Laser Wakefield and foil LCT example set focus origin of transversal laser direction to the center of the direction.
- update documentation strings

Note: This PR is backward compatible with the latest dev branch param files because the variables `FOCUS_ORIGIN_*` are optional.