### PR TITLE
Non-Gaussian temporal envelope for Gaussian beam

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -32,7 +32,7 @@ namespace picongpu
             {
                 namespace defaults
                 {
-                    struct ExpRampWithPrepulseParam : public BaseParam
+                    struct ExpRampWithPrepulseLongitudinalParam : public BaseParam
                     {
                         /** Intensities of prepulse and exponential preramp
                          *
@@ -62,6 +62,17 @@ namespace picongpu
                         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI
                             = 0.0 * WAVE_LENGTH_SI / ::picongpu::SI::SPEED_OF_LIGHT_SI;
 
+
+                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
+                         * plateau and half at the end of the plateau
+                         *
+                         * unit: none
+                         */
+                        static constexpr float_64 RAMP_INIT = 16.0;
+                    };
+
+                    struct ExpRampWithPrepulseParam : public ExpRampWithPrepulseLongitudinalParam
+                    {
                         /** Beam waist: distance from the axis where the pulse intensity (E^2)
                          *              decreases to its 1/e^2-th part,
                          *              at the focus position of the laser
@@ -75,14 +86,8 @@ namespace picongpu
                          */
                         static constexpr float_64 W0_AXIS_1_SI = 4.246e-6;
                         static constexpr float_64 W0_AXIS_2_SI = W0_AXIS_1_SI;
-
-                        /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
-                         * plateau and half at the end of the plateau after TIME_DELAY_SI
-                         *
-                         * unit: none
-                         */
-                        static constexpr float_64 RAMP_INIT = 16.0;
                     };
+
                 } // namespace defaults
 
                 /** Wavepacket with spatial Gaussian envelope and adjustable temporal shape.
@@ -127,6 +132,9 @@ namespace picongpu
                  */
                 template<typename T_Params = defaults::ExpRampWithPrepulseParam>
                 struct ExpRampWithPrepulse;
+
+                template<typename T_Params = defaults::ExpRampWithPrepulseLongitudinalParam>
+                struct ExpRampWithPrepulseLongitudinal;
             } // namespace profiles
         } // namespace incidentField
     } // namespace fields

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -32,6 +32,9 @@ namespace picongpu
             {
                 namespace defaults
                 {
+                    /** Default param set for ExpRampWithPrepulse temporal envelope
+                     *
+                     */
                     struct ExpRampWithPrepulseLongitudinalParam : public BaseParam
                     {
                         /** Intensities of prepulse and exponential preramp
@@ -71,6 +74,11 @@ namespace picongpu
                         static constexpr float_64 RAMP_INIT = 16.0;
                     };
 
+                    /** Default param set for ExpRampWithPrepulse profile
+                     *
+                     * This profile is deprecated, use GaussianPulse profile (Gaussian beam) with the
+                     * ExpRampWithPrepulseLongitudinal temporal envelope.
+                     */
                     struct ExpRampWithPrepulseParam : public ExpRampWithPrepulseLongitudinalParam
                     {
                         /** Beam waist: distance from the axis where the pulse intensity (E^2)
@@ -91,6 +99,9 @@ namespace picongpu
                 } // namespace defaults
 
                 /** Wavepacket with spatial Gaussian envelope and adjustable temporal shape.
+                 *
+                 * Note: This profile is deprecated, use GaussianPulse profile (Gaussian beam) with the
+                 * ExpRampWithPrepulseLongitudinal temporal envelope.
                  *
                  * Allows defining a prepulse and two regions of exponential preramp with
                  * independent slopes. The definition works by specifying three (t, intensity)-
@@ -133,6 +144,12 @@ namespace picongpu
                 template<typename T_Params = defaults::ExpRampWithPrepulseParam>
                 struct ExpRampWithPrepulse;
 
+
+                /** The temporal envelope part of ExpRampWithPrepulse
+                 *
+                 *  To be used with GaussianPulse (Gaussian beam) for focusing.
+                 * @tparam T_Params param class, see defaults namespace for reference
+                 */
                 template<typename T_Params = defaults::ExpRampWithPrepulseLongitudinalParam>
                 struct ExpRampWithPrepulseLongitudinal;
             } // namespace profiles

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -191,7 +191,7 @@ namespace picongpu::fields::incidentField
                 {
                     auto const runTimeShifted = time + Unitless::time_start_init;
                     auto const phase = Unitless::w * runTimeShifted + Unitless::LASER_PHASE + phaseShift;
-                    return math::sin(phase) * Unitless::AMPLITUDE * Envelope::getEnvelope(runTimeShifted);
+                    return math::cos(phase) * Unitless::AMPLITUDE * Envelope::getEnvelope(runTimeShifted);
                 }
             };
         } // namespace detail

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -30,276 +30,285 @@
 #include <string>
 
 
-namespace picongpu
+namespace picongpu::fields::incidentField
 {
-    namespace fields
+    namespace profiles
     {
-        namespace incidentField
+        template<typename T_Params>
+        struct ExpRampWithPrepulse
         {
-            namespace profiles
+            //! Get text name of the incident field profile
+            HINLINE static std::string getName()
             {
-                template<typename T_Params>
-                struct ExpRampWithPrepulse
+                return "ExpRampWithPrepulse";
+            }
+        };
+
+        namespace detail
+        {
+            /** Unitless exponential ramp with prepulse parameters (envelope part)
+             *
+             * @tparam T_Params user (SI) parameters
+             */
+            template<typename T_Params>
+            struct ExpRampWithPrepulsesLongitudinalUnitless : public BaseParamUnitless<T_Params>
+            {
+                //! User SI parameters
+                using Params = T_Params;
+
+                using Base = BaseParamUnitless<T_Params>;
+
+                // unit: UNIT_TIME
+                static constexpr float_X LASER_NOFOCUS_CONSTANT
+                    = static_cast<float_X>(Params::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME);
+
+                static constexpr float_X TIME_PREPULSE = static_cast<float_X>(Params::TIME_PREPULSE_SI / UNIT_TIME);
+                static constexpr float_X TIME_PEAKPULSE = static_cast<float_X>(Params::TIME_PEAKPULSE_SI / UNIT_TIME);
+                static constexpr float_X TIME_1 = static_cast<float_X>(Params::TIME_POINT_1_SI / UNIT_TIME);
+                static constexpr float_X TIME_2 = static_cast<float_X>(Params::TIME_POINT_2_SI / UNIT_TIME);
+                static constexpr float_X TIME_3 = static_cast<float_X>(Params::TIME_POINT_3_SI / UNIT_TIME);
+                static constexpr float_X endUpramp = TIME_PEAKPULSE - 0.5_X * LASER_NOFOCUS_CONSTANT;
+                static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
+
+
+                // compile-time checks for physical sanity:
+                static_assert(
+                    (TIME_1 < TIME_2) && (TIME_2 < TIME_3) && (TIME_3 < endUpramp),
+                    "The times in the parameters TIME_POINT_1/2/3 and the beginning of the plateau (which is "
+                    "at "
+                    "TIME_PEAKPULSE - 0.5*RAMP_INIT*PULSE_DURATION) should be in ascending order");
+
+                // some prerequisites for check of intensities (approximate check, because I can't use exp and
+                // log)
+                static constexpr float_X ratio_dt
+                    = (endUpramp - TIME_3) / (TIME_3 - TIME_2); // ratio of time intervals
+                static constexpr float_X ri1
+                    = Params::INT_RATIO_POINT_3 / Params::INT_RATIO_POINT_2; // first intensity ratio
+                static constexpr float_X ri2
+                    = 0.2_X / Params::INT_RATIO_POINT_3; // second intensity ratio (0.2 is an arbitrary upper
+                                                         // border for the intensity of the exp ramp)
+
+                /* Approximate check, if ri1 ^ ratio_dt > ri2. That would mean, that the exponential curve
+                 * through (time2, int2) and (time3, int3) lies above (endUpramp, 0.2) the power function is
+                 * emulated by "rounding" the exponent to a rational number and expanding both sides by the
+                 * common denominator, to get integer powers, see below for this, the range for ratio_dt is
+                 * split into parts; the checked condition is "rounded down", i.e. it's weaker in every point
+                 * of those ranges except one.
+                 */
+                static constexpr bool intensity_too_big = (ratio_dt >= 3._X && ri1 * ri1 * ri1 > ri2)
+                    || (ratio_dt >= 2._X && ri1 * ri1 > ri2) || (ratio_dt >= 1.5_X && ri1 * ri1 * ri1 > ri2 * ri2)
+                    || (ratio_dt >= 1._X && ri1 > ri2)
+                    || (ratio_dt >= 0.8_X && ri1 * ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.75_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.67_X && ri1 * ri1 > ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.6_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.5_X && ri1 > ri2 * ri2)
+                    || (ratio_dt >= 0.4_X && ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.33_X && ri1 > ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.25_X && ri1 > ri2 * ri2 * ri2 * ri2)
+                    || (ratio_dt >= 0.2_X && ri1 > ri2 * ri2 * ri2 * ri2 * ri2);
+                static_assert(
+                    !intensity_too_big,
+                    "The intensities of the ramp are very large - the extrapolation to the time of the main "
+                    "pulse "
+                    "would give more than half of the pulse amplitude. This is not a Gaussian pulse at all "
+                    "anymore - probably some of the parameters are different from what you think!?");
+                static constexpr float_X INIT_TIME
+                    = static_cast<float_X>((TIME_PEAKPULSE + Params::RAMP_INIT * Base::PULSE_DURATION) / UNIT_TIME);
+
+                /* a symmetric pulse will be initialized at generation plane for
+                 * a time of RAMP_INIT * PULSE_DURATION + LASER_NOFOCUS_CONSTANT = INIT_TIME.
+                 * we shift the complete pulse for the half of this time to start with
+                 * the front of the laser pulse.
+                 */
+                static constexpr float_X time_start_init
+                    = static_cast<float_X>(TIME_1 - (0.5_X * Params::RAMP_INIT * Base::PULSE_DURATION));
+            };
+
+            /** Unitless exponential ramp with prepulse parameters
+             *
+             * @tparam T_Params user (SI) parameters
+             */
+            template<typename T_Params>
+            struct ExpRampWithPrepulseUnitless
+                : public BaseTransversalGaussianParamUnitless<T_Params>
+                , public ExpRampWithPrepulsesLongitudinalUnitless<T_Params>
+            {
+                //! User SI parameters
+                using Params = T_Params;
+            };
+
+            template<typename T_Params>
+            struct ExpRampWithPrepulseLongitudinal : public ExpRampWithPrepulsesLongitudinalUnitless<T_Params>
+            {
+            public:
+                using Unitless = ExpRampWithPrepulsesLongitudinalUnitless<T_Params>;
+                HDINLINE static float_X getEnvelope(float_X const runTime)
                 {
-                    //! Get text name of the incident field profile
-                    HINLINE static std::string getName()
+                    constexpr auto int_ratio_prepule = Unitless::INT_RATIO_PREPULSE;
+                    constexpr auto int_ratio_point_1 = Unitless::INT_RATIO_POINT_1;
+                    constexpr auto int_ratio_point_2 = Unitless::INT_RATIO_POINT_2;
+                    constexpr auto int_ratio_point_3 = Unitless::INT_RATIO_POINT_3;
+                    auto const AMP_PREPULSE = math::sqrt(int_ratio_prepule);
+                    auto const AMP_1 = math::sqrt(int_ratio_point_1);
+                    auto const AMP_2 = math::sqrt(int_ratio_point_2);
+                    auto const AMP_3 = math::sqrt(int_ratio_point_3);
+
+                    auto env = 0.0_X;
+                    bool const before_preupramp = runTime < Unitless::time_start_init;
+                    bool const before_start = runTime < Unitless::TIME_1;
+                    bool const before_peakpulse = runTime < Unitless::endUpramp;
+                    bool const during_first_exp = (Unitless::TIME_1 < runTime) && (runTime < Unitless::TIME_2);
+                    bool const after_peakpulse = Unitless::startDownramp <= runTime;
+
+                    if(before_preupramp)
+                        env = 0._X;
+                    else if(before_start)
                     {
-                        return "ExpRampWithPrepulse";
+                        env = AMP_1 * gauss(runTime - Unitless::TIME_1);
                     }
-                };
+                    else if(before_peakpulse)
+                    {
+                        float_X const ramp_when_peakpulse
+                            = extrapolateExpo(Unitless::TIME_2, AMP_2, Unitless::TIME_3, AMP_3, Unitless::endUpramp);
 
-                namespace detail
+                        // This check exists in original laser, but can't print from device
+                        // if(ramp_when_peakpulse > 0.5_X)
+                        //{
+                        //    log<picLog::PHYSICS>(
+                        //        "Attention, the intensities of the laser upramp are very large! "
+                        //        "The extrapolation of the last exponential to the time of "
+                        //        "the peakpulse gives more than half of the amplitude of "
+                        //        "the peak Gaussian. This is not a Gaussian at all anymore, "
+                        //        "and physically very unplausible, check the params for misunderstandings!");
+                        //}
+
+                        env += (1._X - ramp_when_peakpulse) * gauss(runTime - Unitless::endUpramp);
+                        env += AMP_PREPULSE * gauss(runTime - Unitless::TIME_PREPULSE);
+                        if(during_first_exp)
+                            env += extrapolateExpo(Unitless::TIME_1, AMP_1, Unitless::TIME_2, AMP_2, runTime);
+                        else
+                            env += extrapolateExpo(Unitless::TIME_2, AMP_2, Unitless::TIME_3, AMP_3, runTime);
+                    }
+                    else if(!after_peakpulse)
+                        env = 1.0_X;
+                    else // after startDownramp
+                        env = gauss(runTime - Unitless::startDownramp);
+                    return env;
+                }
+
+                HINLINE static std::string getName()
                 {
-                    /** Unitless exponential ramp with prepulse parameters
-                     *
-                     * @tparam T_Params user (SI) parameters
-                     */
-                    template<typename T_Params>
-                    struct ExpRampWithPrepulseUnitless : public BaseTransversalGaussianParamUnitless<T_Params>
-                    {
-                        //! User SI parameters
-                        using Params = T_Params;
+                    return "ExpRampWithPrepulse";
+                }
 
-                        //! Base unitless parameters
-                        using Base = BaseTransversalGaussianParamUnitless<T_Params>;
+            private:
+                /** takes time t relative to the center of the Gaussian and returns value
+                 * between 0 and 1, i.e. as multiple of the max value.
+                 * use as: amp_t = amp_0 * gauss( t - t_0 )
+                 */
+                HDINLINE static float_X gauss(float_X const t)
+                {
+                    auto const exponent = t / Unitless::PULSE_DURATION;
+                    return math::exp(-0.25_X * exponent * exponent);
+                }
 
-                        // unit: UNIT_TIME
-                        static constexpr float_X LASER_NOFOCUS_CONSTANT
-                            = static_cast<float_X>(Params::LASER_NOFOCUS_CONSTANT_SI / UNIT_TIME);
+                /** get value of exponential curve through two points at given t
+                 * t/t1/t2 given as float_X, since the envelope doesn't need the accuracy
+                 */
+                HDINLINE static float_X extrapolateExpo(
+                    float_X const t1,
+                    float_X const a1,
+                    float_X const t2,
+                    float_X const a2,
+                    float_X const t)
+                {
+                    auto const log1 = (t2 - t) * math::log(a1);
+                    auto const log2 = (t - t1) * math::log(a2);
+                    return math::exp((log1 + log2) / (t2 - t1));
+                }
+            };
 
-                        static constexpr float_X TIME_PREPULSE
-                            = static_cast<float_X>(Params::TIME_PREPULSE_SI / UNIT_TIME);
-                        static constexpr float_X TIME_PEAKPULSE
-                            = static_cast<float_X>(Params::TIME_PEAKPULSE_SI / UNIT_TIME);
-                        static constexpr float_X TIME_1 = static_cast<float_X>(Params::TIME_POINT_1_SI / UNIT_TIME);
-                        static constexpr float_X TIME_2 = static_cast<float_X>(Params::TIME_POINT_2_SI / UNIT_TIME);
-                        static constexpr float_X TIME_3 = static_cast<float_X>(Params::TIME_POINT_3_SI / UNIT_TIME);
-                        static constexpr float_X endUpramp = TIME_PEAKPULSE - 0.5_X * LASER_NOFOCUS_CONSTANT;
-                        static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
 
-                        static constexpr float_X INIT_TIME = static_cast<float_X>(
-                            (TIME_PEAKPULSE + Params::RAMP_INIT * Base::PULSE_DURATION) / UNIT_TIME);
-
-                        // compile-time checks for physical sanity:
-                        static_assert(
-                            (TIME_1 < TIME_2) && (TIME_2 < TIME_3) && (TIME_3 < endUpramp),
-                            "The times in the parameters TIME_POINT_1/2/3 and the beginning of the plateau (which is "
-                            "at "
-                            "TIME_PEAKPULSE - 0.5*RAMP_INIT*PULSE_DURATION) should be in ascending order");
-
-                        // some prerequisites for check of intensities (approximate check, because I can't use exp and
-                        // log)
-                        static constexpr float_X ratio_dt
-                            = (endUpramp - TIME_3) / (TIME_3 - TIME_2); // ratio of time intervals
-                        static constexpr float_X ri1
-                            = Params::INT_RATIO_POINT_3 / Params::INT_RATIO_POINT_2; // first intensity ratio
-                        static constexpr float_X ri2
-                            = 0.2_X / Params::INT_RATIO_POINT_3; // second intensity ratio (0.2 is an arbitrary upper
-                                                                 // border for the intensity of the exp ramp)
-
-                        /* Approximate check, if ri1 ^ ratio_dt > ri2. That would mean, that the exponential curve
-                         * through (time2, int2) and (time3, int3) lies above (endUpramp, 0.2) the power function is
-                         * emulated by "rounding" the exponent to a rational number and expanding both sides by the
-                         * common denominator, to get integer powers, see below for this, the range for ratio_dt is
-                         * split into parts; the checked condition is "rounded down", i.e. it's weaker in every point
-                         * of those ranges except one.
-                         */
-                        static constexpr bool intensity_too_big = (ratio_dt >= 3._X && ri1 * ri1 * ri1 > ri2)
-                            || (ratio_dt >= 2._X && ri1 * ri1 > ri2)
-                            || (ratio_dt >= 1.5_X && ri1 * ri1 * ri1 > ri2 * ri2) || (ratio_dt >= 1._X && ri1 > ri2)
-                            || (ratio_dt >= 0.8_X && ri1 * ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.75_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.67_X && ri1 * ri1 > ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.6_X && ri1 * ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.5_X && ri1 > ri2 * ri2)
-                            || (ratio_dt >= 0.4_X && ri1 * ri1 > ri2 * ri2 * ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.33_X && ri1 > ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.25_X && ri1 > ri2 * ri2 * ri2 * ri2)
-                            || (ratio_dt >= 0.2_X && ri1 > ri2 * ri2 * ri2 * ri2 * ri2);
-                        static_assert(
-                            !intensity_too_big,
-                            "The intensities of the ramp are very large - the extrapolation to the time of the main "
-                            "pulse "
-                            "would give more than half of the pulse amplitude. This is not a Gaussian pulse at all "
-                            "anymore - probably some of the parameters are different from what you think!?");
-
-                        /* a symmetric pulse will be initialized at generation plane for
-                         * a time of RAMP_INIT * PULSE_DURATION + LASER_NOFOCUS_CONSTANT = INIT_TIME.
-                         * we shift the complete pulse for the half of this time to start with
-                         * the front of the laser pulse.
-                         */
-                        static constexpr float_X time_start_init
-                            = static_cast<float_X>(TIME_1 - (0.5_X * Params::RAMP_INIT * Base::PULSE_DURATION));
-                    };
-
-                    /** Exponential ramp with prepulse incident E functor
-                     *
-                     * @tparam T_Params parameters
-                     */
-                    template<typename T_Params>
-                    struct ExpRampWithPrepulseFunctorIncidentE
-                        : public ExpRampWithPrepulseUnitless<T_Params>
-                        , public incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>
-                    {
-                        //! Unitless parameters type
-                        using Unitless = ExpRampWithPrepulseUnitless<T_Params>;
-
-                        //! Base functor type
-                        using Base = incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>;
-
-                        /** Create a functor on the host side for the given time step
-                         *
-                         * @param currentStep current time step index, note that it is fractional
-                         * @param unitField conversion factor from SI to internal units,
-                         *                  fieldE_internal = fieldE_SI / unitField
-                         */
-                        HINLINE ExpRampWithPrepulseFunctorIncidentE(
-                            float_X const currentStep,
-                            float3_64 const unitField)
-                            : Base(currentStep, unitField)
-                        {
-                        }
-
-                        /** Calculate incident field E value for the given position
-                         *
-                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
-                         * @return incident field E value in internal units
-                         */
-                        HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
-                        {
-                            return Base::operator()(*this, totalCellIdx);
-                        }
-
-                        /** Get time-dependent longitudinal scalar factor for the given time
-                         *
-                         * Interface required by Base.
-                         * Gaussian transversal profile not implemented in this class, but provided by Base.
-                         *
-                         * @param time time moment to calculate the factor at
-                         * @param phaseShift additional phase shift to add on top of everything else,
-                         *                   in radian
-                         */
-                        HDINLINE float_X getLongitudinal(float_X const time, float_X const phaseShift) const
-                        {
-                            auto const runTimeShifted = time + Unitless::time_start_init;
-                            auto const phase = Unitless::w * runTimeShifted + Unitless::LASER_PHASE + phaseShift;
-                            return math::sin(phase) * getEnvelope(runTimeShifted);
-                        }
-
-                    private:
-                        HDINLINE float_X getEnvelope(float_X const runTime) const
-                        {
-                            constexpr auto int_ratio_prepule = Unitless::INT_RATIO_PREPULSE;
-                            constexpr auto int_ratio_point_1 = Unitless::INT_RATIO_POINT_1;
-                            constexpr auto int_ratio_point_2 = Unitless::INT_RATIO_POINT_2;
-                            constexpr auto int_ratio_point_3 = Unitless::INT_RATIO_POINT_3;
-                            auto const AMP_PREPULSE = math::sqrt(int_ratio_prepule) * Unitless::AMPLITUDE;
-                            auto const AMP_1 = math::sqrt(int_ratio_point_1) * Unitless::AMPLITUDE;
-                            auto const AMP_2 = math::sqrt(int_ratio_point_2) * Unitless::AMPLITUDE;
-                            auto const AMP_3 = math::sqrt(int_ratio_point_3) * Unitless::AMPLITUDE;
-
-                            auto env = 0.0_X;
-                            bool const before_preupramp = runTime < Unitless::time_start_init;
-                            bool const before_start = runTime < Unitless::TIME_1;
-                            bool const before_peakpulse = runTime < Unitless::endUpramp;
-                            bool const during_first_exp = (Unitless::TIME_1 < runTime) && (runTime < Unitless::TIME_2);
-                            bool const after_peakpulse = Unitless::startDownramp <= runTime;
-
-                            if(before_preupramp)
-                                env = 0._X;
-                            else if(before_start)
-                            {
-                                env = AMP_1 * gauss(runTime - Unitless::TIME_1);
-                            }
-                            else if(before_peakpulse)
-                            {
-                                float_X const ramp_when_peakpulse = extrapolateExpo(
-                                                                        Unitless::TIME_2,
-                                                                        AMP_2,
-                                                                        Unitless::TIME_3,
-                                                                        AMP_3,
-                                                                        Unitless::endUpramp)
-                                    / Unitless::AMPLITUDE;
-
-                                // This check exists in original laser, but can't print from device
-                                // if(ramp_when_peakpulse > 0.5_X)
-                                //{
-                                //    log<picLog::PHYSICS>(
-                                //        "Attention, the intensities of the laser upramp are very large! "
-                                //        "The extrapolation of the last exponential to the time of "
-                                //        "the peakpulse gives more than half of the amplitude of "
-                                //        "the peak Gaussian. This is not a Gaussian at all anymore, "
-                                //        "and physically very unplausible, check the params for misunderstandings!");
-                                //}
-
-                                env += Unitless::AMPLITUDE * (1._X - ramp_when_peakpulse)
-                                    * gauss(runTime - Unitless::endUpramp);
-                                env += AMP_PREPULSE * gauss(runTime - Unitless::TIME_PREPULSE);
-                                if(during_first_exp)
-                                    env += extrapolateExpo(Unitless::TIME_1, AMP_1, Unitless::TIME_2, AMP_2, runTime);
-                                else
-                                    env += extrapolateExpo(Unitless::TIME_2, AMP_2, Unitless::TIME_3, AMP_3, runTime);
-                            }
-                            else if(!after_peakpulse)
-                                env = Unitless::AMPLITUDE;
-                            else // after startDownramp
-                                env = Unitless::AMPLITUDE * gauss(runTime - Unitless::startDownramp);
-                            return env;
-                        }
-
-                        /** takes time t relative to the center of the Gaussian and returns value
-                         * between 0 and 1, i.e. as multiple of the max value.
-                         * use as: amp_t = amp_0 * gauss( t - t_0 )
-                         */
-                        HDINLINE float_X gauss(float_X const t) const
-                        {
-                            auto const exponent = t / Unitless::PULSE_DURATION;
-                            return math::exp(-0.25_X * exponent * exponent);
-                        }
-
-                        /** get value of exponential curve through two points at given t
-                         * t/t1/t2 given as float_X, since the envelope doesn't need the accuracy
-                         */
-                        HDINLINE float_X extrapolateExpo(
-                            float_X const t1,
-                            float_X const a1,
-                            float_X const t2,
-                            float_X const a2,
-                            float_X const t) const
-                        {
-                            auto const log1 = (t2 - t) * math::log(a1);
-                            auto const log2 = (t - t1) * math::log(a2);
-                            return math::exp((log1 + log2) / (t2 - t1));
-                        }
-                    };
-                } // namespace detail
-            } // namespace profiles
-
-            namespace detail
+            /** Exponential ramp with prepulse incident E functor
+             *
+             * @tparam T_Params parameters
+             */
+            template<typename T_Params>
+            struct ExpRampWithPrepulseFunctorIncidentE
+                : public ExpRampWithPrepulseUnitless<T_Params>
+                , public incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>
             {
-                /** Get type of incident field E functor for the exponential ramp with prepulse profile type
-                 *
-                 * @tparam T_Params parameters
-                 */
-                template<typename T_Params>
-                struct GetFunctorIncidentE<profiles::ExpRampWithPrepulse<T_Params>>
-                {
-                    using type = profiles::detail::ExpRampWithPrepulseFunctorIncidentE<T_Params>;
-                };
+                //! Unitless parameters type
+                using Unitless = ExpRampWithPrepulseUnitless<T_Params>;
+                using Envelope = ExpRampWithPrepulseLongitudinal<T_Params>;
 
-                /** Get type of incident field B functor for the exponential ramp with prepulse  profile type
+                //! Base functor type
+                using Base = incidentField::detail::BaseSeparableTransversalGaussianFunctorE<T_Params>;
+
+                /** Create a functor on the host side for the given time step
                  *
-                 * Rely on SVEA to calculate value of B from E.
-                 *
-                 * @tparam T_Params parameters
+                 * @param currentStep current time step index, note that it is fractional
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  fieldE_internal = fieldE_SI / unitField
                  */
-                template<typename T_Params>
-                struct GetFunctorIncidentB<profiles::ExpRampWithPrepulse<T_Params>>
+                HINLINE ExpRampWithPrepulseFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
+                    : Base(currentStep, unitField)
                 {
-                    using type = detail::ApproximateIncidentB<
-                        typename GetFunctorIncidentE<profiles::ExpRampWithPrepulse<T_Params>>::type>;
-                };
-            } // namespace detail
-        } // namespace incidentField
-    } // namespace fields
-} // namespace picongpu
+                }
+
+                /** Calculate incident field E value for the given position
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                 * @return incident field E value in internal units
+                 */
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+                {
+                    return Base::operator()(*this, totalCellIdx);
+                }
+
+                /** Get time-dependent longitudinal scalar factor for the given time
+                 *
+                 * Interface required by Base.
+                 * Gaussian transversal profile not implemented in this class, but provided by Base.
+                 *
+                 * @param time time moment to calculate the factor at
+                 * @param phaseShift additional phase shift to add on top of everything else,
+                 *                   in radian
+                 */
+                HDINLINE float_X getLongitudinal(float_X const time, float_X const phaseShift) const
+                {
+                    auto const runTimeShifted = time + Unitless::time_start_init;
+                    auto const phase = Unitless::w * runTimeShifted + Unitless::LASER_PHASE + phaseShift;
+                    return math::sin(phase) * Unitless::AMPLITUDE * Envelope::getEnvelope(runTimeShifted);
+                }
+            };
+        } // namespace detail
+    } // namespace profiles
+
+    namespace detail
+    {
+        /** Get type of incident field E functor for the exponential ramp with prepulse profile type
+         *
+         * @tparam T_Params parameters
+         */
+        template<typename T_Params>
+        struct GetFunctorIncidentE<profiles::ExpRampWithPrepulse<T_Params>>
+        {
+            using type = profiles::detail::ExpRampWithPrepulseFunctorIncidentE<T_Params>;
+        };
+
+        /** Get type of incident field B functor for the exponential ramp with prepulse  profile type
+         *
+         * Rely on SVEA to calculate value of B from E.
+         *
+         * @tparam T_Params parameters
+         */
+        template<typename T_Params>
+        struct GetFunctorIncidentB<profiles::ExpRampWithPrepulse<T_Params>>
+        {
+            using type = detail::ApproximateIncidentB<
+                typename GetFunctorIncidentE<profiles::ExpRampWithPrepulse<T_Params>>::type>;
+        };
+    } // namespace detail
+} // namespace picongpu::fields::incidentField

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -23,70 +23,67 @@
 #include "picongpu/fields/incidentField/profiles/BaseParam.def"
 
 
