### PR TITLE
add Tests for PyPIConGPU

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,3 +122,28 @@ pmacc-compile-reduced-matrix:
       - artifact: compile.yml
         job: pmacc-generate-reduced-matrix
     strategy: depend
+
+pypicongpu-generate-full-matrix:
+  stage: generate
+  image: ubuntu:22.04
+  script:
+    - apt update
+    - apt install -y python3 python3-pip
+    - pip3 install pyyaml requests
+    - $CI_PROJECT_DIR/share/ci/git_merge.sh
+    - python3 $CI_PROJECT_DIR/share/ci/pypicongpu_generator.py $CI_PROJECT_DIR/lib/python/picongpu/requirements.txt > compile.yml
+    - cat compile.yml
+  artifacts:
+    paths:
+      - compile.yml
+  tags:
+      - x86_64
+  interruptible: true
+
+pypicongpu-full-matrix:
+  stage: test
+  trigger:
+    include:
+      - artifact: compile.yml
+        job: pypicongpu-generate-full-matrix
+    strategy: depend

--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,8 +1,8 @@
-typeguard >= 2.12
+typeguard >= 2.12, < 3.0.0
 sympy >= 1.9
 chevron >= 0.13.1
 jsonschema >= 4.17.3
 scipy >= 1.7.1
-picmistandard >= 0.0.22
+picmistandard == 0.0.22
 
 -r extra/requirements.txt

--- a/share/ci/install/pypicongpu.sh
+++ b/share/ci/install/pypicongpu.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This file is part of the PIConGPU.
+# Copyright 2023 PIConGPU contributors
+# Authors: Simeon Ehrig
+# License: GPLv3+
+
+# - the script installs a Python environment
+# - generates a modified requirements.txt depending of the environment variables for pypicongpu
+# - install the dependencies and runs the quick tests
+
+export PICSRC=$CI_PROJECT_DIR
+export PATH=$PATH:$PICSRC/bin
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+
+# use miniconda as python environment
+apt update && apt install -y wget
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+chmod u+x Miniconda3-latest-Linux-x86_64.sh
+./Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda3
+export PATH=/miniconda3/bin:$PATH
+conda --version
+source /miniconda3/etc/profile.d/conda.sh
+
+# generates modified requirements.txt
+conda create -n pypicongpu python=${PYTHON_VERSION}
+conda activate pypicongpu
+python3 --version
+MODIFIED_REQUIREMENT_TXT=$CI_PROJECT_DIR/lib/python/picongpu/modified_requirements.txt
+python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/requirements.txt $MODIFIED_REQUIREMENT_TXT
+
+echo "modified_requirements.txt: "
+cat $MODIFIED_REQUIREMENT_TXT
+echo ""
+
+# run quick tests
+pip3 install -r $MODIFIED_REQUIREMENT_TXT
+cd $CI_PROJECT_DIR/test/python/picongpu
+python3 -m quick

--- a/share/ci/install/requirements_txt_modifier.py
+++ b/share/ci/install/requirements_txt_modifier.py
@@ -1,0 +1,91 @@
+import os
+import sys
+
+"""
+This file is part of the PIConGPU.
+Copyright 2023 PIConGPU contributors
+Authors: Simeon Ehrig
+License: GPLv3+
+"""
+
+"""@file Fix package version in requirement.txt to a specific version.
+
+Reads an existing requirements.txt file, sets one or more of the packages to a
+fixed version and creates a new requirements.txt file from the modified
+hard set packages and fills up with the remaining packages.
+
+@param First application argument: Path to the original requirements.txt
+@param Second application argument: Path to the mew requirements.txt
+
+@attention Versions of the packages are set via environment variables. The
+variables need to have the shape of: PYPIC_DEP_VERSION_<package_name>=<version>
+"""
+
+
+def cs(text: str, color: str):
+    """Print the text in a different color on the command line. The text after
+       the function has the default color of the command line.
+
+    Parameters
+    ----------
+        @param text (str): text to be colored
+        @param color (str): Name of the color. If wrong color or empty, use
+            default color of the command line.
+
+    Returns
+    -------
+        @return str: text with bash pre and post string for coloring
+    """
+
+    if color is None:
+        return text
+
+    output = ""
+    if color == "Red":
+        output += "\033[0;31m"
+    elif color == "Green":
+        output += "\033[0;32m"
+    elif color == "Yellow":
+        output += "\033[1;33m"
+
+    return output + text + "\033[0m"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(
+            "Set path to requirements.txt as first argument and output path as"
+            " second argument."
+        )
+        exit(1)
+
+    # parse environment variables
+    packages = {}
+    for envvar in os.environ:
+        if envvar.startswith("PYPIC_DEP_VERSION_"):
+            packages[envvar.split("_")[-1]] = os.environ[envvar]
+
+    print("Try to set following package to a fix version")
+    for pkg_name, pkg_version in packages.items():
+        print(f"  {pkg_name} -> {pkg_version}")
+
+    with open(sys.argv[1], "r", encoding="utf-8") as input:
+        with open(sys.argv[2], "w", encoding="utf-8") as output:
+            for line in input.readlines():
+                input_pkg_name = line.split(" ")[0]
+                if input_pkg_name in packages:
+                    output.write(
+                        f"{input_pkg_name} == {packages[input_pkg_name]}\n"
+                    )
+                    packages.pop(input_pkg_name)
+                else:
+                    output.write(line)
+
+    # debug messages
+    for pkg_name in packages.keys():
+        print(
+            cs(
+                f"WARNING: could not find {pkg_name} in requirements.txt",
+                "Yellow",
+            )
+        )

