### PR TITLE
fix using wrong math functions

### DIFF
--- a/include/picongpu/fields/absorber/pml/Pml.kernel
+++ b/include/picongpu/fields/absorber/pml/Pml.kernel
@@ -336,7 +336,7 @@ namespace picongpu
 
                     // For near-zero velocity use an approximate formula
                     constexpr auto eps = 1e-5;
-                    if(abs(vel) < eps * cellSize[axis])
+                    if(math::abs(vel) < eps * cellSize[axis])
                     {
                         auto const startNormalizedSigma = detail::getNormalizedSigma(startPos, parameters, axis);
                         auto const finishNormalizedSigma = detail::getNormalizedSigma(finishPos, parameters, axis);

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -422,7 +422,7 @@ namespace picongpu
                             constexpr double ulp = 4.0;
                             constexpr double eps = std::numeric_limits<double>::epsilon();
                             bool const isMatchingUnit
-                                = (std::fabs(unitField[axis] - UNIT_EFIELD) <= eps * UNIT_EFIELD * ulp);
+                                = (math::abs(unitField[axis] - UNIT_EFIELD) <= eps * UNIT_EFIELD * ulp);
                             if(!isMatchingUnit)
                             {
                                 throw std::runtime_error(

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -326,18 +326,18 @@ namespace picongpu
                         bool const applyIncidentField2
                             = ((isUpdatedFieldTotal && !isLastUpdatedCell[incidentComponent1])
                                || (!isUpdatedFieldTotal && !isLastUpdatedCell[incidentComponent2]));
-                        for(int32_t axisShift = abs(updatedFieldShift); axisShift < margin; axisShift++)
+                        for(int32_t axisShift = math::abs(updatedFieldShift); axisShift < margin; axisShift++)
                         {
                             auto coeffIdx = pmacc::DataSpace<3>::create(0);
                             coeffIdx[axis] = axisShift;
                             incidentIdxShift[dir1] = static_cast<float_X>(1 - sizeDir1);
                             for(int32_t dir1Shift = 1 - sizeDir1; dir1Shift < sizeDir1; dir1Shift++)
                             {
-                                coeffIdx[dir1] = abs(dir1Shift);
+                                coeffIdx[dir1] = math::abs(dir1Shift);
                                 incidentIdxShift[dir2] = static_cast<float_X>(1 - sizeDir2);
                                 for(int32_t dir2Shift = 1 - sizeDir2; dir2Shift < sizeDir2; dir2Shift++)
                                 {
-                                    coeffIdx[dir2] = abs(dir2Shift);
+                                    coeffIdx[dir2] = math::abs(dir2Shift);
                                     // Implement the update scheme, multiply by baseCoefficient after the loops
                                     auto const derivativeCoefficient
                                         = derivativeCoefficients.value[coeffIdx[0]][coeffIdx[1]][coeffIdx[2]];

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.hpp
@@ -127,14 +127,14 @@ namespace picongpu
                             {
                                 // downramp = end
                                 auto const exponent = (time - startDownramp) / tau;
-                                envelope *= exp(-0.5_X * exponent * exponent);
+                                envelope *= math::exp(-0.5_X * exponent * exponent);
                                 integrationCorrectionFactor = (time - startDownramp) / (Unitless::w * tau * tau);
                             }
                             else if(time < endUpramp)
                             {
                                 // upramp = start
                                 auto const exponent = (time - endUpramp) / tau;
-                                envelope *= exp(-0.5_X * exponent * exponent);
+                                envelope *= math::exp(-0.5_X * exponent * exponent);
                                 integrationCorrectionFactor = (time - endUpramp) / (Unitless::w * tau * tau);
                             }
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeterFunctors.hpp
@@ -101,10 +101,10 @@ namespace picongpu
                 pmacc::math::dot(this->calorimeterFrameVecZ, dirVec));
 
             /* convert dirVec to yaw and pitch */
-            const float_X yaw = atan2(dirVec.x(), dirVec.y());
-            const float_X pitch = asin(dirVec.z());
+            const float_X yaw = math::atan2(dirVec.x(), dirVec.y());
+            const float_X pitch = math::asin(dirVec.z());
 
-            if(abs(yaw) < this->maxYaw && abs(pitch) < this->maxPitch)
+            if(math::abs(yaw) < this->maxYaw && math::abs(pitch) < this->maxPitch)
             {
                 const float2_X calorimeterPos
                     = particleCalorimeter::mapYawPitchToNormedRange(yaw, pitch, this->maxYaw, this->maxPitch);

--- a/include/pmacc/math/complex/Bessel.tpp
+++ b/include/pmacc/math/complex/Bessel.tpp
@@ -130,7 +130,7 @@ namespace pmacc
                         complex_T cp0 = cone;
                         for(uint32_t k = 0u; k < kz; k++)
                         {
-                            cp0 += a[k] * pow(z1, float_T(-2.0) * k - float_T(2.0));
+                            cp0 += a[k] * cupla::pow(z1, float_T(-2.0) * k - float_T(2.0));
                         }
                         complex_T cq0 = float_T(-0.125) / z1;
                         for(uint32_t k = 0; k < kz; k++)


### PR DESCRIPTION
fix #4594

C math built-in function where used in some places with the result that float input value is implicitly cast for e.g. `abs` into integer and an integer value where returned and used.

I marked this PR with the BUG label because some places look critical for me where the cast of `abs` to integer could lead to unintended behavior.