### PR TITLE
change class and function names in radPlugin to camelCase

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -91,14 +91,14 @@ Observation directions
 """"""""""""""""""""""
 
 The number of observation directions ``N_theta`` is defined in :ref:`radiation.param <usage-params-plugins>`, but the distribution of observation directions is given in :ref:`radiationObserver.param <usage-params-plugins>`)
-There, the function ``observation_direction`` defines the observation directions.
+There, the function ``observationDirection`` defines the observation directions.
 
 This function returns the x,y and z component of a **unit vector** pointing in the observation direction.
 
 .. code:: cpp
 
    DINLINE vector_64
-   observation_direction( int const observation_id_extern )
+   observationDirection( int const observation_id_extern )
    {
        /* use the scalar index const int observation_id_extern to compute an
         * observation direction (x,y,y) */

--- a/docs/source/usage/plugins/transitionRadiation.rst
+++ b/docs/source/usage/plugins/transitionRadiation.rst
@@ -109,14 +109,14 @@ Observation directions
 """"""""""""""""""""""
 
 The number of observation directions ``N_theta`` and the distribution of observation directions is defined in :ref:`transitionRadiation.param <usage-params-plugins>`.
-There, the function ``observation_direction`` defines the observation directions.
+There, the function ``observationDirection`` defines the observation directions.
 
 This function returns the x,y and z component of a **unit vector** pointing in the observation direction. 
 
 .. code:: cpp
 
    DINLINE vector_64
-   observation_direction( int const observation_id_extern )
+   observationDirection( int const observation_id_extern )
    {
        /* use the scalar index const int observation_id_extern to compute an 
         * observation direction (x,y,y) */

--- a/include/picongpu/param/radiationObserver.param
+++ b/include/picongpu/param/radiationObserver.param
@@ -73,7 +73,7 @@ namespace picongpu
                  *           type: vector_64
                  *
                  */
-                HDINLINE vector_64 observation_direction(const int observation_id_extern)
+                HDINLINE vector_64 observationDirection(const int observation_id_extern)
                 {
                     /* float type used in radiation direction calculations */
                     using float_obs = picongpu::float_X;

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -338,7 +338,7 @@ namespace picongpu
                         /* allocate memory for all amplitudes for temporal data collection
                          * ACCUMULATOR! Should be in double precision for numerical stability.
                          */
-                        tmp_result.resize(elements_amplitude(), Amplitude::zero());
+                        tmp_result.resize(elementsAmplitude(), Amplitude::zero());
 
                         /*only rank 0 creates a file*/
                         isMaster = reduce.hasResult(mpi::reduceMethods::Reduce());
@@ -348,7 +348,7 @@ namespace picongpu
                          * line option numJobs is > 1.
                          */
                         radiation
-                            = std::make_unique<GridBuffer<Amplitude, 2>>(DataSpace<2>(elements_amplitude(), numJobs));
+                            = std::make_unique<GridBuffer<Amplitude, 2>>(DataSpace<2>(elementsAmplitude(), numJobs));
 
                         freqInit.Init(frequencies_from_list::listLocation);
                         freqFkt = freqInit.getFunctor();
@@ -358,14 +358,14 @@ namespace picongpu
 
                         if(isMaster)
                         {
-                            timeSumArray.resize(elements_amplitude(), Amplitude::zero());
+                            timeSumArray.resize(elementsAmplitude(), Amplitude::zero());
 
                             /* save detector position / observation direction */
                             detectorPositions.resize(parameters::N_observer);
                             for(uint32_t detectorIndex = 0; detectorIndex < parameters::N_observer; ++detectorIndex)
                             {
                                 detectorPositions[detectorIndex]
-                                    = radiation_observer::observation_direction(detectorIndex);
+                                    = radiation_observer::observationDirection(detectorIndex);
                             }
 
                             /* save detector frequencies */
@@ -437,7 +437,7 @@ namespace picongpu
                     eventSystem::getTransactionEvent().waitForFinished();
 
                     auto dbox = radiation->getHostBuffer().getDataBox();
-                    int numAmp = elements_amplitude();
+                    int numAmp = elementsAmplitude();
                     // update the main result matrix (y index zero)
                     for(int resultIdx = 1; resultIdx < numJobs; ++resultIdx)
                         for(int ampIdx = 0; ampIdx < numAmp; ++ampIdx)
@@ -477,7 +477,7 @@ namespace picongpu
 
 
                 /** returns number of observers (radiation detectors) */
-                static unsigned int elements_amplitude()
+                static unsigned int elementsAmplitude()
                 {
                     return radiation_frequencies::N_omega
                         * parameters::N_observer; // storage for amplitude results on GPU
@@ -492,7 +492,7 @@ namespace picongpu
                         pmacc::math::operation::Add(),
                         tmp_result.data(),
                         radiation->getHostBuffer().getBasePointer(),
-                        elements_amplitude(),
+                        elementsAmplitude(),
                         mpi::reduceMethods::Reduce());
                 }
 
@@ -504,7 +504,7 @@ namespace picongpu
                     if(isMaster)
                     {
                         // add last amplitudes to previous amplitudes
-                        for(unsigned int i = 0; i < elements_amplitude(); ++i)
+                        for(unsigned int i = 0; i < elementsAmplitude(); ++i)
                             targetArray[i] += summandArray[i];
                     }
                 }
@@ -801,7 +801,7 @@ namespace picongpu
 
                         /* get the radiation amplitude unit */
                         Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
-                        const picongpu::float_64 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME;
+                        const picongpu::float_64 factor = UnityAmplitude.calcRadiation() * UNIT_ENERGY * UNIT_TIME;
 
                         // buffer for data re-arangement
                         const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
@@ -884,7 +884,7 @@ namespace picongpu
 
                         /* get the radiation amplitude unit */
                         Amplitude UnityAmplitude(1., 0., 0., 0., 0., 0.);
-                        const picongpu::float_64 factor = UnityAmplitude.calc_radiation() * UNIT_ENERGY * UNIT_TIME;
+                        const picongpu::float_64 factor = UnityAmplitude.calcRadiation() * UNIT_ENERGY * UNIT_TIME;
 
                         // buffer for data re-arangement
                         const int N_tmpBuffer = radiation_frequencies::N_omega * parameters::N_observer;
@@ -1137,7 +1137,7 @@ namespace picongpu
                                 // calculate the square of the absolute value
                                 // and write to file.
                                 outFile << values[index_omega + index_direction * radiation_frequencies::N_omega]
-                                               .calc_radiation()
+                                               .calcRadiation()
                                         * UNIT_ENERGY * UNIT_TIME
                                         << "\t";
                             }

