### PR TITLE
rename `abs2` -> `l2norm2` and `abs` for  vectors to `l2norm`

### DIFF
--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -167,7 +167,7 @@ The data structures used are those available in PIConGPU.
    {
        /* Channel1
         * computes the absolute value squared of the electric current */
-       return math::abs2(field_Current);
+       return pmacc::math::l2norm2(field_Current);
    }
 
    DINLINE float_X preChannel2( float3_X const & field_B, float3_X const & field_E, float3_X const & field_Current )

--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -35,15 +35,15 @@ Let us select particles with momentum vector within a cone with an opening angle
            {
                bool result = false;
                float3_X const mom = particle[ momentum_ ];
-               float_X const absMom = math::abs( mom );
+               float_X const normMom = pmacc::math::l2norm( mom );
 
-               if( absMom > float_X( 0. ) )
+               if( normMom > float_X( 0. ) )
                {
                    /* place detector in y direction, "infinite distance" to target,
                     * and five degree opening angle
                     */
                    constexpr float_X openingAngle = 5.0 * PI / 180.;
-                   float_X const dotP = mom.y() / absMom;
+                   float_X const dotP = mom.y() / normMom;
                    float_X const degForw = math::acos( dotP );
 
                    if( math::abs( degForw ) <= openingAngle * float_X( 0.5 ) )

--- a/include/picongpu/algorithms/Gamma.hpp
+++ b/include/picongpu/algorithms/Gamma.hpp
@@ -28,7 +28,7 @@ namespace picongpu
     template<typename T_MomType, typename T_MassType>
     HDINLINE T_PrecisionType Gamma<T_PrecisionType>::operator()(T_MomType const& mom, T_MassType const mass) const
     {
-        valueType const fMom2 = pmacc::math::abs2(precisionCast<valueType>(mom));
+        valueType const fMom2 = pmacc::math::l2norm2(precisionCast<valueType>(mom));
         constexpr valueType c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;
 
         valueType const m2_c2_reci = valueType(1.0) / precisionCast<valueType>(mass * mass * c2);

--- a/include/picongpu/algorithms/KinEnergy.hpp
+++ b/include/picongpu/algorithms/KinEnergy.hpp
@@ -44,7 +44,7 @@ namespace picongpu
         HDINLINE ValueType operator()(MomType const& mom, MassType const& mass)
         {
             if(mass == MassType(0.0))
-                return SPEED_OF_LIGHT * math::abs(precisionCast<ValueType>(mom));
+                return SPEED_OF_LIGHT * pmacc::math::l2norm(precisionCast<ValueType>(mom));
 
             /* if mass is non-zero then gamma is well defined */
             const ValueType gamma = Gamma<ValueType>()(mom, mass);
@@ -53,7 +53,7 @@ namespace picongpu
 
             if(gamma < GAMMA_THRESH)
             {
-                const ValueType mom2 = pmacc::math::abs2(precisionCast<ValueType>(mom));
+                const ValueType mom2 = pmacc::math::l2norm2(precisionCast<ValueType>(mom));
                 /* non relativistic kinetic energy expression */
                 kinEnergy = mom2 / (ValueType(2.0) * mass);
             }

--- a/include/picongpu/algorithms/Velocity.hpp
+++ b/include/picongpu/algorithms/Velocity.hpp
@@ -32,7 +32,7 @@ namespace picongpu
         {
             const float_X rc2 = MUE0_EPS0;
             const float_X m0_2 = mass0 * mass0;
-            const float_X fMom2 = pmacc::math::abs2(mom);
+            const float_X fMom2 = pmacc::math::l2norm2(mom);
             float_X t = math::rsqrt(precisionCast<sqrt_X>(m0_2 + fMom2 * rc2));
             return t * mom;
         }

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -549,7 +549,7 @@ namespace picongpu
                         float3_X internalPosition = this->getInternalCoordinates(totalCellIdx);
                         internalPosition[0] = 0.0_X;
                         auto const w0 = float3_X(1.0_X, Unitless::W0_AXIS_1, Unitless::W0_AXIS_2);
-                        auto const r2 = pmacc::math::abs2(internalPosition / w0);
+                        auto const r2 = pmacc::math::l2norm2(internalPosition / w0);
                         return math::exp(-r2);
                     }
                 };

--- a/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
+++ b/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
@@ -156,7 +156,7 @@ namespace picongpu
                             // calculate focus position relative to the current point in the propagation direction
                             auto const focusRelativeToOrigin = this->focus - this->origin;
                             // current distance to focus position
-                            float_X const focusPos = math::sqrt(pmacc::math::abs2(focusRelativeToOrigin)) - pos[0];
+                            float_X const focusPos = math::sqrt(pmacc::math::l2norm2(focusRelativeToOrigin)) - pos[0];
                             // beam waist at the generation plane so that at focus we will get W0
                             float_X const waist = Unitless::W0
                                 * math::sqrt(1.0_X + (focusPos / Unitless::R) * (focusPos / Unitless::R));
@@ -209,7 +209,7 @@ namespace picongpu
 
                             // calculate focus position relative to the current point in the propagation direction
                             auto const focusRelativeToOrigin = this->focus - this->origin;
-                            float_X const focusPos = math::sqrt(pmacc::math::abs2(focusRelativeToOrigin)) - pos[0];
+                            float_X const focusPos = math::sqrt(pmacc::math::l2norm2(focusRelativeToOrigin)) - pos[0];
 
                             // Initial frequency dependent complex phase
                             float_X alpha = expandedWaveVectorX(Omega);

--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
@@ -221,7 +221,7 @@ namespace picongpu
                                                                    Unitless::FOCUS_POSITION_Y,
                                                                    Unitless::FOCUS_POSITION_Z)
                                 - this->origin;
-                            float_X const focusPos = math::sqrt(pmacc::math::abs2(focusRelativeToOrigin)) - pos[0];
+                            float_X const focusPos = math::sqrt(pmacc::math::l2norm2(focusRelativeToOrigin)) - pos[0];
                             // beam waist at the generation plane so that at focus we will get W0
                             float_X const w = Unitless::W0
                                 * math::sqrt(1.0_X + (focusPos / Unitless::R) * (focusPos / Unitless::R));
@@ -248,7 +248,7 @@ namespace picongpu
 
                             auto planeNoNormal = float3_X::create(1.0_X);
                             planeNoNormal[0] = 0.0_X;
-                            auto const transversalDistanceSquared = pmacc::math::abs2(pos * planeNoNormal);
+                            auto const transversalDistanceSquared = pmacc::math::l2norm2(pos * planeNoNormal);
 
                             // inverse radius of curvature of the beam's  wavefronts
                             auto const R_inv = -focusPos / (Unitless::R * Unitless::R + focusPos * focusPos);

--- a/include/picongpu/param/png.param
+++ b/include/picongpu/param/png.param
@@ -80,7 +80,7 @@ namespace picongpu
          */
         DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
         {
-            return pmacc::math::abs2(field_Current);
+            return pmacc::math::l2norm2(field_Current);
         }
 
         DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)

