### PR TITLE
Sliced writing fixes

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -480,6 +480,9 @@ namespace picongpu
                             globalNumParticles,
                             myParticleOffset + particleOffset);
 
+                        log<picLog::INPUT_OUTPUT>("openPMD: flush particle records for %1%, dumping round %2%")
+                            % T_SpeciesFilter::getName() % dumpIteration;
+
                         params->openPMDSeries->flush(PreferredFlushTarget::Disk);
 
                         log<picLog::INPUT_OUTPUT>("openPMD: (end) write particle records for %1%, dumping round %2%")

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -436,6 +436,14 @@ namespace picongpu
 
                     auto hostFrame = strategy->malloc(T_SpeciesFilter::getName(), particleIoChunkInfo.largestChunk);
 
+                    {
+                        meta::ForEach<
+                            typename NewParticleDescription::ValueTypeSeq,
+                            openPMD::InitParticleAttribute<boost::mpl::_1>>
+                            initParticleAttributes;
+                        initParticleAttributes(params, particleSpecies, basename, globalNumParticles);
+                    }
+
                     /** Offset within our global chunk where we are allowed to write particles too.
                      *  The offset is updated each dumping iteration.
                      */


### PR DESCRIPTION
- [x] Merge #4882 first

The current implementation of sliced writing re-initializes the components over and over again for each component. For the attributes, that's just duplicate work, but additionally the array sizes get "changed" over and over again (to the same size as before). This might lead to trouble in backends that have restricted support for extensible arrays.

HOWEVER, this PR runs into a bug on the current dev branch of the openPMD-api, probably introduced by https://github.com/openPMD/openPMD-api/pull/1598 and fixed by https://github.com/openPMD/openPMD-api/pull/1615. Will need to do more testing to confirm this. The latest release seems unaffected, but please don't merge just yet.

Apart from this, to workaround another parallel flushing bug that René discovered, I should probably work sth in to make the iteration artificially dirty anyway.

- [x] see above, find a way to make this all work nicely
