### PR TITLE
changed timeOffset variable type to float_32

### DIFF
--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -147,7 +147,7 @@ namespace picongpu
                 /* @todo check if always correct at this point,
                  * depends on attribute and MW-solver/pusher implementation
                  */
-                float_X const timeOffset = 0.0;
+                float_32 const timeOffset = 0.0;
                 record.setAttribute("timeOffset", timeOffset);
 
                 log<picLog::INPUT_OUTPUT>("openPMD:  ( end ) write species attribute: %1%") % Identifier::getName();


### PR DESCRIPTION
While running PIConGPU in 64 bit precision and writing particle data. PIConGPU threw folowing runtime error:
![image](https://github.com/ComputationalRadiationPhysics/picongpu/assets/64739354/da18020e-94b5-4a69-bcd6-aaaa446b6677)

While reading data using openPMD api there was a following error:
```
ValueError: [Thu Mar 07 18:27:54 2024] [ADIOS2 EXCEPTION] <Core> <IO> <DefineAttribute> : modifiable attribute /data/0/particles/e/position/timeOffset has been defined with type float. Type cannot be changed to double
```

`bpls` also threw an error:
```
Failed to open with BPFile engine: [Fri Mar 08 13:24:13 2024] [ADIOS2 EXCEPTION] <Core> <IO> <DefineAttribute> : modifiable attribute /data/0/particles/e/position/timeOffset has been defined with type float. Type cannot be changed to double
```

