### PR TITLE
create E and B field from moving particles

### DIFF
--- a/include/picongpu/particles/InitFunctors.hpp
+++ b/include/picongpu/particles/InitFunctors.hpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/fields/Fields.def"
 #include "picongpu/particles/Manipulate.hpp"
+#include "picongpu/particles/StaticField.hpp"
 #include "picongpu/particles/densityProfiles/IProfile.def"
 #include "picongpu/particles/filter/filter.def"
 #include "picongpu/particles/manipulators/manipulators.def"
@@ -221,6 +222,96 @@ namespace picongpu
                 speciesPtr->fillAllGaps();
             }
         };
+
+        /** Time step conditional functor execution
+         *
+         * @tparam T_time Timestep to compare
+         * @tparam T_Functor Functor which is executed any time the condition is true.
+         *
+         * @{
+         */
+
+        //! Equal
+        template<uint32_t T_time, typename T_Functor>
+        struct ExecuteIfTimeStepEq
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                if(currentStep == T_time)
+                    T_Functor{}(currentStep);
+            }
+        };
+
+        //! Greater than
+        template<uint32_t T_time, typename T_Functor>
+        struct ExecuteIfTimeStepGt
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                if(currentStep > T_time)
+                    T_Functor{}(currentStep);
+            }
+        };
+
+        //! Greater or Equal
+        template<uint32_t T_time, typename T_Functor>
+        struct ExecuteIfTimeStepGe
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                if(currentStep >= T_time)
+                    T_Functor{}(currentStep);
+            }
+        };
+
+        //! Less than
+        template<uint32_t T_time, typename T_Functor>
+        struct ExecuteIfTimeStepLt
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                if(currentStep < T_time)
+                    T_Functor{}(currentStep);
+            }
+        };
+
+        //! Less or  Equal
+        template<uint32_t T_time, typename T_Functor>
+        struct ExecuteIfTimeStepLe
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                if(currentStep <= T_time)
+                    T_Functor{}(currentStep);
+            }
+        };
+
+        /** @} */
+
+        /** Create static field from the particles current.
+         *
+         * Calculates the current of all species and propagates the electrical and magnetic field T_numFieldSolverSteps
+         * times. The current includes the current background for the corresponding time step.
+         *
+         * @tparam T_numFieldSolverSteps number of steps the field solver should be executed to propagate the field.
+         *
+         * @{
+         */
+        template<uint32_t T_numFieldSolverSteps>
+        struct CreateStaticField
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                StaticField{}(currentStep, T_numFieldSolverSteps);
+            }
+        };
+
+        /** Creates the static field only for the in the initial time step. */
+        template<uint32_t T_numFieldSolverSteps>
+        using CreateInitialStaticField = ExecuteIfTimeStepEq<0u, CreateStaticField<T_numFieldSolverSteps>>;
+
+        /** @} */
+
 
     } // namespace particles
 } // namespace picongpu

--- a/include/picongpu/particles/StaticField.hpp
+++ b/include/picongpu/particles/StaticField.hpp
@@ -1,0 +1,30 @@
+/* Copyright 2023 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace picongpu::particles
+{
+    struct StaticField
+    {
+        void operator()(uint32_t currentStep, uint32_t numFildSolverSteps);
+    };
+} // namespace picongpu::particles

--- a/include/picongpu/particles/StaticField.tpp
+++ b/include/picongpu/particles/StaticField.tpp
@@ -1,0 +1,62 @@
+/* Copyright 2023 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/fields/MaxwellSolver/Solvers.hpp"
+#include "picongpu/simulation/stage/CurrentBackground.hpp"
+#include "picongpu/simulation/stage/CurrentDeposition.hpp"
+#include "picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp"
+#include "picongpu/simulation/stage/CurrentReset.hpp"
+
+#include <pmacc/dataManagement/DataConnector.hpp>
+
+#include <cstdint>
+
+
+namespace picongpu::particles
+{
+    void StaticField::operator()(uint32_t currentStep, uint32_t numFildSolverSteps)
+    {
+        std::cout << "start StaticField " << currentStep << " for " << numFildSolverSteps << " iterations."
+                  << std::endl;
+        simulation::stage::CurrentReset{}(currentStep);
+        simulation::stage::CurrentDeposition{}(currentStep);
+
+        DataConnector& dc = Environment<>::get().DataConnector();
+
+        auto currentBackground
+            = dc.get<simulation::stage::CurrentBackground>(simulation::stage::CurrentBackground::getName());
+        (*currentBackground)(currentStep);
+
+        auto fieldSolver = dc.get<fields::Solver>(fields::Solver::getName());
+        auto currentInterpolationAndAdditionToEMF = dc.get<simulation::stage::CurrentInterpolationAndAdditionToEMF>(
+            simulation::stage::CurrentInterpolationAndAdditionToEMF::getName());
+
+        for(uint32_t step = 0u; step < numFildSolverSteps; ++step)
+        {
+            fieldSolver->update_beforeCurrent(currentStep);
+            (*currentInterpolationAndAdditionToEMF)(currentStep, *fieldSolver, step == 0);
+            fieldSolver->update_afterCurrent(currentStep);
+        }
+
+        simulation::stage::CurrentReset{}(currentStep);
+        std::cout << "end StaticField" << std::endl;
+    }
+} // namespace picongpu::particles

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -780,3 +780,4 @@ namespace picongpu
 } /* namespace picongpu */
 
 #include "picongpu/fields/Fields.tpp"
+#include "picongpu/particles/StaticField.tpp"

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/speciesInitialization.param
@@ -48,7 +48,8 @@ namespace picongpu
             Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::LowerQuarterYPosition>,
             Manipulate<manipulators::AssignXDriftNegative, PIC_Electrons, filter::MiddleHalfYPosition>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::UpperQuarterYPosition>,
-            Manipulate<manipulators::AddTemperature, PIC_Electrons>>;
+            Manipulate<manipulators::AddTemperature, PIC_Electrons>,
+            CreateInitialStaticField<512>>;
 
     } // namespace particles
 } // namespace picongpu


### PR DESCRIPTION
Allow creating the E and B field based on initialized moving particles current.

- [ ] Currently, a draft to check if we need to add ISimulationData to more field solver implementations.