### PR TITLE
rename unit current to unit current density

### DIFF
--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -189,8 +189,8 @@ namespace picongpu
     HDINLINE
     FieldJ::UnitValueType FieldJ::getUnit()
     {
-        const float_64 UNIT_CURRENT_DENSITY = UNIT_CHARGE / UNIT_TIME / (UNIT_LENGTH * UNIT_LENGTH);
-        return UnitValueType(UNIT_CURRENT_DENSITY, UNIT_CURRENT_DENSITY, UNIT_CURRENT_DENSITY);
+        const float_64 unitCurrentDensity = UNIT_CHARGE / UNIT_TIME / (UNIT_LENGTH * UNIT_LENGTH);
+        return UnitValueType(unitCurrentDensity, unitCurrentDensity, unitCurrentDensity);
     }
 
     HINLINE

--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -189,8 +189,8 @@ namespace picongpu
     HDINLINE
     FieldJ::UnitValueType FieldJ::getUnit()
     {
-        const float_64 UNIT_CURRENT = UNIT_CHARGE / UNIT_TIME / (UNIT_LENGTH * UNIT_LENGTH);
-        return UnitValueType(UNIT_CURRENT, UNIT_CURRENT, UNIT_CURRENT);
+        const float_64 UNIT_CURRENT_DENSITY = UNIT_CHARGE / UNIT_TIME / (UNIT_LENGTH * UNIT_LENGTH);
+        return UnitValueType(UNIT_CURRENT_DENSITY, UNIT_CURRENT_DENSITY, UNIT_CURRENT_DENSITY);
     }
 
     HINLINE


### PR DESCRIPTION
After a lengthy discussion today, @ikbuibui, @psychocoderHPC, @BrianMarre and @PrometheusPi found out that the naming of a unit conversion factor in the current density kernel was wrong and resulted in a lot of confusion. 

This pull request fixes the naming. 