### PR TITLE
fix Esirkepov current deposition 2D

### DIFF
--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov2D.hpp
@@ -181,7 +181,7 @@ namespace picongpu
                     if(j < end + bitpacking::getValue(parStatus[1], bitpacking::Status::LEAVE_CELL))
                     {
                         const float_X s0j = shapeJ.S0(j);
-                        const float_X dsj = shapeJ.S0(j) - s0j;
+                        const float_X dsj = shapeJ.S1(j) - s0j;
 
                         float_X tmp = -currentSurfaceDensity * (s0j + 0.5_X * dsj);
 


### PR DESCRIPTION
fix #4581

With #4170 [broken line](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4170/files#diff-525c7dc809f62cebe12cfce4484e98b121bacfceb5c9179f3a41336450d402edL162) we introduced a bug in the 2D implementation of the 2D Esirkepov implementation.
The symptom of this bug is that global energy increases. We observed this issue with high-density target simulation, never the less even in low-densed physics the bug is there.


CC-ing: @HighIander