### PR TITLE
fix crash on AMD (frontier)

### DIFF
--- a/include/picongpu/particles/MoveParticle.hpp
+++ b/include/picongpu/particles/MoveParticle.hpp
@@ -58,7 +58,16 @@ namespace picongpu
              * direction the particle is leaving the cell.
              * The floating point precision is equal for -0.5 and 0.5.
              */
-            floatD_X pos = newPos - 0.5_X;
+#if(BOOST_COMP_HIP)
+            // workaround for a broken HIP optimization
+            // https://github.com/ComputationalRadiationPhysics/picongpu/issues/4561
+            volatile
+#else
+            constexpr
+#endif
+                auto shift
+                = 0.5_X;
+            floatD_X pos = newPos - shift;
 
             DataSpace<simDim> dir;
 
@@ -74,7 +83,7 @@ namespace picongpu
                     moveDir = 1.0_X;
 
                 pos[i] -= moveDir;
-                particle[position_][i] = pos[i] + 0.5_X;
+                particle[position_][i] = pos[i] + shift;
                 dir[i] = precisionCast<int>(moveDir);
             }
 


### PR DESCRIPTION
fix #4561

Most likly the compiler is removing the floating point rounding guard in the pusher and therefore the particle position is after the push not in the valid range `[0;1)`.
Validating the range via a a printf if showing no issue, therefore the possibility of an compiler bug is very high.

The current workaround add `volatile` to break the compiler optimization.