### PR TITLE
Introduce external beam for photon injection at a boundary

### DIFF
--- a/docs/source/usage/workflows.rst
+++ b/docs/source/usage/workflows.rst
@@ -18,3 +18,4 @@ This section contains typical user workflows and best practices.
    workflows/probeParticles
    workflows/tracerParticles
    workflows/particleFilters
+   workflows/particleBasedRadiationtransport

--- a/docs/source/usage/workflows/particleBasedRadiationtransport.rst
+++ b/docs/source/usage/workflows/particleBasedRadiationtransport.rst
@@ -15,7 +15,7 @@ See :ref:`[1] <masterThesis-PawelOrdyna>` for more details.
 --------------------
 
 It is possible to inject photon like macro particles at a simulation boundary for probing like setups.
-The particles are spawned within the first layer of cells (line in 2D, plane in 3D) at a given simulation box side.
+The particles are spawned within the layer of cells at the species boundary offset (line in 2D, plane in 3D) at a given simulation box side.
 At the moment they can only be spawned with their momenta oriented along the direction normal to the boundary, so only probing along one of the simulation box axes is possible.
 
 The beam particle spawning is similar to initial density initialization.
@@ -25,6 +25,8 @@ At the moment all particles are initialized with the same momentum (mono-energet
 These initial attributes as well as additional ones are set with functors that can be configured in ``externalBeam.param``.
 This param file also defines the beam profile and shape. The injection has to be also included in ``iterationStart.param``.
 
+Please note, the particle boundary offset is taken into account when spawning particles, but the beam temporal shape is not automaticaly shifted.
+The offset can be set manually via `beamDelay_SI` in `OffsetParam`.
 Example Configuration
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/usage/workflows/particleBasedRadiationtransport.rst
+++ b/docs/source/usage/workflows/particleBasedRadiationtransport.rst
@@ -1,0 +1,235 @@
+.. _usage-particleBasedRadiationTransport:
+
+Particle based Radiation Transport
+==================================
+
+.. sectionauthor:: Pawel Ordyna
+
+1 Overview
+----------
+
+This page describes the already implemented parts of our particle based Monte-Carlo Radiation Transport implementation.
+See :ref:`[1] <masterThesis-PawelOrdyna>` for more details.
+
+2 Particle Injection
+--------------------
+
+It is possible to inject photon like macro particles at a simulation boundary for probing like setups.
+The particles are spawned within the first layer of cells (line in 2D, plane in 3D) at a given simulation box side.
+At the moment they can only be spawned with their momenta oriented along the direction normal to the boundary, so only probing along one of the simulation box axes is possible.
+
+The beam particle spawning is similar to initial density initialization.
+There is a fixed number of new particles in each boundary cell, either equally distributed within the initialization volume or randomly.
+The particle weighting depends on the local beam density that is defined via an external beam transversal profile and temporal shape.
+At the moment all particles are initialized with the same momentum (mono-energetic beam).
+These initial attributes as well as additional ones are set with functors that can be configured in ``externalBeam.param``.
+This param file also defines the beam profile and shape. The injection has to be also included in ``iterationStart.param``.
+
+Example Configuration
+^^^^^^^^^^^^^^^^^^^^^
+
+Example ``externalBeam.param``:
+
+.. code:: c++
+
+   #pragma once
+
+   #include "picongpu/param/grid.param"
+   #include "picongpu/particles/externalBeam/beam/ProbingBeam.def"
+   #include "picongpu/particles/externalBeam/beam/Side.hpp"
+   #include "picongpu/particles/externalBeam/beam/beamProfiles/profiles.def"
+   #include "picongpu/particles/externalBeam/beam/beamShapes/shapes.def"
+   #include "picongpu/particles/externalBeam/functors.def"
+
+
+   namespace picongpu::namespace particles::externalBeam
+   {
+        /* Choose from:
+         *  - ZSide (probing along z)
+         *  - YSide (probing along y)
+         *  - XSide (probing along x)
+         * - ZRSide (probing against z)
+         * - YRSide (probing against y)
+         * - XRSide (probing against x)
+         */
+        using ProbingSide = beam::ZSide;
+
+        // Params for the Gaussian transversal beam profile (x,y are beam coordinates)
+        PMACC_STRUCT(
+            GaussParam,
+            (PMACC_C_VALUE(float_X, sigmaX_SI, 5e-6))(
+                PMACC_C_VALUE(float_X, sigmaY_SI, 5e-6)));
+        /* Offset from the beam coordinate system default position (x,y) in beam coordinates.
+         * As well as, the temporal delay.
+         * The default position is the center of the initialization boundary.
+         */
+        PMACC_STRUCT(
+            OffsetParam,
+            (PMACC_C_VECTOR_DIM(float_X, DIM2, beamOffset_SI, 0.0, 0.0))(
+                PMACC_C_VALUE(float_X, beamDelay_SI, 0.0)));
+
+        // Constant temporal shape (square pulse)
+        struct ConstShapeParam
+        {
+            static constexpr bool limitStart = true;
+            static constexpr bool limitEnd = true;
+            // does nothing since the limit is disabled
+            static constexpr float_64 startTime_SI = 0.0;
+            static constexpr float_64 endTime_SI =  10e-15;
+        };
+
+        using GaussianProfile = beam::beamProfiles::GaussianProfile<GaussParam>;
+        using ConstShape = beam::beamShapes::ConstShape<ConstShapeParam>;
+
+        using BeamProfile = GaussianProfile;
+        using BeamShape = ConstShape;
+
+        using Beam = beam::ProbingBeam<BeamProfile, BeamShape, ProbingSide, OffsetParam>;
+
+        // Injection density defined by the beam and the maximum particle flux
+        namespace density
+        {
+            struct ProbingBeamDensityParam
+            {
+            private:
+                static constexpr float_64 cellVolumeSI
+                    = SI::CELL_HEIGHT_SI * SI::CELL_WIDTH_SI * SI::CELL_DEPTH_SI;
+
+            public:
+                using ProbingBeam = Beam;
+                //  100000 photons per full cell
+                static constexpr float_64 photonFluxAtMaxBeamIntensity_SI{
+                    100000.0 / cellVolumeSI * SI::SPEED_OF_LIGHT_SI};
+            };
+            using ProbingBeamDensity = ProbingBeamImpl<ProbingBeamDensityParam>;
+        } // namespace density
+        namespace startPosition
+        {
+            // Particle number and particle positioning within a cell:
+            struct QuietProbingBeamParam
+            {
+                using Side = ProbingSide;
+                /** Number of particles in each dimension initialized in a cell (in the beam coordinate
+                 * system).
+                 *
+                 * Keep in mind that the particles are not spaced across the complete cell but rather a reduced
+                 * cell. The cell dimensions along the beam x and y coordinates stay the same but along the
+                 * beam z direction the cell depth is reduced to DELTA_T * SPED_OF_LIGHT.
+                 *
+                 * All 3 components need to be specified.  In the case of a 2 dimensional simulation, the
+                 * component corresponding to the picongpu z direction will be discarded later.
+                 */
+                static constexpr float_X minWeighting = 0.001;
+                using numParticlesPerDimension = mCT::Int<2, 2, 2>;
+            };
+            using QuietBeam = QuietProbingBeam<QuietProbingBeamParam>;
+        } // namespace startPosition
+        namespace momentum
+        {
+            // Initial particle momentum defined as the photon energy in Joule
+            struct BeamMomentumParam
+            {
+                using Side = ProbingSide;
+                static constexpr float_64 photonEnergySI = 6.0 * UNITCONV_keV_to_Joule;
+            };
+            using BeamMomentum = PhotonMomentum<BeamMomentumParam>;
+        } // namespace momentum
+
+        /* StartAttributes is an attribute initialization functor, the position and momentum functors
+         * are always required. Any number of additional functors that are called in order can be added as optional
+         * template arguments.
+         */
+            using BeamStartAttributes = StartAttributes<startPosition::QuietBeam, momentum::BeamMomentum>;
+   } // namespace picongpu::namespace particles::externalBeam
+
+
+Example ``iterationStart.param``:
+
+.. code:: c++
+
+    #pragma once
+
+    #include "picongpu/particles/InitFunctors.hpp"
+
+
+    namespace picongpu
+    {
+        /** IterationStartPipeline defines the functors called at each iteration start
+         *
+         * The functors will be called in the given order.
+         *
+         * The functors must be default-constructible and take the current time iteration as the only parameter.
+         * These are the same requirements as for functors in particles::InitPipeline.
+         */
+        using IterationStartPipeline = pmacc::mp_list<particles::CreateDensity<
+            particles::externalBeam::density::ProbingBeamDensity,
+            particles::externalBeam::BeamStartAttributes,
+            Photons>>;
+    } // namespace picongpu
+
+Supported functors
+^^^^^^^^^^^^^^^^^^
+
+probing beam configuration
+""""""""""""""""""""""""""
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::ProbingBeam
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::beamProfiles::ConstProfile
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::beamProfiles::GaussianProfile
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::beamShapes::ConstShape
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::beamShapes::GaussianPulse
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::beamShapes::LorentzPulse
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::beam::SqrtWrapper
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::density::ProbingBeamImpl
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::density::ProbingBeamImpl
+   :project: PIConGPU
+particle attributes
+"""""""""""""""""""
+
+.. doxygenstruct::  picongpu::particles::externalBeam::momentum::PhotonMomentum
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::phase::FromPhotonMomentum
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::phase::FromSpeciesWavelength
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::polarization::OnePolarization
+   :project: PIConGPU
+
+start position
+""""""""""""""
+
+.. doxygenstruct::  picongpu::particles::externalBeam::startPosition::QuietProbingBeam
+   :project: PIConGPU
+
+.. doxygenstruct::  picongpu::particles::externalBeam::startPosition::RandomProbingBeam
+   :project: PIConGPU
+
+References
+----------
+
+.. container:: references csl-bib-body
+   :name: refs
+
+    .. container:: csl-entry
+       :name: masterThesis-PawelOrdyna
+
+       [1]P. Ordyna, X-ray Radiation Transport in GPU Accelerated Particle in Cell Plasma Simulations, Zenodo, 2022. 10.5281/zenodo.7928423

--- a/include/picongpu/_defaultParam.loader
+++ b/include/picongpu/_defaultParam.loader
@@ -47,6 +47,7 @@
 #include "picongpu/param/density.param"
 #include "picongpu/param/particle.param"
 #include "picongpu/param/unit.param"
+#include "picongpu/param/externalBeam.param"
 #include "picongpu/param/particleFilters.param"
 #include "picongpu/param/radiation.param"
 #include "picongpu/param/transitionRadiation.param"

--- a/include/picongpu/_defaultUnitless.loader
+++ b/include/picongpu/_defaultUnitless.loader
@@ -1,5 +1,5 @@
 /* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
- *                     Marco Garten, Finn-Ole Carstens
+ *                     Marco Garten, Finn-Ole Carstens, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -34,6 +34,7 @@
 #include "picongpu/unitless/density.unitless"
 #include "picongpu/unitless/particle.unitless"
 #include "picongpu/unitless/fieldAbsorber.unitless"
+#include "picongpu/unitless/externalBeam.unitless"
 #include "picongpu/unitless/pusher.unitless"
 #include "picongpu/unitless/ionizer.unitless"
 #include "picongpu/unitless/speciesAttributes.unitless"

--- a/include/picongpu/param/externalBeam.param
+++ b/include/picongpu/param/externalBeam.param
@@ -1,0 +1,46 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Setup external beams
+ *
+ * External beams can be used to inject particles (currently supported are photons) at simulation boundaries. The
+ * actual injection can be set up in interationStart.param.  This param should be used when defining external beam
+ * configurations. The configurations can be then used in interationStart.param.
+ * See share/picongpu/tests/ExternalBeam and share/picongpu/tests/ExternalBeamCompileTest for reference.
+ */
+
+#pragma once
+
+#include "picongpu/particles/externalBeam/beam/ProbingBeam.def"
+#include "picongpu/particles/externalBeam/beam/Side.hpp"
+#include "picongpu/particles/externalBeam/beam/beamProfiles/profiles.def"
+#include "picongpu/particles/externalBeam/beam/beamShapes/shapes.def"
+#include "picongpu/particles/externalBeam/functors.def"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -88,7 +88,7 @@ namespace picongpu
     //! Photon start phase
     value_identifier(float_X, startPhase, 0._X);
 
-    //! Photon polarization angle
+    //! Photon polarization angle in radians
     value_identifier(float_X, polarizationAngle, 0._X);
 
     /** interpolated electric field with respect to particle shape

--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -1,5 +1,5 @@
 /* Copyright 2014-2023 Rene Widera, Marco Garten, Alexander Grund, Axel Huebl,
- *                     Heiko Burau, Brian Marre
+ *                     Heiko Burau, Brian Marre, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -81,6 +81,15 @@ namespace picongpu
      * Thus, for efficiency reasons it is recommended to not enable this attribute by default.
      */
     value_identifier(float_X, weightingDampingFactor, 1._X);
+
+    //! Photon wavelength
+    alias(wavelength);
+
+    //! Photon start phase
+    value_identifier(float_X, startPhase, 0._X);
+
+    //! Photon polarization angle
+    value_identifier(float_X, polarizationAngle, 0._X);
 
     /** interpolated electric field with respect to particle shape
      *

--- a/include/picongpu/particles/PhotonFunctors.hpp
+++ b/include/picongpu/particles/PhotonFunctors.hpp
@@ -1,0 +1,146 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/traits/GetFlagType.hpp>
+#include <pmacc/traits/Resolve.hpp>
+namespace picongpu
+{
+    namespace particles
+    {
+        /** Get photons angular frequency omega
+         *
+         * @tparam T_Species photon species type
+         * @tparam hasWavelength check if the species have a fixed compile time wavelength flag
+         */
+        template<
+            typename T_Species,
+            bool hasWavelength = pmacc::traits::HasFlag<typename T_Species::FrameType, wavelength<>>::type::value>
+        struct GetAngFrequency
+        {
+            //! internal implementation for particles with a wavelength flag
+            HDINLINE static constexpr float_X get()
+            {
+                using FrameType = typename Species::FrameType;
+                using WavelengthFlag =
+                    typename pmacc::traits::Resolve<typename GetFlagType<FrameType, wavelength<>>::type>::type;
+                constexpr float_X wavelength = WavelengthFlag::getValue();
+                return pmacc::math::Pi<float_X>::doubleValue * SPEED_OF_LIGHT / wavelength;
+            }
+            using Species = T_Species;
+            /** operator call for calling without a particle
+             *
+             * Works since the return value does not depend on particle attributes only flags
+             */
+            HDINLINE float_X operator()() const
+            {
+                return get();
+            }
+
+
+            /** alternative call signature with a particle as parameter
+             *
+             * Provides the same signature for species with and without fixed wavelength
+             *
+             * @tparam T_Particle species type
+             * @param particle particle
+             */
+            template<typename T_Particle>
+            HDINLINE float_X operator()(const T_Particle& particle) const
+            {
+                return get();
+            }
+        };
+
+        //! Implementation for particles without the wavelength flag
+        template<typename T_Species>
+        struct GetAngFrequency<T_Species, false>
+        {
+            /** Functor implementation
+             *
+             * Returns the angular frequency calculated from particle momentum.
+             *
+             * @tparam T_Particle species type
+             * @param particle particle
+             */
+            template<typename T_Particle>
+            HDINLINE float_X operator()(const T_Particle& particle) const
+            {
+                float_X weighting = particle[weighting_];
+                float_X momentum = math::abs(particle[momentum_]);
+                return momentum / HBAR / weighting * SPEED_OF_LIGHT;
+            }
+        };
+
+        /** Provide phase for a given timestep
+         *
+         * Phase is defined as @f[\phi = \phi_0 - \omega * t @f]
+         *
+         * @tparam T_Species species type used to get omega
+         */
+        template<typename T_Species>
+        struct GetPhaseByTimestep
+        {
+            using Species = T_Species;
+
+            //! Implementation for calling without a particle. Requires the species to have a wavelength flag.
+            HINLINE float_64 operator()(const uint32_t currentStep, float_64 phi_0 = 0.0) const
+            {
+                static const float_64 omega = GetAngFrequency<Species>()();
+                /* phase phi = phi_0 - omega * t;
+                 * Note: This MUST be calculated in double precision as single precision is inexact after ~100
+                 * timesteps Double precision is enough for about 10^10 timesteps More timesteps (in SP&DP) are
+                 * possible, if the product is implemented as a summation with summands reduced to 2*PI */
+                static const float_64 phaseDiffPerTimestep = math::fmod(omega * DELTA_T, 2.0 * PI);
+                // Reduce summands to range of 2*PI to avoid bit canceling
+                float_64 dPhi = math::fmod(phaseDiffPerTimestep * static_cast<float_64>(currentStep), 2.0 * PI);
+                phi_0 = math::fmod(phi_0, 2.0 * PI);
+                float_64 result = phi_0 - dPhi;
+                // Keep in range of [0,2*PI)
+                if(result < 0)
+                    result += 2.0 * PI;
+                return result;
+            }
+
+            //! Implementation for calling with a particle.
+            HDINLINE float_64
+            operator()(const uint32_t currentStep, Species const& particle, float_64 phi_0 = 0.0) const
+            {
+                const float_64 omega = GetAngFrequency<Species>()(particle);
+                /* phase phi = phi_0 - omega * t;
+                 * Note: This MUST be calculated in double precision as single precision is inexact after ~100
+                 * timesteps Double precision is enough for about 10^10 timesteps More timesteps (in SP&DP) are
+                 * possible, if the product is implemented as a summation with summands reduced to 2*PI */
+                const float_64 phaseDiffPerTimestep = math::fmod(omega * DELTA_T, 2.0 * PI);
+                // Reduce summands to range of 2*PI to avoid bit canceling
+                float_64 dPhi = math::fmod(phaseDiffPerTimestep * static_cast<float_64>(currentStep), 2.0 * PI);
+                phi_0 = math::fmod(phi_0, 2.0 * PI);
+                float_64 result = phi_0 - dPhi;
+                // Keep in range of [0,2*PI)
+                if(result < 0)
+                    result += 2.0 * PI;
+                return result;
+            }
+        };
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/PhotonFunctors.hpp
+++ b/include/picongpu/particles/PhotonFunctors.hpp
@@ -48,6 +48,7 @@ namespace picongpu
                 return pmacc::math::Pi<float_X>::doubleValue * SPEED_OF_LIGHT / wavelength;
             }
             using Species = T_Species;
