### PR TITLE
momentum density output

### DIFF
--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
 #include <pmacc/static_assert.hpp>
@@ -75,7 +76,8 @@ namespace picongpu
                     //! Get text name
                     HINLINE static std::string getName()
                     {
-                        return "particleMomentumDensity";
+                        auto const componentNames = plugins::misc::getComponentNames(3);
+                        return "momentumDensity/" + componentNames[T_direction];
                     }
 
                     /** Calculate value of the derived attribute per particle


### PR DESCRIPTION
fix #3996

Currently, it is not possible to use `deriveField::derivedAttributes::MomentumDensity<...>` twice or more in an output because the name in the output is not unique and therefore overwritten and only the last configuration from `fileOutput.param` is visible.

This PR is 
- giving each component of `MomentumDensity` a unique name
- the naming is changed to `momentumDensity/<x,y,z>`