### PR TITLE
fix 2D current deposition performance

### DIFF
--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -173,8 +173,8 @@ namespace picongpu
                         return;
 
                     auto const shapeI = makeTrajectoryAssignmentShapeFunction(
-                        typename T_Strategy::template ShapeOuterLoop<T_ParticleAssign>{line.m_pos0[0], true},
-                        typename T_Strategy::template ShapeOuterLoop<T_ParticleAssign>{line.m_pos1[0], true});
+                        typename T_Strategy::template ShapeInnerLoop<T_ParticleAssign>{line.m_pos0[0], true},
+                        typename T_Strategy::template ShapeInnerLoop<T_ParticleAssign>{line.m_pos1[0], true});
 
                     auto const shapeJ = makeTrajectoryAssignmentShapeFunction(
                         typename T_Strategy::template ShapeMiddleLoop<T_ParticleAssign>{line.m_pos0[1], true},
@@ -226,8 +226,8 @@ namespace picongpu
                         return;
 
                     auto const shapeI = makeTrajectoryAssignmentShapeFunction(
-                        typename T_Strategy::template ShapeOuterLoop<T_ParticleAssign>{line.m_pos0[0], true},
-                        typename T_Strategy::template ShapeOuterLoop<T_ParticleAssign>{line.m_pos1[0], true});
+                        typename T_Strategy::template ShapeInnerLoop<T_ParticleAssign>{line.m_pos0[0], true},
+                        typename T_Strategy::template ShapeInnerLoop<T_ParticleAssign>{line.m_pos1[0], true});
 
                     auto const shapeJ = makeTrajectoryAssignmentShapeFunction(
                         typename T_Strategy::template ShapeMiddleLoop<T_ParticleAssign>{line.m_pos0[1], true},

--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -156,10 +156,10 @@ namespace picongpu
                     return;
 
                 auto shapeI = makeTrajectoryAssignmentShapeFunction(
-                    typename T_Strategy::template ShapeOuterLoop<ParticleAssign>{
+                    typename T_Strategy::template ShapeInnerLoop<ParticleAssign>{
                         line.m_pos0[0],
                         bitpacking::test(parStatus[0], bitpacking::Status::START_PARTICLE_IN_ASSIGNMENT_CELL)},
-                    typename T_Strategy::template ShapeOuterLoop<ParticleAssign>{
+                    typename T_Strategy::template ShapeInnerLoop<ParticleAssign>{
                         line.m_pos1[0],
                         bitpacking::test(parStatus[0], bitpacking::Status::END_PARTICLE_IN_ASSIGNMENT_CELL)});
 
@@ -217,10 +217,10 @@ namespace picongpu
                     return;
 
                 auto shapeI = makeTrajectoryAssignmentShapeFunction(
-                    typename T_Strategy::template ShapeOuterLoop<ParticleAssign>{
+                    typename T_Strategy::template ShapeInnerLoop<ParticleAssign>{
                         line.m_pos0[0],
                         bitpacking::test(parStatus[0], bitpacking::Status::START_PARTICLE_IN_ASSIGNMENT_CELL)},
-                    typename T_Strategy::template ShapeOuterLoop<ParticleAssign>{
+                    typename T_Strategy::template ShapeInnerLoop<ParticleAssign>{
                         line.m_pos1[0],
                         bitpacking::test(parStatus[0], bitpacking::Status::END_PARTICLE_IN_ASSIGNMENT_CELL)});
 


### PR DESCRIPTION
EZ and Esirkepov current deposition used the cached/jit shape type of the outer loop for the inner loop.
This results in lower performance because the Cached shape which is the default for the outer loop requires more calculations and results in more thread branch differences.

This PR uses the correct shape type for the inner (fast indexing) loop.