--- a/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
@@ -90,16 +90,16 @@ namespace picongpu
                 // sqrt(AU * (AU + AU)) / (AU/J) / c = sqrt(AU^2)/(AU/J) / c = J/c = kg*m^2/s^2/(m/s)
                 // unit: kg*m/s, SI
 
-                float_X previousMomentumVectorLength = pmacc::math::l2norm2(electron[momentum_]);
+                float_X previousMomentumVectorLength2 = pmacc::math::l2norm2(electron[momentum_]);
                 // unit: internal, scaled
 
                 // case: not moving electron
-                if(previousMomentumVectorLength == 0._X)
-                    previousMomentumVectorLength = 1._X; // no need to resize 0-vector
+                if(previousMomentumVectorLength2 == 0._X)
+                    previousMomentumVectorLength2 = 1._X; // no need to resize 0-vector
 
                 // if previous momentum == 0, discards electron,
                 // @todo select random direction to apply momentum, Brian Marre, 2022
-                electron[momentum_] *= 1 / previousMomentumVectorLength // get unity vector of momentum
+                electron[momentum_] *= 1 / previousMomentumVectorLength2 // get unity vector of momentum
                     * static_cast<float_X>(newPhysicalElectronMomentum
                                            * electron[weighting_] // new momentum scaled and in internal units
                                            / (picongpu::UNIT_MASS * picongpu::UNIT_LENGTH / picongpu::UNIT_TIME));

--- a/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
@@ -90,7 +90,7 @@ namespace picongpu
                 // sqrt(AU * (AU + AU)) / (AU/J) / c = sqrt(AU^2)/(AU/J) / c = J/c = kg*m^2/s^2/(m/s)
                 // unit: kg*m/s, SI
 
-                float_X previousMomentumVectorLength = pmacc::math::abs2(electron[momentum_]);
+                float_X previousMomentumVectorLength = pmacc::math::l2norm2(electron[momentum_]);
                 // unit: internal, scaled
 
                 // case: not moving electron

--- a/include/picongpu/particles/atomicPhysics/GetRealKineticEnergy.hpp
+++ b/include/picongpu/particles/atomicPhysics/GetRealKineticEnergy.hpp
@@ -45,7 +45,7 @@ namespace picongpu
 
                     float3_X vectorMomentum_Scaled = particle[momentum_]; // unit: internal, scaled
                     float_X momentumSquared
-                        = pmacc::math::abs2(vectorMomentum_Scaled) / (particle[weighting_] * particle[weighting_]);
+                        = pmacc::math::l2norm2(vectorMomentum_Scaled) / (particle[weighting_] * particle[weighting_]);
                     // unit: internal, not scaled
 
                     float_64 momentumSquared_p_SI_rel = c_SI * c_SI

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollision.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollision.hpp
@@ -182,7 +182,7 @@ namespace picongpu
 
                         // (12) in [Perez 2012]
                         float3_COLL finalVec;
-                        float_COLL const pAbs = math::sqrt(pmacc::math::abs2(p));
+                        float_COLL const pAbs = math::sqrt(pmacc::math::l2norm2(p));
                         float_COLL const pPerp = math::sqrt(p.x() * p.x() + p.y() * p.y());
                         // TODO chose a better limit?
                         // limit px->0 py=0. this also covers the pPerp = pAbs = 0 case. An alternative would
@@ -220,7 +220,7 @@ namespace picongpu
                         PMACC_ALIGN(comsVelocity, float3_COLL);
 
                         PMACC_ALIGN(comsMomentum0, float3_COLL);
-                        PMACC_ALIGN(comsMomentum0Abs2, float_COLL);
+                        PMACC_ALIGN(comsMomentum0Norm, float_COLL);
                         PMACC_ALIGN(gammaComs, float_COLL);
                         PMACC_ALIGN(factorA, float_COLL);
                         PMACC_ALIGN(coeff0, float_COLL);
@@ -244,7 +244,7 @@ namespace picongpu
                             , gamma1(picongpu::gamma<float_COLL>(labMomentum1, mass1))
                             , comsVelocity((labMomentum0 + labMomentum1) / (mass0 * gamma0 + mass1 * gamma1))
                         {
-                            float_COLL const comsVelocityAbs2 = pmacc::math::abs2(comsVelocity);
+                            float_COLL const comsVelocityAbs2 = pmacc::math::l2norm2(comsVelocity);
 
                             if(comsVelocityAbs2 != 0.0_COLL)
                             {
@@ -277,7 +277,7 @@ namespace picongpu
                                 coeff1 = mass1 * gamma1;
                                 comsMomentum0 = labMomentum0;
                             }
-                            comsMomentum0Abs2 = pmacc::math::abs2(comsMomentum0);
+                            comsMomentum0Norm = pmacc::math::l2norm2(comsMomentum0);
                         }
                     };
 
@@ -354,9 +354,9 @@ namespace picongpu
                                 / (4.0_COLL * pmacc::math::Pi<float_COLL>::value * EPS0_COLL * EPS0_COLL * c * c * c
                                    * c * v.mass0 * v.gamma0 * v.mass1 * v.gamma1);
                             s12Factor0 *= 1.0_COLL / WEIGHT_NORM_COLL / WEIGHT_NORM_COLL;
