### PR TITLE
change nameing of methods in Buffer

### DIFF
--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -514,28 +514,28 @@ namespace picongpu
                 pmacc::math::operation::Add(),
                 reducedSumMom2.data(),
                 gSumMom2->getHostBuffer().data(),
-                reducedSumMom2.getCurrentSize(),
+                reducedSumMom2.size(),
                 mpi::reduceMethods::Reduce());
 
             (*planeReduce)(
                 pmacc::math::operation::Add(),
                 reducedSumPos2.data(),
                 gSumPos2->getHostBuffer().data(),
-                reducedSumPos2.getCurrentSize(),
+                reducedSumPos2.size(),
                 mpi::reduceMethods::Reduce());
 
             (*planeReduce)(
                 pmacc::math::operation::Add(),
                 reducedSumMomPos.data(),
                 gSumMomPos->getHostBuffer().data(),
-                reducedSumMomPos.getCurrentSize(),
+                reducedSumMomPos.size(),
                 mpi::reduceMethods::Reduce());
 
             (*planeReduce)(
                 pmacc::math::operation::Add(),
                 reducedCount_e.data(),
                 gCount_e->getHostBuffer().data(),
-                reducedCount_e.getCurrentSize(),
+                reducedCount_e.size(),
                 mpi::reduceMethods::Reduce());
 
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -188,7 +188,7 @@ namespace picongpu
                  * buffer has no pitch
                  */
                 auto* dataPtr = hBufLeftParsCalorimeter.data();
-                for(size_t i = 0u; i < hBufLeftParsCalorimeter.getCurrentSize(); ++i)
+                for(size_t i = 0u; i < hBufLeftParsCalorimeter.size(); ++i)
                     dataPtr[i] /= float_X(numRanks);
             }
 
@@ -196,7 +196,7 @@ namespace picongpu
             eventSystem::getTransactionEvent().waitForFinished();
             MPI_CHECK(MPI_Bcast(
                 hBufLeftParsCalorimeter.data(),
-                hBufLeftParsCalorimeter.getCurrentSize() * sizeof(float_X),
+                hBufLeftParsCalorimeter.size() * sizeof(float_X),
                 MPI_CHAR,
                 0, /* rank 0 */
                 comm.getMPIComm()));
@@ -226,7 +226,7 @@ namespace picongpu
                 pmacc::math::operation::Add(),
                 hBufTotal.data(),
                 hBufLeftParsCalorimeter.data(),
-                hBufTotal.getCurrentSize(),
+                hBufTotal.size(),
                 mpi::reduceMethods::Reduce());
 
             if(!this->allGPU_reduce->hasResult(mpi::reduceMethods::Reduce()))
@@ -369,8 +369,8 @@ namespace picongpu
 
             auto offset = twoDimensional(::openPMD::Offset{0, 0, 0});
 
-            auto dataSize = this->hBufTotalCalorimeter->getCurrentDataSpace();
-            auto dataSize64Bit = precisionCast<size_t>(dataSize);
+            auto dataSizeND = this->hBufTotalCalorimeter->sizeND();
+            auto dataSize64Bit = precisionCast<size_t>(dataSizeND);
             auto extent = twoDimensional(::openPMD::Extent{dataSize64Bit.z(), dataSize64Bit.y(), dataSize64Bit.x()});
 
             auto mesh = series.iterations[currentStep].meshes["calorimeter"];
@@ -590,7 +590,7 @@ namespace picongpu
                 pmacc::math::operation::Add(),
                 this->hBufTotalCalorimeter->data(),
                 this->hBufCalorimeter->data(),
-                this->hBufCalorimeter->getCurrentSize(),
+                this->hBufCalorimeter->size(),
                 mpi::reduceMethods::Reduce());
 
             if(!this->allGPU_reduce->hasResult(mpi::reduceMethods::Reduce()))

