### PR TITLE
fix particle creation

### DIFF
--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -115,7 +115,7 @@ namespace picongpu
                     auto particleCreatorCtx = lockstep::makeVar<T_ParticleCreator>(forEachParticle);
 
                     forEachParticle(
-                        [&](uint32_t const idx, auto& particleCreator)
+                        [&](uint32_t const idx, auto& destParticleCreator)
                         {
                             // cell index within the superCell
                             DataSpace<simDim> const cellIdx
@@ -125,10 +125,10 @@ namespace picongpu
                             pmacc::math::Int<simDim> const localCellIndex = simDomainSupercellCellOffset + cellIdx;
 
                             // create a copy of the functor for each virtual worker
-                            particleCreator = particleCreator;
+                            destParticleCreator = particleCreator;
 
                             // init particle creator functor for each virtual worker
-                            particleCreator.init(worker, supercellCellOffset, localCellIndex);
+                            destParticleCreator.init(worker, supercellCellOffset, localCellIndex);
                         },
                         particleCreatorCtx);
 


### PR DESCRIPTION
fix #4528

With #4460 we introduced a bug in the particle creation used by ionization.
The bug is a result of variable name shadowing :-(