### PR TITLE
fix potential deadlock

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -20,6 +20,8 @@
 
 #include "openPMD/openPMD.hpp"
 
+#include <pmacc/eventSystem/waitForAllTasks.hpp>
+
 #include <cstdlib> // std::getenv
 #include <memory>
 #include <string> // std::stoull
@@ -252,6 +254,9 @@ namespace picongpu
                     switch(target)
                     {
                     case PreferredFlushTarget::Disk:
+                        // avoid deadlocks between not finished pmacc communication tasks and potential blocking
+                        // collectives in openPMD IO backends
+                        pmacc::eventSystem::waitForAllTasks();
                         series.flush(jsonConfigBP5TargetDisk);
                         break;
                     case PreferredFlushTarget::Buffer:

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -832,6 +832,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                      * solver implementation */
                     const float_X timeOffset = 0.0;
 
+                    // avoid deadlock between not finished pmacc MPI communication tasks and mpi blocking collectives
+                    // used during IO
+                    eventSystem::getTransactionEvent().waitForFinished();
                     bool const isDomainBound = traits::IsFieldDomainBound<FieldTmp>::value;
                     /*write data to openPMD Series*/
                     openPMDWriter::template writeField<ComponentType>(

--- a/include/pmacc/eventSystem/eventSystem.hpp
+++ b/include/pmacc/eventSystem/eventSystem.hpp
@@ -24,6 +24,7 @@
 #include "pmacc/eventSystem/events/EventTask.hpp"
 #include "pmacc/eventSystem/streams/EventStream.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
+#include "pmacc/eventSystem/waitForAllTasks.hpp"
 
 namespace pmacc::eventSystem
 {
@@ -72,8 +73,4 @@ namespace pmacc::eventSystem
      *               possible places are: `ITask::TASK_DEVICE`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
      */
     EventStream* getEventStream(ITask::TaskType op);
-
-    /** Blocks the event system until all tasks finished */
-    void waitForAllTasks();
-
 } // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/waitForAllTasks.cpp
+++ b/include/pmacc/eventSystem/waitForAllTasks.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2023 Rene Widera
+/* Copyright 2023 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -20,40 +20,15 @@
  */
 
 
-#include "pmacc/eventSystem/eventSystem.hpp"
+#include "pmacc/eventSystem/waitForAllTasks.hpp"
 
 #include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/transactions/TransactionManager.hpp"
 
 namespace pmacc::eventSystem
 {
-    void startTransaction(EventTask serialEvent)
+    void waitForAllTasks()
     {
-        TransactionManager::getInstance().startTransaction(serialEvent);
-    }
-
-    EventTask endTransaction()
-    {
-        return TransactionManager::getInstance().endTransaction();
-    }
-
-    void startOperation(ITask::TaskType op)
-    {
-        TransactionManager::getInstance().startOperation(op);
-    };
-
-    EventTask setTransactionEvent(const EventTask& event)
-    {
-        return TransactionManager::getInstance().setTransactionEvent(event);
-    }
-
-    EventTask getTransactionEvent()
-    {
-        return TransactionManager::getInstance().getTransactionEvent();
-    }
-
-    EventStream* getEventStream(ITask::TaskType op)
-    {
-        return TransactionManager::getInstance().getEventStream(op);
+        Manager::getInstance().waitForAllTasks();
     }
 } // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/waitForAllTasks.hpp
+++ b/include/pmacc/eventSystem/waitForAllTasks.hpp
@@ -1,0 +1,29 @@
+/* Copyright 2023 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+namespace pmacc::eventSystem
+{
+    /** Blocks the event system until all tasks finished */
+    void waitForAllTasks();
+} // namespace pmacc::eventSystem


### PR DESCRIPTION
Dumping-derived fields require neighbor communications to send the scattered data to the neighbor devices.
Executing a blocking MPI operation, what openPMD internally can do in the IO backends can create a deadlock in the PMacc event system. This is a known issue we can not solve without rewriting the event system.