-                            float_COLL const s12Factor1 = v.gammaComs * math::sqrt(v.comsMomentum0Abs2)
+                            float_COLL const s12Factor1 = v.gammaComs * math::sqrt(v.comsMomentum0Norm)
                                 / (v.mass0 * v.gamma0 + v.mass1 * v.gamma1);
-                            float_COLL const s12Factor2 = v.coeff0 * v.coeff1 * c * c / v.comsMomentum0Abs2 + 1.0_COLL;
+                            float_COLL const s12Factor2 = v.coeff0 * v.coeff1 * c * c / v.comsMomentum0Norm + 1.0_COLL;
                             // Statistical part from [Higginson 2020],
                             // corresponds to n1*n2/n12 in [Perez 2012]:
                             float_COLL const s12Factor3 = potentialPartners
@@ -368,7 +368,7 @@ namespace picongpu
                             // [Perez 2012] (8)
                             // TODO: should we check for the non-relativistic condition? Which gamma should we look at?
                             float_COLL relativeComsVelocity = calcRelativeComsVelocity(
-                                math::sqrt(v.comsMomentum0Abs2),
+                                math::sqrt(v.comsMomentum0Norm),
                                 v.mass0,
                                 v.mass1,
                                 v.gamma0,
@@ -466,7 +466,7 @@ namespace picongpu
                                && (par1[momentum_] == float3_X{0.0_X, 0.0_X, 0.0_X}))
                                 return;
                             const Variables v{par0, par1};
-                            if(v.comsMomentum0Abs2 == 0.0_COLL)
+                            if(v.comsMomentum0Norm == 0.0_COLL)
                                 return;
                             const float_COLL coulombLog = coulombLogFunctor(v);
                             const float_COLL s12 = normalizedPathLength(v, coulombLog);

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollision.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollision.hpp
@@ -182,22 +182,22 @@ namespace picongpu
 
                         // (12) in [Perez 2012]
                         float3_COLL finalVec;
-                        float_COLL const pAbs = math::sqrt(pmacc::math::l2norm2(p));
+                        float_COLL const pNorm2 = math::sqrt(pmacc::math::l2norm2(p));
                         float_COLL const pPerp = math::sqrt(p.x() * p.x() + p.y() * p.y());
                         // TODO chose a better limit?
                         // limit px->0 py=0. this also covers the pPerp = pAbs = 0 case. An alternative would
                         // be to let the momentum unchanged in that case.
-                        if(pPerp <= math::max(std::numeric_limits<float_COLL>::epsilon(), 1.0e-10_COLL) * pAbs)
+                        if(pPerp <= math::max(std::numeric_limits<float_COLL>::epsilon(), 1.0e-10_COLL) * pNorm2)
                         {
-                            finalVec[0] = pAbs * sinXi * cosPhi;
-                            finalVec[1] = pAbs * sinXi * sinPhi;
-                            finalVec[2] = pAbs * cosXi;
+                            finalVec[0] = pNorm2 * sinXi * cosPhi;
+                            finalVec[1] = pNorm2 * sinXi * sinPhi;
+                            finalVec[2] = pNorm2 * cosXi;
                         }
                         else // normal case
                         {
-                            finalVec[0] = (p.x() * p.z() * sinXi * cosPhi - p.y() * pAbs * sinXi * sinPhi) / pPerp
+                            finalVec[0] = (p.x() * p.z() * sinXi * cosPhi - p.y() * pNorm2 * sinXi * sinPhi) / pPerp
                                 + p.x() * cosXi;
-                            finalVec[1] = (p.y() * p.z() * sinXi * cosPhi + p.x() * pAbs * sinXi * sinPhi) / pPerp
+                            finalVec[1] = (p.y() * p.z() * sinXi * cosPhi + p.x() * pNorm2 * sinXi * sinPhi) / pPerp
                                 + p.y() * cosXi;
                             finalVec[2] = -1.0_COLL * pPerp * sinXi * cosPhi + p.z() * cosXi;
                         }
@@ -220,7 +220,7 @@ namespace picongpu
                         PMACC_ALIGN(comsVelocity, float3_COLL);
 
                         PMACC_ALIGN(comsMomentum0, float3_COLL);
-                        PMACC_ALIGN(comsMomentum0Norm, float_COLL);
+                        PMACC_ALIGN(comsMomentum0Norm2, float_COLL);
                         PMACC_ALIGN(gammaComs, float_COLL);
                         PMACC_ALIGN(factorA, float_COLL);
                         PMACC_ALIGN(coeff0, float_COLL);
@@ -244,17 +244,17 @@ namespace picongpu
                             , gamma1(picongpu::gamma<float_COLL>(labMomentum1, mass1))
                             , comsVelocity((labMomentum0 + labMomentum1) / (mass0 * gamma0 + mass1 * gamma1))
                         {
-                            float_COLL const comsVelocityAbs2 = pmacc::math::l2norm2(comsVelocity);
+                            float_COLL const comsVelocityNorm2 = pmacc::math::l2norm2(comsVelocity);
 
-                            if(comsVelocityAbs2 != 0.0_COLL)
+                            if(comsVelocityNorm2 != 0.0_COLL)
                             {
-                                float_COLL const comsVelocityAbs = math::sqrt(comsVelocityAbs2);
+                                float_COLL const comsVelocityAbs = math::sqrt(comsVelocityNorm2);
                                 // written as (1-v)(1+v) rather than (1-v^2) for better performance when v close to
                                 // c
                                 gammaComs = 1.0_COLL
                                     / math::sqrt((1.0_COLL - comsVelocityAbs / c) * (1.0_COLL + comsVelocityAbs / c));
                                 // used later for comsToLab:
-                                factorA = (gammaComs - 1.0_COLL) / comsVelocityAbs2;
+                                factorA = (gammaComs - 1.0_COLL) / comsVelocityNorm2;
 
                                 // Stared gamma times mass, from [Perez 2012].
                                 coeff0 = coeff(labMomentum0, mass0, gamma0, gammaComs, comsVelocity);
@@ -277,7 +277,7 @@ namespace picongpu
                                 coeff1 = mass1 * gamma1;
                                 comsMomentum0 = labMomentum0;
                             }
-                            comsMomentum0Norm = pmacc::math::l2norm2(comsMomentum0);
+                            comsMomentum0Norm2 = pmacc::math::l2norm2(comsMomentum0);
                         }
                     };
 