-namespace picongpu
+namespace picongpu::fields::incidentField::profiles
 {
-    namespace fields
+    namespace defaults
     {
-        namespace incidentField
+        namespace gaussianPulse
         {
-            namespace profiles
-            {
-                namespace defaults
-                {
-                    namespace gaussianPulse
-                    {
-                        //! Use only the 0th Laguerremode for a standard Gaussian
-                        static constexpr uint32_t MODENUMBER = 0;
-                        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
-                        PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
-                        // This is just an example for a more complicated set of Laguerre modes
-                        // constexpr uint32_t MODENUMBER = 12;
-                        // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461,
-                        // -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038,
-                        // -0.00896321, -0.0160788); PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES,
-                        // 0.0, 1.0344594, -0.9384701, -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303,
-                        // -0.8039839, 3.0055385, -0.1503778, -9.6980362, -2.8122287);
-                    } // namespace gaussianPulse
+            //! Use only the 0th Laguerremode for a standard Gaussian
+            static constexpr uint32_t MODENUMBER = 0;
+            PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
+            PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
+            // This is just an example for a more complicated set of Laguerre modes
+            // constexpr uint32_t MODENUMBER = 12;
+            // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461,
+            // -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038,
+            // -0.00896321, -0.0160788); PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES,
+            // 0.0, 1.0344594, -0.9384701, -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303,
+            // -0.8039839, 3.0055385, -0.1503778, -9.6980362, -2.8122287);
+        } // namespace gaussianPulse
 
-                    struct GaussianPulseParam : public BaseParam
-                    {
-                        /** Beam waist: distance from the axis where the pulse intensity (E^2)
-                         *              decreases to its 1/e^2-th part,
-                         *              at the focus position of the laser
-                         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
-                         *                             [   1.17741    ]
-                         *
-                         * unit: meter
-                         */
-                        static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
+        struct GaussianPulseParam : public BaseParam
+        {
+            /** Beam waist: distance from the axis where the pulse intensity (E^2)
+             *              decreases to its 1/e^2-th part,
+             *              at the focus position of the laser
+             * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+             *                             [   1.17741    ]
+             *
+             * unit: meter
+             */
+            static constexpr float_64 W0_SI = 5.0e-6 / 1.17741;
 
-                        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
-                         * TIME_DELAY_SI
-                         *
-                         * unit: none
-                         */
-                        static constexpr float_64 PULSE_INIT = 20.0;
+            /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
+             * TIME_DELAY_SI
+             *
+             * unit: none
+             */
+            static constexpr float_64 PULSE_INIT = 20.0;
 
-                        /** Laguerre mode parameters
-                         *
-                         * @{
-                         */
-                        using LAGUERREMODES_t = gaussianPulse::LAGUERREMODES_t;
-                        using LAGUERREPHASES_t = gaussianPulse::LAGUERREPHASES_t;
-                        static constexpr uint32_t MODENUMBER = gaussianPulse::MODENUMBER;
-                        /** @} */
-                    };
-                } // namespace defaults
 
-                /** GaussianPulse laser profile with finite pulse duration tag
-                 *
-                 * @tparam T_Params class parameter to configure the GaussianPulse profile,
-                 *                  see members of defaults::GaussianPulseParam
-                 *                  for required members
-                 */
-                template<typename T_Params = defaults::GaussianPulseParam>
-                struct GaussianPulse;
-            } // namespace profiles
-        } // namespace incidentField
-    } // namespace fields
-} // namespace picongpu
+            /** Laguerre mode parameters
+             *
+             * @{
+             */
+            using LAGUERREMODES_t = gaussianPulse::LAGUERREMODES_t;
+            using LAGUERREPHASES_t = gaussianPulse::LAGUERREPHASES_t;
+            static constexpr uint32_t MODENUMBER = gaussianPulse::MODENUMBER;
+            /** @} */
+        };
+    } // namespace defaults
+
+    template<typename T_Param>
+    struct GaussianPulseEnvelope;
+
+    /** GaussianPulse laser profile with finite pulse duration tag
+     *
+     * @tparam T_Params class parameter to configure the GaussianPulse profile,
+     *                  see members of defaults::GaussianPulseParam
+     *                  for required members
+     */
+    template<
+        typename T_Params = defaults::GaussianPulseParam,
+        typename T_LongitudinalEnvelope = GaussianPulseEnvelope<BaseParam>>
+    struct GaussianPulse;
+} // namespace picongpu::fields::incidentField::profiles

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -81,9 +81,11 @@ namespace picongpu::fields::incidentField::profiles
      * @tparam T_Params class parameter to configure the GaussianPulse profile,
      *                  see members of defaults::GaussianPulseParam
      *                  for required members
