### PR TITLE
Added script to edit copied PIConGPU checkpoints.

### DIFF
--- a/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
+++ b/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
@@ -1,0 +1,703 @@
+"""
+This file is a modified version of the pipe script from the openPMD-api.
+
+Authors: Richard Pausch, Franz Poeschel, Nico Wrobel
+License: LGPLv3+
+"""
+import argparse
+import os  # os.path.basename
+import sys  # sys.stderr.write
+
+import openpmd_api as io
+import numpy as np
+
+
+class vec3D:
+    """
+    a helper class to easily handle 3D vectors in python without the need
+    to reference another dimension of a numpy array
+    """
+    x = 0
+    y = 0
+    z = 0
+
+    def __init__(self, x, y, z):
+        """
+        initialize with 3 values (x,y,z)
+
+        Arguments:
+        x: first value
+        y: second value
+        z: third value
+        """
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+    def prod(self):
+        """
+        product of all 3 components
+
+        returns x * y * z
+        """
+        return self.x * self.y * self.z
+
+
+    def print(self):
+        """
+        helper function to print values to screen
+        """
+        print("x: {}".format(self.x))
+        print("y: {}".format(self.y))
+        print("z: {}".format(self.z))
+
+
+    def __truediv__(self, other):
+        """
+        component wise division using the '/' operator
+
+        Arguments:
+        other: float value
+               the number by which all 3 components should be divided
+
+        Return:
+        vec3D( x/other, y/other, z/other )
+        """
+        return vec3D(self.x / other, self.y / other, self.z / other)
+
+
+
+class addParticles2Checkpoint:
+
+    def print(self, string):
+        """
+        helper function that prints information depending on the set
+        verbose level
+        
+        Arguments:
+        string: string
+                message to post
+        """
+        if(self.verbose):
+            print("\t"*self.tabs + string)
+
+
+    def __init__(self, filename_in, filename_out, speciesName='e', verbose=True):
+        """
+        initialization of manipulation routine
+
+        This class writes particles named speciesName into a copy of the
+        bp checkpoint given in filename_in into filename_out.
+
+        Arguments:
+        filename_in: string
+                  path to bp file to copy from (only time step 0 accepted)
+        filename_out: string
+                  path to bp file to create         
+        speciesName: string
+                     short name in PIConGPU for the species to manipulate
+        verbose: bool
+                 (True: print output, False: Do not print output to screen)
+        """
+        self.verbose = verbose  # verbose level
+        self.tabs = 0  # tab counter for output
+
+        self.timestep = 0 # time step (fixed to 0)
+        self.speciesName = speciesName
+        self.filename_in = filename_in
+        self.filename_out = filename_out
+        self.f = io.Series(self.filename_in, io.Access.read_only)
+        if int(list(self.f.iterations)[0]) != self.timestep:
+            raise NameError('Not time step zero') # throw error if not time step zero
+        # TODO: maybe raise error, when filename_out already exists to not overwrite it
+        tmp_handle = self.f.iterations[self.timestep].meshes["E"]
+
+        # get cell size per dimension
+        # the * unpacks the arguments for x,y,z
+        self.cellSize = vec3D(*(tmp_handle.grid_unit_SI * np.array(tmp_handle.grid_spacing)))
+
+        # extract number of cells in each dimension
+        tmp_mesh = self.f.iterations[self.timestep].meshes["E"]["x"]
+        
+        tmp_handle = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["offset"]
+        off_x = tmp_handle["x"].load()
+        off_y = tmp_handle["y"].load()
+        off_z = tmp_handle["z"].load()
+        
+        # get extent of each GPU in cells (per dimension)
+        tmp_handle = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["extent"]
+        ext_x = tmp_handle["x"].load()
+        ext_y = tmp_handle["y"].load()
+        ext_z = tmp_handle["z"].load()
+
+        # get number of particles before each patch
+        tmp_numOff = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["numParticlesOffset"][io.Mesh_Record_Component.SCALAR].load()
+        # get number of particles in each patch
+        tmp_num = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["numParticles"][io.Mesh_Record_Component.SCALAR].load()
+        
+        # flush all loads before calculations
+        self.f.flush()
+        
+        
+        tmp = np.shape(tmp_mesh)
+        self.N_cells = vec3D(tmp[0], tmp[1], tmp[2]) # cells in each dimension
+
+        # extract number of GPUs used in each dimension
+        # use np.unique() to reduce patches offset and len() to get number of GPUs per dimension
+        self.N_gpus = vec3D(len(np.unique(off_x)),
+                            len(np.unique(off_y)),
+                            len(np.unique(off_z)))
+
+        # get patch offset
+        self.offset = vec3D(off_x,
+                            off_y,
+                            off_z)
+
+        # get simulation box size in meter
+        self.simBoxSize = vec3D(self.cellSize.x * self.N_cells.x,
+                                self.cellSize.y * self.N_cells.y,
+                                self.cellSize.z * self.N_cells.z)
+
+        self.extent = vec3D(ext_x,
+                            ext_y,
+                            ext_z)
+
+        self.numParticlesOffset = tmp_numOff
+        
+        self.numParticles = tmp_num
+
+        # raise error if there are particles in the checkpoint
+        if np.sum(self.numParticles) > 0:
+            raise NameError('There are particles in the checkpoint')
+
+        # extract momentum unit (attributes don't need flushing)
+        tmp_handle = self.f.iterations[self.timestep].particles[self.speciesName]["momentum"]["x"]
+        self.unitMomentum = tmp_handle.unit_SI
+
+        self.has_probeE = False
+        self.has_probeB = False
+        self.has_id = False
+        
+        # extract data type for position
+        self.dtype_position = self.f.iterations[self.timestep].particles[self.speciesName]["position"]["x"].dtype
+
+        # extract data type for positionOffset
+        self.dtype_positionOffset = self.f.iterations[self.timestep].particles[self.speciesName]["positionOffset"]["x"].dtype
+
+        # extract data type for momentum
+        self.dtype_momentum = self.f.iterations[self.timestep].particles[self.speciesName]["momentum"]["x"].dtype
+
+        if "probeE" in self.f.iterations[self.timestep].particles[self.speciesName]:
+            self.has_probeE = True
+            # type of E-Field
+            self.dtype_probeE = self.f.iterations[self.timestep].particles[self.speciesName]["probeE"]["x"].dtype
+        self.print("contains probeE = {}".format(self.has_probeE))
+
+        if "probeB" in self.f.iterations[self.timestep].particles[self.speciesName]:
+            self.has_probeB = True
+            # type of B-Field
+            self.dtype_probeB = self.f.iterations[self.timestep].particles[self.speciesName]["probeB"]["x"].dtype
+        self.print("contains probeB {}".format(self.has_probeB))
+
+        # extract data type for weighting
+        self.dtype_weighting = self.f.iterations[self.timestep].particles[self.speciesName]["weighting"][io.Mesh_Record_Component.SCALAR].dtype
+
+        if "id" in self.f.iterations[self.timestep].particles[self.speciesName]:
+            self.has_id = True
+            # type of particleID
+            self.dtype_id = self.f.iterations[self.timestep].particles[self.speciesName]["id"][io.Mesh_Record_Component.SCALAR].dtype
+        self.print("contains id =  {}".format(self.has_id))
+
+        del self.f # close checkpoint file
+
+
+    def addParticles(self, pos, mom, w):
+        """
+        add particles to the restart file
+
+        Arguments:
+        pos - vec3 array
+              position in SI units
+        mom - vec3 array
+              momentum in SI units
+        w - float array
+            macro particle weighting
+        """
+        self.N_particles_input = len(w) # number of particles to add
+        
+        # calculate positionOffset (cell location) from given position
+        self.positionOffset = vec3D((pos.x / self.cellSize.x).astype(self.dtype_positionOffset),
+                                    (pos.y / self.cellSize.y).astype(self.dtype_positionOffset),
+                                    (pos.z / self.cellSize.z).astype(self.dtype_positionOffset))
+
+        # calculate (in cell) position from given position
+        self.position = vec3D((np.mod(pos.x, self.cellSize.x)/self.cellSize.x).astype(self.dtype_position),
+                              (np.mod(pos.y, self.cellSize.y)/self.cellSize.y).astype(self.dtype_position),
+                              (np.mod(pos.z, self.cellSize.z)/self.cellSize.z).astype(self.dtype_position))
+
+        # calculate momentum in PIC units from given momentum
+        self.momentum = vec3D((mom.x * w / self.unitMomentum).astype(self.dtype_momentum),
+                              (mom.y * w / self.unitMomentum).astype(self.dtype_momentum),
+                              (mom.z * w / self.unitMomentum).astype(self.dtype_momentum))
+        
+        if self.has_probeE:
+            # data for witnessed E-Field
+            temp_zeros = np.zeros(len(w), dtype=self.dtype_probeE)
+            self.probeE = vec3D(temp_zeros, temp_zeros, temp_zeros)
+        
+        if self.has_probeB:
+            # data for witnessed B-Field
+            temp_zeros = np.zeros(len(w), dtype=self.dtype_probeB)
+            self.probeB = vec3D(temp_zeros, temp_zeros, temp_zeros)
+
+        # copy weighting
+        self.weighting = w.copy().astype(self.dtype_weighting)
+        
+        if self.has_id:
+            # give every particle an ID
+            self.id = np.arange(len(w), dtype=self.dtype_id)
+
+
+    def makePatchMask(self):
+        """
+        calculate particle patches for given particles
+        """
+        # create empty patch mask (N_GPUs x N_particles)
+        self.patch_mask = np.empty((self.N_gpus.prod(), self.N_particles_input), dtype=bool)
+
+        # calculate patch  for each GPU
+        for i in np.arange(self.N_gpus.prod()):
+            # x direction
+            a = np.greater_equal(self.positionOffset.x, self.offset.x[i])
+            b = np.less(self.positionOffset.x, self.offset.x[i] + self.extent.x[i])
+
+            # y direction
+            c = np.greater_equal(self.positionOffset.y, self.offset.y[i])
+            d = np.less(self.positionOffset.y, self.offset.y[i] + self.extent.y[i])
+
+            # z direction:
+            e = np.greater_equal(self.positionOffset.z, self.offset.z[i])
+            f = np.less(self.positionOffset.z, self.offset.z[i] + self.extent.z[i])
+
+            # combine all 3*2 bools to just give true or false for GPU(i)
+            tmp1 = np.logical_and( np.logical_and(a,b), np.logical_and(c,d) )
+            tmp2 = np.logical_and(tmp1 , np.logical_and(e,f) )
+            self.patch_mask[i, :] = tmp2
+
+        # determine number of particles in all patches
+        self.numParticles = np.sum(self.patch_mask, axis=1, dtype=np.uint)
+        # calculate number of particles before the patch
+        self.numParticlesOffset = np.cumsum(self.numParticles, dtype=np.uint) - self.numParticles
+        # fix possible negative value for first patch (if number of particles in first patch != 0)
+        self.numParticlesOffset[0] = 0
+
+
+    def writeParticles(self):
+        """
+        write all particle data to checkpoint with the help of the pipe class
+        """
+        self.print("make patch mask")
+        self.makePatchMask() # calculate particle patch
+        self.N_particles = np.sum(self.numParticles)
+
+        run_pipe = pipe(self.filename_in, self.filename_out, self, verbose=self.verbose)
+        run_pipe.run()
+
+
+
+class Chunk:
+    """
+    A Chunk is an n-dimensional hypercube, defined by an offset and an extent.
+    Offset and extent must be of the same dimensionality (Chunk.__len__).
+    """
+    def __init__(self, offset, extent):
+        """
+        Inititalization of the slicing class.
+        
+        Arguments:
+        offset: array
+                offsets of each slice
+        extent: array
+                extent of each slice
+        
+        """
+        assert (len(offset) == len(extent))
+        self.offset = offset
+        self.extent = extent
+
+
+    def __len__(self):
+        return len(self.offset)
+
+
+    def slice1D(self):
+        """
+        Slice this chunk into a hypercube along the dimension with 
+        the largest extent on this hypercube.
+        
+        Return:
+        the 0'th of the sliced chunks.
+        """
+        # pick that dimension which has the highest count of items
+        dimension = 0
+        maximum = self.extent[0]
+        for k, v in enumerate(self.extent):
+            if v > maximum:
+                dimension = k
+        assert (dimension < len(self))
+        # no offset
+        assert (self.offset == [0 for _ in range(len(self))])
+        offset = [0 for _ in range(len(self))]
+        extent = self.extent.copy()
+
+        return Chunk(offset, extent)
+
+
+
+class deferred_load:
+    def __init__(self, source, dynamicView, offset, extent):
+        self.source = source
+        self.dynamicView = dynamicView
+        self.offset = offset
+        self.extent = extent
+
+
+
+class particle_patch_load:
+    """
+    A deferred load/store operation for a particle patch.
+    The openPMD particle-patch API requires that users pass a concrete value for
+    storing, even if the actual write operation occurs much later at
+    series.flush().
+    So, unlike other record components, we cannot call .store_chunk() with
+    a buffer that has not yet been filled, but must wait until the point where
+    we actual have the data at hand already.
+    In short: calling .store() must be deferred, until the data has been fully
+    read from the sink.
+    This class stores the needed parameters to .store().
+    """
+    def __init__(self, data, dest):
+        self.data = data
+        self.dest = dest
+
+
+    def run(self):
+        for index, item in enumerate(self.data):
+            self.dest.store(index, item)
+
+
+
+class pipe:
+    """
+    Represents the configuration of one "pipe" pass.
+    """
+
+    def print(self, string):
+        """
+        helper function that prints information depending on the set
+        verbose level
+        
+        Arguments:
+        string: string
+                message to post
+        """
+        if(self.verbose):
+            print(string)
+
+
+    def __init__(self, infile, outfile, particles=[], inconfig='{}', outconfig='{}', verbose=False):
+        """
+        routine to copy and overwrite data from one checkpoint to another.
+        
+        Arguments:
+        infile: string
+                path to the checkpoint to copy from
+        outfile: string
+                path to the checkpoint to copy to
+        particles: class
+                class containing the new particle data
+        inconfig: string
+                configuration file when opening checkpoint from infile
+        outconfig: string
+                configuration file when opening checkpoint from outfile     
+        verbose: bool
+                prints verbose messages to the screen if True
+        """
+        self.infile = infile
+        self.outfile = outfile
+        self.particles = particles  # particle data to write
+        self.inconfig = inconfig
+        self.outconfig = outconfig
+        self.loads = []
+        self.verbose = verbose
+
+
+    def run(self):
+        """
+        starts the copy routine.
+        """
+        print("Opening data source")
+        sys.stdout.flush()
+        inseries = io.Series(self.infile, io.Access.read_only,
+                                 self.inconfig)
+        print("Opening data sink")
+        sys.stdout.flush()
+        outseries = io.Series(self.outfile, io.Access.create,
+                                  self.outconfig)
+        print("Opened input and output")
+        sys.stdout.flush()
+        
+        self.__copy(inseries, outseries)
+        print("Finished!")
+
+
+    def __copy(self, src, dest, current_path="/data/"):
+        """
+        Copies data from src to dest. May represent any point in the openPMD
+        hierarchy, but src and dest must both represent the same layer.
+        Writes own data for given particle.
+        
+        Arguments:
+        src: openPMD layer
+                layer of a openPMD series to copy from
+        dest: openPMD layer
+                layer of a openPMD series to copy to
+        current_path: string
+                path of the current layer, only for verbose printing.
+        """
+        self.print(current_path)
+        if (type(src) != type(dest)
+                and not isinstance(src, io.IndexedIteration)
+                and not isinstance(dest, io.Iteration)):
+            raise RuntimeError(
+                "Internal error: Trying to copy mismatching types")
+        
+        # copy attributes of current layer
+        self.copy_attributes(src, dest)
+        
+        container_types = [
+            io.Mesh_Container, io.Particle_Container, io.ParticleSpecies,
+            io.Record, io.Mesh, io.Particle_Patches, io.Patch_Record
+        ]
+        
+        if isinstance(src, io.Series):
+            # main loop: read iterations of src, write to dest
+            write_iterations = dest.write_iterations()
+            for in_iteration in src.read_iterations():
+                print("Iteration {0} contains {1} meshes:".format(
+                    in_iteration.iteration_index,
+                    len(in_iteration.meshes)))
+                for m in in_iteration.meshes:
+                    print("\t {0}".format(m))
+                print("")
+                print(
+                    "Iteration {0} contains {1} particle species:".format(
+                        in_iteration.iteration_index,
+                        len(in_iteration.particles)))
+                for ps in in_iteration.particles:
+                    print("\t {0}".format(ps))
+                    print("With records:")
+                    for r in in_iteration.particles[ps]:
+                        print("\t {0}".format(r))
+                out_iteration = write_iterations[in_iteration.iteration_index]
+                sys.stdout.flush()
+                self.__particle_patches = []
+                self.__copy(
+                    in_iteration, out_iteration,
+                    current_path + str(in_iteration.iteration_index) + "/")
+                for deferred in self.loads:
+                    deferred.source.load_chunk(
+                        deferred.dynamicView.current_buffer(), deferred.offset,
+                        deferred.extent)
+                in_iteration.close()
+                for patch_load in self.__particle_patches:
+                    patch_load.run()
+                
+                # overwrite copied shape attribute of mass and charge to match particle count
+                out_iteration.particles[self.particles.speciesName]["mass"].set_attribute("shape", np.uint64(self.particles.N_particles))
+                out_iteration.particles[self.particles.speciesName]["charge"].set_attribute("shape", np.uint64(self.particles.N_particles))
+    
+                out_iteration.close()
+                self.__particle_patches.clear()
+                self.loads.clear()
+                sys.stdout.flush()
+
+        elif isinstance(src, io.Record_Component):
+            # copies record components
+            shape = src.shape
+            dtype = src.dtype
+            offset = [0 for _ in shape]
+            dest.reset_dataset(io.Dataset(dtype, shape))
+            if src.empty:
+                # empty record component automatically created by
+                # dest.reset_dataset()
+                pass
+            elif src.constant:
+                dest.make_constant(src.get_attribute("value"))
+            else:
+                chunk = Chunk(offset, shape)
+                local_chunk = chunk.slice1D()
+                span = dest.store_chunk(local_chunk.offset, local_chunk.extent)
+                self.loads.append(
+                    deferred_load(src, span, local_chunk.offset,
+                                  local_chunk.extent))
+
+        elif isinstance(src, io.Patch_Record_Component):
+            # copies patch record components
+            dest.reset_dataset(io.Dataset(src.dtype, src.shape))
+            self.__particle_patches.append(
+                particle_patch_load(src.load(), dest))
+
+        elif isinstance(src, io.Iteration):
+            # copies iterations (meshes and particles)
+            self.print("\ncopy meshes")
+            self.__copy(src.meshes, dest.meshes, current_path + "meshes/")
+            self.print("\ncopy particles")
+            self.__copy(src.particles, dest.particles,
+                        current_path + "particles/")
+
+        elif any([
+            # copies containers and other data from container_types list
+                isinstance(src, container_type)
+                for container_type in container_types
+        ]):
+            for key in src:
+                # writes given particle data instead of copying 
+                if key == self.particles.speciesName:
+                    self.print("writing new particles data")
+                    temp_src = src[self.particles.speciesName]
+                    temp_dest = dest[self.particles.speciesName]
+
+                    # iterate and copy all attributes
+                    self.copy_attributes(temp_src, temp_dest, iterate=True)
+
+                    # write own particle data
+                    self.print("\twriting positions")
+                    self.write(temp_src["position"]["x"], temp_dest["position"]["x"], self.particles.position.x)
+                    self.write(temp_src["position"]["y"], temp_dest["position"]["y"], self.particles.position.y)
+                    self.write(temp_src["position"]["z"], temp_dest["position"]["z"], self.particles.position.z)
+
+                    self.print("\twriting position offsets")
+                    self.write(temp_src["positionOffset"]["x"], temp_dest["positionOffset"]["x"], self.particles.positionOffset.x)
+                    self.write(temp_src["positionOffset"]["y"], temp_dest["positionOffset"]["y"], self.particles.positionOffset.y)
+                    self.write(temp_src["positionOffset"]["z"], temp_dest["positionOffset"]["z"], self.particles.positionOffset.z)
+
+                    self.print("\twriting momenta")
+                    self.write(temp_src["momentum"]["x"], temp_dest["momentum"]["x"], self.particles.momentum.x)
+                    self.write(temp_src["momentum"]["y"], temp_dest["momentum"]["y"], self.particles.momentum.y)
+                    self.write(temp_src["momentum"]["z"], temp_dest["momentum"]["z"], self.particles.momentum.z)
+
+                    if self.particles.has_probeE:
+                        self.print("\twriting probeE")
+                        self.write(temp_src["probeE"]["x"], temp_dest["probeE"]["x"], self.particles.probeE.x)
+                        self.write(temp_src["probeE"]["y"], temp_dest["probeE"]["y"], self.particles.probeE.y)
+                        self.write(temp_src["probeE"]["z"], temp_dest["probeE"]["z"], self.particles.probeE.z)
+
+                    if self.particles.has_probeB:
+                        self.print("\twriting probeB")
+                        self.write(temp_src["probeB"]["x"], temp_dest["probeB"]["x"], self.particles.probeB.x)
+                        self.write(temp_src["probeB"]["y"], temp_dest["probeB"]["y"], self.particles.probeB.y)
+                        self.write(temp_src["probeB"]["z"], temp_dest["probeB"]["z"], self.particles.probeB.z)
+
+                    self.print("\twriting weighting")
+                    self.write(temp_src["weighting"][io.Mesh_Record_Component.SCALAR], temp_dest["weighting"][io.Mesh_Record_Component.SCALAR], self.particles.weighting)
+
+                    if self.particles.has_id:
+                        self.print("\twriting id")
+                        self.write(temp_src["id"][io.Mesh_Record_Component.SCALAR], temp_dest["id"][io.Mesh_Record_Component.SCALAR], self.particles.id)
+
+                    # write own particle patches
+                    self.print("\twriting patches")
+                    temp_src = src[self.particles.speciesName].particle_patches["numParticles"][io.Mesh_Record_Component.SCALAR]
+                    temp_dest = dest[self.particles.speciesName].particle_patches["numParticles"][io.Mesh_Record_Component.SCALAR]
+
+                    temp_dest.reset_dataset(io.Dataset(temp_src.dtype, temp_src.shape))
+                    self.__particle_patches.append(particle_patch_load(self.particles.numParticles, temp_dest))
+
+                    temp_src = src[self.particles.speciesName].particle_patches["numParticlesOffset"][io.Mesh_Record_Component.SCALAR]
+                    temp_dest = dest[self.particles.speciesName].particle_patches["numParticlesOffset"][io.Mesh_Record_Component.SCALAR]
+
+                    temp_dest.reset_dataset(io.Dataset(temp_src.dtype, temp_src.shape))
+                    self.__particle_patches.append(particle_patch_load(self.particles.numParticles, temp_dest))
+
+                    # copy offset and extent from old checkpoint
+                    temp_src = src[self.particles.speciesName].particle_patches["offset"]
+                    temp_dest = dest[self.particles.speciesName].particle_patches["offset"]
+
+                    for key in temp_src:
+                        self.__copy(temp_src[key], temp_dest[key])
+
+                    temp_src = src[self.particles.speciesName].particle_patches["extent"]
+                    temp_dest = dest[self.particles.speciesName].particle_patches["extent"]
+
+                    for key in temp_src:
+                        self.__copy(temp_src[key], temp_dest[key])
+                    self.print("resume to copying")
+                else:
+                    self.__copy(src[key], dest[key], current_path + key + "/")
+
+            if isinstance(src, io.ParticleSpecies):
+                # copies particle patches of species
+                self.__copy(src.particle_patches, dest.particle_patches)
+        else:
+            raise RuntimeError("Unknown openPMD class: " + str(src))
+
+
+    def copy_attributes(self, src, dest, iterate=False):
+        """
+        Copies attributes from src to dest. Optionally iterates over them.
+        
+        Arguments:
+        src: openPMD layer
+                layer of a openPMD series to copy attributes from
+        dest: openPMD layer
+                layer of a openPMD series to copy attributes to
+        iterate: Bool
+                if True: iterates over all consecutive layers of the src/dest layer and copies attributes.
+        """
+        attribute_dtypes = src.attribute_dtypes
+        # The following attributes are written automatically by openPMD-api
+        # and should not be manually overwritten here
+        ignored_attributes = {
+            io.Series:
+            ["basePath", "iterationEncoding", "iterationFormat", "openPMD"],
+            io.Iteration: ["snapshot"]
+        }
+        for key in src.attributes:
+            ignore_this_attribute = False
+            for openpmd_group, to_ignore_list in ignored_attributes.items():
+                if isinstance(src, openpmd_group):
+                    for to_ignore in to_ignore_list:
+                        if key == to_ignore:
+                            ignore_this_attribute = True
+            if not ignore_this_attribute:
+                attr = src.get_attribute(key)
+                attr_type = attribute_dtypes[key]
+                dest.set_attribute(key, attr, attr_type)
+        if iterate:
+            for key in src:
+                self.copy_attributes(src[key], dest[key], iterate=True)
+
+                
+    def write(self, src, dest, data):
+        """
+        Writes new data to given record component in dest with data types from src.
+        
+        Arguments:
+        src: openPMD layer
+                layer of a openPMD series to copy datatypes from
+        dest: openPMD layer
+                layer of a openPMD series to copy new data to
+        data: array of data which is written to dest.
+                
+        """
+        shape = (self.particles.N_particles,)
+        dtype = src.dtype
+        
+        dest.reset_dataset(io.Dataset(dtype, shape))
+        # write particle data for each patch
+        for i in range(self.particles.N_gpus.prod()):
+            dest.store_chunk(array = data[self.particles.patch_mask[i, :]], 
+                             offset=[self.particles.numParticlesOffset[i]], 
+                             extent=(self.particles.numParticles[i],))

