### PR TITLE
Time tracing for the openPMD plugin

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -254,8 +254,8 @@ set(PIC_VERBOSE "1" CACHE STRING
     "Set verbosity level for PIConGPU (default is only physics output)")
 add_definitions(-DPIC_VERBOSE_LVL=${PIC_VERBOSE})
 
-set(PIC_TRACE_OPENPMD_TIMES "0" CACHE STRING "Set the maximum number of MPI ranks that create a file with trace information.")
-add_definitions(-DPIC_TRACE_OPENPMD_TIMES=${PIC_TRACE_OPENPMD_TIMES})
+set(PIC_IO_TIMES_NUMBER_OF_FILES "0" CACHE STRING "Set the maximum number of MPI ranks that create a file with trace information.")
+add_definitions(-DPIC_IO_TIMES_NUMBER_OF_FILES=${PIC_IO_TIMES_NUMBER_OF_FILES})
 
 option(PIC_ADD_RPATH "Add RPATH's to binaries." ON)
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -254,6 +254,9 @@ set(PIC_VERBOSE "1" CACHE STRING
     "Set verbosity level for PIConGPU (default is only physics output)")
 add_definitions(-DPIC_VERBOSE_LVL=${PIC_VERBOSE})
 
+set(PIC_TRACE_OPENPMD_TIMES "0" CACHE STRING "Set the maximum number of MPI ranks that create a file with trace information.")
+add_definitions(-DPIC_TRACE_OPENPMD_TIMES=${PIC_TRACE_OPENPMD_TIMES})
+
 option(PIC_ADD_RPATH "Add RPATH's to binaries." ON)
 
 

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -254,8 +254,8 @@ set(PIC_VERBOSE "1" CACHE STRING
     "Set verbosity level for PIConGPU (default is only physics output)")
 add_definitions(-DPIC_VERBOSE_LVL=${PIC_VERBOSE})
 
-set(PIC_IO_TIMES_NUMBER_OF_FILES "0" CACHE STRING "Set the maximum number of MPI ranks that create a file with trace information.")
-add_definitions(-DPIC_IO_TIMES_NUMBER_OF_FILES=${PIC_IO_TIMES_NUMBER_OF_FILES})
+set(PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES "0" CACHE STRING "Set the maximum number of MPI ranks that create a file with trace information.")
+add_definitions(-DPIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES=${PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES})
 
 option(PIC_ADD_RPATH "Add RPATH's to binaries." ON)
 

--- a/include/picongpu/plugins/common/DumpTimes.hpp
+++ b/include/picongpu/plugins/common/DumpTimes.hpp
@@ -45,10 +45,8 @@ namespace picongpu
             using duration = typename Clock::duration;
             using Ret_T = std::pair<time_point, duration>;
 
-            constexpr static char const* ENV_VAR = "PICONGPU_TIME_TRACE_FILE";
             const std::string filename;
 
-            DumpTimes();
             DumpTimes(std::string filename);
 
             template<typename Duration>
@@ -68,16 +66,13 @@ namespace picongpu
         };
 
         template<typename Clock, bool enable>
-        DumpTimes<Clock, enable>::DumpTimes() : DumpTimes(std::string(std::getenv(ENV_VAR)))
-        {
-        }
-
-        template<typename Clock, bool enable>
         DumpTimes<Clock, enable>::DumpTimes(std::string _filename)
             : filename(std::move(_filename))
             , outStream(filename, std::ios_base::out | std::ios_base::app)
             , lastTimePoint(Clock::now())
         {
+            outStream << "timestamp\tdifftime\tdescription";
+            pendingNewline = true;
         }
 
         template<typename Clock, bool enable>

--- a/include/picongpu/plugins/openPMD/DumpTimes.hpp
+++ b/include/picongpu/plugins/openPMD/DumpTimes.hpp
@@ -140,7 +140,7 @@ namespace picongpu
             {
             }
 
-            template<typename, typename... Args>
+            template<typename... Args>
             inline void flush(Args&&...)
             {
             }

