### PR TITLE
fix wrong lockstep kernel call

### DIFF
--- a/include/picongpu/particles/collision/InterCollision.hpp
+++ b/include/picongpu/particles/collision/InterCollision.hpp
@@ -430,8 +430,7 @@ namespace picongpu::particles::collision
             }
             else
             {
-                PMACC_LOCKSTEP_KERNEL(Kernel{})
-                (mapper.getGridDim(), *species0)(
+                PMACC_LOCKSTEP_KERNEL(Kernel{}).config(mapper.getGridDim(), *species0)(
                     species0->getDeviceParticlesBox(),
                     species1->getDeviceParticlesBox(),
                     mapper,


### PR DESCRIPTION
bug was indroduced with #4840

~~It is not clear why the CI has not found this bug. ~~ The bug does not show up in the CI because the tests uses the debug path of the code `RelativisticCollisionDynamicLog<true>,` and the mistake is in the path which is not compiled.