### PR TITLE
pull charge state particle manipulator into code

### DIFF
--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -149,6 +149,12 @@ namespace picongpu
 
             /** Definition of manipulator that changes the in-cell position of each particle of a species. */
             using RandomPosition = unary::RandomPosition;
+
+            /** definition of manipulator that sets the boundElectron attribute(charge state) of each
+             * particle of an ion of a species to neutral
+             */
+            using SetNeutral = unary::ChargeState<0u>;
+
         } // namespace manipulators
 
         namespace startPosition

--- a/include/picongpu/particles/manipulators/manipulators.def
+++ b/include/picongpu/particles/manipulators/manipulators.def
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera, Axel Huebl
+/* Copyright 2014-2023 Rene Widera, Axel Huebl, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -31,6 +31,7 @@
 #include "picongpu/particles/manipulators/generic/Free.def"
 #include "picongpu/particles/manipulators/generic/FreeRng.def"
 #include "picongpu/particles/manipulators/generic/None.def"
+#include "picongpu/particles/manipulators/unary/ChargeState.def"
 #include "picongpu/particles/manipulators/unary/CopyAttribute.def"
 #include "picongpu/particles/manipulators/unary/Drift.def"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.def"

--- a/include/picongpu/particles/manipulators/manipulators.hpp
+++ b/include/picongpu/particles/manipulators/manipulators.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Rene Widera, Axel Huebl
+/* Copyright 2014-2023 Rene Widera, Axel Huebl, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -21,6 +21,7 @@
 
 #include "picongpu/particles/manipulators/generic/Free.hpp"
 #include "picongpu/particles/manipulators/generic/FreeRng.hpp"
+#include "picongpu/particles/manipulators/unary/ChargeState.hpp"
 #include "picongpu/particles/manipulators/unary/Drift.hpp"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffset.hpp"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.hpp"

--- a/include/picongpu/particles/manipulators/unary/ChargeState.def
+++ b/include/picongpu/particles/manipulators/unary/ChargeState.def
@@ -1,0 +1,55 @@
+/* Copyright 2023 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! @file defines of functors setting the charge state of macro-particles
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/manipulators/generic/Free.def"
+
+#include <cstdint>
+
+namespace picongpu::particles::manipulators::unary
+{
+    namespace acc
+    {
+        //! Functors implementing modifying particle charge state
+
+        /** version for fixed charge state
+         *
+         *  @tparam T_chargeState charge state to set macro-ions to
+         */
+        template<uint8_t T_chargeState>
+        struct ChargeState;
+
+        // ... add further versions here
+    } // namespace acc
+
+    //! set macro-ion charge state
+
+    /** version for fixed charge state
+     *
+     * @tparam T_chargeState charge state to set macro ion to
+     */
+    template<uint8_t T_chargeState>
+    using ChargeState = generic::Free<acc::ChargeState<T_chargeState>>;
+
+} // namespace picongpu::particles::manipulators::unary

