### PR TITLE
Add an optional time delay for incident field pulses

### DIFF
--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020-2023 Sergei Bastrakov
+/* Copyright 2020-2023 Sergei Bastrakov, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *
@@ -469,7 +469,8 @@ namespace picongpu
                     template<typename T_SeparableFunctor>
                     HDINLINE float3_X operator()(T_SeparableFunctor const& functor, floatD_X const& totalCellIdx) const
                     {
-                        auto const time = functor.getCurrentTime(totalCellIdx);
+                        auto const time
+                            = functor.getCurrentTime(totalCellIdx) - T_SeparableFunctor::Unitless::TIME_DELAY;
                         // Cut off when the laser has not entered at this point yet to avoid confusion.
                         if(time < 0.0_X)
                             return float3_X::create(0.0_X);

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -113,7 +113,7 @@ namespace picongpu
             };
             namespace detail
             {
-                /** SFINAE dedection if the user parameter define the variable FOCUS_ORIGIN_*
+                /** SFINAE deduction if the user parameter define the variable FOCUS_ORIGIN_*
                  *
                  * This allows that focus origin can be an optional variable a user must only define if needed.
                  * The default if it is not defined is Origin::Zero

--- a/include/picongpu/fields/incidentField/Functors.hpp
+++ b/include/picongpu/fields/incidentField/Functors.hpp
@@ -201,9 +201,9 @@ namespace picongpu
 
                     /** Get current time to calculate field at the given point
                      *
-                     * It accounts for both current PIC iteration and location relative to origin.
-                     * Note that the result may be negative as well, and clients may want to set
-                     * field = 0 when the returned value is negative.
+                     * It accounts for both current PIC iteration, location relative to origin and the given time
+                     * delay. Note that the result may be negative as well, and clients may want to set field = 0 when
+                     * the returned value is negative.
                      *
                      * @param totalCellIdx cell index in the total domain
                      *
@@ -215,7 +215,7 @@ namespace picongpu
                     {
                         auto const shiftFromOrigin = totalCellIdx * cellSize - origin;
                         auto const distance = pmacc::math::dot(shiftFromOrigin, getDirection());
-                        auto const timeDelay = distance / phaseVelocity;
+                        auto const timeDelay = distance / phaseVelocity + Unitless::TIME_DELAY;
                         return currentTimeOrigin - timeDelay;
                     }
 
@@ -469,8 +469,7 @@ namespace picongpu
                     template<typename T_SeparableFunctor>
                     HDINLINE float3_X operator()(T_SeparableFunctor const& functor, floatD_X const& totalCellIdx) const
                     {
-                        auto const time
-                            = functor.getCurrentTime(totalCellIdx) - T_SeparableFunctor::Unitless::TIME_DELAY;
+                        auto const time = functor.getCurrentTime(totalCellIdx);
                         // Cut off when the laser has not entered at this point yet to avoid confusion.
                         if(time < 0.0_X)
                             return float3_X::create(0.0_X);

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 Sergei Bastrakov
+/* Copyright 2023 Sergei Bastrakov, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *
@@ -148,6 +148,17 @@ namespace picongpu
                     static constexpr Origin FOCUS_ORIGIN_Y = Origin::Zero;
                     static constexpr Origin FOCUS_ORIGIN_Z = Origin::Zero;
                     /** @} */
+
+                    /** Time delay
+                     * For e.g. probe pulses, that enter the simulation volume later in time.
+                     * The laser will be initiation will start after the time delay.
+                     * The delay must be positive.
+                     *
+                     * unit: time
+                     *
+                     * @attention TIME_DELAY_SI is optional, default value is 0
+                     */
+                    static constexpr float_64 TIME_DELAY_SI = 0.0;
 
                     /** E polarization type
                      *

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -151,7 +151,7 @@ namespace picongpu
 
                     /** Time delay
                      * For e.g. probe pulses, that enter the simulation volume later in time.
-                     * The laser will be initiation will start after the time delay.
+                     * The laser initiation will be started after the time delay.
                      * The delay must be positive.
                      *
                      * unit: time

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.hpp
@@ -96,7 +96,7 @@ namespace picongpu
                             return 0.0;
                         }
 
-                        /** SFINAE detection if the user parameter define the variable TIME_DELAY_SI
+                        /** SFINAE deduction if the user parameter define the variable TIME_DELAY_SI
                          *
                          * This allows that time delay can be an optional variable a user must only define if needed.
                          * The default if it is not defined is 0.

--- a/include/picongpu/fields/incidentField/profiles/DispersivePulse.def
+++ b/include/picongpu/fields/incidentField/profiles/DispersivePulse.def
@@ -1,6 +1,6 @@
 /* Copyright 2013-2023 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
  *                     Richard Pausch, Alexander Debus, Sergei Bastrakov,
- *                     Fabia Dietrich, Klaus Steiniger
+ *                     Fabia Dietrich, Klaus Steiniger, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *
@@ -45,7 +45,8 @@ namespace picongpu
                          */
                         static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
+                         * TIME_DELAY_SI.
                          * WATCH OUT! Dispersion parameters may lead to pulse lenghtening
                          * Please ensure to choose a value high enough to cover the whole pulse,
                          * otherwise the Fourier Transformation will misbehave.