+     * @tparam T_LongitudinalEnvelope class providing a static method getEnvelope(time)
+     *  that defines laser temporal envelope. The default is a Gaussian pulse.
      */
     template<
         typename T_Params = defaults::GaussianPulseParam,
-        typename T_LongitudinalEnvelope = GaussianPulseEnvelope<BaseParam>>
+        typename T_LongitudinalEnvelope = GaussianPulseEnvelope<T_Params>>
     struct GaussianPulse;
 } // namespace picongpu::fields::incidentField::profiles

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
@@ -103,10 +103,6 @@ namespace picongpu::fields::incidentField
                 // rayleigh length in propagation direction
                 static constexpr float_X rayleighLength
                     = pmacc::math::Pi<float_X>::value * W0 * W0 / Base::WAVE_LENGTH;
-
-                // unit: UNIT_TIME
-                static constexpr float_X INIT_TIME
-                    = static_cast<float_X>((Params::PULSE_INIT * Params::PULSE_DURATION_SI) / UNIT_TIME);
             };
 
 
@@ -227,7 +223,7 @@ namespace picongpu::fields::incidentField
                     // a time of PULSE_INIT * PULSE_DURATION = INIT_TIME.
                     // we shift the complete pulse for the half of this time to start with
                     // the front of the laser pulse.