--- a/include/picongpu/particles/manipulators/unary/ChargeState.hpp
+++ b/include/picongpu/particles/manipulators/unary/ChargeState.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2023 Brian Marre
+ *
+ * based on a previous implementation by Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! @file implements of functors setting the charge state of macro-particles
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+// safe to import in .param files since does not import a .param itself
+#include "picongpu/particles/atomicPhysics/SetToAtomicGroundStateForChargeState.hpp"
+
+#include <pmacc/static_assert.hpp>
+
+#include <cstdint>
+
+namespace picongpu::particles::manipulators::unary::acc
+{
+    //! see ChargeState.def for documentation
+    template<uint8_t T_chargeState>
+    struct ChargeState
+    {
+        //! set boundElectrons(charge state) of macro ion
+        template<typename T_Ion>
+        HDINLINE void operator()(T_Ion& ion)
+        {
+            constexpr float_X numberBoundElectronsNeutralAtom
+                = picongpu::traits::GetAtomicNumbers<T_Ion>::type::numberOfProtons;
+
+            // check if target charge state is physical
+            PMACC_CASSERT_MSG(
+                Too_high_charge_state_for_atomic_number,
+                numberBoundElectronsNeutralAtom >= static_cast<float_X>(T_chargeState));
+
+            constexpr float_X targetNumberBoundElectrons
+                = numberBoundElectronsNeutralAtom - static_cast<float_X>(T_chargeState);
+
+            // set standard charge state
+            ion[boundElectrons_] = targetNumberBoundElectrons;
+
+            // try to set atomic state
+            picongpu::particles::atomicPhysics::SetToAtomicGroundStateForChargeState{}(
+                ion,
+                static_cast<uint8_t>(targetNumberBoundElectrons));
+        }
+    };
+} // namespace picongpu::particles::manipulators::unary::acc

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
@@ -47,37 +47,11 @@ namespace picongpu
 
         namespace manipulators
         {
-            /** Define initial ion charge to once ionized*/
-            struct OnceIonizedImpl
-            {
-                /** Ionize ions once by removing one bound electron */
-                template<typename T_Particle>
-                DINLINE void operator()(T_Particle& particle)
-                {
-                    constexpr float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
-                    particle[boundElectrons_] = protonNumber - 1.0_X;
-                }
-            };
-            /** Definition of manipulator that sets the ionization state of an ion macro-particle
-             * according properties defined in struct OnceIonizedImpl.
-             */
-            using OnceIonized = generic::Free<OnceIonizedImpl>;
+            //! Definition of manipulator that sets the ionization state of an ion macro-particle to once ionized
+            using OnceIonized = unary::ChargeState<1u>;
 
-            /** Define initial ion charge to twice ionized*/
-            struct TwiceIonizedImpl
-            {
-                /** Ionize ions twice by removing two bound electrons */
-                template<typename T_Particle>
-                DINLINE void operator()(T_Particle& particle)
-                {
-                    constexpr float_X protonNumber = GetAtomicNumbers<T_Particle>::type::numberOfProtons;
-                    particle[boundElectrons_] = protonNumber - 2._X;
-                }
-            };
-            /** Definition of manipulator that sets the ionization state of an ion macro-particle
-             * according properties defined in struct TwiceIonizedImpl.
-             */
-            using TwiceIonized = generic::Free<TwiceIonizedImpl>;
+            //! Definition of manipulator that sets the ionization state of an ion macro-particle to twice ionized
+            using TwiceIonized = unary::ChargeState<2u>;
 
 
             /** Definition of manipulator that changes the in-cell position of each particle of a species. */

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/particle.param
@@ -75,27 +75,8 @@ namespace picongpu
 
         namespace manipulators
         {
-            /** Define initial charge state of ion macro-particel species. */
-            struct SetIonToNeutral
-            {
-                /** Set number of bound electrons to number of protons
-                 * to create neutral atoms at initialization.
-                 */
-                template<typename T_Particle>
-                DINLINE void operator()(T_Particle& particle)
-                {
-                    using Particle = T_Particle;
-
-                    // number of bound electrons at initialization state of the neutral atom
-                    float_X const protonNumber = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;
-
-                    particle[boundElectrons_] = protonNumber;
-                }
-            };
-            /** Definition of manipulator that sets boundElectrons attribute an ion macro-particle
-             * according properties defined in struct SetIonToNeutral.
-             */
-            using SetBoundElectrons = generic::Free<SetIonToNeutral>;
+            //! Definition of manipulator that sets boundElectrons attribute to neutral value
+            using SetBoundElectrons = unary::ChargeState<0u>;
 
         } // namespace manipulators
     } // namespace particles

