### PR TITLE
Changes to Synchrotron Radiation from issue #4921. Part 1.

### DIFF
--- a/share/picongpu/tests/Synchrotron_plugin/lib/change_parameters_randomly.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/change_parameters_randomly.py
@@ -1,19 +1,20 @@
-import os
 import numpy as np
 from synchrotron_lib import calculate_dt, predictNumPhotons
+from pathlib import Path
 # dt is in grid.param as DELTA_T_SI
 # Heff is in fieldBackground.param as field_Strength_SI
 # gamma is in particle.param as gamma
 # all are in ./include/picongpu/param
 
-paramsPath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../include/picongpu/param")
+paramsPath = Path(__file__).absolute().parent / "../include/picongpu/param"
 
 
 # read the files change the values and write them back
 def change_param_file(file_name, param_name, value):
-    with open(os.path.join(paramsPath, file_name), "r") as f:
+    filePath = paramsPath / file_name
+    with open(filePath, "r") as f:
         lines = f.readlines()
-    with open(os.path.join(paramsPath, file_name), "w") as f:
+    with open(filePath, "w") as f:
         for line in lines:
             if param_name + " = " in line:
                 changedLine = line.split("=")[0] + "= " + value + ";\n"
@@ -23,6 +24,7 @@ def change_param_file(file_name, param_name, value):
                 f.write(line)
 
 
+# change the three parameters
 def changeParams(dt, Heff, gamma):
     change_param_file("grid.param", "DELTA_T_SI", dt)
     change_param_file("fieldBackground.param", "field_Strength_SI", Heff)
@@ -31,25 +33,30 @@ def changeParams(dt, Heff, gamma):
 
 # the code checks if we have enough photons generated for the given parameters:
 # gamma, Heff can be any value, dt is calculated based on gamma and Heff
-yNum = 0
-while yNum < 5e6:
-    gamma = [10, 50, 100, 500, 1000]  # include all gamma values you want to check
-    Heff = [1e13, 1e14, 1e15, 1e16, 1e17, 1e18]  # similarly with Heff
+def main():
+    yNum = 0
+    while yNum < 5e6:
+        gamma = [10, 50, 100, 500, 1000]  # include all gamma values you want to check
+        Heff = [1e13, 1e14, 1e15, 1e16, 1e17, 1e18]  # similarly with Heff
 
-    gamma = gamma[np.random.randint(len(gamma))]
-    Heff = Heff[np.random.randint(len(Heff))]
-    dt = calculate_dt(gamma, Heff) * 0.95
-    dt = dt if dt < 1e-16 else 1e-16  # if dt is larger than the grid condition, set it to the grid condition
-    yNum = predictNumPhotons(gamma, Heff, dt, 4000, 5e5)
+        gamma = gamma[np.random.randint(len(gamma))]
+        Heff = Heff[np.random.randint(len(Heff))]
+        dt = calculate_dt(gamma, Heff) * 0.95
+        dt = dt if dt < 1e-16 else 1e-16  # if dt is larger than the grid condition, set it to the grid condition
+        yNum = predictNumPhotons(gamma, Heff, dt, 4000, 5e5)
 
-# make Heff, gamma and dt strings in scientific notation
-Heff = "{:.2e}".format(Heff)
-gamma = "{:.3e}".format(gamma)
-dt = "{:.2e}".format(dt)
-changeParams(dt, Heff, gamma)
-print("gamma: ", gamma, "Heff: ", Heff, "dt: ", dt)
-print(f"Predicted number of photons: {yNum}")
+    # make Heff, gamma and dt strings in scientific notation
+    Heff = "{:.2e}".format(Heff)
+    gamma = "{:.3e}".format(gamma)
+    dt = "{:.2e}".format(dt)
+    changeParams(dt, Heff, gamma)
+    print("gamma: ", gamma, "Heff: ", Heff, "dt: ", dt)
+    print(f"Predicted number of photons: {yNum}")
 
