### PR TITLE
add picongpu call validation to tbg

### DIFF
--- a/bin/tbg
+++ b/bin/tbg
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2022 Axel Huebl, Rene Widera, Richard Pausch
+# Copyright 2013-2023 Axel Huebl, Rene Widera, Richard Pausch, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -497,8 +497,13 @@ cp -a "$TBG_cfgFile" tbg/submit.cfg
 #warn, if there are still unresolved !TBG_ variables left
 check_final tbg/submit.start "$tooltpl_file_data"
 
-if [ -n "$submit_command" ] ; then
-    $submit_command tbg/submit.start
-else
-    echo "nothing to submit (-s option set?)"
+# verify picongpu call
+bash tbg/submit.start --validate
+
+if [ $? -eq 0 ] ; then
+  if [ -n "$submit_command" ] ; then
+      $submit_command tbg/submit.start
+  else
+      echo "nothing to submit (-s option set?)"
+  fi
 fi

--- a/etc/picongpu/bash/mpiexec.tpl
+++ b/etc/picongpu/bash/mpiexec.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2023 Axel Huebl, Anton Helm, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -18,6 +18,36 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+help()
+{
+  echo "PIConGPU submit script generated with tbg"
+  echo ""
+  echo "usage: $0 [--verify]"
+  echo ""
+  echo "--validate      - validate picongpu call instead of running the simulation"
+  echo "--h | --help    - print this help message"
+}
+
+VALIDATE_MODE=false
+for arg in "$@"; do
+  case $arg in
+  --validate)
+    VALIDATE_MODE=true
+    shift # Remove --skip-verification from `$@`
+    ;;
+  -h | --help)
+    echo -e "$(help)"
+    shift
+    exit 0
+    ;;
+  *)
+    echo "unrecognized argument"
+    echo -e "$(help)"
+    exit 1
+    ;;
+  esac
+done
+
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
@@ -30,7 +60,7 @@
 ## end calculations ##
 
 
-echo 'Running program...'
+echo "Preparing environment..."
 
 cd !TBG_dstPath
 
@@ -44,13 +74,22 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
-  mpiexec -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+if [[ $VALIDATE_MODE == true ]]; then
+  echo "Validating PIConGPU call..."
+  !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams --validate
+  if [ $? -ne 0 ] ; then
+    exit 1;
+  fi
 else
-  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
-fi
+  # test if cuda_memtest binary is available
+  if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+    mpiexec -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+  else
+    echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
+  fi
 
-if [ $? -eq 0 ] ; then
-  mpiexec -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  if [ $? -eq 0 ] ; then
+    echo "Running PIConGPU..."
+    mpiexec -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  fi
 fi

--- a/etc/picongpu/bash/mpirun.tpl
+++ b/etc/picongpu/bash/mpirun.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2022 Axel Huebl, Anton Helm, Rene Widera
+# Copyright 2013-2023 Axel Huebl, Anton Helm, Rene Widera, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -18,6 +18,36 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
+help()
+{
+  echo "PIConGPU submit script generated with tbg"
+  echo ""
+  echo "usage: $0 [--verify]"
+  echo ""
+  echo "--validate      - validate picongpu call instead of running the simulation"
+  echo "--h | --help    - print this help message"
+}
+
+VALIDATE_MODE=false
+for arg in "$@"; do
+  case $arg in
+  --validate)
+    VALIDATE_MODE=true
+    shift # Remove --skip-verification from `$@`
+    ;;
+  -h | --help)
+    echo -e "$(help)"
+    shift
+    exit 0
+    ;;
+  *)
+    echo "unrecognized argument"
+    echo -e "$(help)"
+    exit 1
+    ;;
+  esac
+done
+
 ##calculations will be performed by tbg##
 
 # settings that can be controlled by environment variables before submit
@@ -30,7 +60,7 @@
 ## end calculations ##
 
 
-echo 'Running program...'
+echo "Preparing environment..."
 
 cd !TBG_dstPath
 
@@ -44,13 +74,22 @@ umask 0027
 mkdir simOutput 2> /dev/null
 cd simOutput
 
