### PR TITLE
fix CUDA 11.0 compile bug

### DIFF
--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -236,7 +236,7 @@ namespace picongpu
 
         using FrameType = typename T_Species::FrameType;
         using ParticleCurrentSolver =
-            typename pmacc::traits::Resolve<typename GetFlagType<FrameType, current<>>::type>::type;
+            typename pmacc::traits::Resolve<typename pmacc::traits::GetFlagType<FrameType, current<>>::type>::type;
 
         using FrameSolver
             = currentSolver::ComputePerFrame<ParticleCurrentSolver, Velocity, MappingDesc::SuperCellSize>;

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -295,7 +295,7 @@ namespace picongpu
     template<typename T_Name, typename T_Flags, typename T_Attributes>
     void Particles<T_Name, T_Flags, T_Attributes>::update(uint32_t const currentStep)
     {
-        using PusherAlias = typename GetFlagType<FrameType, particlePusher<>>::type;
+        using PusherAlias = typename pmacc::traits::GetFlagType<FrameType, particlePusher<>>::type;
         using ParticlePush = typename pmacc::traits::Resolve<PusherAlias>::type;
         // Because of composite pushers, we have to defer using the launcher
         PushLauncher<ParticlePush>{}(*this, currentStep);
@@ -334,8 +334,8 @@ namespace picongpu
             _internal_error_particle_push_instantiated_for_composite_pusher,
             particles::pusher::IsComposite<T_Pusher>::type::value == false);
 
-        using InterpolationScheme =
-            typename pmacc::traits::Resolve<typename GetFlagType<FrameType, interpolation<>>::type>::type;
+        using InterpolationScheme = typename pmacc::traits::Resolve<
+            typename pmacc::traits::GetFlagType<FrameType, interpolation<>>::type>::type;
 
         using FrameSolver = PushParticlePerFrame<T_Pusher, MappingDesc::SuperCellSize, InterpolationScheme>;
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -66,8 +66,8 @@ namespace picongpu
                  * @todo this needs to be done independently/twice if ion species (rho) and electron
                  *       species (ene) are of different shape
                  */
-                using Field2ParticleInterpolation =
-                    typename pmacc::traits::Resolve<typename GetFlagType<FrameType, interpolation<>>::type>::type;
+                using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<FrameType, interpolation<>>::type>::type;
 
                 /* margins around the supercell for the interpolation of the field on the cells */
                 using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -71,8 +71,8 @@ namespace picongpu
                 using FrameType = typename SrcSpecies::FrameType;
 
                 /* specify field to particle interpolation scheme */
-                using Field2ParticleInterpolation =
-                    typename pmacc::traits::Resolve<typename GetFlagType<FrameType, interpolation<>>::type>::type;
+                using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<FrameType, interpolation<>>::type>::type;
 
                 /* margins around the supercell for the interpolation of the field on the cells */
                 using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -70,8 +70,8 @@ namespace picongpu
                 using FrameType = typename SrcSpecies::FrameType;
 
                 /* specify field to particle interpolation scheme */
-                using Field2ParticleInterpolation =
-                    typename pmacc::traits::Resolve<typename GetFlagType<FrameType, interpolation<>>::type>::type;
+                using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<FrameType, interpolation<>>::type>::type;
 
                 /* margins around the supercell for the interpolation of the field on the cells */
                 using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -71,8 +71,8 @@ namespace picongpu
                 using FrameType = typename SrcSpecies::FrameType;
 
                 /* specify field to particle interpolation scheme */
-                using Field2ParticleInterpolation =
-                    typename pmacc::traits::Resolve<typename GetFlagType<FrameType, interpolation<>>::type>::type;
+                using Field2ParticleInterpolation = typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<FrameType, interpolation<>>::type>::type;
 
                 /* margins around the supercell for the interpolation of the field on the cells */
                 using LowerMargin = typename GetMargin<Field2ParticleInterpolation>::LowerMargin;

--- a/include/picongpu/particles/traits/GetAtomicNumbers.hpp
+++ b/include/picongpu/particles/traits/GetAtomicNumbers.hpp
@@ -39,7 +39,7 @@ namespace picongpu
             /* throw static assert if species has no protons or neutrons */
             PMACC_CASSERT_MSG(This_species_has_no_atomic_numbers, hasAtomicNumbers::value == true);
 
-            using FoundAtomicNumbersAlias = typename GetFlagType<FrameType, atomicNumbers<>>::type;
+            using FoundAtomicNumbersAlias = typename pmacc::traits::GetFlagType<FrameType, atomicNumbers<>>::type;
             using type = typename pmacc::traits::Resolve<FoundAtomicNumbersAlias>::type;
         };
     } // namespace traits