--- a/share/ci/pypicongpu.yml
+++ b/share/ci/pypicongpu.yml
@@ -1,0 +1,13 @@
+.base_pypicongpu_quick_test:
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-${CI_CONTAINER_NAME}-pic:${CONTAINER_TAG}
+  variables:
+    GIT_SUBMODULE_STRATEGY: normal
+  script:
+    - echo "CI_CONTAINER_NAME -> $CI_CONTAINER_NAME"
+    - echo "PYTHON_VERSION -> $PYTHON_VERSION"
+    - env | grep PYPIC_DEP_VERSION_
+    - source $CI_PROJECT_DIR/share/ci/install/pypicongpu.sh
+  tags:
+    - cpuonly
+    - x86_64
+  interruptible: true

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -1,0 +1,322 @@
+import requests
+import sys
+import yaml
+import re
+from typing import List, Dict, Callable
+import pkg_resources
+
+"""
+This file is part of the PIConGPU.
+Copyright 2023 PIConGPU contributors
+Authors: Simeon Ehrig
+License: GPLv3+
+"""
+
+"""@file Generate different CI test jobs for different Python version and
+         depending on a requirement.txt.
+
+Prints yaml code for a GitLab CI child pipeline to stdout. The test parameters
+are split in two kinds of inputs. The Python versions to test are defined in
+the script, also the names of dependencies to test and it's test strategy. The
+version range of the dependencies to test are defined in a requirements.txt.
+The path of the requirements.txt is set via first application argument.
+
+First, the script reads the requirements.txt. If a dependency is marked to test
+in the script, it calculates the test versions. Therefore it downloads all
+available versions from pypi.org for each package. Afterwards it filters the
+versions via a filter strategy. For example, take all release versions or take
+each latest major version. Than the script removes all versions, which are not
+supported, defined in the requirements.txt. The result a complete list of all
+Python and dependencies versions to test.
+
+In the second part, the script creates the full combination matrix for all test
+versions and creates a CI job for each combination. Each job is printed on
+stdout.
+
+The number of combinations depends on:
+- number of supported Python version
+- number of dependencies to test
+- the test strategy of each dependencies to test
+- versions restrictions in the requirements.txt
+- releases of the dependencies
+
+@param First application argument: Path to the requirements.txt
+"""
+
+
+# caches the parsed dependencies of the requirements.txt here
+req_versions: Dict[str, pkg_resources.Requirement] = {}
+
+
+def cs(text: str, color: str) -> str:
+    """Print the text in a different color on the command line. The text after
+       the function has the default color of the command line.
+
+    Parameters
+    ----------
+        @param text (str): text to be colored
+        @param color (str): Name of the color. If wrong color or empty, use
+            default color of the command line.
+
+    Returns
+    -------
+        @return str: text with bash pre and post string for coloring
+    """
+
+    if color is None:
+        return text
+
+    output = ""
+    if color == "Red":
+        output += "\033[0;31m"
+    elif color == "Green":
+        output += "\033[0;32m"
+    elif color == "Yellow":
+        output += "\033[1;33m"
+
+    return output + text + "\033[0m"
+
+
+def get_all_pypi_versions(package_name: str) -> List[str]:
+    """Returns all release versions of a package registered on pypi.org
+
+    Parameters
+    ----------
+        @param package_name (str): Name of the searched package.
+
+    Returns
+    -------
+        @return List[str]: List of release versions.
+    """
+
+    url = f"https://pypi.org/pypi/{package_name}/json"
+
+    res = requests.get(url, timeout=5)
+
+    data = res.json()
+    # remove all release candidates, alpha and beta releases
+    # allows only version strings containing numbers and dots
+    versions = [v for v in data["releases"] if re.match(r"^[0-9\.]*$", v)]
+
+    return sorted(versions, key=pkg_resources.parse_version, reverse=True)
+
+
+def get_all_major_pypi_versions(package_name):
+    """Returns the latest release versions of each major release of a package
+    registered on pypi.org
+
+    Parameters
+    ----------
+        @param package_name (str): Name of the searched package.
+
+    Returns
+    -------
+        @return List[str]: List of release versions.
+    """
+    all_versions = get_all_pypi_versions(package_name)
+    version_map = {}
+
+    for version in all_versions:
+        parsed_version = pkg_resources.parse_version(version)
+        # all versions are sorted from the highest to the lowest
+        # therefore no complex comparison of the version is required
+        # simply take the first appearance of a major version
+        if parsed_version.major not in version_map:
+            version_map[parsed_version.major] = parsed_version
+
+    return [str(v) for v in version_map.values()]
+
+
+def get_supported_versions(
+    package_name: str, versions: List[str]
+) -> List[str]:
+    """Take a list of package versions all removes all version, which are not
+    supported by the requirements.txt.
+
+    Parameters
+    ----------
+        @param package_name (str): Name of the package.
+        @param versions (List[str]): List to be filtered
+
+    Returns
+    -------
+        @return List[str]: filtered list
+    """
+    # use global variable to cache parsed versions from the requirements.txt
+    global req_versions
+    filtered_versions = []
+
+    if not req_versions:
+        with open(sys.argv[1], "r", encoding="utf-8") as req_file:
+            parsed_req = pkg_resources.parse_requirements(req_file)
+            # ignore all lines, which cannot be parsed
+            # e.g. `-r extra/requirements.txt`
+            try:
+                for req in parsed_req:
+                    req_versions[req.project_name] = req
+            except Exception:
+                pass
+
+    if package_name not in req_versions:
+        print(
+            cs(f"ERROR: {package_name} is not defined in {sys.argv[1]}", "Red")
+        )
+        exit(1)
+
+    for v in versions:
+        if str(v) in req_versions[package_name]:
+            filtered_versions.append(v)
+
+    return filtered_versions
+
+
+class Job:
+    """The Job class stores a single GitLab CI job description.
+    It actual replace the dictionary data structure {job_name : { # job_body }}
+    and gives the guaranty, that there is only one key on the dict top level,
+    which makes it much easier to access the job name.
+    """
+
+    def __init__(self, name: str, body: Dict):
+        """Creates a Job object, see class description.
+
+        Parameters
+        ----------
+            @param name (str): Name of the job
+            @param body (Dict): Body of the job. Contains for example the
+                entries `variables`, `script` and so one.
+        """
+        self.name = name
+        self.body = body
+
+    def yaml_dumps(self) -> str:
+        """Generate yaml representation of the job.
+
+        Returns
+        -------
+            @return str: Yaml representation as string.
+        """
+        return yaml.dump({self.name: self.body})
+
+
+def extend_job_with_test_requirement(
+    job: Job, package_name: str, package_version: str
+) -> Job:
+    """Copies the input job, adds a new variable to the variables section of
+    the copied job and return it.
+
+    Parameters
+    ----------
+        @param job (Job): Job to be extent
+        @param package_name (str): Name of the package to add
+        @param package_version (str): Version of the package to add
+
+    Returns
+    -------
+        @return Job: Copy of the input job, extend in the variable section a
+        variable containing package name and version.
+    """
+    job_copy_name = job.name + "_" + package_name + package_version
+    job_copy = Job(job_copy_name, job.body)
+    job_copy.body["variables"][
+        "PYPIC_DEP_VERSION_" + package_name
+    ] = package_version
+
+    return job_copy
+
+
+def construct_job(
+    job: Job,
+    current_test_pkgs: List[str],
+    test_pkg_versions: Dict[str, List[str]],
+):
+    """Recursive function to construct all test jobs.
+
+    Starts with an initial job, passed via the argument job. The initial jobs
+    contains attributes like `image`, `extends`, `variables` and so one. Each
+    function call adds a variable to the `variables` section, which describes
+    which version of a dependency should be tested.
+
+    The "counting variable" is the length of the current_test_pkg. Each
+    function call the function takes the first element and adds a variable to
+    the job depending on the package name. Then it calls the function again and
+    remove the first argument. If only one argument is left, the functions adds
+    the variable, generates the job yaml and prints to stdout.
+
+    Parameters
+    ----------
+        @param job (Job): Current job to extent.
+        @param current_test_pkgs (List[str]): Current package to add.
+        @param test_pkg_versions (Dict[str, List[str]]): Versions of each
+            package.
+    """
+    package_name = current_test_pkgs[0]
+
+    if len(current_test_pkgs) == 1:
+        for package_version in test_pkg_versions[package_name]:
+            extended_job = extend_job_with_test_requirement(
+                job, package_name, package_version
+            )
+            print(extended_job.yaml_dumps())
+    else:
+        for package_version in test_pkg_versions[package_name]:
+            construct_job(
+                extend_job_with_test_requirement(
+                    job, package_name, package_version
+                ),
+                current_test_pkgs[1:],
+                test_pkg_versions,
+            )
+
+
+def print_job_yaml(test_pkg_versions: Dict[str, List[str]]):
+    """Prints all GitLab CI jobs on stdout.
+
+    Parameters
+    ----------
+        @param test_pkg_versions (Dict[str, List[str]]): Dependency versions to
+            test.
+    """
+    # contains the .base_pypicongpu_quick_test base job
+    print(yaml.dump({"include": "/share/ci/pypicongpu.yml"}))
+
+    for pyVer in PYTHON_VERSIONS:
+        job = Job(
+            name="PyPIConGPU_Python" + pyVer,
+            body={
+                "variables": {
+                    "PYTHON_VERSION": pyVer + ".*",
+                    "CI_CONTAINER_NAME": "ubuntu20.04",
+                },
+                "extends": ".base_pypicongpu_quick_test",
+            },
+        )
+        construct_job(job, list(test_pkg_versions.keys()), test_pkg_versions)
+
+
+# Python versions to test
+PYTHON_VERSIONS: List[str] = ["3.9", "3.10", "3.11"]
+# Define, which dependencies should be explicit tests.
+# The key is the name of the package, and function returns the versions to
+# test.
+# If a package is not define in the list, but defined in the requirements.txt,
+# pip decides which version is used.
+PACKAGES_TO_TEST: Dict[str, Callable] = {
+    "typeguard": get_all_major_pypi_versions,
+    "jsonschema": get_all_major_pypi_versions,
+    "picmistandard": get_all_pypi_versions,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            cs("ERROR: Set path to requirements.txt as first argument.", "Red")
+        )
+        exit(1)
+
+    test_pkg_versions: Dict[str, List[str]] = {}
+
+    for pkg, version_func in PACKAGES_TO_TEST.items():
+        test_pkg_versions[pkg] = get_supported_versions(pkg, version_func(pkg))
+
+    print_job_yaml(test_pkg_versions)


### PR DESCRIPTION
PICMI and PyPIConGPU CI self tests

# workflow

The CI allows to test PICMI and PyPIConGPU with different Python and dependency versions. If a new CI run is triggered, the following steps are executed for the tests.

1. Run job generator
  - Generates a full test matrix of python and dependencies versions (in the generator script, it is defined if a dependency is tested only with the latest supported version or different versions).
  - Generates for each combination a job where variables defines, which python version should be tested and which dependency should be fixed to a specific version.
 2. Prepare the test
  - Setup a python environment.
  - Takes the `requirments.txt` of PyPIConGPU and generates a new `requirments.txt` with fix dependency versions to a specific depending on the job variables.
 3. Run the quick test

# Following up work

In the following up PR, PyPIConGPU compile test will be implemented. They need more preparation for the environment and a test run takes more time. Therefore special handling is required. 