### PR TITLE
Make cPow's exponent unsigned

### DIFF
--- a/include/pmacc/algorithms/math/PowerFunction.hpp
+++ b/include/pmacc/algorithms/math/PowerFunction.hpp
@@ -35,7 +35,7 @@ namespace pmacc::math
     /** power function for integer exponents, constexpr
      *
      * @tparam T_Type return and accumulation data type
-     * @tparam T_Exp exponent data type, must be an integral type, default uint32_t
+     * @tparam T_Exp exponent data type, must be an unsigned integral type, default uint32_t
      *
      * @param x base
      * @param exp exponent
@@ -44,8 +44,8 @@ namespace pmacc::math
     HDINLINE constexpr T_Type cPow(T_Type const x, T_Exp const exp)
     {
         static_assert(
-            std::is_integral_v<T_Exp>,
-            "This pow() implementation supports only integral types for the exponent.");
+            std::is_unsigned_v<T_Exp>,
+            "This pow() implementation supports only unsigned integral types for the exponent.");
 
         T_Type result = static_cast<T_Type>(1u);
         for(T_Exp e = static_cast<T_Exp>(0u); e < exp; e++)

--- a/share/pmacc/examples/heatEquation2D/include/StencilFourPoint.hpp
+++ b/share/pmacc/examples/heatEquation2D/include/StencilFourPoint.hpp
@@ -103,7 +103,7 @@ struct StencilFourPoint
                 cupla::atomicAdd(
                     worker.getAcc(),
                     &(boxResidual[0]),
-                    pmacc::math::cPow<float>(stencil_sum, 2),
+                    pmacc::math::cPow<float>(stencil_sum, 2u),
                     ::alpaka::hierarchy::Blocks{});
 
                 boxWrite(pos) = stencil_sum + cache(cellIdx);


### PR DESCRIPTION
Closes #4795 by enforcing an unsigned integer type via the static assert. This should potentially rather be a `concept` or SFINAE but I kept as much of the infrastructure as possible. I've also `grep`ed for `cPow` in the root folder and checked that there were no faulty calls. Only the heat equation example was a bit sloppy about the type (albeit not violating positivity), so I made it an unsigned literal there.