### PR TITLE
update system profiles

### DIFF
--- a/etc/picongpu/bash-devServer-hzdr/cpu_install.sh
+++ b/etc/picongpu/bash-devServer-hzdr/cpu_install.sh
@@ -1,10 +1,10 @@
-spack install --reuse cmake@3.25.0 %gcc@12.2.0
-spack load cmake@3.25.0 ^openssl certs=mozilla %gcc@12.2.0
+spack install --reuse cmake@3.26.3 %gcc@12.1.0
+spack load cmake@3.26.3 ^openssl certs=mozilla %gcc@12.1.0
 
 echo "openpmd-api:"
-spack install --reuse openpmd-api@0.14.5 %gcc@12.2.0 \
-    ^adios2@2.8.3 \
-    ^cmake@3.25.0 \
+spack install --reuse openpmd-api@0.15.2 %gcc@12.1.0 \
+    ^adios2@2.9.2 \
+    ^cmake@3.26.3 \
     ^hdf5@1.12.2 \
     ^openmpi@4.1.4 +atomics\
     ^python@3.10.4 \
@@ -15,7 +15,7 @@ spack install --reuse boost@1.80.0 \
     +program_options \
     +atomic \
     ~python \
-    %gcc@12.2.0
+    %gcc@12.1.0
 
 echo "pngwriter"
-spack install --reuse pngwriter@0.7.0 %gcc@12.2.0
+spack install --reuse pngwriter@0.7.0 %gcc@12.1.0

--- a/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
@@ -19,25 +19,25 @@ spack unload
 # PIConGPU build dependencies #################################################
 #   need to load correct cmake and gcc to compile picongpu
 
-spack load gcc@12.2.0
-spack load cmake@3.25.0 ^openssl certs=mozilla %gcc@12.2.0
+spack load gcc@12.1.0
+spack load cmake@3.26.3 ^openssl certs=mozilla %gcc@12.1.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
 #   and no name confilcts in spack, see install.sh for more precise definition
 #   if name conflicts occur
 
-spack load openpmd-api@0.14.5 %gcc@12.2.0 \
-    ^adios2@2.8.3 \
+spack load openpmd-api@0.15.2 %gcc@12.1.0 \
+    ^adios2@2.9.2 \
     ^hdf5@1.12.2 \
     ^openmpi@4.1.4 +atomics ~cuda\
     ^python@3.10.4 \
     ^py-numpy@1.23.3
-spack load boost@1.80.0 %gcc@12.2.0
+spack load boost@1.80.0 %gcc@12.1.0
 
 # PIConGPU output dependencies ################################################
 #
-spack load pngwriter@0.7.0 %gcc@12.2.0
+spack load pngwriter@0.7.0 %gcc@12.1.0
 
 
 # Environment #################################################################

--- a/etc/picongpu/bash-devServer-hzdr/gpu_a30_install.sh
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_a30_install.sh
@@ -1,10 +1,10 @@
-spack install --reuse cmake@3.25.2 %gcc@11.3.0
-spack load cmake@3.25.2 %gcc@11.3.0
+spack install --reuse cmake@3.26.3 %gcc@12.1.0
+spack load cmake@3.26.3 %gcc@12.1.0
 
 echo "openpmd-api:"
-spack install --reuse openpmd-api@0.14.5 %gcc@11.3.0 \
-    ^adios2@2.8.3 +cuda cuda_arch=80\
-    ^cmake@3.25.2 \
+spack install --reuse openpmd-api@0.15.2 %gcc@12.1.0 \
+    ^adios2@2.9.2 +cuda cuda_arch=80\
+    ^cmake@3.26.3 \
     ^hdf5@1.14.0 \
     ^openmpi@4.1.5 +atomics +cuda cuda_arch=80\
     ^python@3.10.10 \
@@ -15,7 +15,7 @@ spack install --reuse boost@1.81.0 \
     +program_options \
     +atomic \
     ~python \
-    %gcc@11.3.0
+    %gcc@12.1.0
 
 echo "pngwriter"
-spack install --reuse pngwriter@0.7.0 %gcc@11.3.0
+spack install --reuse pngwriter@0.7.0 %gcc@12.1.0

