### PR TITLE
openPMD: add parameter `particleIOChunkSize`

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -225,7 +225,8 @@ TBG_openPMD="--openPMD.period 100   \
              --openPMD.file simOutput \
              --openPMD.ext bp \
              --openPMD.json '{ \"adios2\": { \"engine\": { \"type\": \"file\", \"parameters\": { \"BufferGrowthFactor\": \"1.2\", \"InitialBufferSize\": \"2GB\" } } } }' \
-             --openPMD.range 0:100,:,:"
+             --openPMD.range 0:100,:,: \
+             --openPMD.particleIOChunkSize 10240"
 # Further control over the backends used in the openPMD plugins is available
 # through the mechanisms exposed by the openPMD API:
 # * environment variables

--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -134,6 +134,12 @@ PIConGPU command line option          description
 ``--checkpoint.openPMD.jsonRestart``  Set backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint.
 ``--openPMD.dataPreparationStrategy`` Strategy for preparation of particle data ('doubleBuffer' or 'mappedMemory'). Aliases 'adios' and 'hdf5' may be used respectively.
 ``--openPMD.toml``                    Alternatively configure the openPMD plugin via a TOML file (see below).
+``--openPMD.particleIOChunkSize``     Particle data will be written in chunks of the given size. unit: MiB
+                                      The memory footprint on the host side is reduced compared to writing all particles with one write call.
+                                      Currently the memory footprint is only reduced bp5 is used, HDF5 and bp4 does not support partial data dump.
+                                      If your system host memory is small compared to the accelerator memory you should use ``--openPMD.dataPreparationStrategy mappedMemory`` to have
+                                      a smaller host memory footprint.
+                                      The memory footprint required to dump fields will not be affected by this parameter.
 ===================================== ====================================================================================================================================================
 
 .. note::
@@ -254,6 +260,7 @@ As soon as the openPMD plugin is compiled in, one extra ``mallocMC`` heap for th
 During I/O, particle attributes are allocated one after another.
 Using ``--openPMD.dataPreparationStrategy doubleBuffer`` (default) will require at least 2x the GPU memory on the host side.
 For a smaller host side memory footprint (<< GPU main memory) pick ``--openPMD.dataPreparationStrategy mappedMemory``.
+By using additional to the mapped memory strategy ``--openPMD.particleIOChunkSize N`` you can reduce the memory footprint for particle IO to less than ``2*N`` MiB.
 
 Additional Tools
 ^^^^^^^^^^^^^^^^

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -17,6 +17,7 @@ namespace picongpu::openPMD
         std::string fileName; /* Name of the openPMDSeries, excluding the extension */
         std::string fileInfix;
         std::string fileExtension; /* Extension of the file name */
+        std::string particleIOChunkSizeString;
         std::string dataPreparationStrategyString;
         std::string jsonConfigString;
         std::string rangeString;

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -93,6 +93,9 @@ namespace picongpu
 
             Window window; /* window describing the volume to be dumped */
 
+            //! defines the maximal particle data chunk size
+            size_t particleIOChunkSize = 1024llu * 10llu;
+
             /** Offset from local moving window to local domain.
              *  Value for all components will always be >= 0.
              */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -250,6 +250,11 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                    "respectively.",
                    "doubleBuffer"};
 
+            plugins::multi::Option<std::string> particleIOChunkSize
+                = {"particleIOChunkSize",
+                   "Particle data will be written in chunks of the given size. unit: MiB",
+                   "10240"};
+
             /*
              * The openPMD plugin is used as a normal I/O plugin as well as for
              * the creation of checkpoints.
@@ -339,7 +344,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 {&jsonRestartConfig,
                  std::nullopt,
                  &PluginParameters::jsonRestartParams,
-                 ApplyParameter::OnlyInCheckpoint}};
+                 ApplyParameter::OnlyInCheckpoint},
+                {&particleIOChunkSize, "particleIOChunkSize", &PluginParameters::particleIOChunkSizeString}};
 
             std::vector<toml::TomlParameter> tomlParameters()
             {
@@ -653,6 +659,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             /* window selection */
             auto simulationOutputWindow = MovingWindow::getInstance().getWindow(currentStep);
             window = plugins::misc::intersectRangeWithWindow(subGrid, simulationOutputWindow, rangeString);
