### PR TITLE
New version of propose_changelog.py

### DIFF
--- a/docs/propose_changelog.py
+++ b/docs/propose_changelog.py
@@ -108,9 +108,13 @@ def pull_requests(gh_key, version):
     )
 
 
+def remove_quotes(string):
+    return string.replace("'", "")
+
+
 def main(version, gh_key=None):
     """Main logic: Download, categorise, print."""
-    print(to_string(categorise(pull_requests(gh_key, version), CATEGORIES)))
+    print(remove_quotes(to_string(categorise(pull_requests(gh_key, version), CATEGORIES))))
 
 
 if __name__ == "__main__":

--- a/docs/propose_changelog.py
+++ b/docs/propose_changelog.py
@@ -11,7 +11,7 @@
 """
 propose_changelog
 
-This little tool queries the Github API for merged pull requests corresponding to the given milestone and labelled by the label "changelog".
+This little tool queries the Github API for merged pull requests corresponding to the given milestone and labelled by the label "changelog" or "affects latest release".
 The obtained list is categorised and printed to stdout. Suggested usage is:
 
 ```bash
@@ -104,7 +104,7 @@ def to_string(categories):
 def pull_requests(gh_key, version):
     """Query the Github API for the kind of PRs we need."""
     return Github(gh_key).search_issues(
-        f'repo:ComputationalRadiationPhysics/picongpu type:pr is:merged milestone:"{version}" label:changelog'
+        f'repo:ComputationalRadiationPhysics/picongpu type:pr is:merged milestone:"{version}" label:changelog,"affects latest release"'
     )
 
 

--- a/docs/propose_changelog.py
+++ b/docs/propose_changelog.py
@@ -1,177 +1,119 @@
 #!/usr/bin/env python
 #
-# Copyright 2017-2023 Axel Huebl
+# Copyright 2024 Julian J. Lenz
 #
 # License: GPLv3+
 #
 # requirements:
 #   PyGithub
-#   curses-menu
+#   pyyaml
 #
+"""
+propose_changelog.py
+
+This little tool queries the Github API for merged pull requests corresponding to the given milestone and labelled by the label "changelog".
+The obtained list is categorised and printed to stdout. Suggested usage is:
+
+```bash
+$ MILESTONE="0.8.0 / Next stable"  # or whatever version you're interested in
+$ GH_PTA="<your Github personal access token>"
+$ python propose_changelog.py "$MILESTONE" $GH_PTA > changelog.txt
+# edit `changelog.txt` according to your needs
+```
+
+For a typical end user running this once or twice a day, the environment variable "GH_PTA" can be empty.
+If you are running this frequently, e.g., during a debug session, you might want to
+[acquire a personal acces token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+and store it in this environment variable. The most restricted one with public repository read access is sufficient.
+
+For adjustments to the categorisation, you can simply change the global variable `CATEGORIES`.
+"""
+
 from github import Github
-from cursesmenu import SelectionMenu
-
-# config
-#          see: https://github.com/settings/tokens
-g = Github("add token with public repo read rights here")
-org = g.get_organization("ComputationalRadiationPhysics")
-repo = org.get_repo("picongpu")
-milestones = repo.get_milestones(sort="asc", state="all")
-
-m_list = list(map(lambda m: m.title, milestones))
-menu = SelectionMenu(m_list, "Select a Milestone")
-menu.show()
-menu.join()
-m_sel = menu.selected_option
-
-print(m_list[m_sel], milestones[m_sel].number)
-
-# get pulls (all pulls are also issues but not vice versa)
-issues = repo.get_issues(state="closed", sort="updated", direction="asc", milestone=milestones[m_sel])
-# Use this in the future, but pagination seems broken in it:
-# search_string = 'repo:ComputationalRadiationPhysics/picongpu ' +
-#                 'type:pr is:merged milestone:"'+milestones[m_sel].title+'"'
-# print(search_string)
-# issues = g.search_issues(search_string)
+import sys
+import yaml
 
 
-# categories
-user = {"input": []}
-bugs = {"core": [], "pmacc": [], "plugin": [], "tools": [], "other": []}
-features = {"core": [], "pmacc": [], "plugin": [], "tools": [], "other": []}
-refactoring = {"core": [], "pmacc": [], "plugin": [], "tools": [], "other": []}
-misc = {"docs": [], "other": []}
+def make_lambda(main_condition, component=None):
+    """Factory for lambdas encoding the categorisation conditions. Only needed to capture the current iteration by value."""
+    if component:
+        return lambda pr: contains_label(pr, f"component: {component}") and main_condition(pr)
 
-for i in issues:
-    # skip issues, only pull requests
-    if i.pull_request is None:
-        continue
+    # Okay, admittedly this is just a lazy way to sneak the 'other' category into this interface:
+    # A careful review would probably request to split this function up and give both of them better names.
+    return lambda pr: all(
+        not contains_label(pr, f"component: {component}") for component in COMPONENTS.values()
+    ) and main_condition(pr)
 
-    # filter out bugs that only appeared in development
-    pr_nr = i.number
-    pr_labels = i.labels
-    pr_labels_names = list(map(lambda x: x.name, pr_labels))
-    pr_url = "https://github.com/ComputationalRadiationPhysics/picongpu/pull/"
-    if "bug" in pr_labels_names:
-        if "affects latest release" not in pr_labels_names:
-            print("Filtering out development-only bug:")
-            print("  #" + str(pr_nr) + " " + i.title)
-            print("  " + pr_url + str(pr_nr))
-            continue
 
-    # filter out closed (unmerged) PRs
-    pr = repo.get_pull(pr_nr)
-    if not pr.merged:
-        print("Filtering out unmerged PR:")
-        print("  #" + str(pr_nr) + " " + i.title)
-        print("  " + pr_url + str(pr_nr))
-        continue
+# map the changelog naming to the tag naming, e.g., "component: core", etc.
+COMPONENTS = {"PIC": "core", "PMacc": "PMacc", "plugins": "plugin", "tools": "tools"}
 
-    # sort by categories
-    pr_title = i.title
-    if "component: user input" in pr_labels_names:
-        user["input"].append(i.title + " #" + str(pr_nr))
-    if "affects latest release" in pr_labels_names:
-        if "component: core" in pr_labels_names:
-            bugs["core"].append(i.title + " #" + str(pr_nr))
-        elif "component: PMacc" in pr_labels_names:
-            bugs["pmacc"].append(i.title + " #" + str(pr_nr))
-        elif "component: plugin" in pr_labels_names:
-            bugs["plugin"].append(i.title + " #" + str(pr_nr))
-        elif "component: tools" in pr_labels_names:
-            bugs["tools"].append(i.title + " #" + str(pr_nr))
-        else:
-            bugs["other"].append(i.title + " #" + str(pr_nr))
-        continue
-    if "refactoring" in pr_labels_names:
-        if "component: core" in pr_labels_names:
-            refactoring["core"].append(i.title + " #" + str(pr_nr))
-        elif "component: PMacc" in pr_labels_names:
-            refactoring["pmacc"].append(i.title + " #" + str(pr_nr))
-        elif "component: plugin" in pr_labels_names:
-            refactoring["plugin"].append(i.title + " #" + str(pr_nr))
-        elif "component: tools" in pr_labels_names:
-            refactoring["tools"].append(i.title + " #" + str(pr_nr))
-        else:
-            refactoring["other"].append(i.title + " #" + str(pr_nr))
-        continue
-    # all others are features
-    if "component: core" in pr_labels_names:
-        features["core"].append(i.title + " #" + str(pr_nr))
-        continue
-    elif "component: PMacc" in pr_labels_names:
-        features["pmacc"].append(i.title + " #" + str(pr_nr))
-        continue
-    elif "component: plugin" in pr_labels_names:
-        features["plugin"].append(i.title + " #" + str(pr_nr))
-        continue
-    elif "component: tools" in pr_labels_names:
-        features["tools"].append(i.title + " #" + str(pr_nr))
-        continue
-    # all leftovers are miscellaneous changes
-    if "documentation" in pr_labels_names:
-        misc["docs"].append(i.title + " #" + str(pr_nr))
-        continue
-    misc["other"].append(i.title + " #" + str(pr_nr))
+# describe how to detect the main categories
+MAIN_CATEGORIES = {
+    "Features": lambda pr: not contains_label(pr, "bug") and not contains_label(pr, "refactoring"),
+    "Bug Fixes": lambda pr: contains_label(pr, "bug") and contains_label(pr, "affects latest release"),
+    "Refactoring": lambda pr: not contains_label(pr, "bug") and contains_label(pr, "refactoring"),
+    "Documentation": lambda pr: contains_label(pr, "documentation"),
+}
 
-print("")
-print("**User Input Changes:**")
-for p in user["input"]:
-    print(" - " + p)
+# This is the main configuration point: The changelog will have the same tree structure as this nested dict. The leaves
+# however will be replaced with something roughly equivalent to `list(filter(func, PRs))` if `func` is the corresponding
+# function constituting a leave of `CATEGORIES`. In order to save some typing, the bulk of the categorisation is
+# formulated as a cartesion product of `MAIN_CATEGORIES` and `COMPONENTS` but this is only for convenience. Feel free
+# to change this or amend this by hand afterwards.
+CATEGORIES = {
+    "User Input Changes": (lambda pr: contains_label(pr, "component: user input")),
+} | {
+    main_cat: {
+        # This is important: If you create the lambda in-place, variables are captured by reference and the
+        # corresponding value is only fetched upon a call. This leads to all lambdas using the last value of the
+        # iteration.
+        name: make_lambda(main_condition, component)
+        for name, component in COMPONENTS.items()
+    }
+    | {"other": make_lambda(main_condition)}
+    for main_cat, main_condition in MAIN_CATEGORIES.items()
+}
 
-print("")
-print("**New Features:**")
-print(" - PIC:")
-for p in features["core"]:
-    print("   - " + p)
-print(" - PMacc:")
-for p in features["pmacc"]:
-    print("   - " + p)
-print(" - plugins:")
-for p in features["plugin"]:
-    print("   - " + p)
-print(" - tools:")
-for p in features["tools"]:
-    print("   - " + p)
-for p in features["other"]:
-    print(" - " + p)
 
-print("")
-print("**Bug Fixes:**")
-print(" - PIC:")
-for p in bugs["core"]:
-    print("   - " + p)
-print(" - PMacc:")
-for p in bugs["pmacc"]:
-    print("   - " + p)
-print(" - plugins:")
-for p in bugs["plugin"]:
-    print("   - " + p)
-print(" - tools:")
-for p in bugs["tools"]:
-    print("   - " + p)
-for p in bugs["other"]:
-    print(" - " + p)
+def contains_label(issue, label):
+    """Helper function to check if an issue is labelled by label."""
+    return label in map(lambda lab: lab.name, issue.labels)
 
-print("")
-print("**Misc:**")
-print(" - refactoring:")
-print("   - PIC:")
-for p in refactoring["core"]:
-    print("     - " + p)
-print("   - PMacc:")
-for p in refactoring["pmacc"]:
-    print("     - " + p)
-print("   - plugins:")
-for p in refactoring["plugin"]:
-    print("     - " + p)
-print("   - tools:")
-for p in refactoring["tools"]:
-    print("     - " + p)
-for p in refactoring["other"]:
-    print("   - " + p)
-print(" - documentation:")
-for p in misc["docs"]:
-    print("   - " + p)
-for p in misc["other"]:
-    print(" - " + p)
+
+def categorise(prs, categories_or_condition):
+    """Recursively run over the given categories and filter the PRs according to their conditions."""
+    if not isinstance(categories_or_condition, dict):
+        return list(filter(categories_or_condition, prs))
+    return {key: categorise(prs, val) for key, val in categories_or_condition.items()}
+
+
+def apply_to_leaves(func, mapping):
+    """Helper function to recursively apply to the leaves of a nested dictionary (applying to values of a list individually)."""
+    if isinstance(mapping, dict):
+        return {key: apply_to_leaves(func, val) for key, val in mapping.items()}
+    if isinstance(mapping, list):
+        return list(map(func, mapping))
+    return func(mapping)
+
+
+def to_string(categories):
+    """Transform our nested dictionary of GH PR objects into something readable."""
+    return yaml.dump(apply_to_leaves(lambda pr: f"{pr.title} #{pr.number}", categories))
+
+
+def pull_requests(gh_key, version):
+    """Query the Github API for the kind of PRs we need."""
+    return Github(gh_key).search_issues(
+        f'repo:ComputationalRadiationPhysics/picongpu type:pr is:merged milestone:"{version}" label:changelog'
+    )
+
+
+def main(version, gh_key=None):
+    """Main logic: Download, categorise, print."""
+    print(to_string(categorise(pull_requests(gh_key, version), CATEGORIES)))
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])


### PR DESCRIPTION
As requested by @psychocoderHPC, here's a quick rewrite of `propose_changelog.py`. One matter of taste might be that I have chosen to depend on `pyyaml` for the pretty printing of nested dictionaries. That is technically not necessary but I really don't care for writing all the formatting by hand. This comes with the tiny drawback that all the strings containing  `#` are surrounded by single quotes. Theoretically, the formatting can be adjusted arbitrarily by writing custom dumpers but then again, we would be back at writing custom formatting code.

<details><summary>Output at the time of writing</summary>

### Output

```
Bug Fixes:
  PIC:
  - 'fix Gaussian and Dispersive pulse #4889'
  PMacc:
  - 'fix `atomicAllInc()` #4825'
  - 'avoid using uninitialized `pmacc::memory::Array` #4789'
  other:
  - 'Correct spack options for boost #4780'
  - 'fix potential deadlock #4755'
  plugins: []
  tools:
  - 'fix slow tbg substitution #4905'
  - 'fix growth rate and charge conservation test tools #4834'
Documentation:
  PIC:
  - 'replace cupla fully by alpaka #4838'
  PMacc:
  - 'replace cupla fully by alpaka #4838'
  other:
  - 'Correct spack options for boost #4780'
  - 'RISC-V support #4712'
  plugins:
  - 'Add shadowgraphy plugin #4868'
  - 'remove deactivation of ISAAC with HIP #4821'
  - 'change class and function names in radPlugin to camelCase #4734'
  - 'add calorimeter python module #4697'
  tools:
  - 'Pre-commit #4792'
  - 'Remove hemera k80 and k20 partition #4779'
  - 'add calorimeter python module #4697'
Features:
  PIC:
  - 'Add feature `--dump-metadata` #4812'
  - 'PIConGPU unit tests #4723'
  - 'add CKC Solver #4661'
  PMacc:
  - 'Add PMacc example - Solving the 2D HeatEquation #4767'
  other:
  - 'RISC-V support #4712'
  - 'Make fieldAbsorberTest a test for the CI #4682'
  - 'Add CurrentDeposition test #4557'
  plugins:
  - 'Add shadowgraphy plugin #4868'
  - 'remove deactivation of ISAAC with HIP #4821'
  - 'Implement checkpoint and restart capability to the binning plugin #4766'
  - 'change class and function names in radPlugin to camelCase #4734'
  - 'add calorimeter python module #4697'
  - 'change radiation plugin python module to openPMD-api #4680'
  tools:
  - 'Remove hemera k80 and k20 partition #4779'
  - 'add Snakemake workflow example #4774'
  - 'add calorimeter python module #4697'
  - 'change radiation plugin python module to openPMD-api #4680'
Refactoring:
  PIC:
  - 'replace cupla fully by alpaka #4838'
  - 'optimize collision #4828'
  - 'move PMacc and PIConGPU fully to alpaka #4820'
  - 'Topic remove preprocessor struct generator #4750'
  - 'refactor to make superCellSize and frameSize independant #4685'
  - 'refactor particle init kernel #4681'
  - 'Add an optional time delay for incident field pulses #4651'
  PMacc:
  - 'rename `getDataSpace` to `capacityND` #4851'
  - 'refactor lockstep programming model #4840'
  - 'replace cupla fully by alpaka #4838'
  - 'move PMacc and PIConGPU fully to alpaka #4820'
  - 'Topic remove preprocessor struct generator #4750'
  - 'remove accessor from `math::Vector<>` #4746'
  - 'Get supercell index relative to user defined origin #4731'
  - 'remove `atomicAddNoRet()` #4722'
  - 'refactor DataSpaceOperations #4719'
  other:
  - 'remove CONST_VECTOR from OnePositionParameter #4875'
  plugins:
  - 'optimize OpenPMD IO #4882'
  - 'openPMD: add parameter `particleIOChunkSize` #4874'
  - 'Bump openPMD-api to minimal version 0.15 #4782'
  - 'simplify output structure colorimeter plugin  #4695'
  tools:
  - 'Pre-commit #4792'
User Input Changes:
- 'remove CONST_VECTOR from OnePositionParameter #4875'
- 'Topic remove preprocessor struct generator #4750'
- 'change class and function names in radPlugin to camelCase #4734'
- 'refactor to make superCellSize and frameSize independant #4685'
```
</details> 