### PR TITLE
openPMD extension: fix broken C++ syntax

### DIFF
--- a/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
+++ b/include/picongpu/plugins/common/openPMDDefaultExtension.hpp
@@ -84,8 +84,8 @@ namespace picongpu
                 }
                 else
                 {
-                    return "bp4"
-                };
+                    return "bp4";
+                }
 #    else
                 /*
                  * Engine available and supported in all supported versions of ADIOS2 and openPMD-api


### PR DESCRIPTION
Bug introduced with #4883.
The bug is not detected by the CI because the code path depends on the ADIOS2 version.