### PR TITLE
refactor ListEntry used in collision

### DIFF
--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -127,8 +127,8 @@ namespace picongpu::particles::collision
 
             PMACC_SMEM(worker, nppc, memory::Array<uint32_t, numCellsPerSuperCell>);
 
-            PMACC_SMEM(worker, parCellList0, detail::ListEntry<numCellsPerSuperCell>);
-            PMACC_SMEM(worker, parCellList1, detail::ListEntry<numCellsPerSuperCell>);
+            PMACC_SMEM(worker, parCellList0, detail::ListEntry<T_ParBox0, numCellsPerSuperCell>);
+            PMACC_SMEM(worker, parCellList1, detail::ListEntry<T_ParBox1, numCellsPerSuperCell>);
             PMACC_SMEM(worker, densityArray0, memory::Array<float_X, numCellsPerSuperCell>);
             PMACC_SMEM(worker, densityArray1, memory::Array<float_X, numCellsPerSuperCell>);
 
@@ -187,8 +187,8 @@ namespace picongpu::particles::collision
                         superCellIdx,
                         densityArray0[linearIdx],
                         densityArray1[linearIdx],
-                        parCellList0.template getParticlesAccessor<FramePtr0>(linearIdx),
-                        parCellList1.template getParticlesAccessor<FramePtr1>(linearIdx),
+                        parCellList0.getParticlesAccessor(linearIdx),
+                        parCellList1.getParticlesAccessor(linearIdx),
                         linearIdx);
                 });
 

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -105,7 +105,7 @@ namespace picongpu::particles::collision
             constexpr uint32_t numCellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
             PMACC_SMEM(worker, nppc, memory::Array<uint32_t, numCellsPerSuperCell>);
-            PMACC_SMEM(worker, parCellList, detail::ListEntry<numCellsPerSuperCell>);
+            PMACC_SMEM(worker, parCellList, detail::ListEntry<T_ParBox, numCellsPerSuperCell>);
             PMACC_SMEM(worker, densityArray, memory::Array<float_X, numCellsPerSuperCell>);
 
             constexpr bool ifAverageLog = !std::is_same<T_SumCoulombLogBox, std::nullptr_t>::value;
@@ -148,7 +148,7 @@ namespace picongpu::particles::collision
             auto collisionFunctorCtx = forEachCell(
                 [&](int32_t const idx)
                 {
-                    auto parAccess = parCellList.template getParticlesAccessor<FramePtr>(idx);
+                    auto parAccess = parCellList.getParticlesAccessor(idx);
                     uint32_t const sizeAll = parAccess.size();
                     uint32_t potentialPartners = sizeAll - 1u + sizeAll % 2u;
                     auto collisionFunctor = srcCollisionFunctor(

--- a/include/picongpu/particles/collision/detail/cellDensity.hpp
+++ b/include/picongpu/particles/collision/detail/cellDensity.hpp
@@ -42,7 +42,7 @@ namespace picongpu::particles::collision::detail
         forEachCell(
             [&](uint32_t const linearIdx)
             {
-                auto parAccess = parCellList.template getParticlesAccessor<T_FramePtr>(linearIdx);
+                auto parAccess = parCellList.getParticlesAccessor(linearIdx);
                 uint32_t const numParInCell = parAccess.size();
                 float_X density(0.0);
                 for(uint32_t partIdx = 0; partIdx < numParInCell; partIdx++)


### PR DESCRIPTION
Refactor changes introduced in #4745 to avoid void using void pointer as a place holder for the later used frame list.