@@ -354,9 +354,10 @@ namespace picongpu
                                 / (4.0_COLL * pmacc::math::Pi<float_COLL>::value * EPS0_COLL * EPS0_COLL * c * c * c
                                    * c * v.mass0 * v.gamma0 * v.mass1 * v.gamma1);
                             s12Factor0 *= 1.0_COLL / WEIGHT_NORM_COLL / WEIGHT_NORM_COLL;
-                            float_COLL const s12Factor1 = v.gammaComs * math::sqrt(v.comsMomentum0Norm)
+                            float_COLL const s12Factor1 = v.gammaComs * math::sqrt(v.comsMomentum0Norm2)
                                 / (v.mass0 * v.gamma0 + v.mass1 * v.gamma1);
-                            float_COLL const s12Factor2 = v.coeff0 * v.coeff1 * c * c / v.comsMomentum0Norm + 1.0_COLL;
+                            float_COLL const s12Factor2
+                                = v.coeff0 * v.coeff1 * c * c / v.comsMomentum0Norm2 + 1.0_COLL;
                             // Statistical part from [Higginson 2020],
                             // corresponds to n1*n2/n12 in [Perez 2012]:
                             float_COLL const s12Factor3 = potentialPartners
@@ -368,7 +369,7 @@ namespace picongpu
                             // [Perez 2012] (8)
                             // TODO: should we check for the non-relativistic condition? Which gamma should we look at?
                             float_COLL relativeComsVelocity = calcRelativeComsVelocity(
-                                math::sqrt(v.comsMomentum0Norm),
+                                math::sqrt(v.comsMomentum0Norm2),
                                 v.mass0,
                                 v.mass1,
                                 v.gamma0,
@@ -466,7 +467,7 @@ namespace picongpu
                                && (par1[momentum_] == float3_X{0.0_X, 0.0_X, 0.0_X}))
                                 return;
                             const Variables v{par0, par1};
-                            if(v.comsMomentum0Norm == 0.0_COLL)
+                            if(v.comsMomentum0Norm2 == 0.0_COLL)
                                 return;
                             const float_COLL coulombLog = coulombLogFunctor(v);
                             const float_COLL s12 = normalizedPathLength(v, coulombLog);

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
@@ -45,7 +45,7 @@ namespace picongpu
                                    * static_cast<float_COLL>(EPS0 * SPEED_OF_LIGHT * SPEED_OF_LIGHT));
                             const float_COLL factor2 = v.gammaComs / (v.mass0 * v.gamma0 + v.mass1 * v.gamma1);
                             const float_COLL factor3
