### PR TITLE
fix possible missed thread notification

### DIFF
--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -167,6 +167,7 @@ namespace pmacc
 
         // conditional variable to notify all concurrent threads and signal exit of the simulation
         std::condition_variable exitConcurrentThreads;
+        std::mutex concurrentThreadMutex;
 
         /* common directory for checkpoints */
         std::string checkpointDirectory;


### PR DESCRIPTION
The previous implementation was not taking the lock to ensure that the worker thread is not missing the notification.

Use always the lock before calling `notify`.