--- a/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
+++ b/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
@@ -77,7 +77,7 @@ class addParticles2Checkpoint:
             print("\t"*self.tabs + string)
 
     def __init__(
-            self, filename_in, filename_out, speciesName='e', verbose=True):
+            self, filename_in, filename_out, speciesName='e', verbose=False):
         """
         initialization of manipulation routine
 
@@ -322,8 +322,8 @@ class addParticles2Checkpoint:
         # determine number of particles in all patches
         self.numParticles = np.sum(self.patch_mask, axis=1, dtype=np.uint)
         # calculate number of particles before the patch
-        self.numParticlesOffset = np.cumsum(self.numParticles, dtype=np.uint)
-        - self.numParticles
+        self.numParticlesOffset = (np.cumsum(self.numParticles, dtype=np.uint)
+                                   - self.numParticles)
         # fix possible negative value for first patch (if number of particles
         # in first patch != 0)
         self.numParticlesOffset[0] = 0
@@ -477,7 +477,7 @@ class pipe:
         sys.stdout.flush()
 
         self.__copy(inseries, outseries)
-        print("Finished!")
+        print("\nFinished!")
 
     def __copy(self, src, dest, current_path="/data/"):
         """

--- a/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
+++ b/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
@@ -4,8 +4,8 @@ This file is a modified version of the pipe script from the openPMD-api.
 Authors: Richard Pausch, Franz Poeschel, Nico Wrobel
 License: LGPLv3+
 """
-import argparse
-import os  # os.path.basename
+#import argparse
+#import os  # os.path.basename
 import sys  # sys.stderr.write
 
 import openpmd_api as io
@@ -34,7 +34,6 @@ class vec3D:
         self.y = y
         self.z = z
 
-
     def prod(self):
         """
         product of all 3 components
