### PR TITLE
refactor to make superCellSize and frameSize independant

### DIFF
--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -181,7 +181,7 @@ namespace picongpu
         const uint32_t currentStep = Environment<>::get().SimulationDescription().getCurrentStep();
         auto iFilter = particles::filter::IUnary<ParticleFilter>{currentStep};
 
-        auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+        auto workerCfg = lockstep::makeWorkerCfg<ParticlesClass::ParticlesBoxType::FrameType::frameSize>();
         do
         {
             PMACC_LOCKSTEP_KERNEL(KernelComputeSupercells<BlockArea>{}, workerCfg)

--- a/include/picongpu/fields/currentDeposition/Deposit.hpp
+++ b/include/picongpu/fields/currentDeposition/Deposit.hpp
@@ -81,8 +81,8 @@ namespace picongpu
                 // stride 1u means each supercell is used
                 auto mapper = makeStrideAreaMapper<T_area, skipSuperCells + 1u>(cellDescription);
 
-                auto workerCfg = pmacc::lockstep::makeWorkerCfg<
-                    pmacc::math::CT::volume<SuperCellSize>::type::value * T_Strategy::workerMultiplier>();
+                auto workerCfg
+                    = pmacc::lockstep::makeWorkerCfg<T_ParticleBox::frameSize * T_Strategy::workerMultiplier>();
                 do
                 {
                     PMACC_LOCKSTEP_KERNEL(depositionKernel, workerCfg)
@@ -114,8 +114,8 @@ namespace picongpu
             {
                 auto const mapper = makeAreaMapper<T_area>(cellDescription);
 
-                auto workerCfg = pmacc::lockstep::makeWorkerCfg<
-                    pmacc::math::CT::volume<SuperCellSize>::type::value * T_Strategy::workerMultiplier>();
+                auto workerCfg
+                    = pmacc::lockstep::makeWorkerCfg<T_ParticleBox::frameSize * T_Strategy::workerMultiplier>();
                 PMACC_LOCKSTEP_KERNEL(depositionKernel, workerCfg)
                 (mapper.getGridDim())(jBox, parBox, frameSolver, mapper);
             }

--- a/include/picongpu/param/memory.param
+++ b/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -76,6 +76,7 @@ namespace picongpu
         : public ParticlesBase<
               ParticleDescription<
                   T_Name,
+                  std::integral_constant<uint32_t, numFrameSlots>,
                   SuperCellSize,
                   T_Attributes,
                   T_Flags,
@@ -96,6 +97,7 @@ namespace picongpu
     public:
         using SpeciesParticleDescription = pmacc::ParticleDescription<
             T_Name,
+            std::integral_constant<uint32_t, numFrameSlots>,
             SuperCellSize,
             T_Attributes,
             T_Flags,
@@ -268,4 +270,20 @@ namespace pmacc
         };
 
     } // namespace traits
+    namespace lockstep
+    {
+        //! Specialization to create a lockstep worker configuration out of a particle species.
+        template<typename T_Name, typename T_Flags, typename T_Attributes>
+        HDINLINE auto makeWorkerCfg(picongpu::Particles<T_Name, T_Flags, T_Attributes> const&)
+        {
+            return makeWorkerCfg<picongpu::Particles<T_Name, T_Flags, T_Attributes>::FrameType::frameSize>();
+        }
+
+        //! Specialization to create a lockstep worker configuration out of a shared pointer to a particle species.
+        template<typename T_Name, typename T_Flags, typename T_Attributes>
+        HDINLINE auto makeWorkerCfg(std::shared_ptr<picongpu::Particles<T_Name, T_Flags, T_Attributes>> const&)
+        {
+            return makeWorkerCfg<picongpu::Particles<T_Name, T_Flags, T_Attributes>::FrameType::frameSize>();
+        }
+    } // namespace lockstep
 } // namespace pmacc

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -90,7 +90,7 @@ namespace picongpu
             using DestFramePtr = typename T_DestParBox::FramePtr;
             using SrcFramePtr = typename T_SrcParBox::FramePtr;
 
-            constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_SrcParBox::frameSize;
 
             PMACC_SMEM(worker, srcFrame, SrcFramePtr);
             PMACC_SMEM(worker, destFrame, DestFramePtr);

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -353,7 +353,7 @@ namespace picongpu
 
         auto const mapper = makeAreaMapper<CORE + BORDER>(this->cellDescription);
 
-        auto workerCfg = pmacc::lockstep::makeWorkerCfg(SuperCellSize{});
+        auto workerCfg = pmacc::lockstep::makeWorkerCfg(*this);
 
         PMACC_LOCKSTEP_KERNEL(KernelMoveAndMarkParticles<BlockArea>{}, workerCfg)
         (mapper.getGridDim())(
@@ -422,7 +422,7 @@ namespace picongpu
 
         auto const mapper = makeAreaMapper<CORE + BORDER>(this->cellDescription);
 
-        auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+        auto workerCfg = lockstep::makeWorkerCfg(*this);
 
         PMACC_LOCKSTEP_KERNEL(KernelDeriveParticles{}, workerCfg)
         (mapper.getGridDim())(

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -100,8 +100,8 @@ namespace picongpu
             T_ParBox pb,
             T_Mapping mapper) const
         {
-            constexpr int frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
-            PMACC_CONSTEXPR_CAPTURE uint32_t cellsPerSupercell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+            constexpr int frameSize = T_ParBox::frameSize;
+            constexpr uint32_t cellsPerSupercell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
             using FramePtr = typename T_ParBox::FramePtr;
             using FrameType = typename T_ParBox::FrameType;

--- a/include/picongpu/particles/atomicPhysics/AtomicPhysics.kernel
+++ b/include/picongpu/particles/atomicPhysics/AtomicPhysics.kernel
@@ -89,7 +89,7 @@ namespace picongpu
                     uint32_t const step) const
                 {
                     // Create and initialize a histogram on shared memory
-                    constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                    constexpr uint32_t frameSize = T_IonBox::frameSize;
 
                     // TODO: get this from ion species
                     // hard coded for now

--- a/include/picongpu/particles/atomicPhysics/CallAtomicPhysics.hpp
+++ b/include/picongpu/particles/atomicPhysics/CallAtomicPhysics.hpp
@@ -352,7 +352,7 @@ namespace picongpu
                     using Kernel = AtomicPhysicsKernel<picongpu::atomicPhysics::maxNumBins>;
                     auto kernel = Kernel{RngFactoryInt{step}, RngFactoryFloat{step}};
 
-                    auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+                    auto workerCfg = lockstep::makeWorkerCfg<IonFrameType::frameSize>();
 
                     // macro for call of kernel, once for every super cell
                     PMACC_LOCKSTEP_KERNEL(kernel, workerCfg)

--- a/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/DecelerateElectrons.hpp
@@ -127,8 +127,7 @@ namespace picongpu
                 auto frame = electronBox.getLastFrame(superCellIdx);
                 auto particlesInSuperCell = electronBox.getSuperCell(superCellIdx).getSizeLastFrame();
 
-                /// @todo : express framesize better, not via supercell size
-                constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                constexpr uint32_t frameSize = T_ElectronBox::frameSize;
 
                 auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
 

--- a/include/picongpu/particles/atomicPhysics/FillHistogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/FillHistogram.hpp
@@ -59,8 +59,7 @@ namespace picongpu
                 auto frame = electronBox.getLastFrame(superCellIdx);
                 auto particlesInSuperCell = electronBox.getSuperCell(superCellIdx).getSizeLastFrame();
 
-                /// @todo : express framesize better, not via supercell size
-                constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                constexpr uint32_t frameSize = T_ElectronBox::frameSize;
 
                 auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
                 auto onlyMaster = lockstep::makeMaster(worker);

--- a/include/picongpu/particles/atomicPhysics/SolveRateEquation.hpp
+++ b/include/picongpu/particles/atomicPhysics/SolveRateEquation.hpp
@@ -756,8 +756,7 @@ namespace picongpu
                 pmacc::DataSpace<simDim> const supercellIdx(
                     mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc()))));
 
