### PR TITLE
PMacc: rename Stream into Queue

### DIFF
--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -90,7 +90,7 @@ namespace picongpu
             HINLINE void operator()(const std::shared_ptr<T_DeviceHeap>& deviceHeap) const
             {
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-                auto alpakaStream = pmacc::eventSystem::getEventStream(ITask::TASK_DEVICE)->getCudaStream();
+                auto alpakaStream = pmacc::eventSystem::getComputeDeviceQueue(ITask::TASK_DEVICE)->getAlpakaQueue();
                 log<picLog::MEMORY>("mallocMC: free slots for species %3%: %1% a %2%")
                     % deviceHeap->getAvailableSlots(
                         manager::Device<ComputeDevice>::get().current(),

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -701,7 +701,7 @@ namespace picongpu
                     visualization = std::make_unique<VisualizationType>(
                         pmacc::manager::Device<pmacc::HostDevice>::get().current(),
                         pmacc::manager::Device<pmacc::ComputeDevice>::get().current(),
-                        eventSystem::getEventStream(pmacc::ITask::TASK_DEVICE)->getCudaStream(),
+                        eventSystem::getComputeDeviceQueue(pmacc::ITask::TASK_DEVICE)->getAlpakaQueue(),
                         name,
                         0,
                         url,

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -379,7 +379,7 @@ namespace picongpu
             dc.consume(std::move(rngFactory));
 
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-            auto alpakaQueue = pmacc::eventSystem::getEventStream(ITask::TASK_DEVICE)->getCudaStream();
+            auto alpakaQueue = pmacc::eventSystem::getComputeDeviceQueue(ITask::TASK_DEVICE)->getAlpakaQueue();
             auto alpakaDevice = manager::Device<ComputeDevice>::get().current();
             /* Create an empty allocator. This one is resized after all exchanges
              * for particles are created */
@@ -437,8 +437,8 @@ namespace picongpu
             IdProvider<simDim>::init();
 
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-            /* add CUDA streams to the StreamController for concurrent execution */
-            Environment<>::get().StreamController().addStreams(6);
+            /* add CUDA streams to the QueueController for concurrent execution */
+            Environment<>::get().QueueController().addQueues(6);
 #endif
         }
 

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -29,7 +29,7 @@
 #include "pmacc/device/MemoryInfo.hpp"
 #include "pmacc/eventSystem/eventSystem.hpp"
 #include "pmacc/eventSystem/events/EventPool.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/Factory.hpp"
 #include "pmacc/mappings/simulation/Filesystem.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
@@ -58,11 +58,11 @@ namespace pmacc
                 EnvironmentContext::getInstance().finalize();
             }
 
-            /** get the singleton StreamController
+            /** get the singleton QueueController
              *
-             * @return instance of StreamController
+             * @return instance of QueueController
              */
-            HINLINE pmacc::StreamController& StreamController();
+            HINLINE pmacc::QueueController& QueueController();
 
             /** get the singleton EnvironmentController
              *

--- a/include/pmacc/Environment.tpp
+++ b/include/pmacc/Environment.tpp
@@ -48,12 +48,12 @@ namespace pmacc
 {
     namespace detail
     {
-        pmacc::StreamController& Environment::StreamController()
+        pmacc::QueueController& Environment::QueueController()
         {
             PMACC_ASSERT_MSG(
                 EnvironmentContext::getInstance().isDeviceSelected(),
                 "Environment< DIM >::initDevices() must be called before this method!");
-            return StreamController::getInstance();
+            return QueueController::getInstance();
         }
 
         pmacc::EnvironmentController& Environment::EnvironmentController()
@@ -168,7 +168,7 @@ namespace pmacc
 
         detail::EnvironmentContext::getInstance().setDevice(static_cast<int>(GridController().getHostRank()));
 
-        StreamController().activate();
+        QueueController().activate();
 
         MemoryInfo();
 
@@ -247,7 +247,7 @@ namespace pmacc
                 alpaka::wait(manager::Device<ComputeDevice>::get().current());
                 m_isMpiInitialized = false;
                 /* Free the MPI context.
-                 * The gpu context is freed by the `StreamController`, because
+                 * The gpu context is freed by the `QueueController`, because
                  * MPI and CUDA are independent.
                  */
                 MPI_CHECK(MPI_Finalize());

--- a/include/pmacc/eventSystem/Manager.cpp
+++ b/include/pmacc/eventSystem/Manager.cpp
@@ -22,7 +22,7 @@
 #include "pmacc/eventSystem/Manager.hpp"
 
 #include "pmacc/assert.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 
 #include <cstdio>
 #include <cstdlib>

--- a/include/pmacc/eventSystem/eventSystem.cpp
+++ b/include/pmacc/eventSystem/eventSystem.cpp
@@ -52,8 +52,8 @@ namespace pmacc::eventSystem
         return TransactionManager::getInstance().getTransactionEvent();
     }
 