--- a/share/picongpu/examples/atomicPhysics/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/atomicPhysics/include/picongpu/param/particle.param
@@ -110,35 +110,8 @@ namespace picongpu
 
         namespace manipulators
         {
-            /** Define initial ion charge */
-            struct SetIonTo16Ionized
-            {
-                /** set ion bound electrons to yield targetChargeState.
-                 */
-                template<typename T_Particle>
-                DINLINE void operator()(T_Particle& particle)
-                {
-                    constexpr float_X targetChargeState = 16;
-
-                    // number of Electrons for neutral atom
-                    constexpr float_X numberBoundElectrons
-                        = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;
-
-                    PMACC_ASSERT_MSG(
-                        numberBoundElectrons >= targetChargeState,
-                        "too few protons for target charge state");
-
-                    picongpu::particles::atomicPhysics::SetToAtomicGroundStateForChargeState{}(
-                        particle,
-                        numberBoundElectrons - targetChargeState);
-                }
-            };
-
-            /** Definition of manipulator that sets properties of an ion macro-particle
-             * according properties defined in struct SetIonTo16Ionized.
-             */
-            using SetIonization = generic::Free<SetIonTo16Ionized>;
-
+            //! Definition of manipulator to set charge State to 16 times ionized
+            using SetIonization = unary::ChargeState<16u>;
 
             /** Define initial particle drift direction vector.
              *  This vector is used in struct DriftParam.

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
@@ -112,17 +112,8 @@ namespace picongpu
                 {{/species_initmanager.operations.simple_momentum}}
 
                 {{#species_initmanager.operations.set_bound_electrons}}
-                    struct PreIonize_{{{species.typename}}}_Impl
-                    {
-                        template<typename T_Particle>
-                        DINLINE void operator()(T_Particle& particle)
-                        {
-                            particle[boundElectrons_] = {{{bound_electrons}}}._X;
-                        }
-                    };
-
-                    //! definition of TwiceIonizedImpl manipulator
-                    using PreIonize_{{{species.typename}}} = generic::Free<PreIonize_{{{species.typename}}}_Impl>;
+                    //! definition of PreIonized manipulator
+                    using PreIonize_{{{species.typename}}} = unary::ChargeState<{{{bound_electrons}}}u>;;
                 {{/species_initmanager.operations.set_bound_electrons}}
             } // namespace pypicongpu
         } // namespace manipulators

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
@@ -138,35 +138,12 @@ namespace picongpu
             /** Definition of manipulator that sets the ionization state of an ion macro-particle
              * according properties defined in struct OnceIonizedImpl.
              */
-            using IonCharge1 = generic::Free<OnceIonizedImpl>;
+            using IonCharge1 = unary::ChargeState<1u>;
 
-
-            /** Define initial ion charge to thrice ionized*/
-            struct ThriceIonizedImpl
-            {
-                /** Ionize ions thrice by removing three bound electrons */
-                template<typename T_Particle>
-                DINLINE void operator()(T_Particle& particle)
-                {
-                    constexpr float_X targetChargeState = 3; // thrice ionized
-
-                    // number of Electrons for neutral atom
-                    constexpr float_X numberBoundElectrons
-                        = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;
-
-                    PMACC_ASSERT_MSG(
-                        numberBoundElectrons >= targetChargeState,
-                        "too few protons for target charge state");
-
-                    picongpu::particles::atomicPhysics::SetToAtomicGroundStateForChargeState{}(
-                        particle,
-                        numberBoundElectrons - targetChargeState);
-                }
-            };
             /** Definition of manipulator that sets the ionization state of an ion macro-particle
              * according properties defined in struct ThriceIonizedImpl.
              */
-            using IonCharge3 = generic::Free<ThriceIonizedImpl>;
+            using IonCharge3 = unary::ChargeState<3u>;
 
         } // namespace manipulators
 

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
@@ -101,33 +101,10 @@ namespace picongpu
              */
             using AddTemperatureIons = unary::Temperature<TemperatureParamIons>;
 
