### PR TITLE
rename SetToAtomicGroundStateForChargeState functor

### DIFF
--- a/include/picongpu/particles/atomicPhysics/SetChargeState.hpp
+++ b/include/picongpu/particles/atomicPhysics/SetChargeState.hpp
@@ -23,7 +23,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/particles/atomicPhysics/SetToAtomicGroundStateForChargeState.hpp"
+#include "picongpu/particles/atomicPhysics/SetToAtomicGroundState.hpp"
 #include "picongpu/particles/traits/GetAtomicNumbers.hpp"
 
 #include <pmacc/assert.hpp>
@@ -44,7 +44,7 @@ namespace picongpu::particles::atomicPhysics
 
             ion[boundElectrons_] = numberBoundElectrons;
 
-            SetToAtomicGroundStateForChargeState{}(ion, static_cast<uint8_t>(numberBoundElectrons));
+            SetToAtomicGroundState{}(ion, static_cast<uint8_t>(numberBoundElectrons));
         }
     };
 } // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/SetToAtomicGroundState.hpp
+++ b/include/picongpu/particles/atomicPhysics/SetToAtomicGroundState.hpp
@@ -29,7 +29,7 @@ namespace picongpu
     {
         namespace atomicPhysics
         {
-            struct SetToAtomicGroundStateForChargeState
+            struct SetToAtomicGroundState
             {
                 template<typename T_Ion>
                 DINLINE void operator()(T_Ion& ion, uint8_t numberBoundElectrons)


### PR DESCRIPTION
to avoid silently breaking user setups with [PR#4592](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4592) renaming of the `picongpu::particles::atomicPhysics::SetToAtomicGroundStateForChargeState` functor.

**USER**: replace with `picongpu::particles::atomicPhysics::SetChargeState` in setups,

or convert to the new interface `picongpu::particles::manipulators::unary::chargeState< "...charge state as uint8_t..." >`, ;)

- [x] requires [PR#4615](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4615) to be merged first