### PR TITLE
collision: reduce memory fragmentation

### DIFF
--- a/docs/source/models/binary_collisions.rst
+++ b/docs/source/models/binary_collisions.rst
@@ -70,6 +70,13 @@ To enable collisions between the Ions and Electrons with a constant coulomb loga
                 */
                using CollisionPipeline = boost::mp11::
                    mp_list<Collider<relativistic::RelativisticCollisionConstLog<Params>, Pairs> >;
+
+               /** Chunk size used for cell list allocations.
+                *
+                * To reduce the fragmentation of the heap memory on accelerators the collision algorithm is allocating a
+                * multiple of this value to store a cell list of particle IDs. The value must be non zero.
+                */
+               constexpr uint32_t cellListChunkSize = particles::TYPICAL_PARTICLES_PER_CELL;
            } // namespace collision
        } // namespace particles
    } // namespace picongpu

--- a/include/picongpu/param/collision.param
+++ b/include/picongpu/param/collision.param
@@ -47,6 +47,13 @@ namespace picongpu
              */
             using CollisionPipeline = pmacc::mp_list<>;
 
+            /** Chunk size used for cell list allocations.
+             *
+             * To reduce the fragmentation of the heap memory on accelerators the collision algorithm is allocating a
+             * multiple of this value to store a cell list of particle IDs. The value must be non zero.
+             */
+            constexpr uint32_t cellListChunkSize = particles::TYPICAL_PARTICLES_PER_CELL;
+
         } // namespace collision
     } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/collision.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/collision.param
@@ -82,6 +82,13 @@ namespace picongpu
                     ColliderFunctor,
                     MakeSeq_t<Pair<ElectronsLess, IonsMore>>,
                     OneFilter<filter::UpperXPosition>>>;
+
+            /** Chunk size used for cell list allocations.
+             *
+             * To reduce the fragmentation of the heap memory on accelerators the collision algorithm is allocating a
+             * multiple of this value to store a cell list of particle IDs. The value must be non zero.
+             */
+            constexpr uint32_t cellListChunkSize = particles::TYPICAL_PARTICLES_PER_CELL;
         } // namespace collision
     } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/collision.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/collision.param
@@ -77,6 +77,13 @@ namespace picongpu
 #endif
             using CollisionPipeline = pmacc::mp_list<IntraCollider, InterCollider>;
 
+            /** Chunk size used for cell list allocations.
+             *
+             * To reduce the fragmentation of the heap memory on accelerators the collision algorithm is allocating a
+             * multiple of this value to store a cell list of particle IDs. The value must be non zero.
+             */
+            constexpr uint32_t cellListChunkSize = particles::TYPICAL_PARTICLES_PER_CELL;
+
         } // namespace collision
     } // namespace particles
 } // namespace picongpu


### PR DESCRIPTION
Reduce the memory heap fragmentation by allocating always a multiple of the typical number of particles per cell for the particle cell list on GPUs.
This change will waste a little bit of memory but on the other side avoid the mallocMC heap fragmentation becoming too large which can result in out-of-memory errors.

**ATTENTION** in existing `collision.param` files `constexpr uint32_t cellListChunkSize = particles::TYPICAL_PARTICLES_PER_CELL;` must be added by hand to be compatible with this PR.