### PR TITLE
fix pypicongpu error after PR #4418

### DIFF
--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -105,6 +105,7 @@ class Simulation(picmistandard.PICMI_Simulation):
     def __init__(self,
                  picongpu_template_dir: typing.Optional[
                      typing.Union[str, pathlib.Path]] = None,
+                 picongpu_typical_ppc: typing.Optional[int] = None,
                  **kw):
         # delegate actual work to parent
         super().__init__(**kw)
@@ -127,6 +128,8 @@ class Simulation(picmistandard.PICMI_Simulation):
             assert template_path.is_dir(), \
                 "picongpu_template_dir must be existing dir"
             self.picongpu_template_dir = str(template_path)
+
+        self.picongpu_typical_ppc = picongpu_typical_ppc
 
         # store runner state
         self.__runner = None
@@ -481,6 +484,16 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.__resolve_electrons()
 
         s.init_manager = self.__get_init_manager()
+
+        # set typical ppc if not overwritten by user
+        if self.picongpu_typical_ppc is None:
+            s.typical_ppc = (s.init_manager).get_typical_particle_per_cell()
+        else:
+            s.typical_ppc = self.picongpu_typical_ppc
+
+        if s.typical_ppc < 1:
+            raise ValueError("typical_ppc must be >= 1")
+
         return s
 
     def picongpu_run(self) -> None:

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -46,6 +46,13 @@ class Simulation(RenderedObject):
     init_manager = util.build_typesafe_property(species.InitManager)
     """init manager holding all species & their information"""
 
+    typical_ppc = util.build_typesafe_property(int)
+    """
+    typical number of macro particles spawned per cell, >=1
+
+    used for normalization of units
+    """
+
     def __get_output_context(self) -> dict:
         """retrieve all output objects"""
         auto = output.Auto()
