### PR TITLE
Fix errors in python plugin analysis scripts

### DIFF
--- a/lib/python/picongpu/extra/input/parameters.py
+++ b/lib/python/picongpu/extra/input/parameters.py
@@ -9,6 +9,11 @@ import collections
 import pint
 ureg = pint.UnitRegistry()
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 
 class Parameter(object):
     """
@@ -88,7 +93,7 @@ class Parameter(object):
         if values is not None and range is not None:
             raise ValueError("Can only set either 'values' or 'range'!")
         elif values is not None:
-            if not isinstance(values, collections.Iterable):
+            if not isinstance(values, collectionsAbc.Iterable):
                 values = [values]
             if not values:
                 # check empty values list

--- a/lib/python/picongpu/extra/plugins/data/__init__.py
+++ b/lib/python/picongpu/extra/plugins/data/__init__.py
@@ -2,7 +2,6 @@ from .energy_histogram import EnergyHistogramData
 from .phase_space import PhaseSpaceData
 from .png import PNGData
 from .radiation import RadiationData
-from .sliceFieldReader import FieldSliceData
 from .emittance import EmittanceData
 from .transitionradiation import TransitionRadiationData
 
@@ -11,7 +10,6 @@ __all__ = [
     "PhaseSpaceData",
     "PNGData",
     "RadiationData",
-    "FieldSliceData",
     "EmittanceData",
     "TransitionRadiationData"
 ]

--- a/lib/python/picongpu/extra/plugins/data/emittance.py
+++ b/lib/python/picongpu/extra/plugins/data/emittance.py
@@ -12,6 +12,11 @@ import pandas as pd
 import os
 import collections
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 
 class EmittanceData(DataReader):
     """
@@ -133,7 +138,7 @@ class EmittanceData(DataReader):
             time for itteration
         """
         if iteration is not None:
-            if not isinstance(iteration, collections.Iterable):
+            if not isinstance(iteration, collectionsAbc.Iterable):
                 iteration = np.array([iteration])
 
         data_file_path = self.get_data_path(species, species_filter)

--- a/lib/python/picongpu/extra/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/extra/plugins/data/energy_histogram.py
@@ -12,6 +12,11 @@ import pandas as pd
 import os
 import collections
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 
 class EnergyHistogramData(DataReader):
     """
@@ -130,7 +135,7 @@ class EnergyHistogramData(DataReader):
             the timestep between consecutive iterations
         """
         if iteration is not None:
-            if not isinstance(iteration, collections.Iterable):
+            if not isinstance(iteration, collectionsAbc.Iterable):
                 iteration = np.array([iteration])
 
         data_file_path = self.get_data_path(species, species_filter)

--- a/lib/python/picongpu/extra/plugins/data/phase_space.py
+++ b/lib/python/picongpu/extra/plugins/data/phase_space.py
@@ -7,10 +7,15 @@ License: GPLv3+
 """
 from .base_reader import DataReader
 
-import collections
 import numpy as np
 import os
 import openpmd_api as io
+import collections
+
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
 
 
 class PhaseSpaceMeta(object):
@@ -200,7 +205,7 @@ class PhaseSpaceData(DataReader):
         available_iterations = [key for key, _ in series.iterations.items()]
 
         if iteration is not None:
-            if not isinstance(iteration, collections.Iterable):
+            if not isinstance(iteration, collectionsAbc.Iterable):
                 iteration = [iteration]
             # verify requested iterations exist
             if not set(iteration).issubset(available_iterations):

--- a/lib/python/picongpu/extra/plugins/data/png.py
+++ b/lib/python/picongpu/extra/plugins/data/png.py
@@ -9,8 +9,13 @@ from .base_reader import DataReader
 
 import numpy as np
 import os
-import collections
 from imageio import imread
+import collections
+
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
 
 
 SPECIES_LONG_NAMES = {
@@ -186,7 +191,7 @@ class PNGData(DataReader):
             species, species_filter, axis, slice_point)
 
         if iteration is not None:
-            if not isinstance(iteration, collections.Iterable):
+            if not isinstance(iteration, collectionsAbc.Iterable):
                 iteration = [iteration]
             # verify requested iterations exist
             if not set(iteration).issubset(available_iterations):


### PR DESCRIPTION
This pull request first removes the SliceFieldReader from the python analysis script, the plugin was removed in #4112, this was probably just forgotten. 

Additionally `collections.Iterable` moved to `collections.abc.Iterable` in python 3.3. The second commit should fix this for all the plugin analysis scripts that require `Iterable`, as suggested by @cbontoiu. 

I tested it with python 3.9 (where the old `collections.Iterable` still works) and with python 3.10 (where the previous approach fails) and it works in both cases.

This should solve #4529 