### PR TITLE
change the default cellListChunkSize for collisions

### DIFF
--- a/include/picongpu/param/collision.param
+++ b/include/picongpu/param/collision.param
@@ -21,6 +21,8 @@
 
 #include "picongpu/particles/collision/collision.def"
 
+#include <algorithm>
+
 
 namespace picongpu
 {
@@ -51,8 +53,11 @@ namespace picongpu
              *
              * To reduce the fragmentation of the heap memory on accelerators the collision algorithm is allocating a
              * multiple of this value to store a cell list of particle IDs. The value must be non zero.
+             *
+             * Our experience shows that 4 or 8 are working quite well. Higher numbers lead to more inefficient memory
+             * usage, so we cap this chunk size by default at the TYPICAL_PARTICLES_PER_CELL value.
              */
-            constexpr uint32_t cellListChunkSize = particles::TYPICAL_PARTICLES_PER_CELL;
+            constexpr uint32_t cellListChunkSize = std::min(particles::TYPICAL_PARTICLES_PER_CELL, 4u);
 
         } // namespace collision
     } // namespace particles


### PR DESCRIPTION
The `cellListChunkSize` should not be too large, otherwise `mallocMC` can be significantly slowed down. This PR caps the default value at 4.