### PR TITLE
Add missing #include <cstdint>

### DIFF
--- a/include/picongpu/plugins/misc/ComponentNames.hpp
+++ b/include/picongpu/plugins/misc/ComponentNames.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/pmacc/debug/abortWithError.hpp
+++ b/include/pmacc/debug/abortWithError.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
When compiling on my laptop, I would get an error stating that `uint32_t` is unknown, including cstdint.h in both files fixed it for me.