### PR TITLE
Fix openPMD plugin parameter default values

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -133,12 +133,16 @@ PIConGPU command line option          description
 ``--openPMD.json``                    Set backend-specific parameters for openPMD backends in JSON format. Used in writing procedures.
 ``--checkpoint.openPMD.jsonRestart``  Set backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint.
 ``--openPMD.dataPreparationStrategy`` Strategy for preparation of particle data ('doubleBuffer' or 'mappedMemory'). Aliases 'adios' and 'hdf5' may be used respectively.
+``--openPMD.toml``                    Alternatively configure the openPMD plugin via a TOML file (see below).
 ===================================== ====================================================================================================================================================
 
 .. note::
 
    This plugin is a multi plugin.
    Command line parameter can be used multiple times to create e.g. dumps with different dumping period.
+   Each plugin instance requires that either ``--openPMD.period`` XOR ``--openPMD.toml`` is defined.
+   If ``--openPMD.toml`` is defined, the rest of the configuration for this instance is done via the specified TOML file, no other command line parameters may be passed.
+
    In the case where an optional parameter with a default value is explicitly defined, the parameter will always be passed to the instance of the multi plugin where the parameter is not set.
    e.g.
 

--- a/docs/source/usage/plugins/openPMD.toml
+++ b/docs/source/usage/plugins/openPMD.toml
@@ -4,8 +4,8 @@ file = "simData"   # replaces --openPMD.file,
                    # given value is the default
 infix = ""         # replaces --openPMD.infix,
                    # default is "%06T"
-ext = "bp"         # replaces --openPMD.ext,
-                   # given value is the default
+ext = "bp4"        # replaces --openPMD.ext,
+                   # the default is "bp4" if ADIOS2 is available, else ".h5"
 backend_config = "@./adios_config.json"    # replaces --openPMD.json,
                                            # default is "{}"
 data_preparation_strategy = "mappedMemory" # replaces --openPMD.dataPreparationStrategy,

--- a/include/picongpu/plugins/multi/Option.hpp
+++ b/include/picongpu/plugins/multi/Option.hpp
@@ -112,6 +112,16 @@ namespace picongpu
                         (getDescription() + additionalDescription + printDefault).c_str());
                 }
 
