### PR TITLE
update deprecated naming from old CUDA times 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1874,7 +1874,7 @@ for detailed instructions.
    - `MapTuple`: broken compile with icc #1648
    - Missing '%%' to use ptx special register #1737
    - `ConstVector`: check arguments init full length #1803
-   - `CudaEvent`: cyclic include #1836
+   - `ComputeEvent`: cyclic include #1836
    - Add missing `HDINLINE` #1825
    - Remove `BOOST_BIND_NO_PLACEHOLDERS` #1849
    - Remove CUDA native static shared memory #1929
@@ -2099,7 +2099,7 @@ rounded to the closest supercell (`IfRelativeGlobalPositionImpl`).
  - PMacc:
    - remove `BOOST_BIND_NO_PLACEHOLDERS` #1849
    - add missing `HDINLINE` #1825
-   - `CudaEvent`: cyclic include #1836
+   - `ComputeEvent`: cyclic include #1836
  - plugins:
    - std includes: never inside namespaces #1835
    - HDF5/ADIOS openPMD:

--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -90,7 +90,7 @@ namespace picongpu
             HINLINE void operator()(const std::shared_ptr<T_DeviceHeap>& deviceHeap) const
             {
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-                auto alpakaStream = pmacc::eventSystem::getEventStream(ITask::TASK_DEVICE)->getCudaStream();
+                auto alpakaStream = pmacc::eventSystem::getComputeDeviceQueue(ITask::TASK_DEVICE)->getAlpakaQueue();
                 log<picLog::MEMORY>("mallocMC: free slots for species %3%: %1% a %2%")
                     % deviceHeap->getAvailableSlots(
                         manager::Device<ComputeDevice>::get().current(),

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -369,7 +369,7 @@ namespace picongpu
             using VisualizationType = IsaacVisualization<
                 pmacc::HostDevice,
                 pmacc::Acc<DIM3>,
-                pmacc::AccStream,
+                pmacc::ComputeDeviceQueue,
                 pmacc::AlpakaDim<DIM3>,
                 SourceList,
                 VectorFieldSourceList,
@@ -701,7 +701,7 @@ namespace picongpu
                     visualization = std::make_unique<VisualizationType>(
                         pmacc::manager::Device<pmacc::HostDevice>::get().current(),
                         pmacc::manager::Device<pmacc::ComputeDevice>::get().current(),
-                        eventSystem::getEventStream(pmacc::ITask::TASK_DEVICE)->getCudaStream(),
+                        eventSystem::getComputeDeviceQueue(pmacc::ITask::TASK_DEVICE)->getAlpakaQueue(),
                         name,
                         0,
                         url,

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -379,7 +379,7 @@ namespace picongpu
             dc.consume(std::move(rngFactory));
 
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-            auto alpakaQueue = pmacc::eventSystem::getEventStream(ITask::TASK_DEVICE)->getCudaStream();
+            auto alpakaQueue = pmacc::eventSystem::getComputeDeviceQueue(ITask::TASK_DEVICE)->getAlpakaQueue();
             auto alpakaDevice = manager::Device<ComputeDevice>::get().current();
             /* Create an empty allocator. This one is resized after all exchanges
              * for particles are created */
@@ -437,8 +437,8 @@ namespace picongpu
             IdProvider<simDim>::init();
 
 #if(BOOST_LANG_CUDA || BOOST_COMP_HIP)
-            /* add CUDA streams to the StreamController for concurrent execution */
-            Environment<>::get().StreamController().addStreams(6);
+            /* add CUDA streams to the QueueController for concurrent execution */
+            Environment<>::get().QueueController().addQueues(6);
 #endif
         }
 

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -29,7 +29,7 @@
 #include "pmacc/device/MemoryInfo.hpp"
 #include "pmacc/eventSystem/eventSystem.hpp"
 #include "pmacc/eventSystem/events/EventPool.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/Factory.hpp"
 #include "pmacc/mappings/simulation/Filesystem.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
@@ -58,11 +58,11 @@ namespace pmacc
                 EnvironmentContext::getInstance().finalize();
             }
 
-            /** get the singleton StreamController
+            /** get the singleton QueueController
              *
-             * @return instance of StreamController
+             * @return instance of QueueController
              */
-            HINLINE pmacc::StreamController& StreamController();
+            HINLINE pmacc::QueueController& QueueController();
 
             /** get the singleton EnvironmentController
              *

--- a/include/pmacc/Environment.tpp
+++ b/include/pmacc/Environment.tpp
@@ -48,12 +48,12 @@ namespace pmacc
 {
     namespace detail
     {
-        pmacc::StreamController& Environment::StreamController()
+        pmacc::QueueController& Environment::QueueController()
         {
             PMACC_ASSERT_MSG(
                 EnvironmentContext::getInstance().isDeviceSelected(),
                 "Environment< DIM >::initDevices() must be called before this method!");
-            return StreamController::getInstance();
+            return QueueController::getInstance();
         }
 
         pmacc::EnvironmentController& Environment::EnvironmentController()
@@ -168,7 +168,7 @@ namespace pmacc
 
         detail::EnvironmentContext::getInstance().setDevice(static_cast<int>(GridController().getHostRank()));
 
-        StreamController().activate();
+        QueueController().activate();
 
         MemoryInfo();
 
@@ -247,7 +247,7 @@ namespace pmacc
                 alpaka::wait(manager::Device<ComputeDevice>::get().current());
                 m_isMpiInitialized = false;
                 /* Free the MPI context.
-                 * The gpu context is freed by the `StreamController`, because
+                 * The gpu context is freed by the `QueueController`, because
                  * MPI and CUDA are independent.
                  */
                 MPI_CHECK(MPI_Finalize());
@@ -323,7 +323,7 @@ namespace pmacc
                      */
                     try
                     {
-                        auto testStream = AccStream(manager::Device<ComputeDevice>::get().current());
+                        auto testStream = ComputeDeviceQueue(manager::Device<ComputeDevice>::get().current());
                     }
                     catch(const std::system_error& e)
                     {

--- a/include/pmacc/alpakaHelper/acc.hpp
+++ b/include/pmacc/alpakaHelper/acc.hpp
@@ -76,12 +76,12 @@ namespace pmacc
 #endif
 
 #if(PMACC_USE_ASYNC_QUEUES == 1)
-    using AccStream = ::alpaka::Queue<ComputeDevice, ::alpaka::NonBlocking>;
+    using ComputeDeviceQueue = ::alpaka::Queue<ComputeDevice, ::alpaka::NonBlocking>;
 #else
-    using AccStream = ::alpaka::Queue<ComputeDevice, ::alpaka::Blocking>;
+    using ComputeDeviceQueue = ::alpaka::Queue<ComputeDevice, ::alpaka::Blocking>;
 #endif
 
-    using AlpakaEventType = alpaka::Event<AccStream>;
+    using ComputeDeviceEvent = alpaka::Event<ComputeDeviceQueue>;
 
     /*! device compile flag
      *

--- a/include/pmacc/eventSystem/Manager.cpp
+++ b/include/pmacc/eventSystem/Manager.cpp
@@ -22,7 +22,7 @@
 #include "pmacc/eventSystem/Manager.hpp"
 
 #include "pmacc/assert.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 
 #include <cstdio>
 #include <cstdlib>

--- a/include/pmacc/eventSystem/eventSystem.cpp
+++ b/include/pmacc/eventSystem/eventSystem.cpp
@@ -52,8 +52,8 @@ namespace pmacc::eventSystem
         return TransactionManager::getInstance().getTransactionEvent();
     }
 
-    EventStream* getEventStream(ITask::TaskType op)
+    Queue* getComputeDeviceQueue(ITask::TaskType op)
     {
-        return TransactionManager::getInstance().getEventStream(op);
+        return TransactionManager::getInstance().getComputeDeviceQueue(op);
     }
 } // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/eventSystem.hpp
+++ b/include/pmacc/eventSystem/eventSystem.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "pmacc/eventSystem/events/EventTask.hpp"
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/waitForAllTasks.hpp"
 
@@ -46,7 +46,7 @@ namespace pmacc::eventSystem
      * Synchronizes a blocking operation with events on the top-most transaction.
      *
      * @param op operation type for synchronization
-     * @return an AccStream which can be used for StreamTasks
+     * @return an ComputeDeviceQueue which can be used for StreamTasks
      */
     void startOperation(ITask::TaskType op);
 
@@ -65,12 +65,12 @@ namespace pmacc::eventSystem
      */
     EventTask getTransactionEvent();
 
-    /** get a `EventStream` that must be used for cuda calls
+    /** get a `Queue` that must be used for compute tasks
      *
      * depended on the opType this method is blocking
      *
      * @param opType place were the operation is running
      *               possible places are: `ITask::TASK_DEVICE`, `ITask::TASK_MPI`, `ITask::TASK_HOST`
      */
-    EventStream* getEventStream(ITask::TaskType op);
+    Queue* getComputeDeviceQueue(ITask::TaskType op);
 } // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/events/ComputeEvent.cpp
+++ b/include/pmacc/eventSystem/events/ComputeEvent.cpp
@@ -20,35 +20,35 @@
  */
 
 
-#include "pmacc/eventSystem/events/CudaEvent.hpp"
+#include "pmacc/eventSystem/events/ComputeEvent.hpp"
 
 #include "pmacc/Environment.hpp"
 #include "pmacc/alpakaHelper/Device.hpp"
 #include "pmacc/alpakaHelper/acc.hpp"
-#include "pmacc/eventSystem/events/CudaEventHandle.hpp"
+#include "pmacc/eventSystem/events/ComputeEventHandle.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc
 {
-    CudaEvent::CudaEvent() : event(AlpakaEventType(manager::Device<ComputeDevice>::get().current()))
+    ComputeEvent::ComputeEvent() : event(ComputeDeviceEvent(manager::Device<ComputeDevice>::get().current()))
     {
         log(ggLog::CUDA_RT() + ggLog::EVENT(), "create event");
     }
 
 
-    CudaEvent::~CudaEvent()
+    ComputeEvent::~ComputeEvent()
     {
         PMACC_ASSERT(refCounter == 0u);
         log(ggLog::CUDA_RT() + ggLog::EVENT(), "sync and delete event");
         alpaka::wait(event);
     }
 
-    void CudaEvent::registerHandle()
+    void ComputeEvent::registerHandle()
     {
         ++refCounter;
     }
 
-    void CudaEvent::releaseHandle()
+    void ComputeEvent::releaseHandle()
     {
         assert(refCounter != 0u);
         // get old value and decrement
@@ -64,7 +64,7 @@ namespace pmacc
     }
 
 
-    bool CudaEvent::isFinished()
+    bool ComputeEvent::isFinished()
     {
         // avoid alpaka calls if event is already finished
         if(!finished)
@@ -76,7 +76,7 @@ namespace pmacc
     }
 
 
-    void CudaEvent::recordEvent(AccStream const& stream)
+    void ComputeEvent::recordEvent(ComputeDeviceQueue const& stream)
     {
         /* disallow double recording */
         assert(!this->stream.has_value());

--- a/include/pmacc/eventSystem/events/ComputeEvent.hpp
+++ b/include/pmacc/eventSystem/events/ComputeEvent.hpp
@@ -28,27 +28,27 @@
 
 namespace pmacc
 {
-    /** Wrapper for AlpakaEventType
+    /** Wrapper for ComputeDeviceEvent
      *
      * This class follows the RAII rules
      */
-    class CudaEvent
+    class ComputeEvent
     {
     private:
         /** native alpaka event */
-        AlpakaEventType event;
+        ComputeDeviceEvent event;
         /** native alpaka queue where the event is recorded
          *
          *  only valid if isRecorded is true
          */
-        std::optional<AccStream> stream;
+        std::optional<ComputeDeviceQueue> stream;
         /** state if a recorded event is finished
          *
          * avoids that alpaka calls backend API methods after `isFinished()` returns the first time true
          */
         bool finished{true};
 
-        /** number of CudaEventHandle's to the instance */
+        /** number of ComputeEventHandle's to the instance */
         uint32_t refCounter{0u};
 
 
@@ -57,10 +57,10 @@ namespace pmacc
          *
          * if called before the alpaka device is initialized the behavior is undefined
          */
-        CudaEvent();
+        ComputeEvent();
 
         /** Destructor */
-        ~CudaEvent();
+        ~ComputeEvent();
 
         /** register a existing handle to a event instance */
         void registerHandle();
@@ -68,11 +68,11 @@ namespace pmacc
         /** free a registered handle */
         void releaseHandle();
 
-        /** get native AlpakaEventType object
+        /** get native ComputeDeviceEvent object
          *
          * @return native alpaka event
          */
-        AlpakaEventType operator*() const
+        ComputeDeviceEvent operator*() const
         {
             return event;
         }
@@ -81,7 +81,7 @@ namespace pmacc
          *
          * @return native alpaka queue
          */
-        AccStream getStream() const
+        ComputeDeviceQueue getStream() const
         {
             assert(this->stream.has_value());
             return *stream;
@@ -97,6 +97,6 @@ namespace pmacc
          *
          * @param stream native alpaka queue
          */
-        void recordEvent(AccStream const& stream);
+        void recordEvent(ComputeDeviceQueue const& stream);
     };
 } // namespace pmacc

--- a/include/pmacc/eventSystem/events/ComputeEventHandle.cpp
+++ b/include/pmacc/eventSystem/events/ComputeEventHandle.cpp
@@ -19,24 +19,24 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "pmacc/eventSystem/events/CudaEventHandle.hpp"
+#include "pmacc/eventSystem/events/ComputeEventHandle.hpp"
 
 #include "pmacc/alpakaHelper/acc.hpp"
 
 namespace pmacc
 {
-    CudaEventHandle::CudaEventHandle(CudaEvent* const evPointer) : event(evPointer)
+    ComputeEventHandle::ComputeEventHandle(ComputeEvent* const evPointer) : event(evPointer)
     {
         event->registerHandle();
     }
 
-    CudaEventHandle::CudaEventHandle(const CudaEventHandle& other)
+    ComputeEventHandle::ComputeEventHandle(const ComputeEventHandle& other)
     {
         /* register and release handle is done by the assign operator */
         *this = other;
     }
 
-    CudaEventHandle& CudaEventHandle::operator=(const CudaEventHandle& other)
+    ComputeEventHandle& ComputeEventHandle::operator=(const ComputeEventHandle& other)
     {
         /* check if an old event is overwritten */
         if(event)
@@ -48,32 +48,32 @@ namespace pmacc
         return *this;
     }
 
-    CudaEventHandle::~CudaEventHandle()
+    ComputeEventHandle::~ComputeEventHandle()
     {
         if(event)
             event->releaseHandle();
         event = nullptr;
     }
 
-    AlpakaEventType CudaEventHandle::operator*() const
+    ComputeDeviceEvent ComputeEventHandle::operator*() const
     {
         assert(event);
         return **event;
     }
 
-    bool CudaEventHandle::isFinished()
+    bool ComputeEventHandle::isFinished()
     {
         PMACC_ASSERT(event);
         return event->isFinished();
     }
 
-    AccStream CudaEventHandle::getStream() const
+    ComputeDeviceQueue ComputeEventHandle::getStream() const
     {
         PMACC_ASSERT(event);
         return event->getStream();
     }
 
-    void CudaEventHandle::recordEvent(AccStream const& stream)
+    void ComputeEventHandle::recordEvent(ComputeDeviceQueue const& stream)
     {
         PMACC_ASSERT(event);
         event->recordEvent(stream);

--- a/include/pmacc/eventSystem/events/ComputeEventHandle.hpp
+++ b/include/pmacc/eventSystem/events/ComputeEventHandle.hpp
@@ -23,29 +23,29 @@
 #pragma once
 
 #include "pmacc/assert.hpp"
-#include "pmacc/eventSystem/events/CudaEvent.hpp"
+#include "pmacc/eventSystem/events/ComputeEvent.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc
 {
-    /** handle to CudaEvent */
-    class CudaEventHandle
+    /** handle to ComputeEvent */
+    class ComputeEventHandle
     {
     private:
-        /** pointer to the CudaEvent */
-        CudaEvent* event = nullptr;
+        /** pointer to the ComputeEvent */
+        ComputeEvent* event = nullptr;
 
     public:
         /** create invalid handle  */
-        CudaEventHandle() = default;
+        ComputeEventHandle() = default;
 
-        /** create a handle to a valid CudaEvent
+        /** create a handle to a valid ComputeEvent
          *
-         * @param evPointer pointer to a CudaEvent
+         * @param evPointer pointer to a ComputeEvent
          */
-        CudaEventHandle(CudaEvent* const evPointer);
+        ComputeEventHandle(ComputeEvent* const evPointer);
 
-        CudaEventHandle(const CudaEventHandle& other);
+        ComputeEventHandle(const ComputeEventHandle& other);
 
         /** assign an event handle
          *
@@ -54,17 +54,17 @@ namespace pmacc
          * @param other event handle
          * @return this handle
          */
-        CudaEventHandle& operator=(const CudaEventHandle& other);
+        ComputeEventHandle& operator=(const ComputeEventHandle& other);
 
         /** Destructor */
-        ~CudaEventHandle();
+        ~ComputeEventHandle();
 
         /**
          * get native alpaka event
          *
          * @return native alpaka event
          */
-        AlpakaEventType operator*() const;
+        ComputeDeviceEvent operator*() const;
 
         /** check whether the event is finished
          *
@@ -77,12 +77,12 @@ namespace pmacc
          *
          * @return native alpaka queue
          */
-        AccStream getStream() const;
+        ComputeDeviceQueue getStream() const;
 
         /** record event in a device queue
          *
          * @param stream native alpaka queue
          */
-        void recordEvent(AccStream const& stream);
+        void recordEvent(ComputeDeviceQueue const& stream);
     };
 } // namespace pmacc

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -24,8 +24,8 @@
 
 #include "pmacc/Environment.def"
 #include "pmacc/debug/VerboseLog.hpp"
-#include "pmacc/eventSystem/events/CudaEvent.hpp"
-#include "pmacc/eventSystem/events/CudaEventHandle.hpp"
+#include "pmacc/eventSystem/events/ComputeEvent.hpp"
+#include "pmacc/eventSystem/events/ComputeEventHandle.hpp"
 #include "pmacc/types.hpp"
 
 #include <list>
@@ -42,11 +42,11 @@ namespace pmacc
          *
          * @return free alpaka event
          */
-        CudaEventHandle pop()
+        ComputeEventHandle pop()
         {
             if(freeEvents.size() != 0)
             {
-                CudaEventHandle result = freeEvents.front();
+                ComputeEventHandle result = freeEvents.front();
                 freeEvents.pop_front();
                 return result;
             }
@@ -55,19 +55,19 @@ namespace pmacc
         }
 
 
-        /** add CudaEvent to the pool
+        /** add ComputeEvent to the pool
          *
          * the pool takes the ownership of the pointer
          *
-         * @param ev pointer to CudaEvent
+         * @param ev pointer to ComputeEvent
          */
-        void push(CudaEvent* const ev)
+        void push(ComputeEvent* const ev)
         {
             /* Guard that no event is added during the pool is closed (shutdown phase).
              * This method is also called during the evaluation of the destructor.
              */
             if(!isClosed)
-                freeEvents.push_back(CudaEventHandle(ev));
+                freeEvents.push_back(ComputeEventHandle(ev));
         }
 
         /** create and add an alpaka events to the pool
@@ -78,7 +78,7 @@ namespace pmacc
         {
             for(size_t i = 0u; i < count; i++)
             {
-                auto* nativeEvent = new CudaEvent();
+                auto* nativeEvent = new ComputeEvent();
                 events.push_back(nativeEvent);
                 push(nativeEvent);
             }
@@ -114,18 +114,18 @@ namespace pmacc
             log(ggLog::CUDA_RT() + ggLog::EVENT(), "shutdown EventPool with %1% events") % getEventsCount();
             isClosed = true;
             freeEvents.clear();
-            for(std::vector<CudaEvent*>::const_iterator iter = events.begin(); iter != events.end(); ++iter)
+            for(std::vector<ComputeEvent*>::const_iterator iter = events.begin(); iter != events.end(); ++iter)
             {
                 delete *iter;
             }
             events.clear();
         }
 
-        //! hold all CudaEvents
-        std::vector<CudaEvent*> events;
+        //! hold all ComputeEvents
+        std::vector<ComputeEvent*> events;
 
-        //! hold currently free CudaEventHandle's
-        std::list<CudaEventHandle> freeEvents;
+        //! hold currently free ComputeEventHandle's
+        std::list<ComputeEventHandle> freeEvents;
 
         /**! state if the pool is closed
          *

--- a/include/pmacc/eventSystem/queues/Queue.cpp
+++ b/include/pmacc/eventSystem/queues/Queue.cpp
@@ -19,7 +19,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 
 #include "pmacc/alpakaHelper/Device.hpp"
 #include "pmacc/alpakaHelper/acc.hpp"
@@ -28,26 +28,26 @@
 
 namespace pmacc
 {
-    EventStream::EventStream() : stream(AccStream(manager::Device<ComputeDevice>::get().current()))
+    Queue::Queue() : queue(ComputeDeviceQueue(manager::Device<ComputeDevice>::get().current()))
     {
     }
 
-    EventStream::~EventStream()
+    Queue::~Queue()
     {
-        alpaka::wait(stream);
+        alpaka::wait(queue);
     }
 
-    AccStream EventStream::getCudaStream() const
+    ComputeDeviceQueue Queue::getAlpakaQueue() const
     {
-        return stream;
+        return queue;
     }
 
-    void EventStream::waitOn(const CudaEventHandle& ev)
+    void Queue::waitOn(const ComputeEventHandle& ev)
     {
-        if(this->stream != ev.getStream())
+        if(queue != ev.getStream())
         {
             auto alpakaEvent = *ev;
-            auto queue = this->getCudaStream();
+            auto queue = this->getAlpakaQueue();
             alpaka::wait(queue, alpakaEvent);
         }
     }

--- a/include/pmacc/eventSystem/queues/Queue.hpp
+++ b/include/pmacc/eventSystem/queues/Queue.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "pmacc/eventSystem/events/CudaEventHandle.hpp"
+#include "pmacc/eventSystem/events/ComputeEventHandle.hpp"
 #include "pmacc/types.hpp"
 
 
@@ -31,27 +31,27 @@ namespace pmacc
      *
      * Allows recording alpaka events on the queue.
      */
-    class EventStream
+    class Queue
     {
     public:
-        EventStream();
+        Queue();
 
         /** Destructor.
          *
-         * Waits for the stream to finish and destroys it.
+         * Waits for the queue to finish and destroys it.
          */
-        virtual ~EventStream();
+        virtual ~Queue();
 
-        /** Returns the alpaka queue object associated with this EventStream.
+        /** Returns the alpaka queue object associated with this Queue.
          *
          * @return the internal alpaka queue object
          */
-        AccStream getCudaStream() const;
+        ComputeDeviceQueue getAlpakaQueue() const;
 
-        void waitOn(const CudaEventHandle& ev);
+        void waitOn(const ComputeEventHandle& ev);
 
     private:
-        AccStream stream;
+        ComputeDeviceQueue queue;
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "pmacc/eventSystem/Manager.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/Factory.hpp"
 #include "pmacc/eventSystem/tasks/TaskCopy.hpp"
 #include "pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp"

--- a/include/pmacc/eventSystem/tasks/StreamTask.cpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.cpp
@@ -32,15 +32,15 @@ namespace pmacc
         this->setTaskType(ITask::TASK_DEVICE);
     }
 
-    CudaEventHandle StreamTask::getCudaEventHandle() const
+    ComputeEventHandle StreamTask::getComputeEventHandle() const
     {
-        PMACC_ASSERT(hasCudaEventHandle);
+        PMACC_ASSERT(hasComputeEventHandle);
         return m_alpakaEvent;
     }
 
-    void StreamTask::setCudaEventHandle(const CudaEventHandle& alpakaEvent)
+    void StreamTask::setComputeEventHandle(const ComputeEventHandle& alpakaEvent)
     {
-        this->hasCudaEventHandle = true;
+        this->hasComputeEventHandle = true;
         this->m_alpakaEvent = alpakaEvent;
     }
 
@@ -48,7 +48,7 @@ namespace pmacc
     {
         if(alwaysFinished)
             return true;
-        if(hasCudaEventHandle)
+        if(hasComputeEventHandle)
         {
             if(m_alpakaEvent.isFinished())
             {
@@ -59,32 +59,32 @@ namespace pmacc
         return false;
     }
 
-    EventStream* StreamTask::getEventStream()
+    Queue* StreamTask::getComputeDeviceQueue()
     {
         if(stream == nullptr)
-            stream = eventSystem::getEventStream(TASK_DEVICE);
+            stream = eventSystem::getComputeDeviceQueue(TASK_DEVICE);
         return stream;
     }
 
-    void StreamTask::setEventStream(EventStream* newStream)
+    void StreamTask::setQueue(Queue* newStream)
     {
         PMACC_ASSERT(newStream != nullptr);
         PMACC_ASSERT(stream == nullptr); // it is only allowed to set a stream if no stream is set before
         this->stream = newStream;
     }
 
-    AccStream StreamTask::getCudaStream()
+    ComputeDeviceQueue StreamTask::getAlpakaQueue()
     {
         if(stream == nullptr)
-            stream = eventSystem::getEventStream(TASK_DEVICE);
-        return stream->getCudaStream();
+            stream = eventSystem::getComputeDeviceQueue(TASK_DEVICE);
+        return stream->getAlpakaQueue();
     }
 
     void StreamTask::activate()
     {
         m_alpakaEvent = Environment<>::get().EventPool().pop();
-        m_alpakaEvent.recordEvent(getCudaStream());
-        hasCudaEventHandle = true;
+        m_alpakaEvent.recordEvent(getAlpakaQueue());
+        hasComputeEventHandle = true;
     }
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/StreamTask.hpp
+++ b/include/pmacc/eventSystem/tasks/StreamTask.hpp
@@ -21,13 +21,13 @@
 
 #pragma once
 
-#include "pmacc/eventSystem/events/CudaEventHandle.hpp"
-#include "pmacc/eventSystem/streams/EventStream.hpp"
+#include "pmacc/eventSystem/events/ComputeEventHandle.hpp"
+#include "pmacc/eventSystem/queues/Queue.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 
 namespace pmacc
 {
-    class EventStream;
+    class Queue;
 
     /** Abstract base class for all tasks which depend on alpaka queue.
      */
@@ -47,13 +47,13 @@ namespace pmacc
          *
          * @return the task's alpaka event
          */
-        CudaEventHandle getCudaEventHandle() const;
+        ComputeEventHandle getComputeEventHandle() const;
 
         /** Sets the
          *
          * @param alpakaEvent
          */
-        void setCudaEventHandle(const CudaEventHandle& alpakaEvent);
+        void setComputeEventHandle(const ComputeEventHandle& alpakaEvent);
 
         /** Returns if this task is finished.
          *
@@ -61,23 +61,23 @@ namespace pmacc
          */
         bool isFinished();
 
-        /** Returns the EventStream this StreamTask is using.
+        /** Returns the Queue this StreamTask is using.
          *
-         * @return pointer to the EventStream
+         * @return pointer to the Queue
          */
-        EventStream* getEventStream();
+        Queue* getComputeDeviceQueue();
 
-        /** Sets the EventStream for this StreamTask.
+        /** Sets the Queue for this StreamTask.
          *
          * @param newStream new event stream
          */
-        void setEventStream(EventStream* newStream);
+        void setQueue(Queue* newStream);
 
-        /** Returns the alpaka queue of the underlying EventStream.
+        /** Returns the alpaka queue of the underlying Queue.
          *
          * @return the associated alpaka queue
          */
-        AccStream getCudaStream();
+        ComputeDeviceQueue getAlpakaQueue();
 
 
     protected:
@@ -86,9 +86,9 @@ namespace pmacc
         void activate();
 
 
-        EventStream* stream{nullptr};
-        CudaEventHandle m_alpakaEvent;
-        bool hasCudaEventHandle{false};
+        Queue* stream{nullptr};
+        ComputeEventHandle m_alpakaEvent;
+        bool hasComputeEventHandle{false};
         bool alwaysFinished{false};
     };
 

--- a/include/pmacc/eventSystem/tasks/TaskCopy.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskCopy.hpp
@@ -55,7 +55,7 @@ namespace pmacc
 
         void init() override
         {
-            /* @attention: `setSize()` must be called before `getCudaStream()` is called else `setSize()`
+            /* @attention: `setSize()` must be called before `getAlpakaQueue()` is called else `setSize()`
              * is not handled as part of this task. The reason for this is that is not registered to the eventsystem
              * before `init()` is finished.
              */
@@ -66,7 +66,7 @@ namespace pmacc
                 // increasing the latency
                 auto size = alpaka::getExtents(src);
                 destination->setSize(size[0]);
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::memcpy(queue, destination->as1DBuffer(), src, size);
             }
             else
@@ -74,7 +74,7 @@ namespace pmacc
                 size_t currentSize = source->size();
                 destination->setSize(currentSize);
                 auto sizeND = source->sizeND(currentSize);
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::memcpy(queue, destination->getAlpakaView(), source->getAlpakaView(), sizeND.toAlpakaMemVec());
             }
 

--- a/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskGetCurrentSizeFromDevice.hpp
@@ -53,7 +53,7 @@ namespace pmacc
 
         void init() override
         {
-            auto queue = this->getCudaStream();
+            auto queue = this->getAlpakaQueue();
             alpaka::memcpy(
                 queue,
                 buffer->sizeHostSideBuffer(),

--- a/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskLogicalAnd.hpp
@@ -77,10 +77,10 @@ namespace pmacc
                     ITask::TaskType type = task->getTaskType();
                     if(type == ITask::TASK_DEVICE)
                     {
-                        this->stream = static_cast<StreamTask*>(task)->getEventStream();
+                        this->stream = static_cast<StreamTask*>(task)->getComputeDeviceQueue();
                         this->setTaskType(ITask::TASK_DEVICE);
-                        this->m_alpakaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
-                        this->hasCudaEventHandle = true;
+                        this->m_alpakaEvent = static_cast<StreamTask*>(task)->getComputeEventHandle();
+                        this->hasComputeEventHandle = true;
                     }
                 }
             }
@@ -94,10 +94,10 @@ namespace pmacc
                     ITask::TaskType type = task->getTaskType();
                     if(type == ITask::TASK_DEVICE)
                     {
-                        this->stream = static_cast<StreamTask*>(task)->getEventStream();
+                        this->stream = static_cast<StreamTask*>(task)->getComputeDeviceQueue();
                         this->setTaskType(ITask::TASK_DEVICE);
-                        this->m_alpakaEvent = static_cast<StreamTask*>(task)->getCudaEventHandle();
-                        this->hasCudaEventHandle = true;
+                        this->m_alpakaEvent = static_cast<StreamTask*>(task)->getComputeEventHandle();
+                        this->hasComputeEventHandle = true;
                     }
                 }
             }
@@ -124,9 +124,10 @@ namespace pmacc
             if(s1->getTaskType() == ITask::TASK_DEVICE && s2->getTaskType() == ITask::TASK_DEVICE)
             {
                 this->setTaskType(ITask::TASK_DEVICE);
-                this->setEventStream(static_cast<StreamTask*>(s2)->getEventStream());
-                if(static_cast<StreamTask*>(s1)->getEventStream() != static_cast<StreamTask*>(s2)->getEventStream())
-                    this->getEventStream()->waitOn(static_cast<StreamTask*>(s1)->getCudaEventHandle());
+                this->setQueue(static_cast<StreamTask*>(s2)->getComputeDeviceQueue());
+                if(static_cast<StreamTask*>(s1)->getComputeDeviceQueue()
+                   != static_cast<StreamTask*>(s2)->getComputeDeviceQueue())
+                    this->getComputeDeviceQueue()->waitOn(static_cast<StreamTask*>(s1)->getComputeEventHandle());
                 this->activate();
             }
             else if(s1->getTaskType() == ITask::TASK_MPI && s2->getTaskType() == ITask::TASK_DEVICE)

--- a/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp
@@ -83,7 +83,7 @@ namespace pmacc
                 KernelSetValueOnDeviceMemory{},
                 alpaka::getPtrNative(sizeBuff),
                 size);
-            auto queue = this->getCudaStream();
+            auto queue = this->getAlpakaQueue();
             alpaka::enqueue(queue, setValueKernel);
 
             activate();

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -196,7 +196,7 @@ namespace pmacc
                     this->value,
                     areaSizeND,
                     blockCfg);
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::enqueue(queue, kernel);
             }
             this->activate();
@@ -249,7 +249,7 @@ namespace pmacc
                 auto firstElemBuffer = this->destination->as1DBufferNElem(1);
                 alpaka::getPtrNative(*valueBuffer)[0] = this->value; // copy value to new place
 
-                auto queue = this->getCudaStream();
+                auto queue = this->getAlpakaQueue();
                 alpaka::memcpy(queue, firstElemBuffer, *valueBuffer, MemSpace<DIM1>(1).toAlpakaMemVec());
 
                 auto blockCfg = lockstep::makeBlockCfg<xChunkSize>();

--- a/include/pmacc/eventSystem/transactions/Transaction.cpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.cpp
@@ -24,7 +24,7 @@
 #include "pmacc/Environment.hpp"
 #include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/eventSystem/events/EventTask.hpp"
-#include "pmacc/eventSystem/streams/StreamController.hpp"
+#include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/StreamTask.hpp"
 
 namespace pmacc
@@ -63,7 +63,7 @@ namespace pmacc
         baseEvent.waitForFinished();
     }
 
-    EventStream* Transaction::getEventStream(ITask::TaskType)
+    Queue* Transaction::getComputeDeviceQueue(ITask::TaskType)
     {
         Manager& manager = Manager::getInstance();
         ITask* baseTask = manager.getITaskIfNotFinished(this->baseEvent.getTaskId());
@@ -76,11 +76,11 @@ namespace pmacc
                  * that the dependency chain not brake
                  */
                 auto* task = static_cast<StreamTask*>(baseTask);
-                return task->getEventStream();
+                return task->getComputeDeviceQueue();
             }
             baseEvent.waitForFinished();
         }
-        return Environment<>::get().StreamController().getNextStream();
+        return Environment<>::get().QueueController().getNextStream();
     }
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/transactions/Transaction.hpp
+++ b/include/pmacc/eventSystem/transactions/Transaction.hpp
@@ -27,7 +27,7 @@
 
 namespace pmacc
 {
-    class EventStream;
+    class Queue;
 
     /**
      * Represents a single transaction in the task/event synchronization system.
@@ -64,11 +64,11 @@ namespace pmacc
          */
         void operation(ITask::TaskType operation);
 
-        /* Get a EventStream which include all dependencies
+        /* Get a Queue which include all dependencies
          * @param operation type of operation to perform
-         * @return EventStream with solved dependencies
+         * @return Queue with solved dependencies
          */
-        EventStream* getEventStream(ITask::TaskType operation);
+        Queue* getComputeDeviceQueue(ITask::TaskType operation);
 
     private:
         EventTask baseEvent;

--- a/include/pmacc/eventSystem/transactions/TransactionManager.cpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.cpp
@@ -72,12 +72,12 @@ namespace pmacc
         transactions.top().operation(op);
     }
 
-    EventStream* TransactionManager::getEventStream(ITask::TaskType op)
+    Queue* TransactionManager::getComputeDeviceQueue(ITask::TaskType op)
     {
         if(transactions.size() == 0)
             throw std::runtime_error("Calling startOperation on empty transaction stack is not allowed");
 
-        return transactions.top().getEventStream(op);
+        return transactions.top().getComputeDeviceQueue(op);
     }
 
     EventTask TransactionManager::setTransactionEvent(const EventTask& event)

--- a/include/pmacc/eventSystem/transactions/TransactionManager.hpp
+++ b/include/pmacc/eventSystem/transactions/TransactionManager.hpp
@@ -76,7 +76,7 @@ namespace pmacc
          */
         EventTask getTransactionEvent();
 
-        EventStream* getEventStream(ITask::TaskType op);
+        Queue* getComputeDeviceQueue(ITask::TaskType op);
 
         static TransactionManager& getInstance()
         {

--- a/include/pmacc/exec/KernelLauncher.tpp
+++ b/include/pmacc/exec/KernelLauncher.tpp
@@ -104,7 +104,7 @@ namespace pmacc::exec::detail
             auto const kernelTask
                 = ::alpaka::createTaskKernel<Acc<T_dim>>(workDiv, m_kernel, std::forward<T_Args>(args)...);
 
-            auto queue = taskKernel->getCudaStream();
+            auto queue = taskKernel->getAlpakaQueue();
 
             ::alpaka::enqueue(queue, kernelTask);
 

--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.tpp
@@ -70,7 +70,7 @@ namespace pmacc
             (uint8_t*) deviceHeapInfo.p,
             manager::Device<ComputeDevice>::get().current(),
             alpakaBufferSize);
-        auto alpakaStream = pmacc::eventSystem::getEventStream(ITask::TASK_DEVICE)->getCudaStream();
+        auto alpakaStream = pmacc::eventSystem::getComputeDeviceQueue(ITask::TASK_DEVICE)->getAlpakaQueue();
         alpaka::memcpy(alpakaStream, *hostBuffer, devView, alpakaBufferSize);
         alpaka::wait(alpakaStream);
     }


### PR DESCRIPTION
- rename `Stream` into `Queue`
- rename `AccStream` to `ComputeDeviceQueue`
- rename `AlpakaEventType` to `ComputeDeviceEvent`
- rename `CudaEventHandle` to `ComputeEventHandle`
- rename `CudaEvent` to `ComputeEvent`


This PR is not changing the logic it is only renaming things.