@@ -59,6 +66,7 @@ class Simulation(RenderedObject):
         serialized = {
             "delta_t_si": self.delta_t_si,
             "time_steps": self.time_steps,
+            "typical_ppc": self.typical_ppc,
             "solver": self.solver.get_rendering_context(),
             "grid": self.grid.get_rendering_context(),
             "species_initmanager": self.init_manager.get_rendering_context(),

--- a/lib/python/picongpu/pypicongpu/species/initmanager.py
+++ b/lib/python/picongpu/pypicongpu/species/initmanager.py
@@ -9,8 +9,8 @@ from typeguard import typechecked, check_type
 import typing
 from .. import util
 from .species import Species
-from .operation import Operation, SimpleDensity, SimpleMomentum, \
-    SetBoundElectrons
+from .operation import Operation, DensityOperation, SimpleDensity, \
+    SimpleMomentum, SetBoundElectrons
 from .attribute import Attribute
 from .constant import Constant
 from functools import reduce
@@ -448,6 +448,31 @@ class InitManager(RenderedObject):
         # check species themselves
         for species in self.all_species:
             species.check()
+
+    def get_typical_particle_per_cell(self) -> int:
+        """
+        get typical number of macro particles per cell(ppc) of simulation
+
+        @returns middle value of ppc-range of all operations, minimum 1
+        """
+        ppcs = []
+
+        for operation in self.all_operations:
+            if isinstance(operation, DensityOperation):
+                ppcs.append(operation.ppc)
+
+        if len(ppcs) == 0:
+            return 1
+
+        max_ppc = max(ppcs)
+        min_ppc = min(ppcs)
+
+        if max_ppc < 1:
+            max_ppc = 1
+        if min_ppc < 1:
+            min_ppc = 1
+
+        return (max_ppc - min_ppc)//2 + min_ppc
 
     def _get_serialized(self) -> dict:
         """

--- a/lib/python/picongpu/pypicongpu/species/operation/__init__.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/__init__.py
@@ -1,4 +1,5 @@
 from .operation import Operation
+from .densityoperation import DensityOperation
 from .simpledensity import SimpleDensity
 from .notplaced import NotPlaced
 from .simplemomentum import SimpleMomentum
@@ -10,6 +11,7 @@ from . import momentum
 
 __all__ = [
     "Operation",
+    "DensityOperation",
     "SimpleDensity",
     "NotPlaced",
     "SimpleMomentum",

--- a/lib/python/picongpu/pypicongpu/species/operation/densityoperation.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityoperation.py
@@ -1,0 +1,17 @@
+"""
+This file is part of the PIConGPU.
+Copyright 2023 PIConGPU contributors
+Authors: Brian Edward Marre
+License: GPLv3+
+"""
+
+from .operation import Operation
+from typeguard import typechecked
+
+
+@typechecked
+class DensityOperation(Operation):
+    """
+    common interface for all operations that create density
+      and the not-placed operation
+    """

--- a/lib/python/picongpu/pypicongpu/species/operation/notplaced.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/notplaced.py
@@ -5,7 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from .operation import Operation
+from .densityoperation import DensityOperation
 from ..species import Species
 from ..attribute import Position, Weighting
 from ... import util
@@ -13,7 +13,7 @@ from typeguard import typechecked
 
 
 @typechecked
-class NotPlaced(Operation):
+class NotPlaced(DensityOperation):
     """
     assigns a position attribute, but does not place a species
 
@@ -25,6 +25,8 @@ class NotPlaced(Operation):
 
     species = util.build_typesafe_property(Species)
     """species which will not be placed"""
+
+    ppc = 0
 
     def __init__(self):
         pass

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -5,7 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from .operation import Operation
+from .densityoperation import DensityOperation
 from typeguard import typechecked
 from ... import util
 from ..species import Species
@@ -16,7 +16,7 @@ from ..constant import DensityRatio
 
 
 @typechecked
-class SimpleDensity(Operation):
+class SimpleDensity(DensityOperation):
     """
     Place a set of species together, using the same density profile
 

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -12,6 +12,11 @@
             "minimum": 1,
             "description": "total number of time steps to run for"
         },
+        "typical_ppc":{
+            "type": "integer",
+            "minimum": 1,
+            "description": "typical number of macroparticles per cell, used for normalization"
+        },
         "solver": {
             "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver"
         },
@@ -53,6 +58,7 @@
     "required": [
         "delta_t_si",
         "time_steps",
+        "typical_ppc",
         "solver",
         "grid",
         "laser"

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
@@ -66,7 +66,7 @@ namespace picongpu
          *
          * Used internally for unit normalization.
          */
-        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = startPosition::pypicongpu::random_ppc_{{{placed_species_initial.typename}}}::numParticlesPerCell;
+        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = {{{typical_ppc}}}u;
 
         namespace manipulators
         {

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -33,6 +33,7 @@ class TestSimulation(unittest.TestCase):
         sim = pypicongpu.Simulation()
         sim.delta_t_si = 1.39e-16
         sim.time_steps = 1
+        sim.typical_ppc = 1
         sim.grid = pypicongpu.grid.Grid3D()
         sim.grid.cell_size_x_si = 1.776e-07
         sim.grid.cell_size_y_si = 4.43e-08

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -30,6 +30,7 @@ class TestSimulation(unittest.TestCase):
         self.s = Simulation()
         self.s.delta_t_si = 13.37
         self.s.time_steps = 42
+        self.s.typical_ppc = 1
         self.s.grid = grid.Grid3D()
         self.s.grid.cell_size_x_si = 1
         self.s.grid.cell_size_y_si = 2


### PR DESCRIPTION
PR #4418 broke PyPIConGPU, by replacing the hard coded typical ppc in particle.param with a dynamic ppc take from a simple density operation.

This change broke the particle.param template, `/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache`, causing an incomplete name to be generated as the referenced quantity was only defined inside the context of a simple density operation but was used outside, leading to a mustache template generation miss and consequently the template place holder being replaced with an emtpy string, resulting in a not defined c++ name.

This PR fixes this bug by, adding an automatic fallback calculation of the typical_ppc from the set of all density generating operations and a PIConGPU specific parameter in the PICMI simulation object for specifying the typical_ppc of a setup, allowing a user to override the default behavior.

This bug was noticed by @SimeonEhrig while writing the PR #4600.