--- a/include/picongpu/plugins/radiation/Radiation.kernel
+++ b/include/picongpu/plugins/radiation/Radiation.kernel
@@ -145,7 +145,7 @@ namespace picongpu
                     picongpu::float_64 const t(picongpu::float_64(currentStep) * picongpu::float_64(DELTA_T));
 
                     // looking direction (needed for observer) used in the thread
-                    vector_64 const look = radiation_observer::observation_direction(theta_idx);
+                    vector_64 const look = radiation_observer::observationDirection(theta_idx);
 
                     // get extent of guarding super cells (needed to ignore them)
                     DataSpace<simDim> const guardingSuperCells = mapper.getGuardingSuperCells();
@@ -299,11 +299,10 @@ namespace picongpu
                                                     particle_mass);
 
                                                 // set up amplitude calculator
-                                                using Calc_Amplitude_n_sim_1
-                                                    = Calc_Amplitude<Retarded_time_1, Old_DFT>;
+                                                using CalcAmplitudeNSim1 = CalcAmplitude<RetardedTime1, OldDFT>;
 
                                                 // calculate amplitude
-                                                Calc_Amplitude_n_sim_1 const amplitude3(particle, DELTA_T, t);
+                                                CalcAmplitudeNSim1 const amplitude3(particle, DELTA_T, t);
 
                                                 // get charge of single electron ! (weighting=1.0f)
                                                 float_X const particle_charge = frame::getCharge<FrameType>();
