### PR TITLE
fix collision (again)

### DIFF
--- a/include/picongpu/particles/collision/detail/ListEntry.hpp
+++ b/include/picongpu/particles/collision/detail/ListEntry.hpp
@@ -212,9 +212,10 @@ namespace picongpu::particles::collision
                                     uint32_t const parInSuperCellIdx = frameIdx * numFrameSlots + linearIdx;
                                     particleIds(parLocalIndex)[parOffset] = parInSuperCellIdx;
                                 }
-                                ++frameIdx;
                             },
                             frameCtx);
+                        // increment frame index after all particles in the current frame are processed
+                        ++frameIdx;
                     });
             }
 


### PR DESCRIPTION
bug was introduced with #4745

The frame index which is used to calculate particle index within the supercell is not allowed to be updated within the frame lamda, else an accelerator with less threads per block than slots within a frame will produce errors e.g. illegal memory access.