### PR TITLE
fix `setValue`

### DIFF
--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -157,15 +157,7 @@ namespace pmacc
         const TYPE& value,
         ITask* registeringTask)
     {
-        /* sizeof(TYPE)<256 use fast set method for small data and slow method for big data
-         * the rest of 256bytes are reserved for other kernel parameter
-         */
-        enum
-        {
-            isSmall = (sizeof(TYPE) <= 128)
-        }; // if we use const variable the compiler create warnings
-
-        auto* task = new TaskSetValue<TYPE, DIM, isSmall>(dst, value);
+        auto* task = new TaskSetValue<TYPE, DIM>(dst, value);
 
         return startTask(*task, registeringTask);
     }

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -99,10 +99,14 @@ namespace pmacc
      *
      * T_ValueType  = data type (e.g. float, float2)
      * T_dim   = dimension of the GridBuffer
-     * T_isSmallValue = true if T_ValueType can be send via kernel parameter (on cupla T_ValueType must be smaller than
-     * 256 byte)
+     * T_isLess128ByteAndTrivillyCopyable = true if T_ValueType can be send via kernel parameter (on cupla T_ValueType
+     * must be <= 128 byte) and must be trivially copyable
      */
-    template<class T_ValueType, unsigned T_dim, bool T_isSmallValue>
+    template<
+        class T_ValueType,
+        unsigned T_dim,
+        bool T_isLess128ByteAndTrivillayCopyable
+        = sizeof(T_ValueType) <= 128 && std::is_trivially_copyable_v<T_ValueType>>
     class TaskSetValue;
 
     template<class T_ValueType, unsigned T_dim>


### PR DESCRIPTION
`setValue()` is not supporintg non trivially copyable value if these where <=128byte.
For small values we used a optimized version and pass a copy of the value as parameter to the set kernel, therefore the requirement that the value type must be trivially copyable is coming from.In case a value type is not trivially copyable we can us ethe non optimized code path where we must allocate memory to hold one elment of value type in the devices main memory.

This PR is changing that the optimzed code path is only used if the value size if <=128byte and the type is trivially copyable.