### PR TITLE
Use SFINAE for determining if storeChunkRaw should be used

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -25,6 +25,8 @@
 #include <string> // std::stoull
 #include <utility> // std::declval
 
+#include <openPMD/RecordComponent.hpp>
+
 namespace picongpu
 {
     namespace openPMD
@@ -156,6 +158,58 @@ namespace picongpu
                 std::move(extent),
                 useSpanAPI,
                 std::forward<Functor>(createBaseBuffer));
+        }
+
+        namespace detail
+        {
+            template<typename RecordComponent = ::openPMD::RecordComponent, typename Dummy = void>
+            struct StoreChunkRaw
+            {
+                template<typename T>
+                static void store(RecordComponent& rc, T* ptr, ::openPMD::Offset offset, ::openPMD::Extent extent)
+                {
+                    rc.template storeChunk<T>(::openPMD::shareRaw(ptr), std::move(offset), std::move(extent));
+                }
+
+                template<typename T>
+                static void load(RecordComponent& rc, T* ptr, ::openPMD::Offset offset, ::openPMD::Extent extent)
+                {
+                    rc.template loadChunk<T>(::openPMD::shareRaw(ptr), std::move(offset), std::move(extent));
+                }
+            };
+
+            template<typename RecordComponent>
+            struct StoreChunkRaw<
+                RecordComponent,
+                decltype(std::declval<RecordComponent>().storeChunkRaw(
+                    std::declval<char*>(),
+                    std::declval<::openPMD::Offset>(),
+                    std::declval<::openPMD::Extent>()))>
+            {
+                template<typename T>
+                static void store(RecordComponent& rc, T* ptr, ::openPMD::Offset offset, ::openPMD::Extent extent)
+                {
+                    rc.template storeChunkRaw<T>(ptr, std::move(offset), std::move(extent));
+                }
+
+                template<typename T>
+                static void load(RecordComponent& rc, T* ptr, ::openPMD::Offset offset, ::openPMD::Extent extent)
+                {
+                    rc.template loadChunkRaw<T>(ptr, std::move(offset), std::move(extent));
+                }
+            };
+        } // namespace detail
+
+        template<typename T>
+        void storeChunkRaw(::openPMD::RecordComponent& rc, T* ptr, ::openPMD::Offset offset, ::openPMD::Extent extent)
+        {
+            detail::StoreChunkRaw<::openPMD::RecordComponent>::store(rc, ptr, std::move(offset), std::move(extent));
+        }
+
+        template<typename T>
+        void loadChunkRaw(::openPMD::RecordComponent& rc, T* ptr, ::openPMD::Offset offset, ::openPMD::Extent extent)
+        {
+            detail::StoreChunkRaw<::openPMD::RecordComponent>::load(rc, ptr, std::move(offset), std::move(extent));
         }
 
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -740,14 +740,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 // getPointer() will wait for device->host transfer
                 ValueType* nativePtr = buffer.getHostBuffer().getPointer();
                 ReinterpretedType* rawPtr = reinterpret_cast<ReinterpretedType*>(nativePtr);
-#if OPENPMDAPI_VERSION_GE(0, 15, 0)
-                mrc.storeChunkRaw(rawPtr, asStandardVector(recordOffsetDims), asStandardVector(recordLocalSizeDims));
-#else
-                mrc.storeChunk(
-                    ::openPMD::shareRaw(rawPtr),
-                    asStandardVector(recordOffsetDims),
-                    asStandardVector(recordLocalSizeDims));
-#endif
+                storeChunkRaw(mrc, rawPtr, asStandardVector(recordOffsetDims), asStandardVector(recordLocalSizeDims));
                 flushSeries(*params->openPMDSeries, PreferredFlushTarget::Disk);
             }
 
@@ -793,17 +786,11 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 /* Explicit template parameters to asStandardVector required
                  * as we need to change the element type as well
                  */
-#if OPENPMDAPI_VERSION_GE(0, 15, 0)
-                mrc.loadChunkRaw(
+                loadChunkRaw(
+                    mrc,
                     rawPtr,
                     asStandardVector<VecUInt64, ::openPMD::Offset>(recordOffsetDims),
                     asStandardVector<VecUInt64, ::openPMD::Extent>(recordLocalSizeDims));
-#else
-                mrc.loadChunk(
-                    ::openPMD::shareRaw(rawPtr),
-                    asStandardVector<VecUInt64, ::openPMD::Offset>(recordOffsetDims),
-                    asStandardVector<VecUInt64, ::openPMD::Extent>(recordLocalSizeDims));
-#endif
                 params->openPMDSeries->flush();
                 // Copy data to device
                 rngProvider->syncToDevice();


### PR DESCRIPTION
The Hemera installation of openPMD-api uses the dev branch, so the version macro does not work correctly.
--> We need to be a bit more sneaky