### PR TITLE
fix stdlibc++ filesystem compatibility

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -505,6 +505,9 @@ add_library(picongpu-hostonly
     ${SRCFILES}
 )
 target_link_libraries(picongpu-hostonly PUBLIC ${HOST_LIBS})
+# Some host compiled libraries depend on std::filesystem,
+# compatibility to std::experimental::filesystem is handled in pmacc.
+target_link_libraries(picongpu-hostonly PRIVATE pmacc::filesystem)
 
 cupla_add_executable(picongpu
      ${ACCSRCFILES}

--- a/include/picongpu/plugins/common/txtFileHandling.hpp
+++ b/include/picongpu/plugins/common/txtFileHandling.hpp
@@ -19,7 +19,8 @@
 
 #pragma once
 
-#include <filesystem>
+#include <pmacc/filesystem.hpp>
+
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -51,11 +52,11 @@ namespace picongpu
         sStep << restartStep;
 
         /* set location of restart file and output file */
-        std::filesystem::path src(restartDirectory + std::string("/") + filename + std::string(".") + sStep.str());
-        std::filesystem::path dst(filename);
+        stdfs::path src(restartDirectory + std::string("/") + filename + std::string(".") + sStep.str());
+        stdfs::path dst(filename);
 
         /* check whether restart file exists */
-        if(!std::filesystem::exists(src))
+        if(!stdfs::exists(src))
         {
             /* restart file does not exists */
             log<picLog::INPUT_OUTPUT>("Plugin restart file: %1% was not found. \
@@ -69,7 +70,7 @@ namespace picongpu
             if(outFile.is_open())
                 outFile.close();
 
-            std::filesystem::copy_file(src, dst, std::filesystem::copy_options::overwrite_existing);
+            stdfs::copy_file(src, dst, stdfs::copy_options::overwrite_existing);
 
             outFile.open(filename.c_str(), std::ofstream::out | std::ostream::app);
             if(!outFile)
@@ -101,10 +102,10 @@ namespace picongpu
         std::stringstream sStep;
         sStep << currentStep;
 
-        std::filesystem::path src(filename);
-        std::filesystem::path dst(checkpointDirectory + std::string("/") + filename + std::string(".") + sStep.str());
+        stdfs::path src(filename);
+        stdfs::path dst(checkpointDirectory + std::string("/") + filename + std::string(".") + sStep.str());
 
-        std::filesystem::copy_file(src, dst, std::filesystem::copy_options::overwrite_existing);
+        stdfs::copy_file(src, dst, stdfs::copy_options::overwrite_existing);
     }
 
 } /* namespace picongpu */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -55,6 +55,7 @@
 #include <pmacc/communication/manager_common.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/GridLayout.hpp>
+#include <pmacc/filesystem.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/mappings/simulation/SubGrid.hpp>
 #include <pmacc/math/Vector.hpp>
@@ -74,8 +75,6 @@
 #include <boost/mpl/pair.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/vector.hpp>
-
-#include <filesystem>
 
 #include <openPMD/openPMD.hpp>
 
@@ -460,7 +459,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 fileInfix = "";
             }
 
-            fileName = std::filesystem::path(fileName).has_root_path() ? fileName : dir + "/" + fileName;
+            fileName = stdfs::path(fileName).has_root_path() ? fileName : dir + "/" + fileName;
             log<picLog::INPUT_OUTPUT>("openPMD: setting file pattern: %1%%2%.%3%") % fileName % fileInfix
                 % fileExtension;
 

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -27,9 +27,9 @@
 #    include "picongpu/plugins/misc/splitString.hpp"
 
 #    include <pmacc/communication/manager_common.hpp>
+#    include <pmacc/filesystem.hpp>
 
 #    include <chrono>
-#    include <filesystem>
 #    include <sstream>
 #    include <thread> // std::this_thread::sleep_for
 #    include <utility> // std::forward
@@ -228,7 +228,7 @@ namespace
 
             char const* argsv[] = {path.c_str()};
             ChronoDuration waitedFor = 0s;
