### PR TITLE
fix mismatch devServer install script and example profile dependencies

### DIFF
--- a/etc/picongpu/bash-devServer-hzdr/gpu_v100_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_v100_picongpu.profile.example
@@ -20,19 +20,19 @@ spack unload
 #   need to load correct cmake and gcc to compile picongpu
 
 spack load gcc@10.2.0
-spack load cmake@3.23.1 %gcc@10.2.0
+spack load cmake@3.24.2 %gcc@10.2.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
 #   and no name confilcts in spack, see install.sh for more precise definition
 #   if name conflicts occur
 
-spack load openpmd-api@0.14.4 %gcc@10.2.0 \
-    ^adios2@2.8.0 \
-    ^hdf5@1.12.1 \
+spack load openpmd-api@0.14.5 %gcc@10.2.0 \
+    ^adios2@2.8.3 \
+    ^hdf5@1.12.2 \
     ^openmpi@4.1.3 +atomics +cuda cuda_arch=70 \
-    ^python@3.9.12 \
-    ^py-numpy@1.22.3
+    ^python@3.10.4 \
+    ^py-numpy@1.23.3
 spack load boost@1.78.0 +math +filesystem +system %gcc@10.2.0
 
 # PIConGPU output dependencies ################################################


### PR DESCRIPTION
the gpu_v100 profile for the devServer was outdated and used different versions than the install script

this PR fixes that