### PR TITLE
fix broken KHI growth rate test tools

### DIFF
--- a/lib/python/test/testsuite/Reader/readFiles.py
+++ b/lib/python/test/testsuite/Reader/readFiles.py
@@ -65,7 +65,7 @@ class ReadFiles():
         direction = cD.checkDirection(variable=directiontype,
                                       direction=direction)
 
-        self._direction = direction
+        self._direction = direction + "/"
         self._fileExtension = fileExtension
         self._directiontype = directiontype
 
@@ -95,7 +95,7 @@ class ReadFiles():
         direction = cD.checkDirection(variable=self.directiontype,
                                       direction=direction)
 
-        self._direction = direction
+        self._direction = direction + "/"
 
     def setFileExtionsion(self, fileExtension: str):
         self._fileExtension = fileExtension

--- a/share/picongpu/tests/KHI_growthRate/bin/ci.sh
+++ b/share/picongpu/tests/KHI_growthRate/bin/ci.sh
@@ -121,7 +121,7 @@ mpiexec -n 1 $inputDestinationPath/bin/picongpu -d 1 1 1 -g 192 512 12 --periodi
 cd ..
 
 # test with python
-$currentPath/validate.sh $inputDestinationPath -d $dataPath/
+$currentPath/validate.sh $inputDestinationPath -d $dataPath
 ret=$?
 
 if [ "$deleteData" == "true" ] ; then

--- a/share/picongpu/tests/KHI_growthRate/bin/validate.sh
+++ b/share/picongpu/tests/KHI_growthRate/bin/validate.sh
@@ -58,13 +58,13 @@ else
 fi
 
 if [ -z "$dataPath" ] ; then
-    dataPath=$inputSetPath/simOutput/
+    dataPath=$inputSetPath/simOutput
 fi
 
 # test for growth rate
 MAINTEST="$PICSRC/lib/python/test/setups/ESKHI"
 
-python $MAINTEST/main.py -p "$inputSetPath/include/picongpu/param/" -r "$dataPath" -s "$dataPath"
+python $MAINTEST/main.py -p "$inputSetPath/include/picongpu/param" -r "$dataPath" -s "$dataPath"
 exit $?
 
 


### PR DESCRIPTION
Issue introduced with #4334

- remove the slash at the end of a path (do not enforce a slash for a directory)
- add a slash before concatenating a filename with a directory path