### PR TITLE
Suggestions for the Binning plugin

### DIFF
--- a/include/picongpu/param/binningSetup.param
+++ b/include/picongpu/param/binningSetup.param
@@ -23,9 +23,6 @@
 
 #include "picongpu/plugins/binning/binnerPlugin.hpp"
 
-#include <pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp>
-#include <pmacc/particles/meta/FindByNameOrType.hpp>
-
 namespace picongpu
 {
     namespace plugins::binning
@@ -155,14 +152,6 @@ namespace picongpu
                     = [] ALPAKA_FN_ACC(auto const& worker, auto const& particle) -> float_X { return 1.0; };
                 auto getCounts = createFunctorDescription<float_X>(getParticleCount, "Counts");
 
-                /**
-                 * define notify period, dump frequency, normalizeByBinVolume, time averaging
-                 * Note that steps in time averaging are "notify steps" not simulation steps
-                 */
-                uint32_t dataDumpNNotifies = 0u;
-                bool enableTimeAveraging = true;
-                std::string notifyPeriod = "1:500";
-                bool normalizeByBinVolume = true;
 
                 /**
                  * Gives access to series, iteration and mesh to the user
@@ -177,34 +166,14 @@ namespace picongpu
                 { mesh.setAttribute("p_nbins", ax_py.getNBins()); };
 
                 binningCreator
-                    .addBinner(
-                        "chargeDensityBinning",
-                        axisTuple,
-                        speciesTuple,
-                        chargeDepositionData,
-                        notifyPeriod,
-                        dataDumpNNotifies,
-                        enableTimeAveraging,
-                        normalizeByBinVolume,
-                        writeOpenPMD)
-                    .setJsonCfg(R"({"hdf5":{"dataset":{"chunks":"auto"}}})");
-#if false
-    // Commented out since this example should not hardcode the openPMD backend.
-    // When writing your own .param file, it is recommended to include
-    // "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-    // to avoid this. Not done here to keep the example somewhat minimal.
-                    .setOpenPMDSuffix("_%06T.h5");
-#endif
+                    .addBinner("chargeDensityBinning", axisTuple, speciesTuple, chargeDepositionData, writeOpenPMD)
+                    .setNotifyPeriod("1:500")
+                    .setJsonCfg(R"({"hdf5":{"dataset":{"chunks":"auto"}}})")
+                    .setOpenPMDExtension("h5");
 
-                binningCreator.addBinner(
-                    "particleBinning",
-                    createTuple(ax_time, ax_py),
-                    speciesTuple,
-                    getCounts,
-                    "1::",
-                    2000,
-                    false,
-                    false);
+                binningCreator.addBinner("particleBinning", createTuple(ax_time, ax_py), speciesTuple, getCounts)
+                    .setDumpPeriod(2000)
+                    .setNormalizeByBinVolume(false);
             }
         }
     } // namespace plugins::binning

--- a/include/picongpu/param/binningSetup.param
+++ b/include/picongpu/param/binningSetup.param
@@ -176,16 +176,25 @@ namespace picongpu
                     [ax_py](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) -> void
                 { mesh.setAttribute("p_nbins", ax_py.getNBins()); };
 
-                binningCreator.addBinner(
-                    "chargeDensityBinning",
-                    axisTuple,
-                    speciesTuple,
-                    chargeDepositionData,
-                    notifyPeriod,
-                    dataDumpNNotifies,
-                    enableTimeAveraging,
-                    normalizeByBinVolume,
-                    writeOpenPMD);
+                binningCreator
+                    .addBinner(
+                        "chargeDensityBinning",
+                        axisTuple,
+                        speciesTuple,
+                        chargeDepositionData,
+                        notifyPeriod,
+                        dataDumpNNotifies,
+                        enableTimeAveraging,
+                        normalizeByBinVolume,
+                        writeOpenPMD)
+                    .setJsonCfg(R"({"hdf5":{"dataset":{"chunks":"auto"}}})");
+#if false
+    // Commented out since this example should not hardcode the openPMD backend.
+    // When writing your own .param file, it is recommended to include
+    // "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+    // to avoid this. Not done here to keep the example somewhat minimal.
+                    .setOpenPMDSuffix("_%06T.h5");
+#endif
 
                 binningCreator.addBinner(
                     "particleBinning",

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -130,6 +130,8 @@ namespace picongpu
         {
             using TDepositedQuantity = typename TBinningData::DepositedQuantityType;
 
+            friend class BinningCreator;
+
         private:
             TBinningData binningData;
             MappingDesc* cellDescription;

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/plugins/binning/WriteHist.hpp"
 #include "picongpu/plugins/binning/utility.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -160,7 +160,7 @@ namespace picongpu
             }
 
             ~Binner() override
-#if OPENPMDAPI_VERSION_GE(0,15,0)
+#if OPENPMDAPI_VERSION_GE(0, 15, 0)
             {
                 if(m_series.has_value())
                 {
@@ -168,7 +168,7 @@ namespace picongpu
                 }
             }
 #else
-    = default;
+                = default;
 #endif
 
             void notify(uint32_t currentStep) override

--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -22,6 +22,8 @@
 #include "picongpu/plugins/binning/Binner.hpp"
 #include "picongpu/plugins/binning/BinningData.hpp"
 
+#include <memory>
+
 namespace picongpu
 {
     namespace plugins::binning
@@ -42,7 +44,6 @@ namespace picongpu
             {
             }
 
-
             /**
              * Creates a binner from user input and adds it to the vector of all binners
              * @param binnerOutputName filename for openPMD output
@@ -61,10 +62,6 @@ namespace picongpu
                 TAxisTuple axisTupleObject,
                 TSpeciesTuple speciesTupleObject,
                 TDepositionData depositionData,
-                std::string notifyPeriod = "1",
-                uint32_t dumpPeriod = 0u,
-                bool timeAveraging = true,
-                bool normalizeByBinVolume = true,
                 std::function<void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)>
                     writeOpenPMDFunctor
                 = [](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) {})
@@ -75,10 +72,6 @@ namespace picongpu
                     axisTupleObject,
                     speciesTupleObject,
                     depositionData,
-                    notifyPeriod,
-                    dumpPeriod,
-                    timeAveraging,
-                    normalizeByBinVolume,
                     writeOpenPMDFunctor);
                 auto binner = std::make_unique<Binner<BinningData<TAxisTuple, TSpeciesTuple, TDepositionData>>>(
                     bd,

--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -56,7 +56,7 @@ namespace picongpu
              * @param writeOpenPMDFunctor Functor to write out user specified openPMD data
              */
             template<typename TAxisTuple, typename TSpeciesTuple, typename TDepositionData>
-            void addBinner(
+            auto addBinner(
                 std::string binnerOutputName,
                 TAxisTuple axisTupleObject,
                 TSpeciesTuple speciesTupleObject,
@@ -68,6 +68,7 @@ namespace picongpu
                 std::function<void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)>
                     writeOpenPMDFunctor
                 = [](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) {})
+                -> BinningData<TAxisTuple, TSpeciesTuple, TDepositionData>&
             {
                 auto bd = BinningData<TAxisTuple, TSpeciesTuple, TDepositionData>(
                     binnerOutputName,
@@ -82,7 +83,9 @@ namespace picongpu
                 auto binner = std::make_unique<Binner<BinningData<TAxisTuple, TSpeciesTuple, TDepositionData>>>(
                     bd,
                     cellDescription);
+                auto& res = binner->binningData;
                 binnerVector.emplace_back(std::move(binner));
+                return res;
             }
         };
     } // namespace plugins::binning

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/plugins/binning/Axis.hpp"
+#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 
 #include <alpaka/core/Tuple.hpp>
 
