### PR TITLE
Typos in docs [closes #4713]

### DIFF
--- a/docs/source/dev/clangtools.rst
+++ b/docs/source/dev/clangtools.rst
@@ -28,7 +28,7 @@ For example, enable the *OpenMP* backend via:
 .. code-block:: bash
 
    # in an example
-   mkdir .build
+   mkdir build
    cd build
 
    pic-configure -c"-DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON" ..

--- a/docs/source/dev/doxygen.rst
+++ b/docs/source/dev/doxygen.rst
@@ -5,28 +5,12 @@ Doxygen
 
 .. sectionauthor:: Axel Huebl
 
-An online version of our Doxygen build can be found at
-
-http://computationalradiationphysics.github.io/picongpu
-
-We regularly update it via
-
-.. code-block:: bash
-
-   git checkout gh-pages
-
-   # optional argument: branch or tag name
-   ./update.sh
-
-   git commit -a
-   git push
-
-This section explains what is done when this script is run to build it manually.
+PIConGPU uses `Doxygen` for API documentation. Please provide the corresponding annotations in new and updated code as needed. To build this documentation do the following:
 
 Requirements
 ------------
 
-install `Doxygen`_ and its dependencies for graph generation.
+Install `Doxygen`_ and its dependencies for graph generation.
 
 .. _Doxygen: http://doxygen.org
 
@@ -38,7 +22,7 @@ install `Doxygen`_ and its dependencies for graph generation.
 Activate HTML Output
 --------------------
 
-activate the generation of html files in the doxygen config file
+Activate the generation of html files in the doxygen config file
 
 .. code-block:: bash
 

--- a/docs/source/dev/repostructure.rst
+++ b/docs/source/dev/repostructure.rst
@@ -54,12 +54,16 @@ Directory Structure
   * examples, documentation
   * ``picongpu/``
 
+    * ``benchmarks/``: setups used for benchmarking
     * ``completions/``: bash completions
     * ``examples/``: each with same structure as ``/``
     * ``pypicongpu/``: required files for code generation
 
       * ``schema/``: code generation JSON schemas
       * ``template/``: base template for code generation
+
+    * ``tests/``: self-validating examples for different scenarios
+    * ``unit/``: small (hopefully expanding) selection of unit tests
 
 * ``bin/``
 

--- a/docs/source/models/AOFDTD.rst
+++ b/docs/source/models/AOFDTD.rst
@@ -86,7 +86,7 @@ When discretizing on the mesh with centered finite differences, the spatial posi
 chosen such that a field component, whose **temporal derivative** is
 calculated on the left hand side of a Maxwell equation, is spatially positioned between the two field components whose
 **spatial derivative** is evaluated on the right hand side of the respective Maxwell equation.
-In this way, the spatial points where a left hand side temporal derivative of a field is evaluate lies exactly at the
+In this way, the spatial points where a left hand side temporal derivative of a field is evaluated lies exactly at the
 position where the spatial derivative of the right hand side fields is calculated.
 The following image visualizes the arrangement of field components in PIConGPU.
 
@@ -275,7 +275,7 @@ we have :math:`\xi \leq \xi_\mathrm{max}` with equality possible for diagonal wa
 This reveals two important properties of the field solver.
 (The 2D version is obtained by letting :math:`\tilde k_z = 0`.)
 
-First, only within the range :math:`\xi_\mathrm{max} \leq 1` the field solver operates stable.
+First, only within the range :math:`\xi_\mathrm{max} \leq 1` the field solver operates stably.
 This gives the *Courant-Friedrichs-Lewy* stability condition relating time step to mesh spacing
 
 .. math::
@@ -284,7 +284,7 @@ This gives the *Courant-Friedrichs-Lewy* stability condition relating time step 
 
 Typically, :math:`\xi_\mathrm{max} = 0.995` is chosen.
 Outside this stability region, the frequency :math:`\omega` corresponding to a certain wave vector becomes imaginary,
-meaning that wave amplitudes can be nonphysical exponentially amplified [Taflove2005]_.
+meaning that wave amplitudes can be nonphysically exponentially amplified [Taflove2005]_.
 
 Second, there exists a purely numerical anisotropy in a wave's phase velocity :math:`\tilde v_p = \omega / \tilde k`
 (speed of electromagnetic wave propagation) depending on its propagation direction :math:`\phi`, as depicted in the following figure

--- a/docs/source/usage/param.rst
+++ b/docs/source/usage/param.rst
@@ -39,7 +39,7 @@ In order to create an efficient simulation, PIConGPU compiles to **exactly** the
 This comes at a small cost: when **even one of those settings is changed, you need to recompile**.
 Nevertheless, wasting about 5 minutes compiling on a single node is nothing compared to the time you save *at scale*!
 
-All options that are less or non-critical for runtime performance, such as specific ranges observables in :ref:`plugins <usage-plugins>` or how many nodes shall be used, can be set in :ref:`run time configuration files (*.cfg) <usage-tbg>` and do not need a recompile when changed.
+All options that are less or non-critical for runtime performance, such as specific ranges, observables in :ref:`plugins <usage-plugins>` or how many nodes shall be used, can be set in :ref:`run time configuration files (*.cfg) <usage-tbg>` and do not need a recompile when changed.
 
 Files and Their Usage
 ---------------------

--- a/docs/source/usage/reference.rst
+++ b/docs/source/usage/reference.rst
@@ -5,7 +5,7 @@ Reference
 
 .. sectionauthor:: Axel Huebl
 
-PIConGPU is an almost decade-long scientific project with many people contributing to it.
+PIConGPU is a more than decade-long scientific project with many people contributing to it.
 In order to credit the work of others, we expect you to cite our latest paper describing PIConGPU when publishing and/or presenting scientific results.
 
 In addition to that and out of good scientific practice, you should document the version of PIConGPU that was used and any modifications you applied.


### PR DESCRIPTION
Hi, similar to the other PR: Read through some parts of the documentation and found a bunch of typos. Two commits that vaguely resemble interesting things:
- I've updated the description of the directory structure of `share/` as it was outdated. One should probably think about if a manually compiled outline of the directory structure is something we want to maintain. Maybe sub-READMEs would be easier to maintain.
- I've also encountered #4713 and fixed it.