### PR TITLE
TransitionRadiation plugin openPMD output

### DIFF
--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -209,7 +209,7 @@ Command line option                        Description
 ``--<species>_transRad.period``            Gives the number of time steps between which the radiation should be calculated.
 ``--<species>_transRad.foilPositionY``     Absolute position in SI units to put a virtual foil for calculating the transition radiation. See above for more information. Disabled = 0.0. Default: 0.0
 ``--<species>_transRad.file``              File name to stodre transition radiation in. Default: transRad
-``--<species>_transRad.ext``               openPMD filename extension. Default: ext
+``--<species>_transRad.ext``               Backend for openPMD output. Default: default that is used internally
 ``--<species>_transRad.datOutput``         Optional text file output in numpy-readable format. Enabled = 1. Default: 0
 ========================================== ==============================================================================================================================
 

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -53,7 +53,7 @@ The transition radiation can only be calculated for electrons at the moment.
 External Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
-There are no external dependencies.
+The plugin is available as soon as the :ref:`openPMD API <install-dependencies>` is compiled in.
 
 .param files
 ^^^^^^^^^^^^
@@ -135,15 +135,7 @@ Foil Position
 If one wants to virtually propagate the electron bunch to a foil in a further distance to get a rough estimate of the effect of the divergence on the electron bunch, one can include a foil position.
 A foil position which is unequal to zero, adds the electrons momentum vectors onto the electron until they reach the given y-coordinate.
 To contain the longitudinal information of the bunch, the simulation window is actually virtually moved to the foil position and not each single electron.
-
-.. code:: cpp
-
-    namespace SI
-    {
-        // y position of the foil to calculate transition radiation at
-        // leave at 0 for no virtual particle propagation
-        constexpr float_64 foilPosition = 0.0;
-    }
+This is a run time parameter which can be set with ``--<species>_transRad.foilPositionY``.
 
 .. note::
 
@@ -215,6 +207,10 @@ For a specific (charged) species ``<species>`` e.g. ``e``, the radiation can be 
 Command line option                        Description
 ========================================== ==============================================================================================================================
 ``--<species>_transRad.period``            Gives the number of time steps between which the radiation should be calculated.
+``--<species>_transRad.foilPositionY``     Absolute position in SI units to put a virtual foil for calculating the transition radiation. See above for more information. Disabled = 0.0. Default: 0.0
+``--<species>_transRad.file``              File name to stodre transition radiation in. Default: transRad
+``--<species>_transRad.ext``               openPMD filename extension. Default: ext
+``--<species>_transRad.datOutput``         Optional text file output in numpy-readable format. Enabled = 1. Default: 0
 ========================================== ==============================================================================================================================
 
 Memory Complexity

--- a/include/picongpu/param/transitionRadiation.param
+++ b/include/picongpu/param/transitionRadiation.param
@@ -165,14 +165,6 @@ namespace picongpu
                 // phi goes from 0 to 2*pi
                 constexpr float_64 phiMin = 0.0;
                 constexpr float_64 phiMax = 2 * picongpu::PI;
-
-                namespace SI
-                {
-                    // y position of the foil to calculate transition radiation at
-                    // leave at 0 for no virtual particle propagation
-                    constexpr float_64 foilPosition = 0.0;
-                } // namespace SI
-
             } /* end namespace parameters */
 
 

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -65,7 +65,7 @@ namespace picongpu
                  * @param mapper MappingDesction object
                  * @param freqFkt frequency functor
                  * @param simBoxSize size of simulation box
-                 * @param foilPosition position of the virtual foil to calculate the TR for in PIC units
+                 * @param foilPositionY position of the virtual foil to calculate the TR for in PIC units
                  */
                 template<
                     typename T_ParBox,
@@ -84,7 +84,7 @@ namespace picongpu
                     T_Mapping mapper,
                     transitionRadiation::frequencies::FreqFunctor freqFkt,
                     DataSpace<simDim> simBoxSize,
