### PR TITLE
update CMake in profiles to 3.22+

### DIFF
--- a/etc/picongpu/ascent-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/ascent-ornl/gpu_picongpu.profile.example
@@ -26,7 +26,7 @@ export CXX=$(which g++)
 
 # required tools and libs
 module load git/2.20.1
-module load cmake/3.18.2
+module load cmake
 module load cuda/11.2.0
 module load boost/1.66.0
 

--- a/etc/picongpu/cori-nersc/a100_picongpu.profile.example
+++ b/etc/picongpu/cori-nersc/a100_picongpu.profile.example
@@ -25,7 +25,7 @@ module purge
 module load dgx
 module swap PrgEnv-intel PrgEnv-gnu
 module load cuda openmpi
-module load cmake/3.18.2
+module load cmake
 module load boost/1.70.0
 
 # Other Software ##############################################################

--- a/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
+++ b/etc/picongpu/davide-cineca/gpu_picongpu.profile.example
@@ -21,7 +21,7 @@ export proj=$(groups | awk '{print $2}')
 #
 module purge
 module load gnu/6.4.0
-module load cmake/3.15.0
+module load cmake
 module load cuda/9.2.88
 module load openmpi/3.1.0--gnu--6.4.0
 module load boost/1.68.0--openmpi--3.1.0--gnu--6.4.0

--- a/etc/picongpu/draco-mpcdf/picongpu.profile.example
+++ b/etc/picongpu/draco-mpcdf/picongpu.profile.example
@@ -18,8 +18,8 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 
 module load git/2.14
-module load gcc/6.3
-module load cmake/3.15.0
+module load gcc
+module load cmake
 module load boost/gcc/1.64
 module load impi/2017.3
 module load hdf5-mpi/gcc/1.8.18

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/7.3.0
-module load cmake/3.20.2
+module load cmake/3.26.1
 module load openmpi/4.1.1
 module load boost/1.78.0
 

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -31,7 +31,7 @@ module load libfabric/1.11.1-co79
 module load c-blosc/1.14.4
 module load adios2/2.7.1-cuda115
 module load openpmd/0.14.3-cuda115
-module load cmake/3.20.2
+module load cmake/3.26.1
 
 module load libpng/1.6.35
 module load pngwriter/0.7.0

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -18,7 +18,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 module purge
 module load git
 module load gcc/11.2.0
-module load cmake/3.20.2
+module load cmake/3.26.1
 module load cuda/11.5
 module load openmpi/4.1.1-cuda115
 module load boost/1.78.0

--- a/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k20_picongpu.profile.example
@@ -27,7 +27,7 @@ module load git/2.30.1
 module load python/3.6.5
 module load libfabric/1.11.1-co79
 module load c-blosc/1.14.4
-module load cmake/3.20.2
+module load cmake/3.26.1
 module load libpng/1.6.35
 module load pngwriter/0.7.0
 module load adios2/2.7.1-cuda112-kepler

--- a/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/k80_picongpu.profile.example
@@ -28,7 +28,7 @@ module load git/2.30.1
 module load python/3.6.5
 module load libfabric/1.11.1-co79
 module load c-blosc/1.14.4
-module load cmake/3.20.2
+module load cmake/3.26.1
 module load libpng/1.6.35
 module load pngwriter/0.7.0
 module load adios2/2.7.1-cuda112-kepler

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -24,7 +24,7 @@ jutil env activate -p $proj
 #
 module purge
 module load Intel/2019.0.117-GCC-7.3.0
-module load CMake/3.15.0
+module load CMake
 module load IntelMPI/2018.4.274
 module load Python/3.6.6
 module load Boost/1.68.0-Python-3.6.6

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -25,7 +25,7 @@ jutil env activate -p $proj
 module purge
 module load Architecture/KNL
 module load Intel/2019.0.117-GCC-7.3.0
-module load CMake/3.15.0
+module load CMake
 module load IntelMPI/2018.4.274
 module load Python/3.6.6
 module load Boost/1.68.0-Python-3.6.6

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -25,7 +25,7 @@ jutil env activate -p $proj
 module purge
 module load GCC/7.3.0
 module load CUDA/9.2.88
