### PR TITLE
Fix includes, inlining, and the example in the binning plugin

### DIFF
--- a/include/picongpu/param/binningSetup.param
+++ b/include/picongpu/param/binningSetup.param
@@ -91,20 +91,16 @@ namespace picongpu
 
             /// Axis 3
             // Define Functor
-            auto getTime
+            auto getTimeStep
                 = [] ALPAKA_FN_ACC(auto const& domainInfo, auto const& worker, auto const& particle) -> uint32_t
             { return domainInfo.currentStep; };
 
-            // Define units
-            std::array<double, 7> timeDimension{};
-            momentumDimension[SIBaseUnits::time] = 1.0;
-
             // Create Functor Description
-            auto timeDescription = createFunctorDescription<uint32_t>(getTime, "time_axis", timeDimension);
+            auto timeStepDescription = createFunctorDescription<uint32_t>(getTimeStep, "time_axis");
 
             // Create Axis
-            auto ax_time
-                = axis::createLinear(axis::AxisSplitting(axis::Range<uint32_t>{0, 2000}, 2000), timeDescription);
+            auto ax_timeStep
+                = axis::createLinear(axis::AxisSplitting(axis::Range<uint32_t>{0, 2000}, 2000), timeStepDescription);
 
 
             // Bring the axes together in a tuple
@@ -171,7 +167,7 @@ namespace picongpu
                     .setJsonCfg(R"({"hdf5":{"dataset":{"chunks":"auto"}}})")
                     .setOpenPMDExtension("h5");
 
-                binningCreator.addBinner("particleBinning", createTuple(ax_time, ax_py), speciesTuple, getCounts)
+                binningCreator.addBinner("particleBinning", createTuple(ax_timeStep, ax_py), speciesTuple, getCounts)
                     .setDumpPeriod(2000)
                     .setNormalizeByBinVolume(false);
             }

--- a/include/picongpu/plugins/binning/Axis.hpp
+++ b/include/picongpu/plugins/binning/Axis.hpp
@@ -22,7 +22,11 @@
 #include "picongpu/plugins/binning/DomainInfo.hpp"
 #include "picongpu/plugins/binning/UnitConversion.hpp"
 
+#include <array>
 #include <cstdint>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 namespace picongpu
 {

--- a/include/picongpu/plugins/binning/Axis.hpp
+++ b/include/picongpu/plugins/binning/Axis.hpp
@@ -338,7 +338,7 @@ namespace picongpu
              * @param functorDescription
              */
             template<typename T_Attribute, typename T_FunctorDescription>
-            auto createLinear(AxisSplitting<T_Attribute> axSplit, T_FunctorDescription functorDesc)
+            HINLINE auto createLinear(AxisSplitting<T_Attribute> axSplit, T_FunctorDescription functorDesc)
             {
                 static_assert(
                     std::is_same_v<typename T_FunctorDescription::QuantityType, T_Attribute>,
@@ -352,7 +352,7 @@ namespace picongpu
             }
 
             template<typename T_FunctorDescription>
-            auto createBool(T_FunctorDescription functorDesc)
+            HINLINE auto createBool(T_FunctorDescription functorDesc)
             {
                 return BoolAxis<typename T_FunctorDescription::FunctorType>(functorDesc.functor, functorDesc.name);
             }

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "picongpu/plugins/binning/BinningFunctors.hpp"
-#include "picongpu/plugins/binning/DomainInfo.hpp"
 #include "picongpu/plugins/binning/WriteHist.hpp"
 #include "picongpu/plugins/binning/utility.hpp"
 

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -122,7 +122,7 @@ namespace picongpu
             }
         };
 
-        void dimensionSubtraction(std::array<double, 7>& outputDims, const std::array<double, 7>& axisDims)
+        HINLINE void dimensionSubtraction(std::array<double, 7>& outputDims, const std::array<double, 7>& axisDims)
         {
             for(size_t i = 0; i < 7; i++)
             {

--- a/include/picongpu/plugins/binning/BinningDispatcher.hpp
+++ b/include/picongpu/plugins/binning/BinningDispatcher.hpp
@@ -29,7 +29,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <variant>
+#include <vector>
 
 namespace picongpu
 {

--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -24,6 +24,8 @@
 #include "picongpu/plugins/binning/DomainInfo.hpp"
 #include "picongpu/plugins/binning/utility.hpp"
 
+#include <cstdint>
+
 namespace picongpu
 {
     namespace plugins::binning

--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -18,6 +18,9 @@
  */
 
 #pragma once
+
+#include <cstdint>
+
 namespace picongpu
 {
     namespace plugins::binning
@@ -53,5 +56,4 @@ namespace picongpu
             }
         };
     } // namespace plugins::binning
-
 } // namespace picongpu

--- a/include/picongpu/plugins/binning/FunctorDescription.hpp
+++ b/include/picongpu/plugins/binning/FunctorDescription.hpp
@@ -66,13 +66,13 @@ namespace picongpu
          * @returns FunctorDescription object
          */
         template<typename QuantityType, typename FunctorType>
-        auto createFunctorDescription(
+        HINLINE auto createFunctorDescription(
             FunctorType functor,
             std::string name,
-            std::array<double, 7> units = {0, 0, 0, 0, 0, 0, 0})
+            std::array<double, 7> units = std::array<double, 7>({0., 0., 0., 0., 0., 0., 0.}))
         {
             return FunctorDescription<QuantityType, FunctorType>(functor, name, units);
         }
 
-    }; // namespace plugins::binning
+    } // namespace plugins::binning
 } // namespace picongpu