@@ -43,7 +42,6 @@ class vec3D:
         """
         return self.x * self.y * self.z
 
-
     def print(self):
         """
         helper function to print values to screen
@@ -51,7 +49,6 @@ class vec3D:
         print("x: {}".format(self.x))
         print("y: {}".format(self.y))
         print("z: {}".format(self.z))
-
 
     def __truediv__(self, other):
         """
@@ -65,7 +62,6 @@ class vec3D:
         vec3D( x/other, y/other, z/other )
         """
         return vec3D(self.x / other, self.y / other, self.z / other)
-
 
 
 class addParticles2Checkpoint:
@@ -82,9 +78,8 @@ class addParticles2Checkpoint:
         if self.verbose:
             print("\t"*self.tabs + string)
 
-
     def __init__(
-        self, filename_in, filename_out, speciesName='e', verbose=True):
+            self, filename_in, filename_out, speciesName='e', verbose=True):
         """
         initialization of manipulation routine
 
@@ -95,7 +90,7 @@ class addParticles2Checkpoint:
         filename_in: string
                   path to bp file to copy from (only time step 0 accepted)
         filename_out: string
-                  path to bp file to create         
+                  path to bp file to create
         speciesName: string
                      short name in PIConGPU for the species to manipulate
         verbose: bool
@@ -104,7 +99,7 @@ class addParticles2Checkpoint:
         self.verbose = verbose  # verbose level
         self.tabs = 0  # tab counter for output
 
-        self.timestep = 0 # time step (fixed to 0)
+        self.timestep = 0  # time step (fixed to 0)
         self.speciesName = speciesName
         self.filename_in = filename_in
         self.filename_out = filename_out
@@ -145,14 +140,13 @@ class addParticles2Checkpoint:
         # get number of particles in each patch
         tmp_num = self.f.iterations[self.timestep].\
             particles[self.speciesName].particle_patches["numParticles"]\
-                [io.Mesh_Record_Component.SCALAR].load()
+            [io.Mesh_Record_Component.SCALAR].load()
 
         # flush all loads before calculations
         self.f.flush()
 
-
         tmp = np.shape(tmp_mesh)
-        self.N_cells = vec3D(tmp[0], tmp[1], tmp[2]) # cells in each dimension
+        self.N_cells = vec3D(tmp[0], tmp[1], tmp[2])  # cells in each dimension
 
         # extract number of GPUs used in each dimension
         # use np.unique() to reduce patches offset and len() to get number
@@ -205,7 +199,7 @@ class addParticles2Checkpoint:
             particles[self.speciesName]["momentum"]["x"].dtype
 
         if "probeE" in self.f.iterations[self.timestep].\
-            particles[self.speciesName]:
+                particles[self.speciesName]:
             self.has_probeE = True
             # type of E-Field
             self.dtype_probeE = self.f.iterations[self.timestep].\
@@ -213,7 +207,7 @@ class addParticles2Checkpoint:
         self.print("contains probeE = {}".format(self.has_probeE))
 
         if "probeB" in self.f.iterations[self.timestep].\
-            particles[self.speciesName]:
+                particles[self.speciesName]:
             self.has_probeB = True
             # type of B-Field
             self.dtype_probeB = self.f.iterations[self.timestep].\
@@ -226,7 +220,7 @@ class addParticles2Checkpoint:
             [io.Mesh_Record_Component.SCALAR].dtype
 
         if "id" in self.f.iterations[self.timestep].\
-            particles[self.speciesName]:
+                particles[self.speciesName]:
             self.has_id = True
             # type of particleID
             self.dtype_id = self.f.iterations[self.timestep].\
@@ -234,8 +228,7 @@ class addParticles2Checkpoint:
                 [io.Mesh_Record_Component.SCALAR].dtype
         self.print("contains id =  {}".format(self.has_id))
 
-        del self.f # close checkpoint file
-
+        del self.f  # close checkpoint file
 
     def addParticles(self, pos, mom, w):
         """
