### PR TITLE
Fix default value for `--no-start-simulation`

### DIFF
--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -122,7 +122,7 @@ namespace picongpu
             desc.add_options()(
                 "versionOnce", po::value<bool>(&showVersionOnce)->zero_tokens(),
                 "print version information once and start")
-                ("no-start-simulation", po::bool_switch(&skipSimulation)->default_value(true), "Do not actually run the simulation but initialise everything, skip simulation and finalise.")
+                ("no-start-simulation", po::bool_switch(&skipSimulation)->default_value(false), "Do not actually run the simulation but initialise everything, skip simulation and finalise.")
                 ("devices,d", po::value<std::vector<uint32_t>>(&devices)->multitoken(),
                  "number of devices in each dimension")
                 ("grid,g", po::value<std::vector<uint32_t>>(&gridSize)->multitoken(),


### PR DESCRIPTION
Hi,
there was a huge bug in #4812! We have a wrong default value for `--no-start-simulation`. The fix is easy and obvious.

But a more pressing matter: How is it possible that our CI can pass if there is not a single simulation ever running? Feel free to discuss!