### PR TITLE
register solvers to data connector

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
+++ b/include/picongpu/fields/MaxwellSolver/FDTD/FDTD.hpp
@@ -29,6 +29,7 @@
 #include "picongpu/traits/GetMargin.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/traits/GetStringProperties.hpp>
 
 #include <cstdint>
@@ -40,7 +41,9 @@ namespace picongpu
         namespace maxwellSolver
         {
             template<typename T_CurlE, typename T_CurlB>
-            class FDTD : public fdtd::FDTDBase<T_CurlE, T_CurlB>
+            class FDTD
+                : public fdtd::FDTDBase<T_CurlE, T_CurlB>
+                , public ISimulationData
             {
             public:
                 //! Base type
@@ -100,6 +103,28 @@ namespace picongpu
                 {
                     pmacc::traits::StringProperty propList("name", "FDTD");
                     return propList;
+                }
+
+                /** Name of the solver which can be used to share this class via DataConnector */
+                static std::string getName()
+                {
+                    return "FieldSolverFDTD";
+                }
+
+                /**
+                 * Synchronizes simulation data, meaning accessing (host side) data
+                 * will return up-to-date values.
+                 */
+                void synchronize() override{};
+
+                /**
+                 * Return the globally unique identifier for this simulation data.
+                 *
+                 * @return globally unique identifier
+                 */
+                SimulationDataId getUniqueId() override
+                {
+                    return getName();
                 }
             };
 

--- a/include/picongpu/fields/MaxwellSolver/None/None.hpp
+++ b/include/picongpu/fields/MaxwellSolver/None/None.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/cellType/Yee.hpp"
 #include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/types.hpp>
 
 #include <cstdint>
@@ -38,7 +39,7 @@ namespace picongpu
     {
         namespace maxwellSolver
         {
-            class None
+            class None : public ISimulationData
             {
             private:
                 using SuperCellSize = MappingDesc::SuperCellSize;
@@ -67,6 +68,27 @@ namespace picongpu
                 {
                     pmacc::traits::StringProperty propList("name", "none");
                     return propList;
+                }
+
+                static std::string getName()
+                {
+                    return "FieldSolverNone";
+                }
+
+                /**
+                 * Synchronizes simulation data, meaning accessing (host side) data
+                 * will return up-to-date values.
+                 */
+                void synchronize() override{};
+
+                /**
+                 * Return the globally unique identifier for this simulation data.
+                 *
+                 * @return globally unique identifier
+                 */
+                SimulationDataId getUniqueId() override
+                {
+                    return getName();
                 }
             };
 

--- a/include/picongpu/simulation/stage/CurrentBackground.hpp
+++ b/include/picongpu/simulation/stage/CurrentBackground.hpp
@@ -26,6 +26,7 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/type/Area.hpp>
 
@@ -39,7 +40,7 @@ namespace picongpu
         namespace stage
         {
             //! Functor for the stage of the PIC loop applying current background
-            class CurrentBackground
+            class CurrentBackground : public ISimulationData
             {
             public:
                 /** Create a current background functor
@@ -71,6 +72,28 @@ namespace picongpu
                             FieldBackgroundJ(fieldJ.getUnit()),
                             step);
                     }
+                }
+
+                /** Name of the solver which can be used to share this class via DataConnector */
+                static std::string getName()
+                {
+                    return "CurrentBackground";
+                }
+
+                /**
+                 * Synchronizes simulation data, meaning accessing (host side) data
+                 * will return up-to-date values.
+                 */
+                void synchronize() override{};
+
+                /**
+                 * Return the globally unique identifier for this simulation data.
+                 *
+                 * @return globally unique identifier
+                 */
+                SimulationDataId getUniqueId() override
+                {
+                    return getName();
                 }
 
             private:

--- a/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
+++ b/include/picongpu/simulation/stage/CurrentInterpolationAndAdditionToEMF.hpp
@@ -28,6 +28,7 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/dataManagement/ISimulationData.hpp>
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/type/Area.hpp>
@@ -49,7 +50,7 @@ namespace picongpu
             /** Functor for the stage of the PIC loop performing current interpolation
              *  and addition to grid values of the electromagnetic field
              */
-            class CurrentInterpolationAndAdditionToEMF
+            class CurrentInterpolationAndAdditionToEMF : public ISimulationData
             {
             public:
                 /** Register program options for current interpolation
@@ -144,6 +145,28 @@ namespace picongpu
                             fieldSolver.addCurrent<type::CORE + type::BORDER>();
                         }
                     }
+                }
+
+                /** Name of the solver which can be used to share this class via DataConnector */
+                static std::string getName()
+                {
+                    return "CurrentInterpolationAndAdditionToEMF";
+                }
+
+                /**
+                 * Synchronizes simulation data, meaning accessing (host side) data
+                 * will return up-to-date values.
+                 */
+                void synchronize() override{};
+
+                /**
+                 * Return the globally unique identifier for this simulation data.
+                 *
+                 * @return globally unique identifier
+                 */
+                SimulationDataId getUniqueId() override
+                {
+                    return getName();
                 }
 
             private:


### PR DESCRIPTION
Allow the access to field solver, stage current background and current interpolation via the dataconnector.

This is a pre-PR to provide the support of creating fileds based on the particle current in the species initialization pipeline.