### PR TITLE
fix openPMD restart

### DIFF
--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -137,7 +137,7 @@ namespace picongpu
                 FrameType mappedFrame;
 
                 /*malloc mapped memory*/
-                meta::ForEach<typename NewParticleDescription::ValueTypeSeq, MallocHostMemory<boost::mpl::_1>>
+                meta::ForEach<typename NewParticleDescription::ValueTypeSeq, MallocMappedMemory<boost::mpl::_1>>
                     mallocMem;
                 mallocMem(buffers, mappedFrame, totalNumParticles);
 


### PR DESCRIPTION
fix #4865

with #4820 we broke the restart capability.

Checkpoint files are valid but due to we allocated host side only memory for restart PIConGPu crashed with an illegal memory access.