### PR TITLE
refactor memory boxes

### DIFF
--- a/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
+++ b/include/picongpu/fields/currentDeposition/EmZ/DepositCurrent.hpp
@@ -37,7 +37,7 @@ namespace picongpu
                 template<typename T_DataBox, typename T_Worker>
                 DINLINE void operator()(
                     T_Worker const& worker,
-                    const T_DataBox& fieldJ,
+                    T_DataBox fieldJ,
                     const Line<float3_X>& line,
                     const float_X chargeDensity) const
                 {
@@ -140,7 +140,7 @@ namespace picongpu
                 template<typename T_DataBox, typename T_Worker>
                 DINLINE void operator()(
                     T_Worker const& worker,
-                    const T_DataBox& fieldJ,
+                    T_DataBox fieldJ,
                     const Line<float2_X>& line,
                     const float_X chargeDensity) const
                 {

--- a/include/picongpu/fields/incidentField/Solver.kernel
+++ b/include/picongpu/fields/incidentField/Solver.kernel
@@ -95,16 +95,11 @@ namespace picongpu
                  * Performs update by adding terms with the incidentField.
                  * The positions, indices and coefficients for these terms are determined by members.
                  *
-                 * @tparam T_UpdatedFieldBox updatedField box type
                  * @tparam T_CurlIncidentField curl(incidentField) functor type
                  * @tparam T_FunctorIncidentField incidentField source functor type
                  * @tparam T_axis boundary axis, 0 = x, 1 = y, 2 = z
                  */
-                template<
-                    typename T_UpdatedFieldBox,
-                    typename T_CurlIncidentField,
-                    typename T_FunctorIncidentField,
-                    uint32_t T_axis>
+                template<typename T_CurlIncidentField, typename T_FunctorIncidentField, uint32_t T_axis>
                 struct UpdateFunctor
                 {
                     /** Create an update functor instance on the host side for the given time step
@@ -144,7 +139,9 @@ namespace picongpu
                      * @param isLastUpdatedCell whether the cell is the last updated globally along each direction,
                      *                          note it is always 3d, for 2d the last element must be false
                      */
+                    template<typename T_DestFieldDataBox>
                     HDINLINE void operator()(
+                        T_DestFieldDataBox destField,
                         pmacc::DataSpace<simDim> const& beginGridIdx,
                         pmacc::DataSpace<simDim> const& updatedGridIdx,
                         pmacc::math::Vector<bool, 3u> const& isLastUpdatedCell) const
@@ -158,15 +155,12 @@ namespace picongpu
                         auto const incidentFieldShift1 = incidentFieldShiftBase + inCellShift1;
                         auto const incidentFieldShift2 = incidentFieldShiftBase + inCellShift2;
                         auto const updatedFieldShift = (updatedGridIdx - huygensSurfaceIdx)[T_axis];
-                        updatedField(updatedGridIdx) += getUpdatedFieldCorrection(
+                        destField(updatedGridIdx) += getUpdatedFieldCorrection(
                             updatedFieldShift,
                             incidentFieldShift1,
                             incidentFieldShift2,
                             isLastUpdatedCell);
                     }
-
-                    //! UpdatedField box
-                    T_UpdatedFieldBox updatedField;
 
                     //! Derivative functor along T_axis type
                     using DerivativeFunctor
@@ -436,16 +430,19 @@ namespace picongpu
                      *
                      * @tparam T_Worker lockstep worker type
                      * @tparam T_UpdateFunctor update functor type
+                     * @tparam T_DestFieldDataBox type of the destination field box
                      *
                      * @param acc alpaka accelerator
                      * @param functor update functor
+                     * @param destField destination field
                      * @param beginGridIdx begin active grid index, in the local domain with guards
                      * @param endGridIdx end active grid index, in the local domain with guards
                      */
-                    template<typename T_Worker, typename T_UpdateFunctor>
+                    template<typename T_Worker, typename T_UpdateFunctor, typename T_DestFieldDataBox>
                     HDINLINE void operator()(
                         T_Worker const& worker,
-                        T_UpdateFunctor const functor,
+                        T_UpdateFunctor const& functor,
+                        T_DestFieldDataBox destField,
                         DataSpace<simDim> beginGridIdx,
                         DataSpace<simDim> endGridIdx) const
                     {
@@ -476,7 +473,7 @@ namespace picongpu
                                         = functor.isLastLocalDomain[d] && (updatedGridIdx[d] == endGridIdx[d] - 1);
                                 }
                                 if(isInside)
-                                    functor(beginGridIdx, updatedGridIdx, isLastUpdatedCell);
+                                    functor(destField, beginGridIdx, updatedGridIdx, isLastUpdatedCell);
                             });
                     }
                 };

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -95,7 +95,7 @@ namespace picongpu
             ISAAC_NO_HOST_DEVICE_WARNING
             ISAAC_HOST_DEVICE_INLINE isaac_float_dim<featureDim> operator[](const isaac_int3& nIndex) const
             {
-                auto value = shifted[nIndex.z][nIndex.y][nIndex.x];
+                auto value = shifted(DataSpace<DIM3>(nIndex.x, nIndex.y, nIndex.z));
                 return isaac_float_dim<featureDim>(value.x(), value.y(), value.z());
             }
         };