--- a/etc/picongpu/bash-devServer-hzdr/gpu_a30_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_a30_picongpu.profile.example
@@ -19,25 +19,25 @@ spack unload
 # PIConGPU build dependencies #################################################
 #   need to load correct cmake and gcc to compile picongpu
 
-spack load gcc@11.3.0
-spack load cmake@3.25.2 %gcc@11.3.0
+spack load gcc@12.1.0
+spack load cmake@3.26.3 %gcc@12.1.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
 #   and no name confilcts in spack, see install.sh for more precise definition
 #   if name conflicts occur
 
-spack load openpmd-api@0.14.5 %gcc@11.3.0 \
-    ^adios2@2.8.3 \
+spack load openpmd-api@0.15.2 %gcc@12.1.0 \
+    ^adios2@2.9.2 \
     ^hdf5@1.14.0 \
     ^openmpi@4.1.5 +atomics +cuda cuda_arch=80 \
     ^python@3.10.10 \
     ^py-numpy@1.24.2
-spack load boost@1.81.0 %gcc@11.3.0
+spack load boost@1.81.0 %gcc@12.1.0
 
 # PIConGPU output dependencies ################################################
 #
-spack load pngwriter@0.7.0 %gcc@11.3.0
+spack load pngwriter@0.7.0 %gcc@12.1.0
 
 
 # Environment #################################################################

--- a/etc/picongpu/bash-devServer-hzdr/gpu_v100_install.sh
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_v100_install.sh
@@ -1,10 +1,10 @@
-spack install --reuse cmake@3.24.2 %gcc@10.2.0
-spack load cmake@3.24.2 %gcc@10.2.0
+spack install --reuse cmake@3.26.3 %gcc@12.2.0
+spack load cmake@3.26.3 %gcc@12.2.0
 
 echo "openpmd-api:"
-spack install --reuse openpmd-api@0.14.5 %gcc@10.2.0 \
-    ^adios2@2.8.3 +cuda cuda_arch=70\
-    ^cmake@3.24.2 \
+spack install --reuse openpmd-api@0.15.2 %gcc@12.2.0 \
+    ^adios2@2.9.2 +cuda cuda_arch=70\
+    ^cmake@3.26.3 \
     ^hdf5@1.12.2 \
     ^openmpi@4.1.3 +atomics +cuda cuda_arch=70\
     ^python@3.10.4 \
@@ -24,7 +24,7 @@ spack install --reuse boost@1.78.0 \
     +atomic \
     +date_time \
     ~python \
-    %gcc@10.2.0
+    %gcc@12.2.0
 
 echo "pngwriter"
-spack install --reuse pngwriter@0.7.0 %gcc@10.2.0
+spack install --reuse pngwriter@0.7.0 %gcc@12.2.0

--- a/etc/picongpu/bash-devServer-hzdr/gpu_v100_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_v100_picongpu.profile.example
@@ -19,25 +19,25 @@ spack unload
 # PIConGPU build dependencies #################################################
 #   need to load correct cmake and gcc to compile picongpu
 
-spack load gcc@10.2.0
-spack load cmake@3.24.2 %gcc@10.2.0
+spack load gcc@12.2.0
+spack load cmake@3.26.3 %gcc@12.2.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
 #   and no name confilcts in spack, see install.sh for more precise definition
 #   if name conflicts occur
 
-spack load openpmd-api@0.14.5 %gcc@10.2.0 \
-    ^adios2@2.8.3 \
+spack load openpmd-api@0.15.2 %gcc@12.2.0 \
+    ^adios2@2.9.2 \
     ^hdf5@1.12.2 \
     ^openmpi@4.1.3 +atomics +cuda cuda_arch=70 \
     ^python@3.10.4 \
     ^py-numpy@1.23.3
-spack load boost@1.78.0 +math +filesystem +system %gcc@10.2.0
+spack load boost@1.78.0 +math +filesystem +system %gcc@12.2.0
 
 # PIConGPU output dependencies ################################################
 #
-spack load pngwriter@0.7.0 %gcc@10.2.0
+spack load pngwriter@0.7.0 %gcc@12.2.0
 
 
 # Environment #################################################################

--- a/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_craycc_picongpu.profile.example
@@ -62,7 +62,7 @@ module load boost/1.78.0-cxx17
 #
 module load zlib/1.2.11
 module load git/2.35.1
