### PR TITLE
add support for CMake option `alpaka_DISABLE_VENDOR_RNG`

### DIFF
--- a/include/pmacc/random/distributions/normal/Normal_double.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_double.hpp
@@ -21,15 +21,16 @@
 
 #pragma once
 
-#include "pmacc/algorithms/math.hpp"
-#include "pmacc/random/distributions/Normal.hpp"
-#include "pmacc/random/distributions/Uniform.hpp"
-#include "pmacc/random/distributions/misc/MullerBox.hpp"
-#include "pmacc/random/methods/MRG32k3aMin.hpp"
-#include "pmacc/random/methods/XorMin.hpp"
-#include "pmacc/types.hpp"
+#ifndef ALPAKA_DISABLE_VENDOR_RNG
+#    include "pmacc/algorithms/math.hpp"
+#    include "pmacc/random/distributions/Normal.hpp"
+#    include "pmacc/random/distributions/Uniform.hpp"
+#    include "pmacc/random/distributions/misc/MullerBox.hpp"
+#    include "pmacc/random/methods/MRG32k3aMin.hpp"
+#    include "pmacc/random/methods/XorMin.hpp"
+#    include "pmacc/types.hpp"
 
-#include <type_traits>
+#    include <type_traits>
 
 
 namespace pmacc
@@ -43,7 +44,7 @@ namespace pmacc
 /* XorMin and MRG32k3aMin uses the alpaka RNG as fallback for CPU accelerators
  * therefore we are not allowed to add a specialization for those RNG methods
  */
-#if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+#    if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 //! specialization for XorMin
                 template<typename T_Acc>
                 struct Normal<double, methods::XorMin<T_Acc>, void> : public MullerBox<double, methods::XorMin<T_Acc>>
@@ -56,8 +57,9 @@ namespace pmacc
                     : public MullerBox<double, methods::MRG32k3aMin<T_Acc>>
                 {
                 };
-#endif
+#    endif
             } // namespace detail
         } // namespace distributions
     } // namespace random
 } // namespace pmacc
+#endif

--- a/include/pmacc/random/distributions/normal/Normal_float.hpp
+++ b/include/pmacc/random/distributions/normal/Normal_float.hpp
@@ -21,15 +21,17 @@
 
 #pragma once
 
-#include "pmacc/algorithms/math.hpp"
-#include "pmacc/random/distributions/Normal.hpp"
-#include "pmacc/random/distributions/Uniform.hpp"
-#include "pmacc/random/distributions/misc/MullerBox.hpp"
-#include "pmacc/random/methods/MRG32k3aMin.hpp"
-#include "pmacc/random/methods/XorMin.hpp"
-#include "pmacc/types.hpp"
+#ifndef ALPAKA_DISABLE_VENDOR_RNG
 
-#include <type_traits>
+#    include "pmacc/algorithms/math.hpp"
+#    include "pmacc/random/distributions/Normal.hpp"
+#    include "pmacc/random/distributions/Uniform.hpp"
+#    include "pmacc/random/distributions/misc/MullerBox.hpp"
+#    include "pmacc/random/methods/MRG32k3aMin.hpp"
+#    include "pmacc/random/methods/XorMin.hpp"
+#    include "pmacc/types.hpp"
+
+#    include <type_traits>
 
 
 namespace pmacc
@@ -43,7 +45,7 @@ namespace pmacc
 /* XorMin and MRG32k3aMin uses the alpaka RNG as fallback for CPU accelerators
  * therefore we are not allowed to add a specialization for those RNG methods
  */
-#if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
+#    if(PMACC_CUDA_ENABLED == 1 || ALPAKA_ACC_GPU_HIP_ENABLED == 1)
                 //! specialization for XorMin
                 template<typename T_Acc>
                 struct Normal<float, methods::XorMin<T_Acc>, void> : public MullerBox<float, methods::XorMin<T_Acc>>
@@ -56,8 +58,9 @@ namespace pmacc
                     : public MullerBox<float, methods::MRG32k3aMin<T_Acc>>
                 {
                 };
-#endif
+#    endif
             } // namespace detail
         } // namespace distributions
     } // namespace random
 } // namespace pmacc
+#endif

--- a/include/pmacc/random/methods/methods.hpp
+++ b/include/pmacc/random/methods/methods.hpp
@@ -22,5 +22,7 @@
 #pragma once
 
 #include "pmacc/random/methods/AlpakaRand.hpp"
-#include "pmacc/random/methods/MRG32k3aMin.hpp"
-#include "pmacc/random/methods/XorMin.hpp"
+#ifndef ALPAKA_DISABLE_VENDOR_RNG
+#    include "pmacc/random/methods/MRG32k3aMin.hpp"
+#    include "pmacc/random/methods/XorMin.hpp"
+#endif


### PR DESCRIPTION
Add support for alpaka to disable the vendor random number generators. For PIConGPU the user should change the default `XorMin` RNG in `tandom.param` to `AlpakaRAnd` if `alpaka_DISABLE_VENDOR_RNG` is set to `ON`.

#4672 is required that this feature is working but there is no need that #4672 is merged before this PR.