-                    float_X foilPosition) const
+                    float_X foilPositionY) const
                 {
                     using complex_X = alpaka::Complex<float_X>;
                     using complex_64 = alpaka::Complex<float_64>;
@@ -138,7 +138,7 @@ namespace picongpu
                     int const numSuperCells = superCellsCount.productOfComponents();
 
                     // propagation distance for the particle bunch
-                    float_X const propagationDistance = foilPosition - globalOffset[1];
+                    float_X const propagationDistance = foilPositionY - globalOffset[1];
 
 
                     /* go over all super cells on GPU
@@ -264,7 +264,7 @@ namespace picongpu
 
                                                 // only propagate particles if it is set up in
                                                 // transitionRadiation.param
-                                                if(foilPosition != 0.0)
+                                                if(foilPositionY != 0.0)
                                                     particle.propagate(propagationDistance);
 
                                                 // create calculator for TR calculations

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -65,6 +65,7 @@ namespace picongpu
                  * @param mapper MappingDesction object
                  * @param freqFkt frequency functor
                  * @param simBoxSize size of simulation box
+                 * @param foilPosition position of the virtual foil to calculate the TR for in PIC units
                  */
                 template<
                     typename T_ParBox,
@@ -82,7 +83,8 @@ namespace picongpu
                     DataSpace<simDim> globalOffset,
                     T_Mapping mapper,
                     transitionRadiation::frequencies::FreqFunctor freqFkt,
-                    DataSpace<simDim> simBoxSize) const
+                    DataSpace<simDim> simBoxSize,
+                    float_X foilPosition) const
                 {
                     using complex_X = alpaka::Complex<float_X>;
                     using complex_64 = alpaka::Complex<float_64>;
@@ -136,7 +138,7 @@ namespace picongpu
                     int const numSuperCells = superCellsCount.productOfComponents();
 
                     // propagation distance for the particle bunch
-                    float_X const propagationDistance = parameters::foilPosition - globalOffset[1];
+                    float_X const propagationDistance = foilPosition - globalOffset[1];
 
 
                     /* go over all super cells on GPU
@@ -262,7 +264,7 @@ namespace picongpu
 
                                                 // only propagate particles if it is set up in
                                                 // transitionRadiation.param
-                                                if(parameters::foilPosition != 0.0)
+                                                if(foilPosition != 0.0)
                                                     particle.propagate(propagationDistance);
 
                                                 // create calculator for TR calculations

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
@@ -642,6 +642,8 @@ namespace picongpu
                     meshPhi.setGridSpacing(std::vector<double>{1, 1, 1});
                     meshPhi.setGeometry(::openPMD::Mesh::Geometry::cartesian); // set be default
 
+                    meshPhi.setUnitDimension(std::map<::openPMD::UnitDimension, double>{});
+
                     auto phi = meshPhi[::openPMD::RecordComponent::SCALAR];
                     phi.resetDataset(datasetPhi);
 
@@ -676,6 +678,8 @@ namespace picongpu
                     meshTheta.setGridUnitSI(1);
                     meshTheta.setGridSpacing(std::vector<double>{1, 1, 1});
                     meshTheta.setGeometry(::openPMD::Mesh::Geometry::cartesian); // set be default
+
+                    meshTheta.setUnitDimension(std::map<::openPMD::UnitDimension, double>{});
 
                     auto theta = meshTheta[::openPMD::RecordComponent::SCALAR];
                     theta.resetDataset(datasetTheta);
@@ -748,18 +752,18 @@ namespace picongpu
                     PMACC_LOCKSTEP_KERNEL(KernelTransRadParticles{})
                         .config(gridDim_rad, *particles)(
                             /*Pointer to particles memory on the device*/
-                        particles->getDeviceParticlesBox(),
+                            particles->getDeviceParticlesBox(),
 
-                        /*Pointer to memory of radiated amplitude on the device*/
-                        incTransRad->getDeviceBuffer().getDataBox(),
-                        cohTransRadPara->getDeviceBuffer().getDataBox(),
-                        cohTransRadPerp->getDeviceBuffer().getDataBox(),
-                        numParticles->getDeviceBuffer().getDataBox(),
-                        globalOffset,
-                        *m_cellDescription,
-                        freqFkt,
-                        subGrid.getGlobalDomain().size,
-                        foilPositionYSI / UNIT_LENGTH);
+                            /*Pointer to memory of radiated amplitude on the device*/
+                            incTransRad->getDeviceBuffer().getDataBox(),
+                            cohTransRadPara->getDeviceBuffer().getDataBox(),
+                            cohTransRadPerp->getDeviceBuffer().getDataBox(),
+                            numParticles->getDeviceBuffer().getDataBox(),
+                            globalOffset,
+                            *m_cellDescription,
+                            freqFkt,
+                            subGrid.getGlobalDomain().size,
+                            foilPositionYSI / UNIT_LENGTH);
                 }
             };
 

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
@@ -26,49 +26,46 @@
 #include "picongpu/param/transitionRadiation.param"
 // clang-format on
 
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/common/openPMDAttributes.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-#include "picongpu/plugins/common/openPMDVersion.def"
-#include "picongpu/plugins/common/openPMDWriteMeta.hpp"
-#include "picongpu/plugins/common/stringHelpers.hpp"
-#include "picongpu/plugins/misc/misc.hpp"
-#include "picongpu/plugins/multi/multi.hpp"
-#include "picongpu/plugins/transitionRadiation/TransitionRadiation.kernel"
+#    include "picongpu/plugins/transitionRadiation/TransitionRadiation.kernel"
 