@@ -249,7 +242,7 @@ class addParticles2Checkpoint:
         w - float array
             macro particle weighting
         """
-        self.N_particles_input = len(w) # number of particles to add
+        self.N_particles_input = len(w)  # number of particles to add
 
         # calculate positionOffset (cell location) from given position
         self.positionOffset = vec3D(
@@ -259,12 +252,12 @@ class addParticles2Checkpoint:
 
         # calculate (in cell) position from given position
         self.position = vec3D(
-            (np.mod(pos.x, self.cellSize.x)/self.cellSize.x).\
-                astype(self.dtype_position),
-            (np.mod(pos.y, self.cellSize.y)/self.cellSize.y).\
-                astype(self.dtype_position),
-            (np.mod(pos.z, self.cellSize.z)/self.cellSize.z).\
-                astype(self.dtype_position))
+            (np.mod(pos.x, self.cellSize.x)/self.cellSize.x).
+            astype(self.dtype_position),
+            (np.mod(pos.y, self.cellSize.y)/self.cellSize.y).
+            astype(self.dtype_position),
+            (np.mod(pos.z, self.cellSize.z)/self.cellSize.z).
+            astype(self.dtype_position))
 
         # calculate momentum in PIC units from given momentum
         self.momentum = vec3D(
@@ -288,7 +281,6 @@ class addParticles2Checkpoint:
         if self.has_id:
             # give every particle an ID
             self.id = np.arange(len(w), dtype=self.dtype_id)
-
 
     def makePatchMask(self):
         """
@@ -316,8 +308,8 @@ class addParticles2Checkpoint:
                         self.offset.z[i] + self.extent.z[i])
 
             # combine all 3*2 bools to just give true or false for GPU(i)
-            tmp1 = np.logical_and( np.logical_and(a,b), np.logical_and(c,d) )
-            tmp2 = np.logical_and(tmp1 , np.logical_and(e,f) )
+            tmp1 = np.logical_and(np.logical_and(a, b), np.logical_and(c, d))
+            tmp2 = np.logical_and(tmp1, np.logical_and(e, f))
             self.patch_mask[i, :] = tmp2
 
         # determine number of particles in all patches