+                /** Find out if a default value was specified.
+                 *
+                 * @return true If a default was specified.
+                 * @return false Otherwise.
+                 */
+                bool hasDefault() const
+                {
+                    return m_hasDefaultValue;
+                }
+
                 /** get the default value
                  *
                  * Throw an exception if there is no default value defined.

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -8,7 +8,7 @@ namespace picongpu::openPMD
     /*
      * No default values here since those are registered in the
      * plugins::multi::Option data members of openPMDWriter::Help.
-     * The openPMD plugin will automatically those default values here.
+     * The openPMD plugin will automatically use those default values here.
      * Ref.: openPMDWriter::Help::pluginParameters() (when using cmd line parameters)
      *       openPMDWriter::openPMDWriter()          (when using TOML configuration)
      */

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -5,14 +5,21 @@
 
 namespace picongpu::openPMD
 {
+    /*
+     * No default values here since those are registered in the
+     * plugins::multi::Option data members of openPMDWriter::Help.
+     * The openPMD plugin will automatically those default values here.
+     * Ref.: openPMDWriter::Help::pluginParameters() (when using cmd line parameters)
+     *       openPMDWriter::openPMDWriter()          (when using TOML configuration)
+     */
     struct PluginParameters
     {
-        std::string fileName = "simData"; /* Name of the openPMDSeries, excluding the extension */
-        std::string fileInfix = "_%06T";
-        std::string fileExtension = "bp"; /* Extension of the file name */
-        std::string dataPreparationStrategyString = "doubleBuffer";
-        std::string jsonConfigString = "{}";
-        std::string rangeString = ":,:,:";
-        std::string jsonRestartParams = "{}";
+        std::string fileName; /* Name of the openPMDSeries, excluding the extension */
+        std::string fileInfix;
+        std::string fileExtension; /* Extension of the file name */
+        std::string dataPreparationStrategyString;
+        std::string jsonConfigString;
+        std::string rangeString;
+        std::string jsonRestartParams;
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -455,9 +455,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             {
                 if(selfRegister)
                 {
-                    if(tomlSources.empty() && (notifyPeriod.empty() || fileName.empty()))
+                    if(tomlSources.empty() && notifyPeriod.empty())
                         throw std::runtime_error(
-                            name + ": If not defining parameter toml, then parameter period and file must be defined");
+                            name + ": Either parameter .toml XOR parameter .period must be defined.");
 
                     // check if user passed data source names are valid
                     for(auto const& dataSourceNames : source)
@@ -1101,10 +1101,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     }
                     else if(not tomlSourcesSpecified && notifyPeriodSpecified)
                     {
-                        if(m_help->fileName.empty())
-                            throw std::runtime_error("[openPMD plugin] If defining parameter period, then parameter "
-                                                     "file must also be defined");
-
                         std::string const& notifyPeriod = m_help->notifyPeriod.get(id);
                         Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -208,7 +208,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             plugins::multi::Option<std::string> notifyPeriod = {"period", "enable openPMD IO [for each n-th step]"};
             plugins::multi::Option<std::string> range
-                = {"range", "define the output range in cells for each dimension e.g. 1:10,:,42:"};
+                = {"range", "define the output range in cells for each dimension e.g. 1:10,:,42:", ":,:,:"};
 
             plugins::multi::Option<std::string> source = {"source", "data sources: ", "species_all, fields_all"};
 
@@ -216,7 +216,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             std::vector<std::string> allowedDataSources = {"species_all", "fields_all"};
 
-            plugins::multi::Option<std::string> fileName = {"file", "openPMD file basename"};
+            plugins::multi::Option<std::string> fileName = {"file", "openPMD file basename", "simData"};
 
             plugins::multi::Option<std::string> fileNameExtension
                 = {"ext",
@@ -550,11 +550,25 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     {
                         auto const& cmd_param = param.commandLineParameter;
                         auto const& target = param.targetInConfigObject;
-                        if(!target.has_value() || !cmd_param->optionDefined(id))
+
+                        if(!target.has_value())
                         {
                             continue;
                         }
-                        res.*target.value() = cmd_param->get(id);
+                        else if(cmd_param->optionDefined(id))
+                        {
+                            res.** target = cmd_param->get(id);
+                        }
+                        else if(cmd_param->hasDefault())
+                        {
+                            res.** target = cmd_param->getDefault();
+                        }
+                        else
+                        {
+                            throw std::runtime_error(
+                                "[openPMD plugin] Command line parameter '" + cmd_param->getName()
+                                + "'has no default value specified and no user-specified option was passed.");
+                        }
                     }
                     return res;
                 }
@@ -1037,14 +1051,43 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                         std::string const& tomlSources = m_help->tomlSources.get(id);
 
+                        PluginParameters pluginParametersWithDefaults;
+                        for(auto const& parameter : m_help->parameters)
+                        {
+                            auto const& cmd_param = parameter.commandLineParameter;
+                            auto const& target = parameter.targetInConfigObject;
+
+                            if(target.has_value())
+                            {
+                                if(!parameter.tomlParameter.has_value())
+                                {
+                                    continue;
+                                }
+                                else if(cmd_param->hasDefault())
+                                {
+                                    pluginParametersWithDefaults.** target = cmd_param->getDefault();
+                                }
+                                else
+                                {
+                                    throw std::runtime_error(
+                                        "[openPMD plugin] Internal error: Could not initialize TOML param "
+                                        "'"
+                                        + *parameter.tomlParameter
+                                        + "' with a default value because it was not specified "
+                                          "internally. "
+                                          "This is a bug.");
+                                }
+                            }
+                        }
                         auto [emplaced, newly_inserted] = m_help->tomlDataSources.emplace(
                             std::piecewise_construct,
                             std::make_tuple(id),
                             std::make_tuple(
-                                m_help->tomlSources.get(id),
-                                m_help->tomlParameters(),
-                                m_help->allowedDataSources,
-                                mThreadParams.communicator));
+                                /* tomlFile = */ m_help->tomlSources.get(id),
+                                /* tomlParameters = */ m_help->tomlParameters(),
+                                /* allowedDataSources = */ m_help->allowedDataSources,
+                                /* comm = */ mThreadParams.communicator,
+                                /* pluginParameters = */ std::move(pluginParametersWithDefaults)));
                         if(!newly_inserted)
                         {
                             throw std::runtime_error("[openPMD plugin] Internal logic error: Tried parsing the same "

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -275,7 +275,9 @@ namespace picongpu
             std::string const& tomlFile,
             std::vector<picongpu::toml::TomlParameter> tomlParameters,
             std::vector<std::string> const& allowedDataSources,
-            MPI_Comm comm)
+            MPI_Comm comm,
+            openPMD::PluginParameters openPMDPluginParameters_in)
+            : openPMDPluginParameters{std::move(openPMDPluginParameters_in)}
         {
             /*
              * Do NOT put the following line as part of the constructor initializers!

--- a/include/picongpu/plugins/openPMD/toml.hpp
+++ b/include/picongpu/plugins/openPMD/toml.hpp
@@ -76,7 +76,8 @@ namespace picongpu
                 std::string const& tomlFile,
                 std::vector<picongpu::toml::TomlParameter> tomlParameters,
                 std::vector<std::string> const& allowedDataSources,
-                MPI_Comm);
+                MPI_Comm comm,
+                openPMD::PluginParameters pluginParameters);
 
             /*
              * The datasources that are active at currentStep().


### PR DESCRIPTION
I noticed that the `picongpu --help` page claimed that the default value for `--openPMD.ext` is `bp4`, but files are actually created as `simData_000000.bp`. This is because the default values are specified at two places:

1. In the `Option` members of `openPMDWriter::Help`. These values are shown on the command line.
2. In the data members of `PluginParameters`. These are the values that actually count.

This PR removes all default value specification from `PluginParameters` and initializes them from the `Option` data members.
This also serves to unify the default values of command line and TOML parameters.

TODO:

- [x] Update documentation
- [x] The command line now shows that `openPMD.file` has a default value. Maybe make this a non-required parameter.