### PR TITLE
Update sphinx and its dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,19 @@
-sphinx_rtd_theme>=0.3.1
-recommonmark
-sphinx==2.0.1
-breathe>=4.12.0,<4.15.0
+# restrict up to the next major as suggested in the rtd documentation
+sphinx_rtd_theme<=2.0.0
+# recommonmark was discontinued myst-parser is the new replacement
+myst-parser
+# rtd theme supports at least up to 4.1 but newest autoapi requires >=5.2 and myst-parser needs >=5
+sphinx==5.2.0
+breathe>=4.12.0
 sphinxcontrib.programoutput
 sphinxcontrib-napoleon>=0.7
 sphinx-autoapi
 pygments
-Jinja2<3.0
-markupsafe<2.0.0
-# docutils 0.17 breaks HTML tags & RTD theme
-# https://github.com/sphinx-doc/sphinx/issues/9001
-docutils==0.16
+# restrict up to next major
+Jinja2<4.0
+markupsafe<3.0.0
+# rtd theme supports up to 0.17
+docutils<=0.17
 # generate plots
 matplotlib
 scipy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,6 @@
 #
 import os
 import subprocess
-from recommonmark.parser import CommonMarkParser
 import sys
 python_libs = os.path.abspath('../../lib/python')
 sys.path.insert(0, python_libs)
@@ -46,7 +45,8 @@ extensions = ['sphinx.ext.mathjax',
               'breathe',
               'sphinxcontrib.programoutput',
               'matplotlib.sphinxext.plot_directive',
-              'autoapi.extension']
+              'autoapi.extension',
+              'myst_parser']
 
 if not on_rtd:
     extensions.append('sphinx.ext.githubpages')
@@ -93,13 +93,6 @@ else:
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-source_parsers = {
-    '.md': CommonMarkParser,
-}
 
 source_suffix = ['.rst', '.md']
 


### PR DESCRIPTION
# Update sphinx 
## Changes
* Switched sphinx version from 2.0.1 to 5.2.0
* Updated other dependencies so that they work with the new `sphinx`
* switched from `recommonmark` to `myst-parser`  for parsing markdown files since `recommonmark` was discontinued. `myst-parser` should be a drop-in replacement. 

## Justification
We were pinning a very old version of `sphinx` and `pip` wasn't able to install the dependencies for me anymore. The `sphinx-autoapi` requires newer versions of `sphinx`, most likely the very old version that works with 2.0.1 is not available anymore. 

## Validation
I build the readthedocs page and the doxygen page, both look good to me, but I wasn't able to look at all pages ;). There are even positive changes since code and doxygen generated headers support now line braking (our "dependencies" and e.g. "important pmacc classes pages" look better on smaller screens / in smaller windows).

Question to @psychocoderHPC, does the CI include these changes automatically, or do we need to force the software update somehow?
