### PR TITLE
remove warning that particle shape naming changed

### DIFF
--- a/include/picongpu/param/species.param
+++ b/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * @attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/benchmarks/Thermal/include/picongpu/param/species.param
+++ b/share/picongpu/benchmarks/Thermal/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/species.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/species.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/species.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileCurrentSolver/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once

--- a/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileParticlePusher/include/picongpu/param/species.param
@@ -25,13 +25,6 @@
  * @see
  *   **MODELS / Hierarchy of Charge Assignment Schemes**
  *   in the online documentation for information on particle shapes.
- *
- *
- * \attention
- * The higher order shape names are redefined with release 0.6.0 in order to provide a consistent naming:
- *     * PQS is the name of the 3rd order assignment function (instead of PCS)
- *     * PCS is the name of the 4th order assignment function (instead of P4S)
- *     * P4S does not exist anymore
  */
 
 #pragma once


### PR DESCRIPTION
Remove the warning that we renamed the particle shapes with the release 0.6.0. There is still a warning in the file that the naming has changed which we keep but we removed the old naming P4S in the comments to avoid confusing the users.