### PR TITLE
fix collision particle invalid memory

### DIFF
--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -160,8 +160,22 @@ namespace picongpu::particles::collision
 
             using FramePtr0 = typename T_ParBox0::FramePtr;
             using FramePtr1 = typename T_ParBox1::FramePtr;
-            detail::cellDensity<FramePtr0>(worker, forEachCell, parCellList0, densityArray0, accFilter0);
-            detail::cellDensity<FramePtr1>(worker, forEachCell, parCellList1, densityArray1, accFilter1);
+            detail::cellDensity<FramePtr0>(
+                worker,
+                forEachCell,
+                pb0,
+                superCellIdx,
+                parCellList0,
+                densityArray0,
+                accFilter0);
+            detail::cellDensity<FramePtr1>(
+                worker,
+                forEachCell,
+                pb1,
+                superCellIdx,
+                parCellList1,
+                densityArray1,
+                accFilter1);
             worker.sync();
 
             // shuffle indices list of the longest particle list
@@ -187,8 +201,8 @@ namespace picongpu::particles::collision
                         superCellIdx,
                         densityArray0[linearIdx],
                         densityArray1[linearIdx],
-                        parCellList0.template getParticlesAccessor<FramePtr0>(linearIdx),
-                        parCellList1.template getParticlesAccessor<FramePtr1>(linearIdx),
+                        parCellList0.getParticlesAccessor(pb0, superCellIdx, linearIdx),
+                        parCellList1.getParticlesAccessor(pb1, superCellIdx, linearIdx),
                         linearIdx);
                 });
 

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -131,7 +131,7 @@ namespace picongpu::particles::collision
             prepareList(worker, forEachCell, pb, superCellIdx, deviceHeapHandle, parCellList, nppc, accFilter);
 
             using FramePtr = typename T_ParBox::FramePtr;
-            detail::cellDensity<FramePtr>(worker, forEachCell, parCellList, densityArray, accFilter);
+            detail::cellDensity<FramePtr>(worker, forEachCell, pb, superCellIdx, parCellList, densityArray, accFilter);
 
             worker.sync();
 
@@ -148,7 +148,7 @@ namespace picongpu::particles::collision
             auto collisionFunctorCtx = forEachCell(
                 [&](int32_t const idx)
                 {
-                    auto parAccess = parCellList.template getParticlesAccessor<FramePtr>(idx);
+                    auto parAccess = parCellList.getParticlesAccessor(pb, superCellIdx, idx);
                     uint32_t const sizeAll = parAccess.size();
                     uint32_t potentialPartners = sizeAll - 1u + sizeAll % 2u;
                     auto collisionFunctor = srcCollisionFunctor(

--- a/include/picongpu/particles/collision/detail/cellDensity.hpp
+++ b/include/picongpu/particles/collision/detail/cellDensity.hpp
@@ -29,12 +29,15 @@ namespace picongpu::particles::collision::detail
         typename T_FramePtr,
         typename T_Worker,
         typename T_ForEachCell,
+        typename T_ParBox,
         typename T_EntryListArray,
         typename T_Array,
         typename T_Filter>
     DINLINE void cellDensity(
         T_Worker const& worker,
         T_ForEachCell forEachCell,
+        T_ParBox const& pb,
+        DataSpace<simDim> const& superCellIdx,
         T_EntryListArray& parCellList,
         T_Array& densityArray,
         T_Filter& filter)
@@ -42,7 +45,7 @@ namespace picongpu::particles::collision::detail
         forEachCell(
             [&](uint32_t const linearIdx)
             {
-                auto parAccess = parCellList.template getParticlesAccessor<T_FramePtr>(linearIdx);
+                auto parAccess = parCellList.getParticlesAccessor(pb, superCellIdx, linearIdx);
                 uint32_t const numParInCell = parAccess.size();
                 float_X density(0.0);
                 for(uint32_t partIdx = 0; partIdx < numParInCell; partIdx++)


### PR DESCRIPTION
Revert partly changes from #4745 to avoid invalid memory access. Switch back to traversing the frame list for each particle access.

BUg reported by @pordyna 