@@ -311,19 +310,19 @@ namespace picongpu
                                                 /* compute real amplitude of macro-particle with a charge of
                                                  * a single electron
                                                  */
-                                                real_amplitude_s[saveParticleAt] = amplitude3.get_vector(look)
+                                                real_amplitude_s[saveParticleAt] = amplitude3.getVector(look)
                                                     * particle_charge * picongpu::float_64(DELTA_T);
 
                                                 // retarded time stored in shared memory
                                                 t_ret_s[saveParticleAt]
-                                                    = static_cast<float_X>(amplitude3.get_t_ret(look));
+                                                    = static_cast<float_X>(amplitude3.getTRet(look));
 
                                                 lowpass_s[saveParticleAt] = NyquistLowPass(look, particle);
 
                                                 /* the particle amplitude is used to include the weighting
                                                  * of the window function filter without needing more memory
                                                  */
-                                                radWindowFunction::radWindowFunction const winFkt;
+                                                radWindowFunction::RadWindowFunction const winFkt;
 
                                                 /* start with a factor of one */
                                                 float_X windowFactor = 1.0;
@@ -361,7 +360,7 @@ namespace picongpu
                                         picongpu::float_X const omega = static_cast<float_X>(freqFkt(o));
 
                                         // create a form factor functor
-                                        radFormFactor::radFormFactor const myRadFormFactor{omega, look};
+                                        radFormFactor::RadFormFactor const myRadFormFactor{omega, look};
 
                                         /* Particle loop: thread runs through loaded particle data
                                          *

--- a/include/picongpu/plugins/radiation/amplitude.hpp
+++ b/include/picongpu/plugins/radiation/amplitude.hpp
@@ -152,7 +152,7 @@ namespace picongpu
                 /** calculate radiation from *this amplitude
                  *
                  * Returns: \f$\frac{d^2 I}{d \Omega d \omega} = const*Amplitude^2\f$ */
