### PR TITLE
Range specification from --openPMD.toml

### DIFF
--- a/docs/source/usage/plugins/openPMD.toml
+++ b/docs/source/usage/plugins/openPMD.toml
@@ -10,6 +10,8 @@ backend_config = "@./adios_config.json"    # replaces --openPMD.json,
                                            # default is "{}"
 data_preparation_strategy = "mappedMemory" # replaces --openPMD.dataPreparationStrategy,
                                            # default is "doubleBuffer"
+range = "10,:,:"   # replaces --openPMD.range
+                   # default is ":,:,:"
 
 
 # Periods and data sources are specified independently per reading application

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -5,7 +5,7 @@
 
 namespace picongpu::openPMD
 {
-    struct PluginOptions
+    struct PluginParameters
     {
         std::string fileName = "simData";
         std::string fileInfix = "_%06T";

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -16,9 +16,17 @@ namespace picongpu::openPMD
         std::string jsonRestartParams = "{}";
 
         // for using this with std::tie()
-        operator std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>()
+        operator std::
+            tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>()
         {
-            return std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>{
+            return std::tuple<
+                std::string&,
+                std::string&,
+                std::string&,
+                std::string&,
+                std::string&,
+                std::string&,
+                std::string&>{
                 fileName,
                 fileInfix,
                 fileExtension,

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -13,17 +13,19 @@ namespace picongpu::openPMD
         std::string dataPreparationStrategy = "doubleBuffer";
         std::string jsonConfig = "{}";
         std::string range = ":,:,:";
+        std::string jsonRestartParams = "{}";
 
         // for using this with std::tie()
-        operator std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>()
+        operator std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>()
         {
-            return std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>{
+            return std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>{
                 fileName,
                 fileInfix,
                 fileExtension,
                 dataPreparationStrategy,
                 jsonConfig,
-                range};
+                range,
+                jsonRestartParams};
         }
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+#include <tuple>
+
+namespace picongpu::openPMD
+{
+    struct PluginOptions
+    {
+        std::string fileName = "simData";
+        std::string fileInfix = "_%06T";
+        std::string fileExtension = "bp";
+        std::string dataPreparationStrategy = "doubleBuffer";
+        std::string jsonConfig = "{}";
+        std::string range = ":,:,:";
+
+        // for using this with std::tie()
+        operator std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>()
+        {
+            return std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>{
+                fileName,
+                fileInfix,
+                fileExtension,
+                dataPreparationStrategy,
+                jsonConfig,
+                range};
+        }
+    };
+} // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -7,33 +7,12 @@ namespace picongpu::openPMD
 {
     struct PluginParameters
     {
-        std::string fileName = "simData";
+        std::string fileName = "simData"; /* Name of the openPMDSeries, excluding the extension */
         std::string fileInfix = "_%06T";
-        std::string fileExtension = "bp";
-        std::string dataPreparationStrategy = "doubleBuffer";
-        std::string jsonConfig = "{}";
-        std::string range = ":,:,:";
+        std::string fileExtension = "bp"; /* Extension of the file name */
+        std::string dataPreparationStrategyString = "doubleBuffer";
+        std::string jsonConfigString = "{}";
+        std::string rangeString = ":,:,:";
         std::string jsonRestartParams = "{}";
-
-        // for using this with std::tie()
-        operator std::
-            tuple<std::string&, std::string&, std::string&, std::string&, std::string&, std::string&, std::string&>()
-        {
-            return std::tuple<
-                std::string&,
-                std::string&,
-                std::string&,
-                std::string&,
-                std::string&,
-                std::string&,
-                std::string&>{
-                fileName,
-                fileInfix,
-                fileExtension,
-                dataPreparationStrategy,
-                jsonConfig,
-                range,
-                jsonRestartParams};
-        }
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/plugins/openPMD/Json.hpp"
+#include "picongpu/plugins/openPMD/Parameters.hpp"
 #include "picongpu/plugins/openPMD/toml.hpp"
 #include "picongpu/simulation/control/MovingWindow.hpp"
 
@@ -73,7 +74,7 @@ namespace picongpu
         class openPMDWriter;
         class Help;
 
-        struct ThreadParams
+        struct ThreadParams : PluginParameters
         {
             uint32_t currentStep; /** current simulation step */
 
@@ -84,12 +85,8 @@ namespace picongpu
             bool isCheckpoint;
 
             MPI_Comm communicator; /* MPI communicator for openPMD API */
-            std::string fileName; /* Name of the openPMDSeries, excluding the extension */
-            std::string fileExtension; /* Extension of the file name */
-            std::string fileInfix;
 
             std::unique_ptr<AbstractJsonMatcher> jsonMatcher;
-            std::string jsonRestartParams;
 
             WriteSpeciesStrategy strategy = WriteSpeciesStrategy::ADIOS;
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -73,12 +73,6 @@ namespace picongpu
         class openPMDWriter;
         class Help;
 
-        enum class ConfigurationVia : bool
-        {
-            CommandLine,
-            Toml
-        };
-
         struct ThreadParams
         {
             uint32_t currentStep; /** current simulation step */
@@ -97,8 +91,6 @@ namespace picongpu
             std::unique_ptr<AbstractJsonMatcher> jsonMatcher;
             std::string jsonRestartParams;
 
-            std::unique_ptr<toml::DataSources> tomlDataSources;
-
             WriteSpeciesStrategy strategy = WriteSpeciesStrategy::ADIOS;
 
             MappingDesc* cellDescription;
@@ -113,8 +105,6 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
-
-            ConfigurationVia m_configurationSource = ConfigurationVia::CommandLine;
 
             ::openPMD::Series& openSeries(::openPMD::Access at);
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -407,7 +407,11 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                             [[fallthrough]];
                         }
                     case ApplyParameter::Always:
-                        param.commandLineOption->registerHelp(desc, masterPrefix + prefix);
+                        {
+                            std::string additionalDescription
+                                = param.additionalDescription.has_value() ? param.additionalDescription.value()() : "";
+                            param.commandLineOption->registerHelp(desc, masterPrefix + prefix, additionalDescription);
+                        }
                     }
                 }
             }

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -330,7 +330,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 {&fileNameExtension, "ext", &PluginParameters::fileExtension},
                 {&fileNameInfix, "infix", &PluginParameters::fileInfix},
                 {&jsonConfig, "backend_config", &PluginParameters::jsonConfigString},
-                {&dataPreparationStrategy, "data_preparation_strategy", &PluginParameters::dataPreparationStrategyString},
+                {&dataPreparationStrategy,
+                 "data_preparation_strategy",
+                 &PluginParameters::dataPreparationStrategyString},
                 {&range, "range", &PluginParameters::rangeString, ApplyParameter::NotInCheckpoint},
                 {&jsonRestartConfig,
                  std::nullopt,
@@ -434,7 +436,10 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         {
                             std::string additionalDescription
                                 = param.additionalDescription.has_value() ? param.additionalDescription.value()() : "";
-                            param.commandLineParameter->registerHelp(desc, masterPrefix + prefix, additionalDescription);
+                            param.commandLineParameter->registerHelp(
+                                desc,
+                                masterPrefix + prefix,
+                                additionalDescription);
                         }
                     }
                 }

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -123,10 +123,10 @@ namespace
         return res;
     }
 
-    void parsePluginOptions(
-        picongpu::openPMD::PluginOptions& options,
+    void parsePluginParameters(
+        picongpu::openPMD::PluginParameters& options,
         toml::value tomlConfig,
-        std::vector<picongpu::toml::TomlOption> tomlOptions)
+        std::vector<picongpu::toml::TomlParameter> tomlParameters)
     {
         auto parseOption = [&tomlConfig](std::string& target, std::string const& key)
         {
@@ -145,7 +145,7 @@ namespace
             }
         };
 
-        for(auto const& [param, target_pointer] : tomlOptions)
+        for(auto const& [param, target_pointer] : tomlParameters)
         {
             parseOption(options.*target_pointer, param);
         }
@@ -153,7 +153,7 @@ namespace
 
     PeriodTable_t parseTomlFile(
         picongpu::toml::DataSources& dataSources,
-        std::vector<picongpu::toml::TomlOption> tomlOptions,
+        std::vector<picongpu::toml::TomlParameter> tomlParameters,
         std::string const& content,
         std::string const& file = "unknown file")
     {
@@ -163,7 +163,7 @@ namespace
             return toml::parse(istream, file);
         }();
 
-        parsePluginOptions(dataSources.openPMDPluginOptions, data, tomlOptions);
+        parsePluginParameters(dataSources.openPMDPluginParameters, data, tomlParameters);
 
         if(not data.contains("sink"))
         {
@@ -212,7 +212,7 @@ namespace
     template<typename ChronoDuration>
     PeriodTable_t waitForAndParseTomlFile(
         picongpu::toml::DataSources& dataSources,
-        std::vector<picongpu::toml::TomlOption> tomlOptions,
+        std::vector<picongpu::toml::TomlParameter> tomlParameters,
         std::string const path,
         ChronoDuration const& sleepInterval,
         ChronoDuration const& timeout,
@@ -253,7 +253,7 @@ namespace
         picongpu::toml::writeLog("openPMD: Reading TOML file collectively");
         std::string fileContents = picongpu::collective_file_read(path, comm);
 
-        return parseTomlFile(dataSources, tomlOptions, fileContents, path);
+        return parseTomlFile(dataSources, tomlParameters, fileContents, path);
     }
 } // namespace
 
@@ -273,7 +273,7 @@ namespace picongpu
 
         DataSources::DataSources(
             std::string const& tomlFile,
-            std::vector<picongpu::toml::TomlOption> tomlOptions,
+            std::vector<picongpu::toml::TomlParameter> tomlParameters,
             std::vector<std::string> const& allowedDataSources,
             MPI_Comm comm)
         {
@@ -281,7 +281,7 @@ namespace picongpu
              * Do NOT put the following line as part of the constructor initializers!
              * It takes *this as first parameter, so things must be fully default-constructed before calling it.
              */
-            m_periods = waitForAndParseTomlFile(*this, tomlOptions, tomlFile, WAIT_TIME, TIMEOUT, comm);
+            m_periods = waitForAndParseTomlFile(*this, tomlParameters, tomlFile, WAIT_TIME, TIMEOUT, comm);
             for(auto& periodicity : m_periods)
             {
                 for(auto const& source : periodicity.sources)

--- a/include/picongpu/plugins/openPMD/toml.hpp
+++ b/include/picongpu/plugins/openPMD/toml.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "picongpu/plugins/openPMD/Parameters.hpp"
+
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -34,24 +36,10 @@ namespace picongpu
 {
     namespace toml
     {
-        struct PluginOptions
+        struct TomlOption
         {
-            std::string fileName = "simData";
-            std::string fileInfix = "_%06T";
-            std::string fileExtension = "bp";
-            std::string dataPreparationStrategy = "doubleBuffer";
-            std::string jsonConfig = "{}";
-
-            // for using this with std::tie()
-            operator std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&>()
-            {
-                return std::tuple<std::string&, std::string&, std::string&, std::string&, std::string&>{
-                    fileName,
-                    fileInfix,
-                    fileExtension,
-                    dataPreparationStrategy,
-                    jsonConfig};
-            }
+            std::string optionName;
+            std::string openPMD::PluginOptions::*destination;
         };
 
         // We can't use pmacc::pluginSystem::Slice in a hostonly file due to PIConGPU include structure
@@ -82,9 +70,13 @@ namespace picongpu
             std::vector<Periodicity> m_periods;
 
         public:
-            PluginOptions openPMDPluginOptions;
+            openPMD::PluginOptions openPMDPluginOptions;
 
-            DataSources(std::string const& tomlFile, std::vector<std::string> const& allowedDataSources, MPI_Comm);
+            DataSources(
+                std::string const& tomlFile,
+                std::vector<picongpu::toml::TomlOption> tomlOptions,
+                std::vector<std::string> const& allowedDataSources,
+                MPI_Comm);
 
             /*
              * The datasources that are active at currentStep().

--- a/include/picongpu/plugins/openPMD/toml.hpp
+++ b/include/picongpu/plugins/openPMD/toml.hpp
@@ -36,10 +36,10 @@ namespace picongpu
 {
     namespace toml
     {
-        struct TomlOption
+        struct TomlParameter
         {
             std::string optionName;
-            std::string openPMD::PluginOptions::*destination;
+            std::string openPMD::PluginParameters::*destination;
         };
 
         // We can't use pmacc::pluginSystem::Slice in a hostonly file due to PIConGPU include structure
@@ -70,11 +70,11 @@ namespace picongpu
             std::vector<Periodicity> m_periods;
 
         public:
-            openPMD::PluginOptions openPMDPluginOptions;
+            openPMD::PluginParameters openPMDPluginParameters;
 
             DataSources(
                 std::string const& tomlFile,
-                std::vector<picongpu::toml::TomlOption> tomlOptions,
+                std::vector<picongpu::toml::TomlParameter> tomlParameters,
                 std::vector<std::string> const& allowedDataSources,
                 MPI_Comm);
 


### PR DESCRIPTION
The parameter `--openPMD.range` was the only way to specify ranges so far.
Since the parameter specification is a bit all over the place right now in the openPMD plugin, this PR tries to take the chance for cleaning things up a bit. Parameter specification is now mainly moved into the `openPMDWriter::Help` class.

TODO

- [x] Cleanup
- [x] Testing