+            particleIOChunkSize = std::stoull(particleIOChunkSizeString);
         }
 
         /** Writes simulation data to openPMD.

--- a/include/picongpu/plugins/openPMD/writer/misc.hpp
+++ b/include/picongpu/plugins/openPMD/writer/misc.hpp
@@ -1,0 +1,216 @@
+/* Copyright 2014-2023 Rene Widera, Felix Schmitt, Axel Huebl,
+ *                     Alexander Grund, Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/eventSystem/events/kernelEvents.hpp>
+#include <pmacc/mappings/kernel/AreaMapping.hpp>
+#include <pmacc/mappings/kernel/RangeMapping.hpp>
+#include <pmacc/particles/operations/ConcatListOfFrames.hpp>
+#include <pmacc/particles/particleFilter/FilterFactory.hpp>
+#include <pmacc/particles/particleFilter/PositionFilter.hpp>
+
+#include <boost/mpl/placeholders.hpp>
+
+#include <algorithm>
+#include <type_traits> // std::remove_reference_t
+
+namespace picongpu
+{
+    namespace openPMD
+    {
+        struct KernelSuperCellHistogram
+        {
+            template<
+                typename T_Mapping,
+                typename T_Worker,
+                typename T_ParBox,
+                typename T_Filter,
+                typename T_PositionFilter>
+            DINLINE void operator()(
+                T_Worker const& worker,
+                T_ParBox pb,
+                uint32_t* particlesPerSuperCell,
+                T_Filter filter,
+                T_PositionFilter posFilter,
+                T_Mapping mapper) const
+            {
+                DataSpace<simDim> const superCellIdxND(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+
+                PMACC_SMEM(worker, numParticlesInBlock, uint32_t);
+
+                auto onlyMaster = lockstep::makeMaster(worker);
+                onlyMaster([&]() { numParticlesInBlock = 0u; });
+
+                worker.sync();
+
+                auto forEachParticle = pmacc::particles::algorithm::acc::makeForEach(worker, pb, superCellIdxND);
+                if(forEachParticle.hasParticles())
+                {
+                    uint32_t parCount = 0u;
+                    auto accFilter = filter(worker, superCellIdxND - mapper.getGuardingSuperCells());
+                    posFilter.setSuperCellPosition(
+                        (superCellIdxND - mapper.getGuardingSuperCells()) * mapper.getSuperCellSize());
+                    forEachParticle(
+                        [&accFilter, &posFilter, &worker, &parCount](auto const& lockstepWorker, auto& particle)
+                        {
+                            if(accFilter(lockstepWorker, particle) && posFilter(particle))
+                            {
+                                parCount++;
+                            }
+                        });
+
+                    worker.sync();
+                    alpaka::atomicAdd(worker.getAcc(), &numParticlesInBlock, parCount, alpaka::hierarchy::Threads{});
+                }
+
+                worker.sync();
+
+                auto superCellIdx = mapper.superCellIdx(worker.blockDomIdxND());
+                onlyMaster([&]() { particlesPerSuperCell[superCellIdx] = numParticlesInBlock; });
+            }
+        };
+
+        struct ChunkDescription
+        {
+            //! index of the first supercell with particles
+            size_t beginSupercellIdx = 0u;
+            //! index of the supercell behind the last usable supercell
+            size_t endSupercellIdx = 0u;
+            //! number of particles within the range of supercells
+            size_t numberOfParticles = 0u;
+        };
+
+        struct ParticleIoChunkInfo
+        {
+            std::vector<ChunkDescription> ranges;
+            // size of the largest chunk (in number of particles)
+            size_t largestChunk = 0u;
+            // total number of particles on the device
+            size_t totalNumParticles = 0u;
+
+            //! updates
+            void emplace(size_t beginSupercellIdx, size_t endSupercellIdx, size_t numberOfParticles)
+            {
+                ranges.push_back({beginSupercellIdx, endSupercellIdx, numberOfParticles});
+                largestChunk = std::max(largestChunk, numberOfParticles);
+            }
+        };
+
+        /** chunk information required to copy particles to OpenPMD without violating the maximum IO chunk size given
+         * by the user
+         *
+         * @attention In case a single supercell contains more particles than fitting a buffer with the maximum size
+         * given via CLI parameter 'particleIOChunkSize' the maximum will be increased automatically to ensure all
+         * particles can be dumped.
+         *
+         * @param params openPMD plugin parameter (collection class contains nearly every important data for IO)
+         * @param speciedPtr shared pointer to the species which should be dumped
+         * @param particleFilter particle filter to decide which particle is taken into account based on particle
+         * attribute values
+         * @param particleSizeInByte Size of a single particle (in byte) with the attributes used for IO.
+         *                           The size can be different compared to the particle layout used within the
+         *                           simulation.
+         * @return chunk information
+         */
+        template<typename T_IOParameters, typename T_SpeciesPtr, typename T_ParticleFilter>
+        inline ParticleIoChunkInfo createSupercellRangeChunks(
+            T_IOParameters* params,
+            T_SpeciesPtr& speciedPtr,
+            T_ParticleFilter particleFilter,
+            size_t particleSizeInByte)
+        {
+            auto const areaMapper = makeAreaMapper<CORE + BORDER>(*(params->cellDescription));
+            auto rangeMapper = makeRangeMapper(areaMapper);
+
+            // buffer accessible from device and host to store the number of particles within each supercell.
+            auto superCellHistogram = alpaka::allocMappedBufIfSupported<uint32_t, MemIdxType>(
+                manager::Device<HostDevice>::get().current(),
+                manager::Device<ComputeDevice>::get().getPlatform(),
+                MemSpace<DIM1>(rangeMapper.size()).toAlpakaMemVec());
+            uint32_t* histData = alpaka::getPtrNative(superCellHistogram);
+
+            using UsedPositionFilters = mp_list<typename GetPositionFilter<simDim>::type>;
+            using MyParticleFilter = typename FilterFactory<UsedPositionFilters>::FilterType;
+            MyParticleFilter posFilter;
+            posFilter.setWindowPosition(params->localWindowToDomainOffset, params->window.localDimensions.size);
+
+            PMACC_LOCKSTEP_KERNEL(KernelSuperCellHistogram{})
+                .config(rangeMapper.getGridDim(), *speciedPtr)(
+                    speciedPtr->getDeviceParticlesBox(),
+                    histData,
+                    particleFilter,
+                    posFilter,
+                    rangeMapper);
+            eventSystem::getTransactionEvent().waitForFinished();
+
+            // max buffer size in bytes, value is provided as CLI parameter by the user
+            size_t maxBufferSize = params->particleIOChunkSize * 1024u * 1024u;
+
+            log<picLog::INPUT_OUTPUT>("openPMD: Max particle chunk buffer size set by user: %1% MiB")
+                % params->particleIOChunkSize;
+
+            size_t maxAllowedParticlesPerChunk = maxBufferSize / particleSizeInByte;
+            size_t currentChunkSize = 0u;
+
+            ParticleIoChunkInfo particleIoChunkInfo;
+
+            size_t lastBeginSupercellIdx = 0u;
+            // @attention the loop includes the last index, therefore a range check within the body is required
+            for(size_t supercellIdx = 0u; supercellIdx <= rangeMapper.size(); ++supercellIdx)
+            {
+                if(supercellIdx < rangeMapper.size())
+                {
+                    if(histData[supercellIdx] > maxAllowedParticlesPerChunk)
+                    {
+                        size_t increasedParticleChunkSize = histData[supercellIdx];
+                        std::cerr << "Warning: more particles per supercell than we can fit into "
+                                  << (maxAllowedParticlesPerChunk * particleSizeInByte)
+                                  << "byte, chunk limit is increased to "
+                                  << (increasedParticleChunkSize * particleSizeInByte) << " bytes." << std::endl;
+                        maxAllowedParticlesPerChunk = increasedParticleChunkSize;
+                    }
+                    size_t currentDataSizeBytes = currentChunkSize + histData[supercellIdx];
+                    if(currentDataSizeBytes > maxAllowedParticlesPerChunk)
+                    {
+                        particleIoChunkInfo.emplace(lastBeginSupercellIdx, supercellIdx, currentChunkSize);
+                        // start the next chunk
+                        currentChunkSize = histData[supercellIdx];
+                        lastBeginSupercellIdx = supercellIdx;
+                    }
+                    else
+                    {
+                        currentChunkSize += histData[supercellIdx];
+                    }
+                    particleIoChunkInfo.totalNumParticles += histData[supercellIdx];
+                }
+                else if(currentChunkSize != 0u)
+                {
+                    // include all not processed particles within a last chunk
+                    particleIoChunkInfo.emplace(lastBeginSupercellIdx, supercellIdx, currentChunkSize);
+                }
+            }
+
+            return particleIoChunkInfo;
+        }
+    } // namespace openPMD
+} // namespace picongpu

