### PR TITLE
Implement checkpoint and restart capability to the binning plugin

### DIFF
--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -47,7 +47,7 @@ namespace picongpu
             /**
              * Creates a binner from user input and adds it to the vector of all binners
              * @param binnerOutputName filename for openPMD output. It must be unique or will cause overwrites during
-             * data dumps
+             * data dumps and undefined behaviour during restarts
              * @param axisTupleObject tuple holding the axes
              * @param speciesTupleObject tuple holding the species to do the binning with
              * @param depositionData functorDescription of the deposited quantity

--- a/include/picongpu/plugins/binning/BinningDispatcher.hpp
+++ b/include/picongpu/plugins/binning/BinningDispatcher.hpp
@@ -23,8 +23,12 @@
 #include "picongpu/plugins/ISimulationPlugin.hpp"
 #include "picongpu/plugins/binning/BinningCreator.hpp"
 
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <variant>
 
 namespace picongpu
@@ -73,12 +77,20 @@ namespace picongpu
             {
                 /* restart from a checkpoint here
                  * will be called only once per simulation and before notify() */
+                for(auto&& binner : binnerVector)
+                {
+                    binner->restart(restartStep, restartDirectory);
+                }
             }
 
             void checkpoint(uint32_t currentStep, const std::string restartDirectory) override
             {
                 /* create a persistent checkpoint here
                  * will be called before notify() if both will be called for the same timestep */
+                for(auto&& binner : binnerVector)
+                {
+                    binner->checkpoint(currentStep, restartDirectory);
+                }
             }
 
             void notify(uint32_t currentStep) override

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -60,7 +60,9 @@ namespace picongpu
                 std::unique_ptr<HostBuffer<T_Type, 1u>> hReducedBuffer,
                 T_BinningData binningData,
                 const std::array<double, 7>& outputUnits,
-                const uint32_t currentStep)
+                const uint32_t currentStep,
+                const bool isCheckpoint = false,
+                const uint32_t accumulateCounter = 0)
             {
                 using Type = T_Type;
 
@@ -201,6 +203,11 @@ namespace picongpu
 #else
                 openPMD::storeChunkRaw(record, hReducedBuffer->getBasePointer(), histOffset, histExtent);
 #endif
+                if(isCheckpoint)
+                {
+                    iteration.setAttribute("accCounter", accumulateCounter);
+                }
+
                 iteration.close();
             };
         };


### PR DESCRIPTION
Implement checkpoint and restart capability to the binning plugin. 
Checkpointing and restarting is called by PIConGPU for the binningDispatcher, which handles checkpoint and restart for all individual "binners".
Currently the checkpoint information is stored in the default checkpoint directory, in a sub-folder called binningOpenPMD, and the file name and file type for the checkpoints aren't seperately configurable. File name and file type are the same as the ones created during a normal execution data dump.
Also added some previously missing includes