-                    constexpr auto mue = 0.5_X * Unitless::INIT_TIME;
+                    constexpr auto mue = -LongitudinalEnvelope::TIME_SHIFT;
                     auto const phase
                         = Unitless::w * (time - mue - focusPos / SPEED_OF_LIGHT) + Unitless::LASER_PHASE + phaseShift;
 
@@ -314,10 +310,14 @@ namespace picongpu::fields::incidentField
             };
         } // namespace detail
 
+
         template<typename T_Param>
         struct GaussianPulseEnvelope : public detail::BaseParamUnitless<T_Param>
         {
+            using Base = typename detail::BaseParamUnitless<T_Param>;
             using Unitless = detail::BaseParamUnitless<T_Param>;
+
+            static constexpr float_X TIME_SHIFT = -Base::PULSE_INIT * Base::PULSE_DURATION;
 
             HDINLINE static float_X getEnvelope(float_X const time)
             {

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.hpp
@@ -34,328 +34,345 @@
 #include <type_traits>
 
 
-namespace picongpu
+namespace picongpu::fields::incidentField
 {
-    namespace fields
+    namespace profiles
     {
-        namespace incidentField
+        namespace detail
         {
-            namespace profiles
+            /** Base class providing tilt value based on given parameters
+             *
+             * General implementation sets tilts to 0 and does not require T_Params having tilt as member.
+             *
+             * @tparam T_Params user (SI) parameters
+             */
+            template<typename T_Params, typename T_Sfinae = void>
+            struct TiltParam
             {
-                namespace detail
+                // unit: radian
+                static constexpr float_X TILT_AXIS_1 = 0.0_X;
+                // unit: radian
+                static constexpr float_X TILT_AXIS_2 = 0.0_X;
+            };
+
+            /** Helper type to check if T_Params has members TILT_AXIS_1_SI and TILT_AXIS_2_SI.
+             *
+             * Is void for those types, ill-formed otherwise.
+             *
+             * @tparam T_Params user (SI) parameters
+             */
+            template<typename T_Params>
+            using HasTilt = std::void_t<decltype(T_Params::TILT_AXIS_1_SI + T_Params::TILT_AXIS_2_SI)>;
+
+            /** Specialization for T_Params having tilt as member, then use it.
+             *
+             * @tparam T_Params user (SI) parameters
+             */
+            template<typename T_Params>
+            struct TiltParam<T_Params, HasTilt<T_Params>>
+            {
+                // unit: radian
+                static constexpr float_X TILT_AXIS_1
+                    = static_cast<float_X>(T_Params::TILT_AXIS_1_SI * pmacc::math::Pi<float_X>::value / 180.);
+                // unit: radian
+                static constexpr float_X TILT_AXIS_2
+                    = static_cast<float_X>(T_Params::TILT_AXIS_2_SI * pmacc::math::Pi<float_X>::value / 180.);
+            };
+
+            /** Unitless GaussianPulse parameters
+             *
+             * These parameters are shared for tilted and non-tilted Gaussian laser.
+             * The branching in terms of if and how user sets a tilt is encapculated in TiltParam.
+             *
+             * @tparam T_Params user (SI) parameters
+             */
+            template<typename T_Params>
+            struct GaussianPulseUnitless
+                : public BaseParamUnitless<T_Params>
+                , public TiltParam<T_Params>
+            {
+                //! User SI parameters
+                using Params = T_Params;
+
+                //! Base unitless parameters
+                using Base = BaseParamUnitless<T_Params>;
+
+                // unit: UNIT_LENGTH
+                static constexpr float_X W0 = static_cast<float_X>(Params::W0_SI / UNIT_LENGTH);
+
+                // rayleigh length in propagation direction
+                static constexpr float_X rayleighLength
+                    = pmacc::math::Pi<float_X>::value * W0 * W0 / Base::WAVE_LENGTH;
+
+                // unit: UNIT_TIME
+                static constexpr float_X INIT_TIME
+                    = static_cast<float_X>((Params::PULSE_INIT * Params::PULSE_DURATION_SI) / UNIT_TIME);
+            };
+
+
+            /** GaussianPulse incident E functor
+             *
+             * The implementation is shared between a normal GaussianPulse and one with tilted front.
+             * We always take tilt value from the unitless params and apply the tilt (which can be 0).
+             *
+             * @tparam T_Params parameters
+             */
+            template<typename T_Params, typename T_LongitudinalEnvelope>
+            struct GaussianPulseFunctorIncidentE
+                : public GaussianPulseUnitless<T_Params>
+                , public incidentField::detail::BaseFunctorE<T_Params>
+            {
+                //! Unitless parameters type
+                using Unitless = GaussianPulseUnitless<T_Params>;
+                using LongitudinalEnvelope = T_LongitudinalEnvelope;
+
+                //! Base functor type
+                using Base = incidentField::detail::BaseFunctorE<T_Params>;
+
+                /** Create a functor on the host side for the given time step
+                 *
+                 * @param currentStep current time step index, note that it is fractional
+                 * @param unitField conversion factor from SI to internal units,
+                 *                  fieldE_internal = fieldE_SI / unitField
+                 */
+                HINLINE GaussianPulseFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
+                    : Base(currentStep, unitField)
                 {
-                    /** Base class providing tilt value based on given parameters
-                     *
-                     * General implementation sets tilts to 0 and does not require T_Params having tilt as member.
-                     *
-                     * @tparam T_Params user (SI) parameters
-                     */
-                    template<typename T_Params, typename T_Sfinae = void>
-                    struct TiltParam
-                    {
-                        // unit: radian
-                        static constexpr float_X TILT_AXIS_1 = 0.0_X;
-                        // unit: radian
-                        static constexpr float_X TILT_AXIS_2 = 0.0_X;
-                    };
+                    // This check is done here on HOST, since std::numeric_limits<float_X>::epsilon() does not
+                    // compile on laserTransversal(), which is on DEVICE.
+                    auto etrans_norm = 0.0_X;
+                    PMACC_CASSERT_MSG(
+                        MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector,
+                        Unitless::MODENUMBER < Unitless::LAGUERREMODES_t::dim);
+                    for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
+                        etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
+                    PMACC_VERIFY_MSG(
+                        math::abs(etrans_norm) > std::numeric_limits<float_X>::epsilon(),
+                        "Sum of LAGUERREMODES can not be 0.");
+                }
 
-                    /** Helper type to check if T_Params has members TILT_AXIS_1_SI and TILT_AXIS_2_SI.
-                     *
-                     * Is void for those types, ill-formed otherwise.
-                     *
-                     * @tparam T_Params user (SI) parameters
-                     */
-                    template<typename T_Params>
-                    using HasTilt = std::void_t<decltype(T_Params::TILT_AXIS_1_SI + T_Params::TILT_AXIS_2_SI)>;
-
-                    /** Specialization for T_Params having tilt as member, then use it.
-                     *
-                     * @tparam T_Params user (SI) parameters
-                     */
-                    template<typename T_Params>
-                    struct TiltParam<T_Params, HasTilt<T_Params>>
-                    {
-                        // unit: radian
-                        static constexpr float_X TILT_AXIS_1
-                            = static_cast<float_X>(T_Params::TILT_AXIS_1_SI * pmacc::math::Pi<float_X>::value / 180.);
-                        // unit: radian
-                        static constexpr float_X TILT_AXIS_2
-                            = static_cast<float_X>(T_Params::TILT_AXIS_2_SI * pmacc::math::Pi<float_X>::value / 180.);
-                    };
-
-                    /** Unitless GaussianPulse parameters
-                     *
-                     * These parameters are shared for tilted and non-tilted Gaussian laser.
-                     * The branching in terms of if and how user sets a tilt is encapculated in TiltParam.
-                     *
-                     * @tparam T_Params user (SI) parameters
-                     */
-                    template<typename T_Params>
-                    struct GaussianPulseUnitless
-                        : public BaseParamUnitless<T_Params>
-                        , public TiltParam<T_Params>
-                    {
-                        //! User SI parameters
-                        using Params = T_Params;
-
-                        //! Base unitless parameters
-                        using Base = BaseParamUnitless<T_Params>;
-
-                        // unit: UNIT_LENGTH
-                        static constexpr float_X W0 = static_cast<float_X>(Params::W0_SI / UNIT_LENGTH);
-
-                        // rayleigh length in propagation direction
-                        static constexpr float_X rayleighLength
-                            = pmacc::math::Pi<float_X>::value * W0 * W0 / Base::WAVE_LENGTH;
-
-                        // unit: UNIT_TIME
-                        static constexpr float_X INIT_TIME
-                            = static_cast<float_X>((Params::PULSE_INIT * Params::PULSE_DURATION_SI) / UNIT_TIME);
-                    };
-
-                    /** GaussianPulse incident E functor
-                     *
-                     * The implementation is shared between a normal GaussianPulse and one with tilted front.
-                     * We always take tilt value from the unitless params and apply the tilt (which can be 0).
-                     *
-                     * @tparam T_Params parameters
-                     */
-                    template<typename T_Params>
-                    struct GaussianPulseFunctorIncidentE
-                        : public GaussianPulseUnitless<T_Params>
-                        , public incidentField::detail::BaseFunctorE<T_Params>
-                    {
-                        //! Unitless parameters type
-                        using Unitless = GaussianPulseUnitless<T_Params>;
-
-                        //! Base functor type
-                        using Base = incidentField::detail::BaseFunctorE<T_Params>;
-
-                        /** Create a functor on the host side for the given time step
-                         *
-                         * @param currentStep current time step index, note that it is fractional
-                         * @param unitField conversion factor from SI to internal units,
-                         *                  fieldE_internal = fieldE_SI / unitField
-                         */
-                        HINLINE GaussianPulseFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
-                            : Base(currentStep, unitField)
-                        {
-                            // This check is done here on HOST, since std::numeric_limits<float_X>::epsilon() does not
-                            // compile on laserTransversal(), which is on DEVICE.
-                            auto etrans_norm = 0.0_X;
-                            PMACC_CASSERT_MSG(
-                                MODENUMBER_must_be_smaller_than_number_of_entries_in_LAGUERREMODES_vector,
-                                Unitless::MODENUMBER < Unitless::LAGUERREMODES_t::dim);
-                            for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
-                                etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
-                            PMACC_VERIFY_MSG(
-                                math::abs(etrans_norm) > std::numeric_limits<float_X>::epsilon(),
-                                "Sum of LAGUERREMODES can not be 0.");
-                        }
-
-                        /** Calculate incident field E value for the given position
-                         *
-                         * The transverse spatial laser modes are given as a decomposition of Gauss-Laguerre modes
-                         * GLM(m,r,z) : Sum_{m=0}^{m_max} := Snorm * a_m * GLM(m,r,z)
-                         * with a_m being complex-valued coefficients: a_m := |a_m| * exp(I Arg(a_m) )
-                         * |a_m| are equivalent to the LAGUERREMODES vector entries.
-                         * Arg(a_m) are equivalent to the LAGUERREPHASES vector entries.
-                         * The implicit pulse properties w0, lambda0, etc... equally apply to all GLM-modes.
-                         * The on-axis, in-focus field value of the mode decomposition is normalized to unity:
-                         * Snorm := 1 / ( Sum_{m=0}^{m_max}GLM(m,0,0) )
-                         *
-                         * Spatial mode: Arg(a_m) * GLM(m,r,z) := w0/w(zeta) * L_m( 2*r^2/(w(zeta))^2 ) \
-                         *     * exp( I*k*z - I*(2*m+1)*ArcTan(zeta) - r^2 / ( w0^2*(1+I*zeta) ) + I*Arg(a_m) ) )
-                         * with w(zeta) = w0*sqrt(1+zeta^2)
-                         * with zeta = z / zR
-                         * with zR = PI * w0^2 / lambda0
-                         *
-                         * Uses only radial modes (m) of Laguerre-Polynomials: L_m(x)=L_m^n=0(x)
-                         * In the formula above, z is the direction of laser propagation.
-                         * In PIConGPU, the propagation direction can be chosen freely. In the following code,
-                         * pos[0] is the propagation direction.
-                         *
-                         * References:
-                         * F. Pampaloni et al. (2004), Gaussian, Hermite-Gaussian, and Laguerre-GaussianPulses: A
-                         * primer https://arxiv.org/pdf/physics/0410021
-                         *
-                         * Allen, L. (June 1, 1992). "Orbital angular momentum of light
-                         *      and the transformation of Laguerre-Gaussian laser modes"
-                         * https://doi.org/10.1103/physreva.45.8185
-                         *
-                         * Wikipedia on Gaussian laser beams
-                         * https://en.wikipedia.org/wiki/Gaussian_beam
-                         *
-                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
-                         * @return incident field E value in internal units
-                         */
-                        HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
-                        {
-                            if(Unitless::Polarisation == PolarisationType::Linear)
-                                return this->getLinearPolarizationVector() * getValue(totalCellIdx, 0.0_X);
-                            else
-                            {
-                                auto const phaseShift = pmacc::math::Pi<float_X>::halfValue;
-                                return this->getCircularPolarizationVector1() * getValue(totalCellIdx, phaseShift)
-                                    + this->getCircularPolarizationVector2() * getValue(totalCellIdx, 0.0_X);
-                            }
-                        }
-
-                    private:
-                        /** Get value for the given position
-                         *
-                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
-                         * @param phaseShift additional phase shift to add on top of everything else,
-                         *                   in radian
-                         */
-                        HDINLINE float_X getValue(floatD_X const& totalCellIdx, float_X const phaseShift) const
-                        {
-                            // transform to 3d internal coordinate system
-                            float3_X pos = this->getInternalCoordinates(totalCellIdx);
-                            auto const time = this->getCurrentTime(totalCellIdx);
-                            if(time < 0.0_X)
-                                return 0.0_X;
-
-                            // calculate focus position relative to the current point in the propagation direction
-                            auto const focusRelativeToOrigin = this->focus - this->origin;
-
-                            float_X const focusPos = math::sqrt(pmacc::math::l2norm2(focusRelativeToOrigin)) - pos[0];
-                            // beam waist at the generation plane so that at focus we will get W0
-                            float_X const w = Unitless::W0
-                                * math::sqrt(1.0_X
-                                             + (focusPos / Unitless::rayleighLength)
-                                                 * (focusPos / Unitless::rayleighLength));
-
-                            // a symmetric pulse will be initialized at generation plane for
-                            // a time of PULSE_INIT * PULSE_DURATION = INIT_TIME.
-                            // we shift the complete pulse for the half of this time to start with
-                            // the front of the laser pulse.
-                            constexpr auto mue = 0.5_X * Unitless::INIT_TIME;
-                            auto const phase = Unitless::w * (time - mue - focusPos / SPEED_OF_LIGHT)
-                                + Unitless::LASER_PHASE + phaseShift;
-
-                            // Apply tilt if needed
-                            if constexpr(Unitless::TILT_AXIS_1 || Unitless::TILT_AXIS_2)
-                            {
-                                auto const tiltTimeShift = phase / Unitless::w + focusPos / SPEED_OF_LIGHT;
-                                auto const tiltPositionShift = SPEED_OF_LIGHT * tiltTimeShift
-                                    / pmacc::math::dot(this->getDirection(), float3_X{cellSize});
-                                auto const tilt1 = Unitless::TILT_AXIS_1;
-                                pos[1] += math::tan(tilt1) * tiltPositionShift;
-                                auto const tilt2 = Unitless::TILT_AXIS_2;
-                                pos[2] += math::tan(tilt2) * tiltPositionShift;
-                            }
-
-                            auto planeNoNormal = float3_X::create(1.0_X);
-                            planeNoNormal[0] = 0.0_X;
-                            auto const transversalDistanceSquared = pmacc::math::l2norm2(pos * planeNoNormal);
-
-                            // inverse radius of curvature of the pulse's wavefronts
-                            auto const R_inv = -focusPos
-                                / (Unitless::rayleighLength * Unitless::rayleighLength + focusPos * focusPos);
-                            // the Gouy phase shift
-                            auto xi = math::atan(-focusPos / Unitless::rayleighLength);
-                            if(simDim == DIM2)
-                                xi *= 0.5_X;
-                            auto etrans = 0.0_X;
-                            auto const r2OverW2 = transversalDistanceSquared / w / w;
-                            auto const r = 0.5_X * transversalDistanceSquared * R_inv;
-                            for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
-                            {
-                                etrans += typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre(m, 2.0_X * r2OverW2)
-                                    * math::exp(-r2OverW2)
-                                    * math::cos(
-                                              pmacc::math::Pi<float_X>::doubleValue / Unitless::WAVE_LENGTH * focusPos
-                                              - pmacc::math::Pi<float_X>::doubleValue / Unitless::WAVE_LENGTH * r
-                                              + (2._X * float_X(m) + 1._X) * xi + phase +
-                                              typename Unitless::LAGUERREPHASES_t{}[m]);
-                            }
-                            auto const exponent
-                                = (r - focusPos
-                                   - phase / pmacc::math::Pi<float_X>::doubleValue * Unitless::WAVE_LENGTH)
-                                / (SPEED_OF_LIGHT * 2.0_X * Unitless::PULSE_DURATION);
-                            etrans *= math::exp(-exponent * exponent);
-                            auto etrans_norm = 0.0_X;
-                            for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
-                                etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
-                            auto envelope = Unitless::AMPLITUDE;
-                            if(simDim == DIM2)
-                                envelope *= math::sqrt(Unitless::W0 / w);
-                            else if(simDim == DIM3)
-                                envelope *= Unitless::W0 / w;
-                            return envelope * etrans / etrans_norm;
-                        }
-
-                        /** Simple iteration algorithm to implement Laguerre polynomials for GPUs.
-                         *
-                         *  @param n order of the Laguerre polynomial
-                         *  @param x coordinate at which the polynomial is evaluated
-                         */
-                        HDINLINE float_X simpleLaguerre(uint32_t const n, float_X const x) const
-                        {
-                            // Result for special case n == 0
-                            if(n == 0)
-                                return 1.0_X;
-                            uint32_t currentN = 1;
-                            float_X laguerreNMinus1 = 1.0_X;
-                            float_X laguerreN = 1.0_X - x;
-                            float_X laguerreNPlus1(0.0_X);
-                            while(currentN < n)
-                            {
-                                // Core statement of the algorithm
-                                laguerreNPlus1 = ((2.0_X * float_X(currentN) + 1.0_X - x) * laguerreN
-                                                  - float_X(currentN) * laguerreNMinus1)
-                                    / float_X(currentN + 1u);
-                                // Advance by one order
-                                laguerreNMinus1 = laguerreN;
-                                laguerreN = laguerreNPlus1;
-                                currentN++;
-                            }
-                            return laguerreN;
-                        }
-                    };
-                } // namespace detail
-
-                template<typename T_Params>
-                struct GaussianPulse
+                /** Calculate incident field E value for the given position
+                 *
+                 * The transverse spatial laser modes are given as a decomposition of Gauss-Laguerre modes
+                 * GLM(m,r,z) : Sum_{m=0}^{m_max} := Snorm * a_m * GLM(m,r,z)
+                 * with a_m being complex-valued coefficients: a_m := |a_m| * exp(I Arg(a_m) )
+                 * |a_m| are equivalent to the LAGUERREMODES vector entries.
+                 * Arg(a_m) are equivalent to the LAGUERREPHASES vector entries.
+                 * The implicit pulse properties w0, lambda0, etc... equally apply to all GLM-modes.
+                 * The on-axis, in-focus field value of the mode decomposition is normalized to unity:
+                 * Snorm := 1 / ( Sum_{m=0}^{m_max}GLM(m,0,0) )
+                 *
+                 * Spatial mode: Arg(a_m) * GLM(m,r,z) := w0/w(zeta) * L_m( 2*r^2/(w(zeta))^2 ) \
+                 *     * exp( I*k*z - I*(2*m+1)*ArcTan(zeta) - r^2 / ( w0^2*(1+I*zeta) ) + I*Arg(a_m) ) )
+                 * with w(zeta) = w0*sqrt(1+zeta^2)
+                 * with zeta = z / zR
+                 * with zR = PI * w0^2 / lambda0
+                 *
+                 * Uses only radial modes (m) of Laguerre-Polynomials: L_m(x)=L_m^n=0(x)
+                 * In the formula above, z is the direction of laser propagation.
+                 * In PIConGPU, the propagation direction can be chosen freely. In the following code,
+                 * pos[0] is the propagation direction.
+                 *
+                 * References:
+                 * F. Pampaloni et al. (2004), Gaussian, Hermite-Gaussian, and Laguerre-GaussianPulses: A
+                 * primer https://arxiv.org/pdf/physics/0410021
+                 *
+                 * Allen, L. (June 1, 1992). "Orbital angular momentum of light
+                 *      and the transformation of Laguerre-Gaussian laser modes"
+                 * https://doi.org/10.1103/physreva.45.8185
+                 *
+                 * Wikipedia on Gaussian laser beams
+                 * https://en.wikipedia.org/wiki/Gaussian_beam
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                 * @return incident field E value in internal units
+                 */
+                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
                 {
-                    //! Get text name of the incident field profile
-                    HINLINE static std::string getName()
+                    if(Unitless::Polarisation == PolarisationType::Linear)
+                        return this->getLinearPolarizationVector() * getValue(totalCellIdx, 0.0_X);
+                    else
                     {
-                        // This template is used for both Gaussian and PulseFrontTilt, distinguish based on tilt value
-                        using TiltParam = detail::TiltParam<T_Params>;
-                        bool isTilted = (std::abs(TiltParam::TILT_AXIS_1) + std::abs(TiltParam::TILT_AXIS_2) > 0);
-                        return isTilted ? "PulseFrontTilt" : "GaussianPulse";
+                        auto const phaseShift = pmacc::math::Pi<float_X>::halfValue;
+                        return this->getCircularPolarizationVector1() * getValue(totalCellIdx, phaseShift)
+                            + this->getCircularPolarizationVector2() * getValue(totalCellIdx, 0.0_X);
                     }
-                };
+                }
 
-            } // namespace profiles
+            private:
+                /** Get value for the given position
+                 *
+                 * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                 * @param phaseShift additional phase shift to add on top of everything else,
+                 *                   in radian
+                 */
+                HDINLINE float_X getValue(floatD_X const& totalCellIdx, float_X const phaseShift) const
+                {
+                    // transform to 3d internal coordinate system
+                    float3_X pos = this->getInternalCoordinates(totalCellIdx);
+                    auto const time = this->getCurrentTime(totalCellIdx);
+                    if(time < 0.0_X)
+                        return 0.0_X;
 
-            namespace detail
+                    // calculate focus position relative to the current point in the propagation direction
+                    auto const focusRelativeToOrigin = this->focus - this->origin;
+
+                    float_X const focusPos = math::sqrt(pmacc::math::l2norm2(focusRelativeToOrigin)) - pos[0];
+                    // beam waist at the generation plane so that at focus we will get W0
+                    float_X const w = Unitless::W0
+                        * math::sqrt(1.0_X
+                                     + (focusPos / Unitless::rayleighLength) * (focusPos / Unitless::rayleighLength));
+
+                    // a symmetric pulse will be initialized at generation plane for
+                    // a time of PULSE_INIT * PULSE_DURATION = INIT_TIME.
+                    // we shift the complete pulse for the half of this time to start with
+                    // the front of the laser pulse.
+                    constexpr auto mue = 0.5_X * Unitless::INIT_TIME;
+                    auto const phase
+                        = Unitless::w * (time - mue - focusPos / SPEED_OF_LIGHT) + Unitless::LASER_PHASE + phaseShift;
+
+                    // Apply tilt if needed
+                    if constexpr(Unitless::TILT_AXIS_1 || Unitless::TILT_AXIS_2)
+                    {
+                        auto const tiltTimeShift = phase / Unitless::w + focusPos / SPEED_OF_LIGHT;
+                        auto const tiltPositionShift = SPEED_OF_LIGHT * tiltTimeShift
+                            / pmacc::math::dot(this->getDirection(), float3_X{cellSize});
+                        auto const tilt1 = Unitless::TILT_AXIS_1;
+                        pos[1] += math::tan(tilt1) * tiltPositionShift;
+                        auto const tilt2 = Unitless::TILT_AXIS_2;
+                        pos[2] += math::tan(tilt2) * tiltPositionShift;
+                    }
+
+                    auto planeNoNormal = float3_X::create(1.0_X);
+                    planeNoNormal[0] = 0.0_X;
+                    auto const transversalDistanceSquared = pmacc::math::l2norm2(pos * planeNoNormal);
+
+                    // inverse radius of curvature of the pulse's wavefronts
+                    auto const R_inv
+                        = -focusPos / (Unitless::rayleighLength * Unitless::rayleighLength + focusPos * focusPos);
+                    // the Gouy phase shift
+                    auto xi = math::atan(-focusPos / Unitless::rayleighLength);
+                    if(simDim == DIM2)
+                        xi *= 0.5_X;
+                    auto etrans = 0.0_X;
+                    auto const r2OverW2 = transversalDistanceSquared / w / w;
+                    auto const r = 0.5_X * transversalDistanceSquared * R_inv;
+                    for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
+                    {
+                        etrans +=
+                            typename Unitless::LAGUERREMODES_t{}[m] * simpleLaguerre(m, 2.0_X * r2OverW2)
+                            * math::exp(-r2OverW2)
+                            * math::cos(
+                                pmacc::math::Pi<float_X>::doubleValue / Unitless::WAVE_LENGTH * focusPos
+                                - pmacc::math::Pi<float_X>::doubleValue / Unitless::WAVE_LENGTH * r
+                                + (2._X * float_X(m) + 1._X) * xi + phase + typename Unitless::LAGUERREPHASES_t{}[m]);
+                    }
+
+                    auto const shiftedTime
+                        = (r - focusPos - phase / pmacc::math::Pi<float_X>::doubleValue * Unitless::WAVE_LENGTH)
+                        / SPEED_OF_LIGHT;
+                    etrans *= LongitudinalEnvelope::getEnvelope(shiftedTime);
+
+                    auto etrans_norm = 0.0_X;
+                    for(uint32_t m = 0; m <= Unitless::MODENUMBER; ++m)
+                        etrans_norm += typename Unitless::LAGUERREMODES_t{}[m];
+                    auto envelope = Unitless::AMPLITUDE;
+                    if(simDim == DIM2)
+                        envelope *= math::sqrt(Unitless::W0 / w);
+                    else if(simDim == DIM3)
+                        envelope *= Unitless::W0 / w;
+                    return envelope * etrans / etrans_norm;
+                }
+
+                /** Simple iteration algorithm to implement Laguerre polynomials for GPUs.
+                 *
+                 *  @param n order of the Laguerre polynomial
+                 *  @param x coordinate at which the polynomial is evaluated
+                 */
+                HDINLINE float_X simpleLaguerre(uint32_t const n, float_X const x) const
+                {
+                    // Result for special case n == 0
+                    if(n == 0)
+                        return 1.0_X;
+                    uint32_t currentN = 1;
+                    float_X laguerreNMinus1 = 1.0_X;
+                    float_X laguerreN = 1.0_X - x;
+                    float_X laguerreNPlus1(0.0_X);
+                    while(currentN < n)
+                    {
+                        // Core statement of the algorithm
+                        laguerreNPlus1 = ((2.0_X * float_X(currentN) + 1.0_X - x) * laguerreN
+                                          - float_X(currentN) * laguerreNMinus1)
+                            / float_X(currentN + 1u);
+                        // Advance by one order
+                        laguerreNMinus1 = laguerreN;
+                        laguerreN = laguerreNPlus1;
+                        currentN++;
+                    }
+                    return laguerreN;
+                }
+            };
+        } // namespace detail
+
+        template<typename T_Param>
+        struct GaussianPulseEnvelope : public detail::BaseParamUnitless<T_Param>
+        {
+            using Unitless = detail::BaseParamUnitless<T_Param>;
+
+            HDINLINE static float_X getEnvelope(float_X const time)
             {
-                /** Get type of incident field E functor for the GaussianPulse profile type
-                 *
-                 * @tparam T_Params parameters
-                 */
-                template<typename T_Params>
-                struct GetFunctorIncidentE<profiles::GaussianPulse<T_Params>>
-                {
-                    using type = profiles::detail::GaussianPulseFunctorIncidentE<T_Params>;
-                };
+                auto const exponent = time / (2.0_X * Unitless::PULSE_DURATION);
 
-                /** Get type of incident field B functor for the GaussianPulse profile type
-                 *
-                 * Rely on SVEA to calculate value of B from E.
-                 *
-                 * @tparam T_Params parameters
-                 */
-                template<typename T_Params>
-                struct GetFunctorIncidentB<profiles::GaussianPulse<T_Params>>
-                {
-                    using type = detail::ApproximateIncidentB<
-                        typename GetFunctorIncidentE<profiles::GaussianPulse<T_Params>>::type>;
-                };
-            } // namespace detail
-        } // namespace incidentField
-    } // namespace fields
-} // namespace picongpu
+                return math::exp(-exponent * exponent);
+            }
+
+            HINLINE static std::string getName()
+            {
+                return "GaussianPulse";
+            }
+        };
+
+        template<typename T_Params, typename T_LongitudinalEnvelope>
+        struct GaussianPulse
+        {
+            using LongitudinalEnvelope = T_LongitudinalEnvelope;
+            //! Get text name of the incident field profile
+            HINLINE static std::string getName()
+            {
+                // This template is used for both Gaussian and PulseFrontTilt, distinguish based on tilt value
+                using TiltParam = detail::TiltParam<T_Params>;
+                bool isTilted = (std::abs(TiltParam::TILT_AXIS_1) + std::abs(TiltParam::TILT_AXIS_2) > 0);
+                std::string name = isTilted ? "PulseFrontTilt" : "GaussianPulse";
+                name += "_with_" + LongitudinalEnvelope::getName();
+                return name;
+            }
+        };
+
+    } // namespace profiles
+
+    namespace detail
+    {
+        /** Get type of incident field E functor for the GaussianPulse profile type
+         *
+         * @tparam T_Params parameters
+         */
+        template<typename T_Params, typename T_LongitudinalEnvelope>
+        struct GetFunctorIncidentE<profiles::GaussianPulse<T_Params, T_LongitudinalEnvelope>>
+        {
+            using type = profiles::detail::GaussianPulseFunctorIncidentE<T_Params, T_LongitudinalEnvelope>;
+        };
+
+        /** Get type of incident field B functor for the GaussianPulse profile type
+         *
+         * Rely on SVEA to calculate value of B from E.
+         *
+         * @tparam T_Params parameters
+         */
+        template<typename T_Params, typename T_LongitudinalEnvelope>
+        struct GetFunctorIncidentB<profiles::GaussianPulse<T_Params, T_LongitudinalEnvelope>>
+        {
+            using type = detail::ApproximateIncidentB<
+                typename GetFunctorIncidentE<profiles::GaussianPulse<T_Params, T_LongitudinalEnvelope>>::type>;
+        };
+    } // namespace detail
+} // namespace picongpu::fields::incidentField

