### PR TITLE
Small fix and cosmetic changes in snakemake files

### DIFF
--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/README.md
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/README.md
@@ -1,32 +1,32 @@
 Example usage of snakemake to execute PIConGPU parameter scan.
 
-Snakemake is a python based workflow engine which can be use to automate compiling, running and post processing of PIConGPU simulations, or any other workflow which can be represented as a directed acyclic graph (DAG). 
+Snakemake is a python based workflow engine that can be used to automate compiling, running and post-processing of PIConGPU simulations, or any other workflow that can be represented as a directed acyclic graph (DAG). 
 
-Each worklfow consists of a Snakefile in which the workflow is defined using rules. Each rule represents a certain task. The dependencies between rules are defined by input and output files. Each rule can consist out of a shell command , python command or external python scripts (apparently also Rust, R, Julia and JupyterNB are supported). 
+Each workflow consists of a Snakefile in which the workflow is defined using rules. Each rule represents a certain task. The dependencies between rules are defined by input and output files. Each rule can consist out of a shell command, python command or external python scripts (apparently also Rust, R, Julia and JupyterNB are supported). 
 
-This example on how to perform a parameter scan in PIConGPU using Snakemake consits of 5 rules.
+This example of how to perform a parameter scan in PIConGPU using Snakemake consists of 5 rules.
 
 rule all:
-- Is the so called target rule. By default Snakemake only executes the very first rule given in the Snakefile. Therefore this pseudo-rule should contain all the anticipated output data as it's input. Snakemake will then try to generate this input.
+- Is the so-called target rule. By default, Snakemake only executes the very first rule given in the Snakefile. Therefore this pseudo-rule should contain all the anticipated output data as its input. Snakemake will then try to generate this input.
 
 rule compile:
-- Clones a PIConGPU project using 'pic-create'.
-- Since Snakemake relies on files to check dependencies between tasks and a simulation has no predefined unique output file, the idea is to create such a file by appending a 'touch' command to the end of the .tpl file.
+- Clones a PIConGPU project using `pic-create`.
+- Since Snakemake relies on files to check dependencies between tasks and a simulation has no predefined unique output file, the idea is to create such a file by appending a `touch` command to the end of the .tpl file.
 - Compiles and then creates simulation directory.
-- In the shell script: Please check the 'pic-build' and 'tbg' command since they are unique for every usecase and are not completly generalized yet.  
+- In the shell script: Please check the `pic-build` and `tbg` commands since they are unique for every usecase and are not completely generalized yet.  
 
 rule simulate:
-- To use the 'tbg' interface the rule simulate is a local rule.
-- The output file ('simulated/finished_{paramspace.wildcard_pattern}.txt') is created after the simulation but the shell script would be immediately done after submitting the simulation. If the task is done and the output file is not created an error occures and the workflow fails. In order to make Snakemake wait till the simulation is finished, the status of the slurm job is checked every 30 seconds. 
-- The if statements are necessary in case the workflow or the slurm job fails or are canceled during runtime.    
+- To use the `tbg` interface the rule simulate is a local rule.
+- The output file (`simulated/finished_{paramspace.wildcard_pattern}.txt`) is created after the simulation but the shell script would be immediately done after submitting the simulation. If the task is done and the output file is not created an error occurs and the workflow fails. In order to make Snakemake wait till the simulation is finished, the status of the slurm job is checked every 30 seconds. 
+- The if statements are necessary in case the workflow or the slurm job fails or is canceled during runtime.    
 
 rule post_processing:
 - Is a simple example of using an external script to process data.
 
 rule optimize:
-- Like 'post_precessing' but uses 'expand()' method.
-- The 'expand()' method can be used to express that a file for every instance of 'paramspace.instance_patterns' is needed as input (or output). (Hint: can also be used in the target rule)
-- 'expand()' can also be used to combine different variables like wildcards or paramspaces.
+- Like `post_processing` but uses `expand()` method.
+- The `expand()` method can be used to express that a file for every instance of `paramspace.instance_patterns` is needed as input (or output). (Hint: can also be used in the target rule)
+- `expand()` can also be used to combine different variables like wildcards or paramspaces.
 
 
 [![Workflow_structure](dag.png)](dag.pdf)
@@ -34,24 +34,24 @@ rule optimize:
 General comments:
 
 Starting the workflow:
-     - In the directory where your Snakefile is located run 'snakemake --executor slurm --jobs 2 --group-components group1=2 --latency-wait 30 --ignore-incomplete'
-     - If the command gets to long because of too many used flags, consider defining the command line arguments in a profile (config.yaml) and run 'snakemake --profile path/to/profile'
+     - In the directory where your Snakefile is located run `snakemake --executor slurm --jobs 2 --group-components group1=2 --latency-wait 30 --ignore-incomplete`
+     - If the command gets too long because of too many used flags, consider defining the command line arguments in a profile (config.yaml) and run `snakemake --profile path/to/profile`
 
 Cluster execution
