### PR TITLE
fix zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -244,27 +244,6 @@
       "type":"Other"
     }
   ],
-  "grants":[
-    {
-      "acronym":"EUCALL",
-      "code":"654220",
-      "funder":{
-        "acronyms":[
-          "EC"
-        ],
-        "doi":"10.13039/501100000780",
-        "links":{
-          "self":"https://zenodo.org/api/funders/10.13039/501100000780"
-        },
-        "name":"European Commission"
-      },
-      "links":{
-        "self":"https://zenodo.org/api/grants/10.13039/501100000780::654220"
-      },
-      "program":"H2020",
-      "title":"European Cluster of Advanced Laser Light Sources"
-    }
-  ],
   "keywords":[
     "PIConGPU",
     "CUDA",


### PR DESCRIPTION
Zenodo does not support a grant format which is different to:

```
"grants": [
    {
        "id": "10.13039/501100000780::654220"
    }
]
```

The wrong grant format is the reason why the relese 0.7.0 does not have a DOI.
Since the next release does not receive EUCALL money and the DOI's for the grant are removed too we remove it from our zenodo file too.