### PR TITLE
Vector/DataSpace N-dimensional constructor

### DIFF
--- a/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
+++ b/include/picongpu/fields/currentDeposition/Esirkepov/Esirkepov.hpp
@@ -116,13 +116,13 @@ namespace picongpu
 
                 cptCurrent1D(
                     worker,
-                    DataSpace<simDim>(status.y(), status.z(), status.x()),
+                    DataSpace<DIM3>(status.y(), status.z(), status.x()),
                     makePermutatedFieldValueAccess<pmacc::math::CT::Int<1, 2, 0>>(fieldJ),
                     rotateOrigin<1, 2, 0>(line),
                     cellSize.x());
                 cptCurrent1D(
                     worker,
-                    DataSpace<simDim>(status.z(), status.x(), status.y()),
+                    DataSpace<DIM3>(status.z(), status.x(), status.y()),
                     makePermutatedFieldValueAccess<pmacc::math::CT::Int<2, 0, 1>>(fieldJ),
                     rotateOrigin<2, 0, 1>(line),
                     cellSize.y());
@@ -147,7 +147,7 @@ namespace picongpu
             template<typename T_DataBox, typename T_Permutation, typename T_Worker>
             DINLINE void cptCurrent1D(
                 T_Worker const& worker,
-                const DataSpace<simDim>& parStatus,
+                const DataSpace<DIM3>& parStatus,
                 PermutatedFieldValueAccess<T_DataBox, T_Permutation> jField,
                 const Line<float3_X>& line,
 

--- a/include/picongpu/particles/startPosition/OnePositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.hpp
@@ -58,15 +58,19 @@ namespace picongpu::particles::startPosition::acc
                 = pmacc::traits::HasIdentifier<typename T_Particle::FrameType, weighting>::type::value;
 
             // note: m_weighting member might stay uninitialized!
-            uint32_t result(T_ParamClass::numParticlesPerCell);
 
             if constexpr(hasWeighting)
-                result = startPosition::detail::WeightMacroParticles{}(
+            {
+                return startPosition::detail::WeightMacroParticles{}(
                     realParticlesPerCell,
                     T_ParamClass::numParticlesPerCell,
                     m_weighting);
-
-            return result;
+            }
+            else
+            {
+                // note: m_weighting member might stay uninitialized!
+                return T_ParamClass::numParticlesPerCell;
+            }
         }
 
     private:

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -25,6 +25,8 @@
 #include "pmacc/math/Vector.hpp"
 #include "pmacc/types.hpp"
 
+#include <type_traits>
+
 namespace pmacc
 {
     /**
@@ -82,34 +84,16 @@ namespace pmacc
             }
         }
 
-        /**
-         * Constructor for DIM1-dimensional DataSpace.
+        /** Constructor for N-dimensional DataSpace.
          *
-         * @param x size of first dimension
-         */
-        HDINLINE DataSpace(int x) : BaseType(x)
-        {
-        }
-
-        /**
-         * Constructor for DIM2-dimensional DataSpace.
+         * @attention This constructor allows implicit casts.
          *
-         * @param x size of first dimension
-         * @param y size of second dimension
+         * @param args size of each dimension, x,y,z,...
          */
-        HDINLINE DataSpace(int x, int y) : BaseType(x, y)
+        template<typename... T_Args, typename = std::enable_if_t<(std::is_convertible_v<T_Args, int> && ...)>>
+        HDINLINE constexpr DataSpace(T_Args&&... args) : BaseType(std::forward<T_Args>(args)...)
         {
-        }
-
-        /**
-         * Constructor for DIM3-dimensional DataSpace.
-         *
-         * @param x size of first dimension
-         * @param y size of second dimension
-         * @param z size of third dimension
-         */
-        HDINLINE DataSpace(int x, int y, int z) : BaseType(x, y, z)
-        {
+            static_assert(sizeof...(T_Args) == T_dim, "Number of arguments must be equal to the DataSpace dimension.");
         }
 
         HDINLINE DataSpace(const BaseType& vec) : BaseType(vec)

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -108,28 +108,18 @@ namespace pmacc
             {
             }
 
-            HDINLINE
-            constexpr Vector(const type x)
+            /** Constructor for N-dimensional vector
+             *
+             * @attention This constructor allows implicit casts.
+             *
+             * @param args value of each dimension, x,y,z,...
+             */
+            template<typename... T_Args, typename = std::enable_if_t<(std::is_convertible_v<T_Args, T_Type> && ...)>>
+            HDINLINE constexpr Vector(T_Args... args)
             {
-                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM1, dim == 1u);
-                (*this)[0] = x;
-            }
-
-            HDINLINE
-            constexpr Vector(const type x, const type y)
-            {
-                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM2, dim == 2u);
-                (*this)[0] = x;
-                (*this)[1] = y;
-            }
-
-            HDINLINE
-            constexpr Vector(const type x, const type y, const type z)
-            {
-                PMACC_CASSERT_MSG(math_Vector__constructor_is_only_allowed_for_DIM3, dim == 3u);
-                (*this)[0] = x;
-                (*this)[1] = y;
-                (*this)[2] = z;
+                static_assert(sizeof...(T_Args) == dim, "Number of arguments must be equal to the vector dimension.");
+                int i = 0;
+                ([&] { (*this)[i++] = args; }(), ...);
             }
 
             HDINLINE


### PR DESCRIPTION
Provide a constructor to create an N-dimensional Vector/DataSpace with N values.

This PR does not change the register footprint on NVIDIA GPUs.
The constructor supports implicit casts equal to the hard-coded implementation before.