### PR TITLE
Period syntax for progress ouptut

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -1,5 +1,5 @@
-# Copyright 2014-2022 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau,
-#                     Franz Poeschel, Sergei Bastrakov
+# Copyright 2014-2023 Felix Schmitt, Axel Huebl, Richard Pausch, Heiko Burau,
+#                     Franz Poeschel, Sergei Bastrakov, Pawel Ordyna
 #
 # This file is part of PIConGPU.
 #
@@ -78,6 +78,14 @@ TBG_dstPath
 
 # version information on startup
 TBG_version="--versionOnce"
+
+# Set progress output period in stdout:
+# -p or --progress can be used to set an integer percent value (of the total simulation duration).
+# It is also possible to set the exact time steps with --progressPeriod and the plugin period syntax.
+# --progress and --progressPeriod are combined. For setting the period only in percent just leave the --progressPeriod option out.
+# For setting the period only with the plugin syntax use  -p 0 to disable the default -p 5 setting.
+# Example for writing every 2 % as well as every 100 steps and every 20 steps from the 100th to the 1000th step.
+TBG_progress="-p 2 --progressPeriod 100,100:1000:20"
 
 
 # Regex to describe the static distribution of the cells for each device

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -1,5 +1,5 @@
-/* Copyright 2013-2022 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
- *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+/* Copyright 2013-2023 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov, Pawel Ordyna
  *
  * This file is part of PMacc.
  *
@@ -234,6 +234,12 @@ namespace pmacc
 
         uint16_t progress;
         uint32_t showProgressAnyStep;
+
+        /* progress intervals */
+        bool progressStepPeriodEnabled = false;
+        SeqOfTimeSlices seqProgressPeriod;
+        std::string progressPeriod;
+        uint32_t lastProgressStep = 0u;
 
         TimeIntervall tSimulation;
         TimeIntervall tInit;


### PR DESCRIPTION
fix https://github.com/ComputationalRadiationPhysics/picongpu/issues/4593

Add a new command line option `--progressPeriod` for setting the time steps at which the simulation progress is written to the stdout using the period syntax. Document both the old `--progress` and the new options in `TBG_macros.cfg`. This PR implements #4593 requested by @finnolec. 

Tested with only `--progress`, only `--progessPeriod` and with both of them.