### PR TITLE
fixing failing PyPIConGPU CI jobs

### DIFF
--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,7 +1,7 @@
 typeguard >= 2.12, < 3.0.0
 sympy >= 1.9
 chevron >= 0.13.1
-jsonschema >= 4.17.3
+jsonschema == 4.17.3
 scipy >= 1.7.1
 picmistandard == 0.0.22
 

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -303,7 +303,7 @@ PYTHON_VERSIONS: List[str] = ["3.9", "3.10", "3.11"]
 # pip decides which version is used.
 PACKAGES_TO_TEST: Dict[str, Callable] = {
     "typeguard": get_all_major_pypi_versions,
-    "jsonschema": get_all_major_pypi_versions,
+    "jsonschema": get_all_pypi_versions,  # @todo change back
     "picmistandard": get_all_pypi_versions,
 }
 


### PR DESCRIPTION
CI jobs are failing due to a breaking change/bug in the PyPIConGPU dependency jsonschema, in yesterday's new version 4.18.0.

I have fixed this issue for now by fixing the jsonschema version to the last release before the current version, 4.17.3.

fix #4627 