### PR TITLE
refactor flexible binning

### DIFF
--- a/include/picongpu/param/binningSetup.param
+++ b/include/picongpu/param/binningSetup.param
@@ -58,7 +58,7 @@ namespace picongpu
             auto cellPositionYDescription = createFunctorDescription<int>(getPositionY, "position_axisY");
 
             // Create Axis Splitting
-            auto domain_size = Environment<SIMDIM>::get().SubGrid().getGlobalDomain().size;
+            auto domain_size = Environment<simDim>::get().SubGrid().getGlobalDomain().size;
             auto rangeY = axis::Range{0, domain_size[1]};
             auto cellY_splitting = axis::AxisSplitting(rangeY, domain_size[1]);
 

--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <pmacc/dimensions/DataSpace.hpp>
+
 #include <cstdint>
 
 namespace picongpu
@@ -34,20 +36,20 @@ namespace picongpu
             /** Current simulation timestep */
             uint32_t currentStep;
             /** Offset of the global domain on all GPUs */
-            pmacc::DataSpace<SIMDIM> globalOffset;
+            pmacc::DataSpace<simDim> globalOffset;
             /** Offset of the domain simulated on current GPU */
-            pmacc::DataSpace<SIMDIM> localOffset;
+            pmacc::DataSpace<simDim> localOffset;
             /** Offset of domain simulated by current block wrt the border */
-            pmacc::DataSpace<SIMDIM> blockCellOffset;
+            pmacc::DataSpace<simDim> blockCellOffset;
 
             /**
              * @param physicalSuperCellIdx supercell index relative to the border origin
              */
             DINLINE DomainInfo(
                 uint32_t simStep,
-                pmacc::DataSpace<SIMDIM> gOffset,
-                pmacc::DataSpace<SIMDIM> lOffset,
-                DataSpace<SIMDIM> physicalSuperCellIdx)
+                pmacc::DataSpace<simDim> gOffset,
+                pmacc::DataSpace<simDim> lOffset,
+                DataSpace<simDim> physicalSuperCellIdx)
                 : currentStep{simStep}
                 , globalOffset{gOffset}
                 , localOffset{lOffset}


### PR DESCRIPTION
- simplify the internal functor object usage by auto detect type signature during the functor call.
- use right hand side `const`
- add missing includes
- remove usage of `SIMDIM` by `simDim`