+
             /** operator call for calling without a particle
              *
              * Works since the return value does not depend on particle attributes only flags
@@ -56,7 +57,6 @@ namespace picongpu
             {
                 return get();
             }
-
 
             /** alternative call signature with a particle as parameter
              *
@@ -117,7 +117,7 @@ namespace picongpu
                 phi_0 = math::fmod(phi_0, 2.0 * PI);
                 float_64 result = phi_0 - dPhi;
                 // Keep in range of [0,2*PI)
-                if(result < 0)
+                if(result < 0.0)
                     result += 2.0 * PI;
                 return result;
             }
@@ -127,6 +127,7 @@ namespace picongpu
             operator()(const uint32_t currentStep, Species const& particle, float_64 phi_0 = 0.0) const
             {
                 const float_64 omega = GetAngFrequency<Species>()(particle);
+
                 /* phase phi = phi_0 - omega * t;
                  * Note: This MUST be calculated in double precision as single precision is inexact after ~100
                  * timesteps Double precision is enough for about 10^10 timesteps More timesteps (in SP&DP) are
@@ -137,7 +138,7 @@ namespace picongpu
                 phi_0 = math::fmod(phi_0, 2.0 * PI);
                 float_64 result = phi_0 - dPhi;
                 // Keep in range of [0,2*PI)
-                if(result < 0)
+                if(result < 0.0)
                     result += 2.0 * PI;
                 return result;
             }

--- a/include/picongpu/particles/externalBeam/StartAttributesImpl.def
+++ b/include/picongpu/particles/externalBeam/StartAttributesImpl.def
@@ -1,0 +1,63 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            /** Set beam particle attributes
+             *
+             * This is a meta functon wrapper for the apply that returns the host side factory.
+             *
+             * Set the in cell position, the weighting, momentum and additional attributes of a macro particle
+             * created as a part of an external particle beam, that is entering the simulation box.
+             *
+             * The method numberOfMacroParticles provides the number of new particles that need to be created in
+             * a cell.
+             *
+             *  It is impossible to differentiate between newly created and already previously present particles
+             *  after the KernelFillGridWithParticles has run. Hence, when particles are initialized during the
+             *  simulation and not only before the 0th step (when no previous particles exist), all initial
+             *  attributes need to be already set in KernelFillGridWithParticles. That's why this functor wraps
+             *  around a start position functor (setting weighting, position and also providing the
+             *  numberOfMacroParticles method) and combines it with other sub-functors. Each sub-functor is
+             *  responsible for one additional attribute.
+             *
+             *  All sub-functors should be a host side factories that create device side implementations. These host
+             *  side sub-functors need to have a host side   constructor taking the current simulation step as the only
+             *  positional argument `uint32_t const& currentStep`. The position functor device implementation needs
+             *  to provide its own numberOfMacroParticles method.
+             *
+             *  The device side implementation should take an instance of the `StartAttributesContext` class as the
+             *  first attribute instead of the usual worker.
+             *
+             * @tparam T_StartPositionFunctor functor used to set particle position and weighting.
+             * @tparam T_MomentumFunctor functor used to set particle initial momentum.
+             * @tparam T_Functor Additional functors used for setting extra attributes. These are called in order
+             *      after the position and momentum functors.
+             */
+            template<typename T_StartPositionFunctor, typename T_MomentumFunctor, typename... T_Functor>
+            struct StartAttributes;
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/StartAttributesImpl.hpp
+++ b/include/picongpu/particles/externalBeam/StartAttributesImpl.hpp
@@ -1,0 +1,203 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/externalBeam/beam/Side.hpp"
+#include "picongpu/particles/externalBeam/detail/StartAttributesContext.hpp"
+
+#include <pmacc/random/RNGProvider.hpp>
+
+#include <boost/mpl/apply.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace acc
+            {
+                //! Device side implementation of StartAttributes
+                template<
+                    typename T_Context,
+                    typename T_AccStartPositionFunctor,
+                    typename T_AccMomentumFunctor,
+                    typename... T_AccFunctor>
+                struct StartAttributes
+                    : private T_AccStartPositionFunctor
+                    , private T_AccMomentumFunctor
+                    , private T_AccFunctor...
+                {
+                public:
+                    DINLINE StartAttributes(
+                        T_Context const& context,
+                        T_AccStartPositionFunctor const&& accStartPositionFunctor,
+                        T_AccMomentumFunctor const&& accMomentumFunctor,
+                        T_AccFunctor const&&... accFunctor)
+                        : T_AccStartPositionFunctor(accStartPositionFunctor)
+                        , T_AccMomentumFunctor(accMomentumFunctor)
+                        , T_AccFunctor(accFunctor)...
+                        , context_m(context)
+                    {
+                    }
+                    /** Set in-cell position, weighting, and extra attributes
+                     *
+                     * @tparam T_Worker lockstep worker type
+                     * @tparam T_Particle pmacc::Particle, particle type
+                     * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+                     *
+                     * @param worker lockstep worker
+                     * @param particle particle to be manipulated
+                     * @param ... unused particles
+                     */
+                    template<typename T_Acc, typename T_Particle, typename... T_Args>
+                    DINLINE void operator()(T_Acc const& worker, T_Particle& particle, T_Args&&...)
+                    {
+                        // set position and weighting
+                        T_AccStartPositionFunctor::operator()(context_m, particle);
+                        // set momentum (needs weighting to be already set)
+                        T_AccMomentumFunctor::operator()(context_m, particle);
+                        // execute additional functors  e.g. setting the startPhase attribute
+                        (T_AccFunctor::operator()(context_m, particle), ...);
+                    }
+
+
+                    /** Get the number of macro particles that should be created and initialize this functor
+                     *
+                     * This is called only once before the operator is called. Hence this method is also used to
+                     * initialize this functor and the  sub-functors. There is one instance of the low level functor
+                     * for each cell in KernelFillGridWithParticles so that the initialization can depend on the cell
+                     * position.
+                     *
+                     * @tparam T_Particle type of the particles that should be created
+                     *
+                     * @param realParticlesPerCell number of new real particles in the cell in which this instance
+                     * creates particles
+                     *
+                     * @return number of macro particles that need to be created in this cell (The operator() will be
+                     * called that many times)
+                     */
+                    template<typename T_Particle>
+                    DINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                    {
+                        // numberOfMacroParticles also initializes the start position functor
+                        const uint32_t numMacroParticles
+                            = T_AccStartPositionFunctor::template numberOfMacroParticles<T_Particle>(
+                                context_m,
+                                realParticlesPerCell);
+
+                        return numMacroParticles;
+                    }
+
+                private:
+                    PMACC_ALIGN(context_m, T_Context);
+                };
+            } // namespace acc
+
+
+            //! Host factory implementation for StartAttributes
+            template<
+                typename T_Species,
+                typename T_StartPositionFunctor,
+                typename T_MomentumFunctor,
+                typename... T_Functor>
+            struct StartAttributesImpl
+                : private T_StartPositionFunctor
+                , private T_MomentumFunctor
+                , private T_Functor...
+
+            {
+                using RNGFactory = pmacc::random::RNGProvider<simDim, random::Generator>;
+
+                HINLINE StartAttributesImpl(uint32_t const& currentStep)
+                    : T_StartPositionFunctor(currentStep)
+                    , T_MomentumFunctor(currentStep)
+                    , T_Functor(currentStep)...
+                    , rngHandle(RNGFactory::createHandle())
+                {
+                }
+
+                /** Create functor for the accelerator
+                 *
+                 * @tparam T_Worker lockstep worker type
+                 *
+                 * @param worker lockstep worker
+                 * @param localSupercellOffset offset (in superCells, without any guards) relative
+                 *                        to the origin of the local domain
+                 */
+                template<typename T_Worker>
+                DINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset) const
+                {
+                    // initialize a random nuber generator for the sub-functors
+                    RNGFactory::Handle rngHandleLocal = rngHandle;
+                    rngHandleLocal.init(
+                        localSupercellOffset * SuperCellSize::toRT()
+                        + DataSpaceOperations<simDim>::template map<SuperCellSize>(worker.getWorkerIdx()));
+                    // combine worker information and the number generator in a context variable
+                    auto context{detail::makeContext(worker, rngHandleLocal)};
+
+                    return acc::StartAttributes<
+                        ALPAKA_DECAY_T(decltype(context)),
+                        ALPAKA_DECAY_T(decltype(T_StartPositionFunctor::operator()(worker, localSupercellOffset))),
+                        ALPAKA_DECAY_T(decltype(T_MomentumFunctor::operator()(worker, localSupercellOffset))),
+                        ALPAKA_DECAY_T(decltype(T_Functor::operator()(worker, localSupercellOffset)))...>(
+                        context,
+                        T_StartPositionFunctor::operator()(worker, localSupercellOffset),
+                        T_MomentumFunctor::operator()(worker, localSupercellOffset),
+                        T_Functor::operator()(worker, localSupercellOffset)...);
+                }
+
+                static HINLINE std::string getName()
+                {
+                    return std::string("StartAttributes");
+                }
+
+            private:
+                PMACC_ALIGN(rngHandle, RNGFactory::Handle);
+            };
+
+
+            /*
+             * We need this wrapper since we can not use a placeholder for T_Species since we are using a variadic
+             * template for the extra functors.
+             */
+            template<typename T_StartPositionFunctor, typename T_MomentumFunctor, typename... T_Functor>
+            struct StartAttributes
+                : private T_StartPositionFunctor
+                , private T_MomentumFunctor
+                , private T_Functor...
+
+            {
+                template<typename T_Species>
+                struct apply
+                {
+                    using type = StartAttributesImpl<
+                        T_Species,
+                        typename boost::mpl::apply1<T_StartPositionFunctor, T_Species>::type,
+                        typename boost::mpl::apply1<T_MomentumFunctor, T_Species>::type,
+                        typename boost::mpl::apply1<T_Functor, T_Species>::type...>;
+                };
+            };
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/StartAttributesImpl.hpp
+++ b/include/picongpu/particles/externalBeam/StartAttributesImpl.hpp
@@ -167,7 +167,7 @@ namespace picongpu
                         T_Functors::operator()(worker, localSupercellOffset)...);
                 }
 
-                static HINLINE std::string getName()
+                HINLINE static std::string getName()
                 {
                     return std::string("StartAttributes");
                 }

--- a/include/picongpu/particles/externalBeam/beam/ProbingBeam.def
+++ b/include/picongpu/particles/externalBeam/beam/ProbingBeam.def
@@ -1,0 +1,36 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                template<typename T_BeamProfile, typename T_BeamShape, typename T_Side, typename T_OffsetParam>
+                struct ProbingBeam;
+
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/ProbingBeam.hpp
+++ b/include/picongpu/particles/externalBeam/beam/ProbingBeam.hpp
@@ -95,7 +95,7 @@ namespace picongpu::particles::externalBeam::beam
             const float_X beamDelay = OffsetParam::beamDelay_SI / UNIT_TIME;
             const float_X offsetParallel_b = beamDelay * SPEED_OF_LIGHT;
             // Complete offset from the initial position.
-            const float3_X offsetFromMiddlePoint_b{offsetTrans_b[0], offsetTrans_b[1], -1 * offsetParallel_b};
+            const float3_X offsetFromMiddlePoint_b{offsetTrans_b[0], offsetTrans_b[1], -1.0_X * offsetParallel_b};
 
             // Move to the PIC coordinate system.
             const float3_X offsetFromMiddlePoint_s = Side::rotateBeamToSim(offsetFromMiddlePoint_b);

--- a/include/picongpu/particles/externalBeam/beam/ProbingBeam.hpp
+++ b/include/picongpu/particles/externalBeam/beam/ProbingBeam.hpp
@@ -1,0 +1,148 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+// #include "picongpu/particles/externalBeam/beam/CoordinateTransform.hpp"
+#include "picongpu/particles/externalBeam/beam/ProbingBeam.def"
+#include "picongpu/particles/externalBeam/beam/SqrtWrapper.hpp"
+#include "picongpu/particles/externalBeam/beam/beamProfiles/profiles.hpp"
+#include "picongpu/particles/externalBeam/beam/beamShapes/shapes.hpp"
+
+
+namespace picongpu::particles::externalBeam::beam
+{
+    //! Get the global domain size as a 3D float vector.
+    HINLINE float3_X getDomainSize()
+    {
+        if constexpr(simDim == DIM2)
+        {
+            auto globalDomainSize{precisionCast<float_X>(Environment<DIM2>::get().SubGrid().getGlobalDomain().size)};
+            return float3_X{globalDomainSize[0], globalDomainSize[1], 1.0_X};
+        }
+        else
+        {
+            return precisionCast<float_X>(Environment<DIM3>::get().SubGrid().getGlobalDomain().size);
+        }
+    };
+
+    namespace defaults
+    {
+        struct DefaultOffsetParam
+        {
+            static constexpr float_X beamOffsetX_SI{0.0_X};
+            static constexpr float_X beamOffsetY_SI{0.0_X};
+            static constexpr float_X beamDelay_SI{0.0_X};
+        };
+    } // namespace defaults
+
+    /** Defines a coordinate transform from the PIC system into the beam system.
+     *
+
+     */
+
+    /** Defines the probing beam characteristic.
+     *
+     * @tparam T_BeamProfile Beam transverse profile.
+     * @tparam T_BeamShape Beam temporal shape.
+     * @tparam T_Side Side from which the probing beam is shot at the simulation box.
+     * @tparam T_OffsetParam Param class defining spatial and temporal offsets (default is all set to 0).
+     *  Example:
+     *  @code{.cpp}
+     *  struct DefaultOffsetParam
+     *  {
+     *      static constexpr float_X beamOffsetX_SI{0.0_X};
+     *      static constexpr float_X beamOffsetY_SI{0.0_X};
+     *      static constexpr float_X beamDelay_SI{0.0_X};
+     *  };
+     *  @endcode
+     */
+    template<typename T_BeamProfile, typename T_BeamShape, typename T_Side, typename T_OffsetParam>
+    struct ProbingBeam
+    {
+        using BeamProfile = T_BeamProfile;
+        using BeamShape = T_BeamShape;
+        using Side = T_Side;
+        using OffsetParam = T_OffsetParam;
+
+        HINLINE ProbingBeam()
+        {
+            // Find the coordinate system translation:
+            // Starting in the beam coordinate system.
+            // Transverse(to the beam propagation direction) offset from the
+            // initial position (the middle of the simulation box side).
+            const float2_X offsetTrans_b = OffsetParam().beamOffset_SI / UNIT_LENGTH;
+            // Offset along the propagation direction, defined by the beam
+            // delay.
+            const float_X beamDelay = OffsetParam::beamDelay_SI / UNIT_TIME;
+            const float_X offsetParallel_b = beamDelay * SPEED_OF_LIGHT;
+            // Complete offset from the initial position.
+            const float3_X offsetFromMiddlePoint_b{offsetTrans_b[0], offsetTrans_b[1], -1 * offsetParallel_b};
+
+            // Move to the PIC coordinate system.
+            const float3_X offsetFromMiddlePoint_s = Side::rotateBeamToSim(offsetFromMiddlePoint_b);
+
+            // Find the initial position in the PIC coordinate system.
+            float3_X toMiddlePoint_s = cellSize * getDomainSize();
+            for(uint32_t ii = 0; ii < 3; ii++)
+            {
+                toMiddlePoint_s[ii] *= Side::beamStartPosition[ii];
+            }
+            // Combine both translations.
+            translationVector_s = toMiddlePoint_s + offsetFromMiddlePoint_s;
+        }
+
+
+        /** Transforms a vector from the PIC system to the beam comoving system.
+         *
+         * @param currentStep Current simulation step.
+         * @param position_s A 3D vector in the PIC coordinate system.
+         */
+        HDINLINE float3_X coordinateTransform(uint32_t const& currentStep, float3_X const& position_s) const
+        {
+            float3_X result = position_s - translationVector_s;
+            result = Side::rotateSimToBeam(result);
+            result[2] -= currentStep * DELTA_T * SPEED_OF_LIGHT;
+            return result;
+        }
+
+        /** Calculates the probing amplitude at a given position.
+         *
+         * @param currentStep Current simulation step.
+         * @param position_s Position in the simulation coordinate system (x, y, z__at_t_0 - c*t).
+         * @returns Probing wave amplitude scaling at position_b.
+         */
+        HDINLINE float_X operator()(uint32_t const& currentStep, float3_X const& position_s) const
+        {
+            const float3_X position_b{coordinateTransform(currentStep, position_s)};
+            float_X profileFactor = BeamProfile::getFactor(position_b[0], position_b[1]);
+
+            // negative time in front of the pulse positive time behind the pulse
+            float_X beamTime = -1.0_X * position_b[2] / SPEED_OF_LIGHT;
+            float_X shapeFactor = BeamShape::getFactor(beamTime);
+
+            return profileFactor * shapeFactor;
+        }
+
+    private:
+        PMACC_ALIGN(translationVector_s, float3_X);
+    };
+} // namespace picongpu::particles::externalBeam::beam

--- a/include/picongpu/particles/externalBeam/beam/Side.hpp
+++ b/include/picongpu/particles/externalBeam/beam/Side.hpp
@@ -1,0 +1,219 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/math/vector/TwistComponents.hpp>
+
+#include <type_traits>
+
+#include <pmacc/math/vector/compile-time/TwistComponents.hpp>
+
+namespace picongpu::particles::externalBeam::beam
+{
+    /* This file defines the possible base beam orientations.
+     *
+     *  Example: X Side
+     *      The beam propagates along the x axis ( PIC coordinate system).
+     *      The base position of the beam coordinate system (0,0,0)  is placed
+     *      in the middle of the x_PIC=0 plane.
+     *      That is at (0, 0.5 * Y, 0.5 * Z), where Y and Z are the lengths of
+     *      the simulation box sides along y_PIC and z_PIC axes.
+     *      Therefore BeamStartPosition = ( 0.0, 0.5, 0.5 ) for the XSide.
+     *
+     *      SimAxesInBeamOrder  defines how the 3 directions
+     *      (x, y, z) in the PIC system correspond to the ones in the beam
+     *      system. The true/false in reverse define the relative orientations. For XSide:
+     *      SimAxesInBeamOrder = ( 2, 1, 0) and reverse_beam_x = true, reverse_beam_y = false, reverse_beam_z = false
+     *      says:
+     *          * x_beam = - z_PIC,
+     *          * y_beam = y_PIC,
+     *          * z_beam = x_PIC
+     */
+
+    // Start Positions for all orientations:
+    struct XStartPosition
+    {
+        static constexpr float_X x{0.0};
+        static constexpr float_X y{0.5};
+        static constexpr float_X z{0.5};
+    };
+    struct XRStartPosition
+    {
+        static constexpr float_X x{1.0};
+        static constexpr float_X y{0.5};
+        static constexpr float_X z{0.5};
+    };
+    struct YStartPosition
+    {
+        static constexpr float_X x{0.5};
+        static constexpr float_X y{0.0};
+        static constexpr float_X z{0.5};
+    };
+    struct YRStartPosition
+    {
+        static constexpr float_X x{0.5};
+        static constexpr float_X y{1.0};
+        static constexpr float_X z{0.5};
+    };
+    struct ZStartPosition
+    {
+        static constexpr float_X x{0.5};
+        static constexpr float_X y{0.5};
+        static constexpr float_X z{0.0};
+    };
+    struct ZRStartPosition
+    {
+        static constexpr float_X x{0.5};
+        static constexpr float_X y{0.5};
+        static constexpr float_X z{1.0};
+    };
+
+    /** Defines the probing coordinate system
+     *
+     * @tparam T_BeamStartPosition origin of the beam system ([0,1) relative position in the total volume)
+     * @tparam T_SimAxesInBeamOrder defines how the 3 directions  (x, y, z) in the PIC system correspond
+     *      to the ones in the beam.
+     * @tparam reverse_beam_x beam x coordinate orientation
+     * @tparam reverse_beam_y beam x coordinate orientation
+     * @tparam reverse_beam_z beam x coordinate orientation
+     */
+    template<
+        typename T_BeamStartPosition,
+        typename T_SimAxesInBeamOrder,
+        bool reverse_beam_x,
+        bool reverse_beam_y,
+        bool reverse_beam_z>
+    struct ProbingCoordinates
+    {
+        static constexpr float_X beamStartPosition[3]{
+            T_BeamStartPosition::x,
+            T_BeamStartPosition::y,
+            T_BeamStartPosition::z};
+        using SimAxesInBeamOrder = T_SimAxesInBeamOrder;
+
+        using BeamAxesInSimOrder = typename pmacc::math::CT::Int<
+            pmacc::mp_find<SimAxesInBeamOrder, std::integral_constant<int, 0>>::value,
+            pmacc::mp_find<SimAxesInBeamOrder, std::integral_constant<int, 1>>::value,
+            pmacc::mp_find<SimAxesInBeamOrder, std::integral_constant<int, 2>>::value>;
+
+        // Compile time axes order conversion
+        template<typename T_Vector>
+        using TwistSimToBeam_t = typename pmacc::math::CT::TwistComponents<T_Vector, SimAxesInBeamOrder>::type;
+        template<typename T_Vector>
+        using TwistBeamToSim_t = typename pmacc::math::CT::TwistComponents<T_Vector, BeamAxesInSimOrder>::type;
+        static constexpr bool reverse[3] = {reverse_beam_x, reverse_beam_y, reverse_beam_z};
+
+        // Axis index conversion
+        template<uint32_t idx>
+        using BeamToSimIdx_t = pmacc::mp_at_c<SimAxesInBeamOrder, idx>;
+        template<uint32_t idx>
+        using SimToBeamIdx_t = pmacc::mp_at_c<BeamAxesInSimOrder, idx>;
+
+        //! Twist coordinates from sim to beam order for run time vectors (does not change data in memory)
+        template<typename T_Vector>
+        static HDINLINE auto twistSimToBeam(T_Vector& vector)
+        {
+            return pmacc::math::twistComponents<SimAxesInBeamOrder>(vector);
+        }
+        //! Twist coordinates from beam to sim order for run time vectors (does not change memory layout)
+        template<typename T_Vector>
+        static HDINLINE auto twistBeamToSim(T_Vector& vector)
+        {
+            return pmacc::math::twistComponents<BeamAxesInSimOrder>(vector);
+        }
+
+        //! Rotate vector from sim to beam  system (includes orientation and not is not only twisting coordinates)
+        template<typename T_Vector>
+        static HDINLINE auto rotateSimToBeam(T_Vector const& vector)
+        {
+            T_Vector result = T_Vector::create(0.0);
+            auto twisted = twistSimToBeam(vector);
+            if constexpr(reverse_beam_x)
+                result[0] = static_cast<typename T_Vector::type>(-1.0) * twisted[0];
+            else
+                result[0] = twisted[0];
+            if constexpr(reverse_beam_y)
+                result[1] = static_cast<typename T_Vector::type>(-1.0) * twisted[1];
+            else
+                result[1] = twisted[1];
+            if constexpr(reverse_beam_z)
+                result[2] = static_cast<typename T_Vector::type>(-1.0) * twisted[2];
+            else
+                result[2] = twisted[2];
+            return result;
+        }
+
+        //! Rotate vector from beam to sim system (includes orientation and not is not only twisting coordinates)
+        template<typename T_Vector>
+        static HDINLINE auto rotateBeamToSim(T_Vector const& vector)
+        {
+            T_Vector result = T_Vector::create(0.0);
+            if constexpr(reverse_beam_x)
+                result[0] = static_cast<typename T_Vector::type>(-1.0) * vector[0];
+            else
+                result[0] = vector[0];
+            if constexpr(reverse_beam_y)
+                result[1] = static_cast<typename T_Vector::type>(-1.0) * vector[1];
+            else
+                result[1] = vector[1];
+            if constexpr(reverse_beam_z)
+                result[2] = static_cast<typename T_Vector::type>(-1.0) * vector[2];
+            else
+                result[2] = vector[2];
+            return twistBeamToSim(result);
+        }
+
+        //! Transform offsets (like a cell index) from sim to beam coordinates
+        template<typename T_Vector>
+        static HDINLINE T_Vector transformOffsetSimToBeam(T_Vector const& vector, T_Vector const& volumeSize)
+        {
+            T_Vector result = rotateSimToBeam(vector);
+            for(uint32_t i = 1u; 1 < T_Vector::dim; i++)
+                result[i] = math::fmod(vector[i] + volumeSize[i], volumeSize[i]);
+            return result;
+        }
+
+        //! Transform offsets (like a cell index) from beam to sim coordinates
+        template<typename T_Vector>
+        static HDINLINE T_Vector transformOffsetBeamToSim(T_Vector const& vector, T_Vector const& volumeSize)
+        {
+            T_Vector result = rotateBeamToSim(vector);
+            for(uint32_t i = 1u; 1 < T_Vector::dim; i++)
+                result[i] = math::fmod(vector[i] + volumeSize[i], volumeSize[i]);
+            return result;
+        }
+    };
+
+
+    //! Probing along the PIC x basis vector.
+    using XSide = ProbingCoordinates<XStartPosition, pmacc::math::CT::Int<2, 1, 0>, true, false, false>;
+    //! Probing against the PIC x basis vector.
+    using XRSide = ProbingCoordinates<XRStartPosition, pmacc::math::CT::Int<2, 1, 0>, true, true, true>;
+    //! Probing along the PIC y basis vector.
+    using YSide = ProbingCoordinates<YStartPosition, pmacc::math::CT::Int<2, 0, 1>, true, true, false>;
+    //! Probing against the PIC y basis vector.
+    using YRSide = ProbingCoordinates<YRStartPosition, pmacc::math::CT::Int<2, 0, 1>, true, false, true>;
+    //! Probing along the PIC z basis vector.
+    using ZSide = ProbingCoordinates<ZStartPosition, pmacc::math::CT::Int<1, 0, 2>, true, false, false>;
+    //! Probing against the PIC z basis vector.
+    using ZRSide = ProbingCoordinates<ZRStartPosition, pmacc::math::CT::Int<1, 0, 2>, true, true, true>;
+} // namespace picongpu::particles::externalBeam::beam