-            while(!std::filesystem::exists(path))
+            while(!stdfs::exists(path))
             {
                 picongpu::toml::writeLog("openPMD: Still waiting for TOML file:\n\t%1%", 1, argsv);
                 if(waitedFor > timeout)

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -36,6 +36,7 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/dimensions/DataSpaceOperations.hpp>
+#include <pmacc/filesystem.hpp>
 #include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
@@ -44,7 +45,6 @@
 
 #include <algorithm> // std::any
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -968,7 +968,7 @@ namespace picongpu
                     filename << name << timeStep << "_0_0_0" + extension;
 
                     /* check if restart file exists */
-                    if(!std::filesystem::exists(filename.str()))
+                    if(!stdfs::exists(filename.str()))
                     {
                         log<radLog::SIMULATION_STATE>(
                             "Radiation (%1%): restart file not found (%2%) - start with zero values")

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -154,6 +154,20 @@ set_target_properties(pmacc PROPERTIES LINKER_LANGUAGE CXX)
 add_library(pmacc::pmacc ALIAS pmacc)
 target_link_libraries(pmacc PUBLIC cupla::cupla)
 
+# Create traget pmacc::filesystem to handle system where std::filesystem is experimental.
+# e.g. on systems with an old libstdc++ <= 7
+add_library(pmacc_filesystem INTERFACE)
+add_library(pmacc::filesystem ALIAS pmacc_filesystem)
+target_link_libraries(pmacc PUBLIC pmacc::filesystem)
+
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(std::filesystem::path::preferred_separator "filesystem" PMACC_FOUND_CXX17_STD_FILESYSTEM)
+if(NOT PMACC_FOUND_CXX17_STD_FILESYSTEM)
+    message(STATUS "Switch using 'std::experimental::filesystem'")
+    target_compile_definitions(pmacc_filesystem INTERFACE "-DPMACC_USE_STD_EXPERIMENTAL_FILESYSTEM=1")
+    target_link_libraries(pmacc_filesystem INTERFACE stdc++fs)
+endif()
+
 
 ###############################################################################
 # Build Flags

--- a/include/pmacc/filesystem.hpp
+++ b/include/pmacc/filesystem.hpp
@@ -1,0 +1,30 @@
+/* Copyright 2023 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if(PMACC_USE_STD_EXPERIMENTAL_FILESYSTEM == 1)
+#    include <experimental/filesystem>
+namespace stdfs = std::experimental::filesystem;
+#else
+#    include <filesystem>
+namespace stdfs = std::filesystem;
+#endif

--- a/include/pmacc/mappings/simulation/Filesystem.cpp
+++ b/include/pmacc/mappings/simulation/Filesystem.cpp
@@ -26,9 +26,8 @@
 #include "pmacc/mappings/simulation/Filesystem.hpp"
 
 #include "pmacc/Environment.hpp"
+#include "pmacc/filesystem.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
-
-#include <filesystem>
 
 namespace pmacc
 {
@@ -36,13 +35,13 @@ namespace pmacc
     void Filesystem<DIM>::createDirectory(const std::string dir) const
     {
         /* does not throw if the directory exists or has been created */
-        std::filesystem::create_directories(dir);
+        stdfs::create_directories(dir);
     }
 
     template<unsigned DIM>
     void Filesystem<DIM>::setDirectoryPermissions(const std::string dir) const
     {
-        using namespace std::filesystem;
+        using namespace stdfs;
         /* set permissions */
         permissions(
             dir,
@@ -67,7 +66,7 @@ namespace pmacc
     template<unsigned DIM>
     std::string Filesystem<DIM>::basename(const std::string pathFilename) const
     {
-        return std::filesystem::path(pathFilename).filename().string();
+        return stdfs::path(pathFilename).filename().string();
     }
 
     // Explicit template instantiation to provide symbols for usage together with PMacc

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -27,6 +27,7 @@
 #include "pmacc/dataManagement/DataConnector.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/eventSystem/Manager.hpp"
+#include "pmacc/filesystem.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
 #include "pmacc/pluginSystem/containsStep.hpp"
@@ -37,7 +38,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -449,7 +449,7 @@ namespace pmacc
         const std::string checkpointMasterFile
             = this->restartDirectory + std::string("/") + this->CHECKPOINT_MASTER_FILE;
 
-        if(!std::filesystem::exists(checkpointMasterFile))
+        if(!stdfs::exists(checkpointMasterFile))
             return checkpoints;
 
         std::ifstream file(checkpointMasterFile.c_str());

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -84,11 +84,6 @@ def is_valid_combination(row):
         os_name = row[2][0] if n >= 3 else ""
         os_version = get_version(row[2]) if n >= 3 else 0
 
-        # STL of g++ shipped with ubuntu <20.04 does not support full
-        # c++17 standard
-        if os_name == "ubuntu" and is_clang and os_version < 20.04:
-            return False
-
         if is_cuda and os_name == "ubuntu":
             if os_version < 20.04 and v_cuda >= 11.0:
                 return False


### PR DESCRIPTION
On a system with an old stdlibc++ version <= 7 `std::filesystem` is
experimental. Handle this case in PMacc and use the correct includes and
namespace if needed.

- change `#include <filesystem>` to `#inlcude <pmacc/filesystem.hpp>`
- CMake provides target `pmacc::filesystem`
- CI: Re-add the tests to check the workaround for c++17 filesystem includes

The filesystem issue was introduced with #4504 and affects crusher@ORNL.
