### PR TITLE
optimize collision

### DIFF
--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -140,6 +140,16 @@ namespace picongpu::particles::collision
             DataSpace<simDim> const superCellIdx
                 = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())));
 
+            auto& superCell0 = pb0.getSuperCell(superCellIdx);
+            uint32_t numParticles0 = superCell0.getNumParticles();
+
+            auto& superCell1 = pb1.getSuperCell(superCellIdx);
+            uint32_t numParticles1 = superCell1.getNumParticles();
+
+            // if we have no particles in one species there is no need to perform any calculations
+            if(numParticles0 == 0 || numParticles1 == 0)
+                return;
+
             // offset of the superCell (in cells, without any guards) to the
             // origin of the local domain
             DataSpace<simDim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();

--- a/include/picongpu/particles/collision/IntraCollision.hpp
+++ b/include/picongpu/particles/collision/IntraCollision.hpp
@@ -115,6 +115,13 @@ namespace picongpu::particles::collision
             DataSpace<simDim> const superCellIdx
                 = mapper.getSuperCellIndex(DataSpace<simDim>(cupla::blockIdx(worker.getAcc())));
 
+            auto& superCell = pb.getSuperCell(superCellIdx);
+            uint32_t numParticles = superCell.getNumParticles();
+
+            // if we do not have particles there is no need to perform any calculations
+            if(numParticles <= 1u)
+                return;
+
             // offset of the superCell (in cells, without any guards) to the
             // origin of the local domain
             DataSpace<simDim> const localSuperCellOffset = superCellIdx - mapper.getGuardingSuperCells();


### PR DESCRIPTION
Do not perform calculations in the collision kernel if we do not have particles.

Maybe this change is solving a bug @pordyna is observing on Perlmutter.