--- a/include/picongpu/particles/externalBeam/beam/Side.hpp
+++ b/include/picongpu/particles/externalBeam/beam/Side.hpp
@@ -130,20 +130,20 @@ namespace picongpu::particles::externalBeam::beam
 
         //! Twist coordinates from sim to beam order for run time vectors (does not change data in memory)
         template<typename T_Vector>
-        static HDINLINE auto twistSimToBeam(T_Vector& vector)
+        HDINLINE static auto twistSimToBeam(T_Vector& vector)
         {
             return pmacc::math::twistComponents<SimAxesInBeamOrder>(vector);
         }
         //! Twist coordinates from beam to sim order for run time vectors (does not change memory layout)
         template<typename T_Vector>
-        static HDINLINE auto twistBeamToSim(T_Vector& vector)
+        HDINLINE static auto twistBeamToSim(T_Vector& vector)
         {
             return pmacc::math::twistComponents<BeamAxesInSimOrder>(vector);
         }
 
         //! Rotate vector from sim to beam  system (includes orientation and not is not only twisting coordinates)
         template<typename T_Vector>
-        static HDINLINE auto rotateSimToBeam(T_Vector const& vector)
+        HDINLINE static auto rotateSimToBeam(T_Vector const& vector)
         {
             T_Vector result = T_Vector::create(0.0);
             auto twisted = twistSimToBeam(vector);
@@ -165,7 +165,7 @@ namespace picongpu::particles::externalBeam::beam
 
         //! Rotate vector from beam to sim system (includes orientation and not is not only twisting coordinates)
         template<typename T_Vector>
-        static HDINLINE auto rotateBeamToSim(T_Vector const& vector)
+        HDINLINE static auto rotateBeamToSim(T_Vector const& vector)
         {
             T_Vector result = T_Vector::create(0.0);
             using ComponentType = typename T_Vector::type;
@@ -186,7 +186,7 @@ namespace picongpu::particles::externalBeam::beam
 
         //! Transform offsets (like a cell index) from sim to beam coordinates
         template<typename T_Vector>
-        static HDINLINE T_Vector transformOffsetSimToBeam(T_Vector const& vector, T_Vector const& volumeSize)
+        HDINLINE static T_Vector transformOffsetSimToBeam(T_Vector const& vector, T_Vector const& volumeSize)
         {
             T_Vector result = rotateSimToBeam(vector);
             for(uint32_t i = 1u; i < T_Vector::dim; i++)
@@ -196,7 +196,7 @@ namespace picongpu::particles::externalBeam::beam
 
         //! Transform offsets (like a cell index) from beam to sim coordinates
         template<typename T_Vector>
-        static HDINLINE T_Vector transformOffsetBeamToSim(T_Vector const& vector, T_Vector const& volumeSize)
+        HDINLINE static T_Vector transformOffsetBeamToSim(T_Vector const& vector, T_Vector const& volumeSize)
         {
             T_Vector result = rotateBeamToSim(vector);
             for(uint32_t i = 1u; i < T_Vector::dim; i++)

--- a/include/picongpu/particles/externalBeam/beam/Side.hpp
+++ b/include/picongpu/particles/externalBeam/beam/Side.hpp
@@ -147,16 +147,17 @@ namespace picongpu::particles::externalBeam::beam
         {
             T_Vector result = T_Vector::create(0.0);
             auto twisted = twistSimToBeam(vector);
+            using ComponentType = typename T_Vector::type;
             if constexpr(reverse_beam_x)
-                result[0] = static_cast<typename T_Vector::type>(-1.0) * twisted[0];
+                result[0] = static_cast<ComponentType>(-1.0) * twisted[0];
             else
                 result[0] = twisted[0];
             if constexpr(reverse_beam_y)
-                result[1] = static_cast<typename T_Vector::type>(-1.0) * twisted[1];
+                result[1] = static_cast<ComponentType>(-1.0) * twisted[1];
             else
                 result[1] = twisted[1];
             if constexpr(reverse_beam_z)
-                result[2] = static_cast<typename T_Vector::type>(-1.0) * twisted[2];
+                result[2] = static_cast<ComponentType>(-1.0) * twisted[2];
             else
                 result[2] = twisted[2];
             return result;
@@ -167,16 +168,17 @@ namespace picongpu::particles::externalBeam::beam
         static HDINLINE auto rotateBeamToSim(T_Vector const& vector)
         {
             T_Vector result = T_Vector::create(0.0);
+            using ComponentType = typename T_Vector::type;
             if constexpr(reverse_beam_x)
-                result[0] = static_cast<typename T_Vector::type>(-1.0) * vector[0];
+                result[0] = static_cast<ComponentType>(-1.0) * vector[0];
             else
                 result[0] = vector[0];
             if constexpr(reverse_beam_y)
-                result[1] = static_cast<typename T_Vector::type>(-1.0) * vector[1];
+                result[1] = static_cast<ComponentType>(-1.0) * vector[1];
             else
                 result[1] = vector[1];
             if constexpr(reverse_beam_z)
-                result[2] = static_cast<typename T_Vector::type>(-1.0) * vector[2];
+                result[2] = static_cast<ComponentType>(-1.0) * vector[2];
             else
                 result[2] = vector[2];
             return twistBeamToSim(result);
@@ -187,7 +189,7 @@ namespace picongpu::particles::externalBeam::beam
         static HDINLINE T_Vector transformOffsetSimToBeam(T_Vector const& vector, T_Vector const& volumeSize)
         {
             T_Vector result = rotateSimToBeam(vector);
-            for(uint32_t i = 1u; 1 < T_Vector::dim; i++)
+            for(uint32_t i = 1u; i < T_Vector::dim; i++)
                 result[i] = math::fmod(vector[i] + volumeSize[i], volumeSize[i]);
             return result;
         }
@@ -197,7 +199,7 @@ namespace picongpu::particles::externalBeam::beam
         static HDINLINE T_Vector transformOffsetBeamToSim(T_Vector const& vector, T_Vector const& volumeSize)
         {
             T_Vector result = rotateBeamToSim(vector);
-            for(uint32_t i = 1u; 1 < T_Vector::dim; i++)
+            for(uint32_t i = 1u; i < T_Vector::dim; i++)
                 result[i] = math::fmod(vector[i] + volumeSize[i], volumeSize[i]);
             return result;
         }

--- a/include/picongpu/particles/externalBeam/beam/SqrtWrapper.def
+++ b/include/picongpu/particles/externalBeam/beam/SqrtWrapper.def
@@ -1,0 +1,36 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                //! Sqrt wrapper for beam functors, to be used with amplitudons.
+                template<typename T_StaticFunctor>
+                struct SqrtWrapper;
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/SqrtWrapper.hpp
+++ b/include/picongpu/particles/externalBeam/beam/SqrtWrapper.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                template<typename T_StaticFunctor>
+                struct SqrtWrapper
+                {
+                    template<typename... T_Args>
+                    static HDINLINE float_X getFactor(T_Args&&... args)
+                    {
+                        return math::sqrt(T_StaticFunctor::getFactor(args...));
+                    }
+                };
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/SqrtWrapper.hpp
+++ b/include/picongpu/particles/externalBeam/beam/SqrtWrapper.hpp
@@ -31,7 +31,7 @@ namespace picongpu
                 struct SqrtWrapper
                 {
                     template<typename... T_Args>
-                    static HDINLINE float_X getFactor(T_Args&&... args)
+                    HDINLINE static float_X getFactor(T_Args&&... args)
                     {
                         return math::sqrt(T_StaticFunctor::getFactor(args...));
                     }

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.def
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.def
@@ -1,0 +1,37 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamProfiles
+                { //! Homogeneous beam profile.
+                    struct ConstProfile;
+                } // namespace beamProfiles
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.hpp
@@ -34,7 +34,7 @@ namespace picongpu
                 { //! Homogeneous beam profile.
                     struct ConstProfile
                     {
-                        static HDINLINE constexpr float_X getFactor(const float_X& positionX, const float_X& positionY)
+                        HDINLINE static constexpr float_X getFactor(const float_X& positionX, const float_X& positionY)
                         {
                             return float_X(1.0);
                         }

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamProfiles
+                { //! Homogeneous beam profile.
+                    struct ConstProfile
+                    {
+                        static HDINLINE constexpr float_X getFactor(const float_X& positionX, const float_X& positionY)
+                        {
+                            return float_X(1.0);
+                        }
+                    };
+                } // namespace beamProfiles
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.def
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.def
@@ -1,0 +1,50 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamProfiles
+                {
+                    /** Gaussian beam transverse profile
+                     *
+                     * @tparam T_ParamClass Param Class defining @f$ \sigma_x, \sigma_y @f$.
+                     *      Example:
+                     *      @code{.cpp}
+                     *          struct GaussianProfileParam
+                     *          {
+                     *              static constexpr float_64 sigmaX_SI = 5.0e-6;
+                     *              static constexpr float_64 sigmaY_SI = 5.0e-6;
+                     *          };
+                     *      @endcode
+                     */
+                    template<typename T_ParamClass>
+                    struct GaussianProfile;
+                } // namespace beamProfiles
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp
@@ -1,0 +1,53 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamProfiles
+                {
+                    template<typename T_ParamClass>
+                    struct GaussianProfile : public T_ParamClass
+                    {
+                        using ParamClass = T_ParamClass;
+
+                        static HDINLINE float_X getFactor(float_X const& x, float_X const& y)
+                        {
+                            constexpr float_X s_x = ParamClass::sigmaX_SI / UNIT_LENGTH;
+                            constexpr float_X s_y = ParamClass::sigmaY_SI / UNIT_LENGTH;
+                            const float_X tmp_x = x / s_x;
+                            const float_X tmp_y = y / s_y;
+                            float_X exponent = -0.5_X * (tmp_x * tmp_x + tmp_y * tmp_y);
+                            return math::exp(exponent);
+                        }
+                    };
+                } // namespace beamProfiles
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp
@@ -36,7 +36,7 @@ namespace picongpu
                     {
                         using ParamClass = T_ParamClass;
 
-                        static HDINLINE float_X getFactor(float_X const& x, float_X const& y)
+                        HDINLINE static float_X getFactor(float_X const& x, float_X const& y)
                         {
                             constexpr float_X s_x = ParamClass::sigmaX_SI / UNIT_LENGTH;
                             constexpr float_X s_y = ParamClass::sigmaY_SI / UNIT_LENGTH;

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp
@@ -40,6 +40,8 @@ namespace picongpu
                         {
                             constexpr float_X s_x = ParamClass::sigmaX_SI / UNIT_LENGTH;
                             constexpr float_X s_y = ParamClass::sigmaY_SI / UNIT_LENGTH;
+                            static_assert(s_x != 0.0, "sigmaX can't be zero");
+                            static_assert(s_y != 0.0, "sigmaY can't be zero");
                             const float_X tmp_x = x / s_x;
                             const float_X tmp_y = y / s_y;
                             float_X exponent = -0.5_X * (tmp_x * tmp_x + tmp_y * tmp_y);

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/profiles.def
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/profiles.def
@@ -1,0 +1,23 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.def"
+#include "picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.def"

--- a/include/picongpu/particles/externalBeam/beam/beamProfiles/profiles.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamProfiles/profiles.hpp
@@ -1,0 +1,23 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/externalBeam/beam/beamProfiles/ConstProfile.hpp"
+#include "picongpu/particles/externalBeam/beam/beamProfiles/GaussianProfile.hpp"

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/ConstShape.def
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/ConstShape.def
@@ -1,0 +1,59 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamShapes
+                {
+                    struct DefaultParamConstShape
+                    {
+                        static constexpr bool limitStart = true;
+                        static constexpr bool limitEnd = false;
+                    };
+
+                    /** Beam intensity homogeneous along the propagation direction
+                     * @tparam T_ParamClass ParamClass Example configuration:
+                     * @code{.cpp}
+                     *      struct ConstShapeParam
+                     *      {
+                     *          // start pulse at startTime_SI (otherwise, start at the simulation start)
+                     *          static constexpr bool limitStart = false;
+                     *          // end pulse at endTime_SI
+                     *          static constexpr bool limitEnd = false;
+                     *          static constexpr float_64 startTime_SI = 0.0;
+                     *          // does nothing since the limit is disabled
+                     *          static constexpr float_64 endTime_SI = 0.0;
+                     *      };
+                     *  @endcode
+                     */
+                    template<typename T_ParamClass>
+                    struct ConstShape;
+                } // namespace beamShapes
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/ConstShape.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/ConstShape.hpp
@@ -37,7 +37,7 @@ namespace picongpu
                     {
                         static constexpr float_X startTime = T_ParamClass::startTime_SI / UNIT_TIME;
                         static constexpr float_X endTime = T_ParamClass::endTime_SI / UNIT_TIME;
-                        static HDINLINE constexpr float_X getFactor(const float_X& time)
+                        HDINLINE static constexpr float_X getFactor(const float_X& time)
                         {
                             if((time >= startTime || !T_ParamClass::limitStart)
                                && (time <= endTime || !T_ParamClass::limitEnd))

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/ConstShape.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/ConstShape.hpp
@@ -1,0 +1,57 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamShapes
+                {
+                    template<typename T_ParamClass>
+                    struct ConstShape
+                    {
+                        static constexpr float_X startTime = T_ParamClass::startTime_SI / UNIT_TIME;
+                        static constexpr float_X endTime = T_ParamClass::endTime_SI / UNIT_TIME;
+                        static HDINLINE constexpr float_X getFactor(const float_X& time)
+                        {
+                            if((time >= startTime || !T_ParamClass::limitStart)
+                               && (time <= endTime || !T_ParamClass::limitEnd))
+                            {
+                                return 1.0_X;
+                            }
+                            else
+                            {
+                                return 0.0_X;
+                            }
+                        }
+                    };
+                } // namespace beamShapes
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.def
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.def
@@ -1,0 +1,56 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamShapes
+                {
+                    /** Gaussian temporal envelope
+                     * @tparam T_ParamClass ParamClass Example configuration:
+                     * @code{.cpp}
+                     *      struct GaussianPulseParam
+                     *      {
+                     *          // cut the pulse cutTimeFront_SI before the pulse maximum if true
+                     *          static constexpr bool limitStart = false;
+                     *          // cut the pulse at cutTimeBack_SI after the pulse maximum if true
+                     *          static constexpr bool limitEnd = false;
+                     *          static constexpr float_64 FWHM_SI = 30e-15; // 30fs
+                     *
+                     *          static constexpr float_64 cutTimeFront_SI = 3.0 * FWHM_SI;
+                     *          static constexpr float_64 cutTimeBack_SI = 3.0 * FWHM_SI;
+                     *          // when 0 the pulse max is at the beam origin at t_sim = 0
+                     *          static constexpr float_64 timeOffset_SI = 0.0;
+                     *      };
+                     *  @endcode
+                     */
+                    template<typename T_ParamClass>
+                    struct GaussianPulse;
+                } // namespace beamShapes
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp
@@ -1,0 +1,68 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamShapes
+                {
+                    template<typename T_ParamClass>
+                    struct GaussianPulse
+                    {
+                        static constexpr float_X timeOffset = T_ParamClass::timeOffset_SI / UNIT_TIME;
+                        static constexpr float_X cutTimeFront = T_ParamClass::cutTimeFront_SI / UNIT_TIME;
+                        static constexpr float_X cutTimeBack = T_ParamClass::cutTimeBack_SI / UNIT_TIME;
+                        static constexpr float_X startTime = timeOffset - cutTimeFront;
+                        static constexpr float_X endTime = timeOffset + cutTimeBack;
+
+                        static constexpr float_64 conversion = 2.3548200450309493;
+                        static constexpr float_X sigma = T_ParamClass::FWHM_SI / UNIT_TIME / conversion;
+                        static constexpr float_X sigmaSquared = sigma * sigma;
+
+
+                        static HDINLINE constexpr float_X getFactor(const float_X& time)
+                        {
+                            if((time >= startTime || !T_ParamClass::limitStart)
+                               && (time <= endTime || !T_ParamClass::limitEnd))
+                            {
+                                const float_X timeDist = time - timeOffset;
+                                float_X exponent = -0.5 * (timeDist * timeDist / sigmaSquared);
+                                return math::exp(exponent);
+                            }
+                            else
+                            {
+                                return 0.0_X;
+                            }
+                        }
+                    };
+                } // namespace beamShapes
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp
@@ -41,6 +41,7 @@ namespace picongpu
                         static constexpr float_X startTime = timeOffset - cutTimeFront;
                         static constexpr float_X endTime = timeOffset + cutTimeBack;
 
+                        //! FWHM to sigma conversion factor equal to 2 * sqrt(2 * ln(2))
                         static constexpr float_64 conversion = 2.3548200450309493;
                         static constexpr float_X sigma = T_ParamClass::FWHM_SI / UNIT_TIME / conversion;
                         static constexpr float_X sigmaSquared = sigma * sigma;
@@ -52,7 +53,7 @@ namespace picongpu
                                && (time <= endTime || !T_ParamClass::limitEnd))
                             {
                                 const float_X timeDist = time - timeOffset;
-                                float_X exponent = -0.5 * (timeDist * timeDist / sigmaSquared);
+                                float_X exponent = -0.5_X * (timeDist * timeDist / sigmaSquared);
                                 return math::exp(exponent);
                             }
                             else

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp
@@ -47,7 +47,7 @@ namespace picongpu
                         static constexpr float_X sigmaSquared = sigma * sigma;
 
 
-                        static HDINLINE constexpr float_X getFactor(const float_X& time)
+                        HDINLINE static constexpr float_X getFactor(const float_X& time)
                         {
                             if((time >= startTime || !T_ParamClass::limitStart)
                                && (time <= endTime || !T_ParamClass::limitEnd))

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.def
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.def
@@ -1,0 +1,57 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamShapes
+                {
+                    /** Lorentz pulse as a temporal envelope
+                     *
+                     * @tparam T_ParamClass ParamClass Example configuration:
+                     *  @code{.cpp}
+                     *      struct LorentzPulseParam
+                     *      {
+                     *          // cut the pulse cutTimeFront_SI before the pulse maximum if true
+                     *          static constexpr bool limitStart = false;
+                     *          // cut the pulse at cutTimeBack_SI after the pulse maximum if true
+                     *          static constexpr bool limitEnd = false;
+                     *          static constexpr float_64 FWHM_SI = 30e-15; // 30fs
+                     *
+                     *          static constexpr float_64 cutTimeFront_SI = 3.0 * FWHM_SI;
+                     *          static constexpr float_64 cutTimeBack_SI = 3.0 * FWHM_SI;
+                     *          // when 0 the pulse max is at the beam origin at t_sim = 0
+                     *          static constexpr float_64 timeOffset_SI = 0.0;
+                     *      };
+                     *  @endcode
+                     */
+                    template<typename T_ParamClass>
+                    struct LorentzPulse;
+                } // namespace beamShapes
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp
@@ -45,7 +45,7 @@ namespace picongpu
                         static constexpr float_X gammaSquared = gamma * gamma;
 
 
-                        static HDINLINE constexpr float_X getFactor(const float_X& time)
+                        HDINLINE static constexpr float_X getFactor(const float_X& time)
                         {
                             if((time >= startTime || !T_ParamClass::limitStart)
                                && (time <= endTime || !T_ParamClass::limitEnd))

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp
@@ -41,7 +41,7 @@ namespace picongpu
                         static constexpr float_X startTime = timeOffset - cutTimeFront;
                         static constexpr float_X endTime = timeOffset + cutTimeBack;
 
-                        static constexpr float_X gamma = T_ParamClass::FWHM_SI / UNIT_TIME / 2.0;
+                        static constexpr float_X gamma = T_ParamClass::FWHM_SI / UNIT_TIME / 2.0_X;
                         static constexpr float_X gammaSquared = gamma * gamma;
 
 

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp
@@ -1,0 +1,66 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+
+namespace picongpu
+{
+    namespace paticles
+    {
+        namespace externalBeam
+        {
+            namespace beam
+            {
+                namespace beamShapes
+                {
+                    template<typename T_ParamClass>
+                    struct LorentzPulse
+                    {
+                        static constexpr float_X timeOffset = T_ParamClass::timeOffset_SI / UNIT_TIME;
+                        static constexpr float_X cutTimeFront = T_ParamClass::cutTimeFront_SI / UNIT_TIME;
+                        static constexpr float_X cutTimeBack = T_ParamClass::cutTimeBack_SI / UNIT_TIME;
+                        static constexpr float_X startTime = timeOffset - cutTimeFront;
+                        static constexpr float_X endTime = timeOffset + cutTimeBack;
+
+                        static constexpr float_X gamma = T_ParamClass::FWHM_SI / UNIT_TIME / 2.0;
+                        static constexpr float_X gammaSquared = gamma * gamma;
+
+
+                        static HDINLINE constexpr float_X getFactor(const float_X& time)
+                        {
+                            if((time >= startTime || !T_ParamClass::limitStart)
+                               && (time <= endTime || !T_ParamClass::limitEnd))
+                            {
+                                const float_X timeDist = time - timeOffset;
+                                return 1.0_X / (1.0_X + (timeDist * timeDist / gammaSquared));
+                            }
+                            else
+                            {
+                                return 0.0_X;
+                            }
+                        }
+                    };
+                } // namespace beamShapes
+            } // namespace beam
+        } // namespace externalBeam
+    } // namespace paticles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/shapes.def
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/shapes.def
@@ -1,0 +1,24 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/externalBeam/beam/beamShapes/ConstShape.def"
+#include "picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.def"
+#include "picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.def"

--- a/include/picongpu/particles/externalBeam/beam/beamShapes/shapes.hpp
+++ b/include/picongpu/particles/externalBeam/beam/beamShapes/shapes.hpp
@@ -1,0 +1,24 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/externalBeam/beam/beamShapes/ConstShape.hpp"
+#include "picongpu/particles/externalBeam/beam/beamShapes/GaussianPulse.hpp"
+#include "picongpu/particles/externalBeam/beam/beamShapes/LorentzPulse.hpp"

--- a/include/picongpu/particles/externalBeam/density/ProbingBeamImpl.def
+++ b/include/picongpu/particles/externalBeam/density/ProbingBeamImpl.def
@@ -1,0 +1,50 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace density
+            {
+                /** Density functor for beam particles
+                 *
+                 * @tparam T_ParamClass param class providing a beam configuration
+                 *      and the photon flux that corresponds to the relative beam intensity equal 1.
+                 *      Example:
+                 *      @code{.cpp}
+                 *          struct ProbingBeamDensityParam
+                 *          {
+                 *              using ProbingBeam = plugins::externalBeam::PhotonBeam;
+                 *              // unit is m^{-2}s^{-1}
+                 *              static constexpr float_64 photonFluxAtMaxBeamIntensity{1.0e20};
+                 *          };
+                 *     @endcode
+                 *
+                 */
+                template<typename T_ParamClass>
+                struct ProbingBeamImpl;
+            } // namespace density
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/density/ProbingBeamImpl.def
+++ b/include/picongpu/particles/externalBeam/density/ProbingBeamImpl.def
@@ -41,8 +41,9 @@ namespace picongpu
                  *          };
                  *     @endcode
                  *
+                 * @tparam T_SpeciesClass species for that the density is used
                  */
-                template<typename T_ParamClass>
+                template<typename T_ParamClass, typename T_Species = boost::mpl::_1>
                 struct ProbingBeamImpl;
             } // namespace density
         } // namespace externalBeam

--- a/include/picongpu/particles/externalBeam/density/ProbingBeamImpl.hpp
+++ b/include/picongpu/particles/externalBeam/density/ProbingBeamImpl.hpp
@@ -1,0 +1,198 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/externalBeam/beam/ProbingBeam.hpp"
+#include "picongpu/particles/externalBeam/beam/Side.hpp"
+
+#include <pmacc/mappings/simulation/Selection.hpp>
+namespace picongpu::particles::externalBeam::density
+{
+    namespace detail
+    {
+        using namespace picongpu::particles::externalBeam::beam;
+        using namespace picongpu::SI;
+        // Get the area of the cell side that is perpendicular to the beam propagation
+        template<typename T_Side>
+        struct GetCellAreaSI
+        {
+            static constexpr float_64 get();
+        };
+        template<>
+        struct GetCellAreaSI<XSide>
+        {
+            static constexpr float_64 get()
+            {
+                return CELL_DEPTH_SI * CELL_HEIGHT_SI;
+            }
+        };
+        template<>
+        struct GetCellAreaSI<XRSide>
+        {
+            static constexpr float_64 get()
+            {
+                return CELL_DEPTH_SI * CELL_HEIGHT_SI;
+            }
+        };
+        template<>
+        struct GetCellAreaSI<YSide>
+        {
+            static constexpr float_64 get()
+            {
+                return CELL_DEPTH_SI * CELL_WIDTH_SI;
+            }
+        };
+        template<>
+        struct GetCellAreaSI<YRSide>
+        {
+            static constexpr float_64 get()
+            {
+                return CELL_DEPTH_SI * CELL_WIDTH_SI;
+            }
+        };
+        template<>
+        struct GetCellAreaSI<ZSide>
+        {
+            static constexpr float_64 get()
+            {
+                return CELL_WIDTH_SI * CELL_HEIGHT_SI;
+            }
+        };
+        template<>
+        struct GetCellAreaSI<ZRSide>
+        {
+            static constexpr float_64 get()
+            {
+                return CELL_WIDTH_SI * CELL_HEIGHT_SI;
+            }
+        };
+
+    } // namespace detail
+
+    template<typename T_ParamClass>
+    struct ProbingBeamImpl : public T_ParamClass
+    {
+        using ParamClass = T_ParamClass;
+        using ProbingBeam = typename T_ParamClass::ProbingBeam;
+        // Defines from which side the beam enters the simulation box.
+        using Side = typename T_ParamClass::ProbingBeam::Side;
+
+        static constexpr float_64 photonFluxAtMaxBeamIntensity = ParamClass::photonFluxAtMaxBeamIntensity_SI;
+
+    private:
+        // beam <-> pic index conversions
+
+        static constexpr float_X cellSizeCT[3] = {CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH};
+        static constexpr float_X cellDepth{cellSizeCT[Side::template BeamToSimIdx_t<2u>::value]};
+        //  true if the beam is propagating in a negative direction
+        static constexpr bool reverse = Side::reverse[2];
+
+        // the center of the reduce cell (only Delta t * c in prop direction), relative in cell position
+        static constexpr float_X reducedCellCenterBeam[3]
+            = {0.5_X, 0.5_X, 0.5_X * DELTA_T* SPEED_OF_LIGHT / cellDepth};
+        static constexpr float_X reducedCellCenter_x{reducedCellCenterBeam[Side::template SimToBeamIdx_t<0u>::value]};
+        static constexpr float_X reducedCellCenter_y{reducedCellCenterBeam[Side::template SimToBeamIdx_t<1u>::value]};
+        static constexpr float_X reducedCellCenter_z{reducedCellCenterBeam[Side::template SimToBeamIdx_t<2u>::value]};
+
+
+        // the area of the cell side perpendicular to the propagation
+        static constexpr float_64 CELL_AREA_SI = detail::GetCellAreaSI<Side>::get();
+        static constexpr float_X PHOTONS_IN_A_CELL
+            = static_cast<float_X>(photonFluxAtMaxBeamIntensity * SI::DELTA_T_SI * CELL_AREA_SI);
+        // the photon density in the cell in terms of the base density
+        static constexpr float_X REFERENCE_PHOTON_DENSITY = PHOTONS_IN_A_CELL / CELL_VOLUME / BASE_DENSITY;
+
+    public:
+        template<typename T_SpeciesType>
+        struct apply
+        {
+            using type = ProbingBeamImpl<ParamClass>;
+        };
+        /* Host side constructor
+         *
+         * Provides domain info used for checking if the functor is at a simulation boundary
+         */
+        HINLINE ProbingBeamImpl(uint32_t const& currentStep) : probingBeam_m(), currentStep_m(currentStep)
+        {
+            // TODO: modernize it offset  should be in subGrid already?
+            uint32_t const numSlides = MovingWindow::getInstance().getSlideCounter(currentStep);
+            SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
+            DataSpace<simDim> const localCells = subGrid.getLocalDomain().size;
+            globalDomain_m = subGrid.getGlobalDomain();
+            globalDomain_m.offset.y() += numSlides * localCells.y();
+        }
+
+        //! Check if we are in the first row of cells and at the side where the particles are injected
+        DINLINE bool isInjectionBoundary(const DataSpace<simDim>& totalCellOffset)
+        {
+            const auto globalCellOffset = totalCellOffset - globalDomain_m.offset;
+            // Propagation axis
+            constexpr auto d{Side::template BeamToSimIdx_t<2u>::value};
+            bool boundary = false;
+            if constexpr(reverse)
+            {
+                boundary = globalCellOffset[d] == globalDomain_m.size[d] - 1;
+            }
+            else
+            {
+                boundary = globalCellOffset[d] == 0;
+            }
+            return boundary;
+        }
+
+        /** Calculate the normalized density
+         *
+         * @param totalCellOffset total offset including all slides [in cells]
+         */
+        DINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
+        {
+            // Do not create any particles beside the injection cells
+            if(not isInjectionBoundary(totalCellOffset))
+            {
+                return 0.0_X;
+            }
+
+            auto totalCellOffsetVector = float3_X::create(0.0_X);
+            totalCellOffsetVector.x() = totalCellOffset.x();
+            totalCellOffsetVector.y() = totalCellOffset.y();
+            if constexpr(simDim == 3u)
+                totalCellOffsetVector[2] = totalCellOffset[2];
+
+            // We need to evaluate the intensity functor at the center of the reduced cell
+            float3_X reducedCellCenter = {reducedCellCenter_x, reducedCellCenter_y, reducedCellCenter_z};
+            if constexpr(reverse)
+            {
+                reducedCellCenter[Side::template BeamToSimIdx_t<2u>::value]
+                    = 1.0_X - reducedCellCenter[Side::template BeamToSimIdx_t<2u>::value];
+            }
+
+            const float3_X globalCellPos((totalCellOffsetVector + reducedCellCenter) * cellSize);
+            // Get the relative beam intensity from the probing beam configuration
+            return probingBeam_m(currentStep_m, globalCellPos) * REFERENCE_PHOTON_DENSITY;
+        }
+
+    private:
+        PMACC_ALIGN(probingBeam_m, ProbingBeam);
+        PMACC_ALIGN(globalDomain_m, pmacc::Selection<simDim>);
+        PMACC_ALIGN(currentStep_m, uint32_t);
+    };
+} // namespace picongpu::particles::externalBeam::density

--- a/include/picongpu/particles/externalBeam/detail/StartAttributesContext.hpp
+++ b/include/picongpu/particles/externalBeam/detail/StartAttributesContext.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace detail
+            {
+                //! Combine worker information with the random generator handle for StartAttributes sub-functors
+                template<typename T_Worker, typename T_RngHandle>
+                struct StartAttributesContext
+                {
+                    T_Worker const* m_worker;
+                    mutable T_RngHandle* m_hRng;
+
+                    DINLINE StartAttributesContext(T_Worker const& worker, T_RngHandle& hRng)
+                        : m_worker(&worker)
+                        , m_hRng(&hRng)
+                    {
+                    }
+                };
+
+                //! Get the context without knowing the types
+                template<typename T_Worker, typename T_RngHandle>
+                DINLINE auto makeContext(T_Worker const& worker, T_RngHandle& hRng)
+                {
+                    return StartAttributesContext<T_Worker, T_RngHandle>(worker, hRng);
+                }
+
+            } // namespace detail
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/functors.def
+++ b/include/picongpu/particles/externalBeam/functors.def
@@ -1,0 +1,35 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// density:
+#include "picongpu/particles/externalBeam/density/ProbingBeamImpl.def"
+// momentum:
+#include "picongpu/particles/externalBeam/momentum/PhotonMomentum.def"
+// phase:
+#include "picongpu/particles/externalBeam/phase/FromPhotonMomentum.def"
+#include "picongpu/particles/externalBeam/phase/FromSpeciesWavelength.def"
+// start position:
+#include "picongpu/particles/externalBeam/startPosition/QuietProbingBeam.def"
+#include "picongpu/particles/externalBeam/startPosition/RandomProbingBeam.def"
+// polarization
+#include "picongpu/particles/externalBeam/polarization/OnePolarization.def"
+// main functor:
+#include "picongpu/particles/externalBeam/StartAttributesImpl.def"

--- a/include/picongpu/particles/externalBeam/functors.hpp
+++ b/include/picongpu/particles/externalBeam/functors.hpp
@@ -1,0 +1,35 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// density:
+#include "picongpu/particles/externalBeam/density/ProbingBeamImpl.hpp"
+// momentum:
+#include "picongpu/particles/externalBeam/momentum/PhotonMomentum.hpp"
+// phase:
+#include "picongpu/particles/externalBeam/phase/FromPhotonMomentum.hpp"
+#include "picongpu/particles/externalBeam/phase/FromSpeciesWavelength.hpp"
+// start position:
+#include "picongpu/particles/externalBeam/startPosition/QuietProbingBeam.hpp"
+#include "picongpu/particles/externalBeam/startPosition/RandomProbingBeam.hpp"
+// polarization
+#include "picongpu/particles/externalBeam/polarization/OnePolarization.hpp"
+// main functor:
+#include "picongpu/particles/externalBeam/StartAttributesImpl.hpp"

--- a/include/picongpu/particles/externalBeam/momentum/PhotonMomentum.def
+++ b/include/picongpu/particles/externalBeam/momentum/PhotonMomentum.def
@@ -1,0 +1,41 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu::particles::externalBeam::momentum
+{
+    /** Set initial photon momentum
+     *
+     * Sets photon momentum based on beam orientation and photon energy.
+     * This is a host side factory for a device side implementation.
+     *
+     * @tparam T_ParamClass param class providing the beam configuration and the photon energy.
+     *      Example:
+     *      @code{.cpp}
+     *          struct BeamMomentumParam
+     *          {
+     *              using Side = ProbingSide;
+     *              static constexpr float_64 photonEnergySI = 6.0 * UNITCONV_keV_to_Joule;
+                };
+     *      @endcode
+     */
+    template<typename T_ParamClass>
+    struct PhotonMomentum;
+} // namespace picongpu::particles::externalBeam::momentum

--- a/include/picongpu/particles/externalBeam/momentum/PhotonMomentum.hpp
+++ b/include/picongpu/particles/externalBeam/momentum/PhotonMomentum.hpp
@@ -1,0 +1,97 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <type_traits>
+
+namespace picongpu::particles::externalBeam::momentum
+{
+    namespace acc
+    {
+        //! Device side implementation fo the PhotonMomentum functor
+        template<typename T_ParamClass>
+        struct PhotonMomentum
+        {
+        private:
+            using ParamClass = T_ParamClass;
+            // Defines from which side the beam enters the simulation box.
+            using Side = typename T_ParamClass::Side;
+            static constexpr float_64 photonMomentum{
+                ParamClass::photonEnergySI / UNIT_ENERGY / static_cast<float_64>(SPEED_OF_LIGHT)};
+            // Photons propagate along the beam z direction
+            // Check if the beam z axis is a reversed pic axis. If so reverse z before axis swap.
+            static constexpr bool reverse = Side::reverse[2];
+            using DirectionBeam = typename std::conditional<reverse, mCT::Int<0, 0, -1>, mCT::Int<0, 0, 1>>::type;
+            // Convert into the pic simulation system
+            using DirectionSim = typename Side::template TwistBeamToSim_t<DirectionBeam>;
+
+        public:
+            /** Set particle momentum
+             *
+             * @tparam T_Context start attributes context
+             * @tparam T_Particle pmacc::Particle, particle type
+             * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+             *
+             * @param context start attributes context
+             * @param particle particle to be manipulated
+             * @param ... unused particles
+             */
+            template<typename T_Context, typename T_Particle, typename... T_Args>
+            DINLINE void operator()(T_Context const& context, T_Particle& particle, T_Args&&...) const
+            {
+                float_X const macroWeighting{particle[weighting_]};
+                float3_X const direction{precisionCast<float_X>(DirectionSim::toRT())};
+                // Don't need to normalize direction here since the norm is 1.
+                float3_X const mom{direction * (static_cast<float_X>(photonMomentum) * macroWeighting)};
+                particle[momentum_] = mom;
+            }
+        };
+    } // namespace acc
+
+    template<typename T_ParamClass>
+    struct PhotonMomentum
+    {
+        template<typename T_Species>
+        struct apply
+        {
+            using type = PhotonMomentum<T_ParamClass>;
+        };
+
+        HINLINE PhotonMomentum(uint32_t const& currentStep)
+        {
+        }
+
+        /** create functor for the accelerator
+         *
+         * @tparam T_Worker lockstep worker type
+         *
+         * @param worker lockstep worker
+         * @param localSupercellOffset offset (in superCells, without any guards) relative
+         *                        to the origin of the local domain
+         */
+        template<typename T_Worker>
+        DINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset) const
+        {
+            return acc::PhotonMomentum<T_ParamClass>();
+        }
+    };
+} // namespace picongpu::particles::externalBeam::momentum

--- a/include/picongpu/particles/externalBeam/phase/FromPhotonMomentum.def
+++ b/include/picongpu/particles/externalBeam/phase/FromPhotonMomentum.def
@@ -1,0 +1,49 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace phase
+            {
+                /**  Calculate initial phase from the current time-step and the photon momentum
+                 *
+                 *  This is a host side factory for a device side implementation.
+                 *
+                 * @tparam T_ParamClass param class providing a fixed @f$phi_0@f$ offset and the beam setup
+                 *      Example:
+                 *      @code{.cpp}
+                 *          struct Param
+                 *          {
+                 *              using Side = ProbingSide;
+                 *              static constexpr float_64 phi0 = 0.0;
+                 *          };
+                 *      @endcode
+                 */
+                template<typename T_ParamClass>
+                struct FromPhotonMomentum;
+            } // namespace phase
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/phase/FromPhotonMomentum.hpp
+++ b/include/picongpu/particles/externalBeam/phase/FromPhotonMomentum.hpp
@@ -1,0 +1,110 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/PhotonFunctors.hpp"
+
+namespace picongpu::particles::externalBeam::phase
+{
+    namespace acc
+    {
+        //! Device side implementation for FromPhotonMomentum
+        template<typename T_ParamClass>
+        struct FromPhotonMomentum
+        {
+            static constexpr float_64 phi0 = T_ParamClass::phi0;
+
+            using Side = typename T_ParamClass::Side;
+
+            DINLINE FromPhotonMomentum(uint32_t const& currentStep) : currentStep_m(currentStep)
+            {
+            }
+            /* Set phase
+             *
+             * @tparam T_Context start attributes context
+             * @tparam T_Particle pmacc::Particle, particle type
+             * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+             *
+             * @param context start attributes context
+             * @param particle particle to be manipulated
+             * @param ... unused particles
+             */
+            template<typename T_Context, typename T_Particle, typename... T_Args>
+            DINLINE void operator()(T_Context const& context, T_Particle& particle, T_Args&&...) const
+            {
+                float_X phase
+                    = precisionCast<float_X>(GetPhaseByTimestep<T_Particle>()(currentStep_m, particle, phi0));
+
+                static constexpr float_X cellSizeCT[3] = {CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH};
+                static constexpr float_X cellDepth{cellSizeCT[Side::template BeamToSimIdx_t<2u>::value]};
+
+                /* this functor will be called only in the first cell (counting from the boundary where
+                the photon beam enters the simulation. So global position along the propagation axis
+                is just the in cell position. */
+                const floatD_X position = particle[position_];
+                // distance from the z_beam=0 plane (the simulation boundary) where the position contribution
+                // to the plane wave phase is 0.
+                // note:  in theory we could just do operation on the z component only
+                const float_X distance{
+                    Side::transformOffsetSimToBeam(position, floatD_X::create(1.0_X)).z() * cellDepth};
+                const float_X waveNumber{GetAngFrequency<T_Particle>()() / SPEED_OF_LIGHT};
+                const float_X spatialContribution = waveNumber * distance;
+                phase += spatialContribution;
+                particle[startPhase_] = phase;
+            }
+
+        private:
+            PMACC_ALIGN(currentStep_m, uint32_t);
+        };
+    } // namespace acc
+
+    template<typename T_ParamClass>
+    struct FromPhotonMomentum
+    {
+        template<typename T_Species>
+        struct apply
+        {
+            using type = FromPhotonMomentum<T_ParamClass>;
+        };
+
+        HINLINE FromPhotonMomentum(uint32_t const& currentStep) : currentStep_m(currentStep)
+        {
+        }
+
+        /** create functor for the accelerator
+         *
+         * @tparam T_Worker lockstep worker type
+         *
+         * @param worker lockstep worker
+         * @param localSupercellOffset offset (in superCells, without any guards) relative
+         *                        to the origin of the local domain
+         */
+        template<typename T_Worker>
+        DINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset) const
+        {
+            return acc::FromPhotonMomentum<T_ParamClass>(currentStep_m);
+        }
+
+    private:
+        PMACC_ALIGN(currentStep_m, uint32_t);
+    };
+} // namespace picongpu::particles::externalBeam::phase

--- a/include/picongpu/particles/externalBeam/phase/FromSpeciesWavelength.def
+++ b/include/picongpu/particles/externalBeam/phase/FromSpeciesWavelength.def
@@ -1,0 +1,50 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace phase
+            {
+                /** Calculate initial phase from the current time-step and the species wavelength flag
+                 *
+                 *  This is a host side factory for a device side implementation.
+                 *
+                 * @tparam T_ParamClass param class providing a fixed @f$phi_0@f$ offset and the beam setup
+                 *      @code{.cpp}
+                 *          struct Param
+                 *          {
+                 *              using Side = ProbingSide;
+                 *              static constexpr float_64 phi0 = 0.0;
+                 *          };
+                 *      @endcode
+                 */
+                template<typename T_ParamClass>
+                struct FromSpeciesWavelength;
+            } // namespace phase
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/phase/FromSpeciesWavelength.hpp
+++ b/include/picongpu/particles/externalBeam/phase/FromSpeciesWavelength.hpp
@@ -1,0 +1,117 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/PhotonFunctors.hpp"
+
+namespace picongpu::particles::externalBeam::phase
+{
+    namespace acc
+    {
+        template<typename T_ParamClass>
+        struct FromSpeciesWavelength
+        {
+            using Side = typename T_ParamClass::Side;
+
+            DINLINE FromSpeciesWavelength(float_64 const& curPhase) : curPhase_m(curPhase)
+            {
+            }
+            /* Set phase
+             *
+             * @tparam T_Context start attributes context
+             * @tparam T_Particle pmacc::Particle, particle type
+             * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+             *
+             * @param context start attributes context
+             * @param particle particle to be manipulated
+             * @param ... unused particles
+             */
+            template<typename T_Context, typename T_Particle, typename... T_Args>
+            DINLINE void operator()(T_Context const& context, T_Particle& particle, T_Args&&...) const
+            {
+                static constexpr float_X cellSizeCT[3] = {CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH};
+                static constexpr float_X cellDepth{cellSizeCT[Side::template BeamToSimIdx_t<2u>::value]};
+
+                /* this functor will be called only in the first cell (counting from the boundary where
+                the photon beam enters the simulation. So global position along the propagation axis
+                is just the in cell position. */
+                const floatD_X position = particle[position_];
+                // distance from the z_beam=0 plane (the simulation boundary) where the position contribution
+                // to the plane wave phase is 0.
+                // note:  in theory we could just do operation on the z component only
+                const float_X distance{
+                    Side::transformOffsetSimToBeam(position, floatD_X::create(1.0_X)).z() * cellDepth};
+                const float_X waveNumber{GetAngFrequency<T_Particle>()() / SPEED_OF_LIGHT};
+                const float_X spatialContribution = waveNumber * distance;
+                const float_X phase = spatialContribution + curPhase_m;
+
+                particle[startPhase_] = phase;
+            }
+
+        private:
+            PMACC_ALIGN(curPhase_m, float_64);
+        };
+    } // namespace acc
+
+    //! Implementation of the host side factory for FromSpeciesWavelength
+    template<typename T_ParamClass, typename T_Species>
+    struct FromSpeciesWavelengthImpl
+    {
+        using Side = typename T_ParamClass::Side;
+        static constexpr float_64 phi0 = T_ParamClass::phi0;
+
+        HINLINE FromSpeciesWavelengthImpl(uint32_t const& currentStep)
+            : curPhase(precisionCast<float_X>(GetPhaseByTimestep<T_Species>()(currentStep, phi0)))
+        {
+        }
+
+        /** create functor for the accelerator
+         *
+         * @tparam T_Worker lockstep worker type
+         *
+         * @param worker lockstep worker
+         * @param localSupercellOffset offset (in superCells, without any guards) relative
+         *                        to the origin of the local domain
+         */
+        template<typename T_Worker>
+        DINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset) const
+        {
+            return acc::FromSpeciesWavelength<T_ParamClass>(curPhase);
+        }
+        PMACC_ALIGN(curPhase, float_64);
+    };
+
+    /*
+     * We need this type wrapper since using a placeholder for T_Species somehow collides with all the applies
+     * and it is not working correctly. It break the apply in StartAttributes, so that the StartAttributes is used
+     *  instead of the host side factory implementation.
+     */
+    template<typename T_ParamClass>
+    struct FromSpeciesWavelength
+    {
+        template<typename T_SpeciesType>
+        struct apply
+        {
+            using type = FromSpeciesWavelengthImpl<T_ParamClass, T_SpeciesType>;
+        };
+    };
+} // namespace picongpu::particles::externalBeam::phase

--- a/include/picongpu/particles/externalBeam/polarization/OnePolarization.def
+++ b/include/picongpu/particles/externalBeam/polarization/OnePolarization.def
@@ -1,0 +1,48 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace polarization
+            {
+                /** Set the particle polarization. One value for a all particles.
+                 *
+                 * @tparam T_Param param class. Must define the polarization value (-PI, + PI].
+                 *  Example:
+                 *  @code{cpp}
+                 *  struct T_Param
+                 *  {
+                 *      static constexpr float_X polarization{pmacc::math::Pi<float_X>::value /2.0_X};
+                 *  };
+                 *  @endcode
+                 *
+                 */
+                template<typename T_Param>
+                struct OnePolarization;
+
+            } // namespace polarization
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/polarization/OnePolarization.hpp
+++ b/include/picongpu/particles/externalBeam/polarization/OnePolarization.hpp
@@ -1,0 +1,85 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace polarization
+            {
+                namespace acc
+                {
+                    template<typename T_Param>
+                    struct OnePolarization
+                    {
+                        /* Set polarization angle
+                         *
+                         * @tparam T_Context start attributes context
+                         * @tparam T_Particle pmacc::Particle, particle type
+                         * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+                         *
+                         * @param context start attributes context
+                         * @param particle particle to be manipulated
+                         * @param ... unused particles
+                         */
+                        template<typename T_Context, typename T_Particle, typename... T_Args>
+                        DINLINE void operator()(T_Context const& context, T_Particle& particle, T_Args&&...) const
+                        {
+                            particle[polarizationAngle_] = T_Param::polarization;
+                        }
+                    };
+                } // namespace acc
+                template<typename T_Param>
+                struct OnePolarization
+                {
+                    template<typename T_Species>
+                    struct apply
+                    {
+                        using type = OnePolarization<T_Param>;
+                    };
+
+                    HINLINE OnePolarization(uint32_t const& currentStep)
+                    {
+                    }
+
+                    /** create functor for the accelerator
+                     *
+                     * @tparam T_Worker lockstep worker type
+                     *
+                     * @param worker lockstep worker
+                     * @param localSupercellOffset offset (in superCells, without any guards) relative
+                     *                        to the origin of the local domain
+                     */
+                    template<typename T_Worker>
+                    DINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const
+                    {
+                        return acc::OnePolarization<T_Param>();
+                    }
+                };
+            } // namespace polarization
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/startPosition/QuietProbingBeam.def
+++ b/include/picongpu/particles/externalBeam/startPosition/QuietProbingBeam.def
@@ -1,0 +1,55 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace startPosition
+            {
+                /** Evenly spaced position for beam particles
+                 *
+                 * Set the in cell position and the weighting of the macro particle.
+                 * This is a host side factory for a device side implementation.
+
+                 *
+                 * @tparam T_ParamClass should define ProbingCoordinates type, numParticlesPerDimension vector,
+                 *      and minWeighting (particles won't be created in cells where weighting would be smaller
+                 *      than this).
+                 *
+                 *      Example param class:
+                 *      @code{.cpp}
+                 *      struct QuietProbingBeamParam
+                 *      {
+                 *           using Side = ProbingSide;
+                 *           using numParticlesPerDimension = mCT::Int<4, 4, 1>;
+                 *           static constexpr float_X minWeighting = 0.001;
+                 *      };
+                 *      @endcode
+                 */
+                template<typename T_ParamClass>
+                struct QuietProbingBeam;
+            } // namespace startPosition
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/startPosition/QuietProbingBeam.hpp
+++ b/include/picongpu/particles/externalBeam/startPosition/QuietProbingBeam.hpp
@@ -1,0 +1,202 @@
+/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/externalBeam/beam/Side.hpp"
+
+#include <boost/mpl/integral_c.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace startPosition
+            {
+                namespace acc
+                {
+                    //! Device side implementation for QuietProbingBeam
+                    template<typename T_ParamClass>
+                    struct QuietProbingBeam
+                    {
+                        using ParamClass = T_ParamClass;
+                        // Defines from which side the beam enters the simulation box.
+                        using Side = typename T_ParamClass::Side;
+
+                    private:
+                        // number of particles in each direction
+                        using numParPerDimension =
+                            typename Side::template TwistBeamToSim_t<typename T_ParamClass::numParticlesPerDimension>;
+
+                        /* compile-time calculation of the in-cell particle spacing. Along the beam propagation
+                         * direction ( z in the beam system) particles are created only up to the distance that a
+                         * particle travels in one time-step. Here we assume the particles are photons and travel with
+                         * the speed of light.
+                         */
+                        static constexpr float_X cellSizeCT[3] = {CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH};
+                        static constexpr float_X cellDepth{cellSizeCT[Side::template BeamToSimIdx_t<2u>::value]};
+                        static constexpr float_X spacingBeam[3] = {1.0_X, 1.0_X, DELTA_T* SPEED_OF_LIGHT / cellDepth};
+                        static constexpr float_X spacing3D_x{
+                            spacingBeam[Side::template SimToBeamIdx_t<0u>::value]
+                            / static_cast<float_X>(numParPerDimension::template at<0>::type::value)};
+                        static constexpr float_X spacing3D_y{
+                            spacingBeam[Side::template SimToBeamIdx_t<1u>::value]
+                            / static_cast<float_X>(numParPerDimension::template at<1>::type::value)};
+                        static constexpr float_X spacing3D_z{
+                            spacingBeam[Side::template SimToBeamIdx_t<2u>::value]
+                            / static_cast<float_X>(numParPerDimension::template at<2>::type::value)};
+                        // discard the extra dimension in case of a 2D simulation
+                        using numParShrinked = typename mCT::shrinkTo<numParPerDimension, simDim>::type;
+
+                        // This is true when the beam travels **against** one of the simulation coordinate system unit
+                        // vectors.
+                        static constexpr bool reverse = Side::reverse[2];
+
+                    public:
+                        /** Set in-cell position and weighting
+                         *
+                         * @tparam T_Context start attributes context
+                         * @tparam T_Particle pmacc::Particle, particle type
+                         * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+                         *
+                         * @param context start attributes context
+                         * @param particle particle to be manipulated
+                         * @param ... unused particles
+                         */
+                        template<typename T_Context, typename T_Particle, typename... T_Args>
+                        DINLINE void operator()(T_Context const& context, T_Particle& particle, T_Args&&...)
+                        {
+                            uint32_t maxNumMacroParticles = pmacc::math::CT::volume<
+                                typename T_ParamClass::numParticlesPerDimension>::type::value;
+                            /* reset the particle position if the operator is called more times than allowed
+                             * (m_currentMacroParticles underflow protection.
+                             */
+                            if(maxNumMacroParticles <= m_currentMacroParticles)
+                                m_currentMacroParticles = maxNumMacroParticles - 1u;
+
+                            // particle spacing as a run-time float vector
+                            const float3_X spacing3D{spacing3D_x, spacing3D_y, spacing3D_z};
+                            const floatD_X spacing = spacing3D.shrink<simDim>();
+                            /* coordinate in the local in-cell lattice
+                             *   x = [0, numParsPerCell_X-1]
+                             *   y = [0, numParsPerCell_Y-1]
+                             *   z = [0, numParsPerCell_Z-1]
+                             */
+                            DataSpace<simDim> inCellCoordinate
+                                = DataSpaceOperations<simDim>::map(numParShrinked::toRT(), m_currentMacroParticles);
+
+                            floatD_X inCellPosition
+                                = precisionCast<float_X>(inCellCoordinate) * spacing + spacing * float_X(0.5);
+
+                            // Shift the coordinate along the beam propagation direction towards the external boundary
+                            // if the boundary is on the end of the cell. ( The beam enters the simulation from the
+                            // bottom, rear or the right side).
+                            if constexpr(reverse)
+                            {
+                                inCellPosition[Side::template BeamToSimIdx_t<2u>::value]
+                                    = 1.0_X - inCellPosition[Side::template BeamToSimIdx_t<2u>::value];
+                            }
+
+                            particle[position_] = inCellPosition;
+                            particle[weighting_] = m_weighting;
+
+                            // decrease the number of unprocessed particles by 1
+                            --m_currentMacroParticles;
+                        }
+
+                        /* Get the number of particles needed to be created in the simulation cell
+                         *
+                         * @tparam T_Context start attributes context
+                         * @tparam T_Particle type of the particles that should be created
+                         *
+                         * @param context start attributes context
+                         * @param realParticlesPerCell number of new real particles in the cell in which this instance
+                         * creates particles
+                         *
+                         * @return number of macro particles that need to be created in this cell (The operator() will
+                         * be called that many times)
+                         */
+                        template<typename T_Particle, typename T_Context>
+                        HDINLINE uint32_t
+                        numberOfMacroParticles(T_Context const& context, float_X const realParticlesPerCell)
+                        {
+                            m_weighting = float_X(0.0);
+                            uint32_t numMacroParticles = pmacc::math::CT::volume<numParShrinked>::type::value;
+
+                            // particle weighting if all macro particles are created
+                            if(numMacroParticles > 0u)
+                                m_weighting = realParticlesPerCell / float_X(numMacroParticles);
+
+                            // Only create particles if weighting is not below the minimal value.
+                            // Notice this is different as in the usual startPosition functor where the number of macro
+                            // particles would be reduced to satisfy this condition.
+
+                            if(m_weighting < T_ParamClass::minWeighting)
+                                return 0u;
+                            else
+                            {
+                                m_currentMacroParticles = numMacroParticles - 1u;
+                                return numMacroParticles;
+                            }
+                        }
+
+                    private:
+                        PMACC_ALIGN(m_weighting, float_X);
+                        PMACC_ALIGN(m_currentMacroParticles, uint32_t);
+                    };
+
+                } // namespace acc
+
+                template<typename T_ParamClass>
+                struct QuietProbingBeam
+                {
+                    template<typename T_Species>
+                    struct apply
+                    {
+                        using type = QuietProbingBeam<T_ParamClass>;
+                    };
+
+                    HINLINE QuietProbingBeam(uint32_t const& currentStep)
+                    {
+                    }
+
+                    /** create functor for the accelerator
+                     *
+                     * @tparam T_Worker lockstep worker type
+                     *
+                     * @param worker lockstep worker
+                     * @param localSupercellOffset offset (in superCells, without any guards) relative
+                     *                        to the origin of the local domain
+                     */
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const
+                    {
+                        return acc::QuietProbingBeam<T_ParamClass>();
+                    }
+                };
+            } // namespace startPosition
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/startPosition/RandomProbingBeam.def
+++ b/include/picongpu/particles/externalBeam/startPosition/RandomProbingBeam.def
@@ -1,0 +1,56 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace startPosition
+            {
+                /** Random in cell position for beam particles
+                 *
+                 * The particle attribute position is assigned with a random
+                 * in-cell position.  This functor also sets the macro particle weighting.
+                 * This is a host side factory for a device side implementation.
+                 *
+                 * @tparam T_ParamClass should define ProbingCoordinates type, numParticlesPerCell,
+                 *      and minWeighting (particles won't be created in cells where weighting would be smaller
+                 *      than this).
+                 *
+                 *      Example param class:
+                 *      @code{.cpp}
+                 *      struct RandomProbingBeamParam
+                 *      {
+                 *           using Side = ProbingSide;
+                 *           // PhotonBeam needs to be defined by a user as well.
+                 *           static constexpr uint32_t numParticlesPerCell = 64u;
+                 *           static constexpr float_X minWeighting = 0.001;
+                 *      };
+                 *      @endcode
+                 */
+                template<typename T_ParamClass>
+                struct RandomProbingBeam;
+            } // namespace startPosition
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/externalBeam/startPosition/RandomProbingBeam.hpp
+++ b/include/picongpu/particles/externalBeam/startPosition/RandomProbingBeam.hpp
@@ -1,0 +1,168 @@
+/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/startPosition/detail/WeightMacroParticles.hpp"
+#include "picongpu/particles/startPosition/generic/FreeRng.def"
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            namespace startPosition
+            {
+                namespace acc
+                {
+                    //! Device side implementation for RandomProbingBeam
+                    template<typename T_ParamClass>
+                    struct RandomProbingBeam
+                    {
+                        using ParamClass = T_ParamClass;
+                        // Defines from which side the beam enters the simulation box.
+                        using Side = typename T_ParamClass::Side;
+
+                    private:
+                        /* compile-time calculation of the in-cell position range. Along the beam propagation direction
+                         * ( z in the beam system) particles are created only up to the distance that a particle
+                         * travels in one time-step. Here we assume the particles are photons and travel with the speed
+                         * of light.
+                         */
+                        static constexpr float_X cellSizeCT[3] = {CELL_WIDTH, CELL_HEIGHT, CELL_DEPTH};
+                        static constexpr float_X cellDepth{cellSizeCT[Side::template BeamToSimIdx_t<2u>::value]};
+                        static constexpr float_X posLimBeam[3] = {1.0_X, 1.0_X, DELTA_T* SPEED_OF_LIGHT / cellDepth};
+                        static constexpr float_X posLimPic_x = posLimBeam[Side::template SimToBeamIdx_t<0u>::value];
+                        static constexpr float_X posLimPic_y = posLimBeam[Side::template SimToBeamIdx_t<1u>::value];
+                        static constexpr float_X posLimPic_z = posLimBeam[Side::template SimToBeamIdx_t<2u>::value];
+
+                        // This is true when the beam travels **against** one of the simulation coordinate system unit
+                        // vectors.
+                        static constexpr bool reverse = Side::reverse[2];
+
+
+                    public:
+                        /** Set in-cell position and weighting
+                         *
+                         * @tparam T_Context start attributes context
+                         * @tparam T_Particle pmacc::Particle, particle type
+                         * @tparam T_Args pmacc::Particle, arbitrary number of particles types
+                         *
+                         * @param context start attributes context
+                         * @param particle particle to be manipulated
+                         * @param ... unused particles
+                         */
+                        template<typename T_Context, typename T_Particle, typename... T_Args>
+                        DINLINE void operator()(T_Context const& context, T_Particle& particle, T_Args&&...) const
+                        {
+                            // get the random number generator from context
+                            // Get a random float value from 0,1
+                            auto const& worker = *context.m_worker;
+                            auto& rngHandle = *context.m_hRng;
+                            auto rng
+                                = rngHandle
+                                      .template applyDistribution<pmacc::random::distributions::Uniform<float_X>>();
+                            floatD_X tmpPos;
+
+                            // array is not available in device code. even constexpr  array.
+                            const float3_X posLimPicVec{posLimPic_x, posLimPic_y, posLimPic_z};
+
+                            // generate a random in-cell position for each coordinate. In the beam propagation
+                            // direction the position is limited by the distance a particle can travel in one
+                            // time-step.
+                            for(uint32_t d = 0; d < simDim; ++d)
+                                tmpPos[d] = rng(worker) * posLimPicVec[d];
+
+
+                            // Shift the coordinate along the beam propagation direction towards the external boundary
+                            // if the boundary is on the end of the cell. ( The beam enters the simulation from the
+                            // bottom, rear or the right side).
+                            if constexpr(reverse)
+                            {
+                                tmpPos[Side::template BeamToSimIdx_t<2u>::value]
+                                    = 1.0_X - tmpPos[Side::template BeamToSimIdx_t<2u>::value];
+                            }
+
+                            particle[position_] = tmpPos;
+                            particle[weighting_] = m_weighting;
+                        }
+
+                        /* Get the number of particles needed to be created in the simulation cell
+                         *
+                         * @tparam T_Context start attributes context
+                         * @tparam T_Particle type of the particles that should be created
+                         *
+                         * @param context start attributes context
+                         * @param realParticlesPerCell number of new real particles in the cell in which this instance
+                         * creates particles
+                         *
+                         * @return number of macro particles that need to be created in this cell (The operator() will
+                         * be called that many times)
+                         */
+                        template<typename T_Particle, typename T_Context>
+                        HDINLINE uint32_t
+                        numberOfMacroParticles(T_Context const& context, float_X const realParticlesPerCell)
+                        {
+                            // Only create particles if weighting is not below the minimal value.
+                            // Notice this is different as in the usual startPosition functor where the number of macro
+                            // particles would be reduced to satisfy this condition.
+                            m_weighting = realParticlesPerCell / T_ParamClass::numParticlesPerCell;
+                            if(m_weighting < T_ParamClass::minWeighting)
+                                return 0u;
+                            return T_ParamClass::numParticlesPerCell;
+                        }
+
+                        float_X m_weighting;
+                    };
+                } // namespace acc
+                template<typename T_ParamClass>
+                struct RandomProbingBeam
+                {
+                    template<typename T_Species>
+                    struct apply
+                    {
+                        using type = RandomProbingBeam<T_ParamClass>;
+                    };
+
+                    HINLINE RandomProbingBeam(uint32_t const& currentStep)
+                    {
+                    }
+
+                    /** create functor for the accelerator
+                     *
+                     * @tparam T_Worker lockstep worker type
+                     *
+                     * @param worker lockstep worker
+                     * @param localSupercellOffset offset (in superCells, without any guards) relative
+                     *                        to the origin of the local domain
+                     */
+                    template<typename T_Worker>
+                    HDINLINE auto operator()(T_Worker const& worker, DataSpace<simDim> const& localSupercellOffset)
+                        const
+                    {
+                        return acc::RandomProbingBeam<T_ParamClass>();
+                    }
+                };
+            } // namespace startPosition
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/unitless/externalBeam.unitless
+++ b/include/picongpu/unitless/externalBeam.unitless
@@ -1,0 +1,24 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+/* include implemented beam particle initializations */
+#include "picongpu/particles/externalBeam/functors.hpp"

--- a/include/picongpu/unitless/speciesAttributes.unitless
+++ b/include/picongpu/unitless/speciesAttributes.unitless
@@ -1,5 +1,5 @@
 /* Copyright 2013-2023 Rene Widera, Felix Schmitt, Axel Huebl,
- *                     Alexander Grund, Finn-Ole Carstens
+ *                     Alexander Grund, Finn-Ole Carstens, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -589,6 +589,84 @@ namespace picongpu
             static float_64 get()
             {
                 return 1.0;
+            }
+        };
+
+        template<>
+        struct Unit<startPhase>
+        {
+            // unitless and not scaled by a factor: 1.0
+            static std::vector<double> get()
+            {
+                std::vector<double> unit(1, 1.0);
+                return unit;
+            }
+        };
+        template<>
+        struct UnitDimension<startPhase>
+        {
+            static std::vector<float_64> get()
+            {
+                // startPhase is unitless
+                std::vector<float_64> unitDimension(NUnitDimension, 0.0);
+
+                return unitDimension;
+            }
+        };
+        template<>
+        struct MacroWeighted<startPhase>
+        {
+            // phase is identical for all real photons
+            static bool get()
+            {
+                return false;
+            }
+        };
+        template<>
+        struct WeightingPower<startPhase>
+        {
+            // phase doesn't scale with the number of real photons
+            static float_64 get()
+            {
+                return 0.0;
+            }
+        };
+
+        template<>
+        struct Unit<polarizationAngle>
+        {
+            // unitless and not scaled by a factor: 1.0
+            static std::vector<double> get()
+            {
+                std::vector<double> unit(1, 1.0);
+                return unit;
+            }
+        };
+        template<>
+        struct UnitDimension<polarizationAngle>
+        {
+            static std::vector<float_64> get()
+            {
+                // startPhase is unitless
+                std::vector<float_64> unitDimension(NUnitDimension, 0.0);
+
+                return unitDimension;
+            }
+        };
+        template<>
+        struct MacroWeighted<polarizationAngle>
+        {
+            static bool get()
+            {
+                return false;
+            }
+        };
+        template<>
+        struct WeightingPower<polarizationAngle>
+        {
+            static float_64 get()
+            {
+                return 0.0;
             }
         };
 

--- a/include/pmacc/math/vector/TwistComponents.hpp
+++ b/include/pmacc/math/vector/TwistComponents.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/math/vector/navigator/PermutedNavigator.hpp"
 #include "pmacc/math/vector/navigator/StackedNavigator.hpp"
@@ -32,10 +33,7 @@ namespace pmacc
         namespace detail
         {
             template<typename T_Axes, typename T_Vector>
-            struct TwistComponents
-            {
-                using type = typename TwistComponents<T_Axes, typename T_Vector::This>::type;
-            };
+            struct TwistComponents;
 
             template<
                 typename T_Axes,
@@ -52,6 +50,35 @@ namespace pmacc
                     T_Accessor,
                     math::StackedNavigator<T_Navigator, math::PermutedNavigator<T_Axes>>,
                     T_Storage>&;
+            };
+
+            template<typename T_Axes, unsigned dim>
+            struct TwistComponents<T_Axes, DataSpace<dim>>
+            {
+                using type = typename TwistComponents<T_Axes, typename DataSpace<dim>::BaseType>::type;
+            };
+
+            template<
+                typename T_Axes,
+                typename T_Type,
+                uint32_t T_dim,
+                typename T_Accessor,
+                typename T_Navigator,
+                typename T_Storage>
+            struct TwistComponents<T_Axes, const math::Vector<T_Type, T_dim, T_Accessor, T_Navigator, T_Storage>>
+            {
+                using type = math::Vector<
+                    T_Type,
+                    T_dim,
+                    T_Accessor,
+                    math::StackedNavigator<T_Navigator, math::PermutedNavigator<T_Axes>>,
+                    T_Storage> const&;
+            };
+
+            template<typename T_Axes, unsigned dim>
+            struct TwistComponents<T_Axes, const DataSpace<dim>>
+            {
+                using type = typename TwistComponents<T_Axes, const typename DataSpace<dim>::BaseType>::type;
             };
 
         } // namespace detail
@@ -75,6 +102,14 @@ namespace pmacc
              * input type except its navigator policy which does not occupy any memory though.
              */
             return reinterpret_cast<typename detail::TwistComponents<T_Axes, T_Vector>::type>(vector);
+        }
+        template<typename T_Axes, typename T_Vector>
+        HDINLINE auto twistComponents(T_Vector const& vector)
+        {
+            /* The reinterpret_cast is valid because the target type is the same as the
+             * input type except its navigator policy which does not occupy any memory though.
+             */
+            return reinterpret_cast<typename detail::TwistComponents<T_Axes, T_Vector const>::type>(vector);
         }
 
     } // namespace math

--- a/share/picongpu/tests/ExternalBeam/README.rst
+++ b/share/picongpu/tests/ExternalBeam/README.rst
@@ -1,0 +1,13 @@
+Run time test for external beam
+=================================
+
+This test verifies the injection of particles (photons) at a boundary using the external beam module.
+The particles are injection with a gaussian transversal profile and a square temporal pulse.
+A python verifier compares the resulting particle per cell number (real particles not macro particles) with one computed in python.
+This test covers the creation, positioning, and setting up initial momentum in the external beam module.
+
+One way to run all tests in parallel:
+.. code: bash
+    for i in {0..6} ; do mkdir setup$i & done; wait;
+    for i in {0..6} ; do python $PICSRC/share/picongpu/tests/ExternalBeam/lib/python/picongpu/tests/test_debug_external_beam.py -t $i --dir setup$i |& tee setup$i/test.log &  done; wait;
+    for i in {0..6} ; do python $PICSRC/share/picongpu/tests/ExternalBeam/lib/python/picongpu/tests/verify_results.py  --dir setup$i/simOutput |& tee setup$i/verify.log &  done; wait;

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/externalBeam.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/externalBeam.param
@@ -1,0 +1,161 @@
+/* Copyright 2021-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/param/grid.param"
+#include "picongpu/particles/externalBeam/beam/ProbingBeam.def"
+#include "picongpu/particles/externalBeam/beam/Side.hpp"
+#include "picongpu/particles/externalBeam/beam/beamProfiles/profiles.def"
+#include "picongpu/particles/externalBeam/beam/beamShapes/shapes.def"
+#include "picongpu/particles/externalBeam/functors.def"
+
+#include <pmacc/preprocessor/struct.hpp>
+
+#ifndef PARAM_BEAM_OFFSET_X
+#    define PARAM_BEAM_OFFSET_X 0.0_X
+#endif
+#ifndef PARAM_BEAM_OFFSET_Y
+#    define PARAM_BEAM_OFFSET_Y 0.0_X
+#endif
+#ifndef PARAM_SIGMA_X_SI
+#    define PARAM_SIGMA_X_SI 30.0e-6_X
+#endif
+#ifndef PARAM_SIGMA_Y_SI
+#    define PARAM_SIGMA_Y_SI 30.0e-6_X
+#endif
+#ifndef PARAM_BEAM_DELAY_SI
+#    define PARAM_BEAM_DELAY_SI 0.0_X
+#endif
+#ifndef PARAM_BEAM_PROFILE
+#    define PARAM_BEAM_PROFILE GaussianProfile
+#endif
+#ifndef PARAM_BEAM_SHAPE
+#    define PARAM_BEAM_SHAPE ConstShape
+#endif
+#ifndef PARAM_BEAM_SIDE
+#    define PARAM_BEAM_SIDE ZSide
+#endif
+// start and end time are in timesteps
+#ifndef PARAM_BEAM_START_T
+#    define PARAM_BEAM_START_T 0.0
+#endif
+#ifndef PARAM_BEAM_END_T
+#    define PARAM_BEAM_END_T 20.0
+#endif
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            /* Choose from:
+             *  - ZSide
+             *  - YSide
+             *  - XSide
+             * - ZRSide
+             * - YRSide
+             * - XRSide
+             */
+            using ProbingSide = beam::PARAM_BEAM_SIDE;
+
+            PMACC_STRUCT(
+                GaussParam,
+                (PMACC_C_VALUE(float_X, sigmaX_SI, PARAM_SIGMA_X_SI))(
+                    PMACC_C_VALUE(float_X, sigmaY_SI, PARAM_SIGMA_Y_SI)));
+            PMACC_STRUCT(
+                OffsetParam,
+                (PMACC_C_VECTOR_DIM(float_X, DIM2, beamOffset_SI, PARAM_BEAM_OFFSET_X, PARAM_BEAM_OFFSET_Y))(
+                    PMACC_C_VALUE(float_X, beamDelay_SI, PARAM_BEAM_DELAY_SI)));
+
+            struct ConstShapeParam
+            {
+                static constexpr bool limitStart = true;
+                static constexpr bool limitEnd = true;
+                // does nothing since the limit is disabled
+                static constexpr float_64 startTime_SI = PARAM_BEAM_START_T * SI::DELTA_T_SI;
+                static constexpr float_64 endTime_SI = PARAM_BEAM_END_T * SI::DELTA_T_SI;
+            };
+
+            using GaussianProfile = beam::beamProfiles::GaussianProfile<GaussParam>;
+            using ConstProfile = beam::beamProfiles::ConstProfile;
+            using ConstShape = beam::beamShapes::ConstShape<ConstShapeParam>;
+
+            using BeamProfile = PARAM_BEAM_PROFILE;
+            using BeamShape = PARAM_BEAM_SHAPE;
+
+            using Beam = beam::ProbingBeam<BeamProfile, BeamShape, ProbingSide, OffsetParam>;
+
+            namespace density
+            {
+                struct ProbingBeamDensityParam
+                {
+                private:
+                    static constexpr float_64 cellVolumeSI
+                        = SI::CELL_HEIGHT_SI * SI::CELL_WIDTH_SI * SI::CELL_DEPTH_SI;
+
+                public:
+                    using ProbingBeam = Beam;
+                    // Just a test value -> one 100000 photons per full cell
+                    static constexpr float_64 photonFluxAtMaxBeamIntensity_SI{
+                        100000.0 / cellVolumeSI * SI::SPEED_OF_LIGHT_SI};
+                };
+                using ProbingBeamDensity = ProbingBeamImpl<ProbingBeamDensityParam>;
+            } // namespace density
+            namespace startPosition
+            {
+                struct QuietProbingBeamParam
+                {
+                    using Side = ProbingSide;
+                    /** Number of particles in each dimension initialized in a cell (in the beam coordinate
+                     * system).
+                     *
+                     * Keep in mind that the particles are not spaced across the complete cell but rather a reduced
+                     * cell. The cell dimensions along the beam x and y coordinates stay the same but along the
+                     * beam z direction the cell depth is reduced to DELTA_T * SPED_OF_LIGHT.
+                     *
+                     * All 3 components need to be specified.  In the case of a 2 dimensional simulation, the
+                     * component corresponding to the picongpu z direction will be discarded later.
+                     */
+                    static constexpr float_X minWeighting = 0.001;
+                    using numParticlesPerDimension = mCT::Int<2, 2, 2>;
+                };
+                using QuietBeam = QuietProbingBeam<QuietProbingBeamParam>;
+                struct RandomProbingBeamParam
+                {
+                    using Side = ProbingSide;
+                    static constexpr uint32_t numParticlesPerCell = 64u;
+                    static constexpr float_X minWeighting = 0.001;
+                };
+                using RandomBeam = RandomProbingBeam<RandomProbingBeamParam>;
+            } // namespace startPosition
+            namespace momentum
+            {
+                struct BeamMomentumParam
+                {
+                    using Side = ProbingSide;
+                    static constexpr float_64 photonEnergySI = 6.0 * UNITCONV_keV_to_Joule;
+                };
+                using BeamMomentum = PhotonMomentum<BeamMomentumParam>;
+            } // namespace momentum
+
+            using BeamStartAttributes = StartAttributes<startPosition::QuietBeam, momentum::BeamMomentum>;
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/fieldAbsorber.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/fieldAbsorber.param
@@ -1,0 +1,163 @@
+/* Copyright 2019-2023 Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the field absorber parameters.
+ * Field absorber type is set by command-line option --fieldAbsorber.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace absorber
+        {
+            // This variable is not required, defined for convenience
+            constexpr uint32_t THICKNESS = 0u;
+
+            /** Thickness of the absorbing layer, in number of cells
+             *
+             * This setting applies to applies for all absorber kinds.
+             * The absorber layer is located inside the global simulation area, near the outer borders.
+             * Setting size to 0 results in disabling absorption at the corresponding boundary.
+             * Note that for non-absorbing boundaries the actual thickness will be 0 anyways.
+             * There are no requirements on thickness being a multiple of the supercell size.
+             *
+             * For PML the recommended thickness is between 6 and 16 cells.
+             * For the exponential damping it is 32.
+             *
+             * Unit: number of cells.
+             */
+            constexpr uint32_t NUM_CELLS[3][2] = {
+                {THICKNESS, THICKNESS}, // x direction [negative, positive]
+                {THICKNESS, THICKNESS}, // y direction [negative, positive]
+                {THICKNESS, THICKNESS} // z direction [negative, positive]
+            };
+
+            //! Settings for the Exponential absorber
+            namespace exponential
+            {
+                /** Define the strength of the absorber for all directions
+                 *
+                 * Elements corredponding to non-absorber borders will have no effect.
+                 *
+                 * Unit: none
+                 */
+                constexpr float_X STRENGTH[3][2] = {
+                    {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+                    {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+                    {1.0e-3, 1.0e-3} /*z direction [negative,positive]*/
+                };
+            } // namespace exponential
+
+            /** Settings for the Pml absorber
+             *
+             * These parameters can generally be left with default values.
+             * For more details on the meaning of the parameters, refer to the following references.
+             * J.A. Roden, S.D. Gedney. Convolution PML (CPML): An efficient FDTD implementation of the CFS - PML
+             * for arbitrary media. Microwave and optical technology letters. 27 (5), 334-339 (2000).
+             * A. Taflove, S.C. Hagness. Computational Electrodynamics. The Finite-Difference Time-Domain Method.
+             * Third Edition. Artech house, Boston (2005), referred to as [Taflove, Hagness].
+             */
+            namespace pml
+            {
+                /** Order of polynomial grading for artificial electric conductivity and
+                 *  stretching coefficient
+                 *
+                 * The conductivity (sigma) is polynomially scaling from 0 at the internal
+                 * border of PML to the maximum value (defined below) at the external
+                 * border. The stretching coefficient (kappa) scales from 1 to the
+                 * corresponding maximum value (defined below) with the same polynomial.
+                 * The grading is given in [Taflove, Hagness], eq. (7.60a, b), with
+                 * the order denoted 'm'.
+                 * Must be >= 0. Normally between 3 and 4, not required to be integer.
+                 * Unitless.
+                 */
+                constexpr float_64 SIGMA_KAPPA_GRADING_ORDER = 4.0;
+
+                // [Taflove, Hagness], eq. (7.66). Not required, defined for convenience
+                constexpr float_64 SIGMA_OPT_SI[3]
+                    = {0.8 * (SIGMA_KAPPA_GRADING_ORDER + 1.0) / (SI::Z0_SI * SI::CELL_WIDTH_SI),
+                       0.8 * (SIGMA_KAPPA_GRADING_ORDER + 1.0) / (SI::Z0_SI * SI::CELL_HEIGHT_SI),
+                       0.8 * (SIGMA_KAPPA_GRADING_ORDER + 1.0) / (SI::Z0_SI * SI::CELL_DEPTH_SI)};
+
+                // Muptiplier to express SIGMA_MAX_SI with SIGMA_OPT_SI. Not required, defined for convenience
+                constexpr float_64 SIGMA_OPT_MULTIPLIER = 1.0;
+
+                /** Max value of artificial electric conductivity in PML
+                 *
+                 * Components correspond to directions: element 0 corresponds to absorption
+                 * along x direction, 1 = y, 2 = z. Grading is described in comments for
+                 * SIGMA_KAPPA_GRADING_ORDER.
+                 * Too small values lead to significant reflections from the external
+                 * border, too large - to reflections due to discretization errors.
+                 * Artificial magnetic permeability will be chosen to perfectly match this.
+                 * Must be >= 0. Normally between 0.7 * SIGMA_OPT_SI and 1.1 * SIGMA_OPT_SI.
+                 * Unit: siemens / m.
+                 */
+                constexpr float_64 SIGMA_MAX_SI[3]
+                    = {SIGMA_OPT_SI[0] * SIGMA_OPT_MULTIPLIER,
+                       SIGMA_OPT_SI[1] * SIGMA_OPT_MULTIPLIER,
+                       SIGMA_OPT_SI[2] * SIGMA_OPT_MULTIPLIER};
+
+                /** Max value of coordinate stretching coefficient in PML
+                 *
+                 * Components correspond to directions: element 0 corresponds to absorption
+                 * along x direction, 1 = y, 2 = z. Grading is described in comments for
+                 * SIGMA_KAPPA_GRADING_ORDER.
+                 * Must be >= 1. For relatively homogeneous domains 1.0 is a reasonable value.
+                 * Highly elongated domains can have better absorption with values between
+                 * 7.0 and 20.0, for example, see section 7.11.2 in [Taflove, Hagness].
+                 * Unitless.
+                 */
+                constexpr float_64 KAPPA_MAX[3] = {1.0, 1.0, 1.0};
+
+                /** Order of polynomial grading for complex frequency shift
+                 *
+                 * The complex frequency shift (alpha) is polynomially downscaling from the
+                 * maximum value (defined below) at the internal border of PML to 0 at the
+                 * external border. The grading is given in [Taflove, Hagness], eq. (7.79),
+                 * with the order denoted 'm_a'.
+                 * Must be >= 0. Normally values are around 1.0.
+                 * Unitless.
+                 */
+                constexpr float_64 ALPHA_GRADING_ORDER = 1.0;
+
+                /** Complex frequency shift in PML
+                 *
+                 * Components correspond to directions: element 0 corresponds to absorption
+                 * along x direction, 1 = y, 2 = z. Setting it to 0 will make PML behave
+                 * as uniaxial PML. Setting it to a positive value helps to attenuate
+                 * evanescent modes, but can degrade absorption of propagating modes, as
+                 * described in section 7.7 and 7.11.3 in [Taflove, Hagness].
+                 * Must be >= 0. Normally values are 0 or between 0.15 and 0.3.
+                 * Unit: siemens / m.
+                 */
+                constexpr float_64 ALPHA_MAX_SI[3] = {0.2, 0.2, 0.2};
+
+            } // namespace pml
+        } // namespace absorber
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/fieldSolver.param
@@ -1,0 +1,62 @@
+/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the field solver.
+ *
+ * Select the numerical Maxwell solver (e.g. Yee's method).
+ *
+ * \attention
+ * Currently, the laser initialization in PIConGPU is implemented to work with the standard Yee solver.
+ * Using a solver of higher order will result in a slightly increased laser amplitude and energy than expected.
+ *
+ */
+
+#pragma once
+
+#include "picongpu/fields/MaxwellSolver/Solvers.def"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        /** FieldSolver
+         *
+         * Field Solver Selection (note <> for some solvers):
+         *  - Yee<> : Standard Yee solver approximating derivatives with respect to time and
+         * space by second order finite differences.
+         *  - YeePML<>: Standard Yee solver using Perfectly Matched Layer Absorbing Boundary
+         * Conditions (PML)
+         *  - Lehe<>: Num. Cherenkov free field solver in a chosen direction
+         *  - LehePML<>: Num. Cherenkov free field solver in a chosen direction
+         *               using Perfectly Matched Layer Absorbing Boundary Conditions (PML)
+         *  - ArbitraryOrderFDTD<4>: Solver using 4 neighbors to each direction to approximate
+         * *spatial* derivatives by finite differences. The number of neighbors can be changed from 4 to any positive,
+         * integer number. The order of the solver will be twice the number of neighbors in each direction. Yee's
+         * method is a special case of this using one neighbor to each direction.
+         *  - ArbitraryOrderFDTDPML<4>: ArbitraryOrderFDTD solver using Perfectly Matched Layer
+         *                              Absorbing Boundary Conditions (PML)
+         *  - None: disable the vacuum update of E and B
+         */
+        using Solver = maxwellSolver::None;
+
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/fileOutput.param
@@ -1,0 +1,125 @@
+/* Copyright 2013-2023 Axel Huebl, Rene Widera, Felix Schmitt,
+ *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
+/* some forward declarations we need */
+#include "picongpu/fields/Fields.def"
+#include "picongpu/particles/filter/filter.def"
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+#include <boost/mpl/vector.hpp>
+
+
+namespace picongpu
+{
+    /** FieldTmp output (calculated at runtime) *******************************
+     *
+     * Those operations derive scalar field quantities from particle species
+     * at runtime. Each value is mapped per cell. Some operations are identical
+     * up to a constant, so avoid writing those twice to save storage.
+     *
+     * you can choose any of these particle to grid projections:
+     *   - Density: particle position + shape on the grid
+     *   - BoundElectronDensity: density of bound electrons
+     *       note: only makes sense for partially ionized ions
+     *   - ChargeDensity: density * charge
+     *       note: for species that do not change their charge state, this is
+     *             the same as the density times a constant for the charge
+     *   - Energy: sum of kinetic particle energy per cell with respect to shape
+     *   - EnergyDensity: average kinetic particle energy per cell times the
+     *                    particle density
+     *       note: this is the same as the sum of kinetic particle energy
+     *             divided by a constant for the cell volume
+     *   - Momentum: sum of chosen component of momentum per cell with respect to shape
+     *   - MomentumDensity: average chosen component of momentum per cell times the particle density
+     *       note: this is the same as the sum of the chosen momentum component
+     *             divided by a constant for the cell volume
+     *   - LarmorPower: radiated Larmor power
+     *                  (species must contain the attribute `momentumPrev1`)
+     *
+     * for debugging:
+     *   - MidCurrentDensityComponent:
+     *       density * charge * velocity_component
+     *   - Counter: counts point like particles per cell
+     *   - MacroCounter: counts point like macro particles per cell
+     *
+     * combined attributes:
+     *   These attributes are defined as a function of two primary derived attributes.
+     *
+     *   - AverageAttribute: template to compute a per particle average of any derived value
+     *   - RelativisticDensity: equals to 1/gamma^2 * n. Where gamma is the Lorentz factor for the mean kinetic energy
+     *      in the cell and n ist the usual number density. Useful for Faraday Rotation calculation.
+     *
+     *      Example use:
+     *      @code{.cpp}
+     *      using AverageEnergy_Seq = deriveField::CreateEligible_t<
+     *          VectorAllSpecies,
+     *          deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::Energy>>;
+     *      using RelativisticDensity_Seq
+     *          = deriveField::CreateEligible_t<PIC_Electrons, deriveField::combinedAttributes::RelativisticDensity>;
+     *      @endcode
+     *
+     * Filtering:
+     *   You can create derived fields from filtered particles. Only particles passing
+     *   the filter will contribute to the field quantity.
+     *   For that you need to define your filters in `particleFilters.param` and pass a
+     *   filter as the 3rd (optional) template argument in `CreateEligible_t`.
+     *
+     *   Example: This will create charge density field for all species that are
+     *   eligible for the this attribute and the chosen filter.
+     *   @code{.cpp}
+     *   using ChargeDensity_Seq
+         = deriveField::CreateEligible_t< VectorAllSpecies,
+         deriveField::derivedAttributes::ChargeDensity, filter::FilterOfYourChoice>;
+     *   @endcode
+     */
+    namespace deriveField = particles::particleToGrid;
+
+    /* Counter section */
+    using Counter_Seq = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::Counter>;
+
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<Counter_Seq>;
+
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+
+    /** Possible native fields: FieldE, FieldB, FieldJ
+     */
+    using NativeFileOutputFields = MakeSeq_t<>;
+
+    using FileOutputFields = MakeSeq_t<FieldTmpSolvers>;
+
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to disable particle output set to
+     *   using FileOutputParticles = MakeSeq_t< >;
+     */
+    using FileOutputParticles = MakeSeq_t<>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/grid.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/grid.param
@@ -1,0 +1,100 @@
+/* Copyright 2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Definition of cell sizes and time step. Our cells are defining a regular,
+ * cartesian grid. Our explicit FDTD field solvers require an upper bound for
+ * the time step value in relation to the cell size for convergence. Make
+ * sure to resolve important wavelengths of your simulation, e.g. shortest
+ * plasma wavelength, Debye length and central laser wavelength both spatially
+ * and temporarily.
+ *
+ * **Units in reduced dimensions**
+ *
+ * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+ * is still used for normalization of densities, etc..
+ *
+ * A 2D3V simulation in a cartesian PIC simulation such as
+ * ours only changes the degrees of freedom in motion for
+ * (macro) particles and all (field) information in z
+ * travels instantaneously, making the 2D3V simulation
+ * behave like the interaction of infinite "wire particles"
+ * in fields with perfect symmetry in Z.
+ *
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** Duration of one timestep
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = 1.0e-6 / SPEED_OF_LIGHT_SI;
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = 3.0e-6;
+        /** equals Y - the laser & moving window propagation direction
+\         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = 3.0e-6;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+    } // namespace SI
+
+    /** Defines the size of the absorbing zone (in cells)
+     *
+     *  unit: none
+     */
+    constexpr uint32_t ABSORBER_CELLS[3][2] = {
+        {32, 32}, /*x direction [negative,positive]*/
+        {32, 32}, /*y direction [negative,positive]*/
+        {32, 32} /*z direction [negative,positive]*/
+    };
+
+    /** Define the strength of the absorber for any direction
+     *
+     *  unit: none
+     */
+    constexpr float_X ABSORBER_STRENGTH[3][2] = {
+        {1.0e-3, 1.0e-3}, /*x direction [negative,positive]*/
+        {1.0e-3, 1.0e-3}, /*y direction [negative,positive]*/
+        {1.0e-3, 1.0e-3} /*z direction [negative,positive]*/
+    };
+
+    /** When to move the co-moving window.
+     *  An initial pseudo particle, flying with the speed of light,
+     *  is fired at the begin of the simulation.
+     *  When it reaches movePoint % of the absolute(*) simulation area,
+     *  the co-moving window starts to move with the speed of light.
+     *
+     *  (*) Note: beware, that there is one "hidden" row of gpus at the y-front,
+     *            when you use the co-moving window
+     *  0.75 means only 75% of simulation area is used for real simulation
+     *
+     * Warning: this variable is deprecated, but currently still required for
+     * building purposes. Please keep the variable here. In case a moving window
+     * is enabled in your .cfg file, please set the move point using the
+     * 'windowMovePoint' parameter in that file, its default value is movePoint.
+     */
+    constexpr float_64 movePoint = 0.9;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/iterationStart.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/iterationStart.param
@@ -1,0 +1,44 @@
+/* Copyright 2021-2023 Sergei Bastrakov, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Specify a sequence of functors to be called at start of each time iteration.
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+    /** IterationStartPipeline defines the functors called at each iteration start
+     *
+     * The functors will be called in the given order.
+     *
+     * The functors must be default-constructiblpand take the current time iteration as the only parameter.
+     * These are the same requirements as for functors in particles::InitPipeline.
+     */
+    using IterationStartPipeline = pmacc::mp_list<particles::CreateDensity<
+        particles::externalBeam::density::ProbingBeamDensity,
+        particles::externalBeam::BeamStartAttributes,
+        Photons>>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/memory.param
@@ -1,0 +1,117 @@
+/* Copyright 2013-2023 Axel Huebl, Rene Widera, Benjamin Worpitz, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
+#pragma once
+#include <pmacc/mappings/kernel/MappingDescription.hpp>
+#include <pmacc/math/Vector.hpp>
+
+#include <array>
+
+
+namespace picongpu
+{
+    /* We have to hold back 350MiB for gpu-internal operations:
+     *   - random number generator
+     *   - reduces
+     *   - ...
+     */
+    constexpr size_t reservedGpuMemorySize = 350 * 1024 * 1024;
+
+    /* short namespace*/
+    namespace mCT = pmacc::math::CT;
+    /** size of a superCell
+     *
+     * volume of a superCell must be <= 1024
+     */
+    using SuperCellSize = typename mCT::shrinkTo<mCT::Int<3, 3, 3>, simDim>::type;
+
+    /** define mapper which is used for kernel call mappings */
+    using MappingDesc = MappingDescription<simDim, SuperCellSize>;
+
+    /** define the size of the core, border and guard area
+     *
+     * PIConGPU uses spatial domain-decomposition for parallelization
+     * over multiple devices with non-shared memory architecture.
+     * The global spatial domain is organized per device in three
+     * sections: the GUARD area contains copies of neighboring
+     * devices (also known as "halo"/"ghost").
+     * The BORDER area is the outermost layer of cells of a device,
+     * equally to what neighboring devices see as GUARD area.
+     * The CORE area is the innermost area of a device. In union with
+     * the BORDER area it defines the "active" spatial domain on a device.
+     *
+     * GuardSize is defined in units of SuperCellSize per dimension.
+     */
+    using GuardSize = typename mCT::shrinkTo<mCT::Int<1, 1, 1>, simDim>::type;
+
+    /** bytes reserved for species exchange buffer
+     *
+     * This is the default configuration for species exchanges buffer sizes.
+     * The default exchange buffer sizes can be changed per species by adding
+     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
+     * to its flag list.
+     */
+    struct DefaultExchangeMemCfg
+    {
+        // memory used for a direction
+        static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EDGES = 32 * 1024; // 32 kiB
+        static constexpr uint32_t BYTES_CORNER = 8 * 1024; // 8 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
+    };
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 1;
+
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = true;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/precision.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/precision.param
@@ -1,0 +1,56 @@
+/* Copyright 2013-2023 Rene Widera, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define the precision of typically used floating point types in the
+ * simulation.
+ *
+ * PIConGPU normalizes input automatically, allowing to use single-precision by
+ * default for the core algorithms. Note that implementations of various
+ * algorithms (usually plugins or non-core components) might still decide to
+ * hard-code a different (mixed) precision for some critical operations.
+ */
+
+#pragma once
+
+
+namespace picongpu
+{
+    /*! Select a precision for the simulation data
+     *  - precision32Bit : use 32Bit floating point numbers
+     *                     [significant digits 7 to 8]
+     *  - precision64Bit : use 64Bit floating point numbers
+     *                     [significant digits 15 to 16]
+     */
+    namespace precisionPIConGPU = precision64Bit;
+
+    /*! Select a precision special operations (can be different from simulation precision)
+     *  - precisionPIConGPU : use precision which is selected on top (precisionPIConGPU)
+     *  - precision32Bit    : use 32Bit floating point numbers
+     *  - precision64Bit    : use 64Bit floating point numbers
+     */
+    namespace precisionSqrt = precisionPIConGPU;
+    namespace precisionExp = precisionPIConGPU;
+    namespace precisionTrigonometric = precisionPIConGPU;
+
+
+} // namespace picongpu
+
+#include "picongpu/unitless/precision.unitless"

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/species.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/species.param
@@ -1,0 +1,98 @@
+/* Copyright 2014-2023 Rene Widera, Richard Pausch, Annegret Roeszler, Klaus Steiniger, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Particle shape, field to particle interpolation, current solver, and particle pusher
+ * can be declared here for usage in `speciesDefinition.param`.
+ *
+ * @see
+ *   **MODELS / Hierarchy of Charge Assignment Schemes**
+ *   in the online documentation for information on particle shapes.
+ *
+ *
+ * \attention
+ * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
+ *     * PQS is the name of the 3rd order assignment function (instead of PCS)
+ *     * PCS is the name of the 4th order assignment function (instead of P4S)
+ *     * P4S does not exist anymore
+ */
+
+#pragma once
+
+#include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
+#include "picongpu/fields/currentDeposition/Solver.def"
+#include "picongpu/particles/shapes.hpp"
+
+namespace picongpu
+{
+    /** select macroparticle shape
+     *
+     * **WARNING** the shape names are redefined and diverge from PIConGPU versions before 0.6.0.
+     *
+     *  - particles::shapes::CIC : Assignment function is a piecewise linear spline
+     *  - particles::shapes::TSC : Assignment function is a piecewise quadratic spline
+     *  - particles::shapes::PQS : Assignment function is a piecewise cubic spline
+     *  - particles::shapes::PCS : Assignment function is a piecewise quartic spline
+     */
+    using UsedParticleShape = particles::shapes::CIC;
+    /** select interpolation method to be used for interpolation of grid-based field values to particle positions
+     */
+    using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
+
+    /*! select current solver method
+     * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::EZ< SHAPE, STRATEGY >        : same as EmZ (just an alias to match the currently used naming)
+     *
+     * STRATEGY (optional):
+     * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
+     */
+    using UsedParticleCurrentSolver = currentSolver::Esirkepov<UsedParticleShape>;
+
+    /** particle pusher configuration
+     *
+     * Defining a pusher is optional for particles
+     *
+     * - particles::pusher::HigueraCary : Higuera & Cary's relativistic pusher preserving both volume and ExB velocity
+     * - particles::pusher::Vay : Vay's relativistic pusher preserving ExB velocity
+     * - particles::pusher::Boris : Boris' relativistic pusher preserving volume
+     * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+     *                                              with classical radiation reaction
+     * - particles::pusher::Composite : composite of two given pushers,
+     *                                  switches between using one (or none) of those
+     *
+     * For diagnostics & modeling: ------------------------------------------------
+     * - particles::pusher::Acceleration : Accelerate particles by applying a constant electric field
+     * - particles::pusher::Free : free propagation, ignore fields
+     *                             (= free stream model)
+     * - particles::pusher::Photon : propagate with c in direction of normalized mom.
+     * - particles::pusher::Probe : Probe particles that interpolate E & B
+     * For development purposes: --------------------------------------------------
+     * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
+     */
+    using UsedParticlePusher = particles::pusher::Boris;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/ExternalBeam/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,80 @@
+/* Copyright 2013-2023 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define particle species.
+ *
+ * This file collects all previous declarations of base (reference) quantities
+ * and configured solvers for species and defines particle species. This
+ * includes "attributes" (lvalues to store with each species) and "flags"
+ * (rvalues & aliases for solvers to perform with the species for each timestep
+ * and ratios to base quantities). With those information, a `Particles` class
+ * is defined for each species and then collected in the list
+ * `VectorAllSpecies`.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/meta/String.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+namespace picongpu
+{
+    /*########################### define particle attributes #####################*/
+
+    /** describe attributes of a particle*/
+    using DefaultParticleAttributes = MakeSeq_t<position<position_pic>, momentum, weighting>;
+
+    /*########################### end particle attributes ########################*/
+
+    /*########################### define species #################################*/
+
+    /*--------------------------- photons -------------------------------------------*/
+
+    value_identifier(float_X, MassRatioPhotons, 0.0);
+    value_identifier(float_X, ChargeRatioPhotons, 0.0);
+
+    using ParticleFlagsPhotons = MakeSeq_t<
+        particlePusher<particles::pusher::Photon>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        massRatio<MassRatioPhotons>,
+        chargeRatio<ChargeRatioPhotons>>;
+
+    /* define species photons */
+    using Photons = Particles<PMACC_CSTRING("ph"), ParticleFlagsPhotons, DefaultParticleAttributes>;
+
+    /*########################### end species ####################################*/
+
+    /** All known particle species of the simulation
+     *
+     * List all defined particle species from above in this list
+     * to make them available to the PIC algorithm.
+     */
+    using VectorAllSpecies = MakeSeq_t<Photons>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeam/lib/python/picongpu/tests/test_debug_external_beam.py
+++ b/share/picongpu/tests/ExternalBeam/lib/python/picongpu/tests/test_debug_external_beam.py
@@ -1,0 +1,147 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2023 PIConGPU contributors
+Authors: Pawel Ordyna
+License: GPLv3+
+"""
+import os
+import subprocess
+import json
+import argparse
+from pathlib import Path
+
+
+def compile_setup(example_src, example_root, side_str, offset):
+    """Create example and compile it
+    :param example_src: pathlib Path object referring to example source dir
+    :param example_root: pathlib Path object referring to directory where the
+        example will be created and compiled
+    :param side_str: string defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+    """
+    create_result = subprocess.run(["pic-create",
+                                    f"{str(example_src.resolve())}",
+                                    f"{str(example_root.resolve())}"],
+                                   check=True)
+    assert create_result.returncode == 0
+
+    # some simulation params
+
+    cell_size = 3e-6  # in meters
+    sigma = (10, 7)  # in cells x,y beam system coordinates
+    start_time = 0  # time_steps
+    end_time = 20  # time_steps
+
+    side_map = {'x': 'XSide', 'xr': 'XRSide', 'y': 'YSide', 'yr': 'YRSide',
+                'z': 'ZSide', 'zr': 'ZRSide'}
+    # prepare  cmake flags
+
+    overwrite_list = f"-DPARAM_BEAM_OFFSET_X={offset[0] * cell_size:e}_X;" \
+                     f"-DPARAM_BEAM_OFFSET_Y={offset[1] * cell_size:e}_X;" \
+                     f"-DPARAM_SIGMA_X_SI={sigma[0] * cell_size:e}_X;" \
+                     f"-DPARAM_SIGMA_Y_SI={sigma[1] * cell_size:e}_X;" \
+                     f"-DPARAM_BEAM_PROFILE=GaussianProfile;" \
+                     f"-DPARAM_BEAM_SIDE={side_map[side_str]};" \
+                     f"-DPARAM_BEAM_SHAPE=ConstShape;" \
+                     f"-DPARAM_BEAM_START_T={start_time};" \
+                     f"-DPARAM_BEAM_END_T={end_time};"
+    cmake_flags = f"-DPARAM_OVERWRITES:LIST='{overwrite_list}'"
+
+    # compile
+    compile_command = ["pic-build", "-c", f"\"{cmake_flags}\""]
+    compile_result = subprocess.run(compile_command, cwd=example_root)
+    # continue only after a successful compilation
+    assert compile_result.returncode == 0
+
+
+def run_setup(picongpu_run_dir, picongpu_exec):
+    """ Run the compiled example
+
+    :param picongpu_run_dir: run directory, pathlib Path object
+    :param picongpu_exec: picongpu executable, pathlib Path object
+    """
+    steps = 93
+    grid_size_x, grid_size_y, grid_size_z = 24, 24, 24
+    debug_period = "1"
+
+    picongpu_command = ["mpiexec", "-n", "1", f"{picongpu_exec.resolve()}",
+                        "-d", "1", "1", "1", "-s", f"{steps}", "-g",
+                        f"{grid_size_x}", f"{grid_size_y}", f"{grid_size_z}",
+                        "--openPMD.period", f"{debug_period}",
+                        "--openPMD.file", "simData", "--openPMD.source",
+                        "fields_all", "--openPMD.period", "5:5",
+                        "--openPMD.file", "particles", "--openPMD.source",
+                        "species_all"]
+    # run simulation
+    picongpu_result = subprocess.run(picongpu_command, cwd=picongpu_run_dir)
+    # continue only after a successful simulation
+    assert picongpu_result.returncode == 0
+
+
+def test_external_beam(top_path,
+                       side_str,
+                       offset,
+                       compile_only=False,
+                       run_only=False):
+    """ Compile and run external beam test
+
+    :param top_path: test directory, pathlib Path object
+    :param side_str: string defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+    :param offset: offset in cells from the default beam center position
+        in the transversal beam plane. (x,y) in beam coordinate system.
+    :param compile_only: if True only compile the setup
+    :param run_only:  if True only run the setup, it needs to be already
+        compiled in top_path/example.
+    """
+    # use pic create to create a tmp example dir
+    example_root = top_path / "example"
+    example_src = Path(os.environ.get("PICSRC")) / 'share' / 'picongpu'
+    example_src = example_src / 'tests' / 'ExternalBeam'
+
+    if not run_only:
+        compile_setup(example_src, example_root, side_str, offset)
+    if not compile_only:
+        picongpu_run_dir = top_path / "simOutput"
+        picongpu_run_dir.mkdir()
+        picongpu_exec = example_root / 'bin' / 'picongpu'
+        run_setup(picongpu_run_dir, picongpu_exec)
+
+        # write test parameters in a json file
+        parameters = {"side_str": side_str, "offset": offset}
+        with open(picongpu_run_dir / "test_setup.json", "w") as f:
+            json.dump(parameters, f)
+
+
+if __name__ == '__main__':
+    # define test cases: (side_str,offset)
+    setups = [  # test simplest case for all sides
+        ('x', (0, 0)),  # 0
+        ('xr', (0, 0)),  # 1
+        ('y', (0, 0)),  # 2
+        ('yr', (0, 0)),  # 3
+        ('z', (0, 0)),  # 4
+        ('zr', (0, 0)),  # 5
+        # test offset only for one side
+        ('x', (5, 2),)]  # 6
+
+    parser = argparse.ArgumentParser(description="Run an ExternalBeam test")
+    parser.add_argument('--dir',
+                        nargs='?',
+                        help="directory used for compiling and running"
+                             " the test. Default is the current directory",
+                        default=Path.cwd())
+    parser.add_argument('-t',
+                        type=int,
+                        choices=range(len(setups)),
+                        help="setup to run. Possible setups "
+                             f"(side_str, offset): {setups}")
+    parser.add_argument('--compile-only', default=False, action='store_true')
+    parser.add_argument('--run-only', default=False, action='store_true')
+    args = parser.parse_args()
+    top_path = Path(args.dir)
+    test_external_beam(top_path, *setups[args.t],
+                       compile_only=args.compile_only, run_only=args.run_only)

--- a/share/picongpu/tests/ExternalBeam/lib/python/picongpu/tests/verify_results.py
+++ b/share/picongpu/tests/ExternalBeam/lib/python/picongpu/tests/verify_results.py
@@ -1,0 +1,368 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2023 PIConGPU contributors
+Authors: Pawel Ordyna
+License: GPLv3+
+"""
+import openpmd_api as api
+import numpy as np
+import math
+import json
+import argparse
+from pathlib import Path
+import scipy.constants as cs
+
+
+def get_beam_unit_vectors(side_str):
+    """
+    Returns beam coordinate system unit vectors for given side as defined
+    in Side.hpp in PIConGPU.
+
+    :param side_str: String defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+    :return: beam coordinate system unit vectors (x,y,z)
+    """
+    str_to_z_dir = {'x': (1, 0, 0), 'xr': (-1, 0, 0), 'y': (0, 1, 0),
+                    'yr': (0, -1, 0), 'z': (0, 0, 1), 'zr': (0, 0, -1)}
+
+    str_to_y_dir = {'x': (0, 1, 0), 'xr': (0, -1, 0), 'y': (-1, 0, 0),
+                    'yr': (1, 0, 0), 'z': (-1, 0, 0), 'zr': (-1, 0, 0)}
+
+    str_to_x_dir = {'x': (0, 0, -1), 'xr': (0, 0, -1), 'y': (0, 0, -1),
+                    'yr': (0, 0, -1), 'z': (0, 1, 0), 'zr': (0, -1, 0)}
+    # normalize
+    z = np.array(str_to_z_dir[side_str])
+    z = z / np.linalg.norm(z)
+    x = np.array(str_to_x_dir[side_str])
+    x = x / np.linalg.norm(x)
+    y = np.array(str_to_y_dir[side_str])
+    y = y / np.linalg.norm(y)
+    # check orthogonality
+    assert np.dot(x, y) == 0
+    assert np.dot(x, z) == 0
+    # check right-handedness
+    assert np.dot(np.cross(x, y), z) > 0
+    return x, y, z
+
+
+def get_beam_origin(side_str, sim_box_size, offset_pic):
+    """ Get beam coordinate system origin in PIConGPU system
+
+    :param side_str: String defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+    :param sim_box_size: Size of the simulation box (x, y, z) tuple.
+    :param offset_pic: Beam origin offset in PIConGPU coordinates
+    :return: origin position (x, y, z)
+    """
+    str_to_origin = {'x': (0, 0.5, 0.5), 'xr': (1.0, 0.5, 0.5),
+                     'y': (0.5, 0, 0.5), 'yr': (0.5, 1, 0.5),
+                     'z': (0.5, 0.5, 0), 'zr': (0.5, 0.5, 1)}
+    return sim_box_size * np.array(str_to_origin[side_str]) + offset_pic
+
+
+def transfer_coordinates(v, x_hat, y_hat, z_hat):
+    """ Transform a vector into a new coordinate system
+
+    :param v: vector to transfer
+    :param x_hat: x base vector of the new coordinate system
+    :param y_hat: y base vector of the new coordinate system
+    :param z_hat: z base vector of the new coordinate system
+    :return:
+    """
+    return np.array((np.dot(v, x_hat), np.dot(v, y_hat), np.dot(v, z_hat)))
+
+
+def get_beam_coordinate_system(side_str, offset_beam, sim_box_size):
+    """ Get beam coordinate system
+
+    :param side_str: String defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+    :param offset_beam: Beam transversal offset in beam coordinate system (x,y)
+    :param sim_box_size: Size of the simulation box (x, y, z) tuple.
+    :return: beam system origin, x base vector, y base vector, z base vector
+        in PIConGPU coordinates
+    """
+    x_beam, y_beam, z_beam = get_beam_unit_vectors(side_str)
+    x_pic = transfer_coordinates(np.array((1, 0, 0)), x_beam, y_beam, z_beam)
+    y_pic = transfer_coordinates(np.array((0, 1, 0)), x_beam, y_beam, z_beam)
+    z_pic = transfer_coordinates(np.array((0, 0, 1)), x_beam, y_beam, z_beam)
+    offset_beam = np.array([offset_beam[0], offset_beam[1], 0])
+    offset_pic = transfer_coordinates(offset_beam, x_pic, y_pic, z_pic)
+    origin = get_beam_origin(side_str, sim_box_size, offset_pic)
+    return origin, x_beam, y_beam, z_beam
+
+
+class BeamCoordinates:
+    """
+    Functor converting a vector in the PIConGPU coordinate system into
+    the beam coordinate system.
+    """
+
+    def __init__(self, side_str, offset_beam, sim_box_size):
+        """Constructor
+
+        :param side_str: String defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+        :param offset_beam: Beam transversal offset in beam coordinate system
+            (x,y)
+        :param sim_box_size: Size of the simulation box (x, y, z) tuple.
+        """
+        self.origin, self.x_beam, self.y_beam, self.z_beam = \
+            get_beam_coordinate_system(side_str,
+                                       offset_beam,
+                                       sim_box_size)
+
+    def __call__(self, x, y, z):
+        """ Functor implementation
+
+        :param x: x coordinate in PIConGPU system
+        :param y: y coordinate in PIConGPU system
+        :param z: z coordinate in PIConGPU system
+        :return: x, y, z in beam coordinates
+        """
+        x -= self.origin[0]
+        y -= self.origin[1]
+        z -= self.origin[2]
+        x_b = x * self.x_beam[0] + y * self.x_beam[1] + z * self.x_beam[2]
+        y_b = x * self.y_beam[0] + y * self.y_beam[1] + z * self.y_beam[2]
+        z_b = x * self.z_beam[0] + y * self.z_beam[1] + z * self.z_beam[2]
+        return x_b, y_b, z_b
+
+
+def gaussian(x, sigma):
+    """gaussian function"""
+    tmp = x / sigma
+    exponent = -0.5 * (tmp * tmp)
+    return math.exp(exponent)
+
+
+class GaussianProfile:
+    """Gaussian beam profile"""
+
+    def __init__(self, sigma_x, sigma_y):
+        """Constructor
+
+        :param sigma_x: sigma in x direction
+        :param sigma_y: sigma in y direction
+        """
+        self.sigma_x = sigma_x
+        self.sigma_y = sigma_y
+
+    def __call__(self, x, y):
+        """ Functor implementation
+
+        :param x: evaluation position x coordinate
+        :param y: evaluation position y coordinate
+        :return: intensity factor at the given point (normalized to max=1)
+        """
+        x_term = (x / self.sigma_x) ** 2
+        y_term = (y / self.sigma_y) ** 2
+        exponent = -0.5 * (x_term + y_term)
+        return np.exp(exponent)
+
+
+class ConstShape:
+    """Constant beam temporal shape"""
+
+    def __init__(self, start_time, end_time):
+        """Constructor
+
+            :param start_time: beam start time
+            :param end_time: time at which the beam ends
+            """
+        self.start_time = start_time
+        self.end_time = end_time
+
+    def __call__(self, t):
+        """Functor implementation
+
+            :param t: time, numpy array
+            :return: intensity factor normalized to max=1
+            """
+        mask = np.where((t >= self.start_time) & (t < self.end_time))
+        factor = np.zeros_like(t)
+        factor[mask] = 1
+        return factor
+
+
+def generate_intensity_array(sim_shape,
+                             beam_profile,
+                             beam_shape,
+                             coor_trans,
+                             delta_x,
+                             delta_y,
+                             delta_z,
+                             t):
+    """ Generate intensity array for comparison
+
+    :param sim_shape: simulation shape in cells (x, y, z)
+    :param beam_profile: a callable defining the beam transversal profile
+        takes x and y as positional arguments
+    :param beam_shape:  a callable defining the beam temporal shape
+        takes time as positional argument
+    :param coor_trans: a callable defining the coordinate transform to the beam
+        coordinate system. Takes x,y, and z as positional arguments.
+    :param delta_x: cell size in x
+    :param delta_y: cell size in y
+    :param delta_z: cell size in z
+    :param t: time
+    :return: returns the 3D intensity array normed to max=1
+    """
+    x_pic = np.arange(sim_shape[0]) + 0.5
+    y_pic = np.arange(sim_shape[1]) + 0.5
+    z_pic = np.arange(sim_shape[2]) + 0.5
+
+    x_pic *= delta_x
+    y_pic *= delta_y
+    z_pic *= delta_z
+    x_beam, y_beam, z_beam = coor_trans(x_pic[:, None, None],
+                                        y_pic[None, :, None],
+                                        z_pic[None, None, :])
+    return beam_profile(x_beam, y_beam) * beam_shape(t - z_beam / cs.c)
+
+
+def verify_results(picongpu_run_dir, side_str, offset):
+    """ Verify an ExternalBeam test run
+
+    :param picongpu_run_dir: run directory, pathlib Path object
+    :param side_str: String defining from which side the beam enters the
+        simulation. Need to be one of the following: "x", "xr", "y", "yr",
+        "z", "zr". r means the beam propagates against the given axis.
+    :param offset: offset in cells from the default beam center position
+        in the transversal beam plane. (x,y) in beam coordinate system.
+    :return: list of two lists, first list contains test results for all
+        iterations (true or false value), the second list contains interation
+        numbers.
+    """
+    time_step = 1.0e-6 / cs.c
+    cell_size = 3.0e-6
+    sigma = (10, 7)
+    start_time = 0  # time_steps
+    end_time = 20  # time_steps
+    profile = GaussianProfile(sigma[0] * cell_size, sigma[1] * cell_size)
+    shape = ConstShape(time_step * start_time, time_step * end_time)
+    sim_shape = (24, 24, 24)
+    coor_trans = BeamCoordinates(side_str, (offset[0] * cell_size,
+                                            offset[1] * cell_size),
+                                 np.array(sim_shape) * cell_size)
+
+    factor = 1e5  # max photon count per cell
+
+    # load simulation output
+    infix = "_%06T"
+    backend = "bp"
+    mesh_name = "ph_all_particleCounter"
+    openpmd_path = picongpu_run_dir / 'openPMD'
+    series_path_str = "{}/{}{}.{}".format(str(openpmd_path),
+                                          'simData',
+                                          infix,
+                                          backend)
+    series = api.Series(series_path_str, api.Access.read_only)
+
+    checks = [[], []]
+    for iteration in series.read_iterations():
+        mesh = iteration.meshes[mesh_name]
+        mrc = mesh[api.Mesh_Record_Component.SCALAR]
+        data = mrc.load_chunk()
+        series.flush()
+        data *= mrc.unit_SI
+        # we work with PIConGPU coordinates: x,y,z
+        # so that the openPMD array needs to be rearranged first
+        data = data.T  # z,y,x -> x,y,z
+        axis_map = {'x': 0, 'xr': 0, 'y': 1, 'yr': 1, 'z': 2, 'zr': 2}
+        reverse_map = {'x': False, 'xr': True, 'y': False, 'yr': True,
+                       'z': False, 'zr': True}
+        prop_axis_idx = axis_map[side_str]
+
+        # light travels 1/3 of a cell in one time step, so we fill-up only
+        # 1/3 of a cell on an iteration. Here we compute the intensity for an
+        # array of such 1/3 sub-cells and calculate the particle number per
+        # cell with the simulation resolution later by summing over the
+        # sub-cells.
+        reduced_cells_shape = list(sim_shape)
+        reduced_cells_shape[prop_axis_idx] *= 3
+        reduced_cells_shape = tuple(reduced_cells_shape)
+
+        reduced_cell_size = [cell_size, cell_size, cell_size]
+        reduced_cell_size[prop_axis_idx] /= 3
+        reduced_cell_size = tuple(reduced_cell_size)
+
+        particle_count = generate_intensity_array(reduced_cells_shape,
+                                                  profile,
+                                                  shape,
+                                                  coor_trans,
+                                                  *reduced_cell_size,
+                                                  (iteration.iteration_index
+                                                   - 1) * time_step)
+
+        class SwapIdx:
+            """Converts a slicing object by swapping slices for two indices"""
+            def __init__(self, idx1, idx2):
+                """Constructor
+
+                :param idx1: first index to swap
+                :param idx2: second index to swap
+                """
+                self.idx1 = idx1
+                self.idx2 = idx2
+
+            def __getitem__(self, slicing):
+                """ Square brackets operator implementation
+
+                :param slicing: slicing such as e.g. [1:1, :, ::2]
+                :return: the slicing with swapped axes
+                """
+                # make input mutable
+                slicing = list(slicing)
+                # swap slices
+                slicing[self.idx1], slicing[self.idx2] = slicing[self.idx2], \
+                    slicing[self.idx1]
+                # slicing is a tuple of slice objects
+                return tuple(slicing)
+
+        # the rest is written with the propagation axis being the first axis
+        # we use swap to include all possible orientations
+        swap = SwapIdx(0, prop_axis_idx)
+
+        if reverse_map[side_str]:
+            particle_count[swap[:-1, :, :]] = particle_count[swap[1:, :, :]]
+            particle_count[swap[-1, :, :]] = 0.0
+        else:
+            particle_count[swap[1:, :, :]] = particle_count[swap[:-1, :, :]]
+            particle_count[swap[0, :, :]] = 0.0
+
+        # summ-up over sub-cells
+        particle_count = particle_count[swap[0::3, :, :]] / 3 + particle_count[
+            swap[1::3, :, :]] / 3 + particle_count[swap[2::3, :, :]] / 3
+        # multiply th normalized array with the expected max particle count
+        # per cell
+        particle_count *= factor
+        check = np.all(np.isclose(data, particle_count))
+        checks[0].append(check)
+        checks[1].append(iteration.iteration_index)
+    return checks
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Verify an ExternalBeam test")
+    parser.add_argument('--dir',
+                        nargs='?',
+                        help="the simOutput directory",
+                        default=Path.cwd())
+    args = parser.parse_args()
+    picongpu_run_dir = Path(args.dir)
+    with open(picongpu_run_dir / "test_setup.json", "r") as f:
+        parameters = json.load(f)
+    checks = verify_results(picongpu_run_dir, **parameters)
+    test_passed = np.all(checks[0])
+    print(fr"Test result: {test_passed}")
+    if not test_passed:
+        for ii, iteration in enumerate(checks[1]):
+            print(fr"iteration: {iteration}, "
+                  fr"{'passed' if checks[0][ii] else 'failed'} \n")
+    assert np.all(checks[0])

--- a/share/picongpu/tests/ExternalBeamCompileTest/README.rst
+++ b/share/picongpu/tests/ExternalBeamCompileTest/README.rst
@@ -1,0 +1,4 @@
+Compile test for external beam
+=================================
+
+This test compiles external beam start attributes sub functors not used in the ExternalBeam run-time test.

--- a/share/picongpu/tests/ExternalBeamCompileTest/cmakeFlags
+++ b/share/picongpu/tests/ExternalBeamCompileTest/cmakeFlags
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Pawel Ordyna
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# generic compile options
+#
+
+################################################################################
+# add presets here
+#   - default: index 0
+#   - start with zero index
+#   - increase by 1, no gaps
+# Pushers are generally independent from particle shapes, so do not attempt to
+# test all possible combinations, just all pushers except Boris (tested in examples)
+flags[0]="-DPARAM_OVERWRITES:LIST='-DPARAM_PHASE_IMPL=FromSpeciesWavelength'"
+flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_PHASE_IMPL=FromPhotonMomentum'"
+flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_BEAM_SHAPE=LorentzPulse'"
+flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_BEAM_SHAPE=SqrtGauss'"
+
+################################################################################
+# execution
+
+case "$1" in
+    -l)  echo ${#flags[@]}
+         ;;
+    -ll) for f in "${flags[@]}"; do echo $f; done
+         ;;
+    *)   echo -n ${flags[$1]}
+         ;;
+esac

--- a/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/externalBeam.param
+++ b/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/externalBeam.param
@@ -1,0 +1,148 @@
+/* Copyright 2020-2023 Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/param/grid.param"
+#include "picongpu/particles/externalBeam/beam/ProbingBeam.def"
+#include "picongpu/particles/externalBeam/beam/Side.hpp"
+#include "picongpu/particles/externalBeam/beam/SqrtWrapper.def"
+#include "picongpu/particles/externalBeam/beam/beamProfiles/profiles.def"
+#include "picongpu/particles/externalBeam/beam/beamShapes/shapes.def"
+#include "picongpu/particles/externalBeam/functors.def"
+
+#include <pmacc/preprocessor/struct.hpp>
+
+#ifndef PARAM_PHASE_IMPL
+#    define PARAM_PHASE_IMPL FromSpeciesWavelength
+#endif
+#ifndef PARAM_BEAM_SHAPE
+#    define PARAM_BEAM_SHAPE GaussianPulse
+#endif
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace externalBeam
+        {
+            /* Choose from:
+             *  - ZSide
+             *  - YSide
+             *  - XSide
+             * - ZRSide
+             * - YRSide
+             * - XRSide
+             */
+            using ProbingSide = beam::ZSide;
+
+            PMACC_STRUCT(
+                OffsetParam,
+                (PMACC_C_VECTOR_DIM(float_X, DIM2, beamOffset_SI, 0.0_X, 0.0_X))(
+                    PMACC_C_VALUE(float_X, beamDelay_SI, 0.0_X)));
+
+            struct GaussianPulseParam
+            {
+                // cut the pulse cutTimeFront_SI before the pulse maximum if true
+                static constexpr bool limitStart = false;
+                // cut the pulse at cutTimeBack_SI after the pulse maximum if true
+                static constexpr bool limitEnd = false;
+                static constexpr float_64 FWHM_SI = 30e-15; // 30fs
+
+                static constexpr float_64 cutTimeFront_SI = 3.0 * FWHM_SI;
+                static constexpr float_64 cutTimeBack_SI = 3.0 * FWHM_SI;
+                // when 0 the pulse max is at the beam origin at t_sim = 0
+                static constexpr float_64 timeOffset_SI = 0.0;
+            };
+
+
+            using ConstProfile = beam::beamProfiles::ConstProfile;
+            using GaussianPulse = beam::beamShapes::GaussianPulse<GaussianPulseParam>;
+            using LorentzPulse = beam::beamShapes::GaussianPulse<GaussianPulseParam>;
+            using SqrtGauss = beam::SqrtWrapper<GaussianPulse>;
+
+            using BeamProfile = ConstProfile;
+            using BeamShape = PARAM_BEAM_SHAPE;
+
+            using Beam = beam::ProbingBeam<BeamProfile, BeamShape, ProbingSide, OffsetParam>;
+
+            namespace density
+            {
+                struct ProbingBeamDensityParam
+                {
+                private:
+                    static constexpr float_64 cellVolumeSI
+                        = SI::CELL_HEIGHT_SI * SI::CELL_WIDTH_SI * SI::CELL_DEPTH_SI;
+
+                public:
+                    using ProbingBeam = Beam;
+                    // Just a test value -> one 100000 photons per full cell
+                    static constexpr float_64 photonFluxAtMaxBeamIntensity_SI{
+                        100000.0 / cellVolumeSI * SI::SPEED_OF_LIGHT_SI};
+                };
+                using ProbingBeamDensity = ProbingBeamImpl<ProbingBeamDensityParam>;
+            } // namespace density
+            namespace startPosition
+            {
+                struct RandomProbingBeamParam
+                {
+                    using Side = ProbingSide;
+                    // PhotonBeam needs to be defined by a user as well.
+                    static constexpr uint32_t numParticlesPerCell = 64u;
+                    static constexpr float_X minWeighting = 0.001;
+                };
+                using RandomBeam = RandomProbingBeam<RandomProbingBeamParam>;
+            } // namespace startPosition
+            namespace momentum
+            {
+                struct BeamMomentumParam
+                {
+                    using Side = ProbingSide;
+                    static constexpr float_64 photonEnergySI = 6.0 * UNITCONV_keV_to_Joule;
+                };
+                using BeamMomentum = PhotonMomentum<BeamMomentumParam>;
+            } // namespace momentum
+
+            namespace phase
+            {
+                struct Param
+                {
+                    using Side = ProbingSide;
+                    static constexpr float_64 phi0 = 0.0;
+                };
+                using BeamPhase = PARAM_PHASE_IMPL<Param>;
+            } // namespace phase
+            namespace polarization
+            {
+                struct Param
+                {
+                    static constexpr float_X polarization{0.0};
+                };
+                using BeamPolarization = OnePolarization<Param>;
+
+            } // namespace polarization
+
+            using BeamStartAttributes = StartAttributes<
+                startPosition::RandomBeam,
+                momentum::BeamMomentum,
+                phase::BeamPhase,
+                polarization::BeamPolarization>;
+        } // namespace externalBeam
+    } // namespace particles
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/fieldSolver.param
+++ b/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/fieldSolver.param
@@ -1,0 +1,62 @@
+/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the field solver.
+ *
+ * Select the numerical Maxwell solver (e.g. Yee's method).
+ *
+ * \attention
+ * Currently, the laser initialization in PIConGPU is implemented to work with the standard Yee solver.
+ * Using a solver of higher order will result in a slightly increased laser amplitude and energy than expected.
+ *
+ */
+
+#pragma once
+
+#include "picongpu/fields/MaxwellSolver/Solvers.def"
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        /** FieldSolver
+         *
+         * Field Solver Selection (note <> for some solvers):
+         *  - Yee<> : Standard Yee solver approximating derivatives with respect to time and
+         * space by second order finite differences.
+         *  - YeePML<>: Standard Yee solver using Perfectly Matched Layer Absorbing Boundary
+         * Conditions (PML)
+         *  - Lehe<>: Num. Cherenkov free field solver in a chosen direction
+         *  - LehePML<>: Num. Cherenkov free field solver in a chosen direction
+         *               using Perfectly Matched Layer Absorbing Boundary Conditions (PML)
+         *  - ArbitraryOrderFDTD<4>: Solver using 4 neighbors to each direction to approximate
+         * *spatial* derivatives by finite differences. The number of neighbors can be changed from 4 to any positive,
+         * integer number. The order of the solver will be twice the number of neighbors in each direction. Yee's
+         * method is a special case of this using one neighbor to each direction.
+         *  - ArbitraryOrderFDTDPML<4>: ArbitraryOrderFDTD solver using Perfectly Matched Layer
+         *                              Absorbing Boundary Conditions (PML)
+         *  - None: disable the vacuum update of E and B
+         */
+        using Solver = maxwellSolver::None;
+
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/iterationStart.param
+++ b/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/iterationStart.param
@@ -1,0 +1,44 @@
+/* Copyright 2021-2023 Sergei Bastrakov, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Specify a sequence of functors to be called at start of each time iteration.
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+
+namespace picongpu
+{
+    /** IterationStartPipeline defines the functors called at each iteration start
+     *
+     * The functors will be called in the given order.
+     *
+     * The functors must be default-constructible and take the current time iteration as the only parameter.
+     * These are the same requirements as for functors in particles::InitPipeline.
+     */
+    using IterationStartPipeline = pmacc::mp_list<particles::CreateDensity<
+        particles::externalBeam::density::ProbingBeamDensity,
+        particles::externalBeam::BeamStartAttributes,
+        Photons>>;
+
+} // namespace picongpu

--- a/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/ExternalBeamCompileTest/include/picongpu/param/speciesDefinition.param
@@ -1,0 +1,83 @@
+/* Copyright 2013-2023 Rene Widera, Benjamin Worpitz, Heiko Burau, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define particle species.
+ *
+ * This file collects all previous declarations of base (reference) quantities
+ * and configured solvers for species and defines particle species. This
+ * includes "attributes" (lvalues to store with each species) and "flags"
+ * (rvalues & aliases for solvers to perform with the species for each timestep
+ * and ratios to base quantities). With those information, a `Particles` class
+ * is defined for each species and then collected in the list
+ * `VectorAllSpecies`.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/meta/String.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+namespace picongpu
+{
+    /*########################### define particle attributes #####################*/
+
+    /** describe attributes of a particle*/
+    using PhotonParticleAttributes
+        = MakeSeq_t<position<position_pic>, momentum, weighting, polarizationAngle, startPhase>;
+    value_identifier_constexpr(float_X, WavelengthPhotons, 0.1e-9 / UNIT_LENGTH); // 6keV
+
+    /*########################### end particle attributes ########################*/
+
+    /*########################### define species #################################*/
+
+    /*--------------------------- photons -------------------------------------------*/
+
+    value_identifier(float_X, MassRatioPhotons, 0.0);
+    value_identifier(float_X, ChargeRatioPhotons, 0.0);
+
+    using ParticleFlagsPhotons = MakeSeq_t<
+        particlePusher<particles::pusher::Photon>,
+        shape<UsedParticleShape>,
+        interpolation<UsedField2Particle>,
+        massRatio<MassRatioPhotons>,
+        chargeRatio<ChargeRatioPhotons>,
+        wavelength<WavelengthPhotons>>;
+
+    /* define species photons */
+    using Photons = Particles<PMACC_CSTRING("ph"), ParticleFlagsPhotons, PhotonParticleAttributes>;
+
+    /*########################### end species ####################################*/
+
+    /** All known particle species of the simulation
+     *
+     * List all defined particle species from above in this list
+     * to make them available to the PIC algorithm.
+     */
+    using VectorAllSpecies = MakeSeq_t<Photons>;
+
+} // namespace picongpu


### PR DESCRIPTION
# Photon injection at a simulation boundary
## Description
This PR introduces a new module `externalBeam` for injections of particles at a boundary. The code is written with two main assumptions:
 * The particles are photons and move with c
 * Particles don't enter the simulation at an angle (only along one of the simulation axes)

This is a part of the radiation transport prototype from my master thesis. The scattering and detection part will be introduced in separate PRs. 

This code reuses some of the code and therefore also some concepts from the old `xrayScattering`  plugin.  If we ever want to extend this to arbitrary incidence angles, we should probably switch to coordinate transforms and definitions from the incident field laser implementation.


## Preview:
Photon density over time (png plugin output) from an old test:
![injectingPhotons](https://user-images.githubusercontent.com/41141557/225375542-02c6ca05-10b8-45cd-ab8b-391fc802b34f.gif)

## Tests:
This PR includes compile and runtime tests in `share/picongpu/tests/ExternalBeam` and  `share/picongpu/tests/ExternalBeamCompileTest`

@psychocoderHPC @HighIander 