-                                = (v.coeff0 * v.coeff1 / v.comsMomentum0Norm
+                                = (v.coeff0 * v.coeff1 / v.comsMomentum0Norm2
                                        * static_cast<float_COLL>(SPEED_OF_LIGHT * SPEED_OF_LIGHT)
                                    + 1._COLL);
                             /*
@@ -60,7 +60,7 @@ namespace picongpu
                             // formula in line above eq. (22) in [Perez2012]:
                             const float_COLL minImpactParam = math::max(
                                 static_cast<float_COLL>(HBAR) * pmacc::math::Pi<float_COLL>::doubleValue
-                                    / (2._COLL * math::sqrt(v.comsMomentum0Norm) / precision::WEIGHT_NORM_COLL),
+                                    / (2._COLL * math::sqrt(v.comsMomentum0Norm2) / precision::WEIGHT_NORM_COLL),
                                 twoRadImpactParam);
 
                             // eq. (23) in [Perez2012]:

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
@@ -45,7 +45,7 @@ namespace picongpu
                                    * static_cast<float_COLL>(EPS0 * SPEED_OF_LIGHT * SPEED_OF_LIGHT));
                             const float_COLL factor2 = v.gammaComs / (v.mass0 * v.gamma0 + v.mass1 * v.gamma1);
                             const float_COLL factor3
-                                = (v.coeff0 * v.coeff1 / v.comsMomentum0Abs2
+                                = (v.coeff0 * v.coeff1 / v.comsMomentum0Norm
                                        * static_cast<float_COLL>(SPEED_OF_LIGHT * SPEED_OF_LIGHT)
                                    + 1._COLL);
                             /*
@@ -60,7 +60,7 @@ namespace picongpu
                             // formula in line above eq. (22) in [Perez2012]:
                             const float_COLL minImpactParam = math::max(
                                 static_cast<float_COLL>(HBAR) * pmacc::math::Pi<float_COLL>::doubleValue
-                                    / (2._COLL * math::sqrt(v.comsMomentum0Abs2) / precision::WEIGHT_NORM_COLL),
+                                    / (2._COLL * math::sqrt(v.comsMomentum0Norm) / precision::WEIGHT_NORM_COLL),
                                 twoRadImpactParam);
 
                             // eq. (23) in [Perez2012]:

--- a/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianCloudImpl.hpp
@@ -62,7 +62,7 @@ namespace picongpu
                 /* for x, y, z calculate: x-x0 / sigma_x */
                 const floatD_X r0overSigma = (globalCellPos - center) / sigma;
                 /* get lenghts of r0 over sigma */
-                const float_X exponent = math::abs(r0overSigma);
+                const float_X exponent = pmacc::math::l2norm(r0overSigma);
 
                 /* calculate exp(factor * exponent**power) */
                 const float_X power = ParamClass::gasPower;

--- a/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/SphereFlanksImpl.hpp
@@ -61,7 +61,7 @@ namespace picongpu
                 if(globalCellPos.y() < vacuum_y)
                     return float_X(0.0);
 
-                const float_X distance = math::abs(globalCellPos - center);
+                const float_X distance = pmacc::math::l2norm(globalCellPos - center);
 
                 /* "shell": inner radius */
                 if(distance < ri)

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -84,7 +84,7 @@ namespace picongpu
 
                         constexpr float_X pi = pmacc::math::Pi<float_X>::value;
                         /* electric field in atomic units - only absolute value */
-                        float_X const eInAU = math::abs(eField) / ATOMIC_UNIT_EFIELD;
+                        float_X const eInAU = pmacc::math::l2norm(eField) / ATOMIC_UNIT_EFIELD;
 
                         /* the charge that attracts the electron that is to be ionized:
                          * equals `protonNumber - #allInnerElectrons`

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp
@@ -77,7 +77,7 @@ namespace picongpu
                         /* critical field strength in atomic units */
                         float_X const critField = iEnergy * iEnergy / (float_X(4.0) * effectiveCharge);
                         /* ionization condition */
-                        if(math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
+                        if(pmacc::math::l2norm(eField) / ATOMIC_UNIT_EFIELD >= critField)
                         {
                             /* return ionization energy and number of macro electrons to produce */
                             return IonizerReturn{iEnergy, 1u};

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp
@@ -76,7 +76,7 @@ namespace picongpu
                         float_X critField = iEnergy * iEnergy / (float_X(4.0) * ZEff);
 
                         /* ionization condition */
-                        if(math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
+                        if(pmacc::math::l2norm(eField) / ATOMIC_UNIT_EFIELD >= critField)
                         {
                             /* return ionization energy and number of macro electrons to produce */
                             return IonizerReturn{iEnergy, 1u};

--- a/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/AlgorithmBSIStarkShifted.hpp
@@ -75,7 +75,7 @@ namespace picongpu
                             = (math::sqrt(float_X(2.)) - float_X(1.)) * math::pow(iEnergy, float_X(3. / 2.));
 
                         /* ionization condition */
-                        if(math::abs(eField) / ATOMIC_UNIT_EFIELD >= critField)
+                        if(pmacc::math::l2norm(eField) / ATOMIC_UNIT_EFIELD >= critField)
                         {
                             /* return ionization energy number of electrons to produce */
                             return IonizerReturn{iEnergy, 1u};

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp
@@ -37,7 +37,7 @@ namespace picongpu
                  */
                 HDINLINE float3_X operator()(float_X const ionizationEnergy, float3_X const eField)
                 {
-                    float3_X jion = ionizationEnergy * eField / pmacc::math::abs2(eField) / DELTA_T / CELL_VOLUME;
+                    float3_X jion = ionizationEnergy * eField / pmacc::math::l2norm2(eField) / DELTA_T / CELL_VOLUME;
                     return jion;
                 }
             };

--- a/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/AlgorithmKeldysh.hpp
@@ -76,7 +76,7 @@ namespace picongpu
 
                         constexpr float_X pi = pmacc::math::Pi<float_X>::value;
                         /* electric field in atomic units - only absolute value */
-                        float_X eInAU = math::abs(eField) / ATOMIC_UNIT_EFIELD;
+                        float_X eInAU = pmacc::math::l2norm(eField) / ATOMIC_UNIT_EFIELD;
 
                         /* factor two avoid calculation math::pow(2,5./4.); */
                         const float_X twoToFiveQuarters = 2.3784142300054;

--- a/include/picongpu/particles/manipulators/unary/Drift.hpp
+++ b/include/picongpu/particles/manipulators/unary/Drift.hpp
@@ -65,7 +65,7 @@ namespace picongpu
                             float_64 const initFreeBeta = math::sqrt(1.0 - 1.0 / (myGamma * myGamma));
 
                             float3_X const driftDirection(ParamClass().direction);
-                            float3_X const normDir = driftDirection / math::abs(driftDirection);
+                            float3_X const normDir = driftDirection / pmacc::math::l2norm(driftDirection);
 
                             float3_X const mom(
                                 normDir

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/LarmorPower.hpp
@@ -70,9 +70,9 @@ namespace picongpu
                         / (float_X(6.0) * PI * EPS0 * c2 * SPEED_OF_LIGHT * mass * mass) * gamma2 * gamma2;
                     const float_X momentumToBetaConvert = float_X(1.0) / (mass * SPEED_OF_LIGHT * gamma);
                     const float_X larmorPower = el_factor
-                        * (pmacc::math::abs2(mom_dt)
+                        * (pmacc::math::l2norm2(mom_dt)
                            - momentumToBetaConvert * momentumToBetaConvert
-                               * pmacc::math::abs2(pmacc::math::cross(mom, mom_dt)));
+                               * pmacc::math::l2norm2(pmacc::math::cross(mom, mom_dt)));
 
                     /* return attribute */
                     return larmorPower;

--- a/include/picongpu/particles/pusher/particlePusherBoris.hpp
+++ b/include/picongpu/particles/pusher/particlePusherBoris.hpp
@@ -72,7 +72,7 @@ namespace picongpu
                 Gamma gamma;
                 const float_X gamma_reci = float_X(1.0) / gamma(mom_minus, mass);
                 const float3_X t = float_X(0.5) * QoM * bField * gamma_reci * deltaT;
-                auto s = float_X(2.0) * t * (float_X(1.0) / (float_X(1.0) + pmacc::math::abs2(t)));
+                auto s = float_X(2.0) * t * (float_X(1.0) / (float_X(1.0) + pmacc::math::l2norm2(t)));
 
                 const MomType mom_prime = mom_minus + pmacc::math::cross(mom_minus, t);
                 const MomType mom_plus = mom_minus + pmacc::math::cross(mom_prime, s);

--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -99,7 +99,7 @@ namespace picongpu
                 sqrt_HC::float3_X const tau
                     = precisionCast<sqrt_HC::float_X>(float_X(0.5) * bField * charge * deltaT / mass);
 
-                sqrt_HC::float_X const sigma = pmacc::math::abs2(gamma_minus) - pmacc::math::abs2(tau);
+                sqrt_HC::float_X const sigma = math::abs(gamma_minus) - pmacc::math::l2norm2(tau);
 
                 sqrt_HC::float_X const u_star
                     = pmacc::math::dot(mom_minus, tau) / precisionCast<sqrt_HC::float_X>(mass * SPEED_OF_LIGHT);
@@ -108,13 +108,13 @@ namespace picongpu
                     sqrt_HC::float_X(0.5)
                     * (sigma
                        + math::sqrt(
-                           pmacc::math::abs2(sigma)
-                           + sqrt_HC::float_X(4.0) * (pmacc::math::abs2(tau) + pmacc::math::abs2(u_star)))));
+                           math::abs(sigma)
+                           + sqrt_HC::float_X(4.0) * (pmacc::math::l2norm2(tau) + math::abs(u_star)))));
 
                 sqrt_HC::float3_X const t_vector = tau / gamma_plus;
 
                 sqrt_HC::float_X const s
-                    = sqrt_HC::float_X(1.0) / (sqrt_HC::float_X(1.0) + pmacc::math::abs2(t_vector));
+                    = sqrt_HC::float_X(1.0) / (sqrt_HC::float_X(1.0) + pmacc::math::l2norm2(t_vector));
 
                 // Rotation step
                 sqrt_HC::float3_X const mom_plus = s

--- a/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
+++ b/include/picongpu/particles/pusher/particlePusherHigueraCary.hpp
@@ -99,7 +99,7 @@ namespace picongpu
                 sqrt_HC::float3_X const tau
                     = precisionCast<sqrt_HC::float_X>(float_X(0.5) * bField * charge * deltaT / mass);
 
-                sqrt_HC::float_X const sigma = math::abs(gamma_minus) - pmacc::math::l2norm2(tau);
+                sqrt_HC::float_X const sigma = pmacc::math::norm(gamma_minus) - pmacc::math::l2norm2(tau);
 
                 sqrt_HC::float_X const u_star
                     = pmacc::math::dot(mom_minus, tau) / precisionCast<sqrt_HC::float_X>(mass * SPEED_OF_LIGHT);
@@ -108,8 +108,8 @@ namespace picongpu
                     sqrt_HC::float_X(0.5)
                     * (sigma
                        + math::sqrt(
-                           math::abs(sigma)
-                           + sqrt_HC::float_X(4.0) * (pmacc::math::l2norm2(tau) + math::abs(u_star)))));
+                           pmacc::math::norm(sigma)
+                           + sqrt_HC::float_X(4.0) * (pmacc::math::l2norm2(tau) + pmacc::math::norm(u_star)))));
 
                 sqrt_HC::float3_X const t_vector = tau / gamma_plus;
 

