### PR TITLE
remove CONST_VECTOR from OnePositionParameter

### DIFF
--- a/docs/source/usage/workflows/probeParticles.rst
+++ b/docs/source/usage/workflows/probeParticles.rst
@@ -62,23 +62,33 @@ and add it to ``VectorAllSpecies``:
 
 .. code-block:: cpp
 
-   CONST_VECTOR(
-       float_X,
-       3,
-       InCellOffset,
-       /* each x, y, z in-cell position component
-        * in range [0.0, 1.0) */
-       0.0,
-       0.0,
-       0.0
-   );
-   struct OnePositionParameter
-   {
-       static constexpr uint32_t numParticlesPerCell = 1u;
-       const InCellOffset_t inCellOffset;
-   };
+    namespace startPosition
+    {
+        //! Configuration of initial in-cell particle position
+        struct OnePositionParameter
+        {
+            /** Maximum number of macro-particles per cell during density profile evaluation.
+             *
+             * Determines the weighting of a macro particle as well as the number of
+             * macro-particles which sample the evolution of the particle distribution
+             * function in phase space.
+             *
+             * unit: none
+             */
+            static constexpr uint32_t numParticlesPerCell = <PARTICLES_PER_CELL_TO_SPAWN>;
 
-   using OnePosition = OnePositionImpl< OnePositionParameter >;
+            /** each x, y, z in-cell position component in range [0.0, 1.0)
+             *
+             * @details in 2D the last component is ignored
+             */
+            static constexpr auto inCellOffset = float3_X(0., 0., 0.);
+        };
+
+        /** Definition of OnePosition start position functor that
+         * places macro-particles at the initial in-cell position defined above.
+         */
+        using OnePosition = OnePositionImpl<OnePositionParameter>;
+    } // namespace startPosition
 
 * ``speciesInitialization.param``: initialize particles for the probe just as with regular particles
 

