### PR TITLE
simplified directory specification, cmakeFlagReader

### DIFF
--- a/lib/python/test/setups/MI/config.py
+++ b/lib/python/test/setups/MI/config.py
@@ -30,12 +30,14 @@ title = "KHI Growthrate (2D MI)"
 author = "Mika Soren Voss"
 
 # directory specified
+direction = None
 resultDirection = None
 paramDirection = None
 dataDirection = None
+cmakeDirection = None
 
 # parameter information found in .param files
-param_Parameter = ["gamma", "BASE_DENSITY_SI", "DELTA_T_SI"]
+param_Parameter = ["DIMENSION", "gamma", "BASE_DENSITY_SI", "DELTA_T_SI"]
 data_Parameter = ["Bx", "step"]
 
 # acceptance, ratio to 1

--- a/lib/python/test/setups/MI/main.py
+++ b/lib/python/test/setups/MI/main.py
@@ -21,6 +21,14 @@ parser = argparse.ArgumentParser(description="Starts the test suite."
                                  " passed. Please refer to the Data.py"
                                  " documentation for more information.")
 
+parser.add_argument("-d", help="Main path of the simulation, if this"
+                    " is specified, no other one must be specified.",
+                    dest="direction",
+                    type=str,
+                    const=None,
+                    nargs="?",
+                    default=None)
+
 parser.add_argument("-r", help="Path of the folder where the results"
                     " of the test-suite should be saved",
                     dest="result",
@@ -61,10 +69,20 @@ parser.add_argument("-j", help="Path of the folder to the json files"
                     nargs="?",
                     default=None)
 
+parser.add_argument("-c", help="Path of the folder to the cmake files"
+                    " if used.",
+                    dest="cmake",
+                    type=str,
+                    const=None,
+                    nargs="?",
+                    default=None)
+
 args = parser.parse_args()
 
 # start testsuite with all parameter
-manager.run_testsuite(dataDirection=args.data,
+manager.run_testsuite(direction=args.direction,
+                      dataDirection=args.data,
                       paramDirection=args.param,
                       jsonDirection=args.json,
-                      resultDirection=args.result)
+                      resultDirection=args.result,
+                      cmakeDirection=args.cmake)

--- a/lib/python/test/testsuite/Math/_searchData.py
+++ b/lib/python/test/testsuite/Math/_searchData.py
@@ -90,5 +90,4 @@ def searchParameter(parameter: str, directiontype: str = None, **kwargs):
     if result is None:
         raise ValueError("The Parameter {} could not"
                          " be found".format(parameter))
-
     return result

--- a/lib/python/test/testsuite/Reader/_manager.py
+++ b/lib/python/test/testsuite/Reader/_manager.py
@@ -9,12 +9,14 @@ License: GPLv3+
 from . import dataReader
 from . import jsonReader
 from . import paramReader
+from . import cmakeFlagReader as cmakeReader
 import testsuite._checkData as cD
 
 
 def mainsearch(dataDirection: str = None,
                paramDirection: str = None,
-               jsonDirection: str = None):
+               jsonDirection: str = None,
+               cmakeDirection: str = None):
 
     json = {}
     param = {}
