### PR TITLE
update cuda_memtest subtree

### DIFF
--- a/.github/workflows/dependencies/nvcc11.sh
+++ b/.github/workflows/dependencies/nvcc11.sh
@@ -13,18 +13,16 @@ sudo apt-get install -y \
     pkg-config          \
     wget
 
-sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
-sudo apt-key add 7fa2af80.pub
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
-    | sudo tee /etc/apt/sources.list.d/cuda.list
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-0 \
-    cuda-compiler-11-0           \
-    cuda-cupti-dev-11-0          \
-    cuda-minimal-build-11-0      \
-    cuda-nvml-dev-11-0
+    cuda-command-line-tools-11-7 \
+    cuda-compiler-11-7           \
+    cuda-cupti-dev-11-7          \
+    cuda-minimal-build-11-7      \
+    cuda-nvml-dev-11-7
 sudo ln -s cuda-11.0 /usr/local/cuda
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,13 +9,14 @@ jobs:
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_gcc_nvcc:
     name: NVCC 11.0.2 SP [Linux]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - name: install dependencies
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Install dependencies
       run: |
         .github/workflows/dependencies/nvcc11.sh
-    - name: build
+    - name: Build
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,11 @@
 
 cmake_minimum_required(VERSION 3.16.0)
 
-
 ################################################################################
 # Project
 ################################################################################
+
+include(CheckLanguage) # check for CUDA/HIP language support
 
 project(CUDA_memtest LANGUAGES CXX)
 
@@ -70,15 +71,26 @@ else()
     # Find HIP
     ################################################################################
     # supported HIP version range
-    set(CUDA_MEMTEST_HIP_MIN_VER 4.0)
-    set(CUDA_MEMTEST_HIP_MAX_VER 5.0)
-    find_package(hip "${CUDA_MEMTEST_HIP_MAX_VER}")
-    if(NOT TARGET hip)
-        message(STATUS "Could not find HIP ${CUDA_MEMTEST_HIP_MAX_VER}. Now searching for HIP ${CUDA_MEMTEST_HIP_MIN_VER}")
-        find_package(hip "${CUDA_MEMTEST_HIP_MIN_VER}")
-    endif()
+    check_language(HIP)
 
-    if(NOT TARGET hip)
+    if(CMAKE_HIP_COMPILER)
+        enable_language(HIP)
+        find_package(hip REQUIRED)
+
+        set(CUDA_MEMTEST_HIP_MIN_VER 5.2)
+        set(CUDA_MEMTEST_HIP_MAX_VER 6.1)
+
+        # construct hip version only with major and minor level
+        # cannot use hip_VERSION because of the patch level
+        # 6.0 is smaller than 6.0.1234, so CUDA_MEMTEST_HIP_MAX_VER would have to be defined with a large patch level or
+        # the next minor level, e.g. 6.1, would have to be used.
+        set(_hip_MAJOR_MINOR_VERSION "${hip_VERSION_MAJOR}.${hip_VERSION_MINOR}")
+
+        if(${_hip_MAJOR_MINOR_VERSION} VERSION_LESS ${CUDA_MEMTEST_HIP_MIN_VER} OR ${_hip_MAJOR_MINOR_VERSION} VERSION_GREATER ${CUDA_MEMTEST_HIP_MAX_VER})
+            message(WARNING "HIP ${_hip_MAJOR_MINOR_VERSION} is not official supported by cuda_memtest. Supported versions: ${CUDA_MEMTEST_HIP_MIN_VER} - ${CUDA_MEMTEST_HIP_MAX_VER}")
+        endif()
+
+    else()
         message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")
     endif()
 endif()
@@ -135,6 +147,7 @@ if(CUDA_MEMTEST_BACKEND STREQUAL "cuda")
 else()
     target_link_libraries(cuda_memtest PRIVATE hip::host)
     target_link_libraries(cuda_memtest PRIVATE hip::device)
+    target_compile_definitions(cuda_memtest PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:__HIP_PLATFORM_AMD__>")
     target_compile_definitions(cuda_memtest PRIVATE "ENABLE_NVML=0")
 endif()
 
@@ -162,7 +175,7 @@ endif()
 
 option(CUDA_MEMTEST_RELEASE "disable all runtime asserts" ON)
 if(CUDA_MEMTEST_RELEASE)
-    target_compile_definitions(cuda_memtest PRIVATE -DNDEBUG)
+    target_compile_definitions(cuda_memtest PRIVATE NDEBUG)
 endif(CUDA_MEMTEST_RELEASE)
 
 ################################################################################

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -149,7 +149,7 @@ CUDA
 
 ROCm/HIP
 """"""""
-- `5.1+ <https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html>`_
+- `5.2+ <https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html>`_
 - required if you want to run on AMD GPUs
 - *Debian/Ubuntu:*
   - ``export ROCM_VER=5.5.0``

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -226,7 +226,6 @@ compilers.append(hip_clang_compilers)
 # tuple with two components (backend name, version)
 # version is only required for the cuda backend
 backends = [
-    ("hip", 5.1),
     ("hip", 5.2),
     ("hip", 5.3),
     ("hip", 5.4),


### PR DESCRIPTION
- Update to latest [cuda_memtest](https://github.com/ComputationalRadiationPhysics/cuda_memtest/tree/345628a62861b107c8c62bac6ae8fafff7f65abf) with support for ROCm 6.

```
GIT_AUTHOR_NAME="Third Party" GIT_AUTHOR_EMAIL="picongpu@hzdr.de" \
  git subtree pull --prefix thirdParty/cuda_memtest \
  git@github.com:ComputationalRadiationPhysics/cuda_memtest.git dev --squash
```

- remove HIP 5.1 from the CI because cuda_memtest is no supporting it anymore