### PR TITLE
openPMD plugin: Fix TOML parameter for multiplugins

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1025,12 +1025,12 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                         auto [emplaced, newly_inserted] = m_help->tomlDataSources.emplace(
                             std::piecewise_construct,
-                            std::tuple{id},
-                            std::tuple{
+                            std::make_tuple(id),
+                            std::make_tuple(
                                 m_help->tomlSources.get(id),
                                 m_help->tomlParameters(),
                                 m_help->allowedDataSources,
-                                mThreadParams.communicator});
+                                mThreadParams.communicator));
                         if(!newly_inserted)
                         {
                             throw std::runtime_error("[openPMD plugin] Internal logic error: Tried parsing the same "

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -362,7 +362,12 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
              */
             bool selfRegister = false;
 
-            std::optional<toml::DataSources> tomlDataSources;
+            /*
+             * plugin instance id -> TOML Datasources object
+             * If `id` entry exists, then that instance of the object is steered
+             * by TOML params.
+             */
+            std::map<size_t, toml::DataSources> tomlDataSources;
 
             template<typename T_TupleVector>
             using CreateSpeciesFilter = plugins::misc::SpeciesFilter<
@@ -520,9 +525,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             std::vector<std::string> currentDataSources(uint32_t currentStep, size_t id)
             {
-                if(tomlDataSources.has_value())
+                if(auto it = tomlDataSources.find(id); it != tomlDataSources.end())
                 {
-                    return tomlDataSources.value().currentDataSources(currentStep);
+                    return it->second.currentDataSources(currentStep);
                 }
                 else
                 {
@@ -533,9 +538,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             PluginParameters pluginParameters(size_t id)
             {
-                if(tomlDataSources.has_value())
+                if(auto it = tomlDataSources.find(id); it != tomlDataSources.end())
                 {
-                    return tomlDataSources.value().openPMDPluginParameters;
+                    return it->second.openPMDPluginParameters;
                 }
                 else
                 {
@@ -1018,15 +1023,21 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                         std::string const& tomlSources = m_help->tomlSources.get(id);
 
-                        m_help->tomlDataSources = toml::DataSources{
-                            m_help->tomlSources.get(id),
-                            m_help->tomlParameters(),
-                            m_help->allowedDataSources,
-                            mThreadParams.communicator};
+                        auto [emplaced, newly_inserted] = m_help->tomlDataSources.emplace(
+                            std::piecewise_construct,
+                            std::tuple{id},
+                            std::tuple{
+                                m_help->tomlSources.get(id),
+                                m_help->tomlParameters(),
+                                m_help->allowedDataSources,
+                                mThreadParams.communicator});
+                        if(!newly_inserted)
+                        {
+                            throw std::runtime_error("[openPMD plugin] Internal logic error: Tried parsing the same "
+                                                     "plugin instance twice?");
+                        }
 
-                        Environment<>::get().PluginConnector().setNotificationPeriod(
-                            this,
-                            m_help->tomlDataSources.value().periods());
+                        Environment<>::get().PluginConnector().setNotificationPeriod(this, emplaced->second.periods());
 
                         /** create notify directory */
                         Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(outputDirectory);


### PR DESCRIPTION
Close #4590
Follow-up to #4585

The recent refactoring moved the `std::optional<toml::DataSources> tomlDataSources` member to the openPMD-`Help` class. I was not aware that the instance of this class is shared between all instances of the openPMD multiplugin, overriding each other's configuration.

This PR turns that member into a `std::map<size_t, toml::Datasources>`, storing the TOML sources individually for each plugin instance ID.
This way, the command line parameter configuration and the TOML configuration can both be queried from the `Help` object by specifying the plugin ID.