### PR TITLE
fix checkpoint restart

### DIFF
--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -143,7 +143,8 @@ namespace picongpu
                     mallocMem;
                 mallocMem(buffers, mappedFrame, maxChunkSize);
 
-                uint32_t const numLoadIterations = alpaka::core::divCeil(totalNumParticles, maxChunkSize);
+                uint32_t const numLoadIterations
+                    = maxChunkSize == 0u ? 0u : alpaka::core::divCeil(totalNumParticles, maxChunkSize);
 
                 for(uint64_t loadRound = 0u; loadRound < numLoadIterations; ++loadRound)
                 {


### PR DESCRIPTION
Fix division by zero in case the checkpoint file does not contains particles for a single device.
The bug was introduced with PR #4885.