-# test if cuda_memtest binary is available
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
-  mpirun -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+if [[ $VALIDATE_MODE == true ]]; then
+  echo "Validating PIConGPU call..."
+  !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams --validate
+  if [ $? -ne 0 ] ; then
+    exit 1;
+  fi
 else
-  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
-fi
+  # test if cuda_memtest binary is available
+  if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+    mpirun -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+  else
+    echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
+  fi
 
-if [ $? -eq 0 ] ; then
-  mpirun -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  if [ $? -eq 0 ] ; then
+    echo "Running PIConGPU..."
+    mpirun -am !TBG_dstPath/tbg/openib.conf --mca mpi_leave_pinned 0 -npernode !TBG_gpusPerNode -n !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams | tee output
+  fi
 fi

--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera,
-#                     Marco Garten, Alexander Debus
+# Copyright 2013-2023 Axel Huebl, Richard Pausch, Rene Widera,
+#                     Marco Garten, Alexander Debus, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -45,6 +45,35 @@
 #SBATCH -o stdout
 #SBATCH -e stderr
 
+help()
+{
+  echo "PIConGPU submit script generated with tbg"
+  echo ""
+  echo "usage: $0 [--verify]"
+  echo ""
+  echo "--validate      - validate picongpu call instead of running the simulation"
+  echo "--h | --help    - print this help message"
+}
+
+VALIDATE_MODE=false
+for arg in "$@"; do
+  case $arg in
+  --validate)
+    VALIDATE_MODE=true
+    shift # Remove --skip-verification from `$@`
+    ;;
+  -h | --help)
+    echo -e "$(help)"
+    shift
+    exit 0
+    ;;
+  *)
+    echo "unrecognized argument"
+    echo -e "$(help)"
+    exit 1
+    ;;
+  esac
+done
 
 ## calculations will be performed by tbg ##
 .TBG_queue=${TBG_partition:-"fwkt_v100"}
@@ -81,7 +110,7 @@
 
 ## end calculations ##
 
-echo 'Running program...'
+echo "Preparing environment..."
 
 cd !TBG_dstPath
 
@@ -100,15 +129,24 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# test if cuda_memtest binary is available and we have the node exclusive
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
-  # Run CUDA memtest to check GPU's health
-  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+if [[ $VALIDATE_MODE == true ]]; then
+  echo "Validating PIConGPU call..."
+  !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams --validate
+  if [ $? -ne 0 ] ; then
+    exit 1;
+  fi
 else
-  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
-fi
+  # test if cuda_memtest binary is available and we have the node exclusive
+  if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+    # Run CUDA memtest to check GPU's health
+    mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+  else
+    echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+  fi
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  if [ $? -eq 0 ] ; then
+    # Run PIConGPU
+    echo "Running PIConGPU..."
+    source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  fi
 fi

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2022 Axel Huebl, Richard Pausch, Rene Widera, Marco Garten
+# Copyright 2013-2023 Axel Huebl, Richard Pausch, Rene Widera, Marco Garten, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -43,6 +43,35 @@
 #SBATCH -o stdout
 #SBATCH -e stderr
 
+help()
+{
+  echo "PIConGPU submit script generated with tbg"
+  echo ""
+  echo "usage: $0 [--verify]"
+  echo ""
+  echo "--validate      - validate picongpu call instead of running the simulation"
+  echo "--h | --help    - print this help message"
+}
+
+VALIDATE_MODE=false
+for arg in "$@"; do
+  case $arg in
+  --validate)
+    VALIDATE_MODE=true
+    shift # Remove --skip-verification from `$@`
+    ;;
+  -h | --help)
+    echo -e "$(help)"
+    shift
+    exit 0
+    ;;
+  *)
+    echo "unrecognized argument"
+    echo -e "$(help)"
+    exit 1
+    ;;
+  esac
+done
 
 ## calculations will be performed by tbg ##
 .TBG_queue=${TBG_partition:-"gpu"}
@@ -79,7 +108,7 @@
 
 ## end calculations ##
 
