### PR TITLE
fix RNG init in ionization

### DIFF
--- a/include/picongpu/particles/creation/creation.kernel
+++ b/include/picongpu/particles/creation/creation.kernel
@@ -78,10 +78,6 @@ namespace picongpu
 
                     DataSpace<simDim> const supercellCellOffset = superCellIdx * SuperCellSize::toRT();
 
-                    // relative offset to the origin of the local domain (without any guarding cells)
-                    pmacc::math::Int<simDim> const simDomainSupercellCellOffset
-                        = supercellCellOffset - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
-
                     /* "particle box" : container/iterator where the particles live in
                      * and where one can get the frame in a super cell from
                      */
@@ -115,19 +111,13 @@ namespace picongpu
                     auto particleCreatorCtx = lockstep::makeVar<T_ParticleCreator>(forEachParticle);
 
                     forEachParticle(
-                        [&](int32_t const idx, auto& destParticleCreator)
+                        [&](uint32_t const idx, auto& destParticleCreator)
                         {
-                            // cell index within the superCell
-                            DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), idx);
-
-                            // cell offset with respect to the local domain origin (without any guarding cells
-                            pmacc::math::Int<simDim> const localCellIndex = simDomainSupercellCellOffset + cellIdx;
-
                             // create a copy of the functor for each virtual worker
                             destParticleCreator = particleCreator;
 
                             // init particle creator functor for each virtual worker
-                            destParticleCreator.init(worker, supercellCellOffset, localCellIndex);
+                            destParticleCreator.init(worker, superCellIdx - mapper.getGuardingSuperCells(), idx);
                         },
                         particleCreatorCtx);
 

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -212,21 +212,21 @@ namespace picongpu
                  * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is
                  * necessary after initializing the field shared boxes in shared memory.
                  *
-                 * @param blockCell Offset of the cell from the origin of the local domain
-                 *                  *including guarding supercells* in units of cells
-                 * @param linearThreadIdx Linearized thread ID inside the block
-                 * @param localCellOffset Offset of the cell from the origin of the local
-                 *                        domain, i.e. from the @see BORDER
-                 *                        *without guarding supercells*
+                 * @param localSuperCellOffset offset (in superCells, without any guards) relative
+                 *                             to the origin of the local domain
+                 * @param rngIdx linear index rng number index within the supercell, valid range[0;numFrameSlots)
                  */
                 template<typename T_Worker>
                 DINLINE void init(
-                    T_Worker const& worker,
-                    const DataSpace<simDim>& blockCell,
-                    const DataSpace<simDim>& localCellOffset)
+                    [[maybe_unused]] T_Worker const& worker,
+                    const DataSpace<simDim>& localSuperCellOffset,
+                    const uint32_t rngIdx)
                 {
-                    /* initialize random number generator with the local cell index in the simulation */
-                    this->randomGen.init(localCellOffset);
+                    auto rngOffset = DataSpace<simDim>::create(0);
+                    rngOffset.x() = rngIdx;
+                    auto numRNGsPerSuperCell = DataSpace<simDim>::create(1);
+                    numRNGsPerSuperCell.x() = FrameType::frameSize;
+                    this->randomGen.init(localSuperCellOffset * numRNGsPerSuperCell + rngOffset);
                 }
 
                 /** Determine number of new macro electrons due to ionization

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -148,18 +148,15 @@ namespace picongpu
                  * during loop execution. The reason for this is the `cupla::__syncthreads( acc )` call which is
                  * necessary after initializing the E-/B-field shared boxes in shared memory.
                  *
-                 * @param blockCell Offset of the cell from the origin of the local domain
-                 *                  <b>including guarding supercells</b> in units of cells
-                 * @param linearThreadIdx Linearized thread ID inside the block
-                 * @param localCellOffset Offset of the cell from the origin of the local
-                 *                        domain, i.e. from the @see BORDER
-                 *                        <b>without guarding supercells</b>
+                 * @param localSuperCellOffset offset (in superCells, without any guards) relative
+                 *                             to the origin of the local domain
+                 * @param rngIdx linear index rng number index within the supercell, valid range[0;numFrameSlots)
                  */
                 template<typename T_Worker>
                 DINLINE void init(
-                    T_Worker const& worker,
-                    const DataSpace<simDim>& blockCell,
-                    const DataSpace<simDim>& localCellOffset)
+                    [[maybe_unused]] T_Worker const& worker,
+                    [[maybe_unused]] const DataSpace<simDim>& localSuperCellOffset,
+                    [[maybe_unused]] const uint32_t rngIdx)
                 {
                 }
 


### PR DESCRIPTION
With the refactoring of the frame size in #4685 the particle creation kernel used for ionization was not updated.

This PR is fixing the wrong index access to RNG states.

When ionization was enabled the code crashed with illegal memory access.

The bug was first observed by @pordyna.