### PR TITLE
add missing euler number in ADK formula

### DIFF
--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -127,6 +127,7 @@ Leaving out the pre-factor distinguishes ``ADKCircPol`` from ``ADKLinPol``.
     .. attention::
 
         Be aware that :math:`Z` denotes the **residual ion charge** and not the proton number of the nucleus!
+        Be aware that :math:`e` in :math:`D` denotes Euler's number, not the elementary charge
 
 In the following comparison one can see the ``ADKLinPol`` ionization rates for the transition from Carbon II to III (meaning 1+ to 2+).
 For a reference the rates for Hydrogen as well as the barrier suppression field strengths :math:`F_\mathrm{BSI}` have been plotted.

--- a/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/AlgorithmADK.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2023 Marco Garten, Jakob Trojok
+/* Copyright 2015-2023 Marco Garten, Jakob Trojok, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -93,7 +93,8 @@ namespace picongpu
                         /* effective principal quantum number (unitless) */
                         float_X const nEff = effectiveCharge / math::sqrt(float_X(2.0) * iEnergy);
                         /* nameless variable for convenience dFromADK*/
-                        float_X const dBase = float_X(4.0) * util::cube(effectiveCharge) / (eInAU * util::quad(nEff));
+                        float_X const dBase = float_X(4.0) * math::exp(1._X) * util::cube(effectiveCharge)
+                            / (eInAU * util::quad(nEff));
                         float_X const dFromADK = math::pow(dBase, nEff);
 
                         /* ionization rate (for CIRCULAR polarization)*/

--- a/lib/python/picongpu/extra/utils/field_ionization.py
+++ b/lib/python/picongpu/extra/utils/field_ionization.py
@@ -2,7 +2,7 @@
 
 This file is part of the PIConGPU.
 Copyright 2019-2023 PIConGPU contributors
-Authors: Marco Garten
+Authors: Marco Garten, Brian Marre
 License: GPLv3+
 """
 
@@ -93,7 +93,7 @@ class FieldIonization:
                 )
 
         nEff = np.float64(self.n_eff(Z, E_Ip))
-        D = ((4. * Z**3.) / (F * nEff**4.))**nEff
+        D = ((4. * np.exp(1.) * Z**3.) / (F * nEff**4.))**nEff
 
         rate = (F * D**2.) / (8. * np.pi * Z) \
             * np.exp(-(2. * Z**3.) / (3. * nEff**3. * F))


### PR DESCRIPTION
In our implementation of the ADK rate formula the sub term D was missing an euler number compared to our documentation and the reference Publication we were citing.

Since the reference publication does not make it clear whether it meant elementary charge or euler Number, I asked @n01r for clarification which version is correct and he pointed me to a [publication](https://link.aps.org/doi/10.1103/PhysRevA.59.569) confirming the euler number interpretation.

**Note:** the error resulted in an ADK rate which is `1/(<eulerNumber>^(2*n_eff))` of the correct ADK rate.
With `n_eff = (Z+1)/(sqrt(2*E_ionization/E_Hartree)` Z ... current charge state of the ion