### PR TITLE
fix and update for dev server profiles

### DIFF
--- a/etc/picongpu/bash-devServer-hzdr/cpu_install.sh
+++ b/etc/picongpu/bash-devServer-hzdr/cpu_install.sh
@@ -1,21 +1,26 @@
-spack install --reuse cmake@3.26.3 %gcc@12.1.0
-spack load cmake@3.26.3 ^openssl certs=mozilla %gcc@12.1.0
+echo "cmake:"
+spack install --reuse cmake@3.26.6 %gcc@12.2.0
+spack load cmake@3.26.6 ^openssl certs=mozilla %gcc@12.2.0
 
 echo "openpmd-api:"
-spack install --reuse openpmd-api@0.15.2 %gcc@12.1.0 \
-    ^adios2@2.9.2 \
-    ^cmake@3.26.3 \
-    ^hdf5@1.12.2 \
-    ^openmpi@4.1.4 +atomics\
-    ^python@3.10.4 \
-    ^py-numpy@1.23.3
+spack install --reuse openpmd-api@0.15.2 +python %gcc@12.2.0 \
+    ^adios2@2.9.2 ++blosc2 \
+    ^cmake@3.26.6 \
+    ^hdf5@1.14.3 \
+    ^openmpi@4.1.5 +atomics \
+    ^python@3.11.6 \
+    ^py-numpy@1.26.2
 
 echo "boost:"
-spack install --reuse boost@1.80.0 \
+spack install --reuse boost@1.83.0 \
     +program_options \
     +atomic \
     ~python \
-    %gcc@12.1.0
+    cxxstd=17 \
+    %gcc@12.2.0
 
 echo "pngwriter"
-spack install --reuse pngwriter@0.7.0 %gcc@12.1.0
+spack install --reuse pngwriter@0.7.0 %gcc@12.2.0
+
+echo "pip:"
+spack mark -e py-pip ^python@3.11.6 %gcc@12.2.0

--- a/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/cpu_picongpu.profile.example
@@ -11,7 +11,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
-export EDITOR="nano"
+export EDITOR="vim"
 
 # load packages
 spack unload
@@ -19,41 +19,41 @@ spack unload
 # PIConGPU build dependencies #################################################
 #   need to load correct cmake and gcc to compile picongpu
 
-spack load gcc@12.1.0
-spack load cmake@3.26.3 ^openssl certs=mozilla %gcc@12.1.0
+spack load gcc@12.2.0
+spack load cmake@3.26.6 ^openssl certs=mozilla %gcc@12.2.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
 #   and no name confilcts in spack, see install.sh for more precise definition
 #   if name conflicts occur
 
-spack load openpmd-api@0.15.2 %gcc@12.1.0 \
+spack load openpmd-api@0.15.2 %gcc@12.2.0 \
     ^adios2@2.9.2 \
-    ^hdf5@1.12.2 \
-    ^openmpi@4.1.4 +atomics ~cuda\
-    ^python@3.10.4 \
-    ^py-numpy@1.23.3
-spack load boost@1.80.0 %gcc@12.1.0
+    ^hdf5@1.14.3 \
+    ^openmpi@4.1.5 +atomics ~cuda\
+    ^python@3.11.6 \
+    ^py-numpy@1.26.2
+spack load boost@1.83.0 %gcc@12.2.0
 
 # PIConGPU output dependencies ################################################
 #
-spack load pngwriter@0.7.0 %gcc@12.1.0
+spack load pngwriter@0.7.0 %gcc@12.2.0
+
+# Python pip dependency #######################################################
+spack load py-pip ^python@3.11.6 %gcc@12.2.0
 
 
 # Environment #################################################################
 #
-#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BOOST_LIB
-export PIC_BACKEND="omp2b:native" # running on cpu
-
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
-export PIC_BACKEND="omp2b:skylake-avx512"
+export PIC_BACKEND="omp2b:native"
 
 # Path to the required templates of the system,
 # relative to the PIConGPU source code of the tool bin/pic-create.
 export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/bash-devServer-hzdr"}
 
-export PATH=$PICSRC/bin::$PATH
+export PATH=$PICSRC/bin:$PATH
 export PATH=$PICSRC/src/tools/bin:$PATH
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH

--- a/etc/picongpu/bash-devServer-hzdr/gpu_a30_install.sh
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_a30_install.sh
@@ -1,21 +1,26 @@
-spack install --reuse cmake@3.26.3 %gcc@12.1.0
-spack load cmake@3.26.3 %gcc@12.1.0
+echo "cmake:"
+spack install --reuse cmake@3.26.6 %gcc@12.2.0
+spack load cmake@3.26.6 ^openssl certs=mozilla %gcc@12.2.0
 
 echo "openpmd-api:"
-spack install --reuse openpmd-api@0.15.2 %gcc@12.1.0 \
-    ^adios2@2.9.2 +cuda cuda_arch=80\
-    ^cmake@3.26.3 \
-    ^hdf5@1.14.0 \
-    ^openmpi@4.1.5 +atomics +cuda cuda_arch=80\
-    ^python@3.10.10 \
-    ^py-numpy@1.24.2
+spack install --reuse openpmd-api@0.15.2 +python %gcc@12.2.0 \
+    ^adios2@2.9.2 ++blosc2 +cuda cuda_arch=80 \
+    ^cmake@3.26.6 \
+    ^hdf5@1.14.3 \
+    ^openmpi@4.1.5 +atomics +cuda cuda_arch=80 \
+    ^python@3.11.6 \
+    ^py-numpy@1.26.2
 
 echo "boost:"
-spack install --reuse boost@1.81.0 \
+spack install --reuse boost@1.83.0 \
     +program_options \
     +atomic \
     ~python \
-    %gcc@12.1.0
+    cxxstd=17 \
+    %gcc@12.2.0
 
 echo "pngwriter"
-spack install --reuse pngwriter@0.7.0 %gcc@12.1.0
+spack install --reuse pngwriter@0.7.0 %gcc@12.2.0
+
+echo "pip:"
+spack mark -e py-pip ^python@3.11.6 %gcc@12.2.0

--- a/etc/picongpu/bash-devServer-hzdr/gpu_a30_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_a30_picongpu.profile.example
@@ -11,7 +11,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
-export EDITOR="nano"
+export EDITOR="vim"
 
 # load packages
 spack unload
@@ -19,25 +19,28 @@ spack unload
 # PIConGPU build dependencies #################################################
 #   need to load correct cmake and gcc to compile picongpu
 
-spack load gcc@12.1.0
-spack load cmake@3.26.3 %gcc@12.1.0
+spack load gcc@12.2.0
+spack load cmake@3.26.6 ^openssl certs=mozilla %gcc@12.2.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
 #   and no name confilcts in spack, see install.sh for more precise definition
 #   if name conflicts occur
 
-spack load openpmd-api@0.15.2 %gcc@12.1.0 \
+spack load openpmd-api@0.15.2 %gcc@12.2.0 \
     ^adios2@2.9.2 \
-    ^hdf5@1.14.0 \
+    ^hdf5@1.14.3 \
     ^openmpi@4.1.5 +atomics +cuda cuda_arch=80 \
-    ^python@3.10.10 \
-    ^py-numpy@1.24.2
-spack load boost@1.81.0 %gcc@12.1.0
+    ^python@3.11.6 \
+    ^py-numpy@1.26.2
+spack load boost@1.83.0 %gcc@12.2.0
 
 # PIConGPU output dependencies ################################################
 #
-spack load pngwriter@0.7.0 %gcc@12.1.0
+spack load pngwriter@0.7.0 %gcc@12.2.0
+
+# Python pip dependency #######################################################
+spack load py-pip ^python@3.11.6 %gcc@12.2.0
 
 
 # Environment #################################################################
@@ -51,7 +54,7 @@ export PIC_BACKEND="cuda:80"
 export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/bash-devServer-hzdr"}
 
 export PATH=$PICSRC/bin:$PATH
-export PATH=$PICSRC/src/tools/bin
+export PATH=$PICSRC/src/tools/bin:$PATH
 
 export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 