--- a/include/picongpu/fields/incidentField/profiles/DispersivePulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/DispersivePulse.hpp
@@ -267,7 +267,7 @@ namespace picongpu
                          */
                         HDINLINE float_X getValueE(floatD_X const& totalCellIdx, float_X const phaseShift) const
                         {
-                            auto const time = this->getCurrentTime(totalCellIdx) - Unitless::TIME_DELAY;
+                            auto const time = this->getCurrentTime(totalCellIdx);
                             if(time < 0.0_X)
                                 return 0.0_X;
 
@@ -463,7 +463,7 @@ namespace picongpu
                          */
                         HDINLINE float_X getValueB(int const axis, floatD_X const& totalCellIdx) const
                         {
-                            auto const time = this->getCurrentTime(totalCellIdx) - Unitless::TIME_DELAY;
+                            auto const time = this->getCurrentTime(totalCellIdx);
                             if(time < 0.0_X)
                                 return 0.0_X;
 

--- a/include/picongpu/fields/incidentField/profiles/DispersivePulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/DispersivePulse.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 Fabia Dietrich, Klaus Steiniger, Richard Pausch
+/* Copyright 2022-2023 Fabia Dietrich, Klaus Steiniger, Richard Pausch, Finn-Ole Carstens
  *
  * This file is part of PIConGPU.
  *
@@ -267,7 +267,7 @@ namespace picongpu
                          */
                         HDINLINE float_X getValueE(floatD_X const& totalCellIdx, float_X const phaseShift) const
                         {
-                            auto const time = this->getCurrentTime(totalCellIdx);
+                            auto const time = this->getCurrentTime(totalCellIdx) - Unitless::TIME_DELAY;
                             if(time < 0.0_X)
                                 return 0.0_X;
 
@@ -463,7 +463,7 @@ namespace picongpu
                          */
                         HDINLINE float_X getValueB(int const axis, floatD_X const& totalCellIdx) const
                         {
-                            auto const time = this->getCurrentTime(totalCellIdx);
+                            auto const time = this->getCurrentTime(totalCellIdx) - Unitless::TIME_DELAY;
                             if(time < 0.0_X)
                                 return 0.0_X;
 

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -77,7 +77,7 @@ namespace picongpu
                         static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
 
                         /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
-                         * plateau and half at the end of the plateau
+                         * plateau and half at the end of the plateau after TIME_DELAY_SI
                          *
                          * unit: none
                          */

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -60,11 +60,23 @@ namespace picongpu
                          */
                         static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
+                         * TIME_DELAY_SI
                          *
                          *  unit: none
                          */
                         static constexpr float_64 PULSE_INIT = 20.0;
+
+                        /** Time delay
+                         * For e.g. probe pulses, that enter the simulation volume later in time.
+                         * The peak of the laser pulse intensity from the Gauss envelope enters the simulation at
+                         * TIME_DELAY_SI + PULSE_INIT * PULSE_LENGTH_SI / 2
+                         *
+                         * unit: time
+                         *
+                         * @attention TIME_DELAY_SI is optional, default value is 0
+                         */
+                        static constexpr float_64 TIME_DELAY_SI = 0.0;
 
                         /** Laguerre mode parameters
                          *

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -63,20 +63,9 @@ namespace picongpu
                         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
                          * TIME_DELAY_SI
                          *
-                         *  unit: none
+                         * unit: none
                          */
                         static constexpr float_64 PULSE_INIT = 20.0;
-
-                        /** Time delay
-                         * For e.g. probe pulses, that enter the simulation volume later in time.
-                         * The peak of the laser pulse intensity from the Gauss envelope enters the simulation at
-                         * TIME_DELAY_SI + PULSE_INIT * PULSE_LENGTH_SI / 2
-                         *
-                         * unit: time
-                         *
-                         * @attention TIME_DELAY_SI is optional, default value is 0
-                         */
-                        static constexpr float_64 TIME_DELAY_SI = 0.0;
 
                         /** Laguerre mode parameters
                          *

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
@@ -212,7 +212,7 @@ namespace picongpu
                         {
                             // transform to 3d internal coordinate system
                             float3_X pos = this->getInternalCoordinates(totalCellIdx);
-                            auto const time = this->getCurrentTime(totalCellIdx) - Unitless::TIME_DELAY;
+                            auto const time = this->getCurrentTime(totalCellIdx);
                             if(time < 0.0_X)
                                 return 0.0_X;
 

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2013-2023 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
- *                     Richard Pausch, Alexander Debus, Sergei Bastrakov, Finn-Ole Carstens
+ *                     Richard Pausch, Alexander Debus, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *

--- a/include/picongpu/fields/incidentField/profiles/PlaneWave.def
+++ b/include/picongpu/fields/incidentField/profiles/PlaneWave.def
@@ -39,8 +39,8 @@ namespace picongpu
                          *  unit: seconds */
                         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 13.34e-15;
 
-                        /** The laser pulse will be initialized half of PULSE_INIT times of the PULSE_DURATION before
-                         * and after the plateau unit: none */
+                        /** The laser pulse will be initialized after TIME_DELAY_SI half of PULSE_INIT times of the
+                         * PULSE_DURATION before and after the plateau unit: none */
                         static constexpr float_64 RAMP_INIT = 20.6146;
                     };
                 } // namespace defaults

--- a/include/picongpu/fields/incidentField/profiles/Wavepacket.def
+++ b/include/picongpu/fields/incidentField/profiles/Wavepacket.def
@@ -54,7 +54,8 @@ namespace picongpu
                         static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
                         static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
+                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
+                         * TIME_DELAY_SI
                          *
                          *  unit: none
                          */


### PR DESCRIPTION
Add a time delay for ~~Gaussian~~ incident field pulses. This is extremely useful for simulation setups with multiple laser pulses, e.g. optical probe pulses. The parameter should be optional with the SFINAE detection, as many users will probably not need it and I don't want to break existing simulation setups.

@PrometheusPi @steindev @psychocoderHPC 
