### PR TITLE
plugin openPMD: activate support for ED-PIC extension

### DIFF
--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -105,6 +105,10 @@ namespace picongpu
                  * optional metadata:
                  */
 
+                // PIConGPU is writing particles and fields based on the openPMD standard 'ED-PIC' extension.
+                constexpr uint32_t openPMDExtensionMask = 1u;
+                series.setOpenPMDextension(openPMDExtensionMask);
+
                 /*   recommended */
                 const std::string author = Environment<>::get().SimulationDescription().getAuthor();
                 if(author.length() > 0)


### PR DESCRIPTION
fix #4633 #4635

PIConGPU missed to set that openPMD files using the ED_PIC extension.