### PR TITLE
refactor `pic-create`

### DIFF
--- a/bin/pic-create
+++ b/bin/pic-create
@@ -23,11 +23,22 @@ this_dir=$(cd $(dirname $0) && pwd)
 
 # PIConGPU prefix path
 picongpu_prefix=$(cd $this_dir/.. && pwd)
-# files always cloned from defaults, can be overwritten by input set
-default_folder_to_copy="etc/picongpu lib"
-# if we clone an input set we copy from it
+# All files in the folder (no recusion or subfolders) will be copied from PIConGPU source to the input set.
+default_folder_to_copy="etc/picongpu"
+
+# Folder which get recusivly copied from the source input set into the destination input set
 folder_to_clone="etc/picongpu bin include/picongpu lib"
 files_to_copy="cmakeFlags executeOnClone"
+
+if [ -n "$PIC_SYSTEM_TEMPLATE_PATH" ] ; then
+    default_folder_to_copy="$default_folder_to_copy $PIC_SYSTEM_TEMPLATE_PATH"
+else
+    # Fallback to be backward compatible to the old behaviour that all content of picongpu/etc is copied into the
+    # destination input set.
+    # Fallback is only aktive if the environment variable 'PIC_SYSTEM_TEMPLATE_PATH' not exists.
+    # All subfolder will be copied.
+    full_folder_to_copy="etc/picongpu"
+fi
 
 help()
 {
@@ -130,7 +141,7 @@ fi
 
 echo "Cloning from $src_path to $dst_path"
 
-#first copy default parameter
+# first copy from PIConGPU source into the destination input set
 for d in $default_folder_to_copy
 do
     dir_dst="$dst_path/$d"
@@ -138,10 +149,26 @@ do
     if [ ! -d "$dir_dst" ] ; then
         mkdir -p "$dir_dst"
     fi
-    rsync --inplace -r -q -avc --exclude=".*" $dir_src/ $dir_dst
+    rsync --inplace -q -avc --exclude=".*" --exclude="*/" $dir_src/ $dir_dst
 done
 
-#copy all data from src_path if path is not picongpu default param path
+# copy subfolder of PIConGPU source etc/picongpu into the destination input set
+for copy_folder in $full_folder_to_copy
+do
+    dir_to_copy="$picongpu_prefix/$copy_folder"
+    for d in $(ls -w 1 -d "$dir_to_copy/"*/)
+    do
+
+        dir_dst="$dst_path/$copy_folder/$(basename $d)"
+        dir_src="$d"
+        if [ -d "$dir_src" ] ; then
+            mkdir -p "$dir_dst"
+            rsync --inplace -r -q -avc --exclude=".*" "$dir_src" $dir_dst
+        fi
+    done
+done
+
+# copy all data from src_path if path is not picongpu default param path
 if [ "$src_path" != "$picongpu_prefix" ] ; then
     for d in $selected_default_folder_to_copy
     do
@@ -154,14 +181,11 @@ if [ "$src_path" != "$picongpu_prefix" ] ; then
     done
 fi
 
-#copy files
+# copy files from root of the source input set to the destination input set
 for d in $files_to_copy
 do
     file_dst="$dst_path/$d"
     file_src="$src_path/$d"
-    if [ ! -d "$dir_dst" ] ; then
-        mkdir -p "$dir_dst"
-    fi
     if [ -f "$src_path/$d" ] ; then
        rsync --inplace -q -avc --exclude=".*" $file_src $file_dst
     fi

--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -50,6 +50,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:35"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/aris-grnet"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/ascent-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/ascent-ornl/gpu_picongpu.profile.example
@@ -55,6 +55,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:70"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/ascent-ornl"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
@@ -49,6 +49,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:skylake-avx512"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/bash-devServer-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/binspa
@@ -57,7 +61,7 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
 # "tbg" default options #######################################################
 export TBG_SUBMIT="bash"
-export TBG_TPLFILE="etc/picongpu/bash/mpiexec.tpl"
+export TBG_TPLFILE="etc/picongpu/bash-devServer-hzdr/mpiexec.tpl"
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/bash-devServer-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_picongpu.profile.example
@@ -46,6 +46,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:70"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/bash-devServer-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/binspa
@@ -54,7 +58,7 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 
 # "tbg" default options #######################################################
 export TBG_SUBMIT="bash"
-export TBG_TPLFILE="etc/picongpu/bash/mpiexec.tpl"
+export TBG_TPLFILE="etc/picongpu/bash-devServer-hzdr/mpiexec.tpl"
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/bash/bash_picongpu.profile.example
+++ b/etc/picongpu/bash/bash_picongpu.profile.example
@@ -26,6 +26,10 @@ export PIC_BACKEND="omp2b:native" # running on cpu
 # https://picongpu.readthedocs.io/en/latest/usage/basics.html#pic-configure
 # or the provided profiles of other systems.
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/bash"}
+
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 

--- a/etc/picongpu/cori-nersc/a100_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/a100_picongpu.profile.example
@@ -49,6 +49,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:80"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/cori-nersc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
@@ -85,6 +85,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="hip:gfx90a"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/crusher-ornl"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
@@ -84,6 +84,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="hip:gfx90a"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/crusher-ornl"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
+++ b/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
@@ -58,6 +58,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:60"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/davide-cineca"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/draco-mpcdf/picongpu.profile.example
+++ b/etc/picongpu/draco-mpcdf/picongpu.profile.example
@@ -45,6 +45,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:haswell"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/draco-mpcdf"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -44,6 +44,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:skylake-avx512"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/hemera-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -44,6 +44,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:70"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/hemera-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -45,6 +45,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:60"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/hemera-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -41,6 +41,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:35"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/hemera-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -42,6 +42,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:37"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/hemera-hzdr"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -52,6 +52,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:haswell"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/jureca-jsc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -53,6 +53,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:MIC-AVX512"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/jureca-jsc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -60,6 +60,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:37" # Nvidia K80 architecture
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/jureca-jsc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -62,6 +62,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="omp2b:skylake"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/juwels-jsc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -78,6 +78,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:80" # Nvidia A100 architecture
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/juwels-jsc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -66,6 +66,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:70" # Nvidia V100 architecture
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/juwels-jsc"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -75,6 +75,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:60"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/pizdaint-cscs"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/spock-ornl/caar_picongpu.profile.example
+++ b/etc/picongpu/spock-ornl/caar_picongpu.profile.example
@@ -83,6 +83,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="hip:gfx908"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/spock-ornl"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -51,6 +51,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:70"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/summit-ornl"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/taurus-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/A100_picongpu.profile.example
@@ -59,6 +59,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:80"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/taurus-tud"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -51,6 +51,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:70"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/taurus-tud"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -65,6 +65,10 @@ export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:37"
 
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/taurus-tud"}
+
 export PATH=$PATH:$PICSRC
 export PATH=$PATH:$PICSRC/bin
 export PATH=$PATH:$PICSRC/src/tools/bin


### PR DESCRIPTION
Update our tooling to reflect common workflows. 
The python tools will be used mostly from PIConGPU source code and not the input set because we set the python path to PIConGPU source lib folder.
With a new environment variable `PIC_SYSTEM_TEMPLATE_PATH` we can control that only the required profiles and templates for tbg will be compiled by `pic-create`. If the environment variable does not exist we will fall back to the old behavior and copy all system templates/profiles into the input set.

- do not copy picongpu/lib into the input set
- add `PIC_SYSTEM_TEMPLATE_PATH` to control which tbg  templates/profiles will be copied
- update system profiles to expose which system template folder should be used