### PR TITLE
Unification of thrown errors in PyPIConGPU runner interface

### DIFF
--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -10,7 +10,7 @@ from . import util
 from .rendering import Renderer
 
 from os import path, environ, chdir
-from typeguard import typechecked
+import typeguard
 from functools import reduce
 import tempfile
 import subprocess
@@ -62,7 +62,7 @@ def get_tmpdir_with_name(name, parent: str = None):
     return dir_name
 
 
-@typechecked
+@typeguard.typechecked
 class Runner:
     """
     Accepts a PyPIConGPU Simulation and runs it
@@ -191,7 +191,9 @@ class Runner:
         elif isinstance(sim, picmi.Simulation):
             self.sim = sim.get_as_pypicongpu()
         else:
-            raise TypeError("sim must be pypicongpu simulation or picmi simulation, " "got: {}".format(type(sim)))
+            raise typeguard.TypeCheckError(
+                "sim must be pypicongpu simulation or picmi simulation, " "got: {}".format(type(sim))
+            )
 
         # use helper to perform various checks
         # note that the order matters: run_dir depends on scratch_dir

--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,4 +1,4 @@
-typeguard >= 4.1.3, <= 4.1.5
+typeguard >= 4.2.1
 sympy >= 1.9
 chevron >= 0.13.1
 jsonschema == 4.17.3

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -290,8 +290,8 @@ PYTHON_VERSIONS: List[str] = ["3.10", "3.11"]
 # If a package is not define in the list, but defined in the requirements.txt,
 # pip decides which version is used.
 PACKAGES_TO_TEST: Dict[str, Callable] = {
-    "typeguard": get_all_pypi_versions,
-    "jsonschema": get_all_pypi_versions,  # @todo change back
+    "typeguard": get_all_major_pypi_versions,
+    "jsonschema": get_all_pypi_versions,  # @todo change back, Brian Marre, 2023
     "picmistandard": get_all_pypi_versions,
 }
 

--- a/test/python/picongpu/quick/picmi/simulation.py
+++ b/test/python/picongpu/quick/picmi/simulation.py
@@ -671,7 +671,7 @@ class TestPicmiSimulation(unittest.TestCase):
 
         invalid_paths = [1, ["/"], {}]
         for invalid_path in invalid_paths:
-            with self.assertRaises(TypeError):
+            with self.assertRaises(typeguard.TypeCheckError):
                 picmi.Simulation(
                     time_step_size=17,
                     max_steps=4,

--- a/test/python/picongpu/quick/pypicongpu/runner.py
+++ b/test/python/picongpu/quick/pypicongpu/runner.py
@@ -121,13 +121,13 @@ class TestRunner(unittest.TestCase):
         # also check that correct usage works:
         Runner(self.sim)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, pypicongpu_template_dir=1)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, scratch_dir=["/", "tmp"])
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, setup_dir={})
-        with self.assertRaises(TypeError):
+        with self.assertRaises(typeguard.TypeCheckError):
             Runner(self.sim, run_dir=lambda x: x)
 
         r = Runner(self.sim)
@@ -403,7 +403,7 @@ class TestRunner(unittest.TestCase):
         Runner(self.picmi_sim)
 
         for invalid_sim in [None, {}, 0, ""]:
-            with self.assertRaises(TypeError):
+            with self.assertRaises(typeguard.TypeCheckError):
                 Runner(invalid_sim)
 
     def test_applies_templates(self):


### PR DESCRIPTION
changes the error thrown by the PyPIConGPU runner upon passing a neither an instance of pypicongpu.Simulation nor picmi.Simulation as sim to typeguard.TypeCheckError for consistency with the other constructor arguments.