### PR TITLE
Remove reference to Doxygen

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,12 +32,6 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    We are migrating our `wiki`_ to this manual, but some pages might still be missing.
    We also have an `official homepage`_ .
 
-.. note::
-
-   Are you looking for our latest Doxygen docs for the API?
-
-   See http://computationalradiationphysics.github.io/picongpu
-
 .. _wiki: https://github.com/ComputationalRadiationPhysics/picongpu/wiki
 .. _official homepage: http://picongpu.hzdr.de
 


### PR DESCRIPTION
Just found that on the title page there is a link to the gh-pages website which seems to be down for quite a while now.