-module load CMake/3.15.0
+module load CMake
 module load MVAPICH2/2.3-GDR
 module load Python/3.6.6
 

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -35,7 +35,7 @@ fi
 #
 module purge
 module load Intel/2020.2.254-GCC-9.3.0
-module load CMake/3.18.0
+module load CMake
 module load IntelMPI/2019.8.254
 module load Python/3.8.5
 

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -36,7 +36,7 @@ module purge
 module load Stages/2022
 module load GCC/11.2.0
 module load CUDA/11.5
-module load CMake/3.21.1
+module load CMake
 module load ParaStationMPI/5.5.0-1
 module load mpi-settings/CUDA
 module load Python/3.9.6

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -35,7 +35,7 @@ fi
 module purge
 module load GCC/9.3.0
 module load CUDA/11.0
-module load CMake/3.18.0
+module load CMake
 module load ParaStationMPI/5.4.7-1
 module load mpi-settings/CUDA
 module load Python/3.8.5

--- a/etc/picongpu/pizdaint-cscs/picongpu.profile.example
+++ b/etc/picongpu/pizdaint-cscs/picongpu.profile.example
@@ -40,7 +40,7 @@ export CXX=$(which CC)
 export CRAY_CPU_TARGET=x86-64
 
 # Libraries ###################################################################
-module load CMake/3.15.0
+module load CMake
 
 module load cray-mpich/7.6.0
 module load cray-hdf5-parallel/1.10.0.3

--- a/etc/picongpu/spock-ornl/caar_picongpu.profile.example
+++ b/etc/picongpu/spock-ornl/caar_picongpu.profile.example
@@ -36,7 +36,7 @@ export MPIR_CVAR_GPU_EAGER_DEVICE_MEM=0
 export MPICH_GPU_SUPPORT_ENABLED=1
 export MPICH_SMP_SINGLE_COPY_MODE=CMA
 
-module load cmake/3.21.3
+module load cmake
 module load zlib/1.2.11
 module load git/2.31.1
 

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -25,7 +25,7 @@ export CXX=$(which g++)
 
 # required tools and libs
 module load git/2.29.0
-module load cmake/3.20.2
+module load cmake/3.23.2
 module load cuda/11.0.3
 module load boost/1.74.0
 

--- a/etc/picongpu/taurus-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/A100_picongpu.profile.example
@@ -21,7 +21,7 @@ module switch modenv/hiera
 module load foss/2021a
 module load CUDA/11.6.0
 module load HDF5/1.10.7
-module load CMake/3.20.1
+module load CMake
 module load libpng/1.6.37
 module load freetype/2.10.4
 

--- a/etc/picongpu/taurus-tud/V100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/V100_picongpu.profile.example
@@ -19,7 +19,7 @@ module switch modenv/ml
 
 # load CUDA/9.2.88-GCC-7.3.0-2.30, also loads GCC/7.3.0-2.30, zlib, OpenMPI and others
 module load fosscuda/2018b
-module load CMake/3.15.0-GCCcore-7.3.0
+module load CMake
 module load libpng/1.6.34-GCCcore-7.3.0
 
 printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"

--- a/etc/picongpu/taurus-tud/k80_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/k80_picongpu.profile.example
@@ -24,7 +24,7 @@ module load modenv/scs5
 
 module load CUDA/11.0.2-GCC-9.3.0
 module load OpenMPI/4.0.4-GCC-9.3.0
-module load CMake/3.18.4-GCCcore-10.2.0
+module load CMake
 module load libpng/1.6.37-GCCcore-9.3.0
 module load git/2.23.0-GCCcore-9.3.0-nodocs
 module load Python/3.8.2-GCCcore-9.3.0


### PR DESCRIPTION
For the latest alpaka CMake 3.22+ is required. This change is mendentory after #4652 is merged.

- update all profiles to a CMake version 3.22+

For system where I do not have access we will remove defining an explicit version in the hope that a modern CMake is the defult on the system.


- [x] merge after #4652  