@@ -37,10 +39,22 @@ def mainsearch(dataDirection: str = None,
 
         params = cD.checkVariables(variable="param_Parameter")
 
+        if (cD.checkExistVariables(variable="cmakeDirection") or
+                cmakeDirection is not None):
+
+            cR = cmakeReader.CMAKEFlagReader(direction=cmakeDirection,
+                                             directiontype="cmakeDirection")
+            for parameter in params:
+                try:
+                    param[parameter] = cR.getValue(parameter)
+                except Exception:
+                    pass
+
         pR = paramReader.ParamReader(direction=paramDirection,
                                      directiontype="paramDirection")
         for parameter in params:
-            param[parameter] = pR.getValue(parameter)
+            if parameter not in param:
+                param[parameter] = pR.getValue(parameter)
 
     # read .data values
     if (cD.checkExistVariables(variable="dataDirection") or

--- a/lib/python/test/testsuite/Reader/cmakeFlagReader.py
+++ b/lib/python/test/testsuite/Reader/cmakeFlagReader.py
@@ -1,0 +1,150 @@
+"""
+This file is part of the PIConGPU.
+
+Copyright 2023 PIConGPU contributors
+Authors: Mika Soren Voss
+License: GPLv3+
+
+"""
+
+__all__ = ["CMAKEFlagReader"]
+
+from . import readFiles as rF
+import os
+
+
+class CMAKEFlagReader(rF.ReadFiles):
+
+    def __init__(self, fileExtension: str = None,
+                 direction: str = None,
+                 directiontype: str = None):
+        """
+        constructor
+
+        Input:
+        -------
+        fileExtension : str, optional
+                        The file extension to search for
+                        (e.g. .dat, .param, .json,...)
+                        Default: None
+
+        direction :     str, optional
+                        Directory of the files, the value from
+                        config.py is used. Must only be set if config.py is
+                        not used or directiontype is not set there
+                        Default: None
+
+        directiontype : str, optional
+                        Is the designation of the variable in
+                        config.py for the directory
+                        (e.g dataDirection, jsonDirection)
+                        Default: None
+
+        Raise:
+        -------
+        TypeError: If neither a directory nor a directiontype was passed
+        """
+
+        super().__init__(fileExtension, direction, directiontype)
+
+    def checkFilesInDir(self) -> bool:
+        """
+        Checks whether files(cmakeFlags and cmakeFlagsSetup) can be
+        found in the transferred directory
+
+        Return:
+        -------
+        out : bool
+              True if there are cmake files in the specified directory,
+              False otherwise
+        """
+
+        files = os.listdir(self._direction)
+
+        if "cmakeFlags" in files and "cmakeFlagsSetup" in files:
+            return True
+        else:
+            return False
+
+    def usedSetup(self) -> int:
+        """
+        Indicates which simulation setup was used.
+
+        Return:
+        -------
+        out : int
+              Index of list flag from cmakeflag. (simulation setup)
+        """
+
+        with open(self._direction + "cmakeFlagsSetup") as file:
+            line = file.readlines()[0].split(":")
+
+        return int(line[-1])
+
+    def getAllSetups(self) -> list:
+        """
+        Returns the flag list from cmakeflag
+
+        Return:
+        out : list
+               The entire flag list from cmakeflag,
+               and thus all simulation setups
+        """
+
+        flags = []
+
+        file = open(self._direction + "cmakeFlags", 'r')
+        lines = file.readlines()
+
+        i = 0
+        for line in lines:
+            if "flags[" + str(i) + "]=" in line:
+                flags.append(line.split("\"")[1])
+                i += 1
+
+        return flags
+
+    def getValue(self, parameter: str):
+        """
+        determines the value of the parameter from the setup used
+
+        Input:
+        -------
+        parameter : str
+                    name of the Parameter
+                    (for the search to run stable you should use
+                    the whole name as in cmakeflag and not just
+                    parts of it)
+
+        Return:
+        -------
+        out : int, float or str
+              Value of the parameter, note the function tries to
+              convert the values to int or float, if this is not
+              possible it outputs str
+        """
+
+        # check which setup was used
+        setup = self.usedSetup()
+
+        # get all parameter from the setup
+        allparameters = self.getAllSetups()[setup]
+
+        if (parameter and parameter.upper()) not in allparameters:
+            raise ValueError("The parameter {} could not be"
+                             " found.".format(parameter))
+
+        allparameters = allparameters.split(";")
+
+        for para in allparameters:
+            if (parameter in para) or (parameter.upper() in para):
+                value = para.split("=")[-1]
+                try:
+                    value = int(value)
+                except Exception:
+                    try:
+                        value = float(value)
+                    except Exception:
+                        value = value
+
+        return value

--- a/lib/python/test/testsuite/Reader/readFiles.py
+++ b/lib/python/test/testsuite/Reader/readFiles.py
@@ -62,6 +62,9 @@ class ReadFiles():
             raise TypeError("You must set at least one of the"
                             " values(direction or directiontype)")
 
+        if directiontype is None:
+            directiontype = "undefined"
+
         direction = cD.checkDirection(variable=directiontype,
                                       direction=direction)
 

--- a/lib/python/test/testsuite/_manager.py
+++ b/lib/python/test/testsuite/_manager.py
@@ -9,19 +9,87 @@ License: GPLv3+
 import config
 import testsuite.Output.Log as log
 import sys
+from . import _checkData as cD
 
 
-def run_testsuite(dataDirection,
-                  paramDirection,
-                  jsonDirection,
-                  resultDirection):
+def run_testsuite(direction: str = None,
+                  dataDirection: str = None,
+                  paramDirection: str = None,
+                  jsonDirection: str = None,
+                  resultDirection: str = None,
+                  cmakeDirection: str = None):
+    """
+    Main function of the test-suite, starts and runs the test-suite.
+
+    Input:
+    -------
+    direction:  str, optional
+                Main path of the simulation
+                All other paths are determined from this.
+                All others only have to be defined if they
+                deviate from the standard path or direction is None.
+                Default: None
+
+    dataDirection: str, optional
+                   Path of the folder in which the results
+                   of the simulation were saved
+                   Default: None
+
+    paramDirection: str, optional
+                    Path of the folder in which the parameter
+                    files .params of the simulation were saved.
+                    Default: None
+
+    jsonDirection: str, optional
+                   Path of the folder to the json files
+                   if used.
+                   Default: None
+
+    resultDirection: str, optional
+                     Path of the folder where the results
+                     of the test-suite should be saved
+                     Default: None
+
+    cmakeDirection: str, optional
+                        Path of the folder to the cmake files
+                        if used.
+                        Default: None
+
+    Raise:
+    -------
+    InputError:  If all directories are None.
+
+    """
+    # determine all other directories if only "direction" is specified
+    if (cD.checkExistVariables(variable="direction") or
+            direction is not None):
+        direction = cD.checkDirection(variable="direction",
+                                      direction=direction)
+        if (dataDirection is None and not
+                cD.checkExistVariables(variable="dataDirection")):
+            dataDirection = cD.checkDirection(variable="dataDirection",
+                                              direction=direction +
+                                              "simOutput/")
+        if (paramDirection is None and not
+                cD.checkExistVariables(variable="paramDirection")):
+            paramDirection = cD.checkDirection(variable="paramDirection",
+                                               direction=direction +
+                                               "input/include/" +
+                                               "picongpu/param/")
+        if (cmakeDirection is None and not
+                cD.checkExistVariables(variable="cmakeDirection")):
+            cmakeDirection = cD.checkDirection(variable="cmakeDirection",
+                                               direction=direction +
+                                               "input/")
+
     try:
         # read the Data
         from .Reader import _manager as read
 
         json, param, data = read.mainsearch(dataDirection,
                                             paramDirection,
-                                            jsonDirection)
+                                            jsonDirection,
+                                            cmakeDirection)
 
         # now we can determine the theory and simulation
         parameter = {**json, **param, **data}
@@ -34,6 +102,9 @@ def run_testsuite(dataDirection,
 
         # get the result
         from .Output import _manager as output
+
+        if resultDirection is None and direction is not None:
+            resultDirection = direction
 
         output._output(theory=theory,
                        simulation=simData,
@@ -49,5 +120,6 @@ def run_testsuite(dataDirection,
             sys.exit(1)
 
     except Exception:
+
         log.errorLog()
         sys.exit(42)


### PR DESCRIPTION
Simplifies entering the simulation directory. All you have to do is specify the main path, all other paths are determined by the test suite itself. (Furthermore, the paths can be specified separately if the paths differ).

Furthermore, the cmake flag reader was added. This means that changed parameters can now also be read from the cmakFlags file. This is the basis for case differentiation by the test suite.