### PR TITLE
fix running muti-binary within one MPI context

### DIFF
--- a/include/picongpu/fields/EMFieldBase.tpp
+++ b/include/picongpu/fields/EMFieldBase.tpp
@@ -98,6 +98,8 @@ namespace picongpu
             const DataSpace<simDim> originGuard(LowerMargin().toRT());
             const DataSpace<simDim> endGuard(UpperMargin().toRT());
 
+            auto const commTag = pmacc::traits::getUniqueId<uint32_t>();
+
             /*go over all directions*/
             for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
             {
@@ -109,7 +111,6 @@ namespace picongpu
                 DataSpace<simDim> guardingCells;
                 for(uint32_t d = 0; d < simDim; ++d)
                     guardingCells[d] = (relativeMask[d] == -1 ? originGuard[d] : endGuard[d]);
-                auto const commTag = pmacc::traits::GetUniqueTypeId<DerivedField>::uid();
                 buffer->addExchange(GUARD, i, guardingCells, commTag);
             }
         }

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -83,6 +83,9 @@ namespace picongpu
         auto const originGuard = math::max(LowerMarginShapes::toRT(), interpolationLowerMargin);
         auto const endGuard = math::max(UpperMarginShapes::toRT(), interpolationUpperMargin);
 
+        // Type to generate a unique send tag from
+        auto const sendCommTag = pmacc::traits::getUniqueId<uint32_t>();
+
         /*go over all directions*/
         for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
         {
@@ -110,9 +113,6 @@ namespace picongpu
                     break;
                 };
             }
-            // Type to generate a unique send tag from
-            struct SendTag;
-            auto const sendCommTag = pmacc::traits::GetUniqueTypeId<SendTag, uint32_t>::uid();
             buffer.addExchangeBuffer(i, guardingCells, sendCommTag);
         }
 
@@ -123,6 +123,8 @@ namespace picongpu
         if(originRecvGuard != DataSpace<simDim>::create(0) || endRecvGuard != DataSpace<simDim>::create(0))
         {
             fieldJrecv = std::make_unique<Buffer>(buffer.getDeviceBuffer(), cellDescription.getGridLayout());
+            // Type to generate a unique receive tag from
+            auto const recvCommTag = pmacc::traits::getUniqueId<uint32_t>();
 
             /*go over all directions*/
             for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
@@ -135,9 +137,6 @@ namespace picongpu
                 DataSpace<simDim> guardingCells;
                 for(uint32_t d = 0; d < simDim; ++d)
                     guardingCells[d] = (relativMask[d] == -1 ? originRecvGuard[d] : endRecvGuard[d]);
-                // Type to generate a unique receive tag from
-                struct RecvTag;
-                auto const recvCommTag = pmacc::traits::GetUniqueTypeId<RecvTag, uint32_t>::uid();
                 fieldJrecv->addExchange(GUARD, i, guardingCells, recvCommTag);
             }
         }

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -63,12 +63,12 @@ namespace picongpu
         , m_slotId(slotId)
     {
         /* Since this class is instantiated for each temporary field slot,
-         * use getNextId( ) directly to get unique tags for each instance.
+         * use getUniqueId( ) directly to get unique tags for each instance.
          *
          * Warning: this usage relies on the same order of calls to getNextId() on all MPI ranks
          */
-        m_commTagScatter = pmacc::traits::getNextId();
-        m_commTagGather = pmacc::traits::getNextId();
+        m_commTagScatter = pmacc::traits::getUniqueId();
+        m_commTagGather = pmacc::traits::getUniqueId();
 
         using Buffer = GridBuffer<ValueType, simDim>;
         fieldTmp = std::make_unique<Buffer>(cellDescription.getGridLayout());

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -212,7 +212,7 @@ namespace picongpu
 
         size_t sizeOfExchanges = 0u;
 
-        const uint32_t commTag = pmacc::traits::GetUniqueTypeId<FrameType, uint32_t>::uid();
+        const uint32_t commTag = pmacc::traits::getUniqueId();
         log<picLog::MEMORY>("communication tag for species %1%: %2%") % FrameType::getName() % commTag;
 
         auto const numExchanges = NumberOfExchanges<simDim>::value;

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -143,6 +143,7 @@ namespace pmacc
             : superCellSize(superCellSize)
             , gridSize(layout)
             , m_deviceHeap(deviceHeap)
+            , exchangeMemoryIndexerTag(traits::getUniqueId<uint32_t>())
         {
             exchangeMemoryIndexer = std::make_unique<GridBuffer<BorderFrameIndex, DIM1>>(DataSpace<DIM1>(0));
             framesExchanges = std::make_unique<GridBuffer<FrameType, DIM1, FrameTypeBorder>>(DataSpace<DIM1>(0));
@@ -176,15 +177,12 @@ namespace pmacc
             framesExchanges
                 ->addExchangeBuffer(receive, DataSpace<DIM1>(numFrameTypeBorders), communicationTag, true, false);
 
-            /* Generate a new tag from this type
-             *
-             * The tag is the same each time this method is called (per instantiation of this template).
-             * Here it is fine, as there is the only instance object, and
-             * exchangeMemoryIndexer->addExchangeBuffer() requires the same tag on each call
-             */
-            auto const newTag = traits::GetUniqueTypeId<ParticlesBuffer, uint32_t>::uid();
-            exchangeMemoryIndexer
-                ->addExchangeBuffer(receive, DataSpace<DIM1>(numFrameTypeBorders), newTag, true, false);
+            exchangeMemoryIndexer->addExchangeBuffer(
+                receive,
+                DataSpace<DIM1>(numFrameTypeBorders),
+                exchangeMemoryIndexerTag,
+                true,
+                false);
         }
 
         /**
@@ -323,5 +321,7 @@ namespace pmacc
         DataSpace<DIM> superCellSize;
         DataSpace<DIM> gridSize;
         std::shared_ptr<DeviceHeap> m_deviceHeap;
+        // tag used to communicate the exchange memory indexer data via MPI
+        uint32_t exchangeMemoryIndexerTag;
     };
 } // namespace pmacc


### PR DESCRIPTION
In case the user is compiling different binaries for different compute nodes or devices and each binary is compiled by other compiler vendors e.g clang, gcc, ... executing all binaries within one MPI context was not possible.
The reason is that tags used for MPI communication were derived from the type signature. Since this approach depends on the order the compiler is creating types in the internal memory the tags used for MPI communication can differ based on the compiler used to generate the binary.

This PR is changing the way PMacc and PICoNGPU are deriving the tag ID for communication.
The id is now depending on the creation order of objects at runtime.

# Tests

I tested this PR with a binary compiled for NVIDIA CUDA (GCC,nvcc) and a second compiled for AMD ROCM (clang,hipcc) and performed a simulation (KHI) where I executed the simulation on AMD and NVIDIA within one MPI context.