@@ -329,19 +321,17 @@ class addParticles2Checkpoint:
         # in first patch != 0)
         self.numParticlesOffset[0] = 0
 
-
     def writeParticles(self):
         """
         write all particle data to checkpoint with the help of the pipe class
         """
         self.print("make patch mask")
-        self.makePatchMask() # calculate particle patch
+        self.makePatchMask()  # calculate particle patch
         self.N_particles = np.sum(self.numParticles)
 
         run_pipe = pipe(self.filename_in, self.filename_out, self,
                         verbose=self.verbose)
         run_pipe.run()
-
 
 
 class Chunk:
@@ -368,10 +358,9 @@ class Chunk:
     def __len__(self):
         return len(self.offset)
 
-
     def slice1D(self):
         """
-        Slice this chunk into a hypercube along the dimension with 
+        Slice this chunk into a hypercube along the dimension with
         the largest extent on this hypercube.
 
         Return:
@@ -392,7 +381,6 @@ class Chunk:
         return Chunk(offset, extent)
 
 
-
 class deferred_load:
     def __init__(self, source, dynamicView, offset, extent):
         self.source = source
@@ -401,11 +389,10 @@ class deferred_load:
         self.extent = extent
 
 
-
 class particle_patch_load:
     """
     A deferred load/store operation for a particle patch.
-    The openPMD particle-patch API requires that users pass a concrete value 
+    The openPMD particle-patch API requires that users pass a concrete value
     for storing, even if the actual write operation occurs much later at
     series.flush().
     So, unlike other record components, we cannot call .store_chunk() with
@@ -425,7 +412,6 @@ class particle_patch_load:
             self.dest.store(index, item)
 
 
-
 class pipe:
     """
     Represents the configuration of one "pipe" pass.
@@ -443,12 +429,11 @@ class pipe:
         if self.verbose:
             print(string)
 
-
     def __init__(self, infile, outfile, particles=[], inconfig='{}',
-                outconfig='{}', verbose=False):
+                 outconfig='{}', verbose=False):
         """
         routine to copy and overwrite data from one checkpoint to another.
-        
+
         Arguments:
         infile: string
                 path to the checkpoint to copy from
@@ -459,7 +444,7 @@ class pipe:
         inconfig: string
                 configuration file when opening checkpoint from infile
         outconfig: string
-                configuration file when opening checkpoint from outfile     
+                configuration file when opening checkpoint from outfile
         verbose: bool
                 prints verbose messages to the screen if True
         """
@@ -471,7 +456,6 @@ class pipe:
         self.loads = []
         self.verbose = verbose
 
-
     def run(self):
         """
         starts the copy routine.
@@ -479,17 +463,16 @@ class pipe:
         print("Opening data source")
         sys.stdout.flush()
         inseries = io.Series(self.infile, io.Access.read_only,
-                                 self.inconfig)
+                             self.inconfig)
         print("Opening data sink")
         sys.stdout.flush()
         outseries = io.Series(self.outfile, io.Access.create,
-                                  self.outconfig)
+                              self.outconfig)
         print("Opened input and output")
         sys.stdout.flush()
 
         self.__copy(inseries, outseries)
         print("Finished!")
-
 
     def __copy(self, src, dest, current_path="/data/"):
         """
@@ -675,18 +658,18 @@ class pipe:
                                    self.particles.probeB.z)
 
                     self.print("\twriting weighting")
-                    self.write(temp_src["weighting"]\
-                        [io.Mesh_Record_Component.SCALAR],
-                               temp_dest["weighting"]\
-                                [io.Mesh_Record_Component.SCALAR],
+                    self.write(temp_src["weighting"]
+                               [io.Mesh_Record_Component.SCALAR],
+                               temp_dest["weighting"]
+                               [io.Mesh_Record_Component.SCALAR],
                                self.particles.weighting)
 
                     if self.particles.has_id:
                         self.print("\twriting id")
-                        self.write(temp_src["id"]\
-                            [io.Mesh_Record_Component.SCALAR],
-                                   temp_dest["id"]\
-                                    [io.Mesh_Record_Component.SCALAR],
+                        self.write(temp_src["id"]
+                                   [io.Mesh_Record_Component.SCALAR],
+                                   temp_dest["id"]
+                                   [io.Mesh_Record_Component.SCALAR],
                                    self.particles.id)
 
                     # write own particle patches
@@ -741,7 +724,6 @@ class pipe:
         else:
             raise RuntimeError("Unknown openPMD class: " + str(src))
 
-
     def copy_attributes(self, src, dest, iterate=False):
         """
         Copies attributes from src to dest. Optionally iterates over them.
@@ -777,7 +759,6 @@ class pipe:
         if iterate:
             for key in src:
                 self.copy_attributes(src[key], dest[key], iterate=True)
-
 
     def write(self, src, dest, data):
         """

--- a/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
+++ b/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
@@ -74,7 +74,7 @@ class addParticles2Checkpoint:
         """
         helper function that prints information depending on the set
         verbose level
-        
+
         Arguments:
         string: string
                 message to post
@@ -111,6 +111,7 @@ class addParticles2Checkpoint:
         if int(list(self.f.iterations)[0]) != self.timestep:
             raise NameError('Not time step zero') # throw error if not time step zero
         # TODO: maybe raise error, when filename_out already exists to not overwrite it
+
         tmp_handle = self.f.iterations[self.timestep].meshes["E"]
 
         # get cell size per dimension
@@ -119,12 +120,12 @@ class addParticles2Checkpoint:
 
         # extract number of cells in each dimension
         tmp_mesh = self.f.iterations[self.timestep].meshes["E"]["x"]
-        
+
         tmp_handle = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["offset"]
         off_x = tmp_handle["x"].load()
         off_y = tmp_handle["y"].load()
         off_z = tmp_handle["z"].load()
-        
+
         # get extent of each GPU in cells (per dimension)
         tmp_handle = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["extent"]
         ext_x = tmp_handle["x"].load()
@@ -135,11 +136,11 @@ class addParticles2Checkpoint:
         tmp_numOff = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["numParticlesOffset"][io.Mesh_Record_Component.SCALAR].load()
         # get number of particles in each patch
         tmp_num = self.f.iterations[self.timestep].particles[self.speciesName].particle_patches["numParticles"][io.Mesh_Record_Component.SCALAR].load()
-        
+
         # flush all loads before calculations
         self.f.flush()
-        
-        
+
+
         tmp = np.shape(tmp_mesh)
         self.N_cells = vec3D(tmp[0], tmp[1], tmp[2]) # cells in each dimension
 
@@ -178,7 +179,7 @@ class addParticles2Checkpoint:
         self.has_probeE = False
         self.has_probeB = False
         self.has_id = False
-        
+
         # extract data type for position
         self.dtype_position = self.f.iterations[self.timestep].particles[self.speciesName]["position"]["x"].dtype
 
@@ -225,7 +226,7 @@ class addParticles2Checkpoint:
             macro particle weighting
         """
         self.N_particles_input = len(w) # number of particles to add
-        
+
         # calculate positionOffset (cell location) from given position
         self.positionOffset = vec3D((pos.x / self.cellSize.x).astype(self.dtype_positionOffset),
                                     (pos.y / self.cellSize.y).astype(self.dtype_positionOffset),
@@ -240,12 +241,12 @@ class addParticles2Checkpoint:
         self.momentum = vec3D((mom.x * w / self.unitMomentum).astype(self.dtype_momentum),
                               (mom.y * w / self.unitMomentum).astype(self.dtype_momentum),
                               (mom.z * w / self.unitMomentum).astype(self.dtype_momentum))
-        
+
         if self.has_probeE:
             # data for witnessed E-Field
             temp_zeros = np.zeros(len(w), dtype=self.dtype_probeE)
             self.probeE = vec3D(temp_zeros, temp_zeros, temp_zeros)
-        
+
         if self.has_probeB:
             # data for witnessed B-Field
             temp_zeros = np.zeros(len(w), dtype=self.dtype_probeB)
@@ -253,7 +254,7 @@ class addParticles2Checkpoint:
 
         # copy weighting
         self.weighting = w.copy().astype(self.dtype_weighting)
-        
+
         if self.has_id:
             # give every particle an ID
             self.id = np.arange(len(w), dtype=self.dtype_id)
@@ -314,13 +315,13 @@ class Chunk:
     def __init__(self, offset, extent):
         """
         Inititalization of the slicing class.
-        
+
         Arguments:
         offset: array
                 offsets of each slice
         extent: array
                 extent of each slice