--- a/share/picongpu/examples/LaserWakefield/cmakeFlags
+++ b/share/picongpu/examples/LaserWakefield/cmakeFlags
@@ -32,6 +32,7 @@
 flags[0]=""
 flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_DIMENSION=DIM2'"
 flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_IONS=1;-DPARAM_IONIZATION=1'"
+flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_LASERPROFILE=GaussianBeamWithContrastCurve'"
 
 ################################################################################
 # execution

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -74,6 +74,10 @@
 #    define PARAM_PULSE_DURATION_SI 5.e-15
 #endif
 
+#ifndef PARAM_LASERPROFILE
+#    define PARAM_LASERPROFILE GaussianProfile
+#endif
+
 namespace picongpu
 {
     namespace fields
@@ -247,11 +251,53 @@ namespace picongpu
                 /** @} */
             };
 
+
+            //! Laser Profile is taking plane wave param configuration and is overwriting only a few settings
+            struct ExpRampWithPrepulseEnvelopeParam : public LwfaGaussianPulseBaseParams
+            {
+                /** Stretch temporal profile by a constant plateau between the up and downramp
+                 *  unit: seconds */
+                static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0;
+
+                /** Intensities of prepulse and exponential preramp
+                 *
+                 * @{
+                 */
+                static constexpr float_X INT_RATIO_PREPULSE = 0.;
+                static constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
+                static constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
+                static constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
+                /** @} */
+
+                /** Time-positions of prepulse and preramps points
+                 *
+                 * @{
+                 */
+                static constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
+                static constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
+                static constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
+                static constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
+                static constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
+                /** @} */
+
+                /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
+                 * plateau and half at the end of the plateau
+                 *
+                 * unit: none
+                 */
+                static constexpr float_64 RAMP_INIT = 16.0;
+            };
+
+            using GaussianProfile = profiles::GaussianPulse<GaussianPulseParam>;
+            using GaussianBeamWithContrastCurve = profiles::GaussianPulse<
+                GaussianPulseParam,
+                profiles::ExpRampWithPrepulseLongitudinal<ExpRampWithPrepulseEnvelopeParam>>;
+
             /**@{*/
             //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
             using XMin = profiles::None;
             using XMax = profiles::None;
