### PR TITLE
Rename Gaussian laser profile and pulse length parameter

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -79,14 +79,14 @@ namespace picongpu
                      */
                     static constexpr float_64 AMPLITUDE_SI = 1.0e6;
 
-                    /** Pulse length: sigma of std. gauss for intensity (E^2)
-                     *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                    /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                     *  PULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
                      *                                          [    2.354820045     ]
                      *  Info:             FWHM_of_Intensity = FWHM_Illumination
-                     *                      = what a experimentalist calls "pulse duration"
+                     *                      = what an experimentalist calls "pulse duration"
                      *  unit: seconds (1 sigma)
                      */
-                    static constexpr float_64 PULSE_LENGTH_SI = 10.615e-15 / 4.0;
+                    static constexpr float_64 PULSE_DURATION_SI = 10.615e-15 / 4.0;
 
                     /** Laser phase shift (no shift: 0.0)
                      *

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.hpp
@@ -71,12 +71,12 @@ namespace picongpu
                          */
                         static constexpr float_X AMPLITUDE = static_cast<float_X>(Params::AMPLITUDE_SI / UNIT_EFIELD);
 
-                        /** Pulse length
+                        /** Pulse duration
                          *
                          * unit: UNIT_TIME
                          */
-                        static constexpr float_X PULSE_LENGTH
-                            = static_cast<float_X>(Params::PULSE_LENGTH_SI / UNIT_TIME);
+                        static constexpr float_X PULSE_DURATION
+                            = static_cast<float_X>(Params::PULSE_DURATION_SI / UNIT_TIME);
 
                         // Some utility that is not part of public interface
                     private:

--- a/include/picongpu/fields/incidentField/profiles/DispersivePulse.def
+++ b/include/picongpu/fields/incidentField/profiles/DispersivePulse.def
@@ -33,7 +33,7 @@ namespace picongpu
             {
                 namespace defaults
                 {
-                    struct DispersiveLaserParam : public BaseParam
+                    struct DispersivePulseParam : public BaseParam
                     {
                         /** Beam waist: distance from the axis where the pulse intensity (E^2)
                          *              decreases to its 1/e^2-th part,
@@ -45,7 +45,7 @@ namespace picongpu
                          */
                         static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
                          * WATCH OUT! Dispersion parameters may lead to pulse lenghtening
                          * Please ensure to choose a value high enough to cover the whole pulse,
                          * otherwise the Fourier Transformation will misbehave.
@@ -93,14 +93,14 @@ namespace picongpu
                     };
                 } // namespace defaults
 
-                /** Dispersive laser profile with finite pulse length tag
+                /** Dispersive laser profile with finite pulse duration tag
                  *
                  * @tparam T_Params class parameter to configure the dispersive laser profile,
-                 *                  see members of defaults::DispersiveLaserParam
+                 *                  see members of defaults::DispersivePulseParam
                  *                  for required members
                  */
-                template<typename T_Params = defaults::DispersiveLaserParam>
-                struct DispersiveLaser;
+                template<typename T_Params = defaults::DispersivePulseParam>
+                struct DispersivePulse;
             } // namespace profiles
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -76,7 +76,7 @@ namespace picongpu
                         static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
                         static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
 
-                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before
+                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
                          * plateau and half at the end of the plateau
                          *
                          * unit: none
@@ -119,7 +119,7 @@ namespace picongpu
                  * The time of the prepulse and the three preramp points are given in
                  * SI, the intensities are given as multiples of the peak intensity.
                  *
-                 * @tparam T_Params class parameter to configure the beam profile,
+                 * @tparam T_Params class parameter to configure the pulse profile,
                  *                  see members of defaults::ExpRampWithPrepulseParam
                  *                  for required members.
                  *                  The focus position should be at or near the generation surface as the

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -78,14 +78,14 @@ namespace picongpu
                         static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
 
                         static constexpr float_X INIT_TIME = static_cast<float_X>(
-                            (TIME_PEAKPULSE + Params::RAMP_INIT * Base::PULSE_LENGTH) / UNIT_TIME);
+                            (TIME_PEAKPULSE + Params::RAMP_INIT * Base::PULSE_DURATION) / UNIT_TIME);
 
                         // compile-time checks for physical sanity:
                         static_assert(
                             (TIME_1 < TIME_2) && (TIME_2 < TIME_3) && (TIME_3 < endUpramp),
                             "The times in the parameters TIME_POINT_1/2/3 and the beginning of the plateau (which is "
                             "at "
-                            "TIME_PEAKPULSE - 0.5*RAMP_INIT*PULSE_LENGTH) should be in ascending order");
+                            "TIME_PEAKPULSE - 0.5*RAMP_INIT*PULSE_DURATION) should be in ascending order");
 
                         // some prerequisites for check of intensities (approximate check, because I can't use exp and
                         // log)