-module load c-blosc/1.21.1 adios2/2.7.1 hdf5/1.12.0 openpmd-api/0.14.4
+module load c-blosc/1.21.1 adios2/2.7.1 hdf5/1.12.0 openpmd-api/0.15.2
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OLCF_HDF5_ROOT/lib
 module load libpng/1.6.37 freetype/2.11.0
 

--- a/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
+++ b/etc/picongpu/crusher-ornl/batch_hipcc_picongpu.profile.example
@@ -61,7 +61,7 @@ export LDFLAGS="$LDFLAGS -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/li
 #
 module load zlib/1.2.11
 module load git/2.35.1
-module load c-blosc/1.21.1 adios2/2.7.1 hdf5/1.12.0 openpmd-api/0.14.4
+module load c-blosc/1.21.1 adios2/2.7.1 hdf5/1.12.0 openpmd-api/0.15.2
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OLCF_HDF5_ROOT/lib
 module load libpng/1.6.37 freetype/2.11.0
 

--- a/etc/picongpu/frontier-ornl/batch_hipcc_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_hipcc_picongpu.profile.example
@@ -56,7 +56,7 @@ module load libpng/1.6.37
 module load freetype/2.11.1
 
 # ATTENTION: blosc2 is used, please check your cfg's and replace blosc with blosc2
-module load openpmd-api/0.14.4
+module load openpmd-api/0.15.2
 
 # Self-Build Software #########################################################
 # Optional, not required.

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -17,23 +17,23 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load git
-module load gcc/7.3.0
-module load cmake/3.26.1
-module load openmpi/4.1.1
-module load boost/1.78.0
+module load gcc/12.2.0
+module load ucx/1.14.0
+module load libfabric/1.17.0-co79-csk
+module load openmpi/4.1.5-ucx
+module load python/3.10.4
+module load boost/1.82.0
 
 # Other Software ##############################################################
 #
 module load zlib/1.2.11
-module load c-blosc/1.14.4
+module load hdf5-parallel/1.14.0-omp415
+module load c-blosc/1.21.4
+module load adios2/2.9.2-csk
+module load openpmd/0.15.2-csk
+module load cmake/3.26.1
 
-module load hdf5-parallel/1.12.0-omp411
-module load python/3.6.5
-module load libfabric/1.11.1-co79-csk001
-module load adios2/2.7.1-no-cuda
-module load openpmd/0.14.4-no-cuda
-
-module load libpng/1.6.35
+module load libpng/1.6.39
 module load pngwriter/0.7.0
 
 # Environment #################################################################

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -30,8 +30,8 @@ module load boost/1.82.0
 module load zlib/1.2.11
 module load hdf5-parallel/1.12.0-omp415-cuda121
 module load c-blosc/1.21.4
-module load adios2/2.8.3-cuda121
-module load openpmd/0.15.1-cuda121
+module load adios2/2.9.2-cuda121
+module load openpmd/0.15.2-cuda121
 module load cmake/3.26.1
 
 module load libpng/1.6.39

--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -58,7 +58,7 @@ libpng/1.6.38-cpeCray-23.03
 module load freetype/2.12.1-cpeCray-23.03
 
 # ATTENTION: blosc2 is used, please check your cfg's and replace blosc with blosc2
-#module load openpmd-api/0.14.4
+#module load openpmd-api/0.15.2
 
 # Self-Build Software #########################################################
 # Optional, not required.

--- a/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
+++ b/etc/picongpu/summit-ornl/gpu_picongpu.profile.example
@@ -34,7 +34,7 @@ module load hdf5/1.10.7
 module load c-blosc/1.21.0 zfp/0.5.5 sz/2.1.11.1 lz4/1.9.3
 module load adios2/2.7.1
 
-module load openpmd-api/0.14.4
+module load openpmd-api/0.15.2
 
 #export T3PIO_ROOT=$PROJWORK/$proj/lib/t3pio
 #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$T3PIO_ROOT/lib


### PR DESCRIPTION
- update and tested hemera and HZDR dev system profiles
- update in all other profiles with openpmd-api modules the version to 0.15.2


On systems where I have no access, I set the version explicitly to openpmd-api/0.15.2. If the user is loading it and it is not available there will be a clear error message.

I opened a ticket to update openpmd-api on ORNL frontier.