--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -203,21 +203,10 @@ namespace picongpu
             using Quiet = QuietImpl<QuietParam>;
 
 
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
+            /** Configuration of initial in-cell particle position
              *
              * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
              */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
             struct OnePositionParameter
             {
                 /** Maximum number of macro-particles per cell during density profile evaluation.
@@ -230,7 +219,11 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of OnePosition start position functor that
              * places macro-particles at the initial in-cell position defined above.

--- a/include/picongpu/particles/startPosition/OnePositionImpl.def
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.def
@@ -46,8 +46,8 @@ namespace picongpu
              * All macro particles are set to the same in cell position defined in
              * T_ParamClass.
              *
-             * @tparam T_ParamClass Parameter class with off `InCellOffset` defined as
-             *                      CONST_VECTOR of 3 float_X [0.0, 1.0).
+             * @tparam T_ParamClass Parameter class with off `InCellOffset` defined as static constexpr float3_X
+             *                      with each component in [0.0, 1.0).
              */
             template<typename T_ParamClass>
             using OnePositionImpl = generic::Free<acc::OnePositionImpl<T_ParamClass>>;

--- a/include/picongpu/particles/startPosition/OnePositionImpl.hpp
+++ b/include/picongpu/particles/startPosition/OnePositionImpl.hpp
@@ -28,6 +28,7 @@
 
 namespace picongpu::particles::startPosition::acc
 {
+    //! @details shrinks T_ParamClass::inCellOffset to correct length for simDim
     template<typename T_ParamClass>
     struct OnePositionImpl
     {
@@ -42,7 +43,8 @@ namespace picongpu::particles::startPosition::acc
         template<typename T_Particle, typename... T_Args>
         HDINLINE void operator()(T_Particle& particle, T_Args&&...)
         {
-            particle[position_] = T_ParamClass{}.inCellOffset.template shrink<simDim>();
+            constexpr auto initialPosition = T_ParamClass::inCellOffset;
+            particle[position_] = initialPosition.template shrink<simDim>();
 
             // set the weighting attribute if the particle species has it
             constexpr bool hasWeighting

--- a/share/picongpu/examples/Bunch/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/particle.param
@@ -97,22 +97,10 @@ namespace picongpu
             /** Definition of start position functor that randomly distributes macro-particles within a cell. */
             using Random = RandomImpl<RandomParameter>;
 
-
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
+            /** Configuration of initial in-cell particle position
              *
              * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
              */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
             struct OnePositionParameter
             {
                 /** Maximum number of macro-particles per cell during density profile evaluation.
@@ -125,13 +113,16 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of OnePosition start position functor that
              * places macro-particles at the initial in-cell position defined above.
              */
             using OnePosition = OnePositionImpl<OnePositionParameter>;
-
         } // namespace startPosition
     } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/particle.param
@@ -78,22 +78,10 @@ namespace picongpu
             /** Definition of start position functor that randomly distributes macro-particles within a cell. */
             using Random = RandomImpl<RandomParameter>;
 
-
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
+            /** Configuration of initial in-cell particle position
              *
              * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
              */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
             struct OnePositionParameter
             {
                 /** Maximum number of macro-particles per cell during density profile evaluation.
@@ -106,7 +94,11 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = 1u;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of OnePosition start position functor that
              * places macro-particles at the initial in-cell position defined above.

--- a/share/picongpu/examples/SingleParticleTest/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/SingleParticleTest/include/picongpu/param/particle.param
@@ -65,21 +65,10 @@ namespace picongpu
 
         namespace startPosition
         {
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
+            /** Configuration of initial in-cell particle position
              *
              * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
              */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
             struct OnePositionParameter
             {
                 /** Maximum number of macro-particles per cell during density profile evaluation.
@@ -92,7 +81,11 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = 1u;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of OnePosition start position functor that
              * places macro-particles at the initial in-cell position defined above.

--- a/share/picongpu/examples/atomicPhysics/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/atomicPhysics/include/picongpu/param/particle.param
@@ -65,22 +65,10 @@ namespace picongpu
             /** Definition of start position functor that randomly distributes macro-particles within a cell. */
             using Random = RandomImpl<RandomParameter>;
 
-
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
+            /** Configuration of initial in-cell particle position
              *
              * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
              */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
             struct OnePositionParameter
             {
                 /** Maximum number of macro-particles per cell during density profile evaluation.
@@ -93,7 +81,11 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = 1u;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of OnePosition start position functor that
              * places macro-particles at the initial in-cell position defined above.

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
@@ -124,21 +124,7 @@ namespace picongpu
 
         namespace startPosition
         {
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
-             *
-             * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
-             */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
+            //! Define initial in-cell particle position used as parameter in OnePosition functor.
             template<uint32_t numParticles>
             struct OnePositionParam
             {
@@ -152,7 +138,11 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = numParticles;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of start position functor that
              * places macro-particles at the initial in-cell position defined above.

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
@@ -105,21 +105,10 @@ namespace picongpu
 
         namespace startPosition
         {
-            /** Define initial in-cell particle position used as parameter in OnePosition functor.
+            /** Configuration of initial in-cell particle position
              *
              * Here, macro-particles sit directly in lower corner of the cell.
-             *
-             * This defines the type InCellOffset_t
-             * where every instance of this type has the preset values defined here.
              */
-            CONST_VECTOR(
-                float_X,
-                3,
-                InCellOffset,
-                /* each x, y, z in-cell position component in range [0.0, 1.0) */
-                0.0,
-                0.0,
-                0.0);
             template<uint32_t numParticles>
             struct OnePositionParam
             {
@@ -133,7 +122,11 @@ namespace picongpu
                  */
                 static constexpr uint32_t numParticlesPerCell = numParticles;
 
-                const InCellOffset_t inCellOffset;
+                /** each x, y, z in-cell position component in range [0.0, 1.0)
+                 *
+                 * @details in 2D the last component is ignored
+                 */
+                static constexpr auto inCellOffset = float3_X(0., 0., 0.);
             };
             /** Definition of start position functor that
              * places macro-particles at the initial in-cell position defined above.


### PR DESCRIPTION
change from old `CONST_VECTOR` for specifying the initial particle position in the template parameter for the OnePosition startPosition functor to the new `constexpr float3_X` compile time specification.

This breaks old setups, trying to compile a setup using `CONST_VECTOR` will give the following error:
```bash
... picongpu/include/picongpu/../picongpu/particles/startPosition/OnePositionImpl.hpp(45): error: a nonstatic member reference must be relative to a specific object
              constexpr auto initialPosition = T_ParamClass::inCellOffset;
```

To update a setup, replace in `particle.param` your definition of the OnePositionParam, something like the following,
```C++
CONST_VECTOR(
    float_X,
    3,
    InCellOffset,
    /* each x, y, z in-cell position component in range [0.0, 1.0) */
    0.0,
    0.0,
    0.0);
struct OnePositionParam
{
    static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;

    const InCellOffset_t inCellOffset;
};
```
with an updated version along the lines of this
```C++
struct OnePositionParam
{
    static constexpr uint32_t numParticlesPerCell = TYPICAL_PARTICLES_PER_CELL;

    static constexpr auto inCellOffset = float3_X(0., 0., 0.);
};
```
