### PR TITLE
openPMD-api 0.15: Use storeChunkRaw/loadChunkRaw instead of shareRaw

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -740,10 +740,14 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 // getPointer() will wait for device->host transfer
                 ValueType* nativePtr = buffer.getHostBuffer().getPointer();
                 ReinterpretedType* rawPtr = reinterpret_cast<ReinterpretedType*>(nativePtr);
+#if OPENPMDAPI_VERSION_GE(0, 15, 0)
+                mrc.storeChunkRaw(rawPtr, asStandardVector(recordOffsetDims), asStandardVector(recordLocalSizeDims));
+#else
                 mrc.storeChunk(
                     ::openPMD::shareRaw(rawPtr),
                     asStandardVector(recordOffsetDims),
                     asStandardVector(recordLocalSizeDims));
+#endif
                 flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
             }
 
@@ -789,10 +793,17 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 /* Explicit template parameters to asStandardVector required
                  * as we need to change the element type as well
                  */
+#if OPENPMDAPI_VERSION_GE(0, 15, 0)
+                mrc.loadChunkRaw(
+                    rawPtr,
+                    asStandardVector<VecUInt64, ::openPMD::Offset>(recordOffsetDims),
+                    asStandardVector<VecUInt64, ::openPMD::Extent>(recordLocalSizeDims));
+#else
                 mrc.loadChunk(
                     ::openPMD::shareRaw(rawPtr),
                     asStandardVector<VecUInt64, ::openPMD::Offset>(recordOffsetDims),
                     asStandardVector<VecUInt64, ::openPMD::Extent>(recordLocalSizeDims));
+#endif
                 params->openPMDSeries->flush();
                 // Copy data to device
                 rngProvider->syncToDevice();


### PR DESCRIPTION
With https://github.com/openPMD/openPMD-api/pull/1229 (merged as of version 0.15), openPMD-api deprecates the use of `shareRaw()`, introducing instead dedicated raw-pointer functions `storeChunkRaw` and `loadChunkRaw`. 
This uses the new API if the version of openPMD-api is recent enough, mainly to avoid compilation warnings.

@psychocoderHPC 