### PR TITLE
fix Gaussian Beam focus

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianBeam.hpp
@@ -216,11 +216,8 @@ namespace picongpu
                                 return 0.0_X;
 
                             // calculate focus position relative to the current point in the propagation direction
-                            auto const focusRelativeToOrigin = float3_X(
-                                                                   Unitless::FOCUS_POSITION_X,
-                                                                   Unitless::FOCUS_POSITION_Y,
-                                                                   Unitless::FOCUS_POSITION_Z)
-                                - this->origin;
+                            auto const focusRelativeToOrigin = this->focus - this->origin;
+
                             float_X const focusPos = math::sqrt(pmacc::math::l2norm2(focusRelativeToOrigin)) - pos[0];
                             // beam waist at the generation plane so that at focus we will get W0
                             float_X const w = Unitless::W0


### PR DESCRIPTION
With #4507 we introduced a possible relative focal definition. The implementation of the Gaussian beam hardcoded using `FOCUS_POSITION_*` instead of using the pre-computed focus position from the base class therefore the relative focus position was not taken into account.

- use precomputed focus position from the base class