### PR TITLE
fix dispersive laser z-polarization 

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
+++ b/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Fabia Dietrich, Klaus Steiniger
+/* Copyright 2022 Fabia Dietrich, Klaus Steiniger, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -173,20 +173,21 @@ namespace picongpu
                                 -(Omega - Unitless::w) * (Omega - Unitless::w) * Unitless::PULSE_LENGTH
                                 * Unitless::PULSE_LENGTH);
 
+                            // transversal envelope
+                            mag *= math::exp(
+                                -(pos[1] - center) * (pos[1] - center) / waist / waist); // envelope y - direction
+                            mag *= math::exp(
+                                -(pos[2] - center) * (pos[2] - center) / waist / waist); // envelope z - direction
+
                             // distinguish between dimensions
                             if constexpr(simDim == DIM2)
                             {
                                 // pos has just two entries: pos[0] as propagation direction and pos[1] as transversal
                                 // direction
-                                mag *= math::exp(-(pos[1] - center) * (pos[1] - center) / waist / waist);
                                 mag *= math::sqrt(Unitless::W0 / waist);
                             }
                             else if constexpr(simDim == DIM3)
                             {
-                                mag *= math::exp(
-                                    -(pos[1] - center) * (pos[1] - center) / waist / waist); // envelope y - direction
-                                mag *= math::exp(
-                                    -(pos[2] - center) * (pos[2] - center) / waist / waist); // envelope z - direction
                                 mag *= Unitless::W0 / waist;
                             }
 

--- a/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
+++ b/include/picongpu/fields/incidentField/profiles/DispersiveLaser.hpp
@@ -234,21 +234,18 @@ namespace picongpu
                                     * (Omega - Unitless::w)
                                 + phaseShift + Unitless::LASER_PHASE + Omega * timeDelay;
 
+                            phase += ((pos[1] - center) * (pos[1] - center) + (pos[2] - center) * (pos[2] - center))
+                                * Omega * 0.5_X * R_inv / SPEED_OF_LIGHT;
+                            phase -= alpha * (pos[1] + pos[2]) / Unitless::W0;
+
                             // distinguish between dimensions
                             if constexpr(simDim == DIM2)
                             {
-                                phase
-                                    += (pos[1] - center) * (pos[1] - center) * Omega * 0.5_X * R_inv / SPEED_OF_LIGHT;
-                                phase -= alpha * pos[1] / Unitless::W0;
                                 phase += alpha * alpha / 4.0_X * focusPos / Unitless::R;
                                 phase -= 0.5_X * xi;
                             }
                             else if constexpr(simDim == DIM3)
                             {
-                                phase
-                                    += ((pos[1] - center) * (pos[1] - center) + (pos[2] - center) * (pos[2] - center))
-                                    * Omega * 0.5_X * R_inv / SPEED_OF_LIGHT;
-                                phase -= alpha * (pos[1] + pos[2]) / Unitless::W0;
                                 phase += alpha * alpha / 2.0_X * focusPos / Unitless::R;
                                 phase -= xi;
                             }


### PR DESCRIPTION
This pull request fixes the bug #4533 

`dev` x - polarization $E_x$: 
<img width="478" alt="grafik" src="https://user-images.githubusercontent.com/5121158/233069576-a1fe4e8a-f89f-4198-860a-26219990873c.png">

`pull request` z - polarization (fixed) $E_z$: 
<img width="478" alt="grafik" src="https://user-images.githubusercontent.com/5121158/233069806-70880b34-85d1-45b8-a0c7-3f903cf6419f.png">

`dev` z - polarization (wrong) $E_z$: 
<img width="478" alt="grafik" src="https://user-images.githubusercontent.com/5121158/233069702-793beda6-8870-4833-8d9d-8dfcc2e8054e.png">

There seems to be still no curvature in the "fixed" laser - and thus no correct focusing. 