-#include "picongpu/particles/filter/filter.hpp"
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/ILightweightPlugin.hpp"
-#include "picongpu/plugins/ISimulationPlugin.hpp"
-#include "picongpu/plugins/PluginRegistry.hpp"
-#include "picongpu/plugins/common/stringHelpers.hpp"
-#include "picongpu/plugins/radiation/VectorTypes.hpp"
-#include "picongpu/plugins/transitionRadiation/executeParticleFilter.hpp"
-#include "picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp"
-#include "picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp"
-#include "picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp"
-#include "picongpu/unitless/transitionRadiation.unitless"
+#    include "picongpu/particles/filter/filter.hpp"
+#    include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#    include "picongpu/plugins/ILightweightPlugin.hpp"
+#    include "picongpu/plugins/ISimulationPlugin.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/common/openPMDAttributes.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/plugins/common/openPMDVersion.def"
+#    include "picongpu/plugins/common/openPMDWriteMeta.hpp"
+#    include "picongpu/plugins/common/stringHelpers.hpp"
+#    include "picongpu/plugins/misc/misc.hpp"
+#    include "picongpu/plugins/multi/multi.hpp"
+#    include "picongpu/plugins/radiation/VectorTypes.hpp"
+#    include "picongpu/plugins/transitionRadiation/executeParticleFilter.hpp"
+#    include "picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp"
+#    include "picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp"
+#    include "picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp"
+#    include "picongpu/unitless/transitionRadiation.unitless"
 
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/lockstep/lockstep.hpp>
-#include <pmacc/mappings/simulation/Filesystem.hpp>
-#include <pmacc/math/Complex.hpp>
-#include <pmacc/math/operation.hpp>
-#include <pmacc/mpi/MPIReduce.hpp>
-#include <pmacc/mpi/reduceMethods/Reduce.hpp>
-#include <pmacc/traits/HasIdentifier.hpp>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/lockstep/lockstep.hpp>
+#    include <pmacc/math/Complex.hpp>
+#    include <pmacc/math/operation.hpp>
+#    include <pmacc/mpi/MPIReduce.hpp>
+#    include <pmacc/mpi/reduceMethods/Reduce.hpp>
+#    include <pmacc/traits/HasIdentifier.hpp>
 
-#include <boost/filesystem.hpp>
+#    include <boost/filesystem.hpp>
 
-#include <chrono>
-#include <cmath>
-#include <cstdlib>
-#include <ctime>
-#include <fstream>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <vector>
+#    include <chrono>
+#    include <cmath>
+#    include <cstdlib>
+#    include <ctime>
+#    include <fstream>
+#    include <iostream>
+#    include <memory>
+#    include <string>
+#    include <vector>
 
 
 namespace picongpu
@@ -574,8 +571,8 @@ namespace picongpu
                     transitionRadiation.resetDataset(dataset);
 
                     transitionRadiation.setUnitSI(
-                        SI::ELECTRON_CHARGE_SI * SI::ELECTRON_CHARGE_SI
-                        * (1.0 / (4 * PI * SI::EPS0_SI * PI * PI * SI::SPEED_OF_LIGHT_SI)));
+                        sim.si.getElectronCharge() * sim.si.getElectronCharge()
+                        * (1.0 / (4 * PI * SI::EPS0_SI * PI * PI * sim.si.getSpeedOfLight())));
 
                     auto span = transitionRadiation.storeChunk<float_X>(offset, extent);
                     auto spanBuffer = span.currentBuffer();
@@ -763,7 +760,7 @@ namespace picongpu
                             *m_cellDescription,
                             freqFkt,
                             subGrid.getGlobalDomain().size,
-                            foilPositionYSI / UNIT_LENGTH);
+                            foilPositionYSI / sim.unit.length());
                 }
             };
 
@@ -802,6 +799,6 @@ namespace picongpu
     } // namespace particles
 } // namespace picongpu
 
-PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::transitionRadiation::TransitionRadiation<boost::mpl::_1>);
-
+PIC_REGISTER_SPECIES_PLUGIN(
+    picongpu::plugins::multi::Master<picongpu::plugins::transitionRadiation::TransitionRadiation<boost::mpl::_1>>);
 #endif

--- a/include/picongpu/unitless/transitionRadiation.unitless
+++ b/include/picongpu/unitless/transitionRadiation.unitless
@@ -55,13 +55,6 @@ namespace picongpu
                 constexpr unsigned int blocksizeOmega = numFrameSlots;
                 constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
             } // namespace listFrequencies
-
-            //! unit for foil position
-            namespace parameters
-            {
-                constexpr float_X foilPosition = SI::foilPosition / sim.unit.length();
-            }
-
         } // namespace transitionRadiation
     } // namespace plugins
 } // namespace picongpu