@@ -124,12 +124,12 @@ namespace picongpu
                             "anymore - probably some of the parameters are different from what you think!?");
 
                         /* a symmetric pulse will be initialized at generation plane for
-                         * a time of RAMP_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+                         * a time of RAMP_INIT * PULSE_DURATION + LASER_NOFOCUS_CONSTANT = INIT_TIME.
                          * we shift the complete pulse for the half of this time to start with
                          * the front of the laser pulse.
                          */
                         static constexpr float_X time_start_init
-                            = static_cast<float_X>(TIME_1 - (0.5_X * Params::RAMP_INIT * Base::PULSE_LENGTH));
+                            = static_cast<float_X>(TIME_1 - (0.5_X * Params::RAMP_INIT * Base::PULSE_DURATION));
                     };
 
                     /** Exponential ramp with prepulse incident E functor
@@ -252,7 +252,7 @@ namespace picongpu
                          */
                         HDINLINE float_X gauss(float_X const t) const
                         {
-                            auto const exponent = t / Unitless::PULSE_LENGTH;
+                            auto const exponent = t / Unitless::PULSE_DURATION;
                             return math::exp(-0.25_X * exponent * exponent);
                         }
 

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -33,7 +33,7 @@ namespace picongpu
             {
                 namespace defaults
                 {
-                    namespace gaussianBeam
+                    namespace gaussianPulse
                     {
                         //! Use only the 0th Laguerremode for a standard Gaussian
                         static constexpr uint32_t MODENUMBER = 0;
@@ -46,9 +46,9 @@ namespace picongpu
                         // -0.00896321, -0.0160788); PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES,
                         // 0.0, 1.0344594, -0.9384701, -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303,
                         // -0.8039839, 3.0055385, -0.1503778, -9.6980362, -2.8122287);
-                    } // namespace gaussianBeam
+                    } // namespace gaussianPulse
 
-                    struct GaussianBeamParam : public BaseParam
+                    struct GaussianPulseParam : public BaseParam
                     {
                         /** Beam waist: distance from the axis where the pulse intensity (E^2)
                          *              decreases to its 1/e^2-th part,
@@ -60,7 +60,7 @@ namespace picongpu
                          */
                         static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
                          *
                          *  unit: none
                          */
@@ -70,21 +70,21 @@ namespace picongpu
                          *
                          * @{
                          */
-                        using LAGUERREMODES_t = gaussianBeam::LAGUERREMODES_t;
-                        using LAGUERREPHASES_t = gaussianBeam::LAGUERREPHASES_t;
-                        static constexpr uint32_t MODENUMBER = gaussianBeam::MODENUMBER;
+                        using LAGUERREMODES_t = gaussianPulse::LAGUERREMODES_t;
+                        using LAGUERREPHASES_t = gaussianPulse::LAGUERREPHASES_t;
+                        static constexpr uint32_t MODENUMBER = gaussianPulse::MODENUMBER;
                         /** @} */
                     };
                 } // namespace defaults
 
-                /** Gaussian Beam laser profile with finite pulse length tag
+                /** GaussianPulse laser profile with finite pulse duration tag
                  *
-                 * @tparam T_Params class parameter to configure the Gaussian Beam profile,
-                 *                  see members of defaults::GaussianBeamParam
+                 * @tparam T_Params class parameter to configure the GaussianPulse profile,
+                 *                  see members of defaults::GaussianPulseParam
                  *                  for required members
                  */
-                template<typename T_Params = defaults::GaussianBeamParam>
-                struct GaussianBeam;
+                template<typename T_Params = defaults::GaussianPulseParam>
+                struct GaussianPulse;
             } // namespace profiles
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.def
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.def
@@ -39,8 +39,8 @@ namespace picongpu
                          *  unit: seconds */
                         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