--- a/include/picongpu/particles/pusher/particlePusherPhoton.hpp
+++ b/include/picongpu/particles/pusher/particlePusherPhoton.hpp
@@ -57,8 +57,8 @@ namespace picongpu
                 if constexpr(pmacc::traits::HasIdentifier<T_Particle, probeE>::type::value)
                     particle[probeE_] = eField;
 
-                const float_X mom_abs = math::abs(mom);
-                const MomType vel = mom * (SPEED_OF_LIGHT / mom_abs);
+                const float_X normMom = pmacc::math::l2norm(mom);
+                const MomType vel = mom * (SPEED_OF_LIGHT / normMom);
 
                 for(uint32_t d = 0; d < simDim; ++d)
                 {

--- a/include/picongpu/particles/pusher/particlePusherVay.hpp
+++ b/include/picongpu/particles/pusher/particlePusherVay.hpp
@@ -88,14 +88,14 @@ namespace picongpu
                 const sqrt_Vay::float_X u_star
                     = pmacc::math::dot(precisionCast<sqrt_Vay::float_X>(momentum_prime), tau)
                     / precisionCast<sqrt_Vay::float_X>(SPEED_OF_LIGHT * mass);
-                const sqrt_Vay::float_X sigma = gamma_prime * gamma_prime - pmacc::math::abs2(tau);
+                const sqrt_Vay::float_X sigma = gamma_prime * gamma_prime - pmacc::math::l2norm2(tau);
                 const sqrt_Vay::float_X gamma_atPlusHalf = math::sqrt(
                     sqrt_Vay::float_X(0.5)
                     * (sigma
                        + math::sqrt(
-                           sigma * sigma + sqrt_Vay::float_X(4.0) * (pmacc::math::abs2(tau) + u_star * u_star))));
+                           sigma * sigma + sqrt_Vay::float_X(4.0) * (pmacc::math::l2norm2(tau) + u_star * u_star))));
                 const float3_X t(tau * (float_X(1.0) / gamma_atPlusHalf));
-                const float_X s = float_X(1.0) / (float_X(1.0) + pmacc::math::abs2(t));
+                const float_X s = float_X(1.0) / (float_X(1.0) + pmacc::math::l2norm2(t));
                 const MomType momentum_atPlusHalf = s
                     * (momentum_prime + pmacc::math::dot(momentum_prime, t) * t
                        + pmacc::math::cross(momentum_prime, t));

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -224,7 +224,7 @@ namespace picongpu
 
                     /* rho := | div E * eps_0 - rho | */
                     rohBox(globalCellIdx).x()
-                        = math::abs(div(fieldEBox.shift(globalCellIdx)) * EPS0 - rohBox(globalCellIdx).x());
+                        = pmacc::math::l2norm(div(fieldEBox.shift(globalCellIdx)) * EPS0 - rohBox(globalCellIdx).x());
                 });
         };
 

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -114,7 +114,7 @@ namespace picongpu
                     {
                         float3_X const mom = particle[momentum_];
                         // compute square of absolute momentum of the particle
-                        float_X const mom2 = pmacc::math::abs2(mom);
+                        float_X const mom2 = pmacc::math::l2norm2(mom);
                         float_X const weighting = particle[weighting_];
                         float_X const mass = attribute::getMass(weighting, particle);
                         float_X const c2 = SPEED_OF_LIGHT * SPEED_OF_LIGHT;

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -128,7 +128,7 @@ namespace picongpu
             std::cout.precision(dbl::digits10);
             if(math::abs(gCurrent.x()) + math::abs(gCurrent.y()) + math::abs(gCurrent.z()) != float_X(0.0))
                 std::cout << "[ANALYSIS] [" << rank << "] [COUNTER] [SumCurrents] [" << currentStep << std::scientific
-                          << "] " << realCurrent_SI << " Abs:" << math::abs(realCurrent_SI) << std::endl;
+                          << "] " << realCurrent_SI << " l2norm:" << pmacc::math::l2norm(realCurrent_SI) << std::endl;
         }
 
         void pluginRegisterHelp(po::options_description& desc) override

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -336,7 +336,7 @@ namespace picongpu
                 const float3_X vecUp(0.0, 0.0, -1.0);
                 this->calorimeterFrameVecX = pmacc::math::cross(vecUp, this->calorimeterFrameVecY);
                 /* normalize vector */