-echo 'Running program...'
+echo "Preparing environment..."
 
 cd !TBG_dstPath
 
@@ -98,15 +127,24 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# test if cuda_memtest binary is available and we have the node exclusive
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
-  # Run CUDA memtest to check GPU's health
-  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+if [[ $VALIDATE_MODE == true ]]; then
+  echo "Validating PIConGPU call..."
+  !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams --validate
+  if [ $? -ne 0 ] ; then
+    exit 1;
+  fi
 else
-  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
-fi
+  # test if cuda_memtest binary is available and we have the node exclusive
+  if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+    # Run CUDA memtest to check GPU's health
+    mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+  else
+    echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+  fi
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  if [ $? -eq 0 ] ; then
+    # Run PIConGPU
+    echo "Running PIConGPU..."
+    source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+  fi
 fi

--- a/etc/picongpu/hemera-hzdr/k20.tpl
+++ b/etc/picongpu/hemera-hzdr/k20.tpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Copyright 2013-2022 Axel Huebl, Anton Helm, Richard Pausch, Rene Widera,
-#                     Marco Garten
+# Copyright 2013-2023 Axel Huebl, Anton Helm, Richard Pausch, Rene Widera,
+#                     Marco Garten, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -45,6 +45,35 @@
 #SBATCH -o stdout
 #SBATCH -e stderr
 
+help()
+{
+  echo "PIConGPU submit script generated with tbg"
+  echo ""
+  echo "usage: $0 [--verify]"
+  echo ""
+  echo "--validate      - validate picongpu call instead of running the simulation"
+  echo "--h | --help    - print this help message"
+}
+
+VALIDATE_MODE=false
+for arg in "$@"; do
+  case $arg in
+  --validate)
+    VALIDATE_MODE=true
+    shift # Remove --skip-verification from `$@`
+    ;;
+  -h | --help)
+    echo -e "$(help)"
+    shift
+    exit 0
+    ;;
+  *)
+    echo "unrecognized argument"
+    echo -e "$(help)"
+    exit 1
+    ;;
+  esac
+done
 
 ## calculations will be performed by tbg ##
 .TBG_queue=${TBG_partition:-"k20"}
@@ -81,7 +110,7 @@
 
 ## end calculations ##
 
-echo 'Running program...'
+echo "Preparing environment..."
 
 cd !TBG_dstPath
 
@@ -100,16 +129,25 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-# test if cuda_memtest binary is available and we have the node exclusive
-if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
-  # Run CUDA memtest to check GPU's health
-  mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+if [[ $VALIDATE_MODE == true ]]; then
+   echo "Validating PIConGPU call..."
+   !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams --validate
+   if [ $? -ne 0 ] ; then
+     exit 1;
+   fi
 else
-  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
-fi
+    # test if cuda_memtest binary is available and we have the node exclusive
+    if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+      # Run CUDA memtest to check GPU's health
+      mpiexec -np !TBG_tasks !TBG_dstPath/input/bin/cuda_memtest.sh
+    else
+      echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+    fi
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
-    !TBG_author !TBG_programParams
+    if [ $? -eq 0 ] ; then
+      # Run PIConGPU
+      echo "Running PIConGPU..."
+      source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks -tag-output --display-map !TBG_dstPath/input/bin/picongpu \
+        !TBG_author !TBG_programParams
+    fi
 fi


### PR DESCRIPTION
`PIConGPU` can be run with the `--validate`to validate run time options instead of running the simulation. Until now, there was no easy way to use this feature together with `tbg` and `.cfg` files, and so almost no one was using it.

This feature adds the validation to `tbg`. With this commit, the `.tpl` files for `bash` and `hemera` will generate a `submit.start` that can be called with an optional  `--validate`  flag. In that case, `picongpu --validate` is run with the same parameters as the actual simulation, but without the `mpiexec` / `srun` call around it. `tbg` won't submit the job if the validation fails. 
 
With this, we should be able to avoid situations where we wait for days for a job to start just to find out that there was a typo in the `.cfg` file.

If you like this implementation, we can copy and paste it into the other templates.