--- a/etc/picongpu/bash-devServer-hzdr/gpu_v100_install.sh
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_v100_install.sh
@@ -1,30 +1,26 @@
-spack install --reuse cmake@3.26.3 %gcc@12.2.0
-spack load cmake@3.26.3 %gcc@12.2.0
+echo "cmake:"
+spack install --reuse cmake@3.26.6 %gcc@12.2.0
+spack load cmake@3.26.6 ^openssl certs=mozilla %gcc@12.2.0
 
 echo "openpmd-api:"
-spack install --reuse openpmd-api@0.15.2 %gcc@12.2.0 \
-    ^adios2@2.9.2 +cuda cuda_arch=70\
-    ^cmake@3.26.3 \
-    ^hdf5@1.12.2 \
-    ^openmpi@4.1.3 +atomics +cuda cuda_arch=70\
-    ^python@3.10.4 \
-    ^py-numpy@1.23.3
+spack install --reuse openpmd-api@0.15.2 +python %gcc@12.2.0 \
+    ^adios2@2.9.2 ++blosc2 +cuda cuda_arch=70\
+    ^cmake@3.26.6 \
+    ^hdf5@1.14.3 \
+    ^openmpi@4.1.5 +atomics +cuda cuda_arch=70\
+    ^python@3.11.6 \
+    ^py-numpy@1.26.2
 
 echo "boost:"
-spack install --reuse boost@1.78.0 \
+spack install --reuse boost@1.83.0 \
     +program_options \
-    +filesystem \
-    +system \
-    +math \
-    +serialization \
-    +fiber \
-    +context \
-    +thread \
-    +chrono \
     +atomic \
-    +date_time \
     ~python \
+    cxxstd=17 \
     %gcc@12.2.0
 
 echo "pngwriter"
 spack install --reuse pngwriter@0.7.0 %gcc@12.2.0
+
+echo "pip:"
+spack mark -e py-pip ^python@3.11.6 %gcc@12.2.0

--- a/etc/picongpu/bash-devServer-hzdr/gpu_v100_picongpu.profile.example
+++ b/etc/picongpu/bash-devServer-hzdr/gpu_v100_picongpu.profile.example
@@ -11,7 +11,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Text Editor for Tools ###################################### (edit this line)
 #   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
-export EDITOR="nano"
+export EDITOR="vim"
 
 # load packages
 spack unload
@@ -20,7 +20,7 @@ spack unload
 #   need to load correct cmake and gcc to compile picongpu
 
 spack load gcc@12.2.0
-spack load cmake@3.26.3 %gcc@12.2.0
+spack load cmake@3.26.6 ^openssl certs=mozilla %gcc@12.2.0
 
 # General modules #############################################################
 #   correct dependencies are automatically loaded, if successfully installed using install.sh
@@ -29,15 +29,18 @@ spack load cmake@3.26.3 %gcc@12.2.0
 
 spack load openpmd-api@0.15.2 %gcc@12.2.0 \
     ^adios2@2.9.2 \
-    ^hdf5@1.12.2 \
-    ^openmpi@4.1.3 +atomics +cuda cuda_arch=70 \
-    ^python@3.10.4 \
-    ^py-numpy@1.23.3
-spack load boost@1.78.0 +math +filesystem +system %gcc@12.2.0
+    ^hdf5@1.14.3 \
+    ^openmpi@4.1.5 +atomics +cuda cuda_arch=70 \
+    ^python@3.11.6 \
+    ^py-numpy@1.26.2
+spack load boost@1.83.0 %gcc@12.2.0
 
 # PIConGPU output dependencies ################################################
 #
 spack load pngwriter@0.7.0 %gcc@12.2.0
+
+# Python pip dependency #######################################################
+spack load py-pip ^python@3.11.6 %gcc@12.2.0
 
 
 # Environment #################################################################


### PR DESCRIPTION
includes the following changes:
- upgrades gcc to 12.2.0 for the cpu and a30 profiles
- upgrade python to 3.11
- **fixes** the overwrite of $PATH in the a30 profile
- **fixes** the wrong backend set in the cpu profile
- harmonize software version for easier maintenance
- added blosc2 to openpmd-api package
- added py-pip to install scripts and profiles
- switched to py-pip for consistent pip installs of picongpu python dependencies