### PR TITLE
Make fwkt_v100.tpl and respective profile casus compatible

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -48,7 +48,7 @@
 
 ## calculations will be performed by tbg ##
 .TBG_queue=${TBG_partition:-"fwkt_v100"}
-.TBG_account=`if [ $TBG_partition == "casus_low" ] ; then echo "low"; else echo "fwkt_v100"; fi`
+.TBG_account=`if [ $TBG_partition == "casus_low" ] ; then echo "low"; else echo ${TBG_partition:-"fwkt_v100"}; fi`
 # configure if the output file should be appended or overwritten
 .TBG_keepOutputFileOpen=`if [ $TBG_partition == "casus_low" ] ; then echo "SBATCH --open-mode=append"; fi`
 

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -70,7 +70,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=378000 -p fwkt_v100 -A fwkt_v100 --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=378000 -p $TBG_partition -A $TBG_partition --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -86,7 +86,7 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p fwkt_v100 -A fwkt_v100 --pty bash
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition -A $TBG_partition --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
In order to achieve compatibility to casus queues by just changing `TBG_partition` to `casus` in `fwkt_v100_picongpu.profile`.