-        
+
         """
         assert (len(offset) == len(extent))
         self.offset = offset
@@ -335,7 +336,7 @@ class Chunk:
         """
         Slice this chunk into a hypercube along the dimension with 
         the largest extent on this hypercube.
-        
+
         Return:
         the 0'th of the sliced chunks.
         """
@@ -447,7 +448,7 @@ class pipe:
                                   self.outconfig)
         print("Opened input and output")
         sys.stdout.flush()
-        
+
         self.__copy(inseries, outseries)
         print("Finished!")
 
@@ -457,7 +458,7 @@ class pipe:
         Copies data from src to dest. May represent any point in the openPMD
         hierarchy, but src and dest must both represent the same layer.
         Writes own data for given particle.
-        
+
         Arguments:
         src: openPMD layer
                 layer of a openPMD series to copy from
@@ -472,15 +473,15 @@ class pipe:
                 and not isinstance(dest, io.Iteration)):
             raise RuntimeError(
                 "Internal error: Trying to copy mismatching types")
-        
+
         # copy attributes of current layer
         self.copy_attributes(src, dest)
-        
+
         container_types = [
             io.Mesh_Container, io.Particle_Container, io.ParticleSpecies,
             io.Record, io.Mesh, io.Particle_Patches, io.Patch_Record
         ]
-        
+
         if isinstance(src, io.Series):
             # main loop: read iterations of src, write to dest
             write_iterations = dest.write_iterations()
@@ -513,11 +514,11 @@ class pipe:
                 in_iteration.close()
                 for patch_load in self.__particle_patches:
                     patch_load.run()
-                
+
                 # overwrite copied shape attribute of mass and charge to match particle count
                 out_iteration.particles[self.particles.speciesName]["mass"].set_attribute("shape", np.uint64(self.particles.N_particles))
                 out_iteration.particles[self.particles.speciesName]["charge"].set_attribute("shape", np.uint64(self.particles.N_particles))
-    
+
                 out_iteration.close()
                 self.__particle_patches.clear()
                 self.loads.clear()
@@ -647,7 +648,7 @@ class pipe:
     def copy_attributes(self, src, dest, iterate=False):
         """
         Copies attributes from src to dest. Optionally iterates over them.
-        
+
         Arguments:
         src: openPMD layer
                 layer of a openPMD series to copy attributes from
@@ -679,25 +680,24 @@ class pipe:
             for key in src:
                 self.copy_attributes(src[key], dest[key], iterate=True)
 
-                
+
     def write(self, src, dest, data):
         """
         Writes new data to given record component in dest with data types from src.
-        
+
         Arguments:
         src: openPMD layer
                 layer of a openPMD series to copy datatypes from
         dest: openPMD layer
                 layer of a openPMD series to copy new data to
         data: array of data which is written to dest.
-                
         """
         shape = (self.particles.N_particles,)
         dtype = src.dtype
-        
+
         dest.reset_dataset(io.Dataset(dtype, shape))
         # write particle data for each patch
         for i in range(self.particles.N_gpus.prod()):
