### PR TITLE
fix interactive call in 5min tutorial

### DIFF
--- a/docs/source/tutorials/hemeraIn5min.rst
+++ b/docs/source/tutorials/hemeraIn5min.rst
@@ -146,12 +146,13 @@ If this fails, read the manual or ask a colleague.
 
 After a successfull build, run (still on the compute node, still inside your scenario directory)::
 
-  tbg -s bash -c etc/picongpu/1.cfg -t etc/picongpu/bash/mpiexec.tpl $SCRATCH/tinkering/try01/run01
+  tbg -s bash -t $PICSRC/etc/picongpu/bash/mpiexec.tpl -c /etc/picongpu/1.cfg $SCRATCH/tinkering/try01/run01
 
 - :command:`tbg`: tool provided by PIConGPU
 - ``bash``: the “submit system”, e.g. use ``sbatch`` for slurm
+- ``$PICSRC``: the path to your PIConGPU source code, automatically set when sourcing :file:`k80_picongpu.profile`
+- :file:`$PICSRC/etc/picongpu/bash/mpiexec.tpl`: options for the chosen submit system
 - :file:`etc/picongpu/1.cfg`: runtime options (number of GPUs, etc.)
-- :file:`etc/picongpu/bash/mpiexec.tpl`: options for the chosen submit system
 - :file:`$SCRATCH/tinkering/try01/run01`: not-yet-existing destination for your result files
 
 .. note::
@@ -173,6 +174,7 @@ After a successfull build, run (still on the compute node, still inside your sce
 
    Note that we not only used a different "submit system" ``sbatch``,
    but also changed the template file to :file:`etc/picongpu/hemera-hzdr/k80.tpl`.
+   (This template file is directly located in your project directory.`)
    Both profile and template file are built for the same compute device, the NVIDIA Tesla "K80" GPU.
    
 

--- a/docs/source/tutorials/hemeraIn5min.rst
+++ b/docs/source/tutorials/hemeraIn5min.rst
@@ -35,7 +35,7 @@ We will use the following directories:
 - :file:`~/src/picongpu`: source files from github
 - :file:`~/k80_picongpu.profile`: load the dependencies for your local environment
 - :file:`~/picongpu-projects`: scenarios to simulate
-- :file:`/bigdata/hplsim/extern/alice`: result data of the simulation runs (*scratch* storage)
+- :file:`/bigdata/hplsim/external/alice`: result data of the simulation runs (*scratch* storage)
 
 Please replace them whenever appropriate.
 
@@ -74,7 +74,7 @@ Edit the profile file using your favorite editor.
 If unsure use nano: ``nano ~/k80_picongpu.profile`` (save with :kbd:`Control-o`, exit with :kbd:`Control-x`).
 Go to the end of the file and add a new line::
 
-  export SCRATCH=/bigdata/hplsim/extern/alice
+  export SCRATCH=/bigdata/hplsim/external/alice
 
 (Please replace ``alice`` with your username.)
 
@@ -191,7 +191,7 @@ To view pretty pictures from a linux workstation you can use the following proce
   # Mount the data directory using sshfs
   sshfs -o default_permissions -o idmap=user -o uid=$(id -u) -o gid=$(id -g) hemera5:DATADIR ~/mnt/scratch/
 
-Substitute DATADIR with the full path to your data (*scratch*) directory, e.g. :file:`/bigdata/hplsim/extern/alice`.
+Substitute DATADIR with the full path to your data (*scratch*) directory, e.g. :file:`/bigdata/hplsim/external/alice`.
 
 Browse the directory using a file browser/image viewer.
 Check out :file:`~/mnt/scratch/tinkering/try01/run01/simOutput/pngElectronsYX/` for image files.


### PR DESCRIPTION
@max-lehman14 found out that after #4515 we do not copy the `bash` templates when calling `pic-create`. This results in a problem, when following the 5 minutes on hemera tutorial, where the `mpiexec.tpl` is used to run interactively.   

This pull request provided a workaround for the tutorial. 