### PR TITLE
getBinWidth fixes in binning plugin linear axis

### DIFF
--- a/include/picongpu/plugins/binning/Axis.hpp
+++ b/include/picongpu/plugins/binning/Axis.hpp
@@ -125,7 +125,7 @@ namespace picongpu
                     }
 
                     // can have a version without an idx also as the bin width is constant
-                    constexpr T getBinWidth(uint32_t idx) const
+                    constexpr T getBinWidth(uint32_t idx = 0) const
                     {
                         PMACC_ASSERT(idx < nBins);
                         return 1 / scaling;

--- a/include/picongpu/plugins/binning/Axis.hpp
+++ b/include/picongpu/plugins/binning/Axis.hpp
@@ -127,7 +127,7 @@ namespace picongpu
                     // can have a version without an idx also as the bin width is constant
                     constexpr T getBinWidth(uint32_t idx) const
                     {
-                        PMACC_ASSERT(idx < n_bins);
+                        PMACC_ASSERT(idx < nBins);
                         return 1 / scaling;
                     }
 


### PR DESCRIPTION
Allowed getBinWidth to be called without a bin idx for linear axes (by giving a default parameter), as the bin width is constant for these axes.
Fixed an assert using the incorrect variable name.
