### PR TITLE
Update openpmd-api and ADIOS2 dependencies on Karolina

### DIFF
--- a/etc/picongpu/karolina-it4i/README.txt
+++ b/etc/picongpu/karolina-it4i/README.txt
@@ -1,5 +1,8 @@
 - install the Spack package manager
 
+  git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+  spack spec zlib
+
 - copy the compiler and package configuration:
 
   cp ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/spack/packages.yaml ${HOME}/.spack/
@@ -11,9 +14,19 @@
 
 - create a Spack environment and install picongpu dependencies
 
-  spack env create picongpu ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/spack/spack.yaml
-  spack env activate picongpu
+  spack env create picongpu-env ${HOME}/src/picongpu/etc/picongpu/karolina-it4i/spack/spack.yaml
+  spack env activate picongpu-env
 
   spack concretize
   spack install
+
+- in case one needs to start over, the clean-up procedure is the following
+
+  despacktivate
+  spack -e picongpu-env uninstall --all
+  spack env rm picongpu-env
+
+- optionally, for a full reset, do
+
+  rm -rf ${HOME}/spack/ ${HOME}/.spack/
 

--- a/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
+++ b/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
@@ -1,5 +1,5 @@
 # please set your project account
-export proj="DD-23-83"
+export proj="DD-23-157"
 
 # Name and Path of this Script ############################### (DO NOT change!)
 export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
@@ -20,26 +20,23 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
-export EDITOR="vim"
+export EDITOR="vi"
 
 # General modules #############################################################
 #
 module purge
 module load OpenMPI/4.1.4-GCC-11.3.0-CUDA-11.7.0
-module load CMake/3.23.1-GCCcore-11.3.0
-module load OpenBLAS/0.3.20-GCC-11.3.0
-module load Boost/1.79.0-GCC-11.3.0
 
 # PIConGPU dependencies #################################################
 #
-spack env activate picongpu
+spack env activate picongpu-env
 
 # Environment #################################################################
 #
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
 export PIC_BACKEND="cuda:80"
-export SCRATCH="/scratch/project/dd-23-83/${USER}"
+export SCRATCH="/scratch/project/${proj,,}/${USER}"
 
 # Path to the required templates of the system,
 # relative to the PIConGPU source code of the tool bin/pic-create.

--- a/etc/picongpu/karolina-it4i/spack/packages.yaml
+++ b/etc/picongpu/karolina-it4i/spack/packages.yaml
@@ -1,16 +1,4 @@
 packages:
-  boost:
-    externals:
-    - spec: boost@1.79.0%gcc@11.3.0
-      modules:
-      - Boost/1.79.0-GCC-11.3.0
-    buildable: False
-  openblas:
-    externals:
-    - spec: openblas@0.3.20%gcc@11.3.0
-      modules:
-      - OpenBLAS/0.3.20-GCC-11.3.0
-    buildable: False
   openssh:
     externals:
     - spec: openssh@7.4p1
@@ -40,26 +28,7 @@ packages:
       modules:
       - libfabric/1.15.1-GCCcore-11.3.0
     buildable: False
-  binutils:
-    externals:
-    - spec: binutils@2.38%gcc@11.3.0
-      modules:
-      - binutils/2.38-GCCcore-11.3.0
-    buildable: False
-  cmake:
-    externals:
-    - spec: cmake@3.23.1%gcc@11.3.0
-      modules:
-      - CMake/3.23.1-GCCcore-11.3.0
-    buildable: False
-  curl:
-    externals:
-    - spec: curl@7.83.0%gcc@11.3.0
-      modules:
-      - cURL/7.83.0-GCCcore-11.3.0
-    buildable: False
   all:
     providers:
       mpi: [openmpi@4.1.4]
       cuda: [cuda@11.7.0]
-      blas: [openblas@0.3.20]

--- a/etc/picongpu/karolina-it4i/spack/spack.yaml
+++ b/etc/picongpu/karolina-it4i/spack/spack.yaml
@@ -5,8 +5,10 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - openpmd-api@0.14.5%gcc@11.3.0 ^adios2@2.8.3+cuda cuda_arch=80 ^cmake@3.23.1 ^hdf5@1.14.0
+  - cmake@3.26.5%gcc@11.3.0
+  - openpmd-api@0.15.2%gcc@11.3.0 ^adios2@2.9.2+cuda cuda_arch=80 ^cmake@3.26.5 ^hdf5@1.14.0
     ^openmpi@4.1.4+atomics+cuda cuda_arch=80 ^py-numpy@1.24.2 ^python@3.10.10
+  - boost@1.81.0+program_options+atomic~python%gcc@11.3.0
   - pngwriter@0.7.0%gcc@11.3.0
   view: true
   concretizer:


### PR DESCRIPTION
This commit updated openpmd-api to 0.15.2 and ADIOS2 to 2.9.2, in order to use the newer BP5 file engine instead of BP4. This fixes the previous problems encountered on Karolina while using BP4.

Fixes https://github.com/ComputationalRadiationPhysics/picongpu/issues/4744