### PR TITLE
remove env from pinning script

### DIFF
--- a/etc/picongpu/lumi-eurohpc/standard-g.tpl
+++ b/etc/picongpu/lumi-eurohpc/standard-g.tpl
@@ -117,7 +117,6 @@ fi
 cat << EOF > select_gpu
 #!/bin/bash
 
-env
 export ROCR_VISIBLE_DEVICES=\$SLURM_LOCALID
 exec "\$@"
 EOF


### PR DESCRIPTION
This is a fix of #4658. 
The previous pull request still contained a `env` call from testing. This resulted in a lot of output and should not be the default. 