--- a/include/picongpu/plugins/openPMD/DumpTimes.hpp
+++ b/include/picongpu/plugins/openPMD/DumpTimes.hpp
@@ -1,0 +1,150 @@
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace picongpu
+{
+    namespace openPMD
+    {
+        template<typename Clock>
+        struct TimeFormatters
+        {
+            using TimeFormatter = std::function<std::string(typename Clock::time_point const&)>;
+
+            static std::string humanReadable(typename Clock::time_point const& currentTime)
+            {
+                std::stringstream res;
+                std::time_t now_c = Clock::to_time_t(currentTime);
+                res << std::put_time(std::localtime(&now_c), "%F %T") << '.' << std::setfill('0') << std::setw(3)
+                    << std::chrono::duration_cast<std::chrono::milliseconds>(currentTime.time_since_epoch()).count()
+                        % 1000;
+                return res.str();
+            }
+
+            static std::string epochTime(typename Clock::time_point const& currentTime)
+            {
+                return std::to_string(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(currentTime.time_since_epoch()).count());
+            }
+        };
+        template<typename Clock>
+        using TimeFormatter = typename TimeFormatters<Clock>::TimeFormatter;
+
+        // https://en.cppreference.com/w/cpp/named_req/Clock
+        template<typename Clock = std::chrono::system_clock, bool enable = true>
+        class DumpTimes
+        {
+        public:
+            using time_point = typename Clock::time_point;
+            using duration = typename Clock::duration;
+            using Ret_T = std::pair<time_point, duration>;
+
+            constexpr static char const* ENV_VAR = "PICONGPU_TIME_TRACE_FILE";
+            const std::string filename;
+
+            DumpTimes();
+            DumpTimes(std::string filename);
+
+            template<typename Duration>
+            Ret_T now(
+                std::string description,
+                std::string separator = "\t",
+                TimeFormatter<Clock> = &TimeFormatters<Clock>::epochTime);
+
+            void append(std::string const&);
+
+            void flush();
+
+        private:
+            std::fstream outStream;
+            bool pendingNewline = false;
+            time_point lastTimePoint;
+        };
+
+        template<typename Clock, bool enable>
+        DumpTimes<Clock, enable>::DumpTimes() : DumpTimes(std::string(std::getenv(ENV_VAR)))
+        {
+        }
+
+        template<typename Clock, bool enable>
+        DumpTimes<Clock, enable>::DumpTimes(std::string _filename)
+            : filename(std::move(_filename))
+            , outStream(filename, std::ios_base::out | std::ios_base::app)
+            , lastTimePoint(Clock::now())
+        {
+        }
+
+        template<typename Clock, bool enable>
+        template<typename Duration>
+        typename DumpTimes<Clock, enable>::Ret_T DumpTimes<Clock, enable>::now(
+            std::string description,
+            std::string separator,
+            TimeFormatter<Clock> timeFormatter)
+        {
+            auto currentTime = Clock::now();
+            auto delta = currentTime - lastTimePoint;
+            lastTimePoint = currentTime;
+            std::string nowFormatted = timeFormatter(currentTime);
+            if(pendingNewline)
+            {
+                outStream << '\n';
+            }
+            outStream << std::move(nowFormatted) << separator << std::chrono::duration_cast<Duration>(delta).count()
+                      << separator << description;
+            pendingNewline = true;
+            return std::make_pair(currentTime, delta);
+        }
+
+        template<typename Clock, bool enable>
+        void DumpTimes<Clock, enable>::append(std::string const& str)
+        {
+            outStream << str;
+        }
+
+        template<typename Clock, bool enable>
+        void DumpTimes<Clock, enable>::flush()
+        {
+            if(pendingNewline)
+            {
+                outStream << '\n';
+            }
+            pendingNewline = false;
+            outStream << std::flush;
+        }
+
+        template<typename Clock>
+        class DumpTimes<Clock, false>
+        {
+        public:
+            using Ret_T = void;
+            DumpTimes()
+            {
+            }
+            DumpTimes(std::string)
+            {
+            }
+
+            template<typename, typename... Args>
+            inline Ret_T now(Args&&...)
+            {
+            }
+
+            template<typename... Args>
+            inline void append(Args&&...)
+            {
+            }
+
+            template<typename, typename... Args>
+            inline void flush(Args&&...)
+            {
+            }
+        };
+
+    } // namespace openPMD
+} // namespace picongpu

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -506,9 +506,11 @@ namespace picongpu
                         log<picLog::INPUT_OUTPUT>("openPMD: flush particle records for %1%, dumping round %2%")
                             % T_SpeciesFilter::getName() % dumpIteration;
 