-                HDINLINE picongpu::float_64 calc_radiation(void)
+                HDINLINE picongpu::float_64 calcRadiation(void)
                 {
                     // const SI factor radiation
                     const picongpu::float_64 factor = 1.0

--- a/include/picongpu/plugins/radiation/calc_amplitude.hpp
+++ b/include/picongpu/plugins/radiation/calc_amplitude.hpp
@@ -33,16 +33,16 @@ namespace picongpu
             // protected:
             // error class for wrong time access
 
-            class Error_Accessing_Time
+            class ErrorAccessingTime
             {
             public:
-                Error_Accessing_Time(void)
+                ErrorAccessingTime(void)
                 {
                 }
             };
 
 
-            struct One_minus_beta_times_n
+            struct OneMinusBetaTimesN
             {
                 /// Class to calculate \f$1-\beta \times \vec n\f$
                 /// using the best suiting method depending on energy
@@ -55,7 +55,7 @@ namespace picongpu
                 {
                     // 1/gamma^2:
 
-                    const picongpu::float_64 gamma_inv_square(particle.get_gamma_inv_square<When::now>());
+                    const picongpu::float_64 gamma_inv_square(particle.getGammaInvSquare<When::now>());
 
                     // picongpu::float_64 value; // storage for 1-\beta \times \vec n
 
@@ -67,7 +67,7 @@ namespace picongpu
                     // order
                     if(gamma_inv_square < picongpu::GAMMA_INV_SQUARE_RAD_THRESH)
                     {
-                        const picongpu::float_64 cos_theta(particle.get_cos_theta<When::now>(
+                        const picongpu::float_64 cos_theta(particle.getCosTheta<When::now>(
                             n)); // cosine between looking vector and momentum of particle
                         const picongpu::float_64 taylor_approx(
                             cos_theta * Taylor()(gamma_inv_square) + (1.0 - cos_theta));
@@ -75,13 +75,13 @@ namespace picongpu
                     }
                     else
                     {
-                        const vector_64 beta(particle.get_beta<When::now>()); // calculate v/c=beta
+                        const vector_64 beta(particle.getBeta<When::now>()); // calculate v/c=beta
                         return (1.0 - beta * n);
                     }
                 }
             };
 
-            struct Retarded_time_1
+            struct RetardedTime1
             {
                 // interface for combined 'Amplitude_Calc' classes
                 // contains more parameters than needed to have the
@@ -92,13 +92,13 @@ namespace picongpu
                     const vector_64& n,
                     const Particle& particle) const
                 {
-                    const vector_64 r(particle.get_location<When::now>()); // location
+                    const vector_64 r(particle.getLocation<When::now>()); // location
                     return (picongpu::float_64)(t - (n * r) / (picongpu::SPEED_OF_LIGHT));
                 }
             };
 
             template<typename Exponent> // divisor to the power of 'Exponent'
-            struct Old_Method
+            struct OldMethod
             {
                 /// classical method to calculate the real vector part of the radiation's amplitude
                 /// this base class includes both possible interpretations:
@@ -108,40 +108,40 @@ namespace picongpu
                 HDINLINE vector_64
                 operator()(const vector_64& n, const Particle& particle, const picongpu::float_64 delta_t) const
                 {
-                    const vector_64 beta(particle.get_beta<When::now>()); // beta = v/c
+                    const vector_64 beta(particle.getBeta<When::now>()); // beta = v/c
                     const vector_64 beta_dot(
-                        (beta - particle.get_beta<When::now + 1>())
+                        (beta - particle.getBeta<When::now + 1>())
                         / delta_t); // numeric differentiation (backward difference)
                     const Exponent exponent; // instance of the Exponent class // ???is a static class and no instance
-                                             // possible??? const One_minus_beta_times_n one_minus_beta_times_n;
-                    const picongpu::float_64 factor(exponent(1.0 / (One_minus_beta_times_n()(n, particle))));
+                                             // possible??? const OneMinusBetaTimesN one_minus_beta_times_n;
+                    const picongpu::float_64 factor(exponent(1.0 / (OneMinusBetaTimesN()(n, particle))));
                     // factor=1/(1-beta*n)^g   g=2 for DFT and g=3 for FFT
                     return (n % ((n - beta) % beta_dot)) * factor;
                 }
             };
 
-            // typedef of all possible forms of Old_Method
-            // typedef Old_Method<util::Cube<picongpu::float_64> > Old_FFT;
-            typedef Old_Method<util::Square<picongpu::float_64>> Old_DFT;
+            // typedef of all possible forms of OldMethod
+            // typedef OldMethod<util::Cube<picongpu::float_64> > OldFFT;
+            typedef OldMethod<util::Square<picongpu::float_64>> OldDFT;
 
 
             // ------- Calculate Amplitude class ------------- //
 
             template<typename TimeCalc, typename VecCalc>
-            class Calc_Amplitude
+            class CalcAmplitude
             {
                 /// final class for amplitude calculations
                 /// derived from a class to calculate the retarded time (TimeCalc; possibilities:
                 /// Retarded_Time_1 and Retarded_Time_2) and from a class to  calculate
                 /// the real vector part of the amplitude (VecCalc; possibilities:
-                /// Old_FFT, Old_DFT, Partial_Integral_Method_1, Partial_Integral_Method_2)
+                /// OldFFT, OldDFT, Partial_Integral_Method_1, Partial_Integral_Method_2)
             public:
                 /// constructor
                 // takes a lot of parameters to have a general interface
                 // not all parameters are needed for all possible combinations
                 // of base classes
 
-                HDINLINE Calc_Amplitude(
+                HDINLINE CalcAmplitude(
                     const Particle& particle,
                     const picongpu::float_64 delta_t,
                     const picongpu::float_64 t_sim)
@@ -153,21 +153,21 @@ namespace picongpu
 
                 // get real vector part of amplitude
 
-                HDINLINE vector_64 get_vector(const vector_64& n) const
+                HDINLINE vector_64 getVector(const vector_64& n) const
                 {
-                    const vector_64 look_direction(n.unit_vec()); // make sure look_direction is a unit vector
+                    const vector_64 look_direction(n.unitVec()); // make sure look_direction is a unit vector
                     VecCalc vecC;
                     return vecC(look_direction, m_particle, m_delta_t);
                 }
 
                 // get retarded time
 
-                HDINLINE picongpu::float_64 get_t_ret(const vector_64 look_direction) const
+                HDINLINE picongpu::float_64 getTRet(const vector_64 look_direction) const
                 {
                     TimeCalc timeC;
                     return timeC(m_t_sim, look_direction, m_particle);
 
-                    //  const vector_64 r = particle.get_location<When::now > (); // location
+                    //  const vector_64 r = particle.getLocation<When::now > (); // location
                     //  return (picongpu::float_64) (t - (n * r) / (picongpu::SPEED_OF_LIGHT));
                 }
 

--- a/include/picongpu/plugins/radiation/check_consistency.hpp
+++ b/include/picongpu/plugins/radiation/check_consistency.hpp
@@ -30,7 +30,7 @@ namespace picongpu
     {
         namespace radiation
         {
-            HINLINE void check_consistency(void)
+            HINLINE void checkConsistency(void)
             {
                 using namespace parameters;
                 std::cout << " checking efficiency of radiation code: ";

--- a/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
+++ b/include/picongpu/plugins/radiation/nyquist_low_pass.hpp
@@ -33,7 +33,7 @@ namespace picongpu
         namespace radiation
         {
             //! Low pass filter on frequencies, the threshold depends on the Nyquist frequency
-            class NyquistLowPass : public One_minus_beta_times_n
+            class NyquistLowPass : public OneMinusBetaTimesN
             {
             public:
                 /** Calculates the filter threshold, only frequencies below it pass
@@ -45,7 +45,7 @@ namespace picongpu
                  **/
                 HDINLINE NyquistLowPass(const vector_64& n, const Particle& particle)
                 {
-                    auto const omegaNyquist = (PI - 0.01) / (DELTA_T * One_minus_beta_times_n()(n, particle));
+                    auto const omegaNyquist = (PI - 0.01) / (DELTA_T * OneMinusBetaTimesN()(n, particle));
                     threshold = static_cast<float_X>(omegaNyquist * radiationNyquist::NyquistFactor);
                 }
 

--- a/include/picongpu/plugins/radiation/particle.hpp
+++ b/include/picongpu/plugins/radiation/particle.hpp
@@ -85,38 +85,38 @@ namespace picongpu
                 // getters:
 
                 template<unsigned int when>
-                HDINLINE vector_64 get_location(void) const;
+                HDINLINE vector_64 getLocation(void) const;
                 // get location at time when
 
                 template<unsigned int when>
-                HDINLINE vector_64 get_momentum(void) const;
+                HDINLINE vector_64 getMomentum(void) const;
                 // get momentum at time when
 
                 template<unsigned int when>
-                HDINLINE vector_64 get_beta(void) const
+                HDINLINE vector_64 getBeta(void) const
                 {
-                    return calc_beta(get_momentum<when>());
+                    return calcBeta(getMomentum<when>());
                 } // get beta at time when except:
                 // first --> is specialized below
 
                 template<unsigned int when>
-                HDINLINE picongpu::float_64 get_gamma(void) const
+                HDINLINE picongpu::float_64 getGamma(void) const
                 {
-                    return calc_gamma(get_momentum<when>());
+                    return calcGamma(getMomentum<when>());
                 } // get gamma at time when
 
                 template<unsigned int when>
-                HDINLINE picongpu::float_64 get_gamma_inv_square(void) const
+                HDINLINE picongpu::float_64 getGammaInvSquare(void) const
                 {
-                    return calc_gamma_inv_square(get_momentum<when>());
+                    return calcGammaInvSquare(getMomentum<when>());
                 } // get 1/gamma^2
 
                 template<unsigned int when>
-                HDINLINE picongpu::float_64 get_cos_theta(const vector_64& n) const
+                HDINLINE picongpu::float_64 getCosTheta(const vector_64& n) const
                 {
                     // get cos(theta) at time when
-                    const vector_64 beta = get_beta<when>();
-                    return calc_cos_theta(n, beta);
+                    const vector_64 beta = getBeta<when>();
+                    return calcCosTheta(n, beta);
                 }
 
 
@@ -124,14 +124,14 @@ namespace picongpu
                 //////////////////////////////////////////////////////////////////
                 // private methods:
 
-                HDINLINE vector_64 calc_beta(const vector_X& momentum) const
+                HDINLINE vector_64 calcBeta(const vector_X& momentum) const
                 {
                     // returns beta=v/c
-                    const picongpu::float_32 gamma1 = calc_gamma(momentum);
+                    const picongpu::float_32 gamma1 = calcGamma(momentum);
                     return momentum * (1.0 / (mass * picongpu::SPEED_OF_LIGHT * gamma1));
                 }
 
-                HDINLINE picongpu::float_64 calc_gamma(const vector_X& momentum) const
+                HDINLINE picongpu::float_64 calcGamma(const vector_X& momentum) const
                 {
                     // return gamma = E/(mc^2)
                     const picongpu::float_32 x = util::square<vector_X, picongpu::float_32>(
@@ -139,14 +139,14 @@ namespace picongpu
                     return picongpu::math::sqrt(1.0 + x);
                 }
 
-                HDINLINE picongpu::float_64 calc_gamma_inv_square(const vector_X& momentum) const
+                HDINLINE picongpu::float_64 calcGammaInvSquare(const vector_X& momentum) const
                 {
                     // returns 1/gamma^2 = m^2*c^2/(m^2*c^2 + p^2)
                     const picongpu::float_32 Emass = mass * picongpu::SPEED_OF_LIGHT;
                     return Emass / (Emass + (util::square<vector_X, picongpu::float_32>(momentum)) / Emass);
                 }
 
-                HDINLINE picongpu::float_64 calc_cos_theta(const vector_64& n, const vector_64& beta) const
+                HDINLINE picongpu::float_64 calcCosTheta(const vector_64& n, const vector_64& beta) const
                 {
                     // return cos of angle between looking and flight direction
                     return (n * beta) / (std::sqrt(beta * beta));
@@ -158,7 +158,7 @@ namespace picongpu
                 HDINLINE picongpu::float_64 summand(void) const
                 {
                     // return \vec n independend summand (next value to add to \vec n independend sum)
-                    const picongpu::float_64 x = get_gamma_inv_square<When::now>();
+                    const picongpu::float_64 x = getGammaInvSquare<When::now>();
                     return Taylor()(x);
                 }
 
@@ -166,19 +166,19 @@ namespace picongpu
 
 
             template<>
-            HDINLINE vector_64 Particle::get_location<When::now>(void) const
+            HDINLINE vector_64 Particle::getLocation<When::now>(void) const
             {
                 return location_now;
             } // get location at time when
 
             template<>
-            HDINLINE vector_64 Particle::get_momentum<When::now>(void) const
+            HDINLINE vector_64 Particle::getMomentum<When::now>(void) const
             {
                 return momentum_now;
             } // get momentum at time when
 
             template<>
-            HDINLINE vector_64 Particle::get_momentum<When::old>(void) const
+            HDINLINE vector_64 Particle::getMomentum<When::old>(void) const
             {
                 return momentum_old;
             } // get momentum at time when

--- a/include/picongpu/plugins/radiation/radFormFactor.hpp
+++ b/include/picongpu/plugins/radiation/radFormFactor.hpp
@@ -67,14 +67,14 @@ namespace picongpu
                  * @tparam T_shapeOrder order of charge distribution shape in PIC code used for radiation form factor
                  */
                 template<uint32_t T_shapeOrder>
-                struct radFormFactor
+                struct RadFormFactor
                 {
                     /** Construct the form factor functor for the given frequency and observation direction
                      *
                      * @param omega frequency
                      * @param observerUnitVec unit vector of observation direction
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const& observerUnitVec)
                         : normalizedCoherentAmplification(getNormalizedCoherentAmplification(omega, observerUnitVec))
                     {
                     }
@@ -122,15 +122,15 @@ namespace picongpu
             namespace radFormFactor_CIC_3D
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor<1>
+                struct RadFormFactor : public radFormFactor_baseShape_3D::RadFormFactor<1>
                 {
                     /** Construct the form factor functor for the given frequency and observation direction
                      *
                      * @param omega frequency
                      * @param observerUnitVec unit vector of observation direction
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
-                        : radFormFactor_baseShape_3D::radFormFactor<1>(omega, observerUnitVec)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : radFormFactor_baseShape_3D::RadFormFactor<1>(omega, observerUnitVec)
                     {
                     }
                 };
@@ -139,15 +139,15 @@ namespace picongpu
             namespace radFormFactor_TSC_3D
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor<2>
+                struct RadFormFactor : public radFormFactor_baseShape_3D::RadFormFactor<2>
                 {
                     /** Construct the form factor functor for the given frequency and observation direction
                      *
                      * @param omega frequency
                      * @param observerUnitVec unit vector of observation direction
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
-                        : radFormFactor_baseShape_3D::radFormFactor<2>(omega, observerUnitVec)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : radFormFactor_baseShape_3D::RadFormFactor<2>(omega, observerUnitVec)
                     {
                     }
                 };
@@ -156,15 +156,15 @@ namespace picongpu
             namespace radFormFactor_PCS_3D
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor : public radFormFactor_baseShape_3D::radFormFactor<3>
+                struct RadFormFactor : public radFormFactor_baseShape_3D::RadFormFactor<3>
                 {
                     /** Construct the form factor functor for the given frequency and observation direction
                      *
                      * @param omega frequency
                      * @param observerUnitVec unit vector of observation direction
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
-                        : radFormFactor_baseShape_3D::radFormFactor<3>(omega, observerUnitVec)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                        : radFormFactor_baseShape_3D::RadFormFactor<3>(omega, observerUnitVec)
                     {
                     }
                 };
@@ -174,7 +174,7 @@ namespace picongpu
             namespace radFormFactor_CIC_1Dy
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor
+                struct RadFormFactor
                 {
                     /** Construct the form factor functor for the given frequency
                      *
@@ -182,7 +182,7 @@ namespace picongpu
                      * @param observerUnitVec unit vector of observation direction,
                      *                        not used for this form factor but requried by RadFormFactorConcept
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const&)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const&)
                         : normalizedCoherentAmplification(
                             util::square(pmacc::math::sinc(CELL_HEIGHT / (SPEED_OF_LIGHT * 2.0_X) * omega)))
                     {
@@ -213,7 +213,7 @@ namespace picongpu
             namespace radFormFactor_Gauss_spherical
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor
+                struct RadFormFactor
                 {
                     /** Construct the form factor functor for the given frequency
                      *
@@ -224,7 +224,7 @@ namespace picongpu
                      * @param observerUnitVec unit vector of observation direction,
                      *                        not used for this form factor but requried by RadFormFactorConcept
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const&)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const&)
                         : normalizedCoherentAmplification(
                             util::square(math::exp(-0.5_X * util::square(omega * 0.5_X * DELTA_T))))
                     {
@@ -253,14 +253,14 @@ namespace picongpu
             namespace radFormFactor_Gauss_cell
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor
+                struct RadFormFactor
                 {
                     /** Construct the form factor functor for the given frequency and observation direction
                      *
                      * @param omega frequency
                      * @param observerUnitVec unit vector of observation direction
                      */
-                    HDINLINE radFormFactor(const float_X omega, vector_64 const& observerUnitVec)
+                    HDINLINE RadFormFactor(const float_X omega, vector_64 const& observerUnitVec)
                         : normalizedCoherentAmplification(getNormalizedCoherentAmplification(omega, observerUnitVec))
                     {
                     }
@@ -303,7 +303,7 @@ namespace picongpu
             namespace radFormFactor_incoherent
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor
+                struct RadFormFactor
                 {
                     /** Construct the form factor functor for the given frequency
                      *
@@ -312,7 +312,7 @@ namespace picongpu
                      * @param observerUnitVec unit vector of observation direction,
                      *                        not used for this form factor but requried by RadFormFactorConcept
                      */
-                    HDINLINE radFormFactor(const float_X, vector_64 const&)
+                    HDINLINE RadFormFactor(const float_X, vector_64 const&)
                     {
                     }
 
@@ -333,7 +333,7 @@ namespace picongpu
             namespace radFormFactor_coherent
             {
                 //! Adheres to the RadFormFactorConcept concept
-                struct radFormFactor
+                struct RadFormFactor
                 {
                     /** Construct the form factor functor for the given frequency
                      *
@@ -342,7 +342,7 @@ namespace picongpu
                      * @param observerUnitVec unit vector of observation direction,
                      *                        not used for this form factor but requried by RadFormFactorConcept
                      */
-                    HDINLINE radFormFactor(const float_X, vector_64 const&)
+                    HDINLINE RadFormFactor(const float_X, vector_64 const&)
                     {
                     }
 

--- a/include/picongpu/plugins/radiation/vector.hpp
+++ b/include/picongpu/plugins/radiation/vector.hpp
@@ -140,7 +140,7 @@ namespace picongpu
 
                 // unit vector in the direction of the vector
 
-                HDINLINE cuda_vec<V, T> unit_vec(void) const
+                HDINLINE cuda_vec<V, T> unitVec(void) const
                 {
                     return *this / magnitude();
                 }

--- a/include/picongpu/plugins/radiation/windowFunctions.hpp
+++ b/include/picongpu/plugins/radiation/windowFunctions.hpp
@@ -34,7 +34,7 @@ namespace picongpu
 
             namespace radWindowFunctionTriangle
             {
-                struct radWindowFunction
+                struct RadWindowFunction
                 {
                     /** 1D Window function according to the triangle window:
                      *
@@ -62,7 +62,7 @@ namespace picongpu
 
             namespace radWindowFunctionHamming
             {
-                struct radWindowFunction
+                struct RadWindowFunction
                 {
                     /** 1D Window function according to the Hamming window:
                      *
@@ -92,7 +92,7 @@ namespace picongpu
 
             namespace radWindowFunctionTriplett
             {
-                struct radWindowFunction
+                struct RadWindowFunction
                 {
                     /** 1D Window function according to the Triplett window:
                      *
@@ -122,7 +122,7 @@ namespace picongpu
 
             namespace radWindowFunctionGauss
             {
-                struct radWindowFunction
+                struct RadWindowFunction
                 {
                     /** 1D Window function according to the Gauss window:
                      *
@@ -152,7 +152,7 @@ namespace picongpu
 
             namespace radWindowFunctionNone
             {
-                struct radWindowFunction
+                struct RadWindowFunction
                 {
                     /** 1D Window function according to the no window:
                      *

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -297,7 +297,7 @@ namespace picongpu
                                 // create a form factor object for physical correct coherence effects within
                                 // macro-particles
                                 float_X const omega = freqFkt(o);
-                                macroParticleFormFactor::radFormFactor const macroParticleFormFactor{
+                                macroParticleFormFactor::RadFormFactor const macroParticleFormFactor{
                                     omega,
                                     precisionCast<float_64>(look)};
 

--- a/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/radiationObserver.param
@@ -42,7 +42,7 @@ namespace picongpu
                  *           type: vector_64
                  *
                  */
-                HDINLINE vector_64 observation_direction(const int observation_id_extern)
+                HDINLINE vector_64 observationDirection(const int observation_id_extern)
                 {
                     /** Computes observation angles along the x-y plane.
                      *  Assuming electron(s) fly in -y direction and the laser

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/radiationObserver.param
@@ -42,7 +42,7 @@ namespace picongpu
                  *           type: vector_64
                  *
                  */
-                HDINLINE vector_64 observation_direction(const int observation_id_extern)
+                HDINLINE vector_64 observationDirection(const int observation_id_extern)
                 {
                     /** This computes observation directions for one octant
                      *  of a sphere around the simulation area.


### PR DESCRIPTION
This pull request fixes #1642.

It just introduces some long overdue renamings: 
 - changes all non-camel-case class names in the radiation plugin to camel-case
 - changes all non-camel-case function/method names in the radiation plugin to camel-case
 - updates the documentation of the radiation plugin
 - updates the **`radiationObserver.param` ➡️  break to old param file ⬅️**
 - updates the documentation of the transition radiation plugin, where this renaming already occurred, but the documentation was not updated 