### PR TITLE
add missing hierarchy in collision atomics

### DIFF
--- a/include/picongpu/particles/collision/detail/ListEntry.hpp
+++ b/include/picongpu/particles/collision/detail/ListEntry.hpp
@@ -174,7 +174,11 @@ namespace picongpu
                                     if(filter(worker, particle))
                                     {
                                         auto parLocalIndex = particle[localCellIdx_];
-                                        cupla::atomicAdd(worker.getAcc(), &nppc[parLocalIndex], 1u);
+                                        cupla::atomicAdd(
+                                            worker.getAcc(),
+                                            &nppc[parLocalIndex],
+                                            1u,
+                                            ::alpaka::hierarchy::Threads{});
                                     }
                                 }
                             });
@@ -216,8 +220,11 @@ namespace picongpu
                                     if(filter(worker, particle))
                                     {
                                         auto parLocalIndex = particle[localCellIdx_];
-                                        uint32_t parOffset
-                                            = cupla::atomicAdd(worker.getAcc(), &parCellList[parLocalIndex].size, 1u);
+                                        uint32_t parOffset = cupla::atomicAdd(
+                                            worker.getAcc(),
+                                            &parCellList[parLocalIndex].size,
+                                            1u,
+                                            ::alpaka::hierarchy::Threads{});
                                         parCellList[parLocalIndex].ptrToIndicies[parOffset] = parInSuperCellIdx;
                                     }
                                 }


### PR DESCRIPTION
Some atomics in our collision algorithm wasn't using proper hierarchy. This was very likely causing performance issues. 