### PR TITLE
increase required PICMI python version to 3.10+

### DIFF
--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -15,8 +15,8 @@ import picmistandard
 
 import sys
 
-assert sys.version_info.major > 3 or sys.version_info.minor >= 9, \
-    "Python 3.9 is required for PIConGPU PICMI"
+assert sys.version_info.major > 3 or sys.version_info.minor >= 10, \
+    "Python 3.10 is required for PIConGPU PICMI"
 
 __all__ = [
     "Simulation",


### PR DESCRIPTION
since PR #4664 PICMI requires at least python 3.10, this was not reflected in the error message and internal load sanity check, this is fixed with this PR