--- a/include/pmacc/eventSystem/tasks/TaskCopy.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopy.hpp
@@ -55,7 +55,7 @@ namespace pmacc
 
         void init() override
         {
-            /* @attention: `setCurrentSize()` must be called before `getCudaStream()` is called else `setCurrentSize()`
+            /* @attention: `setSize()` must be called before `getCudaStream()` is called else `setSize()`
              * is not handled as part of this task. The reason for this is that is not registered to the eventsystem
              * before `init()` is finished.
              */
@@ -65,21 +65,17 @@ namespace pmacc
                 // no need to call methods of the PMacc buffer again which will only trigger the event system and is
                 // increasing the latency
                 auto size = alpaka::getExtents(src);
-                destination->setCurrentSize(size[0]);
+                destination->setSize(size[0]);
                 auto queue = this->getCudaStream();
                 alpaka::memcpy(queue, destination->as1DBuffer(), src, size);
             }
             else
             {
-                size_t currentSize = source->getCurrentSize();
-                destination->setCurrentSize(currentSize);
-                auto currentExtent = source->getCurrentDataSpace(currentSize);
+                size_t currentSize = source->size();
+                destination->setSize(currentSize);
+                auto sizeND = source->sizeND(currentSize);
                 auto queue = this->getCudaStream();
-                alpaka::memcpy(
-                    queue,
-                    destination->getAlpakaView(),
-                    source->getAlpakaView(),
-                    currentExtent.toAlpakaMemVec());
+                alpaka::memcpy(queue, destination->getAlpakaView(), source->getAlpakaView(), sizeND.toAlpakaMemVec());
             }
 
             this->activate();

--- a/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -56,8 +56,8 @@ namespace pmacc
             auto queue = this->getCudaStream();
             alpaka::memcpy(
                 queue,
-                buffer->getCurrentSizeHostSideBuffer(),
-                buffer->getCurrentSizeDeviceSideBuffer(),
+                buffer->sizeHostSideBuffer(),
+                buffer->sizeDeviceSideBuffer(),
                 MemSpace<DIM1>(1).toAlpakaMemVec());
             this->activate();
         }