-# save parameters in a file in the output directory ./RUN{runNum}
-with open("./simOutput/params.txt", "w") as f:
-    f.write(f"gamma: {gamma}, Heff: {Heff}, dt: {dt}")
+    # save parameters in a file in the output directory ./simOutput
+    with open("./simOutput/params.txt", "w") as f:
+        f.write(f"gamma: {gamma}, Heff: {Heff}, dt: {dt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/share/picongpu/tests/Synchrotron_plugin/lib/change_parameters_randomly.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/change_parameters_randomly.py
@@ -24,7 +24,6 @@ def change_param_file(file_name, param_name, value):
                 f.write(line)
 
 
-# change the three parameters
 def changeParams(dt, Heff, gamma):
     change_param_file("grid.param", "DELTA_T_SI", dt)
     change_param_file("fieldBackground.param", "field_Strength_SI", Heff)

--- a/share/picongpu/tests/Synchrotron_plugin/lib/requirements.txt
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/requirements.txt
@@ -1,5 +1,3 @@
-os
 numpy==1.26.4
 scipy==1.11.4
-pathlib
 openpmd_api==4.5

--- a/share/picongpu/tests/Synchrotron_plugin/lib/requirements.txt
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/requirements.txt
@@ -1,5 +1,5 @@
 os
-numpy
-scipy
+numpy==1.26.4
+scipy==1.11.4
 pathlib
-openpmd_api
+openpmd_api==4.5

--- a/share/picongpu/tests/Synchrotron_plugin/lib/requirements.txt
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/requirements.txt
@@ -1,4 +1,5 @@
 os
 numpy
 scipy
+pathlib
 openpmd_api

--- a/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
@@ -7,15 +7,8 @@ from synchrotron_lib import analytical_Propability, momentum_to_energy, quad, co
 # Used when comparing two sets of histogram data with different binning
 # given two set of vectors x0, y0 and x1, y1 we interpolate second set to the first set and subtract them
 # interpolate y1 to x0 and subtract y0 from y1
+# returns x0 and relative error of y1 compared to y0
 def subtract_functions(x0, y0, x1, y1):
-    minX = max(np.min(x0), np.min(x1))
-    maxX = min(np.max(x0), np.max(x1))
-    #
-    x0 = [x for x in x0 if x >= minX and x <= maxX]
-    x1 = [x for x in x1 if x >= minX and x <= maxX]
-    y0 = [y for x, y in zip(x0, y0) if x >= minX and x <= maxX]
-    y1 = [y for x, y in zip(x1, y1) if x >= minX and x <= maxX]
-
     y1 = np.interp(x0, x1, y1)  # interpolate y1 to the x0 values
     return x0, np.abs(y0 - y1) / y0
 
@@ -88,7 +81,7 @@ def main(dataPath):
 
     min_exp = np.floor(np.log10(np.min(hist_data)))
     max_exp = np.ceil(np.log10(np.max(hist_data)))
-    bins = np.logspace(min_exp, max_exp, 100)
+    bins = np.logspace(min_exp, max_exp, 200)
     a, b = np.histogram(hist_data, bins=bins)
     normalization_factor = iterNo * len(e_w)
 
@@ -114,11 +107,12 @@ def main(dataPath):
     analytical_integrated = np.array(analytical_integrated)[mask]
 
     x, y = subtract_functions(delta, analytical_integrated, b, a)
-    poorness = np.sum(y) / len(y)  # average error
+    poorness = np.sum(y) / len(y)  # average relative error
     poornessBound = 0.1  # 10% error. We want poorness to be less than 10%
     print(f"Poorness: {poorness}")
 
     retValue = int(0) if poorness <= poornessBound else int(1)
+    print(f"Test {'passed' if retValue == 0 else 'failed'}")
 
     sys.exit(retValue)
 

--- a/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
@@ -8,8 +8,8 @@ from synchrotron_lib import analytical_Propability, momentum_to_energy, quad, co
 # given two set of vectors x0, y0 and x1, y1 we interpolate second set to the first set and subtract them
 # interpolate y1 to x0 and subtract y0 from y1
 # returns x0 and relative error of y1 compared to y0
-def subtract_functions(x0, y0, x1, y1):
-    y1 = np.interp(x0, x1, y1)  # interpolate y1 to the x0 values
+def relative_error_array(x0, y0, x1, y1):
+    y1 = np.interp(x0, x1, y1, left=0, right=0)  # interpolate y1 to the x0 values
     return x0, np.abs(y0 - y1) / y0
 
 
@@ -54,7 +54,7 @@ def read_photon_data(series):
     hist_data = np.abs(p_y * const.c / const.elementary_charge)
 
     if len(hist_data) < 5e5:
-        raise SystemExit(
+        raise ValueError(
             f"Number of photons is {len(hist_data)} but expected number of photons to be at least 5e5\n Test failed"
         )
 
@@ -94,7 +94,7 @@ def main(dataPath):
 
     simulation_dt = it.get_attribute("dt") * it.get_attribute("unit_time")
     if abs(simulation_dt - dt) > 1e-10:  # check if the simulation dt is the same as the expected dt. 1e-10 is arbitrary
-        raise SystemExit(f"Simulation dt is {simulation_dt} but expected dt is {dt}\n Test failed")
+        raise ValueError(f"Simulation dt is {simulation_dt} but expected dt is {dt}\n Test failed")
 
     # Reading and processing photon data
     hist_data = read_photon_data(series)
@@ -133,7 +133,7 @@ def main(dataPath):
     delta = delta[mask]
     analytical_integrated = np.array(analytical_integrated)[mask]
 
-    x, y = subtract_functions(delta, analytical_integrated, b, a)
+    x, y = relative_error_array(delta, analytical_integrated, b, a)
     poorness = np.sum(y) / len(y)  # average relative error
     poornessBound = 0.1  # 10% error. We want poorness to be less than 10%
     print(f"Poorness: {poorness}")
@@ -146,5 +146,5 @@ def main(dataPath):
 
 if __name__ == "__main__":
     if len(sys.argv[1:]) != 1:
-        raise SystemExit(f"Usage: {sys.argv[0]} <path_to_simulation_data>")
+        raise ValueError(f"Usage: {sys.argv[0]} <path_to_simulation_data>")
     main(sys.argv[1])

--- a/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
@@ -134,7 +134,7 @@ def main(dataPath):
     analytical_integrated = np.array(analytical_integrated)[mask]
 
     x, y = relative_error_array(delta, analytical_integrated, b, a)
-    poorness = np.sum(y) / len(y)  # average relative error
+    poorness = np.mean(y)  # average relative error
     poornessBound = 0.1  # 10% error. We want poorness to be less than 10%
     print(f"Poorness: {poorness}")
 
@@ -146,5 +146,5 @@ def main(dataPath):
 
 if __name__ == "__main__":
     if len(sys.argv[1:]) != 1:
-        raise ValueError(f"Usage: {sys.argv[0]} <path_to_simulation_data>")
+        raise SystemExit(f"Usage: {sys.argv[0]} <path_to_simulation_data>")
     main(sys.argv[1])


### PR DESCRIPTION
in validate():
- [x] subtract_functions() is now without a bug and unnecessary list truncation
- [x] Changed the number of bins to 200 for better accuracy

Todos from [issue #4912](https://github.com/ComputationalRadiationPhysics/picongpu/issues/4912):
- [x] use `pathlib` instead of `os.path` [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609863570) and [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609864862)
- [x] [question on usage](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609879390) of `change_parameters_randomly.py`
- [x] use [`main` function](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609881468) instead of a script like code
- [x] [question on comment](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609882515) regarding output 
- [x] use of `np.asarray` [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609891973) and [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609899282)
- [x] [question on parameters](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609902008) in `validate.py`
- [x] use seperate functions in python [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609908954) and [here](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609909367)
- [x] better way to handle [input arguments](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4827#discussion_r1609940439)