-                this->calorimeterFrameVecX /= math::abs(this->calorimeterFrameVecX);
+                this->calorimeterFrameVecX /= pmacc::math::l2norm(this->calorimeterFrameVecX);
             }
             this->calorimeterFrameVecZ = pmacc::math::cross(this->calorimeterFrameVecX, this->calorimeterFrameVecY);
 

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -159,7 +159,7 @@ namespace picongpu
                         / (16. * util::cube(pmacc::math::Pi<picongpu::float_64>::value) * picongpu::EPS0
                            * picongpu::SPEED_OF_LIGHT);
 
-                    return factor * (pmacc::math::abs2(amp_x) + pmacc::math::abs2(amp_y) + pmacc::math::abs2(amp_z));
+                    return factor * (pmacc::math::norm(amp_x) + pmacc::math::norm(amp_y) + pmacc::math::norm(amp_z));
                 }
 
 

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -377,8 +377,8 @@ namespace picongpu
                          ************************************************************/
                         for(unsigned int i = 0; i < elementsTransitionRadiation(); ++i)
                         {
-                            const float_X ctrPara = pmacc::math::abs2(ctrParaArray[i]);
-                            const float_X ctrPerp = pmacc::math::abs2(ctrPerpArray[i]);
+                            const float_X ctrPara = pmacc::math::norm(ctrParaArray[i]);
+                            const float_X ctrPerp = pmacc::math::norm(ctrPerpArray[i]);
                             if(numArray[i] != 0.0)
                             {
                                 targetArray[i]

--- a/include/pmacc/algorithms/math/defines/l2norm.hpp
+++ b/include/pmacc/algorithms/math/defines/l2norm.hpp
@@ -28,16 +28,33 @@ namespace pmacc
     namespace math
     {
         template<typename Type>
-        struct Abs2;
+        struct L2norm;
 
+        /** l2norm
+         *
+         * only defined for vectors
+         *
+         * @return sqrt(abs(x)^2 + ...)
+         */
         template<typename T1>
-        HDINLINE typename Abs2<T1>::result abs2(const T1& value)
+        HDINLINE typename L2norm<T1>::result l2norm(const T1& value)
         {
-            return Abs2<T1>()(value);
+            return L2norm<T1>()(value);
         }
 
+        template<typename Type>
+        struct L2norm2;
+
+        /** l2norm2
+         *
+         * only defined for vectors
+         *
+         * @return abs(x)^2 + ...
+         */
+        template<typename T1>
+        HDINLINE typename L2norm2<T1>::result l2norm2(const T1& value)
+        {
+            return L2norm2<T1>()(value);
+        }
     } // namespace math
 } // namespace pmacc
-
-#include "pmacc/algorithms/math/doubleMath/abs.tpp"
-#include "pmacc/algorithms/math/floatMath/abs.tpp"

--- a/include/pmacc/algorithms/math/defines/norm.hpp
+++ b/include/pmacc/algorithms/math/defines/norm.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2022 Heiko Burau, Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -19,28 +19,24 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "pmacc/types.hpp"
-
-#include <cmath>
-
 
 namespace pmacc
 {
     namespace math
     {
-        template<>
-        struct Abs2<double>
+        template<typename Type>
+        struct Norm;
+
+        template<typename T1>
+        HDINLINE typename Norm<T1>::result norm(const T1& value)
         {
-            using result = double;
-
-            HDINLINE double operator()(const double& value)
-            {
-                return value * value;
-            }
-        };
-
+            return Norm<T1>()(value);
+        }
     } // namespace math
 } // namespace pmacc
+
+#include "pmacc/algorithms/math/doubleMath/norm.tpp"
+#include "pmacc/algorithms/math/floatMath/norm.tpp"

--- a/include/pmacc/algorithms/math/doubleMath/norm.tpp
+++ b/include/pmacc/algorithms/math/doubleMath/norm.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Alexander Debus, Brian Marre
+/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PMacc.
  *
@@ -19,16 +19,27 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #pragma once
 
-#include "pmacc/algorithms/math/PowerFunction.hpp"
-#include "pmacc/algorithms/math/defines/bessel.hpp"
-#include "pmacc/algorithms/math/defines/cross.hpp"
-#include "pmacc/algorithms/math/defines/dot.hpp"
-#include "pmacc/algorithms/math/defines/exp.hpp"
-#include "pmacc/algorithms/math/defines/floatingPoint.hpp"
-#include "pmacc/algorithms/math/defines/l2norm.hpp"
-#include "pmacc/algorithms/math/defines/modf.hpp"
-#include "pmacc/algorithms/math/defines/norm.hpp"
-#include "pmacc/algorithms/math/defines/pi.hpp"
-#include "pmacc/algorithms/math/defines/trigo.hpp"
+#include "pmacc/types.hpp"
+
+#include <cmath>
+
+
+namespace pmacc
+{
+    namespace math
+    {
+        template<>
+        struct Norm<double>
+        {
+            using result = double;
+
+            HDINLINE double operator()(const double& value)
+            {
+                return value * value;
+            }
+        };
+    } // namespace math
+} // namespace pmacc

--- a/include/pmacc/algorithms/math/floatMath/norm.tpp
+++ b/include/pmacc/algorithms/math/floatMath/norm.tpp
@@ -31,7 +31,7 @@ namespace pmacc
     namespace math
     {
         template<>
-        struct Abs2<float>
+        struct Norm<float>
         {
             using result = float;
 
@@ -40,6 +40,5 @@ namespace pmacc
                 return value * value;
             }
         };
