### PR TITLE
fix CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,8 @@ variables:
 
 .base_generate-reduced-matrix:
   stage: generate
+  variables:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
   script:
     - apt update
     - apt install -y python3-pip
@@ -35,6 +37,8 @@ variables:
 pull-request-validation:
   stage: validate
   image: ubuntu:focal
+  variables:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
   script:
     - apt update
     - apt install -y -q git curl wget python3 python3-pip
@@ -143,6 +147,8 @@ picongpu-unittest-compile-reduced-matrix:
 pypicongpu-generate-full-matrix:
   stage: generate
   image: ubuntu:22.04
+  variables:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
   script:
     - apt update
     - apt install -y python3 python3-pip
@@ -169,6 +175,7 @@ pypicongpu-compiling-test:
   stage: test
   extends: .base_pypicongpu_compile_test
   variables:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
     CI_CONTAINER_NAME: 'ubuntu20.04'
     PYTHON_VERSION: '3.11.*'
     CXX_VERSION: 'g++-11'


### PR DESCRIPTION
The CI is failing with

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
...
```

when installing packages with pip on new ubuntu versions. I workaround is to pass the parameter `--break-system-packages` to pip. A more clean way would be to use python environments, which is not part of this PR.