### PR TITLE
Documentation: link Romio HDF5 chunking issue

### DIFF
--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -296,7 +296,11 @@ The key 'select' must point to either a single string or an array of strings.)EN
 
     void addDefaults(nlohmann::json& config)
     {
-        // disable HDF5 chunking as it can conflict with MPI-IO backends
+        /*
+         * Disable HDF5 chunking as it can conflict with MPI-IO backends.
+         * This is very likely the same issue as
+         * https://github.com/open-mpi/ompi/issues/7795.
+         */
         {
             auto& hdf5Dataset = config["hdf5"]["dataset"];
             if(!hdf5Dataset.contains("chunks"))


### PR DESCRIPTION
In the openPMD plugin, we specify `{"hdf5":{"dataset":{"chunking":"none"}}}` by default. This seems to also affect #4456.
It looks like this is caused by https://github.com/open-mpi/ompi/issues/7795 (likely to be fixed with Openmpi 5). Put this in the documentation, so we find it again.