### PR TITLE
OneSuperCellPosition particle initialization T_PositionFunctor

### DIFF
--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -1,5 +1,5 @@
-/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
- *                     Richard Pausch, Klaus Steiniger
+/* Copyright 2013-2023 Axel Huebl, Rene Widera, Benjamin Worpitz,
+ *                     Richard Pausch, Klaus Steiniger, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -18,7 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file
+/** @file config file for particle manipulators
  *
  * Configurations for particle manipulators. Set up and declare functors that
  * can be used in speciesInitialization.param for particle species
@@ -233,6 +233,40 @@ namespace picongpu
              * places macro-particles at the initial in-cell position defined above.
              */
             using OnePosition = OnePositionImpl<OnePositionParameter>;
+
+            /** Define initial in-cell particle position used as parameter in OneSuperCellPosition functor.
+             *
+             * Here, macro-particles sit directly in lower corner of the cell.
+             *
+             * This defines the type InCellOffset_OneSuperCellPosition_t
+             * where every instance of this type has the preset values defined here.
+             *
+             * @attention assumes that the density functor gives the per superCell number
+             *  of physical particles for each cell in the same sueprCell
+             */
+            CONST_VECTOR(
+                /*datatype*/ float_X,
+                /*dim*/ 3,
+                /*name*/ InCellOffset_OneSuperCellPosition,
+                /*x*/ 0.0,
+                /*y*/ 0.0,
+                /*z*/ 0.0);
+            struct OneSuperCellPositionParameter
+            {
+                /** Count of particles per cell at initial state
+                 *  unit: none
+                 */
+                static constexpr uint32_t numParticlesPerSuperCell
+                    = TYPICAL_PARTICLES_PER_CELL * pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+                //! initial position of macro particle in-cell, as CONST_VECTOR of relative position in cell (x \in
+                //! [0.,1.), ...)
+                const InCellOffset_OneSuperCellPosition_t inCellOffset;
+
+                //! spawnCell index, @attention must be within superCell extent!
+                using spawnCellIdx = mCT::shrinkTo<mCT::UInt32<0u, 0u, 0u>, picongpu::simDim>::type;
+            };
+            using OneSuperCellPosition = OneSuperCellPositionImpl<OneSuperCellPositionParameter>;
         } // namespace startPosition
     } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -152,7 +152,7 @@ namespace picongpu
 
                     if(realParticlesPerCell > 0.0_X)
                         numParsPerCell
-                            = posFunctor.template numberOfMacroParticles<ParticleType>(realParticlesPerCell);
+                            = posFunctor.template numberOfMacroParticles<ParticleType>(realParticlesPerCell, cellIdx);
 
                     if(numParsPerCell > 0)
                         kernel::atomicAllExch(

--- a/include/picongpu/particles/startPosition/OneSuperCellPositionImpl.def
+++ b/include/picongpu/particles/startPosition/OneSuperCellPositionImpl.def
@@ -1,0 +1,53 @@
+/* Copyright 2023 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file provides def of T_PositionFunctor that places numParticlesPerSuperCell macro particles at a
+ *  fixed location in each super cell with weighting according to the local density
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/startPosition/generic/Free.def"
+
+namespace picongpu::particles::startPosition
+{
+    namespace acc
+    {
+        /** set the particle attribute position
+         *
+         * This functor also sets the macro particle weighting.
+         */
+        template<typename T_ParamClass>
+        struct OneSuperCellPositionImpl;
+    } // namespace acc
+
+    /** Set the in cell position
+     *
+     * All macro particles are set to the same in cell position defined in
+     * T_ParamClass.
+     *
+     * @tparam T_ParamClass Parameter class with off `InCellOffset` defined as
+     *   CONST_VECTOR of 3 float_X [0.0, 1.0) and numParticlesPerSuperCell: static constexpr uint32_t
+     */
+    template<typename T_ParamClass>
+    using OneSuperCellPositionImpl = generic::Free<acc::OneSuperCellPositionImpl<T_ParamClass>>;
+
+} // namespace picongpu::particles::startPosition

