### PR TITLE
custom user input in PyPIConGPU

### DIFF
--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -454,6 +454,9 @@ class Simulation(picmistandard.PICMI_Simulation):
             # explictly disable laser (as required by pypicongpu)
             s.laser = None
 
+        # custom user input must always be set by the user on PyPIConGPU level
+        s.custom_user_input = None
+
         # resolve electrons
         self.__resolve_electrons()
 

--- a/lib/python/picongpu/pypicongpu/__init__.py
+++ b/lib/python/picongpu/pypicongpu/__init__.py
@@ -12,6 +12,7 @@ from . import solver
 from . import species
 from . import util
 from . import output
+from . import customuserinput
 
 __all__ = [
     "Simulation",
@@ -23,6 +24,7 @@ __all__ = [
     "species",
     "util",
     "grid",
+    "customuserinput",
 ]
 
 # note: put down here b/c linter complains if imports are not at top

--- a/lib/python/picongpu/pypicongpu/customuserinput.py
+++ b/lib/python/picongpu/pypicongpu/customuserinput.py
@@ -1,0 +1,62 @@
+"""
+This file is part of the PIConGPU.
+Copyright 2024 PIConGPU contributors
+Authors: Brian Edward Marre
+License: GPLv3+
+"""
+
+from .rendering import RenderedObject
+
+import typeguard
+import typing
+
+
+class CustomUserInput(RenderedObject):
+    """
+    container for easy passing of additional input as dict from user script to rendering context of simulation input
+
+    if additional
+    """
+
+    tags: typing.Optional[list[str]] = None
+    """
+    list of tags
+    """
+
+    rendering_context: typing.Optional[dict[str, typing.Any]] = None
+    """
+    accumulation variable of added dictionaries
+    """
+
+    def __checkDoesNotChangeExistingKeyValues(self, firstDict, secondDict):
+        for key in firstDict.keys():
+            if (key in secondDict) and (firstDict[key] != secondDict[key]):
+                raise ValueError("Key " + str(key) + " exist already, and specified values differ.")
+
+    @typeguard.typechecked
+    def addToCustomInput(self, custom_input: dict[str, typing.Any], tag: str):
+        """
+        append dictionary to custom input dictionary
+        """
+        if tag == "":
+            raise ValueError("tag must not be empty string!")
+        if not custom_input:
+            raise ValueError("custom input must contain at least 1 key")
+
+        if (self.tags is None) and (self.rendering_context is None):
+            self.tags = [tag]
+            self.rendering_context = custom_input
+        else:
+            self.__checkDoesNotChangeExistingKeyValues(self.rendering_context, custom_input)
+
+            if tag in self.tags:
+                raise ValueError("duplicate tag!")
+
+            self.rendering_context.update(custom_input)
+            self.tags.append(tag)
+
+    def get_tags(self) -> list[str]:
+        return self.tags
+
+    def _get_serialized(self) -> dict:
+        return self.rendering_context

--- a/share/picongpu/pypicongpu/schema/customrenderingcontext.CustomRenderingContext.json
+++ b/share/picongpu/pypicongpu/schema/customrenderingcontext.CustomRenderingContext.json
@@ -1,0 +1,19 @@
+{
+    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customrenderingcontext.CustomRenderingContext",
+    "description": "additional input provided by user directly to the PyPIConGPU simulation object for use in custom templates",
+    "type": "object",
+    "properties": {
+        "tags":{
+            "description": "list of unique strings identifying the version/content of the custom input",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1
+        }
+    },
+    "required": [
+        "tags"
+        ],
+    "unevaluatedProperties": true
+}

--- a/share/picongpu/pypicongpu/schema/customuserinput.CustomUserInput.json
+++ b/share/picongpu/pypicongpu/schema/customuserinput.CustomUserInput.json
@@ -1,0 +1,6 @@
+{
+    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customuserinput.CustomUserInput",
+    "description": "container class for passing dictionaries from the user script to the PyPIConGPU renderer",
+    "type": "object",
+    "unevaluatedProperties": true
+}

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -53,6 +53,15 @@
                     ]
                 }
             }
+        },
+        "customuserinput":{
+            "anyOf": [
+            {
+                "type": "null"
+            },
+            {
+                "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customrenderingcontext.CustomRenderingContext"
+            }]
         }
     },
     "required": [
@@ -61,7 +70,8 @@
         "typical_ppc",
         "solver",
         "grid",
-        "laser"
+        "laser",
+        "customuserinput"
     ],
     "unevaluatedProperties": false
 }

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -47,6 +47,7 @@ class TestSimulation(unittest.TestCase):
         sim.grid.boundary_condition_y = pypicongpu.grid.BoundaryCondition.PERIODIC
         sim.grid.boundary_condition_z = pypicongpu.grid.BoundaryCondition.PERIODIC
         sim.laser = None
