### PR TITLE
fix direct_Pause documentation for ISAAC plugin

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -268,7 +268,7 @@ TBG_restartLoop="--checkpoint.restart.loop 5000"
 #     --isaac.width WIDTH
 #     --isaac.height HEIGHT
 #   Pausing directly after the start of the simulation
-#     --isaac.directPause
+#     --isaac.directPause off=0(default)|on=1
 #   By default the ISAAC Plugin tries to reconnect if the sever is not available
 #   at start or the servers crashes. This can be deactivated with this option
 #     --isaac.reconnect false
@@ -277,7 +277,7 @@ TBG_restartLoop="--checkpoint.restart.loop 5000"
 TBG_isaac="--isaac.period 1 --isaac.name !TBG_jobName --isaac.url <server_url>"
 TBG_isaac_quality="--isaac.quality 90"
 TBG_isaac_resolution="--isaac.width 1024 --isaac.height 768"
-TBG_isaac_pause="--isaac.directPause"
+TBG_isaac_pause="--isaac.directPause 1"
 TBG_isaac_reconnect="--isaac.reconnect false"
 
 # Print the maximum charge deviation between particles and div E to textfile 'chargeConservation.dat':

--- a/docs/source/usage/plugins/isaac.rst
+++ b/docs/source/usage/plugins/isaac.rst
@@ -27,9 +27,9 @@ Command line option               Description
                                   the very same hardware.
 ``--isaac.width WIDTH``           Setups the *WIDTH* and *HEIGHT* of the created image(s).
 ``--isaac.height HEIGHT``         Default is ``1024x768``.
-``--isaac.direct_pause``          If activated ISAAC will pause directly after the simulation started.
-                                  Useful for presentations or if you don't want to miss the beginning of
-                                  the simulation.
+``--isaac.direct_pause BOOL``     If activated (argument set to ``1``) ISAAC will pause directly after the
+                                  simulation started. Useful for presentations or if you don't want to miss
+				  the beginning of the simulation.
 ``--isaac.quality QUALITY``       Sets the *QUALITY* of the images, which are compressed right after creation.
                                   Values between ``1`` and ``100`` are possible.
                                   The default is ``90``, but ``70`` does also still produce decent results.


### PR DESCRIPTION
The documentation of [`--isaac.direct_pause`](https://picongpu.readthedocs.io/en/latest/usage/plugins/isaac.html#cfg-file) missed that an argument was needed. This pull request mentions the argument. 