-            dest.store_chunk(array = data[self.particles.patch_mask[i, :]], 
-                             offset=[self.particles.numParticlesOffset[i]], 
+            dest.store_chunk(array=data[self.particles.patch_mask[i, :]],
+                             offset=[self.particles.numParticlesOffset[i]],
                              extent=(self.particles.numParticles[i],))

--- a/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
+++ b/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
@@ -4,9 +4,7 @@ This file is a modified version of the pipe script from the openPMD-api.
 Authors: Richard Pausch, Franz Poeschel, Nico Wrobel
 License: LGPLv3+
 """
-#import argparse
-#import os  # os.path.basename
-import sys  # sys.stderr.write
+import sys
 
 import openpmd_api as io
 import numpy as np
@@ -134,13 +132,15 @@ class addParticles2Checkpoint:
         ext_z = tmp_handle["z"].load()
 
         # get number of particles before each patch
-        tmp_numOff = self.f.iterations[self.timestep].\
-            particles[self.speciesName].particle_patches["numParticlesOffset"]\
-            [io.Mesh_Record_Component.SCALAR].load()
+        tmp_numOff = (
+            self.f.iterations[self.timestep].particles[self.speciesName].
+            particle_patches["numParticlesOffset"]
+            [io.Mesh_Record_Component.SCALAR].load())
         # get number of particles in each patch
-        tmp_num = self.f.iterations[self.timestep].\
-            particles[self.speciesName].particle_patches["numParticles"]\
-            [io.Mesh_Record_Component.SCALAR].load()
+        tmp_num = (
+            self.f.iterations[self.timestep].particles[self.speciesName]
+            .particle_patches["numParticles"]
+            [io.Mesh_Record_Component.SCALAR].load())
 
         # flush all loads before calculations
         self.f.flush()
@@ -187,45 +187,52 @@ class addParticles2Checkpoint:
         self.has_id = False
 
         # extract data type for position
-        self.dtype_position = self.f.iterations[self.timestep].\
-            particles[self.speciesName]["position"]["x"].dtype
+        self.dtype_position = (
+            self.f.iterations[self.timestep].
+            particles[self.speciesName]["position"]["x"].dtype)
 
         # extract data type for positionOffset
-        self.dtype_positionOffset = self.f.iterations[self.timestep].\
-            particles[self.speciesName]["positionOffset"]["x"].dtype
+        self.dtype_positionOffset = (
+            self.f.iterations[self.timestep].
+            particles[self.speciesName]["positionOffset"]["x"].dtype)
 
         # extract data type for momentum
-        self.dtype_momentum = self.f.iterations[self.timestep].\
-            particles[self.speciesName]["momentum"]["x"].dtype
+        self.dtype_momentum = (
+            self.f.iterations[self.timestep].
+            particles[self.speciesName]["momentum"]["x"].dtype)
 
         if "probeE" in self.f.iterations[self.timestep].\
                 particles[self.speciesName]:
             self.has_probeE = True
             # type of E-Field
-            self.dtype_probeE = self.f.iterations[self.timestep].\
-                particles[self.speciesName]["probeE"]["x"].dtype
+            self.dtype_probeE = (
+                self.f.iterations[self.timestep].
+                particles[self.speciesName]["probeE"]["x"].dtype)
         self.print("contains probeE = {}".format(self.has_probeE))
 
         if "probeB" in self.f.iterations[self.timestep].\
                 particles[self.speciesName]:
             self.has_probeB = True
             # type of B-Field
-            self.dtype_probeB = self.f.iterations[self.timestep].\
-                particles[self.speciesName]["probeB"]["x"].dtype
+            self.dtype_probeB = (
+                self.f.iterations[self.timestep].
+                particles[self.speciesName]["probeB"]["x"].dtype)
         self.print("contains probeB {}".format(self.has_probeB))
 
         # extract data type for weighting
-        self.dtype_weighting = self.f.iterations[self.timestep].\
-            particles[self.speciesName]["weighting"]\
-            [io.Mesh_Record_Component.SCALAR].dtype
+        self.dtype_weighting = (
+            self.f.iterations[self.timestep].
+            particles[self.speciesName]["weighting"]
+            [io.Mesh_Record_Component.SCALAR].dtype)
 
         if "id" in self.f.iterations[self.timestep].\
                 particles[self.speciesName]:
             self.has_id = True
             # type of particleID
-            self.dtype_id = self.f.iterations[self.timestep].\
-                particles[self.speciesName]["id"]\
-                [io.Mesh_Record_Component.SCALAR].dtype
+            self.dtype_id = (
+                self.f.iterations[self.timestep].
+                particles[self.speciesName]["id"]
+                [io.Mesh_Record_Component.SCALAR].dtype)
         self.print("contains id =  {}".format(self.has_id))
 
         del self.f  # close checkpoint file
@@ -354,7 +361,6 @@ class Chunk:
         self.offset = offset
         self.extent = extent
 
-
     def __len__(self):
         return len(self.offset)
 
@@ -406,7 +412,6 @@ class particle_patch_load:
         self.data = data
         self.dest = dest
 
-
     def run(self):
         for index, item in enumerate(self.data):
             self.dest.store(index, item)
@@ -421,7 +426,7 @@ class pipe:
         """
         helper function that prints information depending on the set
         verbose level
-        
+
         Arguments:
         string: string
                 message to post
@@ -674,24 +679,24 @@ class pipe:
 
                     # write own particle patches
                     self.print("\twriting patches")
-                    temp_src = src[self.particles.speciesName].\
-                        particle_patches["numParticles"]\
-                        [io.Mesh_Record_Component.SCALAR]
-                    temp_dest = dest[self.particles.speciesName].\
-                        particle_patches["numParticles"]\
-                        [io.Mesh_Record_Component.SCALAR]
+                    temp_src = (src[self.particles.speciesName].
+                                particle_patches["numParticles"]
+                                [io.Mesh_Record_Component.SCALAR])
+                    temp_dest = (dest[self.particles.speciesName].
+                                 particle_patches["numParticles"]
+                                 [io.Mesh_Record_Component.SCALAR])
 
                     temp_dest.reset_dataset(io.Dataset(temp_src.dtype,
                                                        temp_src.shape))
                     self.__particle_patches.append(particle_patch_load(
                         self.particles.numParticles, temp_dest))
 
-                    temp_src = src[self.particles.speciesName].\
-                        particle_patches["numParticlesOffset"]\
-                        [io.Mesh_Record_Component.SCALAR]
-                    temp_dest = dest[self.particles.speciesName].\
-                        particle_patches["numParticlesOffset"]\
-                        [io.Mesh_Record_Component.SCALAR]
+                    temp_src = (src[self.particles.speciesName].
+                                particle_patches["numParticlesOffset"]
+                                [io.Mesh_Record_Component.SCALAR])
+                    temp_dest = (dest[self.particles.speciesName].
+                                 particle_patches["numParticlesOffset"]
+                                 [io.Mesh_Record_Component.SCALAR])
 
                     temp_dest.reset_dataset(io.Dataset(temp_src.dtype,
                                                        temp_src.shape))

--- a/lib/python/picongpu/extra/input/createBunch_example.ipynb
+++ b/lib/python/picongpu/extra/input/createBunch_example.ipynb
@@ -13,10 +13,12 @@
    "source": [
     "## Intro\n",
     "\n",
-    "This notebook allows you to define a PWFA driver bunch using numpy.\n",
+    "This notebook allows you to define a simple PWFA driver bunch using numpy.\n",
     "Each step will be explained on the way.\n",
-    "In the end, you will add your particles (of the driver bunch) to an empty **openPMD-api** checkpoint in **HDF5** format.\n",
-    "Since rewriting the entire code would have taken too long (before you start Nico), you have to stick to **HDF5** for now. "
+    "In the end, the particles (of the driver bunch) will be added to an empty **openPMD-api** checkpoint in **bp** format.\n",
+    "This serves as an example on how to use the checkpoint edit tool.\n",
+    "\n",
+    "**!!! The copying of checkpoints is not optimised and takes up a lot of memory (Roughly the size of the empty checkpoint itself). At least 8 CPUs with 20 GB memory each should be used to run this notebook !!!**"
    ]
   },
   {
@@ -34,11 +36,7 @@
    "source": [
     "# standard modules\n",
     "import numpy as np\n",
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
-    "from matplotlib.colors import LogNorm\n",
     "from scipy import constants\n",
-    "import h5py\n",
     "\n",
     "import sys"
    ]
@@ -49,8 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# own modules\n",
-    "sys.path.append(\"./modules4picongpu/\")\n",
+    "# own modules from script\n",
     "\n",
     "from bunchInit_openPMD_bp import vec3D\n",
     "from bunchInit_openPMD_bp import addParticles2Checkpoint"
@@ -97,14 +94,14 @@
     "# compute relevant quantities\n",
     "\n",
     "# number of macro particles:\n",
-    "N = Q / constants.elementary_charge / mean_weight\n",
+    "N = int(Q / constants.elementary_charge / mean_weight)\n",
     "\n",
     "# convert rms to std of radius\n",
     "sigma_LWFA_exit = radius_LWFA_exit_rms / np.sqrt(2)\n",
     "\n",
     "# monte carlo: transversal position\n",
-    "x = np.random.normal(scale=sigma_LWFA_exit, size=int(N))\n",
-    "z = np.random.normal(scale=sigma_LWFA_exit, size=int(N))\n",
+    "x = np.random.normal(scale=sigma_LWFA_exit, size=N)\n",
+    "z = np.random.normal(scale=sigma_LWFA_exit, size=N)\n",
     "\n",
     "# constant conversion_factor, equals 2*sqrt(2*ln(2))\n",
     "const_FWHM_to_sigma = 2.35482004503\n",
@@ -113,15 +110,15 @@
     "sigma_y = tau_FWHM * constants.c / const_FWHM_to_sigma\n",
     "\n",
     "# monte-carlo longitudinal distribution\n",
-    "y = np.random.normal(scale=sigma_y, size=int(N))\n",
+    "y = np.random.normal(scale=sigma_y, size=N)\n",
     "\n",
     "# monte-carlo energy distribution\n",
-    "E_kin = np.random.normal(loc=E_kin_mean, scale=E_kin_FWHM/const_FWHM_to_sigma, size=int(N))\n",
+    "E_kin = np.random.normal(loc=E_kin_mean, scale=E_kin_FWHM/const_FWHM_to_sigma, size=N)\n",
     "\n",
     "# monte-carlo azimutal angle\n",
-    "theta = np.random.normal(loc=0.0, scale=theta_sigma*np.sqrt(2), size=int(N))\n",
+    "theta = np.random.normal(loc=0.0, scale=theta_sigma*np.sqrt(2), size=N)\n",
     "# monte-carlo polar angle (uniform distribution)\n",
-    "phi = np.random.uniform(low=-np.pi, high=+np.pi, size=int(N))\n",
+    "phi = np.random.uniform(low=-np.pi, high=+np.pi, size=N)\n",
     "\n",
     "# convert kinetic energy to absolute momentum\n",
     "convert_Ekin_to_momentum = (E_kin*constants.elementary_charge)/constants.c * mean_weight\n",
@@ -155,9 +152,7 @@
    "outputs": [],
    "source": [
     "# set parameters\n",
-    "# TODO: should be extracted from the checkpoint directly in the future\n",
-    "delta_t = 1.706e-16 / 1.28631 # [s]\n",
-    "delta_x = 0.5 * 0.1772e-6 # [m]\n",
+    "delta_x = 0.1772e-6 # [m]\n",
     "delta_y = delta_x # [m] \n",
     "delta_z = delta_x # [m]"
    ]
@@ -169,9 +164,7 @@
    "outputs": [],
    "source": [
     "# set distribution to GPUs\n",
-    "cells = (1024, 2048, 1024)\n",
-    "GPUs = (2, 8, 2)\n",
-    "print(\"total number of GPUs:\", np.product(GPUs))"
+    "cells = (512, 1024, 512)"
    ]
   },
   {
@@ -180,8 +173,10 @@
     "tags": []
    },
    "source": [
-    "## place particles inside simulation box\n",
-    "So far, we used a simple coordinate system. Now, we have to decide were to place the center (mean position) of the bunch inside our simulation box. "
+    "### place particles inside simulation box\n",
+    "So far, we used a simple coordinate system. Now, we have to decide were to place the center (mean position) of the bunch inside our simulation box. \n",
+    "\n",
+    "(TODO: should be done by the tool itself)\n"
    ]
   },
   {
@@ -202,11 +197,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# just a variable rename\n",
-    "N_particles = int(N)\n",
-    "\n",
     "# make weighting an array (all macro-particle have the same weighting)\n",
-    "weighting = np.ones(N_particles) * mean_weight\n",
+    "weighting = np.ones(N) * mean_weight\n",
     "\n",
     "# shift particles to new center position\n",
     "x_PIConGPU = x + center_pos_x\n",
@@ -220,7 +212,7 @@
     "tags": []
    },
    "source": [
-    "## convert data and write to checkpoint"
+    "### convert data and write to checkpoint"
    ]
   },
   {
@@ -230,7 +222,7 @@
    "outputs": [],
    "source": [
     "# convert data to 3d vector object\n",
-    "pos = vec3D(x_PIConGPU,y_PIConGPU,z_PIConGPU)\n",
+    "pos = vec3D(x_PIConGPU, y_PIConGPU, z_PIConGPU)\n",
     "mom = vec3D(px/mean_weight, py/mean_weight, pz/mean_weight)"
    ]
   },
