### PR TITLE
add config for Karolina cluster

### DIFF
--- a/etc/picongpu/karolina-it4i/README.txt
+++ b/etc/picongpu/karolina-it4i/README.txt
@@ -1,0 +1,19 @@
+- install the Spack package manager
+
+- copy the compiler and package configuration:
+
+  cp ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/spack/packages.yaml ${HOME}/.spack/
+  cp ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/spack/compilers.yaml ${HOME}/.spack/linux/
+
+- copy (and change if needed) the profile:
+
+  cp ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example ${HOME}/gpu_a100_picongpu.profile
+
+- create a Spack environment and install picongpu dependencies
+
+  spack env create picongpu ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/spack/spack.yaml
+  spack env activate picongpu
+
+  spack concretize
+  spack install
+

--- a/etc/picongpu/karolina-it4i/gpu_a100.tpl
+++ b/etc/picongpu/karolina-it4i/gpu_a100.tpl
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright 2013-2023 Axel Huebl, Richard Pausch, Rene Widera,
+#                     Marco Garten, Alexander Debus,
+#                     Jian Fuh Ong, Andrei Berceanu
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for Karolina's SLURM batch system
+
+#SBATCH --account=!TBG_account
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_gpusPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --gpus-per-node=!TBG_gpusPerNode
+#SBATCH --exclusive
+
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --chdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue=${TBG_partition:-"qgpu"}
+.TBG_account=${proj}
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=8
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=`if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi`
+
+# host memory per gpu
+.TBG_memPerGPU="$((1024000 / $TBG_numHostedGPUPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
+
+# number of cores to block per GPU
+.TBG_coresPerGPU=1
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to calculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# test if cuda_memtest binary is available
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+  # Run CUDA memtest to check GPU's health
+  srun -K1 !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+fi
+

--- a/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
+++ b/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
@@ -1,0 +1,80 @@
+# please set your project account
+export proj="DD-23-83"
+
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+if [ -z ${proj-} ]; then
+    echo "WARNING: The 'proj' variable is not yet set in your $PIC_PROFILE file!"
+    echo "Please edit its line 2 to continue!"
+    return
+fi
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@host.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+export EDITOR="vim"
+
+# General modules #############################################################
+#
+module purge
+module load OpenMPI/4.1.4-GCC-11.3.0-CUDA-11.7.0
+module load CMake/3.23.1-GCCcore-11.3.0
+module load OpenBLAS/0.3.20-GCC-11.3.0
+module load Boost/1.79.0-GCC-11.3.0
+
+# PIConGPU dependencies #################################################
+#
+spack env activate picongpu
+
+# Environment #################################################################
+#
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:80"
+export SCRATCH="/scratch/project/dd-23-83/${USER}"
+
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/karolina-it4i"}
+
+export PATH=$PICSRC/bin:$PATH
+export PATH=$PICSRC/src/tools/bin:$PATH
+
+# python not included yet
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "qgpu" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/karolina-it4i/gpu_a100.tpl"
+export TBG_partition="qgpu"
+
+# allocate an interactive shell for two hours
+#   getNode 2  # allocates two interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    export OMP_NUM_THREADS=16
+    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((8 * $numNodes)) --ntasks-per-node=8 --cpus-per-task=1 --exclusive --gpus-per-node=8 -p $TBG_partition -A $proj --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi
+

--- a/etc/picongpu/karolina-it4i/spack/compilers.yaml
+++ b/etc/picongpu/karolina-it4i/spack/compilers.yaml
@@ -1,0 +1,14 @@
+compilers:
+- compiler:
+    modules: [GCCcore/11.3.0]
+    operating_system: centos7
+    paths:
+      cc: /apps/all/GCCcore/11.3.0/bin/gcc
+      cxx: /apps/all/GCCcore/11.3.0/bin/g++
+      f77: /apps/all/GCCcore/11.3.0/bin/gfortran
+      fc: /apps/all/GCCcore/11.3.0/bin/gfortran
+    spec: gcc@=11.3.0
+    target: x86_64
+    flags: {}
+    environment: {}
+    extra_rpaths: []

--- a/etc/picongpu/karolina-it4i/spack/packages.yaml
+++ b/etc/picongpu/karolina-it4i/spack/packages.yaml
@@ -1,0 +1,65 @@
+packages:
+  boost:
+    externals:
+    - spec: boost@1.79.0%gcc@11.3.0
+      modules:
+      - Boost/1.79.0-GCC-11.3.0
+    buildable: False
+  openblas:
+    externals:
+    - spec: openblas@0.3.20%gcc@11.3.0
+      modules:
+      - OpenBLAS/0.3.20-GCC-11.3.0
+    buildable: False
+  openssh:
+    externals:
+    - spec: openssh@7.4p1
+      prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@1.1.1o
+      modules:
+      - OpenSSL/1.1
+    buildable: False
+  cuda:
+    externals:
+    - spec: cuda@11.7.0
+      modules:
+      - CUDA/11.7.0
+    buildable: False
+  mpi:
+    buildable: False
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.4+atomics+cuda %gcc@11.3.0
+      modules:
+      - OpenMPI/4.1.4-GCC-11.3.0-CUDA-11.7.0
+  libfabric:
+    externals:
+    - spec: libfabric@1.15.1%gcc@11.3.0
+      modules:
+      - libfabric/1.15.1-GCCcore-11.3.0
+    buildable: False
+  binutils:
+    externals:
+    - spec: binutils@2.38%gcc@11.3.0
+      modules:
+      - binutils/2.38-GCCcore-11.3.0
+    buildable: False
+  cmake:
+    externals:
+    - spec: cmake@3.23.1%gcc@11.3.0
+      modules:
+      - CMake/3.23.1-GCCcore-11.3.0
+    buildable: False
+  curl:
+    externals:
+    - spec: curl@7.83.0%gcc@11.3.0
+      modules:
+      - cURL/7.83.0-GCCcore-11.3.0
+    buildable: False
+  all:
+    providers:
+      mpi: [openmpi@4.1.4]
+      cuda: [cuda@11.7.0]
+      blas: [openblas@0.3.20]

--- a/etc/picongpu/karolina-it4i/spack/spack.yaml
+++ b/etc/picongpu/karolina-it4i/spack/spack.yaml
@@ -1,0 +1,13 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - openpmd-api@0.14.5%gcc@11.3.0 ^adios2@2.8.3+cuda cuda_arch=80 ^cmake@3.23.1 ^hdf5@1.14.0
+    ^openmpi@4.1.4+atomics+cuda cuda_arch=80 ^py-numpy@1.24.2 ^python@3.10.10
+  - pngwriter@0.7.0%gcc@11.3.0
+  view: true
+  concretizer:
+    unify: true


### PR DESCRIPTION
This PR adds install instructions and relevant scripts, for setting up `picongpu` on the `Karolina-it4i` cluster.