-
-            /** Define initial ion charge to once ionized*/
-            struct OnceIonizedImpl
-            {
-                /** Ionize ions once by removing one bound electron */
-                template<typename T_Particle>
-                DINLINE void operator()(T_Particle& particle)
-                {
-                    constexpr float_X targetChargeState = 1; // once ionized
-
-                    // number of Electrons for neutral atom
-                    constexpr float_X numberBoundElectrons
-                        = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;
-
-                    PMACC_ASSERT_MSG(
-                        numberBoundElectrons >= targetChargeState,
-                        "too few protons for target charge state");
-
-                    picongpu::particles::atomicPhysics::SetToAtomicGroundStateForChargeState{}(
-                        particle,
-                        numberBoundElectrons - targetChargeState);
-                }
-            };
             /** Definition of manipulator that sets the ionization state of an ion macro-particle
              * according properties defined in struct OnceIonizedImpl.
              */
-            using OnceIonized = generic::Free<OnceIonizedImpl>;
+            using OnceIonized = unary::ChargeState<1u>;
 
         } // namespace manipulators
 


### PR DESCRIPTION
Pulls the setChargeState functors from the `particle.param` into the code itself.

Up to now all PIConGPU setups with ionizers had their only private copy of a set charge state particle manipulator. This creates code duplication and maintenance issues as changes did not propagate to user setups making any changes error prone. This is especially problematic for FLYonPIC(atomicPhysics) which requires the charge state to be consistent with the atomic state and therefore required changes to the initialization of charge states.

Old setups are still valid and compatible, but I strongly encourage all users to switch to the new in code implementation for all future setups, this increases resilience with additional checks and makes the setups guaranteed compatible
 with FLYonPIC.

new manipulator is used as follows:
```C++
[particle.param]
namespace manipulators
{
     using SetChargeState = unary::ChargeState<[ChargeState you want]>;
} // namespace manipulators
```

to update an old setup replace your set charge state implementation in `particle.param`(usually), looking similar to this
```C++
[particle.param]
namespace picongpu::manipulators
{
    /** Define initial ion charge */
    struct SetIonTo16Ionized
    {
        /** set ion bound electrons to yield targetChargeState.
         */
        template<typename T_Particle>
        DINLINE void operator()(T_Particle& particle)
        {
            constexpr float_X targetChargeState = 16;

            // number of Electrons for neutral atom
            constexpr float_X numberBoundElectrons
                = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;

            PMACC_ASSERT_MSG(
                numberBoundElectrons >= targetChargeState,
                "too few protons for target charge state");

            picongpu::particles::atomicPhysics::SetToAtomicGroundStateForChargeState{}(
                particle,
                numberBoundElectrons - targetChargeState);
        }
    };

    /** Definition of manipulator that sets properties of an ion macro-particle
     * according properties defined in struct SetIonTo16Ionized.
     */
    using SetIonization = generic::Free<SetIonTo16Ionized>;
} // namespace picongpu::particles::manipulators
```
or in older setups, like this
```C++
[particle.param]
namespace picongpu::particles::manipulators
{
    /** Define initial charge state of ion macro-particel species. */
    struct SetIonToNeutral
    {
        /** Set number of bound electrons to number of protons
         * to create neutral atoms at initialization.
         */
        template<typename T_Particle>
        DINLINE void operator()(T_Particle& particle)
        {
            using Particle = T_Particle;

            // number of bound electrons at initialization state of the neutral atom
            float_X const protonNumber = picongpu::traits::GetAtomicNumbers<T_Particle>::type::numberOfProtons;

            particle[boundElectrons_] = protonNumber;
        }
    };
    /** Definition of manipulator that sets boundElectrons attribute an ion macro-particle
     * according properties defined in struct SetIonToNeutral.
     */
    using SetBoundElectrons = generic::Free<SetIonToNeutral>;
} // namespace picongpu::particles::manipulators
```
with this
```C++
namespace picongpu::particles::manipulators
{
     using SetIonization = unary::ChargeState<16u>;
} // namespace picongpu::particles::manipulators
```
or for the second example this
```C++
namespace picongpu::particles::manipulators
{
    using SetBoundElectrons = unary::ChargeState<0u>;
} // namespace picongpu::particles::manipulators
```