### PR TITLE
add lumi template and setup profile

### DIFF
--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -1,0 +1,140 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+
+# Project Information ######################################## (edit this line)
+#   - project for allocation and shared directories
+#   - use lumi-allocations to see all your projects
+#export PROJID=<your_project>
+
+# Job control
+# Allocate more nodes then required to execute the jobs to be able to handle broken nodes
+# Oversubscribe the nodes allocated by N per thousand required nodes.
+export PIC_NODE_OVERSUBSCRIPTION_PT=2
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="vim"
+
+# General modules #############################################################
+#
+# There are a lot of required modules already loaded when connecting
+# such as mpi, libfabric and others.
+# The following modules just add to these.
+
+module load PrgEnv-cray-amd/8.3.3 # Compiling with cray compiler wrapper CC
+module load craype-accel-amd-gfx90a
+module load rocm/5.2.3
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+module load cray-mpich/8.1.23
+
+
+module load LUMI/23.03  partition/G
+module load Boost/1.81.0-cpeCray-23.03
+
+module load buildtools/23.03
+
+## set environment variables required for compiling and linking
+##   see (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#compiling-with-hipcc)
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+export CXX=hipcc
+export CXXFLAGS="$CXXFLAGS -I${MPICH_DIR}/include"
+export LDFLAGS="$LDFLAGS -L${MPICH_DIR}/lib -lmpi ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}"
+
+# Other Software ##############################################################
+#
+libpng/1.6.38-cpeCray-23.03
+module load freetype/2.12.1-cpeCray-23.03
+
+# ATTENTION: blosc2 is used, please check your cfg's and replace blosc with blosc2
+#module load openpmd-api/0.14.4
+
+# Self-Build Software #########################################################
+# Optional, not required.
+#
+# needs to be compiled by the user
+#export PIC_LIBS=$HOME/lib/
+
+export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.1
+export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0
+export ADIOS2_ROOT=$PIC_LIBS/adios2-2.7.1.436
+export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.14.4
+
+export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PNGwriter_DIR/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
+
+export PATH=$ADIOS2_ROOT/bin:$PATH
+export PATH=$OPENPMD_ROOT/bin:$PATH
+
+export PYTHONPATH=$ADIOS2_ROOT/lib/python3.9/site-packages/adios2:$PYTHONPATH
+export PYTHONPATH=$OPENPMD_ROOT/lib64/python3.9/site-packages/openpmd_api:$PYTHONPATH
+
+# Environment #################################################################
+#
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="hip:gfx90a"
+
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/frontier-ornl"}
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "caar" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/lumi-eurohpc/standard-g.tpl"
+
+# allocate an interactive shell for one hour
+#   getNode 2  # allocates two interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks=$((numNodes * 8)) --gres=gpu:$((numNodes * 8)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p standard-g -A $PROJID --pty bash
+}
+
+# allocate an interactive shell for one hour
+#   getDevice 2  # allocates two interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        if [ "$1" -gt 8 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
+    fi
+    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p dev-g -A $PROJID --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi

--- a/etc/picongpu/lumi-eurohpc/standard-g.tpl
+++ b/etc/picongpu/lumi-eurohpc/standard-g.tpl
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Copyright 2013-2023 Axel Huebl, Richard Pausch, Rene Widera, Sergei Bastrakov, Klaus Steinger
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for frontier's SLURM batch system
+
+#SBATCH --account=!TBG_nameProject
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes_adjusted
+#SBATCH --ntasks=!TBG_tasks_adjusted
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem-per-gpu=!TBG_memPerDevice
+#SBATCH --ntasks-per-gpu=1
+#SBATCH --gpu-bind=closest
+#SBATCH --gres=gpu:!TBG_devicesPerNode
+
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --chdir=!TBG_dstPath
+
+#SBATCH --open-mode=append
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+## calculations will be performed by tbg ##
+.TBG_queue="standard-g"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${PROJID:-""}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted devices per node in the system
+.TBG_numHostedDevicesPerNode=8
+
+# host memory per device
+# 128 GiB per NUMA = 2 GCD - but only 60 GiB per GCD available
+.TBG_memPerDevice=60000
+
+# number of CPU cores to block per GPU
+# we have 8 CPU cores per GPU (64cores/8gpus ~ 8cores)
+# but one core (= core 0) is reserved for system processes
+# called low-noise mode - see LUMI-G documentation
+.TBG_coresPerGPU=7
+
+# Assign one OpenMP thread per available core per GPU (=task)
+export OMP_NUM_THREADS=!TBG_coresPerGPU
+
+# required GPUs per node for the current job
+.TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
+
+# We only start 1 MPI task per device
+.TBG_mpiTasksPerNode="$(( TBG_devicesPerNode * 1 ))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_devicesPerNode - 1 ) / TBG_devicesPerNode))"
+
+# oversubscribe the node allocation by N per thousand
+# The default can be overwritten by setting the environment variable PIC_NODE_OVERSUBSCRIPTION_PT
+.TBG_node_oversubscription_pt=${PIC_NODE_OVERSUBSCRIPTION_PT:-2}
+
+# adjust number of nodes for fault tolerance adjustments
+.TBG_nodes_adjusted=$((!TBG_nodes * (1000 + !TBG_node_oversubscription_pt) / 1000))
+.TBG_tasks_adjusted=$((!TBG_nodes_adjusted * !TBG_numHostedDevicesPerNode))
+
+## end calculations ##
+
+echo 'Start job with !TBG_nodes_adjusted nodes. Required are !TBG_nodes nodes.'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+    echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+    exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# number of broken nodes
+n_broken_nodes=0
+
+# return code of cuda_memcheck
+node_check_err=1
+
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedDevicesPerNode -eq !TBG_mpiTasksPerNode ] ; then
+    run_cuda_memtest=1
+else
+    run_cuda_memtest=0
+fi
+
+# test if cuda_memtest binary is available and we have the node exclusive
+if [ $run_cuda_memtest -eq 1 ] ; then
+    touch bad_nodes.txt
+    n_tasks=$((!TBG_nodes_adjusted * !TBG_numHostedDevicesPerNode))
+    for((i=0; ($n_tasks >= !TBG_tasks) && ($node_check_err != 0); ++i)) ; do
+        n_tasks_last_check=$n_tasks
+        mkdir "cuda_memtest_$i"
+        cd "cuda_memtest_$i"
+        # Run cuda_memtest (HIP version) to check GPU's health
+        echo "GPU memtest started with $n_tasks tasks. Required are !TBG_tasks tasks."
+        test $n_broken_nodes -ne 0 && exclude_nodes="-x../bad_nodes.txt"
+        # do not bind to any GPU, else we can not use the local MPI rank to select a GPU
+        # - test always all except the broken nodes
+        # - catch error to avoid that the batch script stops processing in case an error happened
+        node_check_err=$(srun -n $n_tasks --nodes=$((n_tasks / !TBG_numHostedDevicesPerNode)) $exclude_nodes -K1 --gpu-bind=none !TBG_dstPath/input/bin/cuda_memtest.sh && echo 0 || echo 1)
+        cd ..
+        ls -1 "cuda_memtest_$i" | sed -n -e 's/cuda_memtest_\([^_]*\)_.*/\1/p' | sort -u >> ./bad_nodes.txt
+        n_broken_nodes=$(cat ./bad_nodes.txt | sort -u | wc -l)
+        n_tasks=$(((!TBG_nodes_adjusted - n_broken_nodes) * !TBG_numHostedDevicesPerNode))
+        # if cuda_memtest not passed and we have no broken nodes something else went wrong
+        if [ $node_check_err -ne 0 ] ; then
+            if [ $n_tasks_last_check -eq $n_tasks ] ; then
+                echo "cuda_memtest: Number of broken nodes has not increased but for unknown reasons cuda_memtest reported errors." >&2
+                break
+            fi
+            if [ $n_broken_nodes -eq 0 ] ; then
+                echo "cuda_memtest: unknown error" >&2
+                break
+            else
+                echo "cuda_memtest: "$n_broken_nodes" broken node(s) detected!. The test will be repeated with healthy nodes only." >&2
+            fi
+        fi
+    done
+    echo "GPU memtest with $n_tasks tasks finished with error code $node_check_err."
+else
+    echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+fi
+
+if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
+    # Run PIConGPU
+    echo "Start PIConGPU."
+    test $n_broken_nodes -ne 0 && exclude_nodes="-x./bad_nodes.txt"
+    srun -n !TBG_tasks --nodes=!TBG_nodes $exclude_nodes -K1 !TBG_dstPath/input/bin/picongpu --mpiDirect !TBG_author !TBG_programParams
+else
+    echo "Job stopped because of previous issues."
+    echo "Job stopped because of previous issues." >&2
+fi


### PR DESCRIPTION
This pull request adds the `*.tpl` for the MI250x queue on [LUMI](https://www.lumi-supercomputer.eu/user-support), called `standard-G` and provides a minimal profile. 
Both template and profile have been tested. 