-
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/complex/Complex.tpp
+++ b/include/pmacc/math/complex/Complex.tpp
@@ -72,18 +72,15 @@ namespace pmacc
             }
         };
 
-        /** Specialize abs2() for complex numbers.
-         *
-         * Note: Abs is specialized in alpaka::math below
-         */
+        //! Specialize norm() for complex numbers following the C++ standard
         template<typename T_Type>
-        struct Abs2<alpaka::Complex<T_Type>>
+        struct Norm<alpaka::Complex<T_Type>>
         {
             using result = typename alpaka::Complex<T_Type>::value_type;
 
             HDINLINE result operator()(const alpaka::Complex<T_Type>& other)
             {
-                return pmacc::math::abs2(other.real()) + pmacc::math::abs2(other.imag());
+                return other.real() * other.real() + other.imag() * other.imag();
             }
         };
 

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -752,15 +752,6 @@ namespace pmacc
             return result;
         }
 
-        struct Abs
-        {
-            template<typename Type, uint32_t dim>
-            HDINLINE Type operator()(const Vector<Type, dim>& vec)
-            {
-                return cupla::math::abs(vec);
-            }
-        };
-
         /** Get the unit basis vector of the given type along the given direction
          *
          * In case 0 <= T_direction < T_Vector::dim, return the basis vector with value

--- a/include/pmacc/math/vector/Vector.tpp
+++ b/include/pmacc/math/vector/Vector.tpp
@@ -106,18 +106,33 @@ namespace pmacc
             }
         };
 
-        /*specialize abs2 algorithm*/
+        /** specialize l2norm2 algorithm
+         */
         template<typename Type, uint32_t dim>
-        struct Abs2<::pmacc::math::Vector<Type, dim>>
+        struct L2norm2<::pmacc::math::Vector<Type, dim>>
         {
             using result = typename ::pmacc::math::Vector<Type, dim>::type;
 
             HDINLINE result operator()(const ::pmacc::math::Vector<Type, dim>& vector)
             {
-                result tmp = pmacc::math::abs2(vector.x());
+                result tmp = pmacc::math::norm(vector.x());
                 for(uint32_t i = 1; i < dim; ++i)
-                    tmp += pmacc::math::abs2(vector[i]);
+                    tmp += pmacc::math::norm(vector[i]);
                 return tmp;
+            }
+        };
+
+        /** specialize l2norm algorithm
+         */
+        template<typename Type, uint32_t dim>
+        struct L2norm<::pmacc::math::Vector<Type, dim>>
+        {
+            using result = typename ::pmacc::math::Vector<Type, dim>::type;
+
+            HDINLINE result operator()(const ::pmacc::math::Vector<Type, dim>& vector)
+            {
+                result tmp = pmacc::math::l2norm2(vector);
+                return cupla::math::sqrt(tmp);
             }
         };
 
@@ -240,26 +255,8 @@ namespace alpaka
             // Floor specialization
             PMACC_UNARY_APAKA_MATH_SPECIALIZATION(floor, Floor);
 
-            /* Abs specialization
-             *
-             * Returns the length of the vector to fit the old implementation.
-             * @todo implement a math function magnitude instead of using abs to get the length of the vector.
-             */
-            template<typename T_Ctx, typename T_ScalarType, uint32_t T_dim>
-            struct Abs<T_Ctx, ::pmacc::math::Vector<T_ScalarType, T_dim>, void>
-            {
-                using ResultType = typename ::pmacc::math::Vector<T_ScalarType, T_dim>::type;
-
-                ALPAKA_FN_HOST_ACC auto operator()(
-                    T_Ctx const& mathConcept,
-                    ::pmacc::math::Vector<T_ScalarType, T_dim> const& vector) -> ResultType
-                {
-                    PMACC_CASSERT(T_dim > 0);
-
-                    ResultType const tmp = pmacc::math::abs2(vector);
-                    return cupla::math::sqrt(tmp);
-                }
-            };
+            // Abs specialization
+            PMACC_UNARY_APAKA_MATH_SPECIALIZATION(abs, Abs);
 
         } // namespace trait
     } // namespace math

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particleFilters.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particleFilters.param
@@ -61,15 +61,15 @@ namespace picongpu
                 {
                     bool result = false;
                     float3_X const mom = particle[momentum_];
-                    float_X const absMom = math::abs(mom);
+                    float_X const normMom = pmacc::math::l2norm(mom);
 
-                    if(absMom > float_X(0.))
+                    if(normMom > float_X(0.))
                     {
                         /* Place detector in y direction, "infinite distance" to target,
                          * and 7.6 degree opening angle (4cm pinhole after 30cm to detector).
                          */
                         constexpr float_X openingAngle = 7.59464 * PI / 180.;
-                        float_X const dotP = mom.y() / absMom;
+                        float_X const dotP = mom.y() / normMom;
                         float_X const degForw = math::acos(dotP);
 
                         if(math::abs(degForw) <= openingAngle * float_X(0.5))

--- a/share/picongpu/examples/Bunch/include/picongpu/param/png.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/png.param
@@ -79,7 +79,7 @@ namespace picongpu
          */
         DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
         {
-            return pmacc::math::abs2(field_Current);
+            return pmacc::math::l2norm2(field_Current);
         }
 
         DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/png.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/png.param
@@ -79,7 +79,7 @@ namespace picongpu
          */
         DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
         {
-            return pmacc::math::abs2(field_Current);
+            return pmacc::math::l2norm2(field_Current);
         }
 
         DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)


### PR DESCRIPTION
All our operations on vectors are normally dot wise
operations expect for `abs` and `abs2` we wrote specializations and
implemented `l2norm` and `l2norm2`.
This was always confusing and it was therefore not possible to call
dot wise `abs` for a vector.

This PR is cleaning the implementations.
  - `cupla::math::abs(vector)` is now dot wise abs
  - `pmacc::math::l2norm2(vector)` norm(component) + ...
  - `pmacc::math::l2norm(vector)` length of the vector `sqrt(norm(components) + ...)`
  - implement `norm()` following the C++ standard