@@ -161,7 +161,7 @@ namespace picongpu
             ISAAC_NO_HOST_DEVICE_WARNING
             ISAAC_HOST_DEVICE_INLINE isaac_float_dim<featureDim> operator[](const isaac_int3& nIndex) const
             {
-                auto value = shifted[nIndex.z][nIndex.y][nIndex.x];
+                auto value = shifted(DataSpace<DIM3>(nIndex.x, nIndex.y, nIndex.z));
                 return isaac_float_dim<featureDim>(value.x());
             }
         };
@@ -212,7 +212,7 @@ namespace picongpu
             ISAAC_NO_HOST_DEVICE_WARNING
             ISAAC_HOST_DEVICE_INLINE isaac_float_dim<featureDim> operator[](const isaac_int3& nIndex) const
             {
-                auto value = shifted[nIndex.z][nIndex.y][nIndex.x];
+                auto value = shifted(DataSpace<DIM3>(nIndex.x, nIndex.y, nIndex.z));
                 return isaac_float_dim<featureDim>(value.x(), value.y(), value.z());
             }
         };

--- a/include/picongpu/simulation/stage/Collision.hpp
+++ b/include/picongpu/simulation/stage/Collision.hpp
@@ -65,7 +65,7 @@ namespace picongpu
                 {
                     using result = T_Type;
 
-                    HDINLINE result operator()(T_Type& vector) const
+                    HDINLINE result operator()(T_Type vector) const
                     {
                         using ScalarType = typename T_Type::type;
                         return T_Type(math::sqrt(static_cast<ScalarType>(vector)));

--- a/include/pmacc/memory/boxes/DataBox.hpp
+++ b/include/pmacc/memory/boxes/DataBox.hpp
@@ -27,48 +27,31 @@
 
 namespace pmacc
 {
-    namespace detail
-    {
-        template<typename DataBox>
-        HDINLINE decltype(auto) access(const DataBox& db, DataSpace<1> const& idx = {})
-        {
-            return db[idx.x()];
-        }
-
-        template<typename DataBox>
-        HDINLINE decltype(auto) access(const DataBox& db, DataSpace<2> const& idx = {})
-        {
-            return db[idx.y()][idx.x()];
-        }
-
-        template<typename DataBox>
-        HDINLINE decltype(auto) access(const DataBox& db, DataSpace<3> const& idx = {})
-        {
-            return db[idx.z()][idx.y()][idx.x()];
-        }
-    } // namespace detail
-
     template<typename Base>
     struct DataBox : Base
     {
-        HDINLINE DataBox() = default;
+        DataBox() = default;
 
         HDINLINE DataBox(Base base) : Base{std::move(base)}
         {
         }
 
-        HDINLINE DataBox(DataBox const&) = default;
+        DataBox(DataBox const&) = default;
 
         HDINLINE decltype(auto) operator()(DataSpace<Base::Dim> const& idx = {}) const
         {
-            ///@todo(bgruber): inline and replace this by if constexpr in C++17
-            return detail::access(*this, idx);
+            return Base::operator[](idx);
+        }
+
+        HDINLINE decltype(auto) operator()(DataSpace<Base::Dim> const& idx = {})
+        {
+            return Base::operator[](idx);
         }
 
         HDINLINE DataBox shift(DataSpace<Base::Dim> const& offset) const
         {
             DataBox result(*this);
-            result.fixedPointer = &((*this)(offset));
+            result.m_ptr = const_cast<typename Base::ValueType*>(&((*this)(offset)));
             return result;
         }
     };

--- a/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
+++ b/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
@@ -48,16 +48,26 @@ namespace pmacc
         {
         }
 
-        HDINLINE DataBoxDim1Access(DataBoxDim1Access const&) = default;
+        DataBoxDim1Access(DataBoxDim1Access const&) = default;
 
-        HDINLINE RefValueType operator()(DataSpace<DIM1> const& idx = {}) const
+        HDINLINE decltype(auto) operator()(DataSpace<DIM1> const& idx = {}) const
         {
             return (*this)[idx.x()];
         }
 
-        HDINLINE RefValueType operator[](const int idx) const
+        HDINLINE decltype(auto) operator()(DataSpace<DIM1> const& idx = {})
         {
-            return Base::operator()(DataSpaceOperations<Dim>::map(originalSize, idx));
+            return (*this)[idx.x()];
+        }
+
+        HDINLINE decltype(auto) operator[](const int idx) const
+        {
+            return Base::operator[](DataSpaceOperations<Dim>::map(originalSize, idx));
+        }
+
+        HDINLINE decltype(auto) operator[](const int idx)
+        {
+            return Base::operator[](DataSpaceOperations<Dim>::map(originalSize, idx));
         }
 
     private:

--- a/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
+++ b/include/pmacc/memory/boxes/DataBoxDim1Access.hpp
@@ -36,7 +36,6 @@ namespace pmacc
         using Base = T_Base;
         static constexpr std::uint32_t Dim = Base::Dim;
         using ValueType = typename Base::ValueType;
-        using RefValueType = typename Base::RefValueType;
 
         HDINLINE DataBoxDim1Access(DataSpace<Dim> const& originalSize) : Base(), originalSize(originalSize)
         {

--- a/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
@@ -55,7 +55,7 @@ namespace pmacc
         template<typename T_Index>
         HDINLINE ValueType operator()(const T_Index& idx) const
         {
-            return UnaryFunctor()(Base::operator()(idx));
+            return UnaryFunctor()(Base::operator[](idx));
         }
 
         template<typename T_Index>

--- a/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
+++ b/include/pmacc/memory/boxes/DataBoxUnaryTransform.hpp
@@ -41,7 +41,7 @@ namespace pmacc
         using Base = T_Base;
         using UnaryFunctor = T_UnaryFunctor<typename Base::ValueType>;
         using ValueType = typename UnaryFunctor::result;
-        using RefValueType = ValueType;
+
         static constexpr std::uint32_t Dim = Base::Dim;
 
         HDINLINE DataBoxUnaryTransform() = default;

--- a/include/pmacc/memory/boxes/PitchedBox.hpp
+++ b/include/pmacc/memory/boxes/PitchedBox.hpp
@@ -70,7 +70,7 @@ namespace pmacc
          * @param pitch line pitch in bytes
          */
         template<typename T_MemoryIdxType>
-        HDINLINE PitchedBox(T_Type* pointer, math::Vector<T_MemoryIdxType, T_dim> const& extent, size_t const pitch)
+        HDINLINE PitchedBox(ValueType* pointer, math::Vector<T_MemoryIdxType, T_dim> const& extent, size_t const pitch)
             : m_ptr(pointer)
         {
             m_pitch.x() = pitch;
@@ -88,15 +88,15 @@ namespace pmacc
          * @{
          */
         template<typename T_MemoryIdxType>
-        HDINLINE T_Type const& operator[](math::Vector<T_MemoryIdxType, T_dim> const& idx) const
+        HDINLINE ValueType const& operator[](math::Vector<T_MemoryIdxType, T_dim> const& idx) const
         {
             return *ptr(idx);
         }
 
         template<typename T_MemoryIdxType>
-        HDINLINE T_Type& operator[](math::Vector<T_MemoryIdxType, T_dim> const& idx)
+        HDINLINE RefValueType operator[](math::Vector<T_MemoryIdxType, T_dim> const& idx)
         {
-            return *const_cast<T_Type*>(ptr(idx));
+            return *const_cast<ValueType*>(ptr(idx));
         }
 
         /** }@ */
@@ -109,20 +109,20 @@ namespace pmacc
          * @return pointer to value
          */
         template<typename T_MemoryIdxType>
-        HDINLINE T_Type const* ptr(math::Vector<T_MemoryIdxType, T_dim> const& idx) const
+        HDINLINE ValueType const* ptr(math::Vector<T_MemoryIdxType, T_dim> const& idx) const
         {
             /** offset in bytes
              *
              * We calculate the complete offset in bytes even if it would be possible to change the x-dimension with
              * the native types pointer, this is reducing the register footprint.
              */
-            size_t offset = sizeof(T_Type) * idx.x();
+            size_t offset = sizeof(ValueType) * idx.x();
             for(uint32_t d = 1u; d < T_dim; ++d)
                 offset += m_pitch[d - 1u] * idx[d];
-            return reinterpret_cast<T_Type const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
+            return reinterpret_cast<ValueType const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
         }
 
-        PMACC_ALIGN(m_ptr, T_Type*);
+        PMACC_ALIGN(m_ptr, ValueType*);
         PMACC_ALIGN(m_pitch, math::Vector<size_t, T_dim - 1>);
     };
 
@@ -169,14 +169,14 @@ namespace pmacc
          */
         template<typename T_MemoryIdxType>
         HDINLINE PitchedBox(
-            T_Type* pointer,
+            ValueType* pointer,
             [[maybe_unused]] math::Vector<T_MemoryIdxType, DIM1> const& extent,
             [[maybe_unused]] size_t const pitch)
             : m_ptr(pointer)
         {
         }
 
-        HDINLINE PitchedBox(T_Type* pointer) : m_ptr(pointer)
+        HDINLINE PitchedBox(ValueType* pointer) : m_ptr(pointer)
         {
         }
 
@@ -189,22 +189,22 @@ namespace pmacc
          * @return reference to the value
          * @{
          */
-        HDINLINE T_Type const& operator[](int const idx) const
+        HDINLINE ValueType const& operator[](int const idx) const
         {
             return *(m_ptr + idx);
         }
 
-        HDINLINE T_Type& operator[](int const idx)
+        HDINLINE RefValueType operator[](int const idx)
         {
             return *(m_ptr + idx);
         }
 
-        HDINLINE T_Type const& operator[](DataSpace<DIM1> const& idx) const
+        HDINLINE ValueType const& operator[](DataSpace<DIM1> const& idx) const
         {
             return *(m_ptr + idx.x());
         }
 
-        HDINLINE T_Type& operator[](DataSpace<DIM1> const& idx)
+        HDINLINE RefValueType operator[](DataSpace<DIM1> const& idx)
         {
             return *(m_ptr + idx.x());
         }
@@ -212,6 +212,6 @@ namespace pmacc
         /** @} */
 
     protected:
-        PMACC_ALIGN(m_ptr, T_Type*);
+        PMACC_ALIGN(m_ptr, ValueType*);
     };
 } // namespace pmacc

--- a/include/pmacc/memory/boxes/PitchedBox.hpp
+++ b/include/pmacc/memory/boxes/PitchedBox.hpp
@@ -23,154 +23,195 @@
 #pragma once
 
 #include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc
 {
-    template<typename TYPE, unsigned DIM>
-    class PitchedBox;
-
-    namespace detail
+    template<typename T_Type, uint32_t T_dim>
+    struct PitchedBox
     {
-        template<typename TYPE, unsigned DIM>
-        struct PitchedBoxCommon
-        {
-            static constexpr std::uint32_t Dim = DIM;
-            using ValueType = TYPE;
-            using RefValueType = ValueType&;
+        static constexpr std::uint32_t Dim = T_dim;
+        using ValueType = T_Type;
+        using RefValueType = ValueType&;
 
-            HDINLINE PitchedBoxCommon(TYPE* p = nullptr) : fixedPointer(p)
-            {
-            }
-
-            HDINLINE PitchedBoxCommon(PitchedBoxCommon const&) = default;
-
-            /*!return the first value in the box (list)
-             * @return first value
-             */
-            HDINLINE RefValueType operator*()
-            {
-                return *fixedPointer;
-            }
-
-            HDINLINE TYPE const* getPointer() const
-            {
-                return fixedPointer;
-            }
-
-            HDINLINE TYPE* getPointer()
-            {
-                return fixedPointer;
-            }
-
-        protected:
-            PMACC_ALIGN(fixedPointer, TYPE*);
-        };
-    } // namespace detail
-
-    template<typename TYPE>
-    class PitchedBox<TYPE, DIM1> : public detail::PitchedBoxCommon<TYPE, DIM1>
-    {
-        using Base = detail::PitchedBoxCommon<TYPE, DIM1>;
-
-    public:
-        using ReducedType = PitchedBox<TYPE, DIM1>;
-
-        /*Object must init by copy a valid instance*/
-        HDINLINE PitchedBox() = default;
-
-        HDINLINE PitchedBox(TYPE* pointer) : Base{pointer}
-        {
-        }
-
-        HDINLINE PitchedBox(PitchedBox const&) = default;
-
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM1>& /*memSize*/, const size_t /*pitch*/) : Base(pointer)
-        {
-        }
-
-        HDINLINE TYPE& operator[](const int idx) const
-        {
-            return this->fixedPointer[idx];
-        }
-    };
-
-    template<typename TYPE>
-    class PitchedBox<TYPE, DIM2> : public detail::PitchedBoxCommon<TYPE, DIM2>
-    {
-        using Base = detail::PitchedBoxCommon<TYPE, DIM2>;
-
-    public:
-        using ReducedType = PitchedBox<TYPE, DIM1>;
-
-        /*Object must init by copy a valid instance*/
-        HDINLINE PitchedBox() = default;
-
-        HDINLINE PitchedBox(TYPE* pointer, size_t pitch) : Base{pointer}, pitch(pitch)
-        {
-        }
-
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM2>& /*memSize*/, const size_t pitch)
-            : Base{pointer}
-            , pitch(pitch)
-        {
-        }
-
-        HDINLINE PitchedBox(PitchedBox const&) = default;
-
-        HDINLINE ReducedType operator[](const int idx) const
-        {
-            return ReducedType((TYPE*) ((char*) this->fixedPointer + idx * pitch));
-        }
-
-    protected:
-        PMACC_ALIGN(pitch, size_t);
-    };
-
-    template<typename TYPE>
-    class PitchedBox<TYPE, DIM3> : public detail::PitchedBoxCommon<TYPE, DIM3>
-    {
-        using Base = detail::PitchedBoxCommon<TYPE, DIM3>;
-
-    public:
-        using ReducedType = PitchedBox<TYPE, DIM2>;
-
-        /*Object must init by copy a valid instance*/
-        HDINLINE PitchedBox() = default;
-
-        HDINLINE PitchedBox(TYPE* pointer, const size_t pitch, const size_t pitch2D)
-            : Base{pointer}
-            , pitch(pitch)
-            , pitch2D(pitch2D)
-        {
-        }
-
-        /** constructor
+        /** return value the origin pointer is pointing to
          *
-         * @param pointer pointer to the origin of the physical memory
-         * @param offset offset (in elements)
-         * @param memSize size of the physical memory (in elements)
-         * @param pitch number of bytes in one line (first dimension)
+         * @return value at the current location
          */
-        ///@todo(bgruber): is this functionality not provide by DataBox::shift?
-        HDINLINE PitchedBox(TYPE* pointer, const DataSpace<DIM3>& memSize, const size_t pitch)
-            : Base{pointer}
-            , pitch(pitch)
-            , pitch2D(memSize[1] * pitch)
+        HDINLINE RefValueType operator*()
         {
+            return *this->m_ptr;
         }
 
-        HDINLINE PitchedBox(PitchedBox const&) = default;
-
-        HDINLINE ReducedType operator[](const int idx) const
+        /** get origin pointer
+         *
+         * @{
+         */
+        HDINLINE ValueType const* getPointer() const
         {
-            return ReducedType((TYPE*) ((char*) (this->fixedPointer) + idx * pitch2D), pitch);
+            return this->m_ptr;
         }
+
+        HDINLINE ValueType* getPointer()
+        {
+            return this->m_ptr;
+        }
+        /** @} */
+
+        /*Object must init by copy a valid instance*/
+        PitchedBox() = default;
+
+        /** Constructor
+         *
+         * @tparam T_MemoryIdxType Index type
+         * @param pointer pointer to the memory
+         * @param extent extent of the memory in elements
+         * @param pitch line pitch in bytes
+         */
+        template<typename T_MemoryIdxType>
+        HDINLINE PitchedBox(T_Type* pointer, math::Vector<T_MemoryIdxType, T_dim> const& extent, size_t const pitch)
+            : m_ptr(pointer)
+        {
+            m_pitch.x() = pitch;
+            for(uint32_t d = 1; d < T_dim - 1; ++d)
+                m_pitch[d] = m_pitch[d - 1u] * static_cast<size_t>(extent[d]);
+        }
+
+        PitchedBox(PitchedBox const&) = default;
+
+        /** get value at the given index
+         *
+         * @tparam T_MemoryIdxType Index type
+         * @param idx n-dimensional offset, relative to the origin pointer
+         * @return reference to the value
+         * @{
+         */
+        template<typename T_MemoryIdxType>
+        HDINLINE T_Type const& operator[](math::Vector<T_MemoryIdxType, T_dim> const& idx) const
+        {
+            return *ptr(idx);
+        }
+
+        template<typename T_MemoryIdxType>
+        HDINLINE T_Type& operator[](math::Vector<T_MemoryIdxType, T_dim> const& idx)
+        {
+            return *const_cast<T_Type*>(ptr(idx));
+        }
+
+        /** }@ */
 
     protected:
-        PMACC_ALIGN(pitch, size_t);
-        PMACC_ALIGN(pitch2D, size_t);
+        /** get the pointer of the value relative to the origin pointer m_ptr
+         *
+         * @tparam T_MemoryIdxType Index type
+         * @param idx n-dimensional offset
+         * @return pointer to value
+         */
+        template<typename T_MemoryIdxType>
+        HDINLINE T_Type const* ptr(math::Vector<T_MemoryIdxType, T_dim> const& idx) const
+        {
+            /** offset in bytes
+             *
+             * We calculate the complete offset in bytes even if it would be possible to change the x-dimension with
+             * the native types pointer, this is reducing the register footprint.
+             */
+            size_t offset = sizeof(T_Type) * idx.x();
+            for(uint32_t d = 1u; d < T_dim; ++d)
+                offset += m_pitch[d - 1u] * idx[d];
+            return reinterpret_cast<T_Type const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
+        }
+
+        PMACC_ALIGN(m_ptr, T_Type*);
+        PMACC_ALIGN(m_pitch, math::Vector<size_t, T_dim - 1>);
     };
 
+    template<typename T_Type>
+    struct PitchedBox<T_Type, DIM1>
+    {
+        static constexpr std::uint32_t Dim = DIM1;
+        using ValueType = T_Type;
+        using RefValueType = ValueType&;
 
+        /** return value the origin pointer is pointing to
+         *
+         * @return value at the current location
+         */
+        HDINLINE RefValueType operator*()
+        {
+            return *this->m_ptr;
+        }
+
+        /** get origin pointer
+         *
+         * @{
+         */
+        HDINLINE ValueType const* getPointer() const
+        {
+            return this->m_ptr;
+        }
+
+        HDINLINE ValueType* getPointer()
+        {
+            return this->m_ptr;
+        }
+        /** @} */
+
+        /*Object must init by copy a valid instance*/
+        PitchedBox() = default;
+
+        /** Constructor
+         *
+         * @tparam T_MemoryIdxType Index type
+         * @param pointer pointer to the memory
+         * @param extent extent of the memory in elements
+         * @param pitch line pitch in bytes
+         */
+        template<typename T_MemoryIdxType>
+        HDINLINE PitchedBox(
+            T_Type* pointer,
+            [[maybe_unused]] math::Vector<T_MemoryIdxType, DIM1> const& extent,
+            [[maybe_unused]] size_t const pitch)
+            : m_ptr(pointer)
+        {
+        }
+
+        HDINLINE PitchedBox(T_Type* pointer) : m_ptr(pointer)
+        {
+        }
+
+        PitchedBox(PitchedBox const&) = default;
+
+        /** get value at the given index
+         *
+         * @tparam T_MemoryIdxType Index type
+         * @param idx offset relative to the origin pointer
+         * @return reference to the value
+         * @{
+         */
+        HDINLINE T_Type const& operator[](int const idx) const
+        {
+            return *(m_ptr + idx);
+        }
+
+        HDINLINE T_Type& operator[](int const idx)
+        {
+            return *(m_ptr + idx);
+        }
+
+        HDINLINE T_Type const& operator[](DataSpace<DIM1> const& idx) const
+        {
+            return *(m_ptr + idx.x());
+        }
+
+        HDINLINE T_Type& operator[](DataSpace<DIM1> const& idx)
+        {
+            return *(m_ptr + idx.x());
+        }
+
+        /** @} */
+
+    protected:
+        PMACC_ALIGN(m_ptr, T_Type*);
+    };
 } // namespace pmacc

--- a/include/pmacc/particles/algorithm/ForEach.hpp
+++ b/include/pmacc/particles/algorithm/ForEach.hpp
@@ -296,7 +296,7 @@ namespace pmacc::particles::algorithm
 
             DINLINE uint32_t numParticles() const
             {
-                auto& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
+                auto const& superCell = m_particlesBox.getSuperCell(m_superCellIdx);
                 return superCell.getNumParticles();
             }
         };

--- a/include/pmacc/particles/memory/boxes/ExchangePopDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePopDataBox.hpp
@@ -48,7 +48,7 @@ namespace pmacc
             PopType tmp = virtualMemory[idx];
 
             superCell = tmp.getSuperCell();
-            return TileDataBox<VALUE>(this->fixedPointer, DataSpace<DIM1>(tmp.getStartIndex()), tmp.getCount());
+            return TileDataBox<VALUE>(this->m_ptr, DataSpace<DIM1>(tmp.getStartIndex()), tmp.getCount());
         }
 
     protected:

--- a/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ExchangePushDataBox.hpp
@@ -91,7 +91,7 @@ namespace pmacc
             tmp[0].setSuperCell(superCell);
             tmp[0].setCount(count);
             tmp[0].setStartIndex(oldSize);
-            return TileDataBox<VALUE>(this->fixedPointer, DataSpace<DIM1>(oldSize), count);
+            return TileDataBox<VALUE>(this->m_ptr, DataSpace<DIM1>(oldSize), count);
         }
 
 

--- a/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
+++ b/include/pmacc/particles/memory/boxes/ParticlesBox.hpp
@@ -135,7 +135,7 @@ namespace pmacc
         }
 
         HDINLINE
-        FramePtr mapPtr(const FramePtr& devPtr) const
+        FramePtr mapPtr(FramePtr devPtr) const
         {
 #if(CUPLA_DEVICE_COMPILE == 1)
             return devPtr;
@@ -298,7 +298,12 @@ namespace pmacc
             return false;
         }
 
-        HDINLINE SuperCellType& getSuperCell(DataSpace<DIM> idx) const
+        HDINLINE decltype(auto) getSuperCell(DataSpace<DIM> idx) const
+        {
+            return BaseType::operator()(idx);
+        }
+
+        HDINLINE decltype(auto) getSuperCell(DataSpace<DIM> idx)
         {
             return BaseType::operator()(idx);
         }

