### PR TITLE
change radiation plugin python module to openPMD-api

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -460,15 +460,19 @@ Please be aware that all datasets in the openPMD output are given in the PIConGP
 
 .. code:: python
 
-   import h5py
-   f = h5py.File("e_radAmplitudes_2800_0_0_0.h5", "r")
-   omega_handler = f['/data/2800/DetectorMesh/DetectorFrequency/omega']
-   omega = omega_handler[0, :, 0] * omega_handler.attrs['unitSI']
-   f.close()
+   import openpmd_api as io
+   series = io.Series("e_radAmplitudes_%T_0_0_0.h5", io.Access_Type.read_only)
+   iteration = series.iterations[2800]
+
+   omega_handler = iteration.meshes["DetectorFrequency"]["omega"]
+   omega = omega_h[0, :, 0]
+   omega_unitSI = omega_h.unit_SI
+   series.flush()
+   omega *= omega_unitSI
 
 In order to extract the radiation data from the openPMD datasets, PIConGPU provides a python module to read the data and obtain the result in SI-units.
 An example python script is given below.
-This currently assumes hdf5 output and will soon become openPMD agnostic.
+This currently assumes hdf5 output but any openPMD output, such as adios, will work too.
 
 .. code:: python
 
@@ -478,8 +482,8 @@ This currently assumes hdf5 output and will soon become openPMD agnostic.
 
     from picongpu.plugins.data import RadiationData
 
-    # access HDF5 radiation file
-    radData = RadiationData("./simOutput/radiationHDF5/e_radAmplitudes_2820_0_0_0.h5")
+    # access openPMD radiation file for specific time step
+    radData = RadiationData("./simOutput/radiationHDF5/e_radAmplitudes_%T_0_0_0.h5", 2820)
 
     # get frequencies
     omega = radData.get_omega()

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -145,9 +145,9 @@ namespace picongpu
 
                 std::optional<::openPMD::Series> m_series;
                 std::string openPMDSuffix
-                    = "_%T_0_0_0." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
+                    = "_%T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::ADIOS);
                 std::string openPMDExtensionCheckpointing
-                    = openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
+                    = openPMD::getDefaultExtension(openPMD::ExtensionPreference::ADIOS);
                 std::string openPMDConfig = "{}";
                 std::string openPMDCheckpointConfig = "{}";
                 bool writeDistributedAmplitudes = false;

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -144,8 +144,7 @@ namespace picongpu
                 static const int numberMeshRecords = 3;
 
                 std::optional<::openPMD::Series> m_series;
-                std::string openPMDSuffix
-                    = "_%T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::ADIOS);
+                std::string openPMDSuffix = "_%T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::ADIOS);
                 std::string openPMDExtensionCheckpointing
                     = openPMD::getDefaultExtension(openPMD::ExtensionPreference::ADIOS);
                 std::string openPMDConfig = "{}";

--- a/lib/python/picongpu/extra/plugins/data/radiation.py
+++ b/lib/python/picongpu/extra/plugins/data/radiation.py
@@ -49,16 +49,17 @@ class RadiationData:
         # Amplitude
         detectorAmplitude = self.iteration.meshes["Amplitude"]
         # A_x
-        self.Ax_Re = detectorAmplitude["x_Re"].load_chunk()
-        self.Ax_Im = detectorAmplitude["x_Im"].load_chunk()
+        self.Ax_Re = detectorAmplitude["x_Re"][:, :, :]
+        self.Ax_Im = detectorAmplitude["x_Im"][:, :, :]
         # A_y
-        self.Ay_Re = detectorAmplitude["y_Re"].load_chunk()
-        self.Ay_Im = detectorAmplitude["y_Im"].load_chunk()
+        self.Ay_Re = detectorAmplitude["y_Re"][:, :, :]
+        self.Ay_Im = detectorAmplitude["y_Im"][:, :, :]
         # A_z
-        self.Az_Re = detectorAmplitude["z_Re"].load_chunk()
-        self.Az_Im = detectorAmplitude["z_Im"].load_chunk()
+        self.Az_Re = detectorAmplitude["z_Re"][:, :, :]
+        self.Az_Im = detectorAmplitude["z_Im"][:, :, :]
 
         # conversion factor for spectra from PIC units to SI units
+        # The value for unit_SI is consistent across all Amplitude datasets
         self.convert_to_SI = detectorAmplitude["x_Re"].unit_SI
 
         self.rad_series.flush()

--- a/lib/python/picongpu/extra/plugins/data/radiation.py
+++ b/lib/python/picongpu/extra/plugins/data/radiation.py
@@ -23,7 +23,8 @@ import openpmd_api as io
 class RadiationData:
     def __init__(self, filename, timestep):
         """
-        Open references to an openPMD-api series or file to access radiation data.
+        Open references to an openPMD-api series or file to access radiation
+        data.
 
         This constructor opens openPMD-api references to the radiation data
         and thus allows easy access to the complex amplitudes from the
@@ -41,9 +42,9 @@ class RadiationData:
 
         # extract time step
         self.timestep = timestep
-        if (not self.timestep in self.rad_series.iterations):
-            raise Exception("The selected timestep {} ".format(self.timestep) +
-                            "is not available in the series.")
+        if (self.timestep not in self.rad_series.iterations):
+            raise Exception("The selected timestep {} ".format(self.timestep)
+                            + "is not available in the series.")
         self.iteration = self.rad_series.iterations[self.timestep]
 
         # Amplitude


### PR DESCRIPTION
This pull request changes the python module for reading radiation data from h5py to openPMD-api 
This follows the changes in #3566. 

- [x] fix pep8
- [x] update documentation 