-            using YMin = profiles::GaussianPulse<GaussianPulseParam>;
+            using YMin = PARAM_LASERPROFILE;
             using YMax = profiles::None;
             using ZMin = profiles::None;
             using ZMax = profiles::None;


### PR DESCRIPTION
## Current status
The current implementation of the `GaussianBeam` profile uses a Gaussian temporal envelope. On the other hand, the `ExpRampWithPrepulse`, that can be used for a more elaborate contrast curves, is also a Gaussian in the transversal plane, but ignores wavefront curvature, and so it is implicitly setting the focus of the Gaussian beam on the initialization plane. At the moment, it is not possible to have a focusing Gaussian beam that includes a contrast curve. 

The major difference between the two implementations is that `GaussianBeam` does not use the cell position for the temporal envelope, but rather the crossing point of the wave front surface (that goes through the cell) and the beam axis.

## Proposed changes
Generalize `GaussianBeam` temporal envelope definition and make it possible to use the `ExpRampWithPrepulse` envelope in `GaussianBeam`.  

## TODO:
- [x] Separate envelope calculation in `ExpRampWithPrepulse` from the rest of the functor.
- [x] Refractor the Gaussian pulse out of  `GaussianBeam`  and include it as a new template argument. 
- [x] Make an example using the `ExpRampWithPrepulse` envelope instead of the Gaussian in  `GaussianBeam`.
- [x] Tests:
  - [x]  verify `ExpRampWithPrepulse`
  - [x]  verify `GaussianBeam` with a Gaussian Profile
  - [x] verify `GaussianBeam` with a `ExpRampWithPrepulse`
- [ ] documentation
  - [ ] basic usage in `incidentField.param`
  - [ ] docstrings
- [x] PICMI integration (doesn't break PICMI, adding the new profile could be a separate PR?)

* (probably not in this PR) remove `ExpRampWithPrepulse` profile, just keep the envelope.

@steindev @wmles What do you think, is this going to work, or am I missing sth?