-    - To submit certain rules to the cluster you need to install an executer plugin, for slurm the 'snakemake-executor-plugin-slurm'.
-    - To use the plugin use the flag '--executor slurm'
-    - The needed ressources can be specified in a config.yaml file or directly in the Snakefile, like in the example. It is also possible to define 'default-resources' if several jobs require the same ressources.
-    - By default snakemake submitts as many jobs as requested to the cluster. To limit the number of submited jobs use '--jobs 10' for a maximum of 10 jobs in parallel.
-    - By default each rule/task is executed in a single job. To execute several tasks in one job define groups in the Snakefile (or command line interface), which only works if the grouped tasks are connected in the DAG.
-    - By using '--group-components' one can specify how many tasks in one group shall be executed in one cluster job.
-    - If some rules shall not be executed on the cluster, specify them in the beginning of your Snakefile using the keyword 'localrule'.
+    - To submit certain rules to the cluster you need to install an executer plugin, for slurm the `snakemake-executor-plugin-slurm`.
+    - To use the plugin use the flag `--executor slurm`
+    - The needed resources can be specified in a config.yaml file or directly in the Snakefile, like in the example. It is also possible to define `default-resources` if several jobs require the same resources.
+    - By default, snakemake submits as many jobs as requested to the cluster. To limit the number of submitted jobs use `--jobs 10` for a maximum of 10 jobs in parallel.
+    - By default, each rule/task is executed in a single job. To execute several tasks in one job define groups in the Snakefile (or command line interface), which only works if the grouped tasks are connected in the DAG.
+    - By using `--group-components` one can specify how many tasks in one group shall be executed in one cluster job.
+    - If some rules shall not be executed on the cluster, specify them at the beginning of your Snakefile using the keyword `localrule`.
 
 Params
     - Defined Params can be used in the shell or python scripts.
-    - To access params in external python script use 'snakemake.params[i]' or 'snakemake.params.name_of_param'.
-    - Accordingly one can use 'snakemake.input' or 'snakemake.output'.
+    - To access params in external python script use `snakemake.params[i]` or `snakemake.params.name_of_param`.
+    - Accordingly one can use `snakemake.input` or `snakemake.output`.
 
 Parameter space exploration
-    - To work efficient with parameters one can use wildcards or the parameter space exploration like in this example.
+    - To work efficiently with parameters one can use wildcards or the parameter space exploration like in this example.
     - In the example the workflow executes the rules compile, simulate and postprocessing for every set of parameters in the input_params file.
-    - The naming scheme of the parameter space is definde by the 'Paramspace()' methode and called by '{paramspace.wildcard_pattern}'.
+    - The naming scheme of the parameter space is defined by the `Paramspace()` method and called by `{paramspace.wildcard_pattern}`.

--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile
@@ -19,37 +19,37 @@ rule all:
 
 # compile for every parameter instance
 rule compile:
