### PR TITLE
PMacc: fix wrong queue CMake usage

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -76,22 +76,22 @@ get_backend_flags()
             result+=" -DCMAKE_CUDA_ARCHITECTURES=52"
         fi
     elif [ "${backend_cfg[0]}" == "omp2b" ] ; then
-        result+=" -Dalpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON -DPMACC_USE_ASYNC_QUEUES=OFF"
+        result+=" -Dalpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "serial" ] ; then
-        result+=" -Dalpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DPMACC_USE_ASYNC_QUEUES=OFF"
+        result+=" -Dalpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "tbb" ] ; then
-        result+=" -Dalpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON -DPMACC_USE_ASYNC_QUEUES=OFF"
+        result+=" -Dalpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi
     elif [ "${backend_cfg[0]}" == "threads" ] ; then
-        result+=" -Dalpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON -DPMACC_USE_ASYNC_QUEUES=OFF"
+        result+=" -Dalpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
             result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
         fi

--- a/docs/source/dev/debugging.rst
+++ b/docs/source/dev/debugging.rst
@@ -24,7 +24,7 @@ An example build command is
 
 .. code:: bash
 
-   pic-build -c "-DPIC_VERBOSE=127 -DPMACC_VERBOSE=127 -DPMACC_BLOCKING_KERNEL=ON -DPMACC_USE_ASYNC_QUEUES=OFF"
+   pic-build -c "-DPIC_VERBOSE=127 -DPMACC_VERBOSE=127 -DPMACC_BLOCKING_KERNEL=ON -DPMACC_ASYNC_QUEUES=OFF"
 
 When reporting a crash, it is helpful if you attached the output ``stdout`` and ``stderr`` of such a build.
 


### PR DESCRIPTION
`pic-configure` used the wrong CMake paremeter for setting synchronous queue usage.

bug introduced with #4820