--- a/include/pmacc/particles/memory/boxes/PushDataBox.hpp
+++ b/include/pmacc/particles/memory/boxes/PushDataBox.hpp
@@ -73,7 +73,7 @@ namespace pmacc
         HDINLINE TileDataBox<VALUE> pushN(T_Worker const& worker, TYPE count, T_Hierarchy const& hierarchy)
         {
             TYPE old_addr = cupla::atomicAdd(worker.getAcc(), currentSize, count, hierarchy);
-            return TileDataBox<VALUE>(this->fixedPointer, DataSpace<DIM1>(old_addr));
+            return TileDataBox<VALUE>(this->m_ptr, DataSpace<DIM1>(old_addr));
         }
 
         /** Adds a value to the stack in an atomic operation.

--- a/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
+++ b/include/pmacc/particles/memory/dataTypes/SuperCell.hpp
@@ -46,12 +46,12 @@ namespace pmacc
             return lastFramePtr;
         }
 
-        HDINLINE T_FrameType const* FirstFramePtr() const
+        HDINLINE T_FrameType* FirstFramePtr() const
         {
             return firstFramePtr;
         }
 
-        HDINLINE T_FrameType const* LastFramePtr() const
+        HDINLINE T_FrameType* LastFramePtr() const
         {
             return lastFramePtr;
         }
@@ -66,7 +66,7 @@ namespace pmacc
             mustShiftVal = value;
         }
 
-        HDINLINE uint32_t getSizeLastFrame()
+        HDINLINE uint32_t getSizeLastFrame() const
 #if(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) == 502)
             /* ROCm 5.2.0 producing particle loss in KernelShiftParticles if this method is defined as `const`.
              * see: https://github.com/ComputationalRadiationPhysics/picongpu/issues/4305
@@ -78,7 +78,7 @@ namespace pmacc
             return numParticles ? ((numParticles - 1u) % frameSize + 1u) : 0u;
         }
 
-        HDINLINE uint32_t getNumParticles()
+        HDINLINE uint32_t getNumParticles() const
 #if(ALPAKA_ACC_GPU_HIP_ENABLED == 1 && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) == 502)
             /* ROCm 5.2.0 producing particle loss in KernelShiftParticles if this method is defined as `const`.
              * see: https://github.com/ComputationalRadiationPhysics/picongpu/issues/4305

--- a/include/pmacc/random/RNGHandle.hpp
+++ b/include/pmacc/random/RNGHandle.hpp
@@ -90,7 +90,7 @@ namespace pmacc
             }
 
         protected:
-            PMACC_ALIGN8(m_rngBox, RNGBox);
+            PMACC_ALIGN(m_rngBox, RNGBox);
         };
 
     } // namespace random

--- a/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -211,8 +211,8 @@ namespace gol
             {
                 for(int x = 0; x < srcSize.x(); ++x)
                 {
-                    dst[y + offsetToSimNull.y()][x + offsetToSimNull.x()]
-                        = src[nodeGuardCells.y() + y][nodeGuardCells.x() + x];
+                    dst[Space{x + offsetToSimNull.x(), y + offsetToSimNull.y()}]
+                        = src[Space{nodeGuardCells.x() + x, nodeGuardCells.y() + y}];
                 }
             }
         }

--- a/share/pmacc/examples/gameOfLife2D/include/PngCreator.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/PngCreator.hpp
@@ -41,7 +41,7 @@ namespace gol
             {
                 for(int x = 0; x < dataSize.x(); ++x)
                 {
-                    float p = data[y][x];
+                    float p = data[Space(x, y)];
                     png.plot(x + 1, dataSize.y() - y, p, p, p);
                 }
             }


### PR DESCRIPTION
Rewrite `PicthedBox` and `SharedBox` to avoid explicit specializations for each dimension.
`PitchedBox` still used a specialization for the one-dimensional memory to reduce the memory footprint.
The address calculation is simplified by using a `n - 1 `-dimensional pitch vector.

This PR is reducing the register footprint for many kernels running on NVIDIA GPUs. The constant memory footprint is slightly increased.
Short tests and a profile of the KHI example do not show performance regressions.