-    EventStream* getEventStream(ITask::TaskType op)
+    Queue* getComputeDeviceQueue(ITask::TaskType op)
     {
-        return TransactionManager::getInstance().getEventStream(op);
+        return TransactionManager::getInstance().getComputeDeviceQueue(op);
     }
 } // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/eventSystem.hpp
+++ b/include/pmacc/eventSystem/eventSystem.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "pmacc/eventSystem/events/EventTask.hpp"
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/waitForAllTasks.hpp"
 
@@ -65,12 +65,12 @@ namespace pmacc::eventSystem
      */
     EventTask getTransactionEvent();
 
-    /** get a `EventStream` that must be used for cuda calls
+    /** get a `Queue` that must be used for compute tasks
      *
      * depended on the opType this method is blocking
      *
      * @param opType place were the operation is running
      *               possible places are: `ITask::TASK_DEVICE`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
      */
-    EventStream* getEventStream(ITask::TaskType op);
+    Queue* getComputeDeviceQueue(ITask::TaskType op);
 } // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/queues/Queue.cpp
+++ b/include/pmacc/eventSystem/queues/Queue.cpp
@@ -19,7 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 
 #include "pmacc/alpakaHelper/Device.hpp"
 #include "pmacc/alpakaHelper/acc.hpp"