--- a/include/picongpu/particles/traits/GetCurrentSolver.hpp
+++ b/include/picongpu/particles/traits/GetCurrentSolver.hpp
@@ -32,7 +32,7 @@ namespace picongpu
         struct GetCurrentSolver
         {
             using type = typename pmacc::traits::Resolve<
-                typename GetFlagType<typename T_Species::FrameType, current<>>::type>::type;
+                typename pmacc::traits::GetFlagType<typename T_Species::FrameType, current<>>::type>::type;
         };
     } // namespace traits
 

--- a/include/picongpu/particles/traits/GetDensityRatio.hpp
+++ b/include/picongpu/particles/traits/GetDensityRatio.hpp
@@ -46,8 +46,8 @@ namespace picongpu
         {
             using FrameType = typename T_Species::FrameType;
             using hasDensityRatio = typename HasFlag<FrameType, densityRatio<>>::type;
-            using DensityRatioOfSpecies =
-                typename pmacc::traits::Resolve<typename GetFlagType<FrameType, densityRatio<>>::type>::type;
+            using DensityRatioOfSpecies = typename pmacc::traits::Resolve<
+                typename pmacc::traits::GetFlagType<FrameType, densityRatio<>>::type>::type;
 
             using type = pmacc::mp_if<hasDensityRatio, DensityRatioOfSpecies, detail::DefaultDensityRatio>;
         };

--- a/include/picongpu/particles/traits/GetEffectiveNuclearCharge.hpp
+++ b/include/picongpu/particles/traits/GetEffectiveNuclearCharge.hpp
@@ -43,7 +43,8 @@ namespace picongpu
                 No_effective_atomic_numbers_are_defined_for_this_species,
                 hasEffectiveNuclearCharge::value == true);
 
-            using FoundEffectiveNuclearChargeAlias = typename GetFlagType<FrameType, effectiveNuclearCharge<>>::type;
+            using FoundEffectiveNuclearChargeAlias =
+                typename pmacc::traits::GetFlagType<FrameType, effectiveNuclearCharge<>>::type;
             /* Extract vector of effective atomic numbers */
             using type = typename pmacc::traits::Resolve<FoundEffectiveNuclearChargeAlias>::type;
 

--- a/include/picongpu/particles/traits/GetExchangeMemCfg.hpp
+++ b/include/picongpu/particles/traits/GetExchangeMemCfg.hpp
@@ -45,7 +45,8 @@ namespace picongpu
 
             using type = pmacc::mp_if<
                 hasMemCfg,
-                typename pmacc::traits::Resolve<typename GetFlagType<FrameType, exchangeMemCfg<>>::type>::type,
+                typename pmacc::traits::Resolve<
+                    typename pmacc::traits::GetFlagType<FrameType, exchangeMemCfg<>>::type>::type,
                 ::picongpu::DefaultExchangeMemCfg>;
         };
 

--- a/include/picongpu/particles/traits/GetInterpolation.hpp
+++ b/include/picongpu/particles/traits/GetInterpolation.hpp
@@ -32,7 +32,7 @@ namespace picongpu
         struct GetInterpolation
         {
             using type = typename pmacc::traits::Resolve<
-                typename GetFlagType<typename T_Species::FrameType, interpolation<>>::type>::type;
+                typename pmacc::traits::GetFlagType<typename T_Species::FrameType, interpolation<>>::type>::type;
         };
     } // namespace traits
 

--- a/include/picongpu/particles/traits/GetIonizationEnergies.hpp
+++ b/include/picongpu/particles/traits/GetIonizationEnergies.hpp
@@ -42,7 +42,8 @@ namespace picongpu
                 No_ionization_energies_are_defined_for_this_species,
                 hasIonizationEnergies::value == true);
 
-            using FoundIonizationEnergiesAlias = typename GetFlagType<FrameType, ionizationEnergies<>>::type;
+            using FoundIonizationEnergiesAlias =
+                typename pmacc::traits::GetFlagType<FrameType, ionizationEnergies<>>::type;
             /* Extract ionization energy vector from AU namespace */
             using type = typename pmacc::traits::Resolve<FoundIonizationEnergiesAlias>::type;
 

--- a/include/picongpu/particles/traits/GetIonizerList.hpp
+++ b/include/picongpu/particles/traits/GetIonizerList.hpp
@@ -50,7 +50,7 @@ namespace picongpu
                 using FrameType = typename SpeciesType::FrameType;
 
                 // the following line only fetches the alias
-                using FoundIonizersAlias = typename GetFlagType<FrameType, ionizers<>>::type;
+                using FoundIonizersAlias = typename pmacc::traits::GetFlagType<FrameType, ionizers<>>::type;
 
                 // this now resolves the alias into the actual object type, a list of ionizers
                 using FoundIonizerList = typename pmacc::traits::Resolve<FoundIonizersAlias>::type;

--- a/include/picongpu/particles/traits/GetPusher.hpp
+++ b/include/picongpu/particles/traits/GetPusher.hpp
@@ -32,7 +32,7 @@ namespace picongpu
         struct GetPusher
         {
             using type = typename pmacc::traits::Resolve<
-                typename GetFlagType<typename T_Species::FrameType, particlePusher<>>::type>::type;
+                typename pmacc::traits::GetFlagType<typename T_Species::FrameType, particlePusher<>>::type>::type;
         };
 
     } // namespace traits

