### PR TITLE
rename `getDataSpace` to `capacityND`

### DIFF
--- a/include/picongpu/fields/FieldJ.tpp
+++ b/include/picongpu/fields/FieldJ.tpp
@@ -62,7 +62,7 @@ namespace picongpu
         , buffer(cellDescription.getGridLayout())
         , fieldJrecv(nullptr)
     {
-        const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout().getDataSpaceWithoutGuarding();
+        const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout().sizeWithoutGuardND();
 
         /* cell margins the current might spread to due to particle shapes */
         using AllSpeciesWithCurrent =

--- a/include/picongpu/fields/FieldTmp.tpp
+++ b/include/picongpu/fields/FieldTmp.tpp
@@ -82,7 +82,7 @@ namespace picongpu
          *  Problem: buffers don't allow "bigger" exchange during run time.
          *           so let's stay with the maximum guards.
          */
-        const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout().getDataSpaceWithoutGuarding();
+        const DataSpace<simDim> coreBorderSize = cellDescription.getGridLayout().sizeWithoutGuardND();
 
         using VectorSpeciesWithInterpolation =
             typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, interpolation<>>::type;

--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -68,7 +68,7 @@ namespace picongpu
                         Thickness const& globalThickness)
                     {
                         // All sizes are without guard, since Pml is only on the internal area
-                        auto const gridDataSpace = gridLayout.getDataSpaceWithoutGuarding();
+                        auto const gridDataSpace = gridLayout.sizeWithoutGuardND();
                         auto const nonPmlDataSpace = gridDataSpace
                             - (globalThickness.getPositiveBorder() + globalThickness.getNegativeBorder());
                         auto const numGridCells = gridDataSpace.productOfComponents();
@@ -111,7 +111,7 @@ namespace picongpu
                     Thickness const& globalThickness,
                     DataBox box)
                     : box(box)