@@ -240,12 +232,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# assigne to (existing) checkpoint file (needs to be hdf5 file)\n",
-    "checkPoint_b = addParticles2Checkpoint(\"/bigdata/hplsim/production/wrobel45/PWFA-bunch-slice/001_empty_slice/simOutput/checkpoints/checkpoint_%T.bp\", \n",
-    "                                       \"/bigdata/hplsim/production/wrobel45/PWFA-bunch-energy/103_particles_energy/simOutput/checkpoint_%06T.bp\",\n",
-    "                                       speciesName=\"b\")\n",
+    "# assigne to (existing) checkpoint file\n",
+    "# replace with your own paths and species name (from speciesDefinition.param of the input simulation)\n",
+    "checkPoint_b = addParticles2Checkpoint(\"/bigdata/hplsim/production/wrobel45/PWFA-bunch-script_test/001_empty_test/simOutput/checkpoints/checkpoint_%T.bp\", \n",
+    "                                       \"/bigdata/hplsim/production/wrobel45/PWFA-bunch-script_test/002_bunch_test/simOutput/checkpoints/checkpoint_%06T.bp\",\n",
+    "                                       speciesName=\"b\", verbose=False)\n",
     "\n",
-    "# this will throw an error if particles are already in the checkpoint - make sure you use an empty checkpoint"
+    "# this will throw an error if particles of speciesName are already in the checkpoint - make sure you use an empty checkpoint"
    ]
   },
   {

--- a/lib/python/picongpu/extra/input/createBunch_example.ipynb
+++ b/lib/python/picongpu/extra/input/createBunch_example.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define a PWFA driver bunch and add it to a PIConGPU simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Intro\n",
+    "\n",
+    "This notebook allows you to define a PWFA driver bunch using numpy.\n",
+    "Each step will be explained on the way.\n",
+    "In the end, you will add your particles (of the driver bunch) to an empty **openPMD-api** checkpoint in **HDF5** format.\n",
+    "Since rewriting the entire code would have taken too long (before you start Nico), you have to stick to **HDF5** for now. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## load modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# standard modules\n",
+    "import numpy as np\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LogNorm\n",
+    "from scipy import constants\n",
+    "import h5py\n",
+    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# own modules\n",
+    "sys.path.append(\"./modules4picongpu/\")\n",
+    "\n",
+    "from bunchInit_openPMD_bp import vec3D\n",
+    "from bunchInit_openPMD_bp import addParticles2Checkpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate a electron bunch at a known location\n",
+    "For our L|PWFA setups, we usually assume that the driver bunch of the 2nd stage/PWFA stage - which originate as witness bunch from the first stage/LWFA stage - is Gaussian/uncorrelated when exiting the LWFA stage and thus easy to define."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### define bunch parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set these values\n",
+    "\n",
+    "Q = 400e-12 # define total charge of driver in [C]\n",
+    "radius_LWFA_exit_rms = 1.0e-6 * 10.0 # rms radius of bunch in [m]\n",
+    "tau_FWHM = 20.0e-15 # FWHM duration of bunch in [s]\n",
+    "E_kin_mean = 250.0e6 # mean energy in [eV]\n",
+    "E_kin_FWHM = 10.0e6 # energy spread in [eV]\n",
+    "theta_sigma = 1.6e-3 # standard deviation of divergence in [rad]\n",
+    "mean_weight = 50000 # define a constant weight for all macro-particles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute relevant quantities\n",
+    "\n",
+    "# number of macro particles:\n",
+    "N = Q / constants.elementary_charge / mean_weight\n",
+    "\n",
+    "# convert rms to std of radius\n",
+    "sigma_LWFA_exit = radius_LWFA_exit_rms / np.sqrt(2)\n",
+    "\n",
+    "# monte carlo: transversal position\n",
+    "x = np.random.normal(scale=sigma_LWFA_exit, size=int(N))\n",
+    "z = np.random.normal(scale=sigma_LWFA_exit, size=int(N))\n",
+    "\n",
+    "# constant conversion_factor, equals 2*sqrt(2*ln(2))\n",
+    "const_FWHM_to_sigma = 2.35482004503\n",
+    "\n",
+    "# convert FWHM to std of duration\n",
+    "sigma_y = tau_FWHM * constants.c / const_FWHM_to_sigma\n",
+    "\n",
+    "# monte-carlo longitudinal distribution\n",
+    "y = np.random.normal(scale=sigma_y, size=int(N))\n",
+    "\n",
+    "# monte-carlo energy distribution\n",
+    "E_kin = np.random.normal(loc=E_kin_mean, scale=E_kin_FWHM/const_FWHM_to_sigma, size=int(N))\n",
+    "\n",
+    "# monte-carlo azimutal angle\n",
+    "theta = np.random.normal(loc=0.0, scale=theta_sigma*np.sqrt(2), size=int(N))\n",
+    "# monte-carlo polar angle (uniform distribution)\n",
+    "phi = np.random.uniform(low=-np.pi, high=+np.pi, size=int(N))\n",
+    "\n",
+    "# convert kinetic energy to absolute momentum\n",
+    "convert_Ekin_to_momentum = (E_kin*constants.elementary_charge)/constants.c * mean_weight\n",
+    "# distribute to direction\n",
+    "px = np.sin(phi) * np.sin(theta) * convert_Ekin_to_momentum\n",
+    "py = 1.0 * np.cos(theta) * convert_Ekin_to_momentum\n",
+    "pz = np.cos(phi) * np.sin(theta) * convert_Ekin_to_momentum\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting particles into the PIC code\n",
+    "\n",
+    "In this section, we will prepare the particle distribution to go into the empty checkpoint of PIConGPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parameters from the actual simulation\n",
+    "Get the resolution of the PIConGPU simulation. These parameters can be found in `include/picongpu/param/grid.param` and the `*.cfg` file you are using."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set parameters\n",
+    "# TODO: should be extracted from the checkpoint directly in the future\n",
+    "delta_t = 1.706e-16 / 1.28631 # [s]\n",
+    "delta_x = 0.5 * 0.1772e-6 # [m]\n",
+    "delta_y = delta_x # [m] \n",
+    "delta_z = delta_x # [m]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set distribution to GPUs\n",
+    "cells = (1024, 2048, 1024)\n",
+    "GPUs = (2, 8, 2)\n",
+    "print(\"total number of GPUs:\", np.product(GPUs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## place particles inside simulation box\n",
+    "So far, we used a simple coordinate system. Now, we have to decide were to place the center (mean position) of the bunch inside our simulation box. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define center position\n",
+    "center_pos_x = delta_x * cells[0]/2.\n",
+    "center_pos_y = delta_y * cells[1] * 2.4/4.\n",
+    "center_pos_z = delta_z * cells[2]/2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# just a variable rename\n",
+    "N_particles = int(N)\n",
+    "\n",
+    "# make weighting an array (all macro-particle have the same weighting)\n",
+    "weighting = np.ones(N_particles) * mean_weight\n",
+    "\n",
+    "# shift particles to new center position\n",
+    "x_PIConGPU = x + center_pos_x\n",
+    "y_PIConGPU = y - np.mean(y) + center_pos_y \n",
+    "z_PIConGPU = z + center_pos_z"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## convert data and write to checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert data to 3d vector object\n",
+    "pos = vec3D(x_PIConGPU,y_PIConGPU,z_PIConGPU)\n",
+    "mom = vec3D(px/mean_weight, py/mean_weight, pz/mean_weight)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assigne to (existing) checkpoint file (needs to be hdf5 file)\n",
+    "checkPoint_b = addParticles2Checkpoint(\"/bigdata/hplsim/production/wrobel45/PWFA-bunch-slice/001_empty_slice/simOutput/checkpoints/checkpoint_%T.bp\", \n",
+    "                                       \"/bigdata/hplsim/production/wrobel45/PWFA-bunch-energy/103_particles_energy/simOutput/checkpoint_%06T.bp\",\n",
+    "                                       speciesName=\"b\")\n",
+    "\n",
+    "# this will throw an error if particles are already in the checkpoint - make sure you use an empty checkpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write data to file\n",
+    "checkPoint_b.addParticles(pos, mom, weighting)\n",
+    "checkPoint_b.writeParticles()\n",
+    "\n",
+    "# delete data we wrote\n",
+    "del(checkPoint_b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
The python script can be used to copy checkpoints and add particles to the copy. 
The added Jupyter Notebook shows, how this could be used to add a driver into an empty checkpoint.
A lot of code from the [pipe script](https://github.com/openPMD/openPMD-api/blob/dev/src/binding/python/openpmd_api/pipe/__main__.py) from the openPMD-api was used, therfore Franz Poeschel is credited.
Tests for the current dev and, if needed, hdf5 checkpoints are pending.

Supported data for particle species inputs are arrays with the position, momentum and weighting of the particles.
probeE, probeB and id data is supported for the new particles.
Currently only overwriting checkpoint 0 is supported and only if there aren't already particles of the given species.