### PR TITLE
Switch default openPMD ADIOS2 file engine from BP4 to BP5

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -535,6 +535,20 @@ if(PIC_HAVE_openPMD)
         SYSTEM PRIVATE
         $<TARGET_PROPERTY:toml11::toml11,INTERFACE_INCLUDE_DIRECTORIES>)
     target_link_libraries(picongpu-hostonly PRIVATE toml11::toml11)
+
+    # This is a workaround for a missing API call in the openPMD-api,
+    # which currently does not re-export backend version information.
+    # https://github.com/openPMD/openPMD-api/issues/1563
+    if(openPMD_HAVE_ADIOS2)
+        foreach(target picongpu picongpu-hostonly)
+            target_compile_definitions(
+                picongpu
+                PRIVATE
+                ADIOS2_VERSION_MAJOR=${ADIOS2_VERSION_MAJOR}
+                ADIOS2_VERSION_MINOR=${ADIOS2_VERSION_MINOR}
+                ADIOS2_VERSION_PATCH=${ADIOS2_VERSION_PATCH})
+        endforeach()
+    endif()
 endif()
 
 ## annotate with RPATH's

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -542,7 +542,7 @@ if(PIC_HAVE_openPMD)
     if(openPMD_HAVE_ADIOS2)
         foreach(target picongpu picongpu-hostonly)
             target_compile_definitions(
-                picongpu
+                ${target}
                 PRIVATE
                 ADIOS2_VERSION_MAJOR=${ADIOS2_VERSION_MAJOR}
                 ADIOS2_VERSION_MINOR=${ADIOS2_VERSION_MINOR}

--- a/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
+++ b/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
@@ -46,19 +46,26 @@ namespace picongpu
             auto getADIOSExtension = []()
             {
                 auto availableExtensions = ::openPMD::getFileExtensions();
-                for(auto const& ext : availableExtensions)
+                if(std::find(availableExtensions.begin(), availableExtensions.end(), "bp5")
+                   != availableExtensions.end())
                 {
-                    if(ext == "bp4")
-                    {
-                        return "bp4";
-                    }
+                    // Engine available in ADIOS2 >= v2.8
+                    // File extension and support for engine available in openPMD-api >= 0.15
+                    return "bp5";
                 }
-                /*
-                 * BP4 engine is always available in all supported ADIOS2 versions,
-                 * but the bp4 extensions is new in openPMD, so we might need to
-                 * fallback to "bp".
-                 */
-                return "bp";
+                else if(
+                    std::find(availableExtensions.begin(), availableExtensions.end(), "bp4")
+                    != availableExtensions.end())
+                {
+                    // Engine available and supported in all supported versions of ADIOS2 and openPMD-api
+                    // File extension available in openPMD-api >= 0.15
+                    return "bp4";
+                }
+                else
+                {
+                    // Extension is always available in all supported versions of ADIOS2 and openPMD-api
+                    return "bp";
+                }
             };
 #if openPMD_HAVE_ADIOS2 && openPMD_HAVE_HDF5
             switch(ep)


### PR DESCRIPTION
While BP5 is not supposed to replace BP4 in ADIOS2, it is the better default engine since it requires no configuration to be performant. BP4 required careful specification of `InitialBufferSize` (which most users did probably not bother with, or were not even aware of it). Additionally, it has support for the `PerformDataWrite()` API call, which PIConGPU uses to flush data to disk at custom times.

Since this is a common header, this affects the default settings of the following plugins:

* PhaseSpace plugin
* MacroParticleCounter
* openPMD I/O plugin
* Radiation plugin
* Binning plugin

(Some of these set HDF5 by default, so they are only affected if openPMD-api is built without HDF5)

The BP4 engine can still be used. Since it requires specific configuration anyway, specifying the engine type is the least of troubles.

TODO:

- [x] Since ADIOS2 <= 2.9.1 had a bug that resulted in unreadable data created from PIConGPU when using Blosc2, activate this only when ADIOS2 is newer than that. (ADIOS2 v2.8 technically did not suffer from this since it still used Blosc1. But I never tested if that actually works with PIConGPU and I won't bother with it either.) 
    https://github.com/ornladios/ADIOS2/issues/3504