### PR TITLE
optimize CI performance

### DIFF
--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -3,26 +3,26 @@
 set -e
 set -o pipefail
 
-# merge the PR to the latest version of the destination branch
+if [ -z "$DISABLE_ISAAC" ] ; then
+    cd $CI_PROJECT_DIR
 
-cd $CI_PROJECT_DIR
+    export GLM_ROOT=/opt/glm/0.9.9.9-dev
+    export CMAKE_PREFIX_PATH=$GLM_ROOT:$CMAKE_PREFIX_PATH
+    git clone https://github.com/g-truc/glm.git
+    cd glm
+    git checkout 6ad79aae3eb5bf809c30bf1168171e9e55857e45
+    mkdir build
+    cd build
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$GLM_ROOT -DGLM_TEST_ENABLE=OFF
+    make install
 
-export GLM_ROOT=/opt/glm/0.9.9.9-dev
-export CMAKE_PREFIX_PATH=$GLM_ROOT:$CMAKE_PREFIX_PATH
-git clone https://github.com/g-truc/glm.git
-cd glm
-git checkout 6ad79aae3eb5bf809c30bf1168171e9e55857e45
-mkdir build
-cd build
-cmake ../ -DCMAKE_INSTALL_PREFIX=$GLM_ROOT -DGLM_TEST_ENABLE=OFF
-make install
-
-cd $CI_PROJECT_DIR
-git clone https://github.com/ComputationalRadiationPhysics/isaac.git
-cd isaac
-git checkout 195420ca1c43f6148c7f6c3a10ad9cad32e04d6a
-mkdir build_isaac
-cd build_isaac
-cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT
-make install
-cd ..
+    cd $CI_PROJECT_DIR
+    git clone https://github.com/ComputationalRadiationPhysics/isaac.git
+    cd isaac
+    git checkout 195420ca1c43f6148c7f6c3a10ad9cad32e04d6a
+    mkdir build_isaac
+    cd build_isaac
+    cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT
+    make install
+    cd ..
+fi

--- a/share/ci/install/openPMD.sh
+++ b/share/ci/install/openPMD.sh
@@ -3,25 +3,27 @@
 set -e
 set -o pipefail
 
-cd $CI_PROJECT_DIR
+if [ -z "$DISABLE_OpenPMD" ] ; then
+    cd $CI_PROJECT_DIR
 
-export openPMD_VERSION=0.15.0
+    export openPMD_VERSION=0.15.0
 
-if ! agc-manager -e openPMD-api@${openPMD_VERSION}; then
-    export OPENPMD_ROOT=/opt/openPMD-api/$openPMD_VERSION
+    if ! agc-manager -e openPMD-api@${openPMD_VERSION}; then
+        export OPENPMD_ROOT=/opt/openPMD-api/$openPMD_VERSION
 
-    export CMAKE_PREFIX_PATH=$GLM_ROOT:$CMAKE_PREFIX_PATH
-    git clone https://github.com/openPMD/openPMD-api.git --depth 1 --branch $openPMD_VERSION
-    mkdir buildOpenPMD
-    cd buildOpenPMD
-    cmake ../openPMD-api -DCMAKE_CXX_STANDARD=17 -DopenPMD_BUILD_CLI_TOOLS=OFF -DCMAKE_INSTALL_PREFIX=$OPENPMD_ROOT -DopenPMD_BUILD_EXAMPLES=OFF -DopenPMD_BUILD_TESTING=OFF -DopenPMD_USE_PYTHON=OFF -DopenPMD_USE_ADIOS2=ON
-    make install
-    cd ..
+        export CMAKE_PREFIX_PATH=$GLM_ROOT:$CMAKE_PREFIX_PATH
+        git clone https://github.com/openPMD/openPMD-api.git --depth 1 --branch $openPMD_VERSION
+        mkdir buildOpenPMD
+        cd buildOpenPMD
+        cmake ../openPMD-api -DCMAKE_CXX_STANDARD=17 -DopenPMD_BUILD_CLI_TOOLS=OFF -DCMAKE_INSTALL_PREFIX=$OPENPMD_ROOT -DopenPMD_BUILD_EXAMPLES=OFF -DopenPMD_BUILD_TESTING=OFF -DopenPMD_USE_PYTHON=OFF -DopenPMD_USE_ADIOS2=ON
+        make install
+        cd ..
 
-    export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
-    export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib:$LD_LIBRARY_PATH
-else
-    export OPENPMD_ROOT="$(agc-manager -b openPMD-api@${openPMD_VERSION})"
-    export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
-    export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib:$LD_LIBRARY_PATH
+        export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
+        export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib:$LD_LIBRARY_PATH
+    else
+        export OPENPMD_ROOT="$(agc-manager -b openPMD-api@${openPMD_VERSION})"
+        export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
+        export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib:$LD_LIBRARY_PATH
+    fi
 fi

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -331,6 +331,8 @@ for stage in range(num_stages):
             print("    CXX_VERSION: '" + compiler + "'")
             print("    CXX_PREFIX_PATH: '/usr/lib/x86_64-linux-gnu/openmpi'")
             print("    LDFLAGS: '-lopen-pal'")
+            if folder == "pmacc" or folder == "pmacc_header":
+                print("    DISABLE_OpenPMD: 'yes'")
             print("  before_script:")
             if backend == "hip":
                 print("    - wget -q -O - " "https://repo.radeon.com/rocm/rocm.gpg.key | " "apt-key add -")


### PR DESCRIPTION
Install/compile ISAAC and OpenPMD-api only if required for testing. This avoids that spezial runner requires 40minutes until we can compile our required tests.