### PR TITLE
RISC-V support

### DIFF
--- a/cmake/riscv64-clang.toolchain.cmake
+++ b/cmake/riscv64-clang.toolchain.cmake
@@ -1,0 +1,54 @@
+# Copyright 2023 Rene Widera
+#
+# This file is part of PMacc.
+#
+# PMacc is free software: you can redistribute it and/or modify
+# it under the terms of either the GNU General Public License or
+# the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PMacc is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License and the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# and the GNU Lesser General Public License along with PMacc.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+if(DEFINED ENV{RISCV_CLANG_INSTALL_ROOT} AND NOT DEFINED RISCV_CLANG_INSTALL_ROOT)
+    set(RISCV_CLANG_INSTALL_ROOT "$ENV{RISCV_CLANG_INSTALL_ROOT}" CACHE PATH "Path to CLANG for RISC-V cross compiler installation directory")
+else()
+    set(RISCV_CLANG_INSTALL_ROOT /opt/riscv CACHE PATH "Path to CLANG for RISC-V cross compiler installation directory")
+endif()
+set(RISCV_GCC_INSTALL_ROOT "${RISCV_CLANG_INSTALL_ROOT}" CACHE PATH "Path to GCC for RISC-V cross compiler installation directory")
+set(CMAKE_SYSROOT ${RISCV_GCC_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
+
+set(CLANG_TARGET_TRIPLE "riscv64-unknown-linux-gnu")
+
+set(CMAKE_C_COMPILER ${RISCV_CLANG_INSTALL_ROOT}/bin/clang)
+set(CMAKE_C_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
+set(CMAKE_CXX_COMPILER ${RISCV_CLANG_INSTALL_ROOT}/bin/clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
+set(CMAKE_ASM_COMPILER ${RISCV_CLANG_INSTALL_ROOT}/bin/clang)
+set(CMAKE_ASM_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
+
+
+# Avoids running the linker for source files passed to add_executable because cross-compiling required special
+# linker flags.
+# Attention, this can create issues during static MPI linking.
+# A workaround is to pass linker option via `CMAKE_EXE_LINKER_FLAGS` and link this CMake variable
+# explicit to target.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+# prefer static libraries
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(BUILD_SHARED_LIBRARIES OFF)
+
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/cmake/riscv64-gnu.toolchain.cmake
+++ b/cmake/riscv64-gnu.toolchain.cmake
@@ -1,0 +1,52 @@
+# Copyright 2023 Rene Widera
+#
+# This file is part of PMacc.
+#
+# PMacc is free software: you can redistribute it and/or modify
+# it under the terms of either the GNU General Public License or
+# the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PMacc is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License and the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# and the GNU Lesser General Public License along with PMacc.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+if(DEFINED ENV{RISCV_GNU_INSTALL_ROOT} AND NOT DEFINED RISCV_GNU_INSTALL_ROOT)
+    set(RISCV_GNU_INSTALL_ROOT "$ENV{RISCV_GNU_INSTALL_ROOT}" CACHE PATH "Path to GNU for RISC-V cross compiler installation directory")
+else()
+    set(RISCV_GNU_INSTALL_ROOT /opt/riscv CACHE PATH "Path to GNU for RISC-V cross compiler installation directory")
+endif()
+set(CMAKE_SYSROOT ${RISCV_GNU_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
+
+set(GNU_TARGET_TRIPLE riscv64-unknown-linux-gnu)
+
+set(CMAKE_C_COMPILER ${RISCV_GNU_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-gcc)
+set(CMAKE_C_COMPILER_TARGET ${GNU_TARGET_TRIPLE})
+set(CMAKE_CXX_COMPILER ${RISCV_GNU_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-g++)
+set(CMAKE_CXX_COMPILER_TARGET ${GNU_TARGET_TRIPLE})
+set(CMAKE_ASM_COMPILER ${RISCV_GNU_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-as)
+set(CMAKE_ASM_COMPILER_TARGET ${GNU_TARGET_TRIPLE})
+
+# Avoids running the linker for source files passed to add_executable because cross-compiling required special
+# linker flags.
+# Attention, this can create issues during static MPI linking.
+# A workaround is to pass linker option via `CMAKE_EXE_LINKER_FLAGS` and link this CMake variable
+# explicit to target.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+# prefer static libraries
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(BUILD_SHARED_LIBRARIES OFF)
+
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    usage/python_utils
    usage/examples
    usage/workflows
+   usage/crosscompile
 
 .. toctree::
    :caption: MODELS

--- a/docs/source/usage/crosscompile.rst
+++ b/docs/source/usage/crosscompile.rst
@@ -32,7 +32,7 @@ Depending on the toolchain the environment variable ``RISCV_GNU_INSTALL_ROOT`` o
 
    export RISCV_GNU_INSTALL_ROOT="$(dirname $(which riscv64-unknown-linux-gnu-gcc))/.."
    export RISCV_CLANG_INSTALL_ROOT="$(dirname $(which clang))/.."
-   
+
 .. code-block:: bash
 
    # ``omp2b`` for OpenMP and ``serial`` for serial execution on one core

--- a/docs/source/usage/crosscompile.rst
+++ b/docs/source/usage/crosscompile.rst
@@ -1,0 +1,42 @@
+.. _crosscompile-riscv:
+
+Cross-compile for RISC-V
+========================
+
+This section contains information on how to cross-compile for RISC-V.
+
+This section assumes you have a x86 system with a compiled gnu/clang compiler which can target RISC-V.
+A detailed description on how to setup can be find under `RISC-V-Toolchain`_.
+
+.. _RISC-V-Toolchain: https://riscv.epcc.ed.ac.uk/issues/toolchains+debugging/
+
+You must compile all dependencies static only!
+We observed problems with the CMake MPI detection therefore we disable the CMake MPI search with `-DMPI_CXX_WORKS=ON`` and provide
+all required compiler and linker parameters via the environment variable ``CXXFLAGS``, ``CFLAGS`` and ``LDFLAGS``.
+
+.. code-block:: bash
+
+   # set MPI_ROOT to the root MPI directory
+   export LDFLAGS="-L$MPI_ROOT/lib -lmpi -lompitrace -lopen-rte -lopen-pal -ldl -lpthread -lutil -lrt"
+   # compile for 64bit RISC-V with double floating point support
+   export CXXFLAGS="-I$MPI_ROOT/include -pthread -march=rv64gc -mabi=lp64d"
+   export CFLAGS=$CXXFLAGS
+
+To be able to cross compile you should point to the CMake toolchain file shipped together with PIConGPU.
+Depending on your environment, please select the Clang or GNU toolchain.
+The execution backend is provided in this example explicitly.
+We recommend to write a :ref:`profile <install-profile>` for the system.
+Depending on the toolchain the environment variable ``RISCV_GNU_INSTALL_ROOT`` or ``RISCV_CLANG_INSTALL_ROOT`` should be provided.
+
+.. code-block:: bash
+
+   export RISCV_GNU_INSTALL_ROOT="$(dirname $(which riscv64-unknown-linux-gnu-gcc))/.."
+   export RISCV_CLANG_INSTALL_ROOT="$(dirname $(which clang))/.."
+   
+.. code-block:: bash
+
+   # ``omp2b`` for OpenMP and ``serial`` for serial execution on one core
+   pic-build -b omp2b -c"-DMPI_CXX_WORKS=ON  -DCMAKE_TOOLCHAIN_FILE=<PATH_TO_PICONGPU_SRC>/cmake/riscv64-gnu.toolchain.cmake"
+
+After PIConGPU is compiled you can interactively join to the RISC-V compute node and test if you compiled for the right target architecture ``./bin/picongpu --help``.
+After this short test you should follow the typical workflow and start your simulation via :ref:`TBG <usage-tbg>`.

--- a/include/mpiInfo/CMakeLists.txt
+++ b/include/mpiInfo/CMakeLists.txt
@@ -80,20 +80,29 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_FLAGS_DEFAULT "-Wall")
 
+################################################################################
+# Find Threads
+################################################################################
+
+# Allow users to override the "-pthread" preference.
+if(NOT THREADS_PREFER_PTHREAD_FLAG)
+     set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+endif()
+
+# WARNING: in case were we cross compile we need to add '-DDMPI_CXX_WORKS=ON` and
+# provide include flags and linker flags manually.
+find_package(Threads REQUIRED)
+if(NOT APPLE)
+    # librt: undefined reference to `clock_gettime'
+    find_library(RT_LIBRARY rt)
+endif()
+
 
 ################################################################################
 # Find MPI
 ################################################################################
 
 find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
-set(MPIINFO_LIBS ${MPIINFO_LIBS} ${MPI_C_LIBRARIES})
-
-# bullxmpi fails if it can not find its c++ counter part
-if(MPI_CXX_FOUND)
-    set(MPIINFO_LIBS ${MPIINFO_LIBS} ${MPI_CXX_LIBRARIES})
-endif(MPI_CXX_FOUND)
-
 
 ################################################################################
 # Find Boost
@@ -116,7 +125,20 @@ add_executable(mpiInfo
     mpiInfo.cpp
 )
 
-target_link_libraries(mpiInfo PRIVATE ${MPIINFO_LIBS})
+target_link_libraries(mpiInfo PRIVATE ${MPIINFO_LIBS} Threads::Threads)
+if(RT_LIBRARY AND NOT APPLE)
+    # MPI runtime libraries
+    target_link_libraries(mpiInfo PRIVATE ${RT_LIBRARY})
+endif()
+target_link_libraries(mpiInfo PRIVATE MPI::MPI_CXX)
+
+if( CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY" AND CMAKE_EXE_LINKER_FLAGS)
+    # Workaround for linker issues when linking static MPI libraries.
+    # Because of CMAKE_TRY_COMPILE_TARGET_TYPE CMake providing the statics libraries before the object file from
+    # `add_executable` therefore MPI, symbols can not be resolved. Linking the linker flags to the target again will
+    # workaround the issue.
+    target_link_libraries(mpiInfo PRIVATE ${CMAKE_EXE_LINKER_FLAGS})
+endif()
 
 ## annotate with RPATH's
 if(MPIINFO_ADD_RPATH)

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -30,7 +30,7 @@ cmake_minimum_required(VERSION 3.22.0)
 # Project
 ################################################################################
 
-project(PIConGPUapp)
+project(PIConGPUapp CXX C)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "install prefix" FORCE)
@@ -154,17 +154,17 @@ find_package(PMacc REQUIRED CONFIG PATHS "${PIConGPUapp_SOURCE_DIR}/../pmacc")
 ################################################################################
 
 find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
-set(HOST_LIBS ${HOST_LIBS} ${MPI_C_LIBRARIES})
-
+list(PREPEND HOST_LIBS MPI::MPI_CXX)
 
 ################################################################################
 # Find PThreads
 ################################################################################
 
+if(NOT THREADS_PREFER_PTHREAD_FLAG)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+endif()
 find_package(Threads REQUIRED)
-set(HOST_LIBS ${HOST_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-
+list(PREPEND HOST_LIBS Threads::Threads)
 
 ################################################################################
 # Find math from stdlib
@@ -173,7 +173,7 @@ set(HOST_LIBS ${HOST_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 if(NOT WIN32 AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     # automatically added on windows
     # should not be added for Intel compiler as it has an optimized lib included
-    set(HOST_LIBS ${HOST_LIBS} m)
+    list(PREPEND HOST_LIBS m)
 endif()
 
 
@@ -183,10 +183,10 @@ endif()
 
 find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options)
 if(TARGET Boost::boost)
-    set(HOST_LIBS ${HOST_LIBS} Boost::boost Boost::program_options)
+    list(PREPEND HOST_LIBS Boost::boost Boost::program_options)
 else()
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-    set(HOST_LIBS ${HOST_LIBS} ${Boost_LIBRARIES})
+    list(PREPEND HOST_LIBS ${Boost_LIBRARIES})
 endif()
 
 
@@ -315,6 +315,10 @@ if(PIC_SEARCH_openPMD)
     # find openPMD installation
     find_package(openPMD 0.14.3 CONFIG COMPONENTS MPI)
     if(openPMD_FOUND)
+        # HDF5 and ADIOS require linking against C libraries but this is not correctly
+        # exposed.
+        list(PREPEND HOST_LIBS MPI::MPI_C)
+
         if(openPMD_HAVE_ADIOS2 OR openPMD_HAVE_HDF5)
             message(STATUS "Found openPMD: ${openPMD_DIR}")
             add_definitions(-DENABLE_OPENPMD=1)
@@ -365,7 +369,7 @@ if(PIC_SEARCH_openPMD)
                 find_package(toml11 3.7.0 CONFIG REQUIRED)
                 message(STATUS "toml11: Found version '${toml11_VERSION}'")
             endif()
-            set(HOST_LIBS ${HOST_LIBS} openPMD::openPMD)
+            list(PREPEND HOST_LIBS openPMD::openPMD)
         else()
             message(STATUS "Found openPMD at ${openPMD_DIR}, but PIConGPU requires"
                            " availability of either its ADIOS2 or HDF5 backend - "
@@ -390,7 +394,7 @@ if(PIC_SEARCH_PNGwriter)
     find_package(PNGwriter 0.7.0 CONFIG)
 
     if(PNGwriter_FOUND)
-        set(HOST_LIBS ${HOST_LIBS} PNGwriter::PNGwriter)
+        list(PREPEND HOST_LIBS PNGwriter::PNGwriter)
         add_definitions(-DPIC_ENABLE_PNG=1)
         message(STATUS "Found PNGwriter: ${PNGwriter_DIR}")
     else()

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CMAKE_CXX_STANDARD 17)
 ################################################################################
 # Directory of this file.
 ################################################################################
-set(PMACC_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(PMACC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Normalize the path (e.g. remove ../)
 get_filename_component(PMACC_ROOT_DIR "${PMACC_ROOT_DIR}" ABSOLUTE)

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -10,6 +10,9 @@
     #  "Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND)"
     PIC_CMAKE_ARGS: "-DMPI_CXX_WORKS=ON -DMPI_CXX_VERSION=0"
     # ISAAC is not working with HIP
+    CXXFLAGS: "-I/usr/lib/x86_64-linux-gnu/openmpi/include"
+    CFLAGS: "$CXXFLAGS"
+    LDFLAGS: "-L/usr/lib/x86_64-linux-gnu/ -lmpi"
     DISABLE_ISAAC: "yes"
     # CI_GPU_ARCH architecture of the hosted GPU is provided by the CI
     GPU_TARGETS: ${CI_GPU_ARCH}


### PR DESCRIPTION
This commit is providing nessesare changes to cross-compile PIConGPU for RISC-V.

- refactor CMake and provide an workaround required to link static MPI libraries during cross compilation
- add short cross compile section to the documentation
- provide GNU and Clang CMake toolchain file