### PR TITLE
Add unit test for `moveParticle`

### DIFF
--- a/share/picongpu/unit/CMakeLists.txt
+++ b/share/picongpu/unit/CMakeLists.txt
@@ -71,6 +71,7 @@ include_directories(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/../../../include")
 ###############################################################################
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test)
+include_directories(BEFORE ./include)
 
 # CTest
 enable_testing()

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -21,10 +21,6 @@
 
 #include <picongpu/simulation_defines.hpp>
 
-#include <functional>
-#include <numeric>
-
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
@@ -39,19 +35,6 @@ using ::picongpu::particles::moveParticle;
 
 const auto superCellSize = ::picongpu::SuperCellSize::toRT();
 constexpr const auto superCellVolume = ::pmacc::math::CT::volume<::picongpu::SuperCellSize>::type::value;
-
-template<typename T>
-static bool isApproxEqual(T const& a, T const& b)
-{
-    return std::transform_reduce(
-        &a[0], // should be std::cbegin(a),
-        (&a[simDim - 1]) + 1, // should be std::cend(a),
-        &b[0], // should be std::cbegin(b),
-        true,
-        std::logical_and{},
-        [](auto const& lhs, auto const& rhs)
-        { return lhs == Catch::Approx(rhs).margin(std::numeric_limits<typename T::type>::epsilon()); });
-}
 
 /** A tiny stub of a particle implementing the interface expected by moveParticle()
  */
@@ -76,9 +59,10 @@ struct ParticleStub
         return multiMaskValue;
     }
 
+    // should be =default in C++20
     bool operator==(ParticleStub const& other) const
     {
-        return isApproxEqual(pos, other.pos) and localCellIdxValue == other.localCellIdxValue
+        return pos == other.pos and localCellIdxValue == other.localCellIdxValue
             and multiMaskValue == other.multiMaskValue;
     }
 

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -1,0 +1,50 @@
+/* Copyright 2023 Julian Lenz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <pmacc/boost_workaround.hpp>
+
+#include <picongpu/simulation_defines.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using ::picongpu::floatD_X;
+using ::picongpu::lcellId_t;
+using position = ::picongpu::position<::picongpu::position_pic>;
+
+/** A tiny stub of a particle implementing the interface expected by moveParticle()
+ */
+struct ParticleStub
+{
+    floatD_X pos;
+    lcellId_t localCellIdx;
+
+    lcellId_t& operator[](lcellId_t const& index)
+    {
+        return localCellIdx;
+    }
+
+    floatD_X& operator[](position const& index)
+    {
+        return pos;
+    }
+};
+
+TEST_CASE("unit::moveParticle", "[moveParticle test]")
+{
+}

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -70,9 +70,23 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         // precondition (not the actual test):
         REQUIRE(newPos == particle.pos);
 
-        auto newParticle = particle;
-        moveParticle(newParticle, newPos);
+        auto expectedParticle = particle;
+        moveParticle(particle, newPos);
 
-        REQUIRE(newParticle == particle);
+        REQUIRE(particle == expectedParticle);
+    }
+
+    SECTION("moves trivially inside cell")
+    {
+        newPos[0] += .5;
+        auto expectedParticle = particle;
+        expectedParticle.pos = newPos;
+
+        // precondition (not the actual test):
+        REQUIRE(newPos != particle.pos);
+
+        moveParticle(particle, newPos);
+
+        REQUIRE(particle == expectedParticle);
     }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -62,17 +62,17 @@ struct ParticleStub
     int localCellIdxValue = 0;
     int multiMaskValue = 1;
 
-    int& operator[](localCellIdx const& index)
+    int& operator[](localCellIdx const&)
     {
         return localCellIdxValue;
     }
 
-    floatD_X& operator[](position const& index)
+    floatD_X& operator[](position const&)
     {
         return pos;
     }
 
-    int& operator[](multiMask const& index)
+    int& operator[](multiMask const&)
     {
         return multiMaskValue;
     }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -67,7 +67,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 {
     ParticleStub particle;
     auto expectedParticle = particle;
-    floatD_X newPos = floatD_X::create(0.);
+    floatD_X newPos = particle.pos;
+    std::array<int, 3> neighbouringLocalCellIdx{1,8,64};
 
     SECTION("does nothing for unchanged position")
     {
@@ -93,9 +94,10 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
     SECTION("moves outside of cell in positive direction")
     {
-        newPos[0] += 1.5;
-        expectedParticle.pos[0] = .5;
-        expectedParticle.localCellIdxValue = 1;
+        auto i = GENERATE(range(0u, simDim));
+        newPos[i] += 1.5;
+        expectedParticle.pos[i] = .5;
+        expectedParticle.localCellIdxValue = neighbouringLocalCellIdx[i];
 
         moveParticle(particle, newPos);
 

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -79,10 +79,11 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         CHECK(particle == expectedParticle);
     }
 
+    auto i = GENERATE(range(0u, simDim));
+
     SECTION("moves trivially inside cell")
     {
-        auto i = GENERATE(range(0u, simDim));
-        newPos[i] += .5;
+        newPos[i] = .5;
         expectedParticle.pos = newPos;
 
         REQUIRE(newPos != particle.pos);
@@ -94,8 +95,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
     SECTION("moves outside of cell in positive direction")
     {
-        auto i = GENERATE(range(0u, simDim));
-        newPos[i] += 1.5;
+        newPos[i] = 1.5;
         expectedParticle.pos[i] = .5;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdx[i];
 

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -62,17 +62,17 @@ struct ParticleStub
     int localCellIdxValue = 0;
     int multiMaskValue = 1;
 
-    int& operator[](localCellIdx const&)
+    int& operator[](localCellIdx const)
     {
         return localCellIdxValue;
     }
 
-    floatD_X& operator[](position const&)
+    floatD_X& operator[](position const)
     {
         return pos;
     }
 
-    int& operator[](multiMask const&)
+    int& operator[](multiMask const)
     {
         return multiMaskValue;
     }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -93,7 +93,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
     SECTION("moves trivially inside cell")
     {
-        newPos[i] = .5;
+        newPos[i] = .42;
         expectedParticle.pos = newPos;
 
         REQUIRE(newPos != particle.pos);
@@ -107,8 +107,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
     SECTION("moves outside of cell in positive direction")
     {
         const std::array<int, 3> neighbouringLocalCellIdxPositive{1, 8, 64};
-        newPos[i] = 1.5;
-        expectedParticle.pos[i] = .5;
+        newPos[i] = 1.1;
+        expectedParticle.pos[i] = .1;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxPositive[i];
 
         moveParticle(particle, newPos);
@@ -128,8 +128,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         // make sure that we don't cross supercell borders just here:
         particle.localCellIdxValue = lastCell;
 
-        newPos[i] = -.5;
-        expectedParticle.pos[i] = .5;
+        newPos[i] = -.3;
+        expectedParticle.pos[i] = .7;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxNegative[i];
 
         moveParticle(particle, newPos);

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -182,4 +182,17 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         CHECK(leftSuperCell);
         CHECK(particle == expectedParticle);
     }
+
+    SECTION("handles rounding near zero correctly")
+    {
+        /* This is so small that 1-newPos[0] = 1.0 (after floating point rounding), so we DO NOT leave the cell after
+         * all but just move to position 0.
+         */
+        newPos[0] = -1.e-9;
+        expectedParticle.pos[0] = 0.;
+
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(not leftSuperCell);
+        CHECK(particle == expectedParticle);
+    }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -22,29 +22,57 @@
 #include <picongpu/simulation_defines.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <picongpu/particles/Particles.hpp>
 
 using ::picongpu::floatD_X;
-using ::picongpu::lcellId_t;
-using position = ::picongpu::position<::picongpu::position_pic>;
+using ::pmacc::localCellIdx;
+using ::pmacc::multiMask;
+using position = ::picongpu::position<>;
+using ::picongpu::particles::moveParticle;
 
 /** A tiny stub of a particle implementing the interface expected by moveParticle()
  */
 struct ParticleStub
 {
-    floatD_X pos;
-    lcellId_t localCellIdx;
+    floatD_X pos = floatD_X::create(0.);
+    int localCellIdxValue;
+    int multiMaskValue;
 
-    lcellId_t& operator[](lcellId_t const& index)
+    int& operator[](localCellIdx const& index)
     {
-        return localCellIdx;
+        return localCellIdxValue;
     }
 
     floatD_X& operator[](position const& index)
     {
         return pos;
     }
+
+    int& operator[](multiMask const& index)
+    {
+        return multiMaskValue;
+    }
+
+    bool operator==(ParticleStub const& other)
+    {
+        return pos == other.pos and localCellIdxValue == other.localCellIdxValue
+            and multiMaskValue == other.multiMaskValue;
+    }
 };
 
 TEST_CASE("unit::moveParticle", "[moveParticle test]")
 {
+    ParticleStub particle;
+    floatD_X newPos = floatD_X::create(0.);
+
+    SECTION("does nothing for unchanged position")
+    {
+        // precondition (not the actual test):
+        REQUIRE(newPos == particle.pos);
+
+        auto newParticle = particle;
+        moveParticle(newParticle, newPos);
+
+        REQUIRE(newParticle == particle);
+    }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -25,7 +25,6 @@
 #include <numeric>
 
 #include <catch2/catch_approx.hpp>
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
@@ -116,13 +115,13 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
         REQUIRE(newPos != particle.pos);
 
-        moveParticle(particle, newPos);
+        CHECK(not moveParticle(particle, newPos));
 
         CHECK(particle == expectedParticle);
     }
 
 
-    SECTION("moves outside of cell in positive direction")
+    SECTION("moves out of cell in positive direction")
     {
         auto i = GENERATE(range(0u, simDim));
 
@@ -131,12 +130,12 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[i] = .1;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxPositive[i];
 
-        moveParticle(particle, newPos);
+        CHECK(not moveParticle(particle, newPos));
 
         CHECK(particle == expectedParticle);
     }
 
-    SECTION("moves outside of cell in negative direction")
+    SECTION("moves out of cell in negative direction")
     {
         auto i = GENERATE(range(0u, simDim));
 
@@ -154,7 +153,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[i] = .7;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxNegative[i];
 
-        moveParticle(particle, newPos);
+        CHECK(not moveParticle(particle, newPos));
 
         CHECK(particle == expectedParticle);
     }
@@ -167,9 +166,18 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[1] = .6;
         expectedParticle.localCellIdxValue = 9;
 
-        moveParticle(particle, newPos);
-        std::cout << particle.toString() << "\n";
+        CHECK(not moveParticle(particle, newPos));
+        CHECK(particle == expectedParticle);
+    }
 
+    SECTION("moves out of super cell")
+    {
+        newPos[0] = -.9;
+        expectedParticle.pos[0] = .1;
+        expectedParticle.localCellIdxValue = superCellSize[0] - 1;
+        expectedParticle.multiMaskValue = 3;
+
+        CHECK(moveParticle(particle, newPos));
         CHECK(particle == expectedParticle);
     }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -34,8 +34,10 @@ using ::picongpu::floatD_X;
 using ::pmacc::localCellIdx;
 using ::pmacc::multiMask;
 using position = ::picongpu::position<>;
+using ::picongpu::float_X;
 using ::picongpu::simDim;
 using ::picongpu::particles::moveParticle;
+using ::picongpu::operator""_X;
 
 const auto superCellSize = ::picongpu::SuperCellSize::toRT();
 constexpr const auto superCellVolume = ::pmacc::math::CT::volume<::picongpu::SuperCellSize>::type::value;
@@ -188,7 +190,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         /* This is so small that 1-newPos[0] = 1.0 (after floating point rounding), so we DO NOT leave the cell after
          * all but just move to position 0.
          */
-        newPos[0] = -1.e-9;
+        newPos[0] = -std::numeric_limits<float_X>::epsilon() / 4._X;
         expectedParticle.pos[0] = 0.;
 
         bool leftSuperCell = moveParticle(particle, newPos);

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -101,8 +101,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
     {
         REQUIRE(newPos == particle.pos);
 
-        moveParticle(particle, newPos);
-
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(not leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -115,8 +115,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
         REQUIRE(newPos != particle.pos);
 
-        CHECK(not moveParticle(particle, newPos));
-
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(not leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -130,8 +130,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[i] = .1;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxPositive[i];
 
-        CHECK(not moveParticle(particle, newPos));
-
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(not leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -153,8 +153,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[i] = .7;
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxNegative[i];
 
-        CHECK(not moveParticle(particle, newPos));
-
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(not leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -166,7 +166,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[1] = .6;
         expectedParticle.localCellIdxValue = 9;
 
-        CHECK(not moveParticle(particle, newPos));
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(not leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -177,7 +178,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.localCellIdxValue = superCellSize[0] - 1;
         expectedParticle.multiMaskValue = 3;
 
-        CHECK(moveParticle(particle, newPos));
+        bool leftSuperCell = moveParticle(particle, newPos);
+        CHECK(leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -86,4 +86,15 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
         CHECK(particle == expectedParticle);
     }
+
+    SECTION("moves outside of cell in positive direction")
+    {
+        newPos[0] += 1.5;
+        expectedParticle.pos[0] = .5;
+        expectedParticle.localCellIdxValue = 1;
+
+        moveParticle(particle, newPos);
+
+        CHECK(particle == expectedParticle);
+    }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -63,30 +63,27 @@ struct ParticleStub
 TEST_CASE("unit::moveParticle", "[moveParticle test]")
 {
     ParticleStub particle;
+    auto expectedParticle = particle;
     floatD_X newPos = floatD_X::create(0.);
 
     SECTION("does nothing for unchanged position")
     {
-        // precondition (not the actual test):
         REQUIRE(newPos == particle.pos);
 
-        auto expectedParticle = particle;
         moveParticle(particle, newPos);
 
-        REQUIRE(particle == expectedParticle);
+        CHECK(particle == expectedParticle);
     }
 
     SECTION("moves trivially inside cell")
     {
         newPos[0] += .5;
-        auto expectedParticle = particle;
         expectedParticle.pos = newPos;
 
-        // precondition (not the actual test):
         REQUIRE(newPos != particle.pos);
 
         moveParticle(particle, newPos);
 
-        REQUIRE(particle == expectedParticle);
+        CHECK(particle == expectedParticle);
     }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -79,8 +79,8 @@ struct ParticleStub
 
     bool operator==(ParticleStub const& other) const
     {
-        return isApproxEqual(pos, other.pos) and localCellIdxValue == other.localCellIdxValue
-            and multiMaskValue == other.multiMaskValue;
+        return isApproxEqual(pos, other.pos) && localCellIdxValue == other.localCellIdxValue
+            && multiMaskValue == other.multiMaskValue;
     }
 
     std::string toString() const
@@ -102,7 +102,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         REQUIRE(newPos == particle.pos);
 
         bool leftSuperCell = moveParticle(particle, newPos);
-        CHECK(not leftSuperCell);
+        CHECK(!leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -116,7 +116,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         REQUIRE(newPos != particle.pos);
 
         bool leftSuperCell = moveParticle(particle, newPos);
-        CHECK(not leftSuperCell);
+        CHECK(!leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -131,7 +131,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxPositive[i];
 
         bool leftSuperCell = moveParticle(particle, newPos);
-        CHECK(not leftSuperCell);
+        CHECK(!leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -154,7 +154,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.localCellIdxValue = neighbouringLocalCellIdxNegative[i];
 
         bool leftSuperCell = moveParticle(particle, newPos);
-        CHECK(not leftSuperCell);
+        CHECK(!leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -167,7 +167,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.localCellIdxValue = 9;
 
         bool leftSuperCell = moveParticle(particle, newPos);
-        CHECK(not leftSuperCell);
+        CHECK(!leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 
@@ -192,7 +192,7 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
         expectedParticle.pos[0] = 0.;
 
         bool leftSuperCell = moveParticle(particle, newPos);
-        CHECK(not leftSuperCell);
+        CHECK(!leftSuperCell);
         CHECK(particle == expectedParticle);
     }
 }

--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -22,12 +22,15 @@
 #include <picongpu/simulation_defines.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
 #include <picongpu/particles/Particles.hpp>
 
 using ::picongpu::floatD_X;
 using ::pmacc::localCellIdx;
 using ::pmacc::multiMask;
 using position = ::picongpu::position<>;
+using ::picongpu::simDim;
 using ::picongpu::particles::moveParticle;
 
 /** A tiny stub of a particle implementing the interface expected by moveParticle()
@@ -77,7 +80,8 @@ TEST_CASE("unit::moveParticle", "[moveParticle test]")
 
     SECTION("moves trivially inside cell")
     {
-        newPos[0] += .5;
+        auto i = GENERATE(range(0u, simDim));
+        newPos[i] += .5;
         expectedParticle.pos = newPos;
 
         REQUIRE(newPos != particle.pos);

--- a/share/picongpu/unit/include/picongpu/param/dimension.param
+++ b/share/picongpu/unit/include/picongpu/param/dimension.param
@@ -1,0 +1,31 @@
+/* Copyright 2014-2023 Axel Huebl, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef TEST_DIM
+#    define TEST_DIM DIM3
+#endif
+
+#define SIMDIM TEST_DIM
+
+namespace picongpu
+{
+    constexpr uint32_t simDim = SIMDIM;
+} // namespace picongpu


### PR DESCRIPTION
Also mostly supposed as a warm-up for me. Nothing fancy.

Basically two changes:
1. Add `include/...` to the unit test directory to make `simulation_defines.hpp` usable (using it to run tests for 2D and 3D).
2. Adding the test file successively.

Caveats we discussed:
This is currently very simple and does not take into account the accelerators at all. This hugely simplifies setup but doesn't help with compiler specific bugs. Particularly, the one about rounding errors will crucially depend on this and is probably insufficiently covered by the current approach.

PS: Feel free to request history cosmetics to your liking.