--- a/lib/python/picongpu/extra/plugins/data/transitionradiation.py
+++ b/lib/python/picongpu/extra/plugins/data/transitionradiation.py
@@ -28,7 +28,6 @@ class TransitionRadiationData(DataReader):
 
         self.data_file_prefix = "_transRad_"
         self.data_file_suffix = ".dat"
-        self.data_file_folder = "transRad/"
         self.data = None
         self.omegas = None
         self.thetas = None
@@ -67,7 +66,8 @@ class TransitionRadiationData(DataReader):
         else:
             data_file_path = os.path.join(
                 sim_output_dir,
-                self.data_file_folder + species + self.data_file_prefix + str(iteration) + self.data_file_suffix,
+                species + self.data_file_prefix +
+                str(iteration) + self.data_file_suffix
             )
             if not os.path.isfile(data_file_path):
                 raise IOError("The file {} does not exist.\nDid the simulation already run?".format(data_file_path))

--- a/lib/python/picongpu/extra/plugins/data/transitionradiation.py
+++ b/lib/python/picongpu/extra/plugins/data/transitionradiation.py
@@ -65,9 +65,7 @@ class TransitionRadiationData(DataReader):
             return sim_output_dir
         else:
             data_file_path = os.path.join(
-                sim_output_dir,
-                species + self.data_file_prefix +
-                str(iteration) + self.data_file_suffix
+                sim_output_dir, species + self.data_file_prefix + str(iteration) + self.data_file_suffix
             )
             if not os.path.isfile(data_file_path):
                 raise IOError("The file {} does not exist.\nDid the simulation already run?".format(data_file_path))

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
@@ -55,7 +55,7 @@ TBG_pngYX="--e_png.period 10 \
 # transition radiation plugin
 TBG_e_transRad="--e_transRad.period 10 \
                 --e_transRad.file transRad \
-                --e_transRad.foilPosition 0.0"
+                --e_transRad.foilPositionY 0.0"
 
 # energy histogram to check amount of electrons and their velocity
 TBG_e_histogram="--e_energyHistogram.period 10 \

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
@@ -52,8 +52,10 @@ TBG_pngYX="--e_png.period 10 \
            --e_png.slicePoint 0.5 \
            --e_png.folder pngElectronsYX"
 
-# transition radiation plugi
-TBG_e_transRad="--e_transRad.period 10"
+# transition radiation plugin
+TBG_e_transRad="--e_transRad.period 10 \
+                --e_transRad.file transRad \
+                --e_transRad.foilPosition 0.0"
 
 # energy histogram to check amount of electrons and their velocity
 TBG_e_histogram="--e_energyHistogram.period 10 \

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
@@ -55,7 +55,7 @@ TBG_pngYX="--e_png.period 10 \
 # transition radiation plugin
 TBG_e_transRad="--e_transRad.period 10 \
                 --e_transRad.file transRad \
-                --e_transRad.foilPosition 0.0"
+                --e_transRad.foilPositionY 0.0"
 
 # energy histogram to check amount of electrons and their velocity
 TBG_e_histogram="--e_energyHistogram.period 10 \

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
@@ -52,8 +52,10 @@ TBG_pngYX="--e_png.period 10 \
            --e_png.slicePoint 0.5 \
            --e_png.folder pngElectronsYX"
 
-# transition radiation plugi
-TBG_e_transRad="--e_transRad.period 10"
+# transition radiation plugin
+TBG_e_transRad="--e_transRad.period 10 \
+                --e_transRad.file transRad \
+                --e_transRad.foilPosition 0.0"
 
 # energy histogram to check amount of electrons and their velocity
 TBG_e_histogram="--e_energyHistogram.period 10 \

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
@@ -161,14 +161,6 @@ namespace picongpu
                 // phi goes from 0 to 2*pi
                 constexpr float_64 phiMin = 0.0;
                 constexpr float_64 phiMax = 2 * picongpu::PI;
-
-                namespace SI
-                {
-                    // z position of the foil to calculate transition radiation at
-                    // leave at 0 for no virtual particle propagation
-                    constexpr float_64 foilPosition = 0.0;
-                } // namespace SI
-
             } // end namespace parameters
 
 


### PR DESCRIPTION
This PR adds openPMD output to the Transition Radiation plugin. Additionally, as a Quality of Life feature, it made the virtual foil position a command line parameter and it changed the plugin to a multi-plugin.

During the refactoring I noticed, that the current value storage implementation is quite messy with the internal 3D to 1D mapping, but this is a task for a future PR. Also this plugin would profit, as soon as the openPMD standard allows axes with different unit systems. The plugin with the openPMD output is probably less flexible in defining the observers now, this might need to be changed in the future as well.

@BeyondEspresso @psychocoderHPC 