### PR TITLE
CI: fix compile issue if `cpuonly` job is executed on a GPU runner

### DIFF
--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -10,6 +10,13 @@ if [[ ! -v PIC_BUILD_TYPE ]] ; then
     PIC_BUILD_TYPE=Release ;
 fi
 
+if [[ "$CI_RUNNER_TAGS" =~ .*cpuonly.* ]] ; then
+    # In cases where the compile-only job is executed on a GPU runner but with different kinds of accelerators
+    # we need to reset the variables to avoid compiling for the wrong architecture and accelerator.
+    unset CI_GPUS
+    unset CI_GPU_ARCH
+fi
+
 if [ -n "$CI_GPUS" ] ; then
     # select randomly a device if multiple exists
     # CI_GPUS is provided by the gitlab CI runner

--- a/share/ci/run_pmacc_tests.sh
+++ b/share/ci/run_pmacc_tests.sh
@@ -97,6 +97,13 @@ if [ $PMACC_PARALLEL_BUILDS -gt $CI_MAX_PARALLELISM ] ; then
     PMACC_PARALLEL_BUILDS=$CI_MAX_PARALLELISM
 fi
 
+if [[ "$CI_RUNNER_TAGS" =~ .*cpuonly.* ]] ; then
+    # In cases where the compile-only job is executed on a GPU runner but with different kinds of accelerators
+    # we need to reset the variables to avoid compiling for the wrong architecture and accelerator.
+    unset CI_GPUS
+    unset CI_GPU_ARCH
+fi
+
 if [ -n "$CI_GPUS" ] ; then
     # select randomly a device if multiple exists
     # CI_GPUS is provided by the gitlab CI runner


### PR DESCRIPTION
In cases where the compile only job job is executed on an GPU runner but with different kind of accelerators we need to reset the variables `CI_GPUS` and `CI_GPU_ARCH` to avoid compiling for the wrong architecture and accelerator.

A list of environment variables available in the gitlab Ci: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html