### PR TITLE
CI: add FFTW and enforce usage

### DIFF
--- a/include/picongpu/plugins/shadowgraphy/Shadowgraphy.hpp
+++ b/include/picongpu/plugins/shadowgraphy/Shadowgraphy.hpp
@@ -121,18 +121,18 @@ namespace picongpu
 
                     void validateOptions() override
                     {
-                        for(int i = 0; i < optionStart.size(); ++i)
+                        for(uint32_t i = 0; i < optionStart.size(); ++i)
                         {
                             if(optionStart.get(i) < 0)
                                 throw std::runtime_error(
                                     name + ": plugin must start after the simulation was started");
                         }
-                        for(int i = 0; i < optionDuration.size(); ++i)
+                        for(uint32_t i = 0; i < optionDuration.size(); ++i)
                         {
                             if(optionDuration.get(i) <= 0)
                                 throw std::runtime_error(name + ": plugin duration must be larger than 0");
                         }
-                        for(int i = 0; i < optionSlicePoint.size(); ++i)
+                        for(uint32_t i = 0; i < optionSlicePoint.size(); ++i)
                         {
                             if((optionSlicePoint.get(i) < 0) || (optionSlicePoint.get(i) > 1.0))
                                 throw std::runtime_error(name + ": the plugin slice point must be between 0 and 1");
@@ -283,7 +283,7 @@ namespace picongpu
                     // Convert currentStep (simulation time-step) into localStep for time domain DFT
                     int localStep = (currentStep - startTime) / params::tRes;
 
-                    bool const dumpFinalData = localStep == (adjustedDuration / params::tRes);
+                    bool const dumpFinalData = localStep == static_cast<int>(adjustedDuration / params::tRes);
                     if(!dumpFinalData)
                     {
                         DataConnector& dc = Environment<>::get().DataConnector();
@@ -357,8 +357,6 @@ namespace picongpu
                     -> std::shared_ptr<HostBuffer<float2_X, DIM2>>
                 {
                     const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
-                    auto globalDomain = subGrid.getGlobalDomain();
-                    auto globalPlaneExtent = globalDomain.size[plane];
 
                     auto localDomainOffset = subGrid.getLocalDomain().offset.shrink<DIM2>(0);
                     auto globalDomainSliceSize = subGrid.getGlobalDomain().size.shrink<DIM2>(0);

--- a/include/picongpu/plugins/shadowgraphy/ShadowgraphyHelper.hpp
+++ b/include/picongpu/plugins/shadowgraphy/ShadowgraphyHelper.hpp
@@ -521,7 +521,7 @@ namespace picongpu
                  *
                  * @return description of return value
                  */
-                auto getFourierBuf(int index)
+                auto getFourierBuf(uint32_t index)
                 {
                     const int nOmegasHalf = numOmegas / 2;
                     auto retBufferF = std::make_shared<HostBuffer<std::complex<float_64>, DIM3>>(
@@ -530,7 +530,7 @@ namespace picongpu
 
                     // The fields are split into 2 parts in the output, because the omega-domain
                     // is not necessarily continuous due to band-pass filters
-                    vec3c* retField;
+                    vec3c* retField = nullptr;
                     if(index <= 1)
                         retField = &ExOmega;
                     else if(index <= 3)
@@ -539,6 +539,9 @@ namespace picongpu
                         retField = &BxOmega;
                     else if(index <= 7)
                         retField = &ByOmega;
+                    else
+                        throw std::runtime_error(
+                            std::string("getFourierBuf() called with unknown index '") + std::to_string(index) + "'");
 
                     for(int i = 0; i < getSizeX(); ++i)
                     {

--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -17,6 +17,7 @@
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
     - source $CI_PROJECT_DIR/share/ci/install/openPMD.sh
+    - source $CI_PROJECT_DIR/share/ci/install/fftw.sh
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -19,6 +19,7 @@
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
     - source $CI_PROJECT_DIR/share/ci/install/openPMD.sh
+    - source $CI_PROJECT_DIR/share/ci/install/fftw.sh
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   interruptible: true
 

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -15,6 +15,7 @@
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
     - source $CI_PROJECT_DIR/share/ci/install/openPMD.sh
+    - source $CI_PROJECT_DIR/share/ci/install/fftw.sh
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   # x86_64 tag is used to get a multi-core CPU for the tests
   tags:

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -26,6 +26,7 @@
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
     - source $CI_PROJECT_DIR/share/ci/install/openPMD.sh
+    - source $CI_PROJECT_DIR/share/ci/install/fftw.sh
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   interruptible: true
 

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -16,6 +16,7 @@
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
     - source $CI_PROJECT_DIR/share/ci/install/openPMD.sh
+    - source $CI_PROJECT_DIR/share/ci/install/fftw.sh
     - $CI_PROJECT_DIR/share/ci/run_tests.sh $PIC_TEST_CASE_FOLDER
   interruptible: true
 

--- a/share/ci/install/fftw.sh
+++ b/share/ci/install/fftw.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+cd $CI_PROJECT_DIR
+
+echo "load/install fftw3"
+
+if ! agc-manager -e fftw3; then
+    apt install -y libfftw3-mpi-dev libfftw3-dev pkg-config
+else
+    FFTW3_BASE_PATH="$(agc-manager -b fftw3)"
+    export CMAKE_PREFIX_PATH=$FFTW3_BASE_PATH:$CMAKE_PREFIX_PATH
+fi

--- a/share/ci/pypicongpu.yml
+++ b/share/ci/pypicongpu.yml
@@ -25,6 +25,7 @@
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - source $CI_PROJECT_DIR/share/ci/bash.profile
     - source $CI_PROJECT_DIR/share/ci/install/openPMD.sh
+    - source $CI_PROJECT_DIR/share/ci/install/fftw.sh
     - source $CI_PROJECT_DIR/share/ci/install/pypicongpu.sh
   tags:
     - cpuonly

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -54,10 +54,10 @@ fi
 if [[ "$PIC_TEST_CASE_FOLDER" =~ .*Empty.* ]] ; then
     # For the empty test case (default param files) we disable all optional dependencies to have at least one check
     # where all dependencies are disabled.
-    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF -DPIC_USE_openPMD=OFF -DPIC_USE_PNGwriter=OFF"
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF -DPIC_USE_openPMD=OFF -DPIC_USE_PNGwriter=OFF -DPIC_USE_FFTW3=OFF"
 else
     # enforce optional dependencies
-    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON"
+    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON -DPIC_USE_FFTW3=ON"
 
     # ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
     if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* ]] ; then


### PR DESCRIPTION
With #4868 FFTW was not added to the CI, therefore the shadography code is not compile tested.

The second commit fixes issues in the Shadowgraphy plugin that were not detected before because the CI was not checking this code due to the missing FFTW3 dependency.

- [x] rebase against #4894, currently the CI should fail because of the bug #4894 is fixing