### PR TITLE
Typos in comments

### DIFF
--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -143,7 +143,7 @@ namespace picongpu
                 log<picLog::PHYSICS>("Resolving plasma oscillations?\n"
                                      "   Estimates are based on DensityRatio to BASE_DENSITY of each species\n"
                                      "   (see: density.param, speciesDefinition.param).\n"
-                                     "   It and does not cover other forms of initialization");
+                                     "   It does not cover other forms of initialization");
                 logOmegaP();
 
                 const int localNrOfCells

--- a/include/picongpu/particles/MoveParticle.hpp
+++ b/include/picongpu/particles/MoveParticle.hpp
@@ -34,12 +34,14 @@ namespace picongpu
          * in case the new position is outside of the cell we adjust
          * the cell index and the multiMask of the particle.
          *
-         * we assume that CFL condition is fulfilled
+         * as everywhere in PIConGPU, we assume that the particle moves at most
+         * one cell per step. This has to be ensured by the caller and
+         * violations are NOT checked for or caught during execution.
          *
          * @tparam T_Particle particle type
          * @param particle particle handle
-         * @param newPos new position relative to the current cell, in units of cells
-         * newPos must be [-1.0, 2.0) (following CFL)
+         * @param newPos new position relative to the current cell's origin, in
+         * units of cells, so all entries of newPos must be [-1.0, 2.0) (see above)
          * @return whether the particle has left the original cell
          */
         template<typename T_Particle>

--- a/include/picongpu/particles/MoveParticle.hpp
+++ b/include/picongpu/particles/MoveParticle.hpp
@@ -104,7 +104,7 @@ namespace picongpu
                 localCell += dir;
 
                 /* ATTENTION ATTENTION we cast to unsigned, this means that a negative
-                 * direction is know a very very big number, than we compare with supercell!
+                 * direction is now a very very big number, then we compare with supercell!
                  *
                  * if particle is inside of the supercell the **unsigned** representation
                  * of dir is always >= size of the supercell
@@ -115,7 +115,7 @@ namespace picongpu
 
                 /* if partice is outside of the supercell we use mod to
                  * set particle at cell supercellSize to 1
-                 * and partticle at cell -1 to supercellSize-1
+                 * and particle at cell -1 to supercellSize-1
                  * % (mod) can't use with negativ numbers, we add one supercellSize to hide this
                  *
                  * localCell.x() = (localCell.x() + TVec::x) % TVec::x;
@@ -126,20 +126,20 @@ namespace picongpu
                  * localCell = localCell - (dir*superCell_size)
                  * localCell = 0 if dir==-1
                  * localCell = superCell_size - 1 if dir==+1
-                 * for dir 0 localCel is not changed
+                 * for dir 0 localCell is not changed
                  */
                 localCell -= (dir * TVec::toRT());
                 // update one dimensional cell index
                 particle[localCellIdx_] = pmacc::math::linearize(TVec::toRT(), localCell);
 
-                // see inlcude/pmacc/type/Exchnages.hpp for RIGHT, BOTTOM and BACK
+                // see include/pmacc/type/Exchanges.hpp for RIGHT, BOTTOM and BACK
                 uint32_t exchangeType = 1;
 
                 /* transform direction vector into a exchange id
                  *
                  * newMultimask:
                  *   0 == is not possible because each particle processed by this function must be a valid particle
-                 *   1 == valid particle whihc is not leaving the supercell
+                 *   1 == valid particle which is not leaving the supercell
                  *   2 >= valid particle which is leaving the supercell into the direction (newMultimask - 1)
                  */
                 for(uint32_t i = 0; i < simDim; ++i)

--- a/include/picongpu/particles/MoveParticle.hpp
+++ b/include/picongpu/particles/MoveParticle.hpp
@@ -34,10 +34,12 @@ namespace picongpu
          * in case the new position is outside of the cell we adjust
          * the cell index and the multiMask of the particle.
          *
+         * we assume that CFL condition is fulfilled
+         *
          * @tparam T_Particle particle type
          * @param particle particle handle
          * @param newPos new position relative to the current cell, in units of cells
-         * newPos must be [-1.0, 2.0)
+         * newPos must be [-1.0, 2.0) (following CFL)
          * @return whether the particle has left the original cell
          */
         template<typename T_Particle>

--- a/share/picongpu/unit/shape.cpp
+++ b/share/picongpu/unit/shape.cpp
@@ -146,7 +146,7 @@ struct TestShape
 
                         for(int g = Shape::begin; g <= Shape::end; ++g)
                         {
-                            // shift the particle position into a valid range to be used to querry the shape
+                            // shift the particle position into a valid range to be used to query the shape
                             auto p = positionShift.template shift<Shape::support % 2 == 0>(positions[valueIdx]);
                             result[valueIdx] += shape(g - p);
                         }
@@ -194,7 +194,7 @@ TEST_CASE("unit::shape", "[shape test]")
 
     meta::ForEach<OnSupportShapes, TestShape<>>{}(inCellPositionBuffer, PositionShift{});
 
-    // check assignment shape outside of the uspport
+    // check assignment shape outside of the support
     using NotOnSupportShapes = pmacc::MakeSeq_t<
         particles::shapes::NGP::ChargeAssignment,
         particles::shapes::CIC::ChargeAssignment,


### PR DESCRIPTION
While reading through some random files, I've found some random typos.

~~fb04f5516a7bcaa4615860ccc93d52d5a736b097 is from #4780 already.~~

I'm not 100% sure if the change in [InitialiserController.hpp](https://github.com/ComputationalRadiationPhysics/picongpu/compare/dev...chillenzer:topic-typosAndStuff?expand=1#diff-4b75d783c44cdb3d2a0316b1e1e387b289fb6d62e09834d62ba680f162206be9) is the one that was intended.

Also, I've found it surprising that `moveParticle` does not handle movement over more than one cell. (I think) I've found out why, so I've clarified that in the docstring. Feel free to enlighten me if I misunderstood.