### PR TITLE
updated gpu.profile modules (adapted to fwkt_v100.profile)

### DIFF
--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -43,7 +43,7 @@ module load pngwriter/0.7.0
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
-export PIC_BACKEND="cuda:70"
+export PIC_BACKEND="cuda:60"
 
 # Path to the required templates of the system,
 # relative to the PIConGPU source code of the tool bin/pic-create.

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -17,24 +17,24 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #
 module purge
 module load git
-module load gcc/11.2.0
-module load cmake/3.26.1
-module load cuda/11.5
-module load openmpi/4.1.1-cuda115
-module load boost/1.78.0
+module load gcc/12.2.0
+module load cuda/12.1
+module load libfabric/1.17.0
+module load ucx/1.14.0-gdr
+module load openmpi/4.1.5-cuda121-gdr
+module load python/3.10.4
+module load boost/1.82.0
 
 # Other Software ##############################################################
 #
 module load zlib/1.2.11
-module load c-blosc/1.14.4
+module load hdf5-parallel/1.12.0-omp415-cuda121
+module load c-blosc/1.21.4
+module load adios2/2.9.2-cuda121
+module load openpmd/0.15.2-cuda121
+module load cmake/3.26.1
 
-module load hdf5-parallel/1.12.0-cuda115
-module load python/3.6.5
-module load libfabric/1.11.1-co79
-module load adios2/2.7.1-cuda115
-module load openpmd/0.14.3-cuda115
-
-module load libpng/1.6.35
+module load libpng/1.6.39
 module load pngwriter/0.7.0
 
 # Environment #################################################################
@@ -43,7 +43,7 @@ module load pngwriter/0.7.0
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
-export PIC_BACKEND="cuda:60"
+export PIC_BACKEND="cuda:70"
 
 # Path to the required templates of the system,
 # relative to the PIConGPU source code of the tool bin/pic-create.
@@ -61,7 +61,6 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/hemera-hzdr/gpu.tpl"
 # use gpu for regular queue and gpu_low for low priority queue
 export TBG_partition="gpu"
-
 
 # allocate an interactive shell for one hour
 #   getNode 2  # allocates two interactive nodes (default: 1)


### PR DESCRIPTION
The modules of the `gpu_picongpu.profile.example` were outdated. A successful PIConGPU build was not possible so I updated them and adapted the structure and versions of the `fwkt_v100_picongpu.profile.example`.