### PR TITLE
fix typo in dev server profile

### DIFF
--- a/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
@@ -19,7 +19,7 @@ spack unload
 # PIConGPU build dependencies #################################################
 #   need to load correct cmake and gcc to compile picongpu
 
-spack load gcc@12.2.0s
+spack load gcc@12.2.0
 spack load cmake@3.25.0 ^openssl certs=mozilla %gcc@12.2.0
 
 # General modules #############################################################


### PR DESCRIPTION
removes an additional `s` in the example cpu profile for the dev server 