### PR TITLE
Add prepulse duration option to ExpRampWithPrepulse

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -61,11 +61,11 @@ namespace picongpu
                         static constexpr float_64 AMPLITUDE_SI = 1.0e6;
 
                         /** Pulse duration: sigma of std. gauss for intensity (E^2)
-                     *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-                     *                                          [    2.354820045     ]
-                     *  Info:             FWHM_of_Intensity = FWHM_Illumination
-                     *                      = what an experimentalist calls "pulse duration"
-                     *  unit: seconds (1 sigma)
+                         *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                         *                                          [    2.354820045     ]
+                         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                         *                      = what an experimentalist calls "pulse duration"
+                         *  unit: seconds (1 sigma)
                          */
                         static constexpr float_64 PREPULSE_DURATION_SI = BaseParam::PULSE_DURATION_SI;
 

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def
@@ -58,6 +58,17 @@ namespace picongpu
                         static constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
                         /** @} */
 
+                        static constexpr float_64 AMPLITUDE_SI = 1.0e6;
+
+                        /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                     *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                     *                                          [    2.354820045     ]
+                     *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                     *                      = what an experimentalist calls "pulse duration"
+                     *  unit: seconds (1 sigma)
+                         */
+                        static constexpr float_64 PREPULSE_DURATION_SI = BaseParam::PULSE_DURATION_SI;
+
                         /** Stretch temporal profile by a constant plateau between the up and downramp
                          *
                          *  unit: seconds

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -108,12 +108,12 @@ namespace picongpu::fields::incidentField
                     || (ratio_dt >= 0.33_X && ri1 > ri2 * ri2 * ri2)
                     || (ratio_dt >= 0.25_X && ri1 > ri2 * ri2 * ri2 * ri2)
                     || (ratio_dt >= 0.2_X && ri1 > ri2 * ri2 * ri2 * ri2 * ri2);
-                static_assert(
-                    !intensity_too_big,
-                    "The intensities of the ramp are very large - the extrapolation to the time of the main "
-                    "pulse "
-                    "would give more than half of the pulse amplitude. This is not a Gaussian pulse at all "
-                    "anymore - probably some of the parameters are different from what you think!?");
+//                static_assert(
+//                    !intensity_too_big,
+//                    "The intensities of the ramp are very large - the extrapolation to the time of the main "
+//                    "pulse "
+//                    "would give more than half of the pulse amplitude. This is not a Gaussian pulse at all "
+//                    "anymore - probably some of the parameters are different from what you think!?");
                 //                static constexpr float_X INIT_TIME
                 //                    = static_cast<float_X>((TIME_PEAKPULSE + Params::RAMP_INIT *
                 //                    Base::PULSE_DURATION) / UNIT_TIME);

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -72,8 +72,8 @@ namespace picongpu::fields::incidentField
                 static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
 
                 /** Pulse duration
-                         *
-                         * unit: UNIT_TIME
+                 *
+                 * unit: UNIT_TIME
                  */
                 static constexpr float_X PREPULSE_DURATION
                     = static_cast<float_X>(Params::PREPULSE_DURATION_SI / UNIT_TIME);
@@ -241,8 +241,8 @@ namespace picongpu::fields::incidentField
                     //        "and physically very unplausible, check the params for misunderstandings!");
                     //}
 
-                    env += (1._X - ramp_when_peakpulse) * gauss(runTime - Unitless::endUpramp,
-                                                                Unitless::PULSE_DURATION);
+                    env += (1._X - ramp_when_peakpulse)
+                        * gauss(runTime - Unitless::endUpramp, Unitless::PULSE_DURATION);
                     env += AMP_PREPULSE * gauss(runTime - Unitless::TIME_PREPULSE, Unitless::PREPULSE_DURATION);
                     if(during_first_exp)
                         env += extrapolateExpo(Unitless::TIME_1, AMP_1, Unitless::TIME_2, AMP_2, runTime);

--- a/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp
@@ -71,6 +71,12 @@ namespace picongpu::fields::incidentField
                 static constexpr float_X endUpramp = TIME_PEAKPULSE - 0.5_X * LASER_NOFOCUS_CONSTANT;
                 static constexpr float_X startDownramp = TIME_PEAKPULSE + 0.5_X * LASER_NOFOCUS_CONSTANT;
 
