### PR TITLE
remove using `ompio`

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -205,8 +205,6 @@ If you want to use chunking, you can ask for it via the following option passed 
     }
   }
 
-In that case, make sure not to use an MPI IO backend that conflicts with HDF5 chunking, e.g. by removing lines such as ``export OMPI_MCA_io=^ompio`` from your batch scripts.
-
 Performance tuning on Summit
 """"""""""""""""""""""""""""
 

--- a/etc/picongpu/aris-grnet/gpu.tpl
+++ b/etc/picongpu/aris-grnet/gpu.tpl
@@ -92,11 +92,6 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/bash-devServer-hzdr/mpiexec.tpl
+++ b/etc/picongpu/bash-devServer-hzdr/mpiexec.tpl
@@ -44,11 +44,6 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   mpiexec -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh

--- a/etc/picongpu/bash/mpiexec.tpl
+++ b/etc/picongpu/bash/mpiexec.tpl
@@ -44,11 +44,6 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   mpiexec -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh

--- a/etc/picongpu/bash/mpirun.tpl
+++ b/etc/picongpu/bash/mpirun.tpl
@@ -44,11 +44,6 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   mpirun -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh

--- a/etc/picongpu/davide-cineca/gpu.tpl
+++ b/etc/picongpu/davide-cineca/gpu.tpl
@@ -94,11 +94,6 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/davinci-rice/picongpu.tpl
+++ b/etc/picongpu/davinci-rice/picongpu.tpl
@@ -72,11 +72,6 @@ unset MODULES_NO_OUTPUT
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   mpirun -n TBG_tasks --display-map -am tbg/openib.conf --mca mpi_leave_pinned 0 !TBG_dstPath/input/bin/cuda_memtest.sh

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -98,11 +98,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 if [ $? -eq 0 ] ; then
   # Run PIConGPU
   source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \

--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -100,11 +100,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -98,11 +98,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -100,11 +100,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/hemera-hzdr/k20_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k20_restart.tpl
@@ -161,11 +161,6 @@ echo "--- end automated restart routine ---"
 #wait that all nodes see ouput folder
 sleep 1
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh

--- a/etc/picongpu/hemera-hzdr/k80.tpl
+++ b/etc/picongpu/hemera-hzdr/k80.tpl
@@ -100,11 +100,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/hemera-hzdr/k80_restart.tpl
+++ b/etc/picongpu/hemera-hzdr/k80_restart.tpl
@@ -162,11 +162,6 @@ echo "--- end automated restart routine ---"
 #wait that all nodes see ouput folder
 sleep 1
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available and we have the node exclusive
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
   mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh

--- a/etc/picongpu/taurus-tud/A100.tpl
+++ b/etc/picongpu/taurus-tud/A100.tpl
@@ -97,11 +97,6 @@ ln -s ../stdout output
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/taurus-tud/A100_restart.tpl
+++ b/etc/picongpu/taurus-tud/A100_restart.tpl
@@ -109,9 +109,6 @@ cd simOutput
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
-# Use ROMIO for IO
-# according to ComputationalRadiationPhysics/picongpu#2857
-export OMPI_MCA_io=^ompio
 
 sleep 1
 

--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -97,11 +97,6 @@ ln -s ../stdout output
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   # Run CUDA memtest to check GPU's health

--- a/etc/picongpu/taurus-tud/V100_restart.tpl
+++ b/etc/picongpu/taurus-tud/V100_restart.tpl
@@ -109,9 +109,6 @@ cd simOutput
 #   support ticket [Ticket:2014052241001186] srun: mpi mca flags
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
-# Use ROMIO for IO
-# according to ComputationalRadiationPhysics/picongpu#2857
-export OMPI_MCA_io=^ompio
 
 sleep 1
 

--- a/etc/picongpu/taurus-tud/k80.tpl
+++ b/etc/picongpu/taurus-tud/k80.tpl
@@ -87,11 +87,6 @@ ln -s ../stdout output
 #   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
 export OMPI_MCA_mpi_leave_pinned=0
 
-# The OMPIO backend in OpenMPI up to 3.1.3 and 4.0.0 is broken, use the
-# fallback ROMIO backend instead.
-#   see bug https://github.com/open-mpi/ompi/issues/6285
-export OMPI_MCA_io=^ompio
-
 # test if cuda_memtest binary is available
 if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
   # Run CUDA memtest to check GPU's health


### PR DESCRIPTION
`ompio` was disabled in the past because of an bug in OpenMPI. This bug is solved and current OpenMPI versions should not be effected anymore by this problem, see https://github.com/open-mpi/ompi/issues/6285#issuecomment-474392527