-                /// todo: express framesize better, not via supercell size
-                constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                constexpr uint32_t frameSize = T_IonBox::frameSize;
 
                 auto forEachParticleSlotInFrame = lockstep::makeForEach<frameSize>(worker);
                 auto onlyMaster = lockstep::makeMaster(worker);

--- a/include/picongpu/particles/collision/detail/ListEntry.hpp
+++ b/include/picongpu/particles/collision/detail/ListEntry.hpp
@@ -170,8 +170,7 @@ namespace picongpu
                     T_Array& nppc,
                     T_Filter& filter)
                 {
-                    using SuperCellSize = typename T_ParBox::FrameType::SuperCellSize;
-                    constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                    constexpr uint32_t frameSize = T_ParBox::frameSize;
 
                     for(uint32_t i = 0; i < numParticlesInSupercell; i += frameSize)
                     {
@@ -216,8 +215,7 @@ namespace picongpu
                     T_EntryListArray& parCellList,
                     T_Filter& filter)
                 {
-                    using SuperCellSize = typename T_ParBox::FrameType::SuperCellSize;
-                    constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                    constexpr uint32_t frameSize = T_ParBox::frameSize;
                     for(uint32_t i = 0; i < numParticlesInSupercell; i += frameSize)
                     {
                         forEach(
@@ -247,8 +245,7 @@ namespace picongpu
                 DINLINE auto getParticle(T_ParBox& parBox, T_FramePtr frame, uint32_t particleId) ->
                     typename T_FramePtr::type::ParticleType
                 {
-                    constexpr uint32_t frameSize
-                        = pmacc::math::CT::volume<typename T_FramePtr::type::SuperCellSize>::type::value;
+                    constexpr int frameSize = T_ParBox::frameSize;
                     uint32_t const skipFrames = particleId / frameSize;
                     for(uint32_t i = 0; i < skipFrames; ++i)
                         frame = parBox.getNextFrame(frame);

--- a/include/picongpu/particles/creation/creation.hpp
+++ b/include/picongpu/particles/creation/creation.hpp
@@ -53,7 +53,7 @@ namespace picongpu
             {
                 auto const mapper = makeAreaMapper<pmacc::type::CORE + pmacc::type::BORDER>(cellDesc);
 
-                auto workerCfg = pmacc::lockstep::makeWorkerCfg(SuperCellSize{});
+                auto workerCfg = pmacc::lockstep::makeWorkerCfg<T_SourceSpecies::FrameType::frameSize>();
                 PMACC_LOCKSTEP_KERNEL(CreateParticlesKernel{}, workerCfg)
                 (mapper.getGridDim())(
                     particleCreator,

--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -91,7 +91,7 @@ namespace picongpu
                     /* for not mixing operations::assign up with the nvidia functor assign */
                     namespace partOp = pmacc::particles::operations;
 
-                    constexpr lcellId_t maxParticlesInFrame = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                    constexpr lcellId_t maxParticlesInFrame = T_ParBoxSource::frameSize;
 
                     /* use two frames to allow that all virtual workers can create new particles
                      * even if newFrameFillLvl is not zero.

--- a/include/picongpu/particles/debyeLength/Estimate.hpp
+++ b/include/picongpu/particles/debyeLength/Estimate.hpp
@@ -60,7 +60,7 @@ namespace picongpu
                 auto hostBox = hostDeviceBuffer.getHostBuffer().getDataBox();
                 hostDeviceBuffer.hostToDevice();
                 auto kernel = DebyeLengthEstimateKernel{};
-                auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+                auto workerCfg = lockstep::makeWorkerCfg<T_ElectronSpecies::FrameType::frameSize>();
                 PMACC_LOCKSTEP_KERNEL(kernel, workerCfg)
                 (mapper.getGridDim())(
                     electrons.getDeviceParticlesBox(),

--- a/include/picongpu/particles/functor/misc/Rng.hpp
+++ b/include/picongpu/particles/functor/misc/Rng.hpp
@@ -74,9 +74,11 @@ namespace picongpu
                         const
                     {
                         RngHandle tmp(rngHandle);
-                        tmp.init(
-                            localSupercellOffset * SuperCellSize::toRT()
-                            + DataSpaceOperations<simDim>::template map<SuperCellSize>(worker.getWorkerIdx()));
+                        auto rngOffset = DataSpace<simDim>::create(0);
+                        rngOffset.x() = worker.getWorkerIdx();
+                        auto numRNGsPerSuperCell = DataSpace<simDim>::create(1);
+                        numRNGsPerSuperCell.x() = numFrameSlots;
+                        tmp.init(localSupercellOffset * numRNGsPerSuperCell + rngOffset);
                         using RandomGen = RngWrapper<T_Worker, typename RngHandle::GetRandomType<Distribution>::type>;
                         return RandomGen(worker, tmp.applyDistribution<Distribution>());
                     }

--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -432,7 +432,7 @@ namespace picongpu
 
             auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 
-            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
 
             auto kernel = PMACC_LOCKSTEP_KERNEL(KernelBinEnergyParticles{}, workerCfg)(
                 mapper.getGridDim(),

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -45,8 +45,6 @@ namespace picongpu
     class CountParticles : public ISimulationPlugin
     {
     private:
-        using SuperCellSize = MappingDesc::SuperCellSize;
-
         MappingDesc* cellDescription{nullptr};
         std::string notifyPeriod;
 

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -466,7 +466,7 @@ namespace picongpu
 
             auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 
-            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
             auto kernel = PMACC_LOCKSTEP_KERNEL(KernelCalcEmittance{}, workerCfg)(mapper.getGridDim());
 
             // Some variables required so that it is possible for the kernel

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -351,7 +351,7 @@ namespace picongpu
 
             auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 
-            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
             auto kernel = PMACC_LOCKSTEP_KERNEL(KernelEnergyParticles{}, workerCfg)(mapper.getGridDim());
             auto binaryKernel = std::bind(
                 kernel,

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -227,21 +227,17 @@ namespace picongpu
             size_t size;
 
             ISAAC_NO_HOST_DEVICE_WARNING
-            ISAAC_HOST_DEVICE_INLINE ParticleIterator(
-                size_t size,
-                ParticlesBoxType pb,
-                FramePtr firstFrame,
-                int frameSize)
+            ISAAC_HOST_DEVICE_INLINE ParticleIterator(size_t size, ParticlesBoxType pb, FramePtr firstFrame)
                 : size(size)
                 , pb(pb)
                 , frame(firstFrame)
-                , frameSize(frameSize)
                 , i(0)
             {
             }
 
             ISAAC_HOST_DEVICE_INLINE void next()
             {
+                constexpr uint32_t frameSize = ParticlesBoxType::frameSize;
                 // iterate particles look for next frame
                 ++i;
                 if(i >= frameSize)
@@ -294,7 +290,6 @@ namespace picongpu
         private:
             ParticlesBoxType pb;
             FramePtr frame;
-            int frameSize;
             int i;
         };
 
@@ -336,7 +331,6 @@ namespace picongpu
             ISAAC_HOST_DEVICE_INLINE ParticleIterator<featureDim, ParticlesBoxType> getIterator(
                 const isaac_uint3& local_grid_coord) const
             {
-                constexpr uint32_t frameSize = pmacc::math::CT::volume<typename FrameType::SuperCellSize>::type::value;
                 DataSpace<simDim> const superCellIdx(
                     local_grid_coord.x + guarding[0],
                     local_grid_coord.y + guarding[1],
@@ -344,7 +338,7 @@ namespace picongpu
                 auto& superCell = pb[0].getSuperCell(superCellIdx);
                 size_t size = superCell.getNumParticles();
                 FramePtr currentFrame = pb[0].getFirstFrame(superCellIdx);
-                return ParticleIterator<featureDim, ParticlesBoxType>(size, pb[0], currentFrame, frameSize);
+                return ParticleIterator<featureDim, ParticlesBoxType>(size, pb[0], currentFrame);
             }
         };
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -248,7 +248,7 @@ namespace picongpu
             {
                 auto const mapper = makeAreaMapper<pmacc::type::CORE + pmacc::type::BORDER>(cellDesc);
 
-                auto workerCfg = pmacc::lockstep::makeWorkerCfg(SuperCellSize{});
+                auto workerCfg = pmacc::lockstep::makeWorkerCfg<TParticlesBox::frameSize>();
                 auto functorBlock = FunctorBlock<Species, float_PS, num_pbins, r_dir, T_Filter>(
                     particlesBox,
                     phaseSpaceBox,

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -40,7 +40,7 @@ namespace picongpu
          *
          * @attention If the version is changed please update openPMDWriter::checkIOFileVersionRestartCompatibility().
          */
-        static constexpr int picongpuIOVersionMajor = 2;
+        static constexpr int picongpuIOVersionMajor = 3;
 
         /** PIConGPU's IO minor file version.
          *

--- a/include/picongpu/plugins/kernel/CopySpecies.kernel
+++ b/include/picongpu/plugins/kernel/CopySpecies.kernel
@@ -79,12 +79,9 @@ namespace picongpu
         {
             using namespace pmacc::particles::operations;
 
-            using DestFrameType = T_DestFrame;
-            using SrcFrameType = typename T_SrcBox::FrameType;
             using SrcFramePtr = typename T_SrcBox::FramePtr;
 
-            constexpr uint32_t numParticlesPerFrame
-                = pmacc::math::CT::volume<typename SrcFrameType::SuperCellSize>::type::value;
+            constexpr uint32_t numParticlesPerFrame = T_SrcBox::frameSize;
 
             PMACC_SMEM(worker, srcFramePtr, SrcFramePtr);
             PMACC_SMEM(worker, localCounter, int);

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -205,7 +205,7 @@ namespace picongpu
             using SuperCellSize = MappingDesc::SuperCellSize;
             auto const mapper = makeAreaMapper<AREA>(*cellDescription);
 
-            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
             PMACC_LOCKSTEP_KERNEL(CountMakroParticle{}, workerCfg)
             (mapper.getGridDim())(
                 particles->getDeviceParticlesBox(),

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -57,6 +57,7 @@ namespace picongpu
         template<typename SpeciesTmp, typename Filter, typename ParticleFilter, typename T_ParticleOffset>
         struct StrategyRunParameters
         {
+            using SpeciesType = SpeciesTmp;
             pmacc::DataConnector& dc;
             ThreadParams& params;
             SpeciesTmp& speciesTmp;
@@ -202,7 +203,8 @@ namespace picongpu
                 GridBuffer<int, DIM1> counterBuffer(DataSpace<DIM1>(1));
                 auto const mapper = makeAreaMapper<CORE + BORDER>(*(rp.params.cellDescription));
 
-                auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+                auto workerCfg
+                    = lockstep::makeWorkerCfg<RunParameters::SpeciesType::element_type::FrameType::frameSize>();
 
                 /* this sanity check costs a little bit of time but hdf5 writing is
                  * slower */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -860,11 +860,16 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 ::openPMD::MeshRecordComponent mrc = mesh[::openPMD::RecordComponent::SCALAR];
                 std::string datasetName = params->openPMDSeries->meshesPath() + name;
 
+                auto numRNGsPerSuperCell = DataSpace<simDim>::create(1);
+                numRNGsPerSuperCell.x() = numFrameSlots;
                 // rng states are always of the domain size therefore query sizes from domain information
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
-                pmacc::math::UInt64<simDim> recordLocalSizeDims = subGrid.getLocalDomain().size;
-                pmacc::math::UInt64<simDim> recordOffsetDims = subGrid.getLocalDomain().offset;
-                pmacc::math::UInt64<simDim> recordGlobalSizeDims = subGrid.getGlobalDomain().size;
+                pmacc::math::UInt64<simDim> recordLocalSizeDims{
+                    subGrid.getLocalDomain().size / SuperCellSize::toRT() * numRNGsPerSuperCell};
+                pmacc::math::UInt64<simDim> recordOffsetDims{
+                    subGrid.getLocalDomain().offset / SuperCellSize::toRT() * numRNGsPerSuperCell};
+                pmacc::math::UInt64<simDim> recordGlobalSizeDims{
+                    subGrid.getGlobalDomain().size / SuperCellSize::toRT() * numRNGsPerSuperCell};
 
                 if(recordLocalSizeDims != rngProvider->getSize())
                     throw std::runtime_error("openPMD: RNG state can't be written due to not matching size");
@@ -917,11 +922,16 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 ::openPMD::Mesh mesh = iteration.meshes[name];
                 ::openPMD::MeshRecordComponent mrc = mesh[::openPMD::RecordComponent::SCALAR];
 
+                auto numRNGsPerSuperCell = DataSpace<simDim>::create(1);
+                numRNGsPerSuperCell.x() = numFrameSlots;
+
                 // rng states are always of the domain size therefore query sizes from pmacc
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
                 using VecUInt64 = pmacc::math::UInt64<simDim>;
-                VecUInt64 recordLocalSizeDims = subGrid.getLocalDomain().size;
-                VecUInt64 recordOffsetDims = subGrid.getLocalDomain().offset;
+                VecUInt64 recordLocalSizeDims{
+                    subGrid.getLocalDomain().size / SuperCellSize::toRT() * numRNGsPerSuperCell};
+                VecUInt64 recordOffsetDims{
+                    subGrid.getLocalDomain().offset / SuperCellSize::toRT() * numRNGsPerSuperCell};
 
                 if(recordLocalSizeDims != rngProvider->getSize())
                     throw std::runtime_error("openPMD: RNG state can't be loaded due to not matching size");

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -784,8 +784,9 @@ namespace picongpu
             DataSpace<simDim> blockSize(MappingDesc::SuperCellSize::toRT());
             DataSpace<DIM2> blockSize2D(blockSize[m_transpose.x()], blockSize[m_transpose.y()]);
 
+            auto particleWorkerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
             // create image particles
-            PMACC_LOCKSTEP_KERNEL(KernelPaintParticles3D{}, workerCfg)
+            PMACC_LOCKSTEP_KERNEL(KernelPaintParticles3D{}, particleWorkerCfg)
             (mapper.getGridDim(), blockSize2D.productOfComponents() * sizeof(float_X))(
                 particles->getDeviceParticlesBox(),
                 img->getDeviceBuffer().getDataBox(),

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -566,7 +566,7 @@ namespace picongpu
             auto beginInternalCellsLocal = pmacc::DataSpace<simDim>::create(0);
             auto endInternalCellsLocal = beginInternalCellsLocal + subGrid.getLocalDomain().size;
 
-            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
 
             auto kernel = PMACC_LOCKSTEP_KERNEL(KernelParticleCalorimeter{}, workerCfg)(grid);
             auto unaryKernel = std::bind(
@@ -632,7 +632,7 @@ namespace picongpu
             auto const beginExternalCellsLocal = beginExternalCellsTotal - shiftTotaltoLocal;
             auto const endExternalCellsLocal = endExternalCellsTotal - shiftTotaltoLocal;
 
-            auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
 
             auto kernel = PMACC_LOCKSTEP_KERNEL(KernelParticleCalorimeter{}, workerCfg)(grid);
             auto unaryKernel = std::bind(

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -1211,7 +1211,7 @@ namespace picongpu
                     DataSpace<simDim> globalOffset(subGrid.getLocalDomain().offset);
                     globalOffset.y() += (localSize.y() * numSlides);
 
-                    auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+                    auto workerCfg = lockstep::makeWorkerCfg<ParticlesType::FrameType::frameSize>();
 
                     // PIC-like kernel call of the radiation kernel
                     PMACC_LOCKSTEP_KERNEL(KernelRadiationParticles{}, workerCfg)

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -104,7 +104,7 @@ namespace picongpu
                 {
                     namespace po = boost::program_options;
                     using Amplitude = picongpu::plugins::radiation::Amplitude<>;
-                    constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                    constexpr uint32_t frameSize = ParBox::frameSize;
 
                     using FrameType = typename ParBox::FrameType;
                     using FramePtr = typename ParBox::FramePtr;
@@ -120,24 +120,23 @@ namespace picongpu
                      * through all particles and calculates the radiation for one direction
                      * for all frequencies
                      */
-                    constexpr int blockSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
                     // vectorial part of the integrand in the Jackson formula
-                    PMACC_SMEM(worker, real_amplitude_s, memory::Array<vector_64, blockSize>);
+                    PMACC_SMEM(worker, real_amplitude_s, memory::Array<vector_64, frameSize>);
 
                     // retarded time
-                    PMACC_SMEM(worker, t_ret_s, memory::Array<picongpu::float_X, blockSize>);
+                    PMACC_SMEM(worker, t_ret_s, memory::Array<picongpu::float_X, frameSize>);
 
                     // storage for macro particle weighting needed if
                     // the coherent and incoherent radiation of a single
                     // macro-particle needs to be considered
-                    PMACC_SMEM(worker, radWeighting_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, radWeighting_s, memory::Array<float_X, frameSize>);
 
                     // particle counter used if not all particles are considered for
                     // radiation calculation
                     PMACC_SMEM(worker, counter_s, int);
 
-                    PMACC_SMEM(worker, lowpass_s, memory::Array<NyquistLowPass, blockSize>);
+                    PMACC_SMEM(worker, lowpass_s, memory::Array<NyquistLowPass, frameSize>);
 
 
                     int const theta_idx = cupla::blockIdx(worker.getAcc()).x; // determine theta

--- a/include/picongpu/plugins/radiation/executeParticleFilter.hpp
+++ b/include/picongpu/plugins/radiation/executeParticleFilter.hpp
@@ -38,12 +38,18 @@ namespace picongpu::plugins::radiation
      * @param species species to be filtered
      */
     template<typename T_Species>
-    inline void executeParticleFilter(std::shared_ptr<T_Species>& species, [[maybe_unused]] const uint32_t currentStep)
+    inline void executeParticleFilter(
+        [[maybe_unused]] std::shared_ptr<T_Species>& species,
+        [[maybe_unused]] const uint32_t currentStep)
     {
         constexpr bool hasRadiationFilter
             = pmacc::traits::HasIdentifier<typename T_Species::FrameType, radiationMask>::type::value;
 
         if constexpr(hasRadiationFilter)
-            particles::Manipulate<picongpu::plugins::radiation::RadiationParticleFilter, T_Species>{}(currentStep);
+        {
+            auto executeFilter
+                = particles::Manipulate<picongpu::plugins::radiation::RadiationParticleFilter, T_Species>{};
+            executeFilter(currentStep);
+        }
     }
 } // namespace picongpu::plugins::radiation

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -83,8 +83,6 @@ namespace picongpu
             class TransitionRadiation : public ILightweightPlugin
             {
             private:
-                using SuperCellSize = MappingDesc::SuperCellSize;
-
                 using radLog = plugins::radiation::PIConGPUVerboseRadiation;
 
                 std::unique_ptr<GridBuffer<float_X, DIM1>> incTransRad;
@@ -482,7 +480,7 @@ namespace picongpu
                     DataSpace<simDim> globalOffset(subGrid.getLocalDomain().offset);
                     globalOffset.y() += (localSize.y() * numSlides);
 
-                    auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+                    auto workerCfg = lockstep::makeWorkerCfg<T_ParticlesType::FrameType::frameSize>();
                     // PIC-like kernel call of the radiation kernel
                     PMACC_LOCKSTEP_KERNEL(KernelTransRadParticles{}, workerCfg)
                     (gridDim_rad)(

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -86,7 +86,7 @@ namespace picongpu
                     using complex_X = alpaka::Complex<float_X>;
                     using complex_64 = alpaka::Complex<float_64>;
 
-                    constexpr uint32_t frameSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                    constexpr uint32_t frameSize = T_ParBox::frameSize;
 
                     using FrameType = typename T_ParBox::FrameType;
                     using FramePtr = typename T_ParBox::FramePtr;
@@ -99,21 +99,20 @@ namespace picongpu
                      * through all particles and calculates the radiation for one direction
                      * for all frequencies
                      */
-                    constexpr int blockSize = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
                     // perpendicular part of normalized energy
-                    PMACC_SMEM(worker, energyPerp_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, energyPerp_s, memory::Array<float_X, frameSize>);
 
                     // parallel part of normalized energy
-                    PMACC_SMEM(worker, energyPara_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, energyPara_s, memory::Array<float_X, frameSize>);
 
                     // exponent of the form factor
-                    PMACC_SMEM(worker, formfactorExponent_s, memory::Array<complex_X, blockSize>);
+                    PMACC_SMEM(worker, formfactorExponent_s, memory::Array<complex_X, frameSize>);
 
                     // storage for macro particle weighting needed if
                     // the coherent and incoherent radiation of a single
                     // macro-particle needs to be considered
-                    PMACC_SMEM(worker, radWeighting_s, memory::Array<float_X, blockSize>);
+                    PMACC_SMEM(worker, radWeighting_s, memory::Array<float_X, frameSize>);
 
                     // particle counter used if not all particles are considered for
                     // radiation calculation

--- a/include/picongpu/unitless/radiation.unitless
+++ b/include/picongpu/unitless/radiation.unitless
@@ -41,8 +41,7 @@ namespace picongpu
                 constexpr float_X delta_omega
                     = (float_X) ((omega_max - omega_min) / (float_X) (N_omega - 1)); // difference beween two omega
 
-                constexpr unsigned int blocksize_omega
-                    = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+                constexpr unsigned int blocksize_omega = numFrameSlots;
                 constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
             } // namespace linear_frequencies
 
@@ -51,15 +50,13 @@ namespace picongpu
                 constexpr float_X omega_min = (SI::omega_min * UNIT_TIME);
                 constexpr float_X omega_max = (SI::omega_max * UNIT_TIME);
 
-                constexpr unsigned int blocksize_omega
-                    = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+                constexpr unsigned int blocksize_omega = numFrameSlots;
                 constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
             } // namespace log_frequencies
 
             namespace frequencies_from_list
             {
-                constexpr unsigned int blocksize_omega
-                    = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+                constexpr unsigned int blocksize_omega = numFrameSlots;
                 constexpr unsigned int gridsize_omega = N_omega / blocksize_omega; // size of grid (dim: x); radiation
             } // namespace frequencies_from_list
 

--- a/include/picongpu/unitless/transitionRadiation.unitless
+++ b/include/picongpu/unitless/transitionRadiation.unitless
@@ -35,8 +35,7 @@ namespace picongpu
                 constexpr float_X deltaOmega
                     = (float_X) ((omegaMax - omegaMin) / (float_X) (nOmega - 1)); // difference beween two omega
 
-                constexpr unsigned int blocksizeOmega
-                    = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+                constexpr unsigned int blocksizeOmega = numFrameSlots;
                 constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
             } // namespace linearFrequencies
 
@@ -46,16 +45,14 @@ namespace picongpu
                 constexpr float_X omegaMin = (SI::omegaMin * UNIT_TIME);
                 constexpr float_X omegaMax = (SI::omegaMax * UNIT_TIME);
 
-                constexpr unsigned int blocksizeOmega
-                    = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+                constexpr unsigned int blocksizeOmega = numFrameSlots;
                 constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
             } // namespace logFrequencies
 
             //! units for frequencies from list for transition radiation calculation
             namespace listFrequencies
             {
-                constexpr unsigned int blocksizeOmega
-                    = pmacc::math::CT::volume<typename MappingDesc::SuperCellSize>::type::value;
+                constexpr unsigned int blocksizeOmega = numFrameSlots;
                 constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
             } // namespace listFrequencies
 

--- a/include/pmacc/exec/KernelLauncher.tpp
+++ b/include/pmacc/exec/KernelLauncher.tpp
@@ -74,13 +74,6 @@ namespace pmacc::exec::detail
             , m_gridExtent(DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toDim3())
             , m_blockExtent(DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toDim3())
         {
-#if 0
-            std::string const kernelName = typeid(m_kernel).name();
-            std::string const kernelInfo = kernelName + std::string(" [") + m_metaData.getFile() + std::string(":")
-                + std::to_string(m_metaData.getLine()) + std::string(" ]");
-
-            std::cout<<DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toString()<<","<<DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toString()<<" "<<kernelInfo<<std::endl;
-#endif
         }
 
         /** Enqueue the kernel functor with the given arguments for execution.

--- a/include/pmacc/exec/KernelLauncher.tpp
+++ b/include/pmacc/exec/KernelLauncher.tpp
@@ -74,6 +74,13 @@ namespace pmacc::exec::detail
             , m_gridExtent(DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toDim3())
             , m_blockExtent(DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toDim3())
         {
+#if 0
+            std::string const kernelName = typeid(m_kernel).name();
+            std::string const kernelInfo = kernelName + std::string(" [") + m_metaData.getFile() + std::string(":")
+                + std::to_string(m_metaData.getLine()) + std::string(" ]");
+
+            std::cout<<DataSpace<traits::GetNComponents<T_VectorGrid>::value>(gridExtent).toString()<<","<<DataSpace<traits::GetNComponents<T_VectorBlock>::value>(blockExtent).toString()<<" "<<kernelInfo<<std::endl;
+#endif
         }
 
         /** Enqueue the kernel functor with the given arguments for execution.

--- a/include/pmacc/particles/ParticleDescription.hpp
+++ b/include/pmacc/particles/ParticleDescription.hpp
@@ -37,7 +37,7 @@ namespace pmacc
      *
      * @tparam T_Name name of described particle (e.g. electron, ion)
      *                type must be a PMACC_CSTRING
-     * @tparam T_SuperCellSize compile time size of a super cell
+     * @tparam T_NumSlots compile time size of a super cell
      * @tparam T_ValueTypeSeq sequence or single type with value_identifier, must not have duplicates
      * @tparam T_Flags sequence or single type with identifier to add flags on a frame, must not have duplicates
      * @tparam T_MethodsList sequence or single class with particle methods
@@ -52,6 +52,7 @@ namespace pmacc
      */
     template<
         typename T_Name,
+        typename T_NumSlots,
         typename T_SuperCellSize,
         typename T_ValueTypeSeq,
         typename T_Flags = mp_list<>,
@@ -62,20 +63,13 @@ namespace pmacc
     struct ParticleDescription
     {
         using Name = T_Name;
+        using NumSlots = T_NumSlots;
         using SuperCellSize = T_SuperCellSize;
         using ValueTypeSeq = ToSeq<T_ValueTypeSeq>;
         using FlagsList = ToSeq<T_Flags>;
         using HandleGuardRegion = T_HandleGuardRegion;
         using MethodsList = ToSeq<T_MethodsList>;
         using FrameExtensionList = ToSeq<T_FrameExtensionList>;
-        using ThisType = ParticleDescription<
-            Name,
-            SuperCellSize,
-            ValueTypeSeq,
-            FlagsList,
-            HandleGuardRegion,
-            MethodsList,
-            FrameExtensionList>;
 
         // Compile-time check uniqueness of attributes and flags
         PMACC_CASSERT_MSG(
@@ -99,6 +93,7 @@ namespace pmacc
         using OldParticleDescription = T_OldParticleDescription;
         using type = ParticleDescription<
             typename OldParticleDescription::Name,
+            typename OldParticleDescription::NumSlots,
             typename OldParticleDescription::SuperCellSize,
             ToSeq<T_NewValueTypeSeq>,
             typename OldParticleDescription::FlagsList,
@@ -119,6 +114,7 @@ namespace pmacc
         using OldParticleDescription = T_OldParticleDescription;
         using type = ParticleDescription<
             typename OldParticleDescription::Name,
+            typename OldParticleDescription::NumSlots,
             typename OldParticleDescription::SuperCellSize,
             typename OldParticleDescription::ValueTypeSeq,
             typename OldParticleDescription::FlagsList,

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -71,12 +71,7 @@ namespace pmacc
         /* Policies for handling particles in guard cells */
         using HandleGuardRegion = typename ParticleDescription::HandleGuardRegion;
 
-        enum
-        {
-            Dim = MappingDesc::Dim,
-            Exchanges = traits::NumberOfExchanges<Dim>::value,
-            TileSize = math::CT::volume<typename MappingDesc::SuperCellSize>::type::value
-        };
+        static constexpr uint32_t dim = MappingDesc::Dim;
 
         /* Mark this simulation data as a particle type */
         using SimulationDataTag = ParticlesTag;
@@ -144,7 +139,7 @@ namespace pmacc
         {
             auto const mapper = mapperFactory(this->cellDescription);
 
-            auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<FrameType::frameSize>();
 
             PMACC_LOCKSTEP_KERNEL(KernelFillGaps{}, workerCfg)
             (mapper.getGridDim())(particlesBuffer->getDeviceParticleBox(), mapper);
@@ -232,7 +227,7 @@ namespace pmacc
             ParticlesBoxType pBox = particlesBuffer->getDeviceParticleBox();
             auto const numSupercellsWithGuards = particlesBuffer->getSuperCellsCount();
 
-            auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<FrameType::frameSize>();
             eventSystem::startTransaction(eventSystem::getTransactionEvent());
             do
             {

--- a/include/pmacc/particles/ParticlesBase.kernel
+++ b/include/pmacc/particles/ParticlesBase.kernel
@@ -73,7 +73,7 @@ namespace pmacc
         {
             using namespace particles::operations;
 
-            constexpr uint32_t frameSize = math::CT::volume<typename T_Mapping::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_ParBox::frameSize;
             constexpr uint32_t dim = T_Mapping::Dim;
 
             using FramePtr = typename T_ParBox::FramePtr;
@@ -198,7 +198,7 @@ namespace pmacc
 
             using FramePtr = typename T_ParBox::FramePtr;
 
-            constexpr uint32_t frameSize = math::CT::volume<typename T_ParBox::FrameType::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_ParBox::frameSize;
             constexpr uint32_t dim = T_Mapping::Dim;
 
             DataSpace<dim> const superCellIdx(
@@ -391,7 +391,7 @@ namespace pmacc
             using FramePtr = typename ParBox::FramePtr;
 
             PMACC_CONSTEXPR_CAPTURE uint32_t dim = Mapping::Dim;
-            constexpr uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_ParBox::frameSize;
             /* number exchanges in 2D=9 and in 3D=27 */
             constexpr uint32_t numExchanges = traits::NumberOfExchanges<dim>::value;
 
@@ -655,7 +655,7 @@ namespace pmacc
             using FramePtr = typename ParticleBox::FramePtr;
 
             constexpr uint32_t dim = T_Mapping::Dim;
-            constexpr uint32_t frameSize = math::CT::volume<typename FrameType::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = ParticleBox::frameSize;
 
             DataSpace<dim> const superCellIdx
                 = mapper.getSuperCellIndex(DataSpace<dim>(cupla::blockIdx(worker.getAcc())));
@@ -730,7 +730,7 @@ namespace pmacc
             using namespace particles::operations;
 
             PMACC_CONSTEXPR_CAPTURE uint32_t dim = T_Mapping::Dim;
-            constexpr uint32_t frameSize = math::CT::volume<typename T_ParBox::FrameType::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_ParBox::frameSize;
 
             using FramePtr = typename T_ParBox::FramePtr;
 
@@ -870,7 +870,7 @@ namespace pmacc
             using namespace particles::operations;
 
             PMACC_CONSTEXPR_CAPTURE uint32_t dim = T_Mapping::Dim;
-            constexpr uint32_t frameSize = math::CT::volume<typename T_ParBox::FrameType::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_ParBox::frameSize;
 
             using FramePtr = typename T_ParBox::FramePtr;
 

--- a/include/pmacc/particles/ParticlesBase.tpp
+++ b/include/pmacc/particles/ParticlesBase.tpp
@@ -37,7 +37,7 @@ namespace pmacc
     {
         ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
 
-        auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
+        auto workerCfg = lockstep::makeWorkerCfg<FrameType::frameSize>();
 
         PMACC_LOCKSTEP_KERNEL(KernelDeleteParticles{}, workerCfg)
         (mapper.getGridDim())(particlesBuffer->getDeviceParticleBox(), mapper);
@@ -49,7 +49,7 @@ namespace pmacc
     {
         auto const mapper = makeAreaMapper<T_area>(this->cellDescription);
 
-        auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
+        auto workerCfg = lockstep::makeWorkerCfg<FrameType::frameSize>();
 
         PMACC_LOCKSTEP_KERNEL(KernelDeleteParticles{}, workerCfg)
         (mapper.getGridDim())(particlesBuffer->getDeviceParticleBox(), mapper);
@@ -71,7 +71,7 @@ namespace pmacc
 
             particlesBuffer->getSendExchangeStack(exchangeType).setCurrentSize(0);
 
-            auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<FrameType::frameSize>();
 
             PMACC_LOCKSTEP_KERNEL(KernelCopyGuardToExchange{}, workerCfg)
             (mapper.getGridDim())(
@@ -96,7 +96,7 @@ namespace pmacc
             {
                 ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
 
-                auto workerCfg = lockstep::makeWorkerCfg(typename FrameType::SuperCellSize{});
+                auto workerCfg = lockstep::makeWorkerCfg<FrameType::frameSize>();
 
                 PMACC_LOCKSTEP_KERNEL(KernelInsertParticles{}, workerCfg)
                 (numParticles)(

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -58,8 +58,9 @@ namespace pmacc
         using FrameType = T_FrameType;
         using ValueTypeSeq = T_ValueTypeSeq;
         using Name = typename FrameType::Name;
+
+        // required to map local `cellIdx` to a cell within a supercell
         using SuperCellSize = typename FrameType::SuperCellSize;
-        using ThisType = Particle<FrameType, ValueTypeSeq>;
         using MethodsList = typename FrameType::MethodsList;
 
         /** pointer to parent frame where this particle is from
@@ -136,12 +137,12 @@ namespace pmacc
         }
 
         HDINLINE
-        ThisType& operator=(const ThisType& other) = default;
+        Particle& operator=(const Particle& other) = default;
 
     private:
         /* we disallow to assign this class*/
         template<typename T_OtherParticle>
-        HDINLINE ThisType& operator=(const T_OtherParticle& other);
+        HDINLINE Particle& operator=(const T_OtherParticle& other);
     };
 
     namespace traits

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -28,10 +28,12 @@
 
 namespace pmacc
 {
-    template<class T_FrameType>
+    template<typename T_FrameType, typename T_SuperCellSize>
     class SuperCell
     {
     public:
+        using SuperCellSize = T_SuperCellSize;
+
         HDINLINE SuperCell() : firstFramePtr(nullptr), lastFramePtr(nullptr)
         {
         }
@@ -74,7 +76,7 @@ namespace pmacc
             volatile
 #endif
         {
-            constexpr uint32_t frameSize = math::CT::volume<typename T_FrameType::SuperCellSize>::type::value;
+            constexpr uint32_t frameSize = T_FrameType::frameSize;
             return numParticles ? ((numParticles - 1u) % frameSize + 1u) : 0u;
         }
 

--- a/include/pmacc/particles/memory/frames/Frame.hpp
+++ b/include/pmacc/particles/memory/frames/Frame.hpp
@@ -66,18 +66,25 @@ namespace pmacc
     {
         using ParticleDescription = T_ParticleDescription;
         using Name = typename ParticleDescription::Name;
-        using SuperCellSize = typename ParticleDescription::SuperCellSize;
+        //! Number of particle slots within the frame
+        using NumSlots = typename ParticleDescription::NumSlots;
+        static constexpr uint32_t frameSize = NumSlots::value;
         using ValueTypeSeq = typename ParticleDescription::ValueTypeSeq;
         using MethodsList = typename ParticleDescription::MethodsList;
         using FlagList = typename ParticleDescription::FlagsList;
         using FrameExtensionList = typename ParticleDescription::FrameExtensionList;
-        using ThisType = Frame<T_CreatePairOperator, ParticleDescription>;
         /* definition of the MapTupel where we inherit from*/
         using BaseType = pmath::MapTuple<typename SeqToMap<ValueTypeSeq, T_CreatePairOperator>::type>;
 
         /* type of a single particle*/
-        using ParticleType = pmacc::Particle<ThisType>;
+        using ParticleType = pmacc::Particle<Frame>;
 
+        using SuperCellSize = typename ParticleDescription::SuperCellSize;
+        static_assert(
+            pmacc::math::CT::volume<SuperCellSize>::type::value <= frameSize,
+            "Cells per supercell must be <= the number of particle slots in a frame!");
+
+    public:
         /** access the Nth particle*/
         HDINLINE ParticleType operator[](const uint32_t idx)
         {

--- a/include/pmacc/particles/operations/ConcatListOfFrames.hpp
+++ b/include/pmacc/particles/operations/ConcatListOfFrames.hpp
@@ -103,7 +103,7 @@ namespace pmacc
                         typedef typename Mapping::SuperCellSize SuperCellSize;
 
 
-                        const int particlesPerFrame = pmacc::math::CT::volume<SuperCellSize>::type::value;
+                        const int particlesPerFrame = T_SrcBox::frameSize;
                         int localIdxs[particlesPerFrame];
 
                         const DataSpace<Mapping::Dim> superCellIdx = mapper.getSuperCellIndex(blockIndex);

--- a/include/pmacc/particles/operations/CountParticles.hpp
+++ b/include/pmacc/particles/operations/CountParticles.hpp
@@ -133,7 +133,7 @@ namespace pmacc
             GridBuffer<uint64_cu, DIM1> counter(DataSpace<DIM1>(1));
 
             auto const mapper = makeAreaMapper<AREA>(cellDescription);
-            auto workerCfg = lockstep::makeWorkerCfg(typename CellDesc::SuperCellSize{});
+            auto workerCfg = lockstep::makeWorkerCfg<PBuffer::FrameType::frameSize>();
 
             PMACC_LOCKSTEP_KERNEL(KernelCountParticles{}, workerCfg)
             (mapper.getGridDim())(

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -93,10 +93,10 @@ namespace pmacc
                         using SrcFrameType = T_SrcFrame;
                         using DestFrameType = typename T_DestBox::FrameType;
                         using DestFramePtr = typename T_DestBox::FramePtr;
-                        using SuperCellSize = typename DestFrameType::SuperCellSize;
+                        using SuperCellSize = typename T_CellDescription::SuperCellSize;
 
                         constexpr uint32_t numDims = T_DestBox::Dim;
-                        constexpr uint32_t particlesPerFrame = math::CT::volume<SuperCellSize>::type::value;
+                        constexpr uint32_t particlesPerFrame = T_DestBox::frameSize;
 
                         PMACC_SMEM(worker, destFramePtr, memory::Array<DestFramePtr, particlesPerFrame>);
                         PMACC_SMEM(worker, sharedLinearSuperCellIds, memory::Array<int, particlesPerFrame>);
@@ -290,9 +290,6 @@ namespace pmacc
                 T_CellDescription const& cellDesc,
                 T_LogLvl const& logLvl = T_LogLvl())
             {
-                using SuperCellSize = typename T_CellDescription::SuperCellSize;
-                uint32_t const cellsInSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
-
                 /* counter is used to apply for work, count used frames and count loaded particles
                  * [0] -> offset for loading particles
                  * [1] -> number of loaded particles
@@ -313,10 +310,11 @@ namespace pmacc
                     log(logLvl, "load particles on device chunk offset=%1%; chunk size=%2%; left particles %3%")
                         % (i * chunkSize) % currentChunkSize % leftOverParticles;
 
-                    auto workerCfg = lockstep::makeWorkerCfg(SuperCellSize{});
+                    constexpr uint32_t frameSize = T_SrcFrame::frameSize;
+                    auto workerCfg = lockstep::makeWorkerCfg<frameSize>();
 
                     PMACC_LOCKSTEP_KERNEL(detail::KernelSplitIntoListOfFrames{}, workerCfg)
-                    (math::float2int_ru(double(currentChunkSize) / double(cellsInSuperCell)))(
+                    (math::float2int_ru(double(currentChunkSize) / double(frameSize)))(
                         counterBuffer.getDeviceBuffer().getDataBox(),
                         destSpecies.getDeviceParticlesBox(),
                         srcFrame,

--- a/include/pmacc/particles/tasks/TaskParticlesReceive.hpp
+++ b/include/pmacc/particles/tasks/TaskParticlesReceive.hpp
@@ -38,11 +38,7 @@ namespace pmacc
         using HandleExchanged = typename HandleGuardRegion::HandleExchanged;
         using HandleNotExchanged = typename HandleGuardRegion::HandleNotExchanged;
 
-        enum
-        {
-            Dim = Particles::Dim,
-            Exchanges = traits::NumberOfExchanges<Dim>::value
-        };
+        static constexpr uint32_t dim = Particles::dim;
 
         TaskParticlesReceive(Particles& parBase) : parBase(parBase), state(Constructor)
         {
@@ -55,7 +51,8 @@ namespace pmacc
             HandleExchanged handleExchanged;
             HandleNotExchanged handleNotExchanged;
 
-            for(int i = 1; i < Exchanges; ++i)
+            static constexpr int32_t numExchanges = traits::NumberOfExchanges<dim>::value;
+            for(int i = 1; i < numExchanges; ++i)
             {
                 /* Start new transaction */
                 eventSystem::startTransaction(serialEvent);

--- a/include/pmacc/particles/tasks/TaskParticlesSend.hpp
+++ b/include/pmacc/particles/tasks/TaskParticlesSend.hpp
@@ -37,11 +37,7 @@ namespace pmacc
         using HandleExchanged = typename HandleGuardRegion::HandleExchanged;
         using HandleNotExchanged = typename HandleGuardRegion::HandleNotExchanged;
 
-        enum
-        {
-            Dim = Particles::Dim,
-            Exchanges = traits::NumberOfExchanges<Dim>::value
-        };
+        static constexpr uint32_t dim = Particles::dim;
 
         TaskParticlesSend(Particles& parBase) : parBase(parBase), state(Constructor)
         {
@@ -54,7 +50,8 @@ namespace pmacc
             HandleExchanged handleExchanged;
             HandleNotExchanged handleNotExchanged;
 
-            for(int i = 1; i < Exchanges; ++i)
+            static constexpr int32_t numExchanges = traits::NumberOfExchanges<dim>::value;
+            for(int i = 1; i < numExchanges; ++i)
             {
                 /* Start new transaction */
                 eventSystem::startTransaction(serialEvent);

--- a/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskReceiveParticlesExchange.hpp
@@ -34,12 +34,6 @@ namespace pmacc
     class TaskReceiveParticlesExchange : public MPITask
     {
     public:
-        enum
-        {
-            Dim = ParBase::Dim,
-            Exchanges = traits::NumberOfExchanges<Dim>::value
-        };
-
         TaskReceiveParticlesExchange(ParBase& parBase, uint32_t exchange)
             : parBase(parBase)
             , state(Constructor)

--- a/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
+++ b/include/pmacc/particles/tasks/TaskSendParticlesExchange.hpp
@@ -34,11 +34,6 @@ namespace pmacc
     class TaskSendParticlesExchange : public MPITask
     {
     public:
-        enum
-        {
-            Dim = ParBase::Dim,
-        };
-
         TaskSendParticlesExchange(ParBase& parBase, uint32_t exchange)
             : parBase(parBase)
             , state(Constructor)

--- a/include/pmacc/test/particles/memory/SuperCell.hpp
+++ b/include/pmacc/test/particles/memory/SuperCell.hpp
@@ -23,6 +23,8 @@
 
 #include <pmacc/particles/memory/dataTypes/SuperCell.hpp>
 
+#include <pmacc/math/vector/compile-time/Vector.hpp>
+
 
 namespace pmacc
 {
@@ -38,6 +40,7 @@ namespace pmacc
                     struct FrameTypeDummy
                     {
                         using SuperCellSize = T_SuperCell;
+                        static constexpr uint32_t frameSize = math::CT::volume<SuperCellSize>::type::value;
                     };
 
                     /** test a combination
@@ -48,7 +51,7 @@ namespace pmacc
                      */
                     HINLINE void operator()(uint32_t numParticlesPerCell, uint32_t particleLastFrame)
                     {
-                        pmacc::SuperCell<FrameTypeDummy> superCell;
+                        pmacc::SuperCell<FrameTypeDummy, typename FrameTypeDummy::SuperCellSize> superCell;
                         superCell.setNumParticles(numParticlesPerCell);
 
                         REQUIRE(superCell.getSizeLastFrame() == particleLastFrame);

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/memory.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/benchmarks/Thermal/include/picongpu/param/memory.param
+++ b/share/picongpu/benchmarks/Thermal/include/picongpu/param/memory.param
@@ -48,6 +48,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define the object for mapping superCells to cells*/
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FieldAbsorberTest/include/picongpu/param/memory.param
@@ -49,6 +49,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<2, 2, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -49,6 +49,8 @@ namespace picongpu
      * volume of a superCell must be <= 1024
      */
     using SuperCellSize = mCT::Int<16, 16>;
+
+    /** number of slots for particles within a frame */
     static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
     /** define mapper which is used for kernel call mappings */

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/memory.param
@@ -49,6 +49,7 @@ namespace picongpu
      * volume of a superCell must be <= 1024
      */
     using SuperCellSize = mCT::Int<16, 16>;
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define the object for mapping superCells to cells*/
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define the object for mapping superCells to cells*/
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/examples/atomicPhysics/include/picongpu/param/memory.param
+++ b/share/picongpu/examples/atomicPhysics/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<2, 2, 2>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/memory.param
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<16, 16, 1>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<16, 16, 1>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define the object for mapping superCells to cells*/
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 

--- a/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/memory.param
+++ b/share/picongpu/tests/compileCombinedAttributes/include/picongpu/param/memory.param
@@ -50,6 +50,9 @@ namespace picongpu
      */
     using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
 
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
     /** define mapper which is used for kernel call mappings */
     using MappingDesc = MappingDescription<simDim, SuperCellSize>;
 


### PR DESCRIPTION
- param-files: add `numFrameSlots` to set the number of particle slots per frame
- Refactor the PIConGPU extents for the random number factory used in PIConGPU.
  - each number of RNG states for each supercell is now dimensionless

# Update old setups:
  - add to `memory.param` after the definition of `SuperCellSize`

```C++
    /** number of slots for particles within a frame */
    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
```

# Refactorings required if you develop extensions for PIConGPU

There are now `numFrameSlots` RNG states per supercell available. Instead of mapping the worker ID to a cell within the supercell you should calculate the RNG state cell this way:

```C++
// offset of the superCell (in cells, without any guards) to the
// origin of the local domain
DataSpace<simDim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();
auto rngOffset = DataSpace<simDim>::create(0);
rngOffset.x() = worker.getWorkerIdx();
auto numRNGsPerSuperCell = DataSpace<simDim>::create(1);
numRNGsPerSuperCell.x() = numFrameSlots;
rngHandle.init(localSuperCellOffset * numRNGsPerSuperCell + rngOffset);
```