+                /** Pulse duration
+                         *
+                         * unit: UNIT_TIME
+                 */
+                static constexpr float_X PREPULSE_DURATION
+                    = static_cast<float_X>(Params::PREPULSE_DURATION_SI / UNIT_TIME);
 
                 // compile-time checks for physical sanity:
                 static_assert(
@@ -108,15 +114,6 @@ namespace picongpu::fields::incidentField
                     || (ratio_dt >= 0.33_X && ri1 > ri2 * ri2 * ri2)
                     || (ratio_dt >= 0.25_X && ri1 > ri2 * ri2 * ri2 * ri2)
                     || (ratio_dt >= 0.2_X && ri1 > ri2 * ri2 * ri2 * ri2 * ri2);
-//                static_assert(
-//                    !intensity_too_big,
-//                    "The intensities of the ramp are very large - the extrapolation to the time of the main "
-//                    "pulse "
-//                    "would give more than half of the pulse amplitude. This is not a Gaussian pulse at all "
-//                    "anymore - probably some of the parameters are different from what you think!?");
-                //                static constexpr float_X INIT_TIME
-                //                    = static_cast<float_X>((TIME_PEAKPULSE + Params::RAMP_INIT *
-                //                    Base::PULSE_DURATION) / UNIT_TIME);
 
                 /* a symmetric pulse will be initialized at generation plane for
                  * a time of RAMP_INIT * PULSE_DURATION + LASER_NOFOCUS_CONSTANT = INIT_TIME.
@@ -226,7 +223,7 @@ namespace picongpu::fields::incidentField
                     env = 0._X;
                 else if(before_start)
                 {
-                    env = AMP_1 * gauss(runTime - Unitless::TIME_1);
+                    env = AMP_1 * gauss(runTime - Unitless::TIME_1, Unitless::PULSE_DURATION);
                 }
                 else if(before_peakpulse)
                 {
@@ -244,8 +241,9 @@ namespace picongpu::fields::incidentField
                     //        "and physically very unplausible, check the params for misunderstandings!");
                     //}
 
-                    env += (1._X - ramp_when_peakpulse) * gauss(runTime - Unitless::endUpramp);
-                    env += AMP_PREPULSE * gauss(runTime - Unitless::TIME_PREPULSE);
+                    env += (1._X - ramp_when_peakpulse) * gauss(runTime - Unitless::endUpramp,
+                                                                Unitless::PULSE_DURATION);
+                    env += AMP_PREPULSE * gauss(runTime - Unitless::TIME_PREPULSE, Unitless::PREPULSE_DURATION);
                     if(during_first_exp)
                         env += extrapolateExpo(Unitless::TIME_1, AMP_1, Unitless::TIME_2, AMP_2, runTime);
                     else
@@ -254,7 +252,7 @@ namespace picongpu::fields::incidentField
                 else if(!after_peakpulse)
                     env = 1.0_X;
                 else // after startDownramp
-                    env = gauss(runTime - Unitless::startDownramp);
+                    env = gauss(runTime - Unitless::startDownramp, Unitless::PULSE_DURATION);
                 return env;
             }
 
@@ -268,9 +266,9 @@ namespace picongpu::fields::incidentField
              * between 0 and 1, i.e. as multiple of the max value.
              * use as: amp_t = amp_0 * gauss( t - t_0 )
              */
-            HDINLINE static float_X gauss(float_X const t)
+            HDINLINE static float_X gauss(float_X const t, float_X const pulseDuration)
             {
-                auto const exponent = t / Unitless::PULSE_DURATION;
+                auto const exponent = t / pulseDuration;
                 return math::exp(-0.25_X * exponent * exponent);
             }
 

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
@@ -264,6 +264,15 @@ namespace picongpu
                  *             value in 15fs, approx 6 wavelengths). Those are 4.8 wavelenghts.
                  */
                 static constexpr float_64 PULSE_DURATION_SI = 3.0e-14 / 2.35482;
+
+                /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                 *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                 *                                          [    2.354820045     ]
+                 *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                 *                      = what an experimentalist calls "pulse duration"
+                 *  unit: seconds (1 sigma)
+                 */
+                static constexpr float_64 PREPULSE_DURATION_SI = PULSE_DURATION_SI;
             };
 
             using ExpRampWithPrepulseBeam = profiles::ExpRampWithPrepulse<ExpRampWithPrepulseParam>;

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -281,11 +281,11 @@ namespace picongpu
                 /** @} */
 
                 /** Pulse duration: sigma of std. gauss for intensity (E^2)
-                     *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-                     *                                          [    2.354820045     ]
-                     *  Info:             FWHM_of_Intensity = FWHM_Illumination
-                     *                      = what an experimentalist calls "pulse duration"
-                     *  unit: seconds (1 sigma)
+                 *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                 *                                          [    2.354820045     ]
+                 *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                 *                      = what an experimentalist calls "pulse duration"
+                 *  unit: seconds (1 sigma)
                  */
                 static constexpr float_64 PREPULSE_DURATION_SI = LwfaGaussianPulseBaseParams::PULSE_DURATION_SI;
 

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -280,6 +280,15 @@ namespace picongpu
                 static constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
                 /** @} */
 
+                /** Pulse duration: sigma of std. gauss for intensity (E^2)
+                     *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+                     *                                          [    2.354820045     ]
+                     *  Info:             FWHM_of_Intensity = FWHM_Illumination
+                     *                      = what an experimentalist calls "pulse duration"
+                     *  unit: seconds (1 sigma)
+                 */
+                static constexpr float_64 PREPULSE_DURATION_SI = LwfaGaussianPulseBaseParams::PULSE_DURATION_SI;
+
                 /** The laser pulse will be initialized half of RAMP_INIT times of the PULSE_DURATION before
                  * plateau and half at the end of the plateau
                  *


### PR DESCRIPTION
Adds an option for setting the prepulse duration independently of the main pulse duration (in `ExpRampWithPrepulse`). 
Also removes a static assert in  `ExpRampWithPrepulse` and some old, unused, already commented out code. @wmles already removed the assert in his production code. The simulation can be valid also when the requirement is not full field. 