### PR TITLE
Add PMacc example - Solving the 2D HeatEquation

### DIFF
--- a/include/pmacc/mpi/MPIReduce.hpp
+++ b/include/pmacc/mpi/MPIReduce.hpp
@@ -67,7 +67,7 @@ namespace pmacc
 
             /** defines if the result of the MPI operation is valid
              *
-             * The reduction method reduceMethods::Reduce is used.
+             * The reduction method reduceMethods::AllReduce is used.
              *
              * @return if result of operator() is valid
              */

--- a/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/GatherSlice.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "types.hpp"
+
 #include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/mappings/simulation/GridController.hpp>
 #include <pmacc/memory/boxes/PitchedBox.hpp>

--- a/share/pmacc/examples/gameOfLife2D/include/PngCreator.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/PngCreator.hpp
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "types.hpp"
+
 #include <pmacc/types.hpp>
 
 #include <pngwriter.h>

--- a/share/pmacc/examples/heatEquation2D/CMakeLists.txt
+++ b/share/pmacc/examples/heatEquation2D/CMakeLists.txt
@@ -1,0 +1,156 @@
+# Copyright 2013-2023 Rene Widera, Axel Huebl, Tapish Narwal
+#
+# This file is part of PMacc.
+#
+# PMacc is free software: you can redistribute it and/or modify
+# it under the terms of either the GNU General Public License or
+# the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PMacc is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License and the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# and the GNU Lesser General Public License along with PMacc.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Required cmake version
+################################################################################
+
+cmake_minimum_required(VERSION 3.15.0)
+
+
+################################################################################
+# Project
+################################################################################
+
+project(heatEq)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "install prefix" FORCE)
+endif()
+
+# set helper pathes to find libraries and packages
+# Add specific hints
+list(APPEND CMAKE_PREFIX_PATH "$ENV{MPI_ROOT}")
+list(APPEND CMAKE_PREFIX_PATH "$ENV{BOOST_ROOT}")
+
+# Add from environment after specific env vars
+list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
+
+
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+################################################################################
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+
+###############################################################################
+# Language Flags
+###############################################################################
+
+# enforce C++17
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
+
+
+################################################################################
+# Find PMacc
+################################################################################
+
+find_package(PMacc REQUIRED CONFIG PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/pmacc")
+
+# ################################################################################
+# # Build type (debug, release)
+# ################################################################################
+
+# option(HEATEQ_RELEASE "Build release version, disables all runtime asserts" OFF)
+# if(HEATEQ_RELEASE)
+#     message(STATUS "Release version")
+#     set(CMAKE_BUILD_TYPE Release)
+#     add_definitions(-DNDEBUG)
+# else(HEATEQ_RELEASE)
+#     message(STATUS "Debug version")
+#     set(CMAKE_BUILD_TYPE Debug)
+# endif(HEATEQ_RELEASE)
+
+################################################################################
+# PNGwriter
+################################################################################
+
+# find PNGwriter installation
+find_package(PNGwriter 0.7.0 REQUIRED CONFIG)
+
+if(PNGwriter_FOUND)
+    list(APPEND PNGwriter_DEFINITIONS "-DGOL_ENABLE_PNG=1")
+endif(PNGwriter_FOUND)
+
+
+################################################################################
+# Warnings
+################################################################################
+
+# GNU
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+    # new warning in gcc 4.8 (flag ignored in previous version)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+# ICC
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+# PGI
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=inform")
+endif()
+
+
+################################################################################
+# Compile & Link  heatEq
+################################################################################
+
+include_directories(include)
+
+file(GLOB SRCFILES "*.cpp")
+
+cupla_add_executable(heatEq
+    ${SRCFILES}
+)
+
+target_link_libraries(heatEq PRIVATE pmacc::pmacc)
+if(PNGwriter_FOUND)
+    target_link_libraries(heatEq PRIVATE PNGwriter::PNGwriter)
+endif()
+
+
+################################################################################
+# Math
+################################################################################
+
+if(NOT WIN32)
+    # automatically added on windows
+    target_link_libraries(heatEq PRIVATE m)
+endif()
+
+
+################################################################################
+# Install heatEq
+################################################################################
+
+install(TARGETS heatEq
+        RUNTIME DESTINATION bin)

--- a/share/pmacc/examples/heatEquation2D/CMakeLists.txt
+++ b/share/pmacc/examples/heatEquation2D/CMakeLists.txt
@@ -77,15 +77,15 @@ find_package(PMacc REQUIRED CONFIG PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../.
 # # Build type (debug, release)
 # ################################################################################
 
-# option(HEATEQ_RELEASE "Build release version, disables all runtime asserts" OFF)
-# if(HEATEQ_RELEASE)
-#     message(STATUS "Release version")
-#     set(CMAKE_BUILD_TYPE Release)
-#     add_definitions(-DNDEBUG)
-# else(HEATEQ_RELEASE)
-#     message(STATUS "Debug version")
-#     set(CMAKE_BUILD_TYPE Debug)
-# endif(HEATEQ_RELEASE)
+option(HEATEQ_RELEASE "Build release version, disables all runtime asserts" OFF)
+if(HEATEQ_RELEASE)
+    message(STATUS "Release version")
+    set(CMAKE_BUILD_TYPE Release)
+    add_definitions(-DNDEBUG)
+else(HEATEQ_RELEASE)
+    message(STATUS "Debug version")
+    set(CMAKE_BUILD_TYPE Debug)
+endif(HEATEQ_RELEASE)
 
 ################################################################################
 # PNGwriter

--- a/share/pmacc/examples/heatEquation2D/README.md
+++ b/share/pmacc/examples/heatEquation2D/README.md
@@ -1,0 +1,30 @@
+/* Copyright 2023 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+## Installing
+- Make a build directory
+- cmake ..
+- ccmake .
+    - choose accelerator backend, configure and generate
+- cmake --build .
+
+## Running
+- mpirun -npernode 4 -n 4 ./heatEq
+    - make sure that -npernode and -n are set according to the number of devices in the code, when you initialize the pmacc::Environment

--- a/share/pmacc/examples/heatEquation2D/include/PngCreator.hpp
+++ b/share/pmacc/examples/heatEquation2D/include/PngCreator.hpp
@@ -1,0 +1,49 @@
+/* Copyright 2013-2023 Heiko Burau, Rene Widera, Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/types.hpp>
+
+#include <pngwriter.h>
+
+struct PngCreator
+{
+    template<class DBox>
+    void operator()(uint32_t currentStep, DBox data, pmacc::DataSpace<DIM2> dataSize)
+    {
+        std::stringstream step;
+        step << std::setw(6) << std::setfill('0') << currentStep;
+        std::string filename("heat_" + step.str() + ".png");
+        pngwriter png(dataSize.x(), dataSize.y(), 0, filename.c_str());
+        png.setcompressionlevel(9);
+
+        for(int y = 0; y < dataSize.y(); ++y)
+        {
+            for(int x = 0; x < dataSize.x(); ++x)
+            {
+                float p = data[pmacc::DataSpace<DIM2>(x, y)];
+                png.plot(x + 1, dataSize.y() - y, p, 0., 1. - p);
+            }
+        }
+        png.close();
+    }
+};

--- a/share/pmacc/examples/heatEquation2D/include/SetBoundaryConditions.hpp
+++ b/share/pmacc/examples/heatEquation2D/include/SetBoundaryConditions.hpp
@@ -1,0 +1,81 @@
+/* Copyright 2023 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/lockstep.hpp>
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/math/operation.hpp>
+
+struct SetBoundaryConditions
+{
+    /** initialize each cell
+     *
+     * @tparam T_BoxWriteOnly PMacc::DataBox, box type of the new grid data
+     * @tparam T_Mapping mapping functor type
+     *
+     * @param buffRead buffer with cell data of the current step
+     * @param mapper functor to map a block to a supercell
+     */
+    template<typename T_Box, typename T_Mapping, typename T_Worker>
+    DINLINE void operator()(
+        T_Worker const& worker,
+        T_Box buff1,
+        uint32_t const devicesPerDim,
+        pmacc::DataSpace<DIM2> const& globalPos,
+        pmacc::DataSpace<DIM2> const& localOffset,
+        pmacc::DataSpace<DIM2> const& gridSize,
+        T_Mapping const& mapper) const
+    {
+        // check if gpu is a border gpu
+        bool xBorder = globalPos.x() % devicesPerDim == 0 || globalPos.x() % devicesPerDim == devicesPerDim - 1;
+        bool yBorder = globalPos.y() % devicesPerDim == 0 || globalPos.y() % devicesPerDim == devicesPerDim - 1;
+        // return immidiately if not a border gpu
+        if(!(xBorder || yBorder))
+        {
+            return;
+        }
+
+        using SuperCellSize = typename T_Mapping::SuperCellSize;
+        constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+        // get position in grid in units of SuperCells from blockID
+        pmacc::DataSpace<DIM2> const block(
+            mapper.getSuperCellIndex(pmacc::DataSpace<DIM2>(cupla::blockIdx(worker.getAcc()))));
+        // convert position in unit of cells
+        pmacc::DataSpace<DIM2> const blockCell = block * SuperCellSize::toRT();
+
+        pmacc::lockstep::makeForEach<cellsPerSuperCell>(worker)(
+            [&](int32_t const linearIdx)
+            {
+                pmacc::DataSpace<DIM2> bufPos = blockCell + pmacc::math::mapToND(SuperCellSize::toRT(), linearIdx);
+
+                pmacc::DataSpace<DIM2> pos = localOffset + bufPos - SuperCellSize::toRT();
+
+                // global border means pos < 0 or > grid size
+                if(pos.x() == 0 || pos.x() == gridSize.x() - 1 || pos.y() == 0 || pos.y() == gridSize.y() - 1)
+                {
+                    // Set all borders as hot == 1.
+                    buff1(bufPos) = 1.;
+                }
+            });
+    };
+};

--- a/share/pmacc/examples/heatEquation2D/include/StencilFourPoint.hpp
+++ b/share/pmacc/examples/heatEquation2D/include/StencilFourPoint.hpp
@@ -1,0 +1,112 @@
+/* Copyright 2023 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/lockstep.hpp>
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/math/operation.hpp>
+#include <pmacc/memory/boxes/CachedBox.hpp>
+
+enum Directions
+{
+    LEFT = 1u,
+    RIGHT = 2u,
+    UP = 3u,
+    DOWN = 6u
+};
+
+struct StencilFourPoint
+{
+    const std::array<uint32_t, 4> stencilDirections{LEFT, RIGHT, UP, DOWN};
+
+    /** run a 4 point stencil for a supercell
+     *
+     * @tparam T_Box PMacc::DataBox, box type
+     * @tparam T_Mapping mapping functor type
+     * @param buff databox of the buffer
+     * @param mapper functor to map a block to a supercell
+     */
+    template<typename T_Box, typename T_BoxRes, typename T_Mapping, typename T_Worker>
+    DINLINE void operator()(
+        const T_Worker& worker,
+        const T_Box& boxRead,
+        T_Box boxWrite,
+        T_BoxRes boxResidual,
+        const float alpha,
+        const float dx,
+        const float dt,
+        const T_Mapping& mapper) const
+    {
+        using Type = typename T_Box::ValueType;
+        using SuperCellSize = typename T_Mapping::SuperCellSize;
+        using BlockArea = pmacc::SuperCellDescription<
+            SuperCellSize,
+            typename pmacc::math::CT::make_Int<SuperCellSize::dim, 1>::type,
+            typename pmacc::math::CT::make_Int<SuperCellSize::dim, 1>::type>;
+
+        pmacc::DataSpace<DIM2> const block(
+            mapper.getSuperCellIndex(pmacc::DataSpace<DIM2>(cupla::blockIdx(worker.getAcc()))));
+        pmacc::DataSpace<DIM2> const blockCell = block * T_Mapping::SuperCellSize::toRT();
+
+        constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+        // use the cached buffer, beacuse I am doing multiple reads, moves the blockArea to shared memory
+        auto cache = pmacc::CachedBox::create<0, Type>(worker, BlockArea());
+        auto buff_shifted = boxRead.shift(blockCell);
+
+        // the thread collective is a convenience wrapper for lockstep make for each
+        // it deals with the guard offset, subtracts the origin offset
+        auto collective = pmacc::makeThreadCollective<BlockArea>();
+
+        pmacc::math::operation::Assign assign;
+        collective(worker, assign, cache, buff_shifted);
+
+        worker.sync();
+
+        // 2D heat equation solver
+        // https://levelup.gitconnected.com/solving-2d-heat-equation-numerically-using-python-3334004aa01a
+        // using dx = dy
+
+        pmacc::lockstep::makeForEach<cellsPerSuperCell>(worker)(
+            [&](int32_t const linearIdx)
+            {
+                // cell index within the superCell
+                pmacc::DataSpace<DIM2> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearIdx);
+                auto pos = cellIdx + blockCell;
+
+                Type stencil_sum = 0;
+                for(auto i : stencilDirections)
+                {
+                    stencil_sum += cache(cellIdx + pmacc::Mask::getRelativeDirections<DIM2>(i));
+                }
+                stencil_sum = alpha * dt * 0.25 * (stencil_sum - 4 * cache(cellIdx)) / (dx * dx);
+
+                cupla::atomicAdd(
+                    worker.getAcc(),
+                    &(boxResidual[0]),
+                    pmacc::math::cPow<float>(stencil_sum, 2),
+                    ::alpaka::hierarchy::Blocks{});
+
+                boxWrite(pos) = stencil_sum + cache(cellIdx);
+            });
+    };
+};