--- a/include/pmacc/eventSystem/tasks/TaskReceive.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskReceive.hpp
@@ -72,11 +72,11 @@ namespace pmacc
                 {
                     if(Environment<>::get().isMpiDirectEnabled())
                     {
-                        exchange->getDeviceDoubleBuffer().setCurrentSize(newBufferSize);
+                        exchange->getDeviceDoubleBuffer().setSize(newBufferSize);
                     }
                     else
                     {
-                        exchange->getHostBuffer().setCurrentSize(newBufferSize);
+                        exchange->getHostBuffer().setSize(newBufferSize);
                         Environment<>::get().Factory().createTaskCopy(
                             exchange->getHostBuffer(),
                             exchange->getDeviceDoubleBuffer());
@@ -91,8 +91,8 @@ namespace pmacc
                 {
                     if(Environment<>::get().isMpiDirectEnabled())
                     {
-                        exchange->getDeviceBuffer().setCurrentSize(newBufferSize);
-                        /* We can not be notified from setCurrentSize() therefore
+                        exchange->getDeviceBuffer().setSize(newBufferSize);
+                        /* We can not be notified from setSize() therefore
                          * we need to wait that the current event is finished.
                          */
                         setSizeEvent = eventSystem::getTransactionEvent();
@@ -100,7 +100,7 @@ namespace pmacc
                     }
                     else
                     {
-                        exchange->getHostBuffer().setCurrentSize(newBufferSize);
+                        exchange->getHostBuffer().setSize(newBufferSize);
                         Environment<>::get().Factory().createTaskCopy(
                             exchange->getHostBuffer(),
                             exchange->getDeviceBuffer(),

--- a/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -73,7 +73,7 @@ namespace pmacc
     private:
         void setSize()
         {
-            auto sizeBuff = destination->getCurrentSizeOnDeviceBuffer();
+            auto sizeBuff = destination->sizeOnDeviceBuffer();
 
             auto alpakaAllOne = DataSpace<DIM1>(1).toAlpakaKernelVec();
             auto oneThread

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -163,13 +163,13 @@ namespace pmacc
         void init() override
         {
             // number of elements in destination
-            size_t const current_size = this->destination->getCurrentSize();
+            size_t const current_size = this->destination->size();
             // n-dimensional size of destination based on `current_size`
-            MemSpace<dim> const area_size(this->destination->getCurrentDataSpace(current_size));
+            MemSpace<dim> const areaSizeND(this->destination->sizeND(current_size));
 
-            if(area_size.productOfComponents() != 0)
+            if(areaSizeND.productOfComponents() != 0)
             {
-                auto gridSize = area_size;
+                auto gridSize = areaSizeND;
 
                 /* number of elements in x direction used to chunk the destination buffer
                  * for block parallel processing
@@ -194,7 +194,7 @@ namespace pmacc
                     KernelSetValue<xChunkSize>{},
                     destBox,
                     this->value,
-                    area_size,
+                    areaSizeND,
                     blockCfg);
                 auto queue = this->getCudaStream();
                 alpaka::enqueue(queue, kernel);
@@ -232,11 +232,11 @@ namespace pmacc
 
         void init() override
         {
-            size_t current_size = this->destination->getCurrentSize();
-            const MemSpace<dim> area_size(this->destination->getCurrentDataSpace(current_size));
-            if(area_size.productOfComponents() != 0)
+            size_t size = this->destination->size();
+            const MemSpace<dim> areaSizeND(this->destination->sizeND(size));
+            if(areaSizeND.productOfComponents() != 0)
             {
-                auto gridSize = area_size;
+                auto gridSize = areaSizeND;
 
                 /* number of elements in x direction used to chunk the destination buffer
                  * for block parallel processing
@@ -267,7 +267,7 @@ namespace pmacc
                     KernelSetValue<xChunkSize>{},
                     destBox,
                     alpaka::getPtrNative(firstElemBuffer),
-                    area_size,
+                    areaSizeND,
                     blockCfg);
                 alpaka::enqueue(queue, kernel);
             }

--- a/include/pmacc/memory/buffers/Buffer.hpp
+++ b/include/pmacc/memory/buffers/Buffer.hpp
@@ -66,7 +66,7 @@ namespace pmacc
             , m_capacityND(size)
             , isMemoryContiguous(true)
         {
-            Buffer::setCurrentSize(size.productOfComponents());
+            Buffer::setSize(size.productOfComponents());
         }
 
         virtual ~Buffer()
@@ -96,7 +96,7 @@ namespace pmacc
          *
          * @return count of current elements per dimension
          */
-        virtual size_t getCurrentSize()
+        virtual size_t size()
         {
             eventSystem::startOperation(ITask::TASK_HOST);
             return alpaka::getPtrNative(this->currentSizeBufferHost)[0];
@@ -106,7 +106,7 @@ namespace pmacc
          *
          * @param newSize number of elements per dimension
          */
-        virtual void setCurrentSize(size_t const newSize)
+        virtual void setSize(size_t const newSize)
         {
             eventSystem::startOperation(ITask::TASK_HOST);
             PMACC_ASSERT(static_cast<size_t>(newSize) <= static_cast<size_t>(capacityND().productOfComponents()));
@@ -114,9 +114,9 @@ namespace pmacc
         }
 
         /** Total number of elements mapped to the N-dimensional size of the buffer */
-        virtual MemSpace<T_dim> getCurrentDataSpace()
+        virtual MemSpace<T_dim> sizeND()
         {
-            return getCurrentDataSpace(getCurrentSize());
+            return sizeND(size());
         }
 
         /** Spread of memory per dimension which is currently used
@@ -125,7 +125,7 @@ namespace pmacc
          * if DIM == DIM2 than return how many lines (y-direction) of memory is used
          * if DIM == DIM3 than return how many slides (z-direction) of memory is used
          */
-        virtual MemSpace<T_dim> getCurrentDataSpace(size_t size)
+        virtual MemSpace<T_dim> sizeND(size_t size)
         {
             MemSpace<T_dim> tmp;
             auto current_size = size;

--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -71,17 +71,17 @@ namespace pmacc
 
         BufferType1D as1DBuffer()
         {
-            auto currentSize = this->getCurrentSize();
+            auto numElements = this->size();
             eventSystem::startOperation(ITask::TASK_DEVICE);
             return BufferType1D(
                 alpaka::getPtrNative(*view),
                 alpaka::getDev(*devBuffer),
-                MemSpace<DIM1>(currentSize).toAlpakaMemVec());
+                MemSpace<DIM1>(numElements).toAlpakaMemVec());
         }
 
         BufferType1D as1DBufferNElem(size_t const numElements)
         {
-            PMACC_ASSERT(numElements < this->getCurrentSize());
+            PMACC_ASSERT(numElements < this->size());
             eventSystem::startOperation(ITask::TASK_DEVICE);
             return BufferType1D(
                 alpaka::getPtrNative(*view),
@@ -122,7 +122,7 @@ namespace pmacc
             {
                 createSizeOnDeviceBuffers();
             }
-            this->setCurrentSize(size.productOfComponents());
+            this->setSize(size.productOfComponents());
             this->isMemoryContiguous = true;
             reset(false);
         }
@@ -154,7 +154,7 @@ namespace pmacc
             {
                 createSizeOnDeviceBuffers();
             }
-            this->setCurrentSize(size.productOfComponents());
+            this->setSize(size.productOfComponents());
             this->isMemoryContiguous = T_dim == DIM1;
             reset(true);
         }
@@ -166,7 +166,7 @@ namespace pmacc
 
         void reset(bool preserveData = true) override
         {
-            this->setCurrentSize(Buffer<T_Type, T_dim>::capacityND().productOfComponents());
+            this->setSize(Buffer<T_Type, T_dim>::capacityND().productOfComponents());
 
             eventSystem::startOperation(ITask::TASK_DEVICE);
             if(!preserveData)
@@ -205,7 +205,7 @@ namespace pmacc
          *
          * @return device side current size buffer
          */
-        CurrentSizeBufferDevice getCurrentSizeOnDeviceBuffer()
+        CurrentSizeBufferDevice sizeOnDeviceBuffer()
         {
             eventSystem::startOperation(ITask::TASK_DEVICE);
             if(!hasCurrentSizeOnDevice())
@@ -219,13 +219,13 @@ namespace pmacc
          *
          * @return host side current size buffer
          */
-        typename Buffer<T_Type, T_dim>::CurrentSizeBufferHost getCurrentSizeHostSideBuffer()
+        typename Buffer<T_Type, T_dim>::CurrentSizeBufferHost sizeHostSideBuffer()
         {
             eventSystem::startOperation(ITask::TASK_HOST);
             return this->currentSizeBufferHost;
         }
 
-        size_t getCurrentSize() override
+        size_t size() override
         {
             if(hasCurrentSizeOnDevice())
             {
@@ -234,12 +234,12 @@ namespace pmacc
                 eventSystem::endTransaction().waitForFinished();
             }
 
-            return Buffer<T_Type, T_dim>::getCurrentSize();
+            return Buffer<T_Type, T_dim>::size();
         }
 
-        void setCurrentSize(const size_t newSize) override
+        void setSize(const size_t newSize) override
         {
-            Buffer<T_Type, T_dim>::setCurrentSize(newSize);
+            Buffer<T_Type, T_dim>::setSize(newSize);
 
             if(hasCurrentSizeOnDevice())
             {
@@ -270,7 +270,7 @@ namespace pmacc
             Environment<>::get().Factory().createTaskSetValue(*this, value);
         };
 
-        auto getCurrentSizeDeviceSideBuffer()
+        auto sizeDeviceSideBuffer()
         {
             eventSystem::startOperation(ITask::TASK_DEVICE);
             return currentSizeBufferDevice.value();
@@ -279,7 +279,7 @@ namespace pmacc
         typename Buffer<T_Type, T_dim>::CPtr getCPtrCurrentSize() final
         {
             PMACC_ASSERT_MSG(this->isContiguous(), "Memory must be contiguous!");
-            size_t const size = this->getCurrentSize();
+            size_t const size = this->size();
             eventSystem::startOperation(ITask::TASK_DEVICE);
             return {alpaka::getPtrNative(*view), size};
         }

--- a/include/pmacc/memory/buffers/HostBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostBuffer.hpp
@@ -62,12 +62,12 @@ namespace pmacc
 
         BufferType1D as1DBuffer()
         {
-            auto currentSize = this->getCurrentSize();
+            auto numElements = this->size();
             eventSystem::startOperation(ITask::TASK_HOST);
             return BufferType1D(
                 alpaka::getPtrNative(*view),
                 alpaka::getDev(*hostBuffer),
-                MemSpace<DIM1>(currentSize).toAlpakaMemVec());
+                MemSpace<DIM1>(numElements).toAlpakaMemVec());
         }
 
         ViewType getAlpakaView() const
@@ -144,7 +144,7 @@ namespace pmacc
         void reset(bool preserveData = true) override
         {
             eventSystem::startOperation(ITask::TASK_HOST);
-            this->setCurrentSize(this->capacityND().productOfComponents());
+            this->setSize(this->capacityND().productOfComponents());
             if(!preserveData)
             {
                 /* if it is a pointer out of other memory we can not assume that
@@ -170,7 +170,7 @@ namespace pmacc
         {
             // getDataBox is notifying the event system, no need to do it manually
             auto memBox = this->getDataBox();
-            auto current_size = static_cast<int64_t>(this->getCurrentSize());
+            auto current_size = static_cast<int64_t>(this->size());
             using D1Box = DataBoxDim1Access<DataBoxType>;
             D1Box d1Box(memBox, this->capacityND());
 #pragma omp parallel for
@@ -190,8 +190,8 @@ namespace pmacc
         typename Buffer<T_Type, T_dim>::CPtr getCPtrCurrentSize() final
         {
             PMACC_ASSERT_MSG(this->isContiguous(), "Memory must be contiguous!");
-            // getCurrentSize is notifying the event system, no need to do it manually
-            size_t const size = this->getCurrentSize();
+            // size is notifying the event system, no need to do it manually
+            size_t const size = this->size();
             return {alpaka::getPtrNative(*view), size};
         }
 

--- a/include/pmacc/particles/ParticlesBase.tpp
+++ b/include/pmacc/particles/ParticlesBase.tpp
@@ -65,7 +65,7 @@ namespace pmacc
         {
             ExchangeMapping<GUARD, MappingDesc> mapper(this->cellDescription, exchangeType);
 
-            particlesBuffer->getSendExchangeStack(exchangeType).setCurrentSize(0);
+            particlesBuffer->getSendExchangeStack(exchangeType).setSize(0);
 
             PMACC_LOCKSTEP_KERNEL(KernelCopyGuardToExchange{})
                 .config(mapper.getGridDim(), *particlesBuffer)(

--- a/include/pmacc/particles/memory/buffers/StackExchangeBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/StackExchangeBuffer.hpp
@@ -73,11 +73,11 @@ namespace pmacc
             PMACC_ASSERT(stackIndexer.getDeviceBuffer().hasCurrentSizeOnDevice() == true);
             return ExchangePushDataBox<vint_t, FRAME, DIM>(
                 stack.getDeviceBuffer().data(),
-                (vint_t*) alpaka::getPtrNative(stack.getDeviceBuffer().getCurrentSizeDeviceSideBuffer()),
+                (vint_t*) alpaka::getPtrNative(stack.getDeviceBuffer().sizeDeviceSideBuffer()),
                 stack.getDeviceBuffer().capacityND().productOfComponents(),
                 PushDataBox<vint_t, FRAMEINDEX>(
                     stackIndexer.getDeviceBuffer().data(),
-                    (vint_t*) alpaka::getPtrNative(stackIndexer.getDeviceBuffer().getCurrentSizeDeviceSideBuffer())));
+                    (vint_t*) alpaka::getPtrNative(stackIndexer.getDeviceBuffer().sizeDeviceSideBuffer())));
         }
 
         /**
@@ -92,25 +92,25 @@ namespace pmacc
                 stackIndexer.getDeviceBuffer().getDataBox());
         }
 
-        void setCurrentSize(const size_t size)
+        void setSize(const size_t size)
         {
-            // do host and device setCurrentSize parallel
+            // do host and device setSize parallel
             EventTask split = eventSystem::getTransactionEvent();
             EventTask e1;
 
             if(!Environment<>::get().isMpiDirectEnabled())
             {
                 eventSystem::startTransaction(split);
-                stackIndexer.getHostBuffer().setCurrentSize(size);
-                stack.getHostBuffer().setCurrentSize(size);
+                stackIndexer.getHostBuffer().setSize(size);
+                stack.getHostBuffer().setSize(size);
                 e1 = eventSystem::endTransaction();
             }
 
             eventSystem::startTransaction(split);
-            stackIndexer.getDeviceBuffer().setCurrentSize(size);
+            stackIndexer.getDeviceBuffer().setSize(size);
             EventTask e2 = eventSystem::endTransaction();
             eventSystem::startTransaction(split);
-            stack.getDeviceBuffer().setCurrentSize(size);
+            stack.getDeviceBuffer().setSize(size);
             EventTask e3 = eventSystem::endTransaction();
 
             eventSystem::setTransactionEvent(e1 + e2 + e3);
@@ -120,29 +120,29 @@ namespace pmacc
         {
             size_t result = 0u;
             if(Environment<>::get().isMpiDirectEnabled())
-                result = stackIndexer.getDeviceBuffer().getCurrentSize();
+                result = stackIndexer.getDeviceBuffer().size();
             else
-                result = stackIndexer.getHostBuffer().getCurrentSize();
+                result = stackIndexer.getHostBuffer().size();
 
             return result;
         }
 
         size_t getDeviceCurrentSize()
         {
-            return stackIndexer.getDeviceBuffer().getCurrentSize();
+            return stackIndexer.getDeviceBuffer().size();
         }
 
         size_t getDeviceParticlesCurrentSize()
         {
-            return stack.getDeviceBuffer().getCurrentSize();
+            return stack.getDeviceBuffer().size();
         }
 
         size_t getHostParticlesCurrentSize()
         {
             if(Environment<>::get().isMpiDirectEnabled())
-                return stack.getDeviceBuffer().getCurrentSize();
+                return stack.getDeviceBuffer().size();
 
-            return stack.getHostBuffer().getCurrentSize();
+            return stack.getHostBuffer().size();
         }
 
         size_t getMaxParticlesCount()

--- a/include/pmacc/test/lockstep/lockstepUT.cpp
+++ b/include/pmacc/test/lockstep/lockstepUT.cpp
@@ -77,7 +77,7 @@ struct IotaGenericKernel
 template<uint32_t T_chunkSize, typename T_DeviceBuffer>
 inline void iotaGerneric(T_DeviceBuffer& devBuffer)
 {
-    auto bufferSize = devBuffer.getCurrentSize();
+    auto bufferSize = devBuffer.size();
     // use only half of the blocks needed to process the full data
     uint32_t const numBlocks = bufferSize / T_chunkSize / 2u;
     PMACC_LOCKSTEP_KERNEL(IotaGenericKernel{}).config<T_chunkSize>(numBlocks)(devBuffer.getDataBox(), bufferSize);
@@ -98,7 +98,7 @@ namespace pmacc::lockstep::traits
 template<typename T_DeviceBuffer>
 inline void iotaGernericBufferDerivedChunksize(T_DeviceBuffer& devBuffer)
 {
-    auto bufferSize = devBuffer.getCurrentSize();
+    auto bufferSize = devBuffer.size();
     constexpr uint32_t numBlocks = 9;
     PMACC_LOCKSTEP_KERNEL(IotaGenericKernel{}).config(numBlocks, devBuffer)(devBuffer.getDataBox(), bufferSize);
 }
@@ -139,7 +139,7 @@ struct IotaFixedChunkSizeKernel
 template<typename T_DeviceBuffer>
 inline void iotaFixedChunkSize(T_DeviceBuffer& devBuffer)
 {
-    auto bufferSize = devBuffer.getCurrentSize();
+    auto bufferSize = devBuffer.size();
     constexpr uint32_t numBlocks = 10;
     PMACC_LOCKSTEP_KERNEL(IotaFixedChunkSizeKernel{}).config(numBlocks)(devBuffer.getDataBox(), bufferSize);
 }
@@ -182,7 +182,7 @@ struct IotaFixedChunkSizeKernelND
 template<typename T_DeviceBuffer>
 inline void iotaFixedChunkSizeND(T_DeviceBuffer& devBuffer)
 {
-    auto bufferSize = devBuffer.getCurrentSize();
+    auto bufferSize = devBuffer.size();
     constexpr uint32_t numBlocks = 11;
     PMACC_LOCKSTEP_KERNEL(IotaFixedChunkSizeKernelND{}).config(numBlocks)(devBuffer.getDataBox(), bufferSize);
 }
@@ -223,7 +223,7 @@ struct IotaGenericKernelWithDynSharedMem
 template<uint32_t T_chunkSize, typename T_DeviceBuffer>
 inline void iotaGernericWithDynSharedMem(T_DeviceBuffer& devBuffer)
 {
-    auto bufferSize = devBuffer.getCurrentSize();
+    auto bufferSize = devBuffer.size();
     // use only half of the blocks needed to process the full data
     uint32_t const numBlocks = bufferSize / T_chunkSize / 2u;
     constexpr size_t requiredSharedMemBytes = T_chunkSize * sizeof(uint32_t);
@@ -235,10 +235,10 @@ inline void iotaGernericWithDynSharedMem(T_DeviceBuffer& devBuffer)
 template<typename T_HostBuffer>
 void validate(T_HostBuffer& results, T_HostBuffer& reference)
 {
-    auto refBufferSize = reference.getCurrentSize();
+    auto refBufferSize = reference.size();
     auto* refPtr = reference.data();
 
-    auto resultBufferSize = results.getCurrentSize();
+    auto resultBufferSize = results.size();
     auto* resultPtr = results.data();
 
     PMACC_VERIFY(resultBufferSize == refBufferSize);


### PR DESCRIPTION
- change the naming for getting the size of an buffer to be near to the C++ STL.
- for N-dimensional values use the postfix `ND`