### PR TITLE
fix openPMD plugin output

### DIFF
--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -65,6 +65,7 @@ namespace picongpu
              */
             std::tuple<::openPMD::MeshRecordComponent, ::openPMD::Offset, ::openPMD::Extent> prepare(
                 ThreadParams& params,
+                uint32_t const currentStep,
                 T_Attribute attribute)
             {
                 auto name = baseName + "/" + group + "/" + dataset;
@@ -85,7 +86,7 @@ namespace picongpu
 
                 ::openPMD::Series& series = *params.openPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
-                    = series.writeIterations()[params.currentStep].meshes[baseName + "_" + group][dataset];
+                    = series.writeIterations()[currentStep].meshes[baseName + "_" + group][dataset];
 
                 if(!attrName.empty())
                 {
@@ -105,9 +106,13 @@ namespace picongpu
             }
 
         public:
-            void operator()(ThreadParams& params, T_Scalar value, T_Attribute attribute = T_Attribute())
+            void operator()(
+                ThreadParams& params,
+                uint32_t const currentStep,
+                T_Scalar value,
+                T_Attribute attribute = T_Attribute())
             {
-                auto tuple = prepare(params, std::move(attribute));
+                auto tuple = prepare(params, currentStep, std::move(attribute));
                 auto name = baseName + "/" + group + "/" + dataset;
                 log<picLog::INPUT_OUTPUT>("openPMD: write %1%D scalars: %2%") % simDim % name;
 
@@ -139,6 +144,7 @@ namespace picongpu
              * referenced by the pointers */
             void operator()(
                 ThreadParams& params,
+                const uint32_t currentStep,
                 const std::string& baseName,
                 const std::string& group,
                 const std::string& dataset,
@@ -153,7 +159,7 @@ namespace picongpu
                 auto datasetName = baseName + "/" + group + "/" + dataset;
                 ::openPMD::Series& series = *params.openPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
-                    = series.iterations[params.currentStep].meshes[baseName + "_" + group][dataset];
+                    = series.iterations[currentStep].meshes[baseName + "_" + group][dataset];
                 auto ndim = mrc.getDimensionality();
                 if(ndim != simDim)
                 {

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -76,9 +76,6 @@ namespace picongpu
 
         struct ThreadParams : PluginParameters
         {
-            uint32_t currentStep; /** current simulation step */
-
-
             std::unique_ptr<::openPMD::Series> openPMDSeries; /* is null iff there is no series currently open */
 
             /** current dump is a checkpoint */
@@ -90,7 +87,7 @@ namespace picongpu
 
             WriteSpeciesStrategy strategy = WriteSpeciesStrategy::ADIOS;
 
-            MappingDesc* cellDescription;
+            MappingDesc* cellDescription = nullptr;
 
             std::vector<char> fieldBuffer; /* temp. buffer for fields */
 
@@ -110,7 +107,12 @@ namespace picongpu
             /*
              * If file is empty, read from command line parameters.
              */
-            void initFromConfig(Help&, size_t id, std::string const& dir, std::optional<std::string> file = {});
+            void initFromConfig(
+                Help&,
+                size_t id,
+                uint32_t const currentStep,
+                std::string const& dir,
+                std::optional<std::string> file = {});
 
             /**
              * Wrapper for ::openPMD::resetDataset, set dataset parameters

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -77,7 +77,7 @@ namespace picongpu
              * @param restartChunkSize number of particles processed in one kernel
              * call
              */
-            HINLINE void operator()(ThreadParams* params, const uint32_t restartChunkSize)
+            HINLINE void operator()(ThreadParams* params, uint32_t const currentStep, const uint32_t restartChunkSize)
             {
                 std::string const speciesName = FrameType::getName();
                 log<picLog::INPUT_OUTPUT>("openPMD: (begin) load species: %1%") % speciesName;
@@ -85,8 +85,7 @@ namespace picongpu
                 GridController<simDim>& gc = Environment<simDim>::get().GridController();
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Container<::openPMD::ParticleSpecies>& particles
-                    = series.iterations[params->currentStep].particles;
+                ::openPMD::Container<::openPMD::ParticleSpecies>& particles = series.iterations[currentStep].particles;
                 ::openPMD::ParticleSpecies particleSpecies = particles[speciesName];
 
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -60,6 +60,7 @@ namespace picongpu
                 const uint32_t numComponents,
                 std::string objectName,
                 ThreadParams* params,
+                uint32_t const currentStep,
                 bool const isDomainBound)
             {
                 log<picLog::INPUT_OUTPUT>("Begin loading field '%1%'") % objectName;
@@ -122,7 +123,7 @@ namespace picongpu
                 }
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Container<::openPMD::Mesh>& meshes = series.iterations[params->currentStep].meshes;
+                ::openPMD::Container<::openPMD::Mesh>& meshes = series.iterations[currentStep].meshes;
 
                 auto destBox = field.getHostBuffer().getDataBox();
                 for(uint32_t n = 0; n < numComponents; ++n)
@@ -203,7 +204,7 @@ namespace picongpu
         struct LoadFields
         {
         public:
-            HDINLINE void operator()(ThreadParams* params)
+            HDINLINE void operator()(ThreadParams* params, uint32_t const restartStep)
             {
 #ifndef __CUDA_ARCH__
                 DataConnector& dc = Environment<>::get().DataConnector();
@@ -223,6 +224,7 @@ namespace picongpu
                     (uint32_t) T_Field::numComponents,
                     T_Field::getName(),
                     tp,
+                    restartStep,
                     isDomainBound);
 #endif
             }


### PR DESCRIPTION
fix #4641

bug introduced with #4585

In the openPMD plugin we use a param class `ThreadParams` where we collect many information for the dumping process to avoid forwarding all in via function parameters. The object is very dirty and we can not track life-times and different kind of data are stored together. The bug was introduced because the timestep which was not default initilized on all systems was required in one of the dumping function `intersectRangeWithWindow()`  to
calculate the intersection of the range parameter in the openPMD plugin and the moving window of the simulation.

**ATTENTION** The restart is affected by this bug too! IMO it is not guaranteed that the restarted timestep is what you selected or all could simply crash at runtime.

This PR refactore the interfaces and is passing now the timestep as function parameter.