--- a/include/picongpu/particles/traits/GetShape.hpp
+++ b/include/picongpu/particles/traits/GetShape.hpp
@@ -32,7 +32,7 @@ namespace picongpu
         struct GetShape
         {
             using type = typename pmacc::traits::Resolve<
-                typename GetFlagType<typename T_Species::FrameType, shape<>>::type>::type;
+                typename pmacc::traits::GetFlagType<typename T_Species::FrameType, shape<>>::type>::type;
         };
 
     } // namespace traits

--- a/include/picongpu/particles/traits/GetSpeciesFlagName.hpp
+++ b/include/picongpu/particles/traits/GetSpeciesFlagName.hpp
@@ -43,7 +43,7 @@ namespace picongpu
         struct GetSpeciesFlagName
         {
             using SpeciesFlag = typename pmacc::traits::Resolve<
-                typename GetFlagType<typename T_Species::FrameType, T_Flag>::type>::type;
+                typename pmacc::traits::GetFlagType<typename T_Species::FrameType, T_Flag>::type>::type;
 
             std::string operator()() const
             {

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -141,7 +141,7 @@ namespace pmacc
         {
         private:
             using FrameType = pmacc::Frame<T_CreatePairOperator, T_ParticleDescription>;
-            using SolvedAliasName = typename GetFlagType<FrameType, T_IdentifierName>::type;
+            using SolvedAliasName = typename pmacc::traits::GetFlagType<FrameType, T_IdentifierName>::type;
             using FlagList = typename FrameType::FlagList;
 
         public:


### PR DESCRIPTION
nvcc11.0 compile failed with the message `GetFlagType` is not a template. Fixed by fully quallify the namespaces.
example LWFA with `pic-build -t 2` failed.

compiler error:

```
picongpu/include/picongpu/../picongpu/particles/traits/GetIonizerList.hpp(53): error #864: GetFlagType is not a template
          detected during:
            instantiation of class "picongpu::particles::traits::GetIonizerList<T_SpeciesType> [with T_SpeciesType=pmacc::particles::meta::FindByNameOrType_t<picongpu::VectorAllSpecies, picongpu::PIC_Ions, pmacc::errorHandlerPolicies::ThrowValueNotFound>]" 
picongpu/include/picongpu/../picongpu/particles/ParticlesFunctors.hpp(313): here
            instantiation of class "picongpu::particles::CallIonization<T_SpeciesType> [with T_SpeciesType=picongpu::PIC_Ions]" 
/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/boost-1.74.0-sq2qiot2ulwfoz4dgwwle3iqzm5z2qpr/include/boost/mpl/aux_/has_type.hpp(20): here
            instantiation of class "boost::mpl::aux::has_type<T, fallback_> [with T=picongpu::particles::CallIonization<picongpu::PIC_Ions>, fallback_=mpl_::bool_<true>]" 
/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/boost-1.74.0-sq2qiot2ulwfoz4dgwwle3iqzm5z2qpr/include/boost/mpl/aux_/has_type.hpp(20): here
            instantiation of class "boost::mpl::aux::has_type<T, fallback_> [with T=picongpu::particles::CallIonization<picongpu::PIC_Ions>, fallback_=mpl_::bool_<true>]" 
/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/boost-1.74.0-sq2qiot2ulwfoz4dgwwle3iqzm5z2qpr/include/boost/mpl/aux_/preprocessed/gcc/quote.hpp(36): here
            instantiation of class "boost::mpl::quote1<F, Tag>::apply<U1> [with F=picongpu::particles::CallIonization, Tag=mpl_::void_, U1=picongpu::PIC_Ions]" 
/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-9.3.0/boost-1.74.0-sq2qiot2ulwfoz4dgwwle3iqzm5z2qpr/include/boost/mpl/aux_/preprocessed/gcc/apply_wrap.hpp(38): here
```

# module li
```
  1) lsf-tools/2.0                5) DefApps                          9) cmake/3.20.2                13) boost/1.74.0    17) sz/2.1.11.1         21) zlib/1.2.11
  2) hsi/5.0.2.p5                 6) gcc/9.3.0                       10) nsight-compute/2021.2.1     14) hdf5/1.10.7     18) lz4/1.9.3           22) libpng/1.6.37
  3) darshan-runtime/3.4.0-lite   7) spectrum-mpi/10.4.0.3-20210112  11) nsight-systems/2021.3.1.54  15) c-blosc/1.21.0  19) adios2/2.7.1        23) freetype/2.10.4
  4) xalt/1.2.1                   8) git/2.29.0                      12) cuda/11.0.3                 16) zfp/0.5.5       20) openpmd-api/0.13.4
```

cc-ing: @PrometheusPi 