### PR TITLE
fix CI pypicongpu tests

### DIFF
--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,4 +1,4 @@
-typeguard >= 4.1.3
+typeguard >= 4.1.3, <= 4.1.5
 sympy >= 1.9
 chevron >= 0.13.1
 jsonschema == 4.17.3

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -290,7 +290,7 @@ PYTHON_VERSIONS: List[str] = ["3.10", "3.11"]
 # If a package is not define in the list, but defined in the requirements.txt,
 # pip decides which version is used.
 PACKAGES_TO_TEST: Dict[str, Callable] = {
-    "typeguard": get_all_major_pypi_versions,
+    "typeguard": get_all_pypi_versions,
     "jsonschema": get_all_pypi_versions,  # @todo change back
     "picmistandard": get_all_pypi_versions,
 }


### PR DESCRIPTION
fix #4853 

Change supported typeguard versions to workaround the current CI issue.

Use typeguard `typeguard >= 4.1.3, < 4.1.5`

Equally to #4853 but try to change the required typeguard version until someone knows how to fix the error.