### PR TITLE
Optimizations for Frontier Streaming template and for KelvinHelmholtz Streaming configs

### DIFF
--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_pipe.cfg
@@ -70,6 +70,7 @@ TBG_PIC_config="\
   \"iteration_encoding\": \"variable_based\", \
   \"adios2\": { \
     \"use_group_table\": true, \
+    \"attribute_writing_ranks\": 0, \
     \"engine\": { \
       \"parameters\": { \
         \"QueueLimit\": \"1\", \
@@ -118,6 +119,7 @@ TBG_inconfig_pipe="\
 TBG_outconfig_pipe="\
 { \
     \"adios2\": { \
+        \"attribute_writing_ranks\": 0, \
         \"engine\": { \
             \"usesteps\": true, \
             \"type\": \"nullcore\", \

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
@@ -65,6 +65,7 @@ TBG_PIC_config="\
   \"iteration_encoding\": \"variable_based\", \
   \"adios2\": { \
     \"use_group_table\": true, \
+    \"attribute_writing_ranks\": 0, \
     \"engine\": { \
       \"parameters\": { \
         \"QueueLimit\": \"1\", \
@@ -113,6 +114,7 @@ TBG_inconfig_pipe="\
 TBG_outconfig_pipe="\
 { \
     \"adios2\": { \
+        \"attribute_writing_ranks\": 0, \
         \"engine\": { \
             \"usesteps\": true, \
             \"type\": \"nullcore\", \

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_pipe.cfg
@@ -70,6 +70,7 @@ TBG_PIC_config="\
   \"iteration_encoding\": \"variable_based\", \
   \"adios2\": { \
     \"use_group_table\": true, \
+    \"attribute_writing_ranks\": 0, \
     \"engine\": { \
       \"parameters\": { \
         \"QueueLimit\": \"1\", \
@@ -118,6 +119,7 @@ TBG_inconfig_pipe="\
 TBG_outconfig_pipe="\
 { \
     \"adios2\": { \
+        \"attribute_writing_ranks\": 0, \
         \"engine\": { \
             \"usesteps\": true, \
             \"type\": \"nullcore\", \


### PR DESCRIPTION
1. As seen in the [Frontier node diagram](https://docs.olcf.ornl.gov/_images/Frontier_Node_Diagram.jpg), the system has four Slingshot network cards per node. This sets the `FABRIC_IFACE` environment variable such that each rank uses the card pertaining the the L3 cache group that it was pinned to.
2. The SST engine of ADIOS2 has some trouble handling lots of metadata at large scale due to MPI collectives restricted to 2GB. As long as metadata is treated collectively (which it is in PIConGPU), we can instruct the [dev version](https://github.com/openPMD/openPMD-api/pull/1542) of openPMD-api to consider metadata only from some ranks and discard the other. Note that since this is dev, the API is not stable yet.

TODO

- [x] Test run