### PR TITLE
simplify output structure colorimeter plugin 

### DIFF
--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2016-2023 Heiko Burau, Rene Widera, Sergei Bastrakov
+/* Copyright 2016-2023 Heiko Burau, Rene Widera, Sergei Bastrakov,
+ * Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -353,7 +354,7 @@ namespace picongpu
                 this->calorimeterFrameVecY,
                 this->calorimeterFrameVecZ);
 
-            /* create folder for hdf5 files*/
+            /* create folder for openPMD files*/
             Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(this->foldername);
 
             // set how often the plugin should be executed while PIConGPU is running
@@ -527,9 +528,8 @@ namespace picongpu
             , m_cellDescription(cellDescription)
             , leftParticlesDatasetName("calorimeterLeftParticles")
         {
-            foldername = m_help->getOptionPrefix() + "/" + m_help->filter.get(m_id);
-            filenamePrefix
-                = m_help->getOptionPrefix() + "_" + m_help->fileName.get(m_id) + "_" + m_help->filter.get(m_id);
+            foldername = m_help->getOptionPrefix() + "/";
+            filenamePrefix = m_help->getOptionPrefix() + "_" + m_help->filter.get(m_id);
             filenameExtension = m_help->extension.get(m_id);
             numBinsYaw = m_help->numBinsYaw.get(m_id);
             numBinsPitch = m_help->numBinsPitch.get(m_id);


### PR DESCRIPTION
The openPMD output of the calorimeter plugin had an unusual file name and sub-directory structure.

Currently, it looks like:
```
e_calorimeter/
└── all
    ├── e_calorimeter_bp_all_0.bp
    ├── e_calorimeter_bp_all_100.bp
```

 - with a subdirectory for every filter **and** the filter name in the file name
 - and with the file format at the end and in the middle of the file name
 
 This pull request changes this to a more common form with no duplications:
 ``` 
 e_calorimeter/
├── e_calorimeter_all_0.bp
├── e_calorimeter_all_100.bp
```
- no subdirectory for filters - filter names are only in the file name
- file format only at the end of the file


