### PR TITLE
Special handling in mesh writing if getName() contains a slash

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -75,6 +75,7 @@
 
 #include <tuple>
 
+#include <openPMD/auxiliary/StringManip.hpp>
 #include <openPMD/openPMD.hpp>
 
 #if !defined(_WIN32)
@@ -1429,7 +1430,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 ThreadParams* params,
                 uint32_t currentStep,
                 const uint32_t nComponents,
-                const std::string name,
+                std::string name,
                 FieldBuffer& buffer,
                 std::vector<float_64> unit,
                 std::vector<float_64> unitDimension,
@@ -1438,6 +1439,28 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 bool isDomainBound)
             {
                 auto const name_lookup_tpl = plugins::misc::getComponentNames(nComponents);
+                std::optional<std::string> pathToRecordComponentSpecifiedViaMeshName = std::nullopt;
+                if(nComponents == 1)
+                {
+                    // Name might be specified e.g. as "midCurrentDensity/x", meaning that only
+                    // the x component should be written during this invocation of writeField().
+                    // If there is one component only, then check if this is the case.
+                    auto splitted = ::openPMD::auxiliary::split(name, "/");
+                    switch(splitted.size())
+                    {
+                    case 1: // No slashes found, just continue
+                        break;
+                    case 2: // Slash found
+                        name = splitted.at(0);
+                        pathToRecordComponentSpecifiedViaMeshName = splitted.at(1);
+                        break;
+                    default:
+                        throw std::runtime_error(
+                            "Internal error: Illegal mesh name '" + name
+                            + "'. The mesh name must contain either no slashes '/' at all or exactly one slash. (The "
+                              "latter case bears a special meaning.)");
+                    }
+                }
                 ::openPMD::Datatype const openPMDType = ::openPMD::determineDatatype<ComponentType>();
 
                 if(openPMDType == ::openPMD::Datatype::UNDEFINED)
@@ -1527,8 +1550,30 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 /* write the actual field data */
                 for(uint32_t d = 0; d < nComponents; d++)
                 {
-                    ::openPMD::MeshRecordComponent mrc
-                        = mesh[nComponents > 1 ? name_lookup_tpl[d] : ::openPMD::RecordComponent::SCALAR];
+                    auto pathToRecordComponent = [&]() -> std::string
+                    {
+                        // Normally, the name of the record component is implicitly defined by the
+                        // inherent dimensionality of the mesh: x, y, z.
+                        if(nComponents > 1)
+                        {
+                            return name_lookup_tpl[d];
+                        }
+                        // But it might also have been specified as part of ::getName(),
+                        // e.g. as "C_all_momentumDensity/x".
+                        // In that case, writeField() is called multiple times for each component.
+                        else if(pathToRecordComponentSpecifiedViaMeshName.has_value())
+                        {
+                            return *pathToRecordComponentSpecifiedViaMeshName;
+                        }
+                        // If none of the above apply, the component is scalar and we use a special
+                        // openPMD-defined string to indicate that we skip the last level in the
+                        // openPMD hierarchy.
+                        else
+                        {
+                            return ::openPMD::RecordComponent::SCALAR;
+                        }
+                    }();
+                    ::openPMD::MeshRecordComponent mrc = mesh[pathToRecordComponent];
                     std::string datasetName = nComponents > 1
                         ? params->openPMDSeries->meshesPath() + name + "/" + name_lookup_tpl[d]
                         : params->openPMDSeries->meshesPath() + name;


### PR DESCRIPTION
Fix #4698, bug introduced by https://github.com/ComputationalRadiationPhysics/picongpu/pull/4606 https://github.com/ComputationalRadiationPhysics/picongpu/pull/4607 https://github.com/ComputationalRadiationPhysics/picongpu/pull/4608.

This PR is mutually exclusive with #4703 which uses a workaround  for fixing the same bug.

In this case, the part behind the slash indicates the name of the mesh component to be written and should be used instead of `openPMD::RecordComponent::SCALAR`.

With this fix:

```
$ openpmd-ls openPMD/simData_%T.bp/
openPMD series: simData_%T
openPMD standard: 1.1.0
openPMD extensions: 1

data author: unknown
data created: 2023-10-10 14:47:29 +0200
data backend: ADIOS2
generating machine: unknown
generating software: PIConGPU (version: 0.8.0-dev)
generating software dependencies: unknown

number of iterations: 2 (fileBased)
  all iterations: 0 100 

number of meshes: 16
  all meshes:
    B
    C_all_density
    C_all_energyDensity
    C_all_momentumDensity
    E
    H_all_density
    H_all_energyDensity
    H_all_momentumDensity
    J
    N_all_density
    N_all_energyDensity
    N_all_momentumDensity
    e_all_density
    e_all_energyDensity
    e_all_momentumDensity
    picongpu_idProvider

number of particle species: 1
  all particle species:
    probe
```

```
$ bpls openPMD/simData_000100.bp/
  float     /data/100/fields/B/x                                          {48, 48}
  float     /data/100/fields/B/y                                          {48, 48}
  float     /data/100/fields/B/z                                          {48, 48}
  float     /data/100/fields/C_all_density                                {48, 48}
  float     /data/100/fields/C_all_energyDensity                          {48, 48}
  float     /data/100/fields/C_all_momentumDensity/x                      {48, 48}
  float     /data/100/fields/C_all_momentumDensity/y                      {48, 48}
  float     /data/100/fields/E/x                                          {48, 48}
  float     /data/100/fields/E/y                                          {48, 48}
  float     /data/100/fields/E/z                                          {48, 48}
  float     /data/100/fields/H_all_density                                {48, 48}
  float     /data/100/fields/H_all_energyDensity                          {48, 48}
  float     /data/100/fields/H_all_momentumDensity/x                      {48, 48}
  float     /data/100/fields/H_all_momentumDensity/y                      {48, 48}
  float     /data/100/fields/J/x                                          {48, 48}
  float     /data/100/fields/J/y                                          {48, 48}
  float     /data/100/fields/J/z                                          {48, 48}
  float     /data/100/fields/N_all_density                                {48, 48}
  float     /data/100/fields/N_all_energyDensity                          {48, 48}
  float     /data/100/fields/N_all_momentumDensity/x                      {48, 48}
  float     /data/100/fields/N_all_momentumDensity/y                      {48, 48}
  float     /data/100/fields/e_all_density                                {48, 48}
  float     /data/100/fields/e_all_energyDensity                          {48, 48}
  float     /data/100/fields/e_all_momentumDensity/x                      {48, 48}
  float     /data/100/fields/e_all_momentumDensity/y                      {48, 48}
  uint64_t  /data/100/fields/picongpu_idProvider/nextId                   {1, 1}
  uint64_t  /data/100/fields/picongpu_idProvider/startId                  {1, 1}
  uint64_t  /data/100/particles/probe/particlePatches/extent/x            {1}
  uint64_t  /data/100/particles/probe/particlePatches/extent/y            {1}
  uint64_t  /data/100/particles/probe/particlePatches/numParticles        {1}
  uint64_t  /data/100/particles/probe/particlePatches/numParticlesOffset  {1}
  uint64_t  /data/100/particles/probe/particlePatches/offset/x            {1}
  uint64_t  /data/100/particles/probe/particlePatches/offset/y            {1}
  float     /data/100/particles/probe/position/x                          {144}
  float     /data/100/particles/probe/position/y                          {144}
  int32_t   /data/100/particles/probe/positionOffset/x                    {144}
  int32_t   /data/100/particles/probe/positionOffset/y                    {144}
  float     /data/100/particles/probe/probeB/x                            {144}
  float     /data/100/particles/probe/probeB/y                            {144}
  float     /data/100/particles/probe/probeB/z                            {144}
  float     /data/100/particles/probe/probeE/x                            {144}
  float     /data/100/particles/probe/probeE/y                            {144}
  float     /data/100/particles/probe/probeE/z                            {144}
```

Tested in a FoilLCT simulation with modified param:
```diff
--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/fileOutput.param
@@ -72,11 +72,28 @@ namespace picongpu
     using EnergyDensity_Seq
         = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::EnergyDensity>;
 
+    /* MomentumDensity X section */
+    using MomentumDensity_X_Seq = deriveField::CreateEligible_t<
+        VectorAllSpecies,
+        deriveField::derivedAttributes::MomentumDensity<0>
+    >;
+
+    /* MomentumDensity Y section */
+    using MomentumDensity_Y_Seq = deriveField::CreateEligible_t<
+        VectorAllSpecies,
+        deriveField::derivedAttributes::MomentumDensity<1>
+    >;
+
     /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
      *
      * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
      */
-    using FieldTmpSolvers = MakeSeq_t<Density_Seq, BoundElectronDensity_Seq, ChargeDensity_Seq, EnergyDensity_Seq>;
+    using FieldTmpSolvers = MakeSeq_t<
+        Density_Seq,
+        EnergyDensity_Seq,
+        MomentumDensity_X_Seq,
+        MomentumDensity_Y_Seq
+    >;
 
 
     /** FileOutputFields: Groups all Fields that shall be dumped *************/
```