### PR TITLE
Get supercell index relative to user defined origin

### DIFF
--- a/include/pmacc/mappings/kernel/AreaMapping.hpp
+++ b/include/pmacc/mappings/kernel/AreaMapping.hpp
@@ -75,12 +75,24 @@ namespace pmacc
 
         /** Return index of a supercell to be processed by the given alpaka block
          *
+         * @tparam T_origin Which origin (CORE/BORDER/GUARD) to return supercell index relative to (default: GUARD)
          * @param blockIdx alpaka block index
          * @return mapped SuperCell index including guards
          */
+        template<uint32_t T_origin = GUARD>
         HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
-            return AreaMappingMethods<areaType, DIM>::getSuperCellIndex(*this, this->getGridSuperCells(), blockIdx);
+            auto result
+                = AreaMappingMethods<areaType, DIM>::getSuperCellIndex(*this, this->getGridSuperCells(), blockIdx);
+            if constexpr(T_origin == CORE)
+            {
+                result = result - 2 * this->getGuardingSuperCells();
+            }
+            if constexpr(T_origin == BORDER)
+            {
+                result = result - this->getGuardingSuperCells();
+            }
+            return result;
         }
     };
 

--- a/include/pmacc/mappings/kernel/AreaMappingMethods.hpp
+++ b/include/pmacc/mappings/kernel/AreaMappingMethods.hpp
@@ -30,10 +30,10 @@ namespace pmacc
      * Helper class for AreaMapping.
      * Provides methods called by AreaMapping using template specialization.
      *
-     * @tparam areaType the area to map to
+     * @tparam T_area the area to map to
      * @tparam DIM dimension of the mapping
      */
-    template<uint32_t areaType, unsigned DIM>
+    template<uint32_t T_area, unsigned DIM>
     class AreaMappingMethods;
 
     // CORE + BORDER + GUARD

--- a/include/pmacc/mappings/kernel/BorderMapping.hpp
+++ b/include/pmacc/mappings/kernel/BorderMapping.hpp
@@ -111,9 +111,11 @@ namespace pmacc
 
         /** Return index of a supercell to be processed by the given alpaka block
          *
+         * @tparam T_origin Which origin (CORE/BORDER/GUARD) to return supercell index relative to (default: GUARD)
          * @param blockIdx alpaka block index
          * @return mapped SuperCell index including guards
          */
+        template<uint32_t T_origin = GUARD>
         HDINLINE DimDataSpace getSuperCellIndex(const DimDataSpace& blockIdx) const
         {
             DimDataSpace result = blockIdx;
@@ -127,7 +129,14 @@ namespace pmacc
                 else
                     result[i] += this->getGuardingSuperCells()[i];
             }
-
+            if constexpr(T_origin == CORE)
+            {
+                result = result - 2 * this->getGuardingSuperCells();
+            }
+            if constexpr(T_origin == BORDER)
+            {
+                result = result - this->getGuardingSuperCells();
+            }
             return result;
         }
 

--- a/include/pmacc/mappings/kernel/ExchangeMapping.hpp
+++ b/include/pmacc/mappings/kernel/ExchangeMapping.hpp
@@ -92,12 +92,23 @@ namespace pmacc
 
         /** Return index of a supercell to be processed by the given alpaka block
          *
+         * @tparam T_origin Which origin (CORE/BORDER/GUARD) to return supercell index relative to (default: GUARD)
          * @param blockIdx alpaka block index
          * @return mapped SuperCell index including guards
          */
+        template<uint32_t T_origin = GUARD>
         HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
-            return ExchangeMappingMethods<areaType, DIM>::getSuperCellIndex(*this, blockIdx, exchangeType);
+            auto result = ExchangeMappingMethods<areaType, DIM>::getSuperCellIndex(*this, blockIdx, exchangeType);
+            if constexpr(T_origin == CORE)
+            {
+                result = result - 2 * this->getGuardingSuperCells();
+            }
+            if constexpr(T_origin == BORDER)
+            {
+                result = result - this->getGuardingSuperCells();
+            }
+            return result;
         }
     };
 

--- a/include/pmacc/mappings/kernel/StrideMapping.hpp
+++ b/include/pmacc/mappings/kernel/StrideMapping.hpp
@@ -88,13 +88,24 @@ namespace pmacc
 
         /** Return index of a supercell to be processed by the given alpaka block
          *
+         * @tparam T_origin Which origin (CORE/BORDER/GUARD) to return supercell index relative to (default: GUARD)
          * @param blockIdx alpaka block index
          * @return mapped SuperCell index including guards
          */
+        template<uint32_t T_origin = GUARD>
         HDINLINE DataSpace<DIM> getSuperCellIndex(const DataSpace<DIM>& blockIdx) const
         {
             const DataSpace<DIM> blockId((blockIdx * stride) + offset);
-            return StrideMappingMethods<areaType, DIM>::shift(*this, blockId);
+            auto result = StrideMappingMethods<areaType, DIM>::shift(*this, blockId);
+            if constexpr(T_origin == CORE)
+            {
+                result = result - 2 * this->getGuardingSuperCells();
+            }
+            if constexpr(T_origin == BORDER)
+            {
+                result = result - this->getGuardingSuperCells();
+            }
+            return result;
         }
 
         HDINLINE DataSpace<DIM> getOffset() const


### PR DESCRIPTION
Supercell index relative to user defined origin
Add a template parameter to `getSupercellIndex` which defines the origin with respect to which to return the supercell index (Core/Border/Guard)
Defaults to Guard to maintain current functionality
Closes #4683