-                        params->m_dumpTimes.now<std::chrono::milliseconds>("\tslice "+ std::to_string(dumpIteration)+" flush");
+                        params->m_dumpTimes.now<std::chrono::milliseconds>(
+                            "\tslice " + std::to_string(dumpIteration) + " flush");
                         params->openPMDSeries->flush(PreferredFlushTarget::Disk);
-                        params->m_dumpTimes.now<std::chrono::milliseconds>("\tslice "+ std::to_string(dumpIteration) + " end");
+                        params->m_dumpTimes.now<std::chrono::milliseconds>(
+                            "\tslice " + std::to_string(dumpIteration) + " end");
 
 
                         log<picLog::INPUT_OUTPUT>("openPMD: (end) write particle records for %1%, dumping round %2%")

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -103,10 +103,15 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
-            DumpTimes<std::chrono::system_clock, true> m_dumpTimes{
+            static constexpr bool do_trace_times = PIC_TRACE_OPENPMD_TIMES > 0;
+            DumpTimes<std::chrono::system_clock, do_trace_times> m_dumpTimes
+            {
+#if PIC_TRACE_OPENPMD_TIMES == 0
+                "/dev/null"
+#else
                 []()
                 {
-                    constexpr unsigned MAX_LOGS = 20;
+                    constexpr unsigned MAX_LOGS = PIC_TRACE_OPENPMD_TIMES;
                     static GridController<simDim>& gc = Environment<simDim>::get().GridController();
                     auto const size = gc.getGlobalSize();
                     auto const rank = gc.getGlobalRank();
@@ -139,7 +144,9 @@ namespace picongpu
                         size_t rank_of_that_log = (proposed_log_idx * size) / MAX_LOGS;
                         return rank == rank_of_that_log ? outputFile : "/dev/null";
                     }
-                }()};
+                }()
+#endif
+            };
 
             ::openPMD::Series& openSeries(::openPMD::Access at);
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -103,45 +103,45 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
-            static constexpr bool do_trace_times = PIC_IO_TIMES_NUMBER_OF_FILES > 0;
-            DumpTimes<std::chrono::system_clock, do_trace_times> m_dumpTimes
+            static constexpr bool enableTimeTrace = PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES > 0;
+            DumpTimes<std::chrono::system_clock, enableTimeTrace> m_dumpTimes
             {
-#if PIC_IO_TIMES_NUMBER_OF_FILES < 1
+#if PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES < 1
                 "/dev/null"
 #else
                 []()
                 {
-                    constexpr unsigned MAX_LOGS = PIC_IO_TIMES_NUMBER_OF_FILES;
+                    constexpr unsigned maxLogFiles = PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES;
                     static GridController<simDim>& gc = Environment<simDim>::get().GridController();
                     auto const size = gc.getGlobalSize();
                     auto const rank = gc.getGlobalRank();
-                    std::string outputFile = "PIC_times_" + std::to_string(rank) + ".txt";
-                    if(size <= MAX_LOGS)
+                    std::string outputFile = "PIC_openPMD_TimeTrace_" + std::to_string(rank) + ".txt";
+                    if(size <= maxLogFiles)
                     {
                         return outputFile;
                     }
                     else
                     {
                         /*
-                         * Only up to MAX_LOGS logs should be written in parallel in order not to
+                         * Only up to maxLogFiles logs should be written in parallel in order not to
                          * overload the file system with measuring I/O efficiency, e.g. 20 logs.
                          * The following logic figures out if this rank should write a log and
                          * which log index from 0 to 19 should be used locally.
                          *
-                         * Log file with index i is written from `rank = bottom(i/logs * size)`
-                         * This means that there exists an e < 1 s.t. `rank + e = i/logs * size`,
-                         * which can be given as `i = rank*logs/size + e*logs/size`.
-                         * In this if branch, `logs/size < 1` was checked before entering,
-                         * hence also `e*logs/size < 1`.
+                         * Log file with index i is written from `rank = bottom(i/maxLogFiles * size)`
+                         * This means that there exists an e < 1 s.t. `rank + e = i/maxLogFiles * size`,
+                         * which can be given as `i = rank*maxLogFiles/size + e*maxLogFiles/size`.
+                         * In this if branch, `maxLogFiles/size < 1` was checked before entering,
+                         * hence also `e*maxLogFiles/size < 1`.
                          * This means that the log index `i` can be computed
-                         * via `i = ceil(rank*logs/size)`.
+                         * via `i = ceil(rank*maxLogFiles/size)`.
                          * In order to find out if this rank writes a log, the rank is then
-                         * computed with `rank = bottom(i/logs * size)` (see first formula above)
+                         * computed with `rank = bottom(i/maxLogFiles * size)` (see first formula above)
                          * and compared to the actual rank ID.
                          */
                         auto div_ceil = [](auto a, auto b) { return (a + b - 1) / b; };
-                        size_t proposed_log_idx = div_ceil(rank * MAX_LOGS, size);
-                        size_t rank_of_that_log = (proposed_log_idx * size) / MAX_LOGS;
+                        size_t proposed_log_idx = div_ceil(rank * maxLogFiles, size);
+                        size_t rank_of_that_log = (proposed_log_idx * size) / maxLogFiles;
                         return rank == rank_of_that_log ? outputFile : "/dev/null";
                     }
                 }()

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -104,7 +104,7 @@ namespace picongpu
 
             std::vector<double> times;
             static constexpr bool enableTimeTrace = PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES > 0;
-            DumpTimes<std::chrono::system_clock, enableTimeTrace> m_dumpTimes
+            DumpTimes<enableTimeTrace> m_dumpTimes
             {
 #if PIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES < 1
                 "/dev/null"

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -21,7 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/plugins/openPMD/DumpTimes.hpp"
+#include "picongpu/plugins/common/DumpTimes.hpp"
 #include "picongpu/plugins/openPMD/Json.hpp"
 #include "picongpu/plugins/openPMD/Parameters.hpp"
 #include "picongpu/plugins/openPMD/toml.hpp"
@@ -103,15 +103,15 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
-            static constexpr bool do_trace_times = PIC_TRACE_OPENPMD_TIMES > 0;
+            static constexpr bool do_trace_times = PIC_IO_TIMES_NUMBER_OF_FILES > 0;
             DumpTimes<std::chrono::system_clock, do_trace_times> m_dumpTimes
             {
-#if PIC_TRACE_OPENPMD_TIMES == 0
+#if PIC_IO_TIMES_NUMBER_OF_FILES < 1
                 "/dev/null"
 #else
                 []()
                 {
-                    constexpr unsigned MAX_LOGS = PIC_TRACE_OPENPMD_TIMES;
+                    constexpr unsigned MAX_LOGS = PIC_IO_TIMES_NUMBER_OF_FILES;
                     static GridController<simDim>& gc = Environment<simDim>::get().GridController();
                     auto const size = gc.getGlobalSize();
                     auto const rank = gc.getGlobalRank();
@@ -123,10 +123,10 @@ namespace picongpu
                     else
                     {
                         /*
-                         * Only up to logs=20 logs should be written in parallel in order not to
-                         * overload the file system with measuring I/O efficiency.
+                         * Only up to MAX_LOGS logs should be written in parallel in order not to
+                         * overload the file system with measuring I/O efficiency, e.g. 20 logs.
                          * The following logic figures out if this rank should write a log and
-                         * which log index from 0 to 19 should be used.
+                         * which log index from 0 to 19 should be used locally.
                          *
                          * Log file with index i is written from `rank = bottom(i/logs * size)`
                          * This means that there exists an e < 1 s.t. `rank + e = i/logs * size`,

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "picongpu/plugins/openPMD/DumpTimes.hpp"
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/plugins/openPMD/DumpTimes.hpp"
 #include "picongpu/plugins/openPMD/Json.hpp"
 #include "picongpu/plugins/openPMD/Parameters.hpp"
 #include "picongpu/plugins/openPMD/toml.hpp"
@@ -103,11 +103,43 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
-            DumpTimes<> m_dumpTimes{[]() {
-                static GridController<simDim>& gc = Environment<simDim>::get().GridController();
-                static std::string dumpFile = "PIC_times_" + std::to_string(gc.getGlobalRank()) + ".txt";
-                return dumpFile;
-            }()};
+            DumpTimes<std::chrono::system_clock, true> m_dumpTimes{
+                []()
+                {
+                    constexpr unsigned MAX_LOGS = 20;
+                    static GridController<simDim>& gc = Environment<simDim>::get().GridController();
+                    auto const size = gc.getGlobalSize();
+                    auto const rank = gc.getGlobalRank();
+                    std::string outputFile = "PIC_times_" + std::to_string(rank) + ".txt";
+                    if(size <= MAX_LOGS)
+                    {
+                        return outputFile;
+                    }
+                    else
+                    {
+                        /*
+                         * Only up to logs=20 logs should be written in parallel in order not to
+                         * overload the file system with measuring I/O efficiency.
+                         * The following logic figures out if this rank should write a log and
+                         * which log index from 0 to 19 should be used.
+                         *
+                         * Log file with index i is written from `rank = bottom(i/logs * size)`
+                         * This means that there exists an e < 1 s.t. `rank + e = i/logs * size`,
+                         * which can be given as `i = rank*logs/size + e*logs/size`.
+                         * In this if branch, `logs/size < 1` was checked before entering,
+                         * hence also `e*logs/size < 1`.
+                         * This means that the log index `i` can be computed
+                         * via `i = ceil(rank*logs/size)`.
+                         * In order to find out if this rank writes a log, the rank is then
+                         * computed with `rank = bottom(i/logs * size)` (see first formula above)
+                         * and compared to the actual rank ID.
+                         */
+                        auto div_ceil = [](auto a, auto b) { return (a + b - 1) / b; };
+                        size_t proposed_log_idx = div_ceil(rank * MAX_LOGS, size);
+                        size_t rank_of_that_log = (proposed_log_idx * size) / MAX_LOGS;
+                        return rank == rank_of_that_log ? outputFile : "/dev/null";
+                    }
+                }()};
 
             ::openPMD::Series& openSeries(::openPMD::Access at);
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picongpu/plugins/openPMD/DumpTimes.hpp"
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/plugins/openPMD/Json.hpp"
@@ -102,6 +103,11 @@ namespace picongpu
             DataSpace<simDim> localWindowToDomainOffset;
 
             std::vector<double> times;
+            DumpTimes<> m_dumpTimes{[]() {
+                static GridController<simDim>& gc = Environment<simDim>::get().GridController();
+                static std::string dumpFile = "PIC_times_" + std::to_string(gc.getGlobalRank()) + ".txt";
+                return dumpFile;
+            }()};
 
             ::openPMD::Series& openSeries(::openPMD::Access at);
 

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -127,7 +127,8 @@ namespace picongpu
                 std::string const& basepath,
                 const size_t elements,
                 const size_t globalElements,
-                const size_t globalOffset)
+                const size_t globalOffset,
+                size_t & accumulate_writtenBytes)
             {
                 using Identifier = T_Identifier;
                 using ValueType = typename pmacc::traits::Resolve<Identifier>::type::type;
@@ -154,10 +155,13 @@ namespace picongpu
                 }
                 if(elements == 0)
                 {
+                    // accumulate_writtenBytes += 0;
                     return;
                 }
 
                 log<picLog::INPUT_OUTPUT>("openPMD:  (begin) write species attribute: %1%") % Identifier::getName();