--- a/share/pmacc/examples/heatEquation2D/main.cpp
+++ b/share/pmacc/examples/heatEquation2D/main.cpp
@@ -1,0 +1,227 @@
+/* Copyright 2023 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "../gameOfLife2D/include/GatherSlice.hpp"
+#include "include/PngCreator.hpp"
+#include "include/SetBoundaryConditions.hpp"
+#include "include/StencilFourPoint.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/algorithms/GlobalReduce.hpp>
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/lockstep.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/mappings/kernel/MappingDescription.hpp>
+#include <pmacc/math/Vector.hpp>
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+#include <pmacc/mpi/MPIReduce.hpp>
+#include <pmacc/mpi/reduceMethods/Reduce.hpp>
+
+#include <fstream>
+#include <iostream>
+
+#define NUM_STEPS 1000
+#define NUM_DEVICES_PER_DIM 2
+#define THERMAL_DIFFUSIVITY 4 // POSITIVE FACTOR
+#define DX 4 // GRID SPACING
+#define DT 1 // TIME STEP - STABLE IF DT < (DX * DX) / (4 * THERMAL_DIFFUSIVITY)
+
+
+auto main(int argc, char** argv) -> int
+{
+    const auto devices = pmacc::DataSpace<DIM2>::create(NUM_DEVICES_PER_DIM);
+    const auto periodic = pmacc::DataSpace<DIM2>::create(0);
+    pmacc::Environment<DIM2>::get().initDevices(devices, periodic);
+
+    /** define a gloabl grid */
+    const pmacc::DataSpace<DIM2> gridSize{256u, 256u};
+
+    auto& gc = pmacc::Environment<DIM2>::get().GridController();
+
+    /** device local grid size */
+    const pmacc::DataSpace<DIM2> localGridSize{gridSize / devices};
+
+    pmacc::Environment<DIM2>::get().initGrids(gridSize, localGridSize, gc.getPosition() * localGridSize);
+
+    /** Get reference to subGrid object, which holds local position, global
+     *  position, and size information, as offset of local position wrt global
+     *  position
+     */
+    const auto& subGrid = pmacc::Environment<DIM2>::get().SubGrid();
+
+    /** define mapping description, this defines the supercell size */
+    using MappingDesc = pmacc::MappingDescription<DIM2, pmacc::math::CT::Int<16, 16>>;
+
+    /** adds guards to the dataspace
+     *  here guard size is calulated by using the supercell size
+     */
+    pmacc::GridLayout<DIM2> layout{subGrid.getLocalDomain().size, MappingDesc::SuperCellSize::toRT()};
+
+    /** mapping description
+     *  takes in the grid layout - CELLS dataspace + guard, and num of SUPERCELLS in guard
+     */
+    pmacc::DataSpace<DIM2> guardingSuperCells{1, 1};
+    auto mapping = std::make_unique<MappingDesc>(layout.getDataSpace(), guardingSuperCells);
+
+    /** define grid buffers, two because we dont do in place writes */
+
+    auto buff1 = std::make_unique<pmacc::GridBuffer<float, DIM2>>(layout);
+    auto buff2 = std::make_unique<pmacc::GridBuffer<float, DIM2>>(layout);
+
+    pmacc::DataSpace<DIM2> guardingCells{1, 1};
+
+    // add stencil directions only add up, down, left, and right exchanges. dont need
+    // diagonals both buffers need exchanges because later we will swap pointers
+    // and do exhanges in an alternating fashion
+    StencilFourPoint stencilKernel{};
+    for(auto i : stencilKernel.stencilDirections)
+    {
+        buff1->addExchange(pmacc::GUARD, pmacc::Mask(i), guardingCells, 0u);
+        buff2->addExchange(pmacc::GUARD, pmacc::Mask(i), guardingCells, 1u);
+    }
+
+    /** Make locktep workercfg, takes in supercell size */
+    auto workerCfg = pmacc::lockstep::makeWorkerCfg(typename MappingDesc::SuperCellSize{});
+
+    // define mappers which run over the certain area, with a supercell size
+    pmacc::AreaMapping<pmacc::type::CORE, MappingDesc> coreMapper(*mapping);
+    pmacc::AreaMapping<pmacc::type::BORDER, MappingDesc> borderMapper(*mapping);
+
+    auto setBoundaryConditions = SetBoundaryConditions{};
+
+    /** the databox should be accessed from the buffer->getDataBox,
+     *  as the state of the databox can change when someone else writes to the buffer
+     */
+    PMACC_LOCKSTEP_KERNEL(setBoundaryConditions, workerCfg)
+    (borderMapper.getGridDim())(
+        buff1->getDeviceBuffer().getDataBox(),
+        NUM_DEVICES_PER_DIM,
+        gc.getPosition(),
+        subGrid.getLocalDomain().offset,
+        gridSize,
+        borderMapper);
+    PMACC_LOCKSTEP_KERNEL(setBoundaryConditions, workerCfg)
+    (borderMapper.getGridDim())(
+        buff2->getDeviceBuffer().getDataBox(),
+        NUM_DEVICES_PER_DIM,
+        gc.getPosition(),
+        subGrid.getLocalDomain().offset,
+        gridSize,
+        borderMapper);
+
+    // create png on host of the initial conditions
+    gol::GatherSlice gather;
+    bool isMaster;
+
+    gol::MessageHeader header(gridSize, layout, subGrid.getLocalDomain().offset);
+    isMaster = gather.init(header, true);
+
+    // gather needs to be global
+    // transfer the simulations calculated on device to host
+    buff1->deviceToHost();
+
+    auto picture = gather(buff1->getHostBuffer().getDataBox());
+
+    if(isMaster)
+    {
+        PngCreator png;
+        png(0u, picture, gridSize);
+    }
+
+    // buffer to store residual
+    auto residualBuffer = std::make_unique<pmacc::HostDeviceBuffer<float, DIM1>>(pmacc::DataSpace<DIM1>::create(1));
+
+    auto hReducedResidual = pmacc::HostBuffer<float, DIM1>(pmacc::DataSpace<DIM1>::create(1));
+
+    // scope for reduce
+    {
+        pmacc::mpi::MPIReduce reduce;
+
+        // run the simulation for steps
+        for(uint32_t i = 0; i < NUM_STEPS; i++)
+        {
+            auto splitEvent = pmacc::eventSystem::getTransactionEvent();
+            auto send = buff1->asyncCommunication(splitEvent);
+
+            /* Update Core Cells */
+            PMACC_LOCKSTEP_KERNEL(StencilFourPoint{}, workerCfg)
+            (coreMapper.getGridDim())(
+                buff1->getDeviceBuffer().getDataBox(),
+                buff2->getDeviceBuffer().getDataBox(),
+                residualBuffer->getDeviceBuffer().getDataBox(),
+                THERMAL_DIFFUSIVITY,
+                DX,
+                DT,
+                coreMapper);
+
+            /** Reset boundary borders to boundary conditions
+             * not required for iter 0 as borders havent been updated yet, but is done anyway
+             */
+            PMACC_LOCKSTEP_KERNEL(SetBoundaryConditions{}, workerCfg)
+            (borderMapper.getGridDim())(
+                buff1->getDeviceBuffer().getDataBox(),
+                NUM_DEVICES_PER_DIM,
+                gc.getPosition(),
+                subGrid.getLocalDomain().offset,
+                gridSize,
+                borderMapper);
+
+            pmacc::eventSystem::setTransactionEvent(send);
+
+            /* Update Border Cells */
+            PMACC_LOCKSTEP_KERNEL(StencilFourPoint{}, workerCfg)
+            (borderMapper.getGridDim())(
+                buff1->getDeviceBuffer().getDataBox(),
+                buff2->getDeviceBuffer().getDataBox(),
+                residualBuffer->getDeviceBuffer().getDataBox(),
+                THERMAL_DIFFUSIVITY,
+                DX,
+                DT,
+                borderMapper);
+
+            // Swap the read and write buffers
+            std::swap(buff1, buff2);
+            buff1->deviceToHost();
+            residualBuffer->deviceToHost();
+
+            // MPI Reduce the residual
+            reduce(
+                pmacc::math::operation::Add(),
+                hReducedResidual.getBasePointer(),
+                residualBuffer->getHostBuffer().getBasePointer(),
+                1, // this is a 1D dataspace, just access it?
+                pmacc::mpi::reduceMethods::Reduce());
+            // Reset residuals to zero for next iteration
+            residualBuffer->reset(false);
+            picture = gather(buff1->getHostBuffer().getDataBox());
+            PngCreator png;
+            if(isMaster)
+                png(i + 1, picture, gridSize);
+            if(reduce.hasResult(pmacc::mpi::reduceMethods::Reduce()))
+                std::cout << "Residual at time " << DT * i << " = " << hReducedResidual.getDataBox()[0] << std::endl;
+        }
+    }
+    /* Finalize */
+    gather.finalize();
+    pmacc::eventSystem::getTransactionEvent().waitForFinished();
+    pmacc::Environment<DIM2>::get().finalize();
+
+    return 0;
+}


### PR DESCRIPTION
Added a more physically motivated example for PMacc. This is a simple solver for the 2D heat equation. 
The attempt was to make it more accessible than the game of life (GoL) example, so it skips over some of the command line configuration options included in the GoL example too. 
A README is included which explains how to build and run this example.
It aims to introduce some of the commonly used classes of PMacc in a logically linear fashion in the main file.
In many places it is heavily influenced by the GoL example and also depends on GatherSlice from GoL.