-                    , guardSize(gridLayout.getGuard())
+                    , guardSize(gridLayout.guardSizeND())
 
                 {
                     auto const negativeSize = globalThickness.getNegativeBorder();
@@ -119,7 +119,7 @@ namespace picongpu
                     /* The region of interest is grid without guard,
                      * which consists of PML and internal area
                      */
-                    auto const gridSize = gridLayout.getDataSpaceWithoutGuarding();
+                    auto const gridSize = gridLayout.sizeWithoutGuardND();
                     auto const positiveBegin = gridSize - positiveSize;
 
                     // Note: since this should compile for 2d, .z( ) can't be used
@@ -270,9 +270,8 @@ namespace picongpu
 
                 Field::OuterLayerBoxType Field::getDeviceOuterLayerBox()
                 {
-                    auto const boxWrapper1d = pmacc::DataBoxDim1Access<DataBoxType>{
-                        getDeviceDataBox(),
-                        data->getGridLayout().getDataSpace()};
+                    auto const boxWrapper1d
+                        = pmacc::DataBoxDim1Access<DataBoxType>{getDeviceDataBox(), data->getGridLayout().sizeND()};
                     /* Note: the outer layer box type just provides access to data,
                      * it does not own or make copy of the data (nor is that required)
                      */

--- a/include/picongpu/initialization/InitialiserController.hpp
+++ b/include/picongpu/initialization/InitialiserController.hpp
@@ -145,8 +145,7 @@ namespace picongpu
                                      "   It does not cover other forms of initialization");
                 logOmegaP();
 
-                const int localNrOfCells
-                    = cellDescription->getGridLayout().getDataSpaceWithoutGuarding().productOfComponents();
+                const int localNrOfCells = cellDescription->getGridLayout().sizeWithoutGuardND().productOfComponents();
                 log<picLog::PHYSICS>("macro particles per device: %1%")
                     % (localNrOfCells * particles::TYPICAL_PARTICLES_PER_CELL
                        * (pmacc::mp_size<VectorAllSpecies>::value));

--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -114,7 +114,7 @@ namespace picongpu
                     auto& fieldBuffer = fieldTmp->getGridBuffer();
                     // Set all values to the default values, the values present in the file will be overwritten
                     fieldBuffer.getHostBuffer().setValue(ParamClass::defaultDensity);
-                    auto const guards = fieldBuffer.getGridLayout().getGuard();
+                    auto const guards = fieldBuffer.getGridLayout().guardSizeND();
                     deviceDataBox = fieldBuffer.getDeviceBuffer().getDataBox().shift(guards);
 
                     /* Open a series (this does not read the dataset itself).

--- a/include/picongpu/plugins/ChargeConservation.tpp
+++ b/include/picongpu/plugins/ChargeConservation.tpp
@@ -240,13 +240,13 @@ namespace picongpu
 
         // find global max error
         auto memLayoutRoh = fieldTmp->getGridLayout();
-        int localSizeRoh = memLayoutRoh.getDataSpaceWithoutGuarding().productOfComponents();
+        int localSizeRoh = memLayoutRoh.sizeWithoutGuardND().productOfComponents();
 
         using D1Box = DataBoxDim1Access<typename FieldTmp::DataBoxType>;
         // ignore guards and operate on CORE+BORDER only
         D1Box d1access(
-            fieldTmp->getGridBuffer().getDeviceBuffer().getDataBox().shift(memLayoutRoh.getGuard()),
-            memLayoutRoh.getDataSpaceWithoutGuarding());
+            fieldTmp->getGridBuffer().getDeviceBuffer().getDataBox().shift(memLayoutRoh.guardSizeND()),
+            memLayoutRoh.sizeWithoutGuardND());
 
         auto maxChargeDiff = (*globalReduce)(pmacc::math::operation::Max(), d1access, localSizeRoh, mpiReduceMethod);
 

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -469,7 +469,7 @@ namespace picongpu
 
             // Some variables required so that it is possible for the kernel
             // to calculate the absolute position of the particles
-            DataSpace<simDim> localSize(m_cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
+            DataSpace<simDim> localSize(m_cellDescription->getGridLayout().sizeWithoutGuardND());
             const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
             const int globalDomainSizeY = subGrid.getGlobalDomain().size.y();
             auto movingWindow = MovingWindow::getInstance().getWindow(currentStep);

--- a/include/picongpu/plugins/EnergyFields.hpp
+++ b/include/picongpu/plugins/EnergyFields.hpp
@@ -247,8 +247,8 @@ namespace picongpu
             using D1Box = DataBoxDim1Access<Box64bit>;
 
             /* reduce field E*/
-            DataSpace<simDim> fieldSize = field->getGridLayout().getDataSpaceWithoutGuarding();
-            DataSpace<simDim> fieldGuard = field->getGridLayout().getGuard();
+            DataSpace<simDim> fieldSize = field->getGridLayout().sizeWithoutGuardND();
+            DataSpace<simDim> fieldGuard = field->getGridLayout().guardSizeND();
 
             TransformedBox fieldTransform(field->getDeviceDataBox().shift(fieldGuard));
             Box64bit field64bit(fieldTransform);

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -767,7 +767,7 @@ namespace picongpu
                     else
                     {
                         const int localNrOfCells
-                            = cellDescription->getGridLayout().getDataSpaceWithoutGuarding().productOfComponents();
+                            = cellDescription->getGridLayout().sizeWithoutGuardND().productOfComponents();
                         cellCount = localNrOfCells * numProc;
                         particleCount = localNrOfCells * particles::TYPICAL_PARTICLES_PER_CELL
                             * (pmacc::mp_size<VectorAllSpecies>::type::value) * numProc;

--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
@@ -95,7 +95,7 @@ namespace picongpu
                 softwareVersion << "-" << PICONGPU_VERSION_LABEL;
             series.setSoftware(software, softwareVersion.str());
 
-            auto bufferExtents = hBuffer.getDataSpace();
+            auto bufferExtents = hBuffer.capacityND();
 
             /** calculate local and global size of the phase space ***********/
             const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(currentStep);

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.tpp
@@ -90,7 +90,7 @@ namespace picongpu
             const uint32_t r_element = axis_element.space;
 
             /* CORE + BORDER elements for spatial bins */
-            this->r_bins = this->m_cellDescription->getGridLayout().getDataSpaceWithoutGuarding()[r_element];
+            this->r_bins = this->m_cellDescription->getGridLayout().sizeWithoutGuardND()[r_element];
 
             auto const num_pbinsToAvoidOdrUse = this->num_pbins;
             this->dBuffer
@@ -210,9 +210,9 @@ namespace picongpu
 
         /* transfer to host */
         this->dBuffer->deviceToHost();
-        auto bufferExtent = this->dBuffer->getDeviceBuffer().getDataSpace();
+        auto bufferExtent = this->dBuffer->getDeviceBuffer().capacityND();
 
-        auto hReducedBuffer = HostBuffer<float_PS, 2>(this->dBuffer->getDeviceBuffer().getDataSpace());
+        auto hReducedBuffer = HostBuffer<float_PS, 2>(this->dBuffer->getDeviceBuffer().capacityND());
 
         eventSystem::getTransactionEvent().waitForFinished();
 

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -191,7 +191,7 @@ namespace picongpu
                 ++accumulateCounter;
                 if(accumulateCounter >= binningData.dumpPeriod)
                 {
-                    auto bufferExtent = this->histBuffer->getHostBuffer().getDataSpace();
+                    auto bufferExtent = this->histBuffer->getHostBuffer().capacityND();
 
                     // Do time Averaging
                     if(binningData.dumpPeriod > 1 && binningData.timeAveraging)
@@ -294,7 +294,7 @@ namespace picongpu
 
                 // do the mpi reduce (can be avoided if the notify did a data dump and histBuffer is empty)
                 this->histBuffer->deviceToHost();
-                auto bufferExtent = this->histBuffer->getHostBuffer().getDataSpace();
+                auto bufferExtent = this->histBuffer->getHostBuffer().capacityND();
 
                 // allocate this only once?
                 // using a unique_ptr here since HostBuffer does not implement move semantics

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -1529,10 +1529,10 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                 /* data to describe source buffer */
                 GridLayout<simDim> bufferGridLayout = buffer.getGridLayout();
-                DataSpace<simDim> bufferSize = bufferGridLayout.getDataSpace();
+                DataSpace<simDim> bufferSize = bufferGridLayout.sizeND();
 
                 DataSpace<simDim> localWindowSize = params->window.localDimensions.size;
-                DataSpace<simDim> bufferOffset = bufferGridLayout.getGuard() + params->localWindowToDomainOffset;
+                DataSpace<simDim> bufferOffset = bufferGridLayout.guardSizeND() + params->localWindowToDomainOffset;
                 std::vector<char>& fieldBuffer = params->fieldBuffer;
 
                 pmacc::math::UInt64<simDim> recordLocalSizeDims = localWindowSize;
@@ -1544,8 +1544,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                  */
                 if(!isDomainBound)
                 {
-                    localWindowSize = bufferGridLayout.getDataSpaceWithoutGuarding();
-                    bufferOffset = bufferGridLayout.getGuard();
+                    localWindowSize = bufferGridLayout.sizeWithoutGuardND();
+                    bufferOffset = bufferGridLayout.guardSizeND();
 
                     recordLocalSizeDims = precisionCast<uint64_t>(localWindowSize);
 

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -66,7 +66,7 @@ namespace picongpu
                 log<picLog::INPUT_OUTPUT>("Begin loading field '%1%'") % objectName;
 
                 auto const name_lookup_tpl = plugins::misc::getComponentNames(numComponents);
-                const DataSpace<simDim> field_guard = field.getGridLayout().getGuard();
+                const DataSpace<simDim> field_guard = field.getGridLayout().guardSizeND();
 
                 const pmacc::Selection<simDim> localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
 
@@ -83,7 +83,7 @@ namespace picongpu
                 if(!isDomainBound)
                 {
                     auto const field_layout = field.getGridLayout();
-                    auto const field_no_guard = field_layout.getDataSpaceWithoutGuarding();
+                    auto const field_no_guard = field_layout.sizeWithoutGuardND();
                     auto const elementCount = field_no_guard.productOfComponents();
 
                     /* Scan the PML buffer local size along all local domains

--- a/include/picongpu/plugins/output/images/Visualisation.hpp
+++ b/include/picongpu/plugins/output/images/Visualisation.hpp
@@ -676,7 +676,7 @@ namespace picongpu
         void notify(uint32_t currentStep) override
         {
             PMACC_ASSERT(cellDescription != nullptr);
-            const DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
+            const DataSpace<simDim> localSize(cellDescription->getGridLayout().sizeWithoutGuardND());
             Window window(MovingWindow::getInstance().getWindow(currentStep));
 
             /*sliceOffset is only used in 3D*/
@@ -731,11 +731,11 @@ namespace picongpu
                     mapper);
 
             // find maximum for img.x()/y and z and return it as float3_X
-            int elements = img->getGridLayout().getDataSpace().productOfComponents();
+            int elements = img->getGridLayout().sizeND().productOfComponents();
 
             // Add one dimension access to 2d DataBox
             using D1Box = DataBoxDim1Access<typename GridBuffer<float3_X, 2U>::DataBoxType>;
-            D1Box d1access(img->getDeviceBuffer().getDataBox(), img->getGridLayout().getDataSpace());
+            D1Box d1access(img->getDeviceBuffer().getDataBox(), img->getGridLayout().sizeND());
 
             constexpr uint32_t cellsPerSupercell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
@@ -793,7 +793,7 @@ namespace picongpu
 
             eventSystem::getTransactionEvent().waitForFinished(); // wait for copy picture
 
-            DataSpace<DIM2> size = img->getGridLayout().getDataSpace();
+            DataSpace<DIM2> size = img->getGridLayout().sizeND();
             if(picongpu::white_box_per_GPU)
             {
                 // mark local cell slice edges
@@ -836,7 +836,7 @@ namespace picongpu
             if(!m_notifyPeriod.empty())
             {
                 PMACC_ASSERT(cellDescription != nullptr);
-                const DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
+                const DataSpace<simDim> localSize(cellDescription->getGridLayout().sizeWithoutGuardND());
 
                 Window window(MovingWindow::getInstance().getWindow(0));
                 sliceOffset = (int) ((float_32) (window.globalDimensions.size[sliceDim]) * m_slicePoint)

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -155,7 +155,7 @@ namespace picongpu
     public:
         void restart(uint32_t restartStep, const std::string& restartDirectory) override
         {
-            HBufCalorimeter hBufLeftParsCalorimeter(this->dBufLeftParsCalorimeter->getDataSpace());
+            HBufCalorimeter hBufLeftParsCalorimeter(this->dBufLeftParsCalorimeter->capacityND());
 
             pmacc::GridController<simDim>& gridCon = pmacc::Environment<simDim>::get().GridController();
             pmacc::CommunicatorMPI<simDim>& comm = gridCon.getCommunicator();
@@ -213,7 +213,7 @@ namespace picongpu
              */
             Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(
                 checkpointDirectory + "/" + this->foldername);
-            auto dataSize = this->dBufLeftParsCalorimeter->getDataSpace();
+            auto dataSize = this->dBufLeftParsCalorimeter->capacityND();
             HBufCalorimeter hBufLeftParsCalorimeter(dataSize);
             HBufCalorimeter hBufTotal(dataSize);
 

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -1202,7 +1202,7 @@ namespace picongpu
 
                     // Some funny things that make it possible for the kernel to calculate
                     // the absolute position of the particles
-                    DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
+                    DataSpace<simDim> localSize(cellDescription->getGridLayout().sizeWithoutGuardND());
                     const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(currentStep);
                     const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
                     DataSpace<simDim> globalOffset(subGrid.getLocalDomain().offset);

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -473,7 +473,7 @@ namespace picongpu
 
                     // Some funny things that make it possible for the kernel to calculate
                     // the absolute position of the particles
-                    DataSpace<simDim> localSize(cellDescription->getGridLayout().getDataSpaceWithoutGuarding());
+                    DataSpace<simDim> localSize(cellDescription->getGridLayout().sizeWithoutGuardND());
                     const uint32_t numSlides = MovingWindow::getInstance().getSlideCounter(currentStep);
                     const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
                     DataSpace<simDim> globalOffset(subGrid.getLocalDomain().offset);

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -292,8 +292,7 @@ namespace picongpu
             SimulationHelper<simDim>::pluginLoad();
 
             GridLayout<simDim> layout(gridSizeLocal, GuardSize::toRT() * SuperCellSize::toRT());
-            cellDescription
-                = std::make_unique<MappingDesc>(layout.getDataSpace(), DataSpace<simDim>(GuardSize::toRT()));
+            cellDescription = std::make_unique<MappingDesc>(layout.sizeND(), DataSpace<simDim>(GuardSize::toRT()));
 
             if(gc.getGlobalRank() == 0)
             {

--- a/include/picongpu/simulation/stage/Collision.hpp
+++ b/include/picongpu/simulation/stage/Collision.hpp
@@ -121,11 +121,10 @@ namespace picongpu
                             collision::Sqrt1DimVector>;
                         DataBoxDim1Access<SqrtBox> d1access(
                             SqrtBox(screeningLengthSquared->getDeviceDataBox().shift(
-                                screeningLengthSquared->getGridLayout().getGuard())),
-                            screeningLengthSquared->getGridLayout().getDataSpaceWithoutGuarding());
-                        const auto elements = static_cast<uint32_t>(screeningLengthSquared->getGridLayout()
-                                                                        .getDataSpaceWithoutGuarding()
-                                                                        .productOfComponents());
+                                screeningLengthSquared->getGridLayout().guardSizeND())),
+                            screeningLengthSquared->getGridLayout().sizeWithoutGuardND());
+                        const auto elements = static_cast<uint32_t>(
+                            screeningLengthSquared->getGridLayout().sizeWithoutGuardND().productOfComponents());
                         auto reducedValue = globalReduce(pmacc::math::operation::Add(), d1access, elements);
 
                         mpi::MPIReduce reduce{};

--- a/include/pmacc/dimensions/GridLayout.hpp
+++ b/include/pmacc/dimensions/GridLayout.hpp
@@ -27,15 +27,15 @@
 namespace pmacc
 {
     /**
-     * Describes layout of a DIM-dimensional data grid including the actual grid and optional guards.
+     * Describes layout of a T_dim-dimensional data grid including the actual grid and optional guards.
      *
-     * @tparam DIM dimension of the grid
+     * @tparam T_dim dimension of the grid
      */
-    template<unsigned DIM>
+    template<unsigned T_dim>
     class GridLayout
     {
     public:
-        HDINLINE GridLayout() : dataSpace(DataSpace<DIM>::create(1)), guard(DataSpace<DIM>::create(0))
+        HDINLINE GridLayout() : m_sizeND(DataSpace<T_dim>::create(1)), m_guardSizeND(DataSpace<T_dim>::create(0))
         {
         }
 
@@ -45,39 +45,42 @@ namespace pmacc
          * @param guard DataSpace defining size of the guard cells. Guard is added to actual grid (dataSpace). Will be
          * initialized to 0.
          */
-        HDINLINE GridLayout(const DataSpace<DIM>& dataSpace, DataSpace<DIM> guard = DataSpace<DIM>())
-            : dataSpace(dataSpace)
-            , guard(guard)
+        HDINLINE GridLayout(DataSpace<T_dim> const& sizeND, DataSpace<T_dim> const& guardSizeND = DataSpace<T_dim>())
+            : m_sizeND(sizeND)
+            , m_guardSizeND(guardSizeND)
         {
         }
 
-        /**
-         * returns the DataSpace for the data
-         * (include guarding for overlap neighbor areas)
-         * @return the data DataSpace
+        /** N-dimensional size of the domain
+         *
+         * @return number of cells per dimension including guard cells
          */
-        HDINLINE DataSpace<DIM> getDataSpace() const
+        HDINLINE DataSpace<T_dim> sizeND() const
         {
-            return dataSpace + guard + guard;
+            return m_sizeND + m_guardSizeND + m_guardSizeND;
         }
 
-        HDINLINE DataSpace<DIM> getDataSpaceWithoutGuarding() const
-        {
-            return dataSpace;
-        }
-
-        /**
-         * returns the DataSpace for the guard
-         * @return the guard DataSpace
+        /** N-dimensional size of the domain
+         *
+         * @return number of cells per dimension without guard cells
          */
-        HDINLINE DataSpace<DIM> getGuard() const
+        HDINLINE DataSpace<T_dim> sizeWithoutGuardND() const
         {
-            return guard;
+            return m_sizeND;
+        }
+
+        /** N-dimensional size of the guard
+         *
+         * @return number of cells in the guard area
+         */
+        HDINLINE DataSpace<T_dim> guardSizeND() const
+        {
+            return m_guardSizeND;
         }
 
     private:
-        DataSpace<DIM> dataSpace;
-        DataSpace<DIM> guard;
+        DataSpace<T_dim> m_sizeND;
+        DataSpace<T_dim> m_guardSizeND;
     };
 
 } // namespace pmacc

--- a/include/pmacc/fields/operations/AddExchangeToBorder.hpp
+++ b/include/pmacc/fields/operations/AddExchangeToBorder.hpp
@@ -167,9 +167,9 @@ namespace pmacc
                      * @warning pmacc restriction: all dimension must have the some number of guarding
                      * supercells
                      */
-                    auto const numGuardSuperCells = destBuffer.getGridLayout().getGuard() / SuperCellSize::toRT();
+                    auto const numGuardSuperCells = destBuffer.getGridLayout().guardSizeND() / SuperCellSize::toRT();
 
-                    MappingDesc const mappingDesc(destBuffer.getGridLayout().getDataSpace(), numGuardSuperCells);
+                    MappingDesc const mappingDesc(destBuffer.getGridLayout().sizeND(), numGuardSuperCells);
 
                     ExchangeMapping<GUARD, MappingDesc> mapper(mappingDesc, exchangeType);
 
@@ -179,7 +179,7 @@ namespace pmacc
                         .config(mapper.getGridDim(), SuperCellSize{})(
                             destBuffer.getDeviceBuffer().getDataBox(),
                             destBuffer.getReceiveExchange(exchangeType).getDeviceBuffer().getDataBox(),
-                            destBuffer.getReceiveExchange(exchangeType).getDeviceBuffer().getDataSpace(),
+                            destBuffer.getReceiveExchange(exchangeType).getDeviceBuffer().capacityND(),
                             direction,
                             mapper);
                 }

--- a/include/pmacc/fields/operations/CopyGuardToExchange.hpp
+++ b/include/pmacc/fields/operations/CopyGuardToExchange.hpp
@@ -157,9 +157,9 @@ namespace pmacc
                      * pmacc restriction: all dimension must have the some number of guarding
                      * supercells.
                      */
-                    auto const numGuardSuperCells = srcBuffer.getGridLayout().getGuard() / SuperCellSize::toRT();
+                    auto const numGuardSuperCells = srcBuffer.getGridLayout().guardSizeND() / SuperCellSize::toRT();
 
-                    MappingDesc const mappingDesc(srcBuffer.getGridLayout().getDataSpace(), numGuardSuperCells);
+                    MappingDesc const mappingDesc(srcBuffer.getGridLayout().sizeND(), numGuardSuperCells);
 
                     ExchangeMapping<GUARD, MappingDesc> mapper(mappingDesc, exchangeType);
 
@@ -169,7 +169,7 @@ namespace pmacc
                         .config(mapper.getGridDim(), SuperCellSize{})(
                             srcBuffer.getSendExchange(exchangeType).getDeviceBuffer().getDataBox(),
                             srcBuffer.getDeviceBuffer().getDataBox(),
-                            srcBuffer.getSendExchange(exchangeType).getDeviceBuffer().getDataSpace(),
+                            srcBuffer.getSendExchange(exchangeType).getDeviceBuffer().capacityND(),
                             direction,
                             mapper);
                 }

--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -166,7 +166,7 @@ namespace pmacc
 
         void reset(bool preserveData = true) override
         {
-            this->setCurrentSize(Buffer<T_Type, T_dim>::getDataSpace().productOfComponents());
+            this->setCurrentSize(Buffer<T_Type, T_dim>::capacityND().productOfComponents());
 
             eventSystem::startOperation(ITask::TASK_DEVICE);
             if(!preserveData)
@@ -288,7 +288,7 @@ namespace pmacc
         {
             PMACC_ASSERT_MSG(this->isContiguous(), "Memory must be contiguous!");
             eventSystem::startOperation(ITask::TASK_DEVICE);
-            size_t const size = this->getDataSpace().productOfComponents();
+            size_t const size = this->capacityND().productOfComponents();
             return {alpaka::getPtrNative(*view), size};
         }
     };
@@ -305,7 +305,7 @@ namespace pmacc
     HINLINE std::unique_ptr<DeviceBuffer<T_Type, T_dim>> makeDeepCopy(DeviceBuffer<T_Type, T_dim>& source)
     {
         // We have to call this constructor to allocate a new data storage and not shallow-copy the source
-        auto result = std::make_unique<DeviceBuffer<T_Type, T_dim>>(source.getDataSpace());
+        auto result = std::make_unique<DeviceBuffer<T_Type, T_dim>>(source.capacityND());
         result->copyFrom(source);
         // Wait for copy to finish, so that the resulting object is safe to use after return
         eventSystem::getTransactionEvent().waitForFinished();

--- a/include/pmacc/memory/buffers/Exchange.hpp
+++ b/include/pmacc/memory/buffers/Exchange.hpp
@@ -65,7 +65,7 @@ namespace pmacc
             , exchange(extype)
             , communicationTag(commTag)
         {
-            DataSpace<DIM> tmp_size = memoryLayout.getDataSpaceWithoutGuarding();
+            DataSpace<DIM> tmp_size = memoryLayout.sizeWithoutGuardND();
 
             DataSpace<DIM> exchangeDimensions = exchangeTypeToDim(exchange);
 
@@ -151,8 +151,8 @@ namespace pmacc
             DataSpace<DIM> guardingCells,
             uint32_t area) const
         {
-            DataSpace<DIM> size = memoryLayout.getDataSpace();
-            DataSpace<DIM> border = memoryLayout.getGuard();
+            DataSpace<DIM> size = memoryLayout.sizeND();
+            DataSpace<DIM> border = memoryLayout.guardSizeND();
             Mask mask(exchange);
             DataSpace<DIM> tmp_offset;
             if constexpr(DIM >= DIM1)

--- a/include/pmacc/memory/buffers/GridBuffer.hpp
+++ b/include/pmacc/memory/buffers/GridBuffer.hpp
@@ -94,7 +94,7 @@ namespace pmacc
          * @param sizeOnDevice if true, size information exists on device, too.
          */
         GridBuffer(const GridLayout<DIM>& gridLayout, bool sizeOnDevice = false)
-            : Parent(gridLayout.getDataSpace(), sizeOnDevice)
+            : Parent(gridLayout.sizeND(), sizeOnDevice)
             , hasOneExchange(false)
             , gridLayout(gridLayout)
             , maxExchange(0)
@@ -136,7 +136,7 @@ namespace pmacc
             DeviceBuffer<TYPE, DIM>& otherDeviceBuffer,
             const GridLayout<DIM>& gridLayout,
             bool sizeOnDevice = false)
-            : Parent(otherDeviceBuffer, gridLayout.getDataSpace(), sizeOnDevice)
+            : Parent(otherDeviceBuffer, gridLayout.sizeND(), sizeOnDevice)
             , hasOneExchange(false)
             , gridLayout(gridLayout)
             , maxExchange(0)
@@ -151,13 +151,7 @@ namespace pmacc
             const DataSpace<DIM>& offsetDevice,
             const GridLayout<DIM>& gridLayout,
             bool sizeOnDevice = false)
-            : Parent(
-                otherHostBuffer,
-                offsetHost,
-                otherDeviceBuffer,
-                offsetDevice,
-                gridLayout.getDataSpace(),
-                sizeOnDevice)
+            : Parent(otherHostBuffer, offsetHost, otherDeviceBuffer, offsetDevice, gridLayout.sizeND(), sizeOnDevice)
             , hasOneExchange(false)
             , gridLayout(gridLayout)
             , maxExchange(0)

--- a/include/pmacc/memory/buffers/HostBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostBuffer.hpp
@@ -144,7 +144,7 @@ namespace pmacc
         void reset(bool preserveData = true) override
         {
             eventSystem::startOperation(ITask::TASK_HOST);
-            this->setCurrentSize(this->getDataSpace().productOfComponents());
+            this->setCurrentSize(this->capacityND().productOfComponents());
             if(!preserveData)
             {
                 /* if it is a pointer out of other memory we can not assume that
@@ -154,7 +154,7 @@ namespace pmacc
                     memset(
                         reinterpret_cast<void*>(alpaka::getPtrNative(*view)),
                         0,
-                        this->getDataSpace().productOfComponents() * sizeof(T_Type));
+                        this->capacityND().productOfComponents() * sizeof(T_Type));
                 else
                 {
                     // Using Array is a workaround for types without default constructor
@@ -172,7 +172,7 @@ namespace pmacc
             auto memBox = this->getDataBox();
             auto current_size = static_cast<int64_t>(this->getCurrentSize());
             using D1Box = DataBoxDim1Access<DataBoxType>;
-            D1Box d1Box(memBox, this->getDataSpace());
+            D1Box d1Box(memBox, this->capacityND());
 #pragma omp parallel for
             for(int64_t i = 0; i < current_size; i++)
             {
@@ -198,7 +198,7 @@ namespace pmacc
         typename Buffer<T_Type, T_dim>::CPtr getCPtrCapacity() final
         {
             PMACC_ASSERT_MSG(this->isContiguous(), "Memory must be contiguous!");
-            size_t const size = this->getDataSpace().productOfComponents();
+            size_t const size = this->capacityND().productOfComponents();
             eventSystem::startOperation(ITask::TASK_HOST);
             return {alpaka::getPtrNative(*view), size};
         }

--- a/include/pmacc/mpi/GatherSlice.hpp
+++ b/include/pmacc/mpi/GatherSlice.hpp
@@ -171,7 +171,7 @@ namespace pmacc
                 // get number of elements per participating mpi rank
                 auto extentPerDevice = std::vector<DataSpace<DIM2>>(numRanksInPlane);
 
-                auto localSliceSize = localInputSlice.getDataSpace();
+                auto localSliceSize = localInputSlice.capacityND();
 
                 // gather extents
                 MPI_CHECK(MPI_Gather(

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -83,10 +83,8 @@ namespace pmacc
             : SimulationFieldHelper<MappingDesc>(description)
             , particlesBuffer(nullptr)
         {
-            particlesBuffer = new BufferType(
-                deviceHeap,
-                description.getGridLayout().getDataSpace(),
-                MappingDesc::SuperCellSize::toRT());
+            particlesBuffer
+                = new BufferType(deviceHeap, description.getGridLayout().sizeND(), MappingDesc::SuperCellSize::toRT());
         }
 
         ~ParticlesBase() override

--- a/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/ParticlesBuffer.hpp
@@ -280,7 +280,7 @@ namespace pmacc
         DataSpace<DIM> getSuperCellsCount()
         {
             PMACC_ASSERT(superCells != nullptr);
-            return superCells->getGridLayout().getDataSpace();
+            return superCells->getGridLayout().sizeND();
         }
 
         /**

--- a/include/pmacc/particles/memory/buffers/StackExchangeBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/StackExchangeBuffer.hpp
@@ -74,7 +74,7 @@ namespace pmacc
             return ExchangePushDataBox<vint_t, FRAME, DIM>(
                 stack.getDeviceBuffer().data(),
                 (vint_t*) alpaka::getPtrNative(stack.getDeviceBuffer().getCurrentSizeDeviceSideBuffer()),
-                stack.getDeviceBuffer().getDataSpace().productOfComponents(),
+                stack.getDeviceBuffer().capacityND().productOfComponents(),
                 PushDataBox<vint_t, FRAMEINDEX>(
                     stackIndexer.getDeviceBuffer().data(),
                     (vint_t*) alpaka::getPtrNative(stackIndexer.getDeviceBuffer().getCurrentSizeDeviceSideBuffer())));
@@ -149,9 +149,9 @@ namespace pmacc
         {
             size_t result = 0u;
             if(Environment<>::get().isMpiDirectEnabled())
-                result = stack.getDeviceBuffer().getDataSpace().productOfComponents();
+                result = stack.getDeviceBuffer().capacityND().productOfComponents();
             else
-                result = stack.getHostBuffer().getDataSpace().productOfComponents();
+                result = stack.getHostBuffer().capacityND().productOfComponents();
 
             return result;
         }

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -119,7 +119,7 @@ namespace pmacc
             template<class T_Buffer>
             void writePGM(const std::string& filePath, T_Buffer& buffer)
             {
-                const Space2D size = buffer.getDataSpace();
+                const Space2D size = buffer.capacityND();
                 uint32_t maxVal = 0;
                 for(int y = 0; y < size.y(); y++)
                 {
@@ -177,8 +177,7 @@ namespace pmacc
                 timer.toggleStart();
 
                 PMACC_LOCKSTEP_KERNEL(RandomFiller<blockSize>{})
-                    .template config<blockSize>(
-                        gridSize)(buffer.getDataBox(), buffer.getDataSpace(), rand, numSamples);
+                    .template config<blockSize>(gridSize)(buffer.getDataBox(), buffer.capacityND(), rand, numSamples);
 
                 eventSystem::getTransactionEvent().waitForFinished();
                 timer.toggleEnd();

--- a/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/share/pmacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -145,7 +145,7 @@ namespace gol
              * MappingDesc stores the layout regarding Core, Border and Guard     *
              * in units of SuperCells.                                            *
              * This is saved by init to be used by the kernel to identify itself. */
-            evo.init(layout.getDataSpace(), Space::create(1));
+            evo.init(layout.sizeND(), Space::create(1));
 
             buff1 = std::make_unique<Buffer>(layout, false);
             buff2 = std::make_unique<Buffer>(layout, false);
@@ -215,11 +215,11 @@ namespace gol
             {
                 const SubGrid<DIM2>& subGrid = Environment<DIM2>::get().SubGrid();
                 auto bufferLayout = write->getGridLayout();
-                auto localDataExtents = bufferLayout.getDataSpaceWithoutGuarding();
+                auto localDataExtents = bufferLayout.sizeWithoutGuardND();
                 auto view = std::make_unique<DeviceBuffer<uint8_t, DIM2>>(
                     write->getDeviceBuffer(),
                     localDataExtents,
-                    bufferLayout.getGuard());
+                    bufferLayout.guardSizeND());
                 // create a contiguous buffer required for gathering the data
                 auto dataWithoutGuard = std::make_unique<HostBuffer<uint8_t, DIM2>>(localDataExtents);
                 dataWithoutGuard->copyFrom(*view.get());
@@ -229,7 +229,7 @@ namespace gol
                     subGrid.getLocalDomain().offset);
                 PngCreator png;
                 if(isMaster)
-                    png(currentStep, picture->getDataBox(), picture->getDataSpace());
+                    png(currentStep, picture->getDataBox(), picture->capacityND());
             }
         }
     };

--- a/share/pmacc/examples/heatEquation2D/main.cpp
+++ b/share/pmacc/examples/heatEquation2D/main.cpp
@@ -55,11 +55,11 @@ inline auto createPng(uint32_t currentStep, T_Gather& gather, std::unique_ptr<T_
     {
         const pmacc::SubGrid<DIM2>& subGrid = pmacc::Environment<DIM2>::get().SubGrid();
         auto bufferLayout = gridBuffer->getGridLayout();
-        auto localDataExtents = bufferLayout.getDataSpaceWithoutGuarding();
+        auto localDataExtents = bufferLayout.sizeWithoutGuardND();
         auto view = std::make_unique<pmacc::DeviceBuffer<float, DIM2>>(
             gridBuffer->getDeviceBuffer(),
             localDataExtents,
-            bufferLayout.getGuard());
+            bufferLayout.guardSizeND());
         // create a contiguous buffer required for gathering the data
         auto dataWithoutGuard = std::make_unique<pmacc::HostBuffer<float, DIM2>>(localDataExtents);
         dataWithoutGuard->copyFrom(*view.get());
@@ -69,7 +69,7 @@ inline auto createPng(uint32_t currentStep, T_Gather& gather, std::unique_ptr<T_
             subGrid.getLocalDomain().offset);
         PngCreator png;
         if(gather->isMaster())
-            png(currentStep, picture->getDataBox(), picture->getDataSpace());
+            png(currentStep, picture->getDataBox(), picture->capacityND());
     }
 }
 
@@ -107,7 +107,7 @@ auto main(int argc, char** argv) -> int
      *  takes in the grid layout - CELLS dataspace + guard, and num of SUPERCELLS in guard
      */
     pmacc::DataSpace<DIM2> guardingSuperCells{1, 1};
-    auto mapping = std::make_unique<MappingDesc>(layout.getDataSpace(), guardingSuperCells);
+    auto mapping = std::make_unique<MappingDesc>(layout.sizeND(), guardingSuperCells);
 
     /** define grid buffers, two because we dont do in place writes */
 


### PR DESCRIPTION
- Buffers:
  - rename `getDataSpace` to `capacityND`
- GridLayout
  - rename `getDataSpcae()` to `sizeND()`
  - rename `getGuard()` to `guardSizeND()`
  - rename `getDataSPaceWithoutGarding()` to `sizeWithoutGuardND()`

**Note:** I only renamed the functions, I did not update the variable names inside of function where the changed functions are used.