+
+                accumulate_writtenBytes += components * elements * sizeof(ComponentType);
 
                 for(uint32_t d = 0; d < components; d++)
                 {

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -128,7 +128,7 @@ namespace picongpu
                 const size_t elements,
                 const size_t globalElements,
                 const size_t globalOffset,
-                size_t& accumulate_writtenBytes)
+                size_t& accumulateWrittenBytes)
             {
                 using Identifier = T_Identifier;
                 using ValueType = typename pmacc::traits::Resolve<Identifier>::type::type;
@@ -155,13 +155,13 @@ namespace picongpu
                 }
                 if(elements == 0)
                 {
-                    // accumulate_writtenBytes += 0;
+                    // accumulateWrittenBytes += 0;
                     return;
                 }
 
                 log<picLog::INPUT_OUTPUT>("openPMD:  (begin) write species attribute: %1%") % Identifier::getName();
 
-                accumulate_writtenBytes += components * elements * sizeof(ComponentType);
+                accumulateWrittenBytes += components * elements * sizeof(ComponentType);
 
                 for(uint32_t d = 0; d < components; d++)
                 {

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -128,7 +128,7 @@ namespace picongpu
                 const size_t elements,
                 const size_t globalElements,
                 const size_t globalOffset,
-                size_t & accumulate_writtenBytes)
+                size_t& accumulate_writtenBytes)
             {
                 using Identifier = T_Identifier;
                 using ValueType = typename pmacc::traits::Resolve<Identifier>::type::type;


### PR DESCRIPTION
This is something that I've been using for years now on a private branch of PIConGPU, but having an approachable way to get detailed timing information from the openPMD plugin is probably not only relevant for me.

This is disabled by default (via a no-op template specialization), but can be enabled in CMake via `-DPIC_IO_TIMES_NUMBER_OF_FILES`. The value of this parameter is an integer that specifies how many MPI ranks should participate in this time tracing. Every MPI rank writes its own output file with timing information, and at large scale only a subselection of MPI ranks should do that in order not to accidentally destroy the performance while trying to measure it.

The output for one run of the plugin may look sth like this:

```
1716472984082   2624    Beginning iteration 50
1716472984135   53      Begin write field E: 25165824 bytes for 2097152 cells 
1716472984135   0               Component 0 prepare
1716472984140   5               Component 0 flush
1716472984153   12              Component 0 end
1716472984153   0               Component 1 prepare
1716472984159   5               Component 1 flush
1716472984171   12              Component 1 end
1716472984171   0               Component 2 prepare
1716472984176   5               Component 2 flush
1716472984189   12              Component 2 end
1716472984192   2       Begin write field B: 25165824 bytes for 2097152 cells 
1716472984192   0               Component 0 prepare
1716472984197   5               Component 0 flush
1716472984209   12              Component 0 end
1716472984209   0               Component 1 prepare
1716472984215   5               Component 1 flush
1716472984227   12              Component 1 end
1716472984227   0               Component 2 prepare
1716472984232   5               Component 2 flush
1716472984244   12              Component 2 end
1716472984244   0       Begin write field e_all_chargeDensity: 8388608 bytes for 2097152 cells
1716472984248   3               Component 0 prepare
1716472984253   4               Component 0 flush
1716472984265   12              Component 0 end
1716472984265   0       Begin write field e_all_energyDensity: 8388608 bytes for 2097152 cells
1716472984268   3               Component 0 prepare
1716472984273   4               Component 0 flush
1716472984285   12              Component 0 end
1716472984285   0       Begin write species e
1716472984315   29              slice 0 prepare: 52428800 bytes for 1310720 particles from offset 0
1716472984346   31              slice 0 flush
1716472984423   76              slice 0 end
1716472984434   11              slice 1 prepare: 52428800 bytes for 1310720 particles from offset 1310720
1716472984465   30              slice 1 flush
1716472984543   78              slice 1 end
1716472984543   0               slice 2 prepare: 0 bytes for 0 particles from offset 2621440
1716472984543   0               slice 2 flush
1716472984676   132             slice 2 end
1716472984676   0               slice 3 prepare: 0 bytes for 0 particles from offset 2621440
1716472984676   0               slice 3 flush
1716472984700   24              slice 3 end
1716472984703   3               Flush species e
1716472984704   0               Finished flush species
1716472984704   0       Closing iteration 50
1716472984840   136     Done.
```
The first column is the UNIX time stamp, the second column the diff time in milliseconds to the previous event, the rest is description.