-                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and
-                         * after the plateau unit: none */
+                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_DURATION before
+                         * and after the plateau unit: none */
                         static constexpr float_64 RAMP_INIT = 20.6146;
                     };
                 } // namespace defaults

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
@@ -66,7 +66,7 @@ namespace picongpu
                             = static_cast<float_X>(Params::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME);
                         // unit: UNIT_TIME
                         static constexpr float_X INIT_TIME = static_cast<float_X>(
-                            (Params::RAMP_INIT * Params::PULSE_LENGTH_SI + Params::LASER_NOFOCUS_CONSTANT_SI)
+                            (Params::RAMP_INIT * Params::PULSE_DURATION_SI + Params::LASER_NOFOCUS_CONSTANT_SI)
                             / UNIT_TIME);
                     };
 
@@ -118,8 +118,8 @@ namespace picongpu
                         HDINLINE float_X getLongitudinal(float_X const time, float_X const phaseShift) const
                         {
                             auto envelope = Unitless::AMPLITUDE;
-                            auto const mue = 0.5_X * Unitless::RAMP_INIT * Unitless::PULSE_LENGTH;
-                            auto const tau = Unitless::PULSE_LENGTH * math::sqrt(2.0_X);
+                            auto const mue = 0.5_X * Unitless::RAMP_INIT * Unitless::PULSE_DURATION;
+                            auto const tau = Unitless::PULSE_DURATION * math::sqrt(2.0_X);
                             auto const endUpramp = mue;
                             auto const startDownramp = mue + Unitless::LASER_NOFOCUS_CONSTANT;
                             auto integrationCorrectionFactor = 0.0_X;

--- a/include/picongpu/fields/incidentField/profiles/Polynom.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Polynom.hpp
@@ -62,7 +62,8 @@ namespace picongpu
                         using Base = BaseTransversalGaussianParamUnitless<T_Params>;
 
                         // unit: UNIT_TIME
-                        static constexpr float_X INIT_TIME = static_cast<float_X>(Params::PULSE_LENGTH_SI / UNIT_TIME);
+                        static constexpr float_X INIT_TIME
+                            = static_cast<float_X>(Params::PULSE_DURATION_SI / UNIT_TIME);
                     };
 
                     /** Polynom incident E functor
@@ -116,7 +117,7 @@ namespace picongpu
                              * the laser amplitude rises  for riseTime and falls for riseTime
                              * making the laser pulse 2*riseTime long
                              */
-                            const float_X riseTime = 0.5_X * Unitless::PULSE_LENGTH;
+                            const float_X riseTime = 0.5_X * Unitless::PULSE_DURATION;
                             const float_X tau = time / riseTime;
                             auto const phase = Unitless::w * (time - riseTime) + Unitless::LASER_PHASE + phaseShift;
                             auto const amplitude = Unitless::AMPLITUDE * polynomial(tau);

--- a/include/picongpu/fields/incidentField/profiles/PulseFrontTilt.def
+++ b/include/picongpu/fields/incidentField/profiles/PulseFrontTilt.def
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "picongpu/fields/incidentField/profiles/GaussianBeam.def"
+#include "picongpu/fields/incidentField/profiles/GaussianPulse.def"
 
 
 namespace picongpu
