### PR TITLE
Remove assert limiting the binning plugin to 3 dimensions

### DIFF
--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -76,7 +76,6 @@ namespace picongpu
                 , depositionData{depositData}
                 , writeOpenPMDFunctor{writeOpenPMD}
             {
-                static_assert(getNAxes() <= 3, "Only upto 3 binning axes are supported for now");
                 std::apply(
                     [&](auto const&... tupleArgs)
                     {

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -35,7 +35,7 @@ namespace pmacc
      * DataSpace describes a T_dim-dimensional data space with a specific size for each dimension.
      * It only describes the space and does not hold any actual data.
      *
-     * @tparam T_dim dimension (1-3) of the dataspace
+     * @tparam T_dim dimension N of the dataspace
      */
     template<unsigned T_dim>
     class DataSpace : public math::Vector<int, T_dim>


### PR DESCRIPTION
With #4715 it was possible to have an N dimensional dataspace. The binning plugin internally uses a 1D buffer, so with that change ND binning was made possible.
This PR removes an old assert limiting the number of axes in the binning plugin to 3.