### PR TITLE
fix ExpRampWithPrepulseBeam

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -181,8 +181,9 @@ namespace picongpu
                          */
                         HDINLINE float_X getLongitudinal(float_X const time, float_X const phaseShift) const
                         {
-                            auto const phase = Unitless::w * time + Unitless::LASER_PHASE + phaseShift;
-                            return math::sin(phase) * getEnvelope(time);
+                            auto const runTimeShifted = time + Unitless::time_start_init;
+                            auto const phase = Unitless::w * runTimeShifted + Unitless::LASER_PHASE + phaseShift;
+                            return math::sin(phase) * getEnvelope(runTimeShifted);
                         }
 
                     private:


### PR DESCRIPTION
With #4077 (transition from old laser profiles to the incident field laser) there was a bug introduced, within the laser implementation a time shift was removed which led to the wrong longitudinal shifted laser profile.