### PR TITLE
make math::Vector<> constexpr constructable 

### DIFF
--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -96,7 +96,7 @@ namespace pmacc
             static_assert(sizeof...(T_Args) == T_dim, "Number of arguments must be equal to the DataSpace dimension.");
         }
 
-        HDINLINE DataSpace(const BaseType& vec) : BaseType(vec)
+        HDINLINE constexpr DataSpace(const BaseType& vec) : BaseType(vec)
         {
         }
 

--- a/include/pmacc/math/ConstVector.hpp
+++ b/include/pmacc/math/ConstVector.hpp
@@ -80,7 +80,7 @@
             }                                                                                                         \
         };                                                                                                            \
         /*define a const vector type, ConstArrayStorage is used as Storage policy*/                                   \
-        typedef const pmacc::math::Vector<Type, Dim, pmacc::math::StandardNavigator, ConstArrayStorage<Type, Dim>>    \
+        typedef const pmacc::math::Vector<Type, Dim, pmacc::math::IdentityNavigator, ConstArrayStorage<Type, Dim>>    \
             PMACC_JOIN(Name, _t);                                                                                     \
     } /* namespace pmacc_static_const_storage + id */                                                                 \
     using namespace PMACC_JOIN(pmacc_static_const_storage, id)

--- a/include/pmacc/math/vector/navigator/IdentityNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/IdentityNavigator.hpp
@@ -27,14 +27,12 @@ namespace pmacc
 {
     namespace math
     {
-        /** \todo rename this class to NavigatorIdentity*/
-        struct StandardNavigator
+        struct IdentityNavigator
         {
-            HDINLINE int operator()(int component) const
+            HDINLINE constexpr int operator()(int component) const
             {
                 return component;
             }
         };
-
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/vector/navigator/PermutedNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/PermutedNavigator.hpp
@@ -30,7 +30,7 @@ namespace pmacc
         template<typename Permutation>
         struct PermutedNavigator
         {
-            HDINLINE int operator()(int component) const
+            HDINLINE constexpr int operator()(int component) const
             {
                 return Permutation().toRT()[component];
             }

--- a/include/pmacc/math/vector/navigator/StackedNavigator.hpp
+++ b/include/pmacc/math/vector/navigator/StackedNavigator.hpp
@@ -35,7 +35,7 @@ namespace pmacc
         template<typename NaviA, typename NaviB>
         struct StackedNavigator
         {
-            HDINLINE int operator()(int component) const
+            HDINLINE constexpr int operator()(int component) const
             {
                 return NaviB()(NaviA()(component));
             }


### PR DESCRIPTION
- allow constructing `math::Vector<>` at compile time
- add support to call the member `shrink<>()` at compile time
- rename `StandardNavigator` into `IdentityNavigator`

- [x] merge after #4746 (the first commit is the pull request #4746)

This refactoring is required for the upcoming PIConGPU density functor refactoring (removing the ugly macro struct generator)