### PR TITLE
derived output particle momentum

### DIFF
--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.def
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/misc/ComponentNames.hpp"
 #include "picongpu/traits/SIBaseUnits.hpp"
 
 #include <pmacc/static_assert.hpp>
@@ -75,7 +76,8 @@ namespace picongpu
                     //! Get text name
                     HINLINE static std::string getName()
                     {
-                        return "particleMomentum";
+                        auto const componentNames = plugins::misc::getComponentNames(3);
+                        return "particleMomentum/" + componentNames[T_direction];
                     }
 
                     /** Calculate value of the derived attribute per particle


### PR DESCRIPTION
Rename output name from `particleMomentum` to
`particleMomentum/<x,y,z>`.
Similar to #4606 it is not possible to use this functor with different component twice or more in the output.