@@ -33,8 +33,8 @@ namespace picongpu
             {
                 namespace defaults
                 {
-                    // All parameters are same as for GaussianBeam, plus one extra parameter
-                    struct PulseFrontTiltParam : public GaussianBeamParam
+                    // All parameters are same as for GaussianPulse, plus one extra parameter
+                    struct PulseFrontTiltParam : public GaussianPulseParam
                     {
                         /** The tilt angles from laser propagation direction
                          *
@@ -55,14 +55,14 @@ namespace picongpu
                     };
                 } // namespace defaults
 
-                /** Gaussian Beam laser profile with titled pulse front tag
+                /** GaussianPulse laser profile with titled pulse front tag
                  *
-                 * @tparam T_Params class parameter to configure the Gaussian Beam with tilted front profile,
+                 * @tparam T_Params class parameter to configure the GaussianPulse with tilted front profile,
                  *                  see members of defaults::PulseFrontTiltParam
                  *                  for required members
                  */
                 template<typename T_Params = defaults::PulseFrontTiltParam>
-                using PulseFrontTilt = GaussianBeam<T_Params>;
+                using PulseFrontTilt = GaussianPulse<T_Params>;
             } // namespace profiles
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.def
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.def
@@ -54,7 +54,7 @@ namespace picongpu
                         static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
                         static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
                          *
                          *  unit: none
                          */

--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.hpp
@@ -68,7 +68,7 @@ namespace picongpu
 
                         // unit: UNIT_TIME
                         static constexpr float_X INIT_TIME
-                            = Params::PULSE_INIT * Base::PULSE_LENGTH + LASER_NOFOCUS_CONSTANT;
+                            = Params::PULSE_INIT * Base::PULSE_DURATION + LASER_NOFOCUS_CONSTANT;
                         // unit: UNIT_TIME
                         static constexpr float_X endUpramp = -0.5_X * LASER_NOFOCUS_CONSTANT;
                         // unit: UNIT_TIME
@@ -123,19 +123,19 @@ namespace picongpu
                         HDINLINE float_X getLongitudinal(float_X const time, float_X const phaseShift) const
                         {
                             // a symmetric pulse will be initialized at generation position
-                            // a time of PULSE_INIT * PULSE_LENGTH + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+                            // a time of PULSE_INIT * PULSE_DURATION + LASER_NOFOCUS_CONSTANT = INIT_TIME.
                             // we shift the complete pulse for the half of this time to start with
                             // the front of the laser pulse.
                             auto const mue = 0.5_X * Unitless::INIT_TIME;
                             auto const runTime = static_cast<float_X>(time) - mue;
-                            auto const tau = Unitless::PULSE_LENGTH * math::sqrt(2.0_X);
+                            auto const tau = Unitless::PULSE_DURATION * math::sqrt(2.0_X);
                             auto envelope = Unitless::AMPLITUDE;
                             auto correctionFactor = 0.0_X;
                             if(runTime > Unitless::startDownramp)
                             {
                                 // downramp = end
                                 auto const exponent
-                                    = ((runTime - Unitless::startDownramp) / Unitless::PULSE_LENGTH
+                                    = ((runTime - Unitless::startDownramp) / Unitless::PULSE_DURATION
                                        / math::sqrt(2.0_X));
                                 envelope *= math::exp(-0.5_X * exponent * exponent);
                                 correctionFactor = (runTime - Unitless::startDownramp) / (tau * tau * Unitless::w);
@@ -144,7 +144,7 @@ namespace picongpu
                             {
                                 // upramp = start
                                 auto const exponent
-                                    = ((runTime - Unitless::endUpramp) / Unitless::PULSE_LENGTH / math::sqrt(2.0_X));
+                                    = ((runTime - Unitless::endUpramp) / Unitless::PULSE_DURATION / math::sqrt(2.0_X));
                                 envelope *= math::exp(-0.5_X * exponent * exponent);
                                 correctionFactor = (runTime - Unitless::endUpramp) / (tau * tau * Unitless::w);
                             }

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -19,10 +19,10 @@
 
 #pragma once
 
-#include "picongpu/fields/incidentField/profiles/DispersiveLaser.def"
+#include "picongpu/fields/incidentField/profiles/DispersivePulse.def"
 #include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def"
 #include "picongpu/fields/incidentField/profiles/Free.def"
-#include "picongpu/fields/incidentField/profiles/GaussianBeam.def"
+#include "picongpu/fields/incidentField/profiles/GaussianPulse.def"
 #include "picongpu/fields/incidentField/profiles/None.def"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
 #include "picongpu/fields/incidentField/profiles/Polynom.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -19,10 +19,10 @@
 
 #pragma once
 
-#include "picongpu/fields/incidentField/profiles/DispersiveLaser.hpp"
+#include "picongpu/fields/incidentField/profiles/DispersivePulse.hpp"
 #include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp"
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
-#include "picongpu/fields/incidentField/profiles/GaussianBeam.hpp"
+#include "picongpu/fields/incidentField/profiles/GaussianPulse.hpp"
 #include "picongpu/fields/incidentField/profiles/None.hpp"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.hpp"
 #include "picongpu/fields/incidentField/profiles/Polynom.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -39,7 +39,7 @@ class GaussianLaser(RenderedObject):
     waist = util.build_typesafe_property(float)
     """beam waist in m"""
     duration = util.build_typesafe_property(float)
-    """length in s (1 sigma)"""
+    """duration in s (1 sigma)"""
     focus_pos = util.build_typesafe_property(typing.List[float])
     """focus position vector in m"""
     phase = util.build_typesafe_property(float)
@@ -77,7 +77,7 @@ class GaussianLaser(RenderedObject):
         return {
             "wave_length_si": self.wavelength,
             "waist_si": self.waist,
-            "pulse_length_si": self.duration,
+            "pulse_duration_si": self.duration,
             "focus_pos_si": list(map(lambda x: {"component": x},
                                      self.focus_pos)),
             "phase": self.phase,

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -47,7 +47,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::Free<AnotherUserFunctorIncidentE, AnotherUserFunctorIncidentB>;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode

--- a/share/picongpu/examples/Bunch/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse  with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode
@@ -86,7 +86,7 @@ namespace picongpu
                 static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI
                     = 50.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and
+                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_DURATION before and
                  * after the plateau unit: none */
                 static constexpr float_64 RAMP_INIT = 20.6146;
 
@@ -101,14 +101,14 @@ namespace picongpu
                 /** unit: Volt / meter */
                 static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
-                /** Pulse length: sigma of std. gauss for intensity (E^2)
-                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                 *  PULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
                  *                                          [    2.354820045     ]
                  *  Info:             FWHM_of_Intensity = FWHM_Illumination
                  *                      = what a experimentalist calls "pulse duration"
                  *  unit: seconds (1 sigma)
                  */
-                static constexpr float_64 PULSE_LENGTH_SI = 2.65e-15;
+                static constexpr float_64 PULSE_DURATION_SI = 2.65e-15;
 
                 /** Laser phase shift (no shift: 0.0)
                  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode
@@ -89,7 +89,7 @@ namespace picongpu
                  *  unit: seconds */
                 static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0;
 
-                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_LENGTH before and
+                /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_DURATION before and
                  * after the plateau unit: none */
                 static constexpr float_64 RAMP_INIT = 3. * 2.354820045;
 
@@ -104,14 +104,14 @@ namespace picongpu
                 /** unit: Volt / meter */
                 static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
-                /** Pulse length: sigma of std. gauss for intensity (E^2)
-                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                 *  PULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
                  *                                          [    2.354820045     ]
                  *  Info:             FWHM_of_Intensity = FWHM_Illumination
                  *                      = what a experimentalist calls "pulse duration"
                  *  unit: seconds (1 sigma)
                  */
-                static constexpr float_64 PULSE_LENGTH_SI = 25.0e-15 / 2.354820045;
+                static constexpr float_64 PULSE_DURATION_SI = 25.0e-15 / 2.354820045;
 
                 /** Laser phase shift (no shift: 0.0)
                  *
@@ -246,15 +246,15 @@ namespace picongpu
 
                 //***** Overwritten settings from plane wave params *****
 
-                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_LENGTH before
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
                  * plateau and half at the end of the plateau
                  *
                  * unit: none
                  */
                 static constexpr float_64 RAMP_INIT = 16.0;
 
-                /** Pulse length: sigma of std. gauss for intensity (E^2)
-                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                 *  PULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
                  *                                          [    2.354820045     ]
                  *  Info:             FWHM_of_Intensity = FWHM_Illumination
                  *                      = what a experimentalist calls "pulse duration"
@@ -263,7 +263,7 @@ namespace picongpu
                  *  @attention half of the time in which E falls to half its initial value (then I falls to half its
                  *             value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
                  */
-                static constexpr float_64 PULSE_LENGTH_SI = 3.0e-14 / 2.35482;
+                static constexpr float_64 PULSE_DURATION_SI = 3.0e-14 / 2.35482;
             };
 
             using ExpRampWithPrepulseBeam = profiles::ExpRampWithPrepulse<ExpRampWithPrepulseParam>;

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode

--- a/share/picongpu/examples/LaserWakefield/README.rst
+++ b/share/picongpu/examples/LaserWakefield/README.rst
@@ -5,12 +5,12 @@ LaserWakefield: Laser Electron Acceleration
 .. moduleauthor:: Axel Huebl <a.huebl (at) hzdr.de>, René Widera, Heiko Burau, Richard Pausch, Marco Garten
 
 Setup for a laser-driven electron accelerator [TajimaDawson]_ in the blowout regime of an underdense plasma [Modena]_ [PukhovMeyerterVehn]_.
-A short (fs) laser beam with ultra-high intensity (a_0 >> 1), modeled as a finite Gaussian beam is focussed in a hydrogen gas target.
+A short (fs) laser pulse with ultra-high intensity (a_0 >> 1), modeled as a finite Gaussian pulse is focussed in a hydrogen gas target.
 The target is assumed to be pre-ionized with negligible temperature.
 The relevant area of interaction is followed by a co-moving window, in whose time span the movement of ions is considered irrelevant which allows us to exclude those from our setup.
 
 This is a demonstration setup to get a visible result quickly and test available methods and I/O.
-The plasma gradients are unphysically high, the resolution of the laser wavelength is seriously bad, the laser parameters (e.g. pulse length, focusing) are challening to achieve technically and interaction region is too close to the boundaries of the simulation box.
+The plasma gradients are unphysically high, the resolution of the laser wavelength is seriously bad, the laser parameters (e.g. pulse duration, focusing) are challenging to achieve technically and interaction region is too close to the boundaries of the simulation box.
 Nevertheless, this setup will run on a single GPU in full 3D in a few minutes, so just enjoy running it and interact with our plugins!
 
 

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>        : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode
@@ -70,8 +70,8 @@
 #    define PARAM_WAVE_LENGTH_SI 0.8e-6
 #endif
 
-#ifndef PARAM_PULSE_LENGTH_SI
-#    define PARAM_PULSE_LENGTH_SI 5.e-15
+#ifndef PARAM_PULSE_DURATION_SI
+#    define PARAM_PULSE_DURATION_SI 5.e-15
 #endif
 
 namespace picongpu
@@ -85,7 +85,7 @@ namespace picongpu
              * The particular used parameter structures do not have to inherit this, but must define same members
              * with same meaning.
              */
-            struct LwfaGaussianBeamBaseParams
+            struct LwfaGaussianPulseBaseParams
             {
                 /** Wave length along propagation direction
                  *
@@ -110,14 +110,14 @@ namespace picongpu
                  */
                 static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
 
-                /** Pulse length: sigma of std. gauss for intensity (E^2)
-                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                 *  PULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
                  *                                          [    2.354820045     ]
                  *  Info:             FWHM_of_Intensity = FWHM_Illumination
                  *                      = what a experimentalist calls "pulse duration"
                  *  unit: seconds (1 sigma)
                  */
-                static constexpr float_64 PULSE_LENGTH_SI = PARAM_PULSE_LENGTH_SI;
+                static constexpr float_64 PULSE_DURATION_SI = PARAM_PULSE_DURATION_SI;
 
                 /** Laser phase shift (no shift: 0.0)
                  *
@@ -207,21 +207,21 @@ namespace picongpu
                 /** @} */
             };
 
-            namespace lwfaGaussianBeam
+            namespace lwfaGaussianPulse
             {
                 //! Use only the 0th Laguerremode for a standard Gaussian
                 static constexpr uint32_t MODENUMBER = 0;
                 PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
                 PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
-            } // namespace lwfaGaussianBeam
+            } // namespace lwfaGaussianPulse
 
             /** Special structure for parameters of Gaussian laser pulses.
              *
-             * Inherits from LwfaGaussianBeamBaseParams in order to combine all Gaussian pulse parameters.
+             * Inherits from LwfaGaussianPulseBaseParams in order to combine all Gaussian pulse parameters.
              */
-            struct GaussianBeamParam : public LwfaGaussianBeamBaseParams
+            struct GaussianPulseParam : public LwfaGaussianPulseBaseParams
             {
-                /** Beam waist: distance from the axis where the pulse intensity (E^2)
+                /** Beam waist distance from the axis where the pulse intensity (E^2)
                  *              decreases to its 1/e^2-th part,
                  *              at the focus position of the laser
                  * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
@@ -231,7 +231,7 @@ namespace picongpu
                  */
                 static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
-                /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+                /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
                  *
                  *  unit: none
                  */
@@ -241,9 +241,9 @@ namespace picongpu
                  *
                  * @{
                  */
-                using LAGUERREMODES_t = lwfaGaussianBeam::LAGUERREMODES_t;
-                using LAGUERREPHASES_t = lwfaGaussianBeam::LAGUERREPHASES_t;
-                static constexpr uint32_t MODENUMBER = lwfaGaussianBeam::MODENUMBER;
+                using LAGUERREMODES_t = lwfaGaussianPulse::LAGUERREMODES_t;
+                using LAGUERREPHASES_t = lwfaGaussianPulse::LAGUERREPHASES_t;
+                static constexpr uint32_t MODENUMBER = lwfaGaussianPulse::MODENUMBER;
                 /** @} */
             };
 
@@ -251,7 +251,7 @@ namespace picongpu
             //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
             using XMin = profiles::None;
             using XMax = profiles::None;
-            using YMin = profiles::GaussianBeam<GaussianBeamParam>;
+            using YMin = profiles::GaussianPulse<GaussianPulseParam>;
             using YMax = profiles::None;
             using ZMin = profiles::None;
             using ZMax = profiles::None;

--- a/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
+++ b/share/picongpu/examples/LaserWakefield/lib/python/picongpu/params.py
@@ -32,7 +32,7 @@ PARAMETERS = {
             default=800.0, range=(400.0, 1400.0)),
 
         Parameter(
-            name="Pulse_Length_SI", ptype="compile", unit="fs",
+            name="Pulse_Duration_SI", ptype="compile", unit="fs",
             default=5.0, range=(1.0, 150.0)),
     ],
     'target': [

--- a/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
@@ -13,7 +13,7 @@
             "description": "Waist of the Gaussian pulse at focus [m]",
             "exclusiveMinimum": 0
         },
-        "pulse_length_si": {
+        "pulse_duration_si": {
             "type": "number",
             "description": "sigma of std. gauss for intensity (E^2) [s]",
             "exclusiveMinimum": 0
@@ -44,7 +44,7 @@
             "exclusiveMinimum": 0
         },
         "pulse_init": {
-            "description": " The laser pulse will be initialized pulse_init times of the pulse_length_si",
+            "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
             "type": "number",
             "exclusiveMinimum": 0
         },
@@ -95,7 +95,7 @@
                     "single_laguerre_mode": {
                         "type": "number"
                     }
-                }   
+                }
             }
         },
         "laguerre_phases": {
@@ -146,7 +146,7 @@
     "required": [
         "wave_length_si",
         "waist_si",
-        "pulse_length_si",
+        "pulse_duration_si",
         "focus_pos_si",
         "phase",
         "E0_si",

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode
@@ -74,7 +74,7 @@ namespace picongpu::fields::incidentField
     {
         static constexpr float_64 WAVE_LENGTH_SI = {{{wave_length_si}}}; // m
         static constexpr float_64 AMPLITUDE_SI = {{{E0_si}}}; // V/m
-        static constexpr float_64 PULSE_LENGTH_SI = {{{pulse_length_si}}}; // s (1 sigma)
+        static constexpr float_64 PULSE_DURATION_SI = {{{pulse_duration_si}}}; // s (1 sigma)
         static constexpr float_X LASER_PHASE = {{{phase}}}; // unitless
 
         static constexpr float_64 propagation_direction[3u] = {
@@ -107,11 +107,11 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
     };
 
-    namespace PyPIConGPUGaussianBeam
+    namespace PyPIConGPUGaussianPulse
     {
                 //! Use only the 0th Laguerremode for a standard Gaussian
                 static constexpr uint32_t MODENUMBER = {{{modenumber}}};
-                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 
+                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES,
                 {{#laguerre_modes}}
                 {{{single_laguerre_mode}}}{{^_last}},{{/_last}}
                 {{/laguerre_modes}}
@@ -121,9 +121,9 @@ namespace picongpu::fields::incidentField
                 {{{single_laguerre_phase}}}{{^_last}},{{/_last}}
                 {{/laguerre_phases}}
                 );
-    } // namespace PyPIConGPUGaussianBeam
+    } // namespace PyPIConGPUGaussianPulse
 
-    struct PyPIConGPUGaussianBeamParam : public PyPIConGPULaserBaseParam
+    struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
     {
         /** Beam waist: distance from the axis where the pulse intensity (E^2)
          *              decreases to its 1/e^2-th part,
@@ -135,7 +135,7 @@ namespace picongpu::fields::incidentField
          */
         static constexpr float_64 W0_SI = {{{waist_si}}};
 
-        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_LENGTH
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
          *
          *  unit: none
          */
@@ -145,9 +145,9 @@ namespace picongpu::fields::incidentField
          *
          * @{
          */
-        using LAGUERREMODES_t = PyPIConGPUGaussianBeam::LAGUERREMODES_t;
-        using LAGUERREPHASES_t = PyPIConGPUGaussianBeam::LAGUERREPHASES_t;
-        static constexpr uint32_t MODENUMBER = PyPIConGPUGaussianBeam::MODENUMBER;
+        using LAGUERREMODES_t = PyPIConGPUGaussianPulse::LAGUERREMODES_t;
+        using LAGUERREPHASES_t = PyPIConGPUGaussianPulse::LAGUERREPHASES_t;
+        static constexpr uint32_t MODENUMBER = PyPIConGPUGaussianPulse::MODENUMBER;
         /** @} */
     };
 
@@ -186,7 +186,7 @@ namespace picongpu::fields::incidentField
 
     /**@{*/
     //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
-    using YMin = profiles::GaussianBeam<PyPIConGPUGaussianBeamParam>;
+    using YMin = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>;
     {{/laser}}
     {{^laser}}
     // no laser defined case

--- a/share/picongpu/tests/compileLaser/include/picongpu/param/incidentField.param
+++ b/share/picongpu/tests/compileLaser/include/picongpu/param/incidentField.param
@@ -22,16 +22,16 @@
  * Configure incident field profile and offset of the Huygens surface for each boundary.
  *
  * Available profiles:
- *  - profiles::DispersiveLaser<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianBeam<>        : Gaussian beam with given parameters
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
  *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
  * parameters
- *  - profiles::PulseFrontTilt<>      : Gaussian beam with tilted pulse front with given parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
  *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
  * parameters
  *
@@ -52,7 +52,7 @@
  * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
  * using YMax = profiles::None;
  * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianBeam<UserGaussianBeamParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
  *
  * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
  * @endcode
@@ -61,18 +61,6 @@
 #pragma once
 
 #include "picongpu/fields/incidentField/profiles/profiles.def"
-
-#ifndef PARAM_A0
-#    define PARAM_A0 8.0
-#endif
-
-#ifndef PARAM_WAVE_LENGTH_SI
-#    define PARAM_WAVE_LENGTH_SI 0.8e-6
-#endif
-
-#ifndef PARAM_PULSE_LENGTH_SI
-#    define PARAM_PULSE_LENGTH_SI 5.e-15
-#endif
 
 namespace picongpu
 {
@@ -96,10 +84,10 @@ namespace picongpu
             };
 
             using AllLaserProfiles = MakeSeq_t<
-                profiles::DispersiveLaser<>,
+                profiles::DispersivePulse<>,
                 profiles::ExpRampWithPrepulse<>,
                 profiles::Free<ZeroField, ZeroField>,
-                profiles::GaussianBeam<>,
+                profiles::GaussianPulse<>,
                 profiles::PlaneWave<>,
                 profiles::Polynom<>,
                 profiles::PulseFrontTilt<>,

--- a/test/python/picongpu/quick/pypicongpu/laser.py
+++ b/test/python/picongpu/quick/pypicongpu/laser.py
@@ -157,7 +157,7 @@ class TestGaussianLaser(unittest.TestCase):
         context = self.laser.get_rendering_context()
         self.assertEqual(context["wave_length_si"], self.laser.wavelength)
         self.assertEqual(context["waist_si"], self.laser.waist)
-        self.assertEqual(context["pulse_length_si"], self.laser.duration)
+        self.assertEqual(context["pulse_duration_si"], self.laser.duration)
         self.assertEqual(context["focus_pos_si"], [
             {"component": self.laser.focus_pos[0]},
             {"component": self.laser.focus_pos[1]},


### PR DESCRIPTION
In order to express the physical properties of simulation variables/names more precise, this PR suggests a renaming of `PULSE_LENGTH` -> `PULSE_DURATION` and `GaussianBeam` -> `GaussianPulse`, with updated info strings for the respective quantities `incidentField.param`