### PR TITLE
remove missed references to master branch

### DIFF
--- a/docs/COMMIT.md
+++ b/docs/COMMIT.md
@@ -4,7 +4,7 @@ PIConGPU Commit Rulez
 We agree on the following simple rules to make our lives easier :)
 
 - Stick to the **style** below for **commit messages**
-- **Commit compiling patches** for the `dev` branche,
+- **Commit compiling patches** for the `dev` branch,
   you can be less strict for (unshared) *topic branches*
 - Commits should be formated with clang-format-12 (version 12.0.1)
 

--- a/docs/COMMIT.md
+++ b/docs/COMMIT.md
@@ -4,7 +4,7 @@ PIConGPU Commit Rulez
 We agree on the following simple rules to make our lives easier :)
 
 - Stick to the **style** below for **commit messages**
-- **Commit compiling patches** for the *main* branches (`master` and `dev`),
+- **Commit compiling patches** for the `dev` branche,
   you can be less strict for (unshared) *topic branches*
 - Commits should be formated with clang-format-12 (version 12.0.1)
 

--- a/docs/source/dev/repostructure.rst
+++ b/docs/source/dev/repostructure.rst
@@ -8,7 +8,6 @@ Repository Structure
 Branches
 --------
 
-* ``master``: the latest stable release, always tagged with a version
 * ``dev``: the development branch where all features start from and are merged to
 * ``release-X.Y.Z``: release candiate for version ``X.Y.Z`` with an upcoming release, receives updates for bug fixes and documentation such as change logs but usually no new features
 

--- a/docs/source/tutorials/hemeraIn5min.rst
+++ b/docs/source/tutorials/hemeraIn5min.rst
@@ -46,13 +46,11 @@ Use :command:`git` to obtain the source and use the current ``dev`` branch and p
 
   mkdir -p ~/src
   git clone https://github.com/ComputationalRadiationPhysics/picongpu ~/src/picongpu
-  cd ~/src/picongpu
-  git checkout dev
 
 .. note::
    If you get the error ``git: command not found`` load git by invoking ``module load git`` and try again.
-   Attention: the example uses the ``dev`` branch instead of the latest stable release ``master``.
-   Due to driver changes on hemera the master branch modules configuration is outdated.
+   Attention: the example uses the ``dev`` branch instead of the latest stable release.
+   Due to driver changes on hemera the modules configuration of the last release might be outdated.
 
 Setup
 -----


### PR DESCRIPTION
After the removal of the `master` branch and the removal of several references to that branch in the docs #4677, some references still stayed in the documentation. This pull request removes those forgotten references. 