### PR TITLE
fix derived field dataset naming

### DIFF
--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MidCurrentDensityComponent.def
@@ -83,7 +83,7 @@ namespace picongpu
                     HINLINE static std::string getName()
                     {
                         auto const componentNames = plugins::misc::getComponentNames(3);
-                        return "midCurrentDensity/" + componentNames[T_direction];
+                        return "midCurrentDensity-" + componentNames[T_direction];
                     }
 
                     /** Calculate a new attribute per particle

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/Momentum.def
@@ -77,7 +77,7 @@ namespace picongpu
                     HINLINE static std::string getName()
                     {
                         auto const componentNames = plugins::misc::getComponentNames(3);
-                        return "particleMomentum/" + componentNames[T_direction];
+                        return "particleMomentum-" + componentNames[T_direction];
                     }
 
                     /** Calculate value of the derived attribute per particle

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/MomentumDensity.def
@@ -77,7 +77,7 @@ namespace picongpu
                     HINLINE static std::string getName()
                     {
                         auto const componentNames = plugins::misc::getComponentNames(3);
-                        return "momentumDensity/" + componentNames[T_direction];
+                        return "momentumDensity-" + componentNames[T_direction];
                     }
 
                     /** Calculate value of the derived attribute per particle

--- a/include/picongpu/particles/particleToGrid/derivedAttributes/WeightedVelocity.def
+++ b/include/picongpu/particles/particleToGrid/derivedAttributes/WeightedVelocity.def
@@ -78,7 +78,7 @@ namespace picongpu
                     HINLINE static std::string getName()
                     {
                         auto const componentNames = plugins::misc::getComponentNames(3);
-                        return "weightedVelocity/" + componentNames[T_direction];
+                        return "weightedVelocity-" + componentNames[T_direction];
                     }
 
                     /** Calculate value of the derived attribute per particle


### PR DESCRIPTION
fix #4698

With #4606 #4607 and #4680 we allow that more than one direction of derived fields can be printed. W used `/` to separate the component name from the data/mesh name. This is not valid openPMD or can at least confuse users because `/` is the separator used for openPMD ADIOS data.

This PR is changing the separation to `-` (minus) to not collide with the `_` (underscore) used for the data set name.
Derived fields will be independent data sets even if both show the same property but a different component e.g. x,y,z


**This PR must be backported to the release candidate 0.7.0!**