@@ -28,26 +28,26 @@
 
 namespace pmacc
 {
-    EventStream::EventStream() : stream(AccStream(manager::Device<ComputeDevice>::get().current()))
+    Queue::Queue() : queue(AccStream(manager::Device<ComputeDevice>::get().current()))
     {
     }
 
-    EventStream::~EventStream()
+    Queue::~Queue()
     {
-        alpaka::wait(stream);
+        alpaka::wait(queue);
     }
 
-    AccStream EventStream::getCudaStream() const
+    AccStream Queue::getAlpakaQueue() const
     {
-        return stream;
+        return queue;
     }
 
-    void EventStream::waitOn(const CudaEventHandle& ev)
+    void Queue::waitOn(const CudaEventHandle& ev)
     {
-        if(this->stream != ev.getStream())
+        if(queue != ev.getStream())
         {
             auto alpakaEvent = *ev;
-            auto queue = this->getCudaStream();
+            auto queue = this->getAlpakaQueue();
             alpaka::wait(queue, alpakaEvent);
         }
     }

--- a/include/pmacc/eventSystem/queues/Queue.hpp
+++ b/include/pmacc/eventSystem/queues/Queue.hpp
@@ -31,27 +31,27 @@ namespace pmacc
      *
      * Allows recording alpaka events on the queue.
      */
-    class EventStream
+    class Queue
     {
     public:
-        EventStream();
+        Queue();
 
         /** Destructor.
          *
-         * Waits for the stream to finish and destroys it.
+         * Waits for the queue to finish and destroys it.
          */
-        virtual ~EventStream();
+        virtual ~Queue();
 
-        /** Returns the alpaka queue object associated with this EventStream.
+        /** Returns the alpaka queue object associated with this Queue.
          *
          * @return the internal alpaka queue object
          */
-        AccStream getCudaStream() const;
+        AccStream getAlpakaQueue() const;
 
         void waitOn(const CudaEventHandle& ev);
 
     private:
-        AccStream stream;
+        AccStream queue;
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/queues/QueueController.hpp
+++ b/include/pmacc/eventSystem/queues/QueueController.hpp
@@ -26,7 +26,7 @@
 #include "pmacc/Environment.def"
 #include "pmacc/alpakaHelper/Device.hpp"
 #include "pmacc/alpakaHelper/acc.hpp"
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 #include "pmacc/types.hpp"
 
 #include <stdexcept>
@@ -39,34 +39,34 @@ namespace pmacc
      * Manages a pool of AccStreams and gives access to them.
      * This class is a singleton.
      */
-    class StreamController
+    class QueueController
     {
     public:
         /**
-         * Returns a pointer to the next EventStream in the controller's queue.
-         * @return pointer to next EventStream
+         * Returns a pointer to the next Queue in the controller's queue.
+         * @return pointer to next Queue
          */
-        EventStream* getNextStream()
+        Queue* getNextStream()
         {
             if(!isActivated)
                 throw std::runtime_error(
-                    std::string("StreamController is not activated but getNextStream() was called"));
+                    std::string("QueueController is not activated but getNextStream() was called"));
             size_t oldIndex = currentStreamIndex;
             currentStreamIndex++;
-            if(currentStreamIndex == streams.size())
+            if(currentStreamIndex == queues.size())
                 currentStreamIndex = 0;
 
-            return streams[oldIndex].get();
+            return queues[oldIndex].get();
         }
 
         /**
          * Destructor.
          * Deletes internal streams. Tears down CUDA.
          */
-        virtual ~StreamController()
+        virtual ~QueueController()
         {
             // First delete the streams
-            streams.clear();
+            queues.clear();
 
             /* This is the single point in PIC where ALL CUDA work must be finished. */
             /* Accessing CUDA objects after this point may fail! */
@@ -75,34 +75,34 @@ namespace pmacc
         }
 
         /**
-         * Add additional EventStreams to the queue.
-         * @param count number of EventStreams to add.
+         * Add additional Queues to the queue.
+         * @param count number of Queues to add.
          */
-        void addStreams(size_t count)
+        void addQueues(size_t count)
         {
             for(size_t i = 0; i < count; i++)
             {
-                streams.push_back(std::make_shared<EventStream>());
+                queues.push_back(std::make_shared<Queue>());
             }
         }
 
-        /** enable StreamController and add one stream
+        /** enable QueueController and add one stream
          *
-         * If StreamController is not activated getNextStream() will crash on its first call
+         * If QueueController is not activated getNextStream() will crash on its first call
          */
         void activate()
         {
-            addStreams(1);
+            addQueues(1);
             isActivated = true;
         }
 
         /**
-         * Returns the number of available EventStreams in the queue.
-         * @return number of EventStreams
+         * Returns the number of available Queues in the queue.
+         * @return number of Queues
          */
         size_t getStreamsCount()
         {
-            return streams.size();
+            return queues.size();
         }
 
     private:
@@ -111,20 +111,20 @@ namespace pmacc
         /**
          * Constructor.
          */
-        StreamController() = default;
+        QueueController() = default;
 
         /**
          * Get instance of this class.
          * This class is a singleton class.
          * @return an instance
          */
-        static StreamController& getInstance()
+        static QueueController& getInstance()
         {
-            static StreamController instance;
+            static QueueController instance;
             return instance;
         }
 
-        std::vector<std::shared_ptr<EventStream>> streams;
+        std::vector<std::shared_ptr<Queue>> queues;
         size_t currentStreamIndex{0};
         bool isActivated{false};
     };

--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "pmacc/eventSystem/Manager.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/Factory.hpp"
 #include "pmacc/eventSystem/tasks/TaskCopy.hpp"
 #include "pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp"

--- a/include/pmacc/eventSystem/tasks/StreamTask.cpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.cpp
@@ -59,31 +59,31 @@ namespace pmacc
         return false;
     }
 