@@ -51,6 +52,11 @@ namespace picongpu
             std::function<void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)>
                 writeOpenPMDFunctor;
             DataSpace<std::tuple_size_v<T_AxisTuple>> axisExtentsND;
+
+            /* Optional parameters not initialized by constructor.
+             * Use the return value of addBinner() to modify them if needed. */
+            std::string openPMDSuffix = "_%T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
+            std::string jsonCfg = "{}";
 
             BinningData(
                 const std::string binnerName,
@@ -89,6 +95,17 @@ namespace picongpu
                 return std::tuple_size_v<T_AxisTuple>;
                 // return utility::tuple::size(axisTuple);
                 // return utility::tuple::size(declval<T_AxisTuple>());
+            }
+
+            BinningData& setOpenPMDSuffix(std::string suffix)
+            {
+                this->openPMDSuffix = std::move(suffix);
+                return *this;
+            }
+            BinningData& setJsonCfg(std::string cfg)
+            {
+                this->jsonCfg = std::move(cfg);
+                return *this;
             }
         };
     }; // namespace plugins::binning

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -55,7 +55,7 @@ namespace picongpu
 
             /* Optional parameters not initialized by constructor.
              * Use the return value of addBinner() to modify them if needed. */
-            std::string openPMDSuffix = "_%T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
+            std::string openPMDSuffix = "_%06T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
             std::string jsonCfg = "{}";
 
             BinningData(

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -65,13 +65,29 @@ namespace picongpu
                 {
                     auto const& extension = binningData.openPMDExtension;
                     std::ostringstream filename;
-                    if(std::any_of(extension.begin(), extension.end(), [](char const c) { return c == '.'; }))
+                    filename << binningData.binnerOutputName;
+                    if(auto& infix = binningData.openPMDInfix; !infix.empty())
                     {
-                        filename << binningData.binnerOutputName << binningData.openPMDInfix << extension;
+                        if(*infix.begin() != '_')
+                        {
+                            filename << '_';
+                        }
+                        if(*infix.rbegin() == '.')
+                        {
+                            filename << infix.substr(0, infix.size() - 1);
+                        }
+                        else
+                        {
+                            filename << infix;
+                        }
+                    }
+                    if(*extension.begin() == '.')
+                    {
+                        filename << extension;
                     }
                     else
                     {
-                        filename << binningData.binnerOutputName << binningData.openPMDInfix << '.' << extension;
+                        filename << '.' << extension;
                     }
 
                     maybe_series = ::openPMD::Series(dir + '/' + filename.str(), ::openPMD::Access::CREATE);

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -25,7 +25,6 @@
 
 #include "picongpu/plugins/binning/UnitConversion.hpp"
 #include "picongpu/plugins/binning/utility.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 #include "picongpu/plugins/common/openPMDVersion.def"
 #include "picongpu/plugins/common/stringHelpers.hpp"
 
@@ -49,9 +48,6 @@ namespace picongpu
          */
         class WriteHist
         {
-        private:
-            std::string openPMDSuffix = "_%T." + openPMD::getDefaultExtension(openPMD::ExtensionPreference::HDF5);
-
         public:
             template<typename T_Type, typename T_BinningData>
             void operator()(

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -29,6 +29,7 @@
 #include "picongpu/plugins/common/stringHelpers.hpp"
 
 #include <memory>
+#include <optional>
 
 #include <openPMD/openPMD.hpp>
 
@@ -55,24 +56,22 @@ namespace picongpu
                 std::unique_ptr<HostBuffer<T_Type, 1u>> hReducedBuffer,
                 T_BinningData binningData,
                 std::string const& dir,
-                // WriteOpenPMDParams const& params,
                 std::array<double, 7> outputUnits,
                 const uint32_t currentStep)
             {
                 using Type = T_Type;
 
-                // auto const& [extension, jsonConfig] = params;
                 if(!maybe_series.has_value())
                 {
-                    auto const& extension = binningData.openPMDSuffix;
+                    auto const& extension = binningData.openPMDExtension;
                     std::ostringstream filename;
                     if(std::any_of(extension.begin(), extension.end(), [](char const c) { return c == '.'; }))
                     {
-                        filename << binningData.binnerOutputName << extension;
+                        filename << binningData.binnerOutputName << binningData.openPMDInfix << extension;
                     }
                     else
                     {
-                        filename << binningData.binnerOutputName << '.' << extension;
+                        filename << binningData.binnerOutputName << binningData.openPMDInfix << '.' << extension;
                     }
 
                     maybe_series = ::openPMD::Series(dir + '/' + filename.str(), ::openPMD::Access::CREATE);

--- a/include/picongpu/plugins/binning/binnerPlugin.hpp
+++ b/include/picongpu/plugins/binning/binnerPlugin.hpp
@@ -23,3 +23,6 @@
 #include "picongpu/plugins/binning/BinningCreator.hpp"
 #include "picongpu/plugins/binning/FunctorDescription.hpp"
 #include "picongpu/plugins/binning/utility.hpp"
+
+#include <pmacc/meta/errorHandlerPolicies/ThrowValueNotFound.hpp>
+#include <pmacc/particles/meta/FindByNameOrType.hpp>


### PR DESCRIPTION
1. commit: Use optimized `storeChunk()` calls (unique_ptr or raw pointer) instead of fake shared pointer
2. commit: Add logic for configuring optional (compile-time) parameters and use this for making the openPMD extension and JSON config configurable 
3. commit: Keep `Series` open across calls to the plugin in order to enable iteration encodings that require this (group-based, variable-based, streaming)
4. commit: filename padding