+        sim.custom_user_input = None
         sim.solver = pypicongpu.solver.YeeSolver()
         sim.init_manager = pypicongpu.species.InitManager()
 

--- a/test/python/picongpu/quick/pypicongpu/__init__.py
+++ b/test/python/picongpu/quick/pypicongpu/__init__.py
@@ -7,3 +7,4 @@ from .species import *  # pyflakes.ignore
 from .output import *  # pyflakes.ignore
 from .rendering import *  # pyflakes.ignore
 from .laser import *  # pyflakes.ignore
+from .customuserinput import *  # pyflakes.ignore

--- a/test/python/picongpu/quick/pypicongpu/customuserinput.py
+++ b/test/python/picongpu/quick/pypicongpu/customuserinput.py
@@ -1,0 +1,70 @@
+"""
+This file is part of the PIConGPU.
+Copyright 2024 PIConGPU contributors
+Authors: Brian Edward Marre
+License: GPLv3+
+"""
+
+from picongpu.pypicongpu import customuserinput
+
+import unittest
+
+
+class TestCustomUserInput(unittest.TestCase):
+    # test standard workflow is possible and data+tag is passed on
+    def test_standard_case_works(self):
+        c = customuserinput.CustomUserInput()
+        data1 = {"test_data_1": 1}
+        data2 = {"test_data_2": 2}
+
+        tag1 = "tag_1"
+        tag2 = "tag_2"
+
+        c.addToCustomInput(data1, tag1)
+        c.addToCustomInput(data2, tag2)
+
+        rendering_context = c.get_rendering_context()
+
+        self.assertEqual(rendering_context["test_data_1"], 1)
+        self.assertEqual(rendering_context["test_data_2"], 2)
+
+        tags = c.get_tags()
+        self.assertIn(tag1, tags)
+        self.assertIn(tag2, tags)
+
+    def test_wrong_tags(self):
+        c = customuserinput.CustomUserInput()
+
+        data1 = {"test_data_1": 1}
+        data2 = {"test_data_2": 2}
+
+        tag1_1 = "tag_1"
+        tag1_2 = "tag_1"
+
+        # first add must succeed
+        c.addToCustomInput(data1, tag1_1)
+        with self.assertRaisesRegex(ValueError, "duplicate tag!"):
+            c.addToCustomInput(data2, tag1_2)
+
+        with self.assertRaisesRegex(ValueError, "tag must not be empty"):
+            c.addToCustomInput(data2, "")
+
+    def test_wrong_custom_input(self):
+        c = customuserinput.CustomUserInput()
+
+        data1_1 = {"test_data_1": 1}
+        data1_2 = {"test_data_1": 2}
+        empty_data = {}
+
+        tag1 = "tag_1"
+        tag2 = "tag_2"
+
+        with self.assertRaisesRegex(ValueError, "custom input must contain at least 1 key"):
+            c.addToCustomInput(empty_data, tag1)
+
+        c.addToCustomInput(data1_1, tag1)
+        with self.assertRaisesRegex(ValueError, "Key test_data_1 exist already, and specified values differ."):
+            c.addToCustomInput(data1_2, tag2)
+
+        # test same key with same value is allowed
+        c.addToCustomInput(data1_1, tag2)


### PR DESCRIPTION
Adds the possibility to add custom data to a PyPIConGPU simulation object, either via
- container object `picongpu.pypicongpu.customuserinput.CustomUserInput`
- user script defined class inheriting from `picongpu.pypicongpu.rendering.RenderedObject` and implementing `_get_serialized(self) -> dict` and `get_tags(self) -> list[str]`.

**Custom data may be referenced in custom templates to influence picongpu input generation and/or written to future simulation data bases, searchable by "tag".**

Example for using `picongpu.pypicongpu.customuserinput.CustomUserInput`
```python

from picongpu.pypicongpu import customuserinput

#(either by hand or generated from PICMI simulation)
simulation : picongpu.pypicongpu.simulation.Simulation = ... 

i_1 = customuserinput.CustomUserInput()
i_2 = customuserinput.CustomUserInput()

i_1.addToCustomInput({"test_data_1": 1}, "tag_1")
i_2.addToCustomInput({"test_data_2": 2}, "tag_2")

simulation.add_custom_user_input(i_1)
simulation.add_custom_user_input(i_2)

---------------------------------------------------------

simulation.get_rendering_context()["customuserinput"] == {"test_data_1": 1, "test_data_2": 2, "tags" : ["tag_1", "tag_2"]}
```