-    EventStream* StreamTask::getEventStream()
+    Queue* StreamTask::getComputeDeviceQueue()
     {
         if(stream == nullptr)
-            stream = eventSystem::getEventStream(TASK_DEVICE);
+            stream = eventSystem::getComputeDeviceQueue(TASK_DEVICE);
         return stream;
     }
 
-    void StreamTask::setEventStream(EventStream* newStream)
+    void StreamTask::setQueue(Queue* newStream)
     {
         PMACC_ASSERT(newStream != nullptr);
         PMACC_ASSERT(stream == nullptr); // it is only allowed to set a stream if no stream is set before
         this->stream = newStream;
     }
 
-    AccStream StreamTask::getCudaStream()
+    AccStream StreamTask::getAlpakaQueue()
     {
         if(stream == nullptr)
-            stream = eventSystem::getEventStream(TASK_DEVICE);
-        return stream->getCudaStream();
+            stream = eventSystem::getComputeDeviceQueue(TASK_DEVICE);
+        return stream->getAlpakaQueue();
     }
 
     void StreamTask::activate()
     {
         m_alpakaEvent = Environment<>::get().EventPool().pop();
-        m_alpakaEvent.recordEvent(getCudaStream());
+        m_alpakaEvent.recordEvent(getAlpakaQueue());
         hasCudaEventHandle = true;
     }
 

--- a/include/pmacc/eventSystem/tasks/StreamTask.hpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.hpp
@@ -22,12 +22,12 @@
 #pragma once
 
 #include "pmacc/eventSystem/events/CudaEventHandle.hpp"
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 
 namespace pmacc
 {
-    class EventStream;
+    class Queue;
 
     /** Abstract base class for all tasks which depend on alpaka queue.
      */
@@ -61,23 +61,23 @@ namespace pmacc
          */
         bool isFinished();
 
-        /** Returns the EventStream this StreamTask is using.
+        /** Returns the Queue this StreamTask is using.
          *
-         * @return pointer to the EventStream
+         * @return pointer to the Queue
          */
-        EventStream* getEventStream();
+        Queue* getComputeDeviceQueue();
 
-        /** Sets the EventStream for this StreamTask.
+        /** Sets the Queue for this StreamTask.
          *
          * @param newStream new event stream
          */
-        void setEventStream(EventStream* newStream);
+        void setQueue(Queue* newStream);
 
-        /** Returns the alpaka queue of the underlying EventStream.
+        /** Returns the alpaka queue of the underlying Queue.
          *
          * @return the associated alpaka queue
          */
-        AccStream getCudaStream();
+        AccStream getAlpakaQueue();
 
 
     protected:
@@ -86,7 +86,7 @@ namespace pmacc
         void activate();
 
 
-        EventStream* stream{nullptr};
+        Queue* stream{nullptr};
         CudaEventHandle m_alpakaEvent;
         bool hasCudaEventHandle{false};
         bool alwaysFinished{false};

--- a/include/pmacc/eventSystem/tasks/TaskCopy.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopy.hpp
@@ -55,7 +55,7 @@ namespace pmacc
 
         void init() override
         {
-            /* @attention: `setSize()` must be called before `getCudaStream()` is called else `setSize()`
+            /* @attention: `setSize()` must be called before `getAlpakaQueue()` is called else `setSize()`
              * is not handled as part of this task. The reason for this is that is not registered to the eventsystem
              * before `init()` is finished.
              */
@@ -66,7 +66,7 @@ namespace pmacc
                 // increasing the latency
                 auto size = alpaka::getExtents(src);
                 destination->setSize(size[0]);
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::memcpy(queue, destination->as1DBuffer(), src, size);
             }
             else
@@ -74,7 +74,7 @@ namespace pmacc
                 size_t currentSize = source->size();
                 destination->setSize(currentSize);
                 auto sizeND = source->sizeND(currentSize);
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::memcpy(queue, destination->getAlpakaView(), source->getAlpakaView(), sizeND.toAlpakaMemVec());
             }
 