--- a/include/picongpu/particles/startPosition/OneSuperCellPositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OneSuperCellPositionImpl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2023 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -17,11 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file implements a T_PositionFunctor that places numParticlesPerSuperCell macro particles at a
+ *  fixed location in each super cell with weighting according to the local density
+ */
+
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/particles/startPosition/OnePositionImpl.def"
+#include "picongpu/particles/startPosition/OneSuperCellPositionImpl.def"
 #include "picongpu/particles/startPosition/detail/WeightMacroParticles.hpp"
 
 #include <pmacc/traits/HasIdentifier.hpp>
@@ -29,15 +33,15 @@
 namespace picongpu::particles::startPosition::acc
 {
     template<typename T_ParamClass>
-    struct OnePositionImpl
+    struct OneSuperCellPositionImpl
     {
-        /** set in-cell position and weighting
+        /** set in-superCell position and weighting
          *
          * @tparam T_Particle pmacc::Particle, particle type
          * @tparam T_Args pmacc::Particle, arbitrary number of particles types
          *
          * @param particle particle to be manipulated
-         * @param ... unused particles
+         * @param ... init input particles particles, unused here
          */
         template<typename T_Particle, typename... T_Args>
         HDINLINE void operator()(T_Particle& particle, T_Args&&...)
@@ -45,32 +49,64 @@ namespace picongpu::particles::startPosition::acc
             particle[position_] = T_ParamClass{}.inCellOffset.template shrink<simDim>();
 
             // set the weighting attribute if the particle species has it
-            bool const hasWeighting
+            constexpr bool hasWeighting
                 = pmacc::traits::HasIdentifier<typename T_Particle::FrameType, weighting>::type::value;
             if constexpr(hasWeighting)
                 particle[weighting_] = m_weighting;
         }
 
+        /** predictor for number of macro particles to create in a cell
+         *
+         * @attention expects realParticlesPerCell to be per superCell
+         */
         template<typename T_Particle>
-        HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const)
+        HDINLINE uint32_t
+        numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const cellIdx) const
         {
-            bool const hasWeighting
+            PMACC_CASSERT_MSG(
+                spawnCellIdx_dim_and_simDim_are_inconsistent,
+                T_ParamClass::spawnCellIdx::dim != picongpu::simDim);
+
+            auto spawnCellIdx = T_ParamClass::spawnCellIdx::toRT();
+            auto superCellSize = picongpu::SuperCellSize::toRT();
+
+            // check for invalid spawnCellIdx
+            for(uint8_t i = static_cast<uint8_t>(0u); i < picongpu::simDim; i++)
+            {
+                if(spawnCellIdx[i] >= superCellSize[i])
+                    return static_cast<uint32_t>(0u);
+            }
+
+            // is cellIdx == spawnCellIdx?
+            bool cellIsSpawnCell = true;
+            for(uint8_t i = static_cast<uint8_t>(0u); i < picongpu::simDim; i++)
+            {
+                if(spawnCellIdx[i] != cellIdx[i])
+                {
+                    cellIsSpawnCell = false;
+                }
+            }
+
+            if(!cellIsSpawnCell)
+                return static_cast<uint32_t>(0u);
+
+            /// @attention m_weighting member might stay uninitialized!
+            uint32_t result = T_ParamClass::numParticlesPerSuperCell;
+
+            constexpr bool hasWeighting
                 = pmacc::traits::HasIdentifier<typename T_Particle::FrameType, weighting>::type::value;
 
-            // note: m_weighting member might stay uninitialized!
-            uint32_t result(T_ParamClass::numParticlesPerCell);
-
-            if(hasWeighting)
+            if constexpr(hasWeighting)
                 result = startPosition::detail::WeightMacroParticles{}(
                     realParticlesPerCell,
-                    T_ParamClass::numParticlesPerCell,
+                    T_ParamClass::numParticlesPerSuperCell,
                     m_weighting);
 
             return result;
         }
 
     private:
+        //! position dependent weighting init
         float_X m_weighting;
     };
-
 } // namespace picongpu::particles::startPosition::acc

--- a/include/picongpu/particles/startPosition/QuietImpl.hpp
+++ b/include/picongpu/particles/startPosition/QuietImpl.hpp
@@ -78,7 +78,8 @@ namespace picongpu
                     }
 
                     template<typename T_Particle>
-                    HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                    HDINLINE uint32_t
+                    numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const)
                     {
                         m_numParDirection = T_ParamClass::numParticlesPerDimension::toRT();
 

--- a/include/picongpu/particles/startPosition/RandomImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomImpl.hpp
@@ -59,7 +59,8 @@ namespace picongpu
                     }
 
                     template<typename T_Particle>
-                    HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                    HDINLINE uint32_t
+                    numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const)
                     {
                         return startPosition::detail::WeightMacroParticles{}(
                             realParticlesPerCell,

--- a/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
+++ b/include/picongpu/particles/startPosition/RandomPositionAndWeightingImpl.hpp
@@ -87,7 +87,8 @@ namespace picongpu
                      * @param realParticlesPerCell number of real particles for the cell
                      */
                     template<typename T_Particle>
-                    HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                    HDINLINE uint32_t
+                    numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const)
                     {
                         m_remainingMacroparticles = startPosition::detail::WeightMacroParticles{}(
                             realParticlesPerCell,

--- a/include/picongpu/particles/startPosition/functors.def
+++ b/include/picongpu/particles/startPosition/functors.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera
+/* Copyright 2014-2023 Rene Widera, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "picongpu/particles/startPosition/OnePositionImpl.def"
+#include "picongpu/particles/startPosition/OneSuperCellPositionImpl.def"
 #include "picongpu/particles/startPosition/QuietImpl.def"
 #include "picongpu/particles/startPosition/RandomBinomialImpl.def"
 #include "picongpu/particles/startPosition/RandomImpl.def"

--- a/include/picongpu/particles/startPosition/functors.hpp
+++ b/include/picongpu/particles/startPosition/functors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera
+/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "picongpu/particles/startPosition/OnePositionImpl.hpp"
+#include "picongpu/particles/startPosition/OneSuperCellPositionImpl.hpp"
 #include "picongpu/particles/startPosition/QuietImpl.hpp"
 #include "picongpu/particles/startPosition/RandomBinomialImpl.hpp"
 #include "picongpu/particles/startPosition/RandomImpl.hpp"

--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -66,9 +66,10 @@ namespace picongpu
                         }
 
                         template<typename T_Particle>
-                        HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                        HDINLINE uint32_t
+                        numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const cellIdx)
                         {
-                            return Functor::template numberOfMacroParticles<T_Particle>(realParticlesPerCell);
+                            return Functor::template numberOfMacroParticles<T_Particle>(realParticlesPerCell, cellIdx);
                         }
                     };
                 } // namespace acc

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -68,9 +68,10 @@ namespace picongpu
                         }
 
                         template<typename T_Particle>
-                        HDINLINE uint32_t numberOfMacroParticles(float_X const realParticlesPerCell)
+                        HDINLINE uint32_t
+                        numberOfMacroParticles(float_X const realParticlesPerCell, DataSpace<simDim> const cellIdx)
                         {
-                            return Functor::template numberOfMacroParticles<T_Particle>(realParticlesPerCell);
+                            return Functor::template numberOfMacroParticles<T_Particle>(realParticlesPerCell, cellIdx);
                         }
 
                     private:


### PR DESCRIPTION
new T_PositionFunctor `OneSuperCellPosition` for the speciesInitialization pipeline,
- spawns all macro particles in at one position in one specified cell of each superCell

useful for super-cell based algorithm degbugging, like FLYonPIC