-     input:
-         pic_project="path_to/picongpu_project",
-         pic_profile="path_to_profile/picongpu.profile"
-     # to use the paramspace naming pattern use python f-string formatting
-     output:  directory(f"path_to_simulations/sim_{paramspace.wildcard_pattern}")
-     resources: # define needed cluster resources
-         slurm_partition="fwkt_v100",
-         slurm_account="fwkt_v100",
-         runtime=60,
-         nodes=1,
-         ntasks=4,
-         cpus_per_task=6,
-         mem_mb=378000,
-         slurm="gres=gpu:1"
-     params:
-         # access one parameter set with the instance methode
-         sim_params=paramspace.instance,
-         # define name to use paramspace naming pattern in shell commands
-         name=f"{paramspace.wildcard_pattern}"
-     retries: 2 # defines number of retries if execution fails
-     shell:
-         """
-         source {input.pic_profile}
-         pic-create {input.pic_project} projects/run_{params.name}/
-         cd projects/run_{params.name}/
-         # append touch command to .tpl -> creates file when simulation is finished
-         echo "if [[ ! -z \`grep \\\"100 % =\\\" output\` ]]; then touch ../../../simulated/finished_{params.name}.txt; fi" >> etc/picongpu/hemera-hzdr/fwkt_v100.tpl
-         # parameter dependent compile
-         pic-build -c "-DPARAM_OVERWRITES:LIST='-DPARAM_A0={params.sim_params[A0]};-DPARAM_PULSE_DURATION_SI={params.sim_params[PULSEDURATION]}'"
-         # create simulation directory, define which cfg should be used
-         tbg -c etc/picongpu/4_test.cfg -t etc/picongpu/hemera-hzdr/fwkt_v100.tpl {current_dir}/{output}
+    input:
+        pic_project="path_to/picongpu_project",
+        pic_profile="path_to_profile/picongpu.profile"
+    # to use the paramspace naming pattern use python f-string formatting
+    output:  directory(f"path_to_simulations/sim_{paramspace.wildcard_pattern}")
+    resources: # define needed cluster resources
+        slurm_partition="fwkt_v100",
+        slurm_account="fwkt_v100",
+        runtime=60,
+        nodes=1,
+        ntasks=4,
+        cpus_per_task=6,
+        mem_mb=378000,
+        slurm="gres=gpu:1"
+    params:
+        # access one parameter set with the instance methode
+        sim_params=paramspace.instance,
+        # define name to use paramspace naming pattern in shell commands
+        name=f"{paramspace.wildcard_pattern}"
+    retries: 2 # defines number of retries if execution fails
+    shell:
+        """
+        source {input.pic_profile}
+        pic-create {input.pic_project} projects/run_{params.name}/
+        cd projects/run_{params.name}/
+        # append touch command to .tpl -> creates file when simulation is finished
+        echo "if [[ ! -z \`grep \\\"100 % =\\\" output\` ]]; then touch ../../../simulated/finished_{params.name}.txt; fi" >> etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+        # parameter dependent compile
+        pic-build -c "-DPARAM_OVERWRITES:LIST='-DPARAM_A0={params.sim_params[A0]};-DPARAM_PULSE_DURATION_SI={params.sim_params[PULSEDURATION]}'"
+        # create simulation directory, define which cfg should be used
+        tbg -c etc/picongpu/4_test.cfg -t etc/picongpu/hemera-hzdr/fwkt_v100.tpl {current_dir}/{output}
         """
 
 # start and track simulation
@@ -60,28 +60,28 @@ rule simulate:
         name=f"{paramspace.wildcard_pattern}"
     retries: 3
     shell:
-         """
-         # if no job id is known -> start simulation
-         if ! [ -f simulated/job_id_{params.name}.txt ]; then
-             sbatch {input}/tbg/submit.start > simulated/job_id_{params.name}.txt
-         fi
+        """
+        # if no job id is known -> start simulation
+        if ! [ -f simulated/job_id_{params.name}.txt ]; then
+            sbatch {input}/tbg/submit.start > simulated/job_id_{params.name}.txt
+        fi
 
-         job_id=$(cut -c 21-27 simulated/job_id_{params.name}.txt
-         status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
+        job_id=$(cut -c 21-27 simulated/job_id_{params.name}.txt)
+        status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
 
-         # if job isn't running or pending -> restart job
-         if ! [[ "$status" == "PD" || "$status" == "R " ]]; then
-             sbatch {input}/tbg/submit.start >  simulated/job_id_{params.name}.txt
-             job_id=$(cut -c 21-27 simulated/job_id_{params.name}.txt)
-             status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
-         fi
-         # wait till job is finished
-         while [[ "$status" == "PD" || "$status" == "R " ]]
-         do
-             sleep 30
-             status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
-         done
-         """
+        # if job isn't running or pending -> restart job
+        if ! [[ "$status" == "PD" || "$status" == "R " ]]; then
+            sbatch {input}/tbg/submit.start >  simulated/job_id_{params.name}.txt
+            job_id=$(cut -c 21-27 simulated/job_id_{params.name}.txt)
+            status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
+        fi
+        # wait till job is finished
+        while [[ "$status" == "PD" || "$status" == "R " ]]
+        do
+            sleep 30
+            status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
+        done
+        """
 
 # simple example of python post processing
 rule post_processing:
@@ -90,11 +90,11 @@ rule post_processing:
     output:
         f"results/result_{paramspace.wildcard_pattern}.npy"
     resources:
-         slurm_partition="defq",
-         runtime=60,  # [min]
-         nodes=1,
-         ntasks=20,
-         mem_mb=95000
+        slurm_partition="defq",
+        runtime=60,  # [min]
+        nodes=1,
+        ntasks=20,
+        mem_mb=95000
     # groups allow to execute multiple task in one slurm job (works for multiple tasks of a kind or different tasks)
     group: "group1"
     params:
@@ -111,11 +111,11 @@ rule optimization:
     output:
         new_params=output_params
     resources:
-         slurm_partition="defq",
-         runtime=60,
-         nodes=1,
-         ntasks=20,
-         mem_mb=95000
+        slurm_partition="defq",
+        runtime=60,
+        nodes=1,
+        ntasks=20,
+        mem_mb=95000
     params:
         n_new_params=5
     script:


### PR DESCRIPTION
- Fix typos in snakemake README
- Add a missing paranthesis in Snakefile
- Transform all tabs in Snakefile to 4-space tabs
- Use ` in README so markdown file viewers show these lines as code