--- a/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -53,7 +53,7 @@ namespace pmacc
 
         void init() override
         {
-            auto queue = this->getCudaStream();
+            auto queue = this->getAlpakaQueue();
             alpaka::memcpy(
                 queue,
                 buffer->sizeHostSideBuffer(),

--- a/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -77,7 +77,7 @@ namespace pmacc
                     ITask::TaskType type = task->getTaskType();
                     if(type == ITask::TASK_DEVICE)
                     {
-                        this->stream = static_cast<StreamTask*>(task)->getEventStream();
+                        this->stream = static_cast<StreamTask*>(task)->getComputeDeviceQueue();
                         this->setTaskType(ITask::TASK_DEVICE);
                         this->m_alpakaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
                         this->hasCudaEventHandle = true;
@@ -94,7 +94,7 @@ namespace pmacc
                     ITask::TaskType type = task->getTaskType();
                     if(type == ITask::TASK_DEVICE)
                     {
-                        this->stream = static_cast<StreamTask*>(task)->getEventStream();
+                        this->stream = static_cast<StreamTask*>(task)->getComputeDeviceQueue();
                         this->setTaskType(ITask::TASK_DEVICE);
                         this->m_alpakaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
                         this->hasCudaEventHandle = true;
@@ -124,9 +124,10 @@ namespace pmacc
             if(s1->getTaskType() == ITask::TASK_DEVICE && s2->getTaskType() == ITask::TASK_DEVICE)
             {
                 this->setTaskType(ITask::TASK_DEVICE);
-                this->setEventStream(static_cast<StreamTask*>(s2)->getEventStream());
-                if(static_cast<StreamTask*>(s1)->getEventStream() != static_cast<StreamTask*>(s2)->getEventStream())
-                    this->getEventStream()->waitOn(static_cast<StreamTask*>(s1)->getCudaEventHandle());
+                this->setQueue(static_cast<StreamTask*>(s2)->getComputeDeviceQueue());
+                if(static_cast<StreamTask*>(s1)->getComputeDeviceQueue()
+                   != static_cast<StreamTask*>(s2)->getComputeDeviceQueue())
+                    this->getComputeDeviceQueue()->waitOn(static_cast<StreamTask*>(s1)->getCudaEventHandle());
                 this->activate();
             }
             else if(s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_DEVICE)

--- a/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -83,7 +83,7 @@ namespace pmacc
                 KernelSetValueOnDeviceMemory{},
                 alpaka::getPtrNative(sizeBuff),
                 size);
-            auto queue = this->getCudaStream();
+            auto queue = this->getAlpakaQueue();
             alpaka::enqueue(queue, setValueKernel);
 
             activate();

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -196,7 +196,7 @@ namespace pmacc
                     this->value,
                     areaSizeND,
                     blockCfg);
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::enqueue(queue, kernel);
             }
             this->activate();
@@ -249,7 +249,7 @@ namespace pmacc
                 auto firstElemBuffer = this->destination->as1DBufferNElem(1);
                 alpaka::getPtrNative(*valueBuffer)[0] = this->value; // copy value to new place
 
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::memcpy(queue, firstElemBuffer, *valueBuffer, MemSpace<DIM1>(1).toAlpakaMemVec());
 
                 auto blockCfg = lockstep::makeBlockCfg<xChunkSize>();

--- a/include/pmacc/eventSystem/transactions/Transaction.cpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.cpp
@@ -24,7 +24,7 @@
 #include "pmacc/Environment.hpp"
 #include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventTask.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/StreamTask.hpp"
 
 namespace pmacc
@@ -63,7 +63,7 @@ namespace pmacc
         baseEvent.waitForFinished();
     }
 
-    EventStream* Transaction::getEventStream(ITask::TaskType)
+    Queue* Transaction::getComputeDeviceQueue(ITask::TaskType)
     {
         Manager& manager = Manager::getInstance();
         ITask* baseTask = manager.getITaskIfNotFinished(this->baseEvent.getTaskId());
@@ -76,11 +76,11 @@ namespace pmacc
                  * that the dependency chain not brake
                  */
                 auto* task = static_cast<StreamTask*>(baseTask);
-                return task->getEventStream();
+                return task->getComputeDeviceQueue();
             }
             baseEvent.waitForFinished();
         }
-        return Environment<>::get().StreamController().getNextStream();
+        return Environment<>::get().QueueController().getNextStream();
     }
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/transactions/Transaction.hpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.hpp
@@ -27,7 +27,7 @@
 
 namespace pmacc
 {
-    class EventStream;
+    class Queue;
 
     /**
      * Represents a single transaction in the task/event synchronization system.
@@ -64,11 +64,11 @@ namespace pmacc
          */
         void operation(ITask::TaskType operation);
 
-        /* Get a EventStream which include all dependencies
+        /* Get a Queue which include all dependencies
          * @param operation type of operation to perform
-         * @return EventStream with solved dependencies
+         * @return Queue with solved dependencies
          */
-        EventStream* getEventStream(ITask::TaskType operation);
+        Queue* getComputeDeviceQueue(ITask::TaskType operation);
 
     private:
         EventTask baseEvent;

--- a/include/pmacc/eventSystem/transactions/TransactionManager.cpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.cpp
@@ -72,12 +72,12 @@ namespace pmacc
         transactions.top().operation(op);
     }
 
-    EventStream* TransactionManager::getEventStream(ITask::TaskType op)
+    Queue* TransactionManager::getComputeDeviceQueue(ITask::TaskType op)
     {
         if(transactions.size() == 0)
             throw std::runtime_error("Calling startOperation on empty transaction stack is not allowed");
 
-        return transactions.top().getEventStream(op);
+        return transactions.top().getComputeDeviceQueue(op);
     }
 
     EventTask TransactionManager::setTransactionEvent(const EventTask& event)

--- a/include/pmacc/eventSystem/transactions/TransactionManager.hpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.hpp
@@ -76,7 +76,7 @@ namespace pmacc
          */
         EventTask getTransactionEvent();
 
-        EventStream* getEventStream(ITask::TaskType op);
+        Queue* getComputeDeviceQueue(ITask::TaskType op);
 
         static TransactionManager& getInstance()
         {

--- a/include/pmacc/exec/KernelLauncher.tpp
+++ b/include/pmacc/exec/KernelLauncher.tpp
@@ -104,7 +104,7 @@ namespace pmacc::exec::detail
             auto const kernelTask
                 = ::alpaka::createTaskKernel<Acc<T_dim>>(workDiv, m_kernel, std::forward<T_Args>(args)...);
 
-            auto queue = taskKernel->getCudaStream();
+            auto queue = taskKernel->getAlpakaQueue();
 
             ::alpaka::enqueue(queue, kernelTask);
 

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
@@ -70,7 +70,7 @@ namespace pmacc
             (uint8_t*) deviceHeapInfo.p,
             manager::Device<ComputeDevice>::get().current(),
             alpakaBufferSize);
-        auto alpakaStream = pmacc::eventSystem::getEventStream(ITask::TASK_DEVICE)->getCudaStream();
+        auto alpakaStream = pmacc::eventSystem::getComputeDeviceQueue(ITask::TASK_DEVICE)->getAlpakaQueue();
         alpaka::memcpy(alpakaStream, *hostBuffer, devView, alpakaBufferSize);
         alpaka::wait(alpakaStream);
     }


### PR DESCRIPTION
Our naming still based on CUDA namings, this PR is updating the naming to fit with the alpaka object naming.