### PR TITLE
remove particle merger from `TBG_macros.cfg`

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -177,15 +177,6 @@ TBG_transRad="--<species>_transRad.period 1000"
 TBG_<species>_pngYZ="--<species>_png.period 10 --<species>_png.axis yz --<species>_png.slicePoint 0.5 --<species>_png.folder pngElectronsYZ"
 TBG_<species>_pngYX="--<species>_png.period 10 --<species>_png.axis yx --<species>_png.slicePoint 0.5 --<species>_png.folder pngElectronsYX"
 
-# Enable macro particle merging
-TBG_<species>_merger="--<species>_merger.period 100 --<species>_merger.minParticlesToMerge 8 --<species>_merger.posSpreadThreshold 0.2 --<species>_merger.absMomSpreadThreshold 0.01"
-
-# Enable probabilistic version of particle merging
-TBG_<species>_randomizedMerger="--<species>_randomizedMerger.period 100 --<species>_randomizedMerger.maxParticlesToMerge 8                  \
-                                --<species>_randomizedMerger.ratioDeletedParticles 0.9 --<species>_randomizedMerger.posSpreadThreshold 0.01 \
-                                --<species>_randomizedMerger.momSpreadThreshold  0.0005"
-
-
 # Create a particle-energy histogram [in keV] per species for every .period steps
 TBG_<species>_histogram="--<species>_energyHistogram.period 500 --<species>_energyHistogram.binCount 1024     \
                          --<species>_energyHistogram.minEnergy 0 --<species>_energyHistogram.maxEnergy 500000 \


### PR DESCRIPTION
With PR #4388 we forgot to remove the examples for the coresponding particle merger plugins.