### PR TITLE
fix typeguard errors

### DIFF
--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,4 +1,4 @@
-typeguard >= 4.1.3
+typeguard >= 4.2.1
 sympy >= 1.9
 chevron >= 0.13.1
 jsonschema == 4.17.3

--- a/test/python/picongpu/quick/picmi/simulation.py
+++ b/test/python/picongpu/quick/picmi/simulation.py
@@ -671,7 +671,7 @@ class TestPicmiSimulation(unittest.TestCase):
 
         invalid_paths = [1, ["/"], {}]
         for invalid_path in invalid_paths:
-            with self.assertRaises(TypeError):
+            with self.assertRaises(typeguard.TypeCheckError):
                 picmi.Simulation(
                     time_step_size=17,
                     max_steps=4,

--- a/test/python/picongpu/quick/pypicongpu/runner.py
+++ b/test/python/picongpu/quick/pypicongpu/runner.py
@@ -121,13 +121,13 @@ class TestRunner(unittest.TestCase):
         # also check that correct usage works:
         Runner(self.sim)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, pypicongpu_template_dir=1)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, scratch_dir=["/", "tmp"])
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, setup_dir={})
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, run_dir=lambda x: x)
 
         r = Runner(self.sim)
@@ -403,7 +403,7 @@ class TestRunner(unittest.TestCase):
         Runner(self.picmi_sim)
 
         for invalid_sim in [None, {}, 0, ""]:
-            with self.assertRaises(TypeError):
+            with self.assertRaises(typeguard.TypeCheckError):
                 Runner(invalid_sim)
 
     def test_applies_templates(self):


### PR DESCRIPTION
fix https://github.com/ComputationalRadiationPhysics/picongpu/issues/4853

With typeguard 3.0.0 the error code type changed from `TypeError` to `TypeCheckError`

see: https://typeguard.readthedocs.io/en/stable/versionhistory.html