--- a/include/pmacc/mappings/kernel/RangeMapping.hpp
+++ b/include/pmacc/mappings/kernel/RangeMapping.hpp
@@ -1,0 +1,183 @@
+/* Copyright 2024 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "pmacc/dimensions/DataSpace.hpp"
+#include "pmacc/types.hpp"
+
+#include <cstdint>
+
+namespace pmacc
+{
+    /** Mapping from block indices to supercells in the given area for alpaka kernels
+     *
+     * @tparam T_BaseMapper Mapper which should be mapped to a one dimension domain.
+     *                      Supports non contiguous mapper e.g. StrideMapper too.
+     */
+    template<typename T_BaseMapper>
+    class RangeMapping : T_BaseMapper
+    {
+    public:
+        using BaseClass = T_BaseMapper;
+        using BaseClass::getGuardingSuperCells;
+        using BaseClass::getSuperCellSize;
+
+        static constexpr uint32_t Dim = BaseClass::Dim;
+
+        using SuperCellSize = typename BaseClass::SuperCellSize;
+
+        /** constructor
+         *
+         * @param base mapper to be wrapped and linearized
+         * @param begin index (included) of the first elements
+         * @param end index one behind the last valid index, -1 will automaticlally derive the end from the wrapped
+         * mapper
+         */
+        HINLINE RangeMapping(BaseClass const& base, uint32_t const begin, uint32_t const end)
+            : BaseClass(base)
+            , baseGridDim(base.getGridDim())
+            , userDefinedBeginIdx(begin)
+            , userDefinedEndIdx(end)
+        {
+            clampRange();
+        }
+
+        RangeMapping(RangeMapping const&) = default;
+
+        /** Generate grid dimension information for alpaka kernel calls
+         *
+         * A kernel using this mapping must use exactly the returned number of blocks.
+         * The range will automatically clamped to fit into the N-dimensional block range of the wrapped mapper.
+         * To support mapper with dynamic grid dimensions the range e.g. StrideMapper each call to this method is
+         * updating the range.
+         *
+         * @return number of blocks in a grid
+         */
+        HINLINE DataSpace<DIM1> getGridDim()
+        {
+            clampRange();
+            return {size()};
+        }
+
+        /** Number of elements described by the range
+         *
+         * @return  size of the range
+         */
+        HDINLINE uint32_t size() const
+        {
+            return endIdx - beginIdx;
+        }
+
+        /** Supercell index of the first element */
+        HDINLINE uint32_t begin() const
+        {
+            return beginIdx;
+        }
+
+        /** Supercell index of the element behind the last valid element */
+        HDINLINE uint32_t end() const
+        {
+            return endIdx;
+        }
+
+        /** Supercell index of tha last valid element */
+        HDINLINE uint32_t last() const
+        {
+            return endIdx == 0u ? 0u : endIdx - 1u;
+        }
+
+        /** N-dimensional supercell index of the first element */
+        HDINLINE DataSpace<Dim> beginND() const
+        {
+            return pmacc::math::mapToND(baseGridDim, beginIdx);
+        }
+
+        /** N-dimensional supercell index of the element behind the last valid element */
+        HDINLINE DataSpace<Dim> endND() const
+        {
+            return pmacc::math::mapToND(baseGridDim, endIdx);
+        }
+
+        /** N-dimensional supercell index of tha last valid element */
+        HDINLINE DataSpace<Dim> lastND() const
+        {
+            return pmacc::math::mapToND(baseGridDim, last());
+        }
+
+        /** Return index of a supercell to be processed by the given alpaka block
+         *
+         * @param blockIdx alpaka block index
+         * @return mapped SuperCell index including guards
+         */
+        HDINLINE DataSpace<Dim> getSuperCellIndex(const DataSpace<DIM1>& blockIdx) const
+        {
+            auto const blockIdxNDim = pmacc::math::mapToND(baseGridDim, static_cast<int>(beginIdx + blockIdx.x()));
+            return BaseClass::getSuperCellIndex(blockIdxNDim);
+        }
+
+        /** 1-dimensional supercell index */
+        HDINLINE int superCellIdx(DataSpace<DIM1> const& blockIdx) const
+        {
+            return blockIdx.x();
+        }
+
+    private:
+        /** clamp range to valid values based on the wrapped mapper
+         *
+         * Calling this method is updating baseGridDim to the grid dimensions of the wrapped mapper.
+         */
+        HINLINE void clampRange()
+        {
+            /* Update the base grid size in case it is change over time if the mapper instance is used
+             * multiple times e.g. StridingMapping
+             */
+            baseGridDim = BaseClass::getGridDim();
+            uint32_t const baseMapperLast = static_cast<uint32_t>(baseGridDim.productOfComponents());
+            endIdx = userDefinedEndIdx == uint32_t(-1) ? baseMapperLast : userDefinedEndIdx;
+            endIdx = std::min(endIdx, baseMapperLast);
+            beginIdx = std::min(userDefinedBeginIdx, endIdx);
+        }
+
+        DataSpace<Dim> baseGridDim;
+        uint32_t beginIdx = 0u;
+        uint32_t endIdx = 0u;
+        uint32_t const userDefinedBeginIdx = 0u;
+        uint32_t const userDefinedEndIdx = uint32_t(-1);
+    };
+
+    /** Construct an area mapper instance for the given area and description
+     *
+     * @tparam T_area area, a value from type::AreaType or a sum of such values
+     * @tparam T_MappingDescription mapping description type
+     *
+     * @param baseMapper mapper to be wrapped and linearized
+     * @param begin index (included) of the first elements
+     * @param end index one behind the last valid index, -1 will automaticlally derive the end from the wrapped mapper
+     */
+    template<typename T_BaseMapper>
+    HINLINE auto makeRangeMapper(T_BaseMapper baseMapper, uint32_t begin = 0u, uint32_t end = uint32_t(-1))
+    {
+        return RangeMapping(baseMapper, begin, end);
+    }
+
+} // namespace pmacc


### PR DESCRIPTION
# PIConGPU 
Allow defining a chunk size which is used to write particles with multiple write calls instead of a single.
The benefits are that the host memory footprint to write particles with the Adios2 bp5 engine is drastically reduced.
For systems like ORNL Frontier where the amount of GPU memory is equal to the host memory, we can now fill the full GPU memory with particles without running out of memory during the IO.

By default `particleIOChunkSize` is set to 10 GiB which is a reasonable value that our data chunks are not too small but typically fit for a system with a low amount of host memory.

Field IO is not affected by this feature.

# PMacc add `RangeMapper`
 - Add a mapper wrapper to map any PMacc mapper to a one dimensional index
    domain. The mapper supports addressing a sub index range of the wrapped
    mapping domain.

- [x] ~~run test on frontier~~ Currently it is not possible to get a job on Frontier. Never the less restarting is not possible because we have the same memory issue when restarting a simulation. This will be addressed in a separate PR.
- [x] hdf5/bp4 and bp5 test on our dev server (restart from a chunked checkpoint)