--- a/include/picongpu/plugins/binning/UnitConversion.hpp
+++ b/include/picongpu/plugins/binning/UnitConversion.hpp
@@ -18,6 +18,10 @@
  */
 
 #pragma once
+
+#include <array>
+#include <map>
+
 #include <openPMD/openPMD.hpp>
 
 namespace picongpu
@@ -48,7 +52,7 @@ namespace picongpu
                 conversion_factor *= std::pow(UnitDimensions[i], myDimension[i]);
             };
             return conversion_factor;
-        };
+        }
 
         template<typename T>
         T toPICUnits(T varSI, const std::array<double, 7>& myDimension)
@@ -61,13 +65,13 @@ namespace picongpu
                 }
             };
             return static_cast<T>(static_cast<double>(varSI) / get_conversion_factor(myDimension));
-        };
+        }
 
         template<typename T>
         double toSIUnits(T varPIC, const std::array<double, 7>& myDimension)
         {
             return static_cast<double>(varPIC) * get_conversion_factor(myDimension);
-        };
+        }
 
 
         std::map<::openPMD::UnitDimension, double> makeOpenPMDUnitMap(const std::array<double, 7>& myDimension)

--- a/include/picongpu/plugins/binning/UnitConversion.hpp
+++ b/include/picongpu/plugins/binning/UnitConversion.hpp
@@ -44,7 +44,7 @@ namespace picongpu
          * In this format the conversion factor needs to be divided(?)
          * is it faster/better to calculate the inverse and then multiply?
          */
-        double get_conversion_factor(const std::array<double, 7>& myDimension)
+        HINLINE double get_conversion_factor(const std::array<double, 7>& myDimension)
         {
             double conversion_factor = 1.;
             for(size_t i = 0; i < 7; i++)
@@ -55,7 +55,7 @@ namespace picongpu
         }
 
         template<typename T>
-        T toPICUnits(T varSI, const std::array<double, 7>& myDimension)
+        HINLINE T toPICUnits(T varSI, const std::array<double, 7>& myDimension)
         {
             if constexpr(std::is_integral_v<T>)
             {
@@ -68,13 +68,13 @@ namespace picongpu
         }
 
         template<typename T>
-        double toSIUnits(T varPIC, const std::array<double, 7>& myDimension)
+        HINLINE double toSIUnits(T varPIC, const std::array<double, 7>& myDimension)
         {
             return static_cast<double>(varPIC) * get_conversion_factor(myDimension);
         }
 
 
-        std::map<::openPMD::UnitDimension, double> makeOpenPMDUnitMap(const std::array<double, 7>& myDimension)
+        HINLINE std::map<::openPMD::UnitDimension, double> makeOpenPMDUnitMap(const std::array<double, 7>& myDimension)
         {
             using UD = ::openPMD::UnitDimension;
 

--- a/include/picongpu/plugins/binning/utility.hpp
+++ b/include/picongpu/plugins/binning/utility.hpp
@@ -18,7 +18,11 @@
  */
 
 #pragma once
+
 #include <pmacc/memory/STLTuple.hpp>
+
+#include <tuple>
+#include <utility>
 
 namespace picongpu
 {

--- a/include/picongpu/plugins/binning/utility.hpp
+++ b/include/picongpu/plugins/binning/utility.hpp
@@ -72,7 +72,7 @@ namespace picongpu
         }
 
         template<typename... Args>
-        auto createTuple(Args const&... args)
+        HDINLINE auto createTuple(Args const&... args)
         {
             return std::make_tuple(args...);
         }


### PR DESCRIPTION
Added many missing includes.
Made many free functions inline. 
Also to work around a nvcc bug found by @BrianMarre, changed the way an ``std::array`` is given in as a default parameter to a ``createFunctorDescription()`` in ``FunctorDescription.hpp``.
Fixed the binning example to more accurately describe a timeStep axis instead of the preious time axis.