### PR TITLE
better on device out of memory handling

### DIFF
--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -33,6 +33,8 @@
 #include "pmacc/particles/memory/dataTypes/FramePointer.hpp"
 #include "pmacc/particles/memory/dataTypes/SuperCell.hpp"
 
+#include <pmacc/verify.hpp>
+
 namespace pmacc
 {
     /**
@@ -109,17 +111,9 @@ namespace pmacc
                     alpaka::mem_fence(worker.getAcc(), alpaka::memory_scope::Block{});
                     break;
                 }
-                else
-                {
-#ifndef BOOST_COMP_HIP
-                    printf(
-                        "%s: mallocMC out of memory (try %i of %i)\n",
-                        (numTries + 1) == maxTries ? "ERROR" : "WARNING",
-                        numTries + 1,
-                        maxTries);
-#endif
-                }
             }
+
+            PMACC_DEVICE_VERIFY_MSG(tmp != nullptr, "Error: Out of device heap memory in %s:%u\n", __FILE__, __LINE__);
 
             return FramePtr(tmp);
         }


### PR DESCRIPTION
- add function `PMACC_DEVICE_VERIFY_MSG()`
- use `PMACC_DEVICE_VERIFY_MSG` to provide a error message in cases where we run out of device heap memory

In many where we run out if heap memory we do not stop the execution and the contained `printf` error message was not shown on the host side.

example:
```
Error: Out of device heap memory in picongpu/include/picongpu/../pmacc/particles/memory/boxes/ParticlesBox.hpp:116
Error: Out of device heap memory in picongpu/include/picongpu/../pmacc/particles/memory/boxes/ParticlesBox.hpp:116
Error: Out of device heap memory in picongpu/include/picongpu/../pmacc/particles/memory/boxes/ParticlesBox.hpp:116
/home/rwidera/workspace/picongpu/thirdParty/cupla/alpaka/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp(324) 'TApi::hostFree(ptr)' returned error  : 'cudaErrorLaunchFailure': 'unspecified launch failure'!
terminate called after throwing an instance of 'std::runtime_error'
  what():  picongpu/thirdParty/cupla/alpaka/include/alpaka/event/EventUniformCudaHipRt.hpp(148) 'ret = TApi::eventQuery(event.getNativeHandle())' returned error  : 'cudaErrorLaunchFailure': 'unspecified launch failure'!
Aborted (core dumped)
```