### PR TITLE
Add laser parameter output for --dump-metadata

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -213,43 +213,45 @@ namespace picongpu
                         return origin == Origin::Zero ? "zero" : "center";
                     }
 
-                    template<typename My = BaseParam>
+                    template<typename T_Self = BaseParam>
                     static nlohmann::json metadata()
                     {
                         // We make this a function template in order to gain control over the type we are applying this
                         // to. A derived class of the BaseParam should similarly make their own `.metadata()` member a
-                        // `template<typename My =Derived>` and should use `BaseParam::metadata<My>()` as a starting
-                        // point for customisation.
+                        // `template<typename T_Self =Derived>` and should use `BaseParam::metadata<T_Self>()` as a
+                        // starting point for customisation.
 
                         auto result = nlohmann::json::object();
 
-                        result["wavelength"] = {{"value", My::WAVE_LENGTH_SI}, {"unit", "m"}};
-                        result["amplitude"] = {{"value", My::AMPLITUDE_SI}, {"unit", "V/m"}};
-                        result["pulse_duration"] = {{"value", My::PULSE_DURATION_SI}, {"unit", "s"}};
-                        result["laser_phase"] = {{"value", My::LASER_PHASE}, {"unit", "rad"}};
+                        result["wavelength"] = {{"value", T_Self::WAVE_LENGTH_SI}, {"unit", "m"}};
+                        result["amplitude"] = {{"value", T_Self::AMPLITUDE_SI}, {"unit", "V/m"}};
+                        result["pulse_duration"] = {{"value", T_Self::PULSE_DURATION_SI}, {"unit", "s"}};
+                        result["laser_phase"] = {{"value", T_Self::LASER_PHASE}, {"unit", "rad"}};
                         result["direction"]
-                            = {{"value", vector<float_64>{{My::DIRECTION_X, My::DIRECTION_Y, My::DIRECTION_Z}}},
+                            = {{"value",
+                                vector<float_64>{{T_Self::DIRECTION_X, T_Self::DIRECTION_Y, T_Self::DIRECTION_Z}}},
                                {"unit", "none"}};
                         result["focus_position"]
                             = {{"value",
                                 vector<float_64>{
-                                    {My::FOCUS_POSITION_X_SI, My::FOCUS_POSITION_Y_SI, My::FOCUS_POSITION_Z_SI}}},
+                                    {T_Self::FOCUS_POSITION_X_SI,
+                                     T_Self::FOCUS_POSITION_Y_SI,
+                                     T_Self::FOCUS_POSITION_Z_SI}}},
                                {"unit", "m"}};
                         result["focus_origin"]
                             = {{"type",
                                 vector<std::string>{
-
-                                    originToString(My::FOCUS_ORIGIN_X),
-                                    originToString(My::FOCUS_ORIGIN_Y),
-                                    originToString(My::FOCUS_ORIGIN_Z)}}};
-                        result["time_delay"] = {{"value", GetTimeDelay<My>::value}, {"unit", "s"}};
+                                    originToString(T_Self::FOCUS_ORIGIN_X),
+                                    originToString(T_Self::FOCUS_ORIGIN_Y),
+                                    originToString(T_Self::FOCUS_ORIGIN_Z)}}};
+                        result["time_delay"] = {{"value", GetTimeDelay<T_Self>::value}, {"unit", "s"}};
                         result["polarisation"]
                             = {{"direction",
                                 vector<float_64>{
-                                    {My::POLARISATION_DIRECTION_X,
-                                     My::POLARISATION_DIRECTION_Y,
-                                     My::POLARISATION_DIRECTION_Z}}},
-                               {"type", My::Polarisation == PolarisationType::Linear ? "linear" : "circular"}};
+                                    {T_Self::POLARISATION_DIRECTION_X,
+                                     T_Self::POLARISATION_DIRECTION_Y,
+                                     T_Self::POLARISATION_DIRECTION_Z}}},
+                               {"type", T_Self::Polarisation == PolarisationType::Linear ? "linear" : "circular"}};
 
                         return result;
                     }

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -53,6 +53,24 @@ namespace picongpu
                 Center
             };
 
+            /** SFINAE deduction if the user parameter define the variable TIME_DELAY_SI
+             *
+             * This allows that time delay can be an optional variable a user must only define if needed.
+             * The default if it is not defined is 0.
+             * @{
+             */
+            template<typename T, typename = void>
+            struct GetTimeDelay
+            {
+                static constexpr float_X value = 0.0;
+            };
+
+            template<typename T>
+            struct GetTimeDelay<T, decltype((void) T::TIME_DELAY_SI, void())>
+            {
+                static constexpr float_X value = T::TIME_DELAY_SI;
+            };
+
             namespace profiles
             {
                 /** Base structure for parameters of all lasers
@@ -220,10 +238,11 @@ namespace picongpu
                         result["focus_origin"]
                             = {{"type",
                                 vector<std::string>{
+
                                     originToString(My::FOCUS_ORIGIN_X),
                                     originToString(My::FOCUS_ORIGIN_Y),
                                     originToString(My::FOCUS_ORIGIN_Z)}}};
-                        result["time_delay"] = {{"value", My::TIME_DELAY_SI}, {"unit", "s"}};
+                        result["time_delay"] = {{"value", GetTimeDelay<My>::value}, {"unit", "s"}};
                         result["polarisation"]
                             = {{"direction",
                                 vector<float_64>{

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.def
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.def
@@ -190,6 +190,11 @@ namespace picongpu
                     static constexpr float_64 POLARISATION_DIRECTION_Z = 0.0;
                     /** @} */
 
+                    static std::string originToString(Origin origin)
+                    {
+                        return origin == Origin::Zero ? "zero" : "center";
+                    }
+
                     template<typename My = BaseParam>
                     static nlohmann::json metadata()
                     {
@@ -199,12 +204,34 @@ namespace picongpu
                         // point for customisation.
 
                         auto result = nlohmann::json::object();
-                        result["polarisation"]["direction"] = vector<float_64>{
-                            {My::POLARISATION_DIRECTION_X,
-                             My::POLARISATION_DIRECTION_Y,
-                             My::POLARISATION_DIRECTION_Z}};
-                        result["polarisation"]["type"]
-                            = My::Polarisation == PolarisationType::Linear ? "linear" : "circular";
+
+                        result["wavelength"] = {{"value", My::WAVE_LENGTH_SI}, {"unit", "m"}};
+                        result["amplitude"] = {{"value", My::AMPLITUDE_SI}, {"unit", "V/m"}};
+                        result["pulse_duration"] = {{"value", My::PULSE_DURATION_SI}, {"unit", "s"}};
+                        result["laser_phase"] = {{"value", My::LASER_PHASE}, {"unit", "rad"}};
+                        result["direction"]
+                            = {{"value", vector<float_64>{{My::DIRECTION_X, My::DIRECTION_Y, My::DIRECTION_Z}}},
+                               {"unit", "none"}};
+                        result["focus_position"]
+                            = {{"value",
+                                vector<float_64>{
+                                    {My::FOCUS_POSITION_X_SI, My::FOCUS_POSITION_Y_SI, My::FOCUS_POSITION_Z_SI}}},
+                               {"unit", "m"}};
+                        result["focus_origin"]
+                            = {{"type",
+                                vector<std::string>{
+                                    originToString(My::FOCUS_ORIGIN_X),
+                                    originToString(My::FOCUS_ORIGIN_Y),
+                                    originToString(My::FOCUS_ORIGIN_Z)}}};
+                        result["time_delay"] = {{"value", My::TIME_DELAY_SI}, {"unit", "s"}};
+                        result["polarisation"]
+                            = {{"direction",
+                                vector<float_64>{
+                                    {My::POLARISATION_DIRECTION_X,
+                                     My::POLARISATION_DIRECTION_Y,
+                                     My::POLARISATION_DIRECTION_Z}}},
+                               {"type", My::Polarisation == PolarisationType::Linear ? "linear" : "circular"}};
+
                         return result;
                     }
                 };

--- a/include/picongpu/fields/incidentField/profiles/BaseParam.hpp
+++ b/include/picongpu/fields/incidentField/profiles/BaseParam.hpp
@@ -96,24 +96,6 @@ namespace picongpu
                             return 0.0;
                         }
 
-                        /** SFINAE deduction if the user parameter define the variable TIME_DELAY_SI
-                         *
-                         * This allows that time delay can be an optional variable a user must only define if needed.
-                         * The default if it is not defined is 0.
-                         * @{
-                         */
-                        template<typename T, typename = void>
-                        struct GetTimeDelay
-                        {
-                            static constexpr float_X value = 0.0;
-                        };
-
-                        template<typename T>
-                        struct GetTimeDelay<T, decltype((void) T::TIME_DELAY_SI, void())>
-                        {
-                            static constexpr float_X value = T::TIME_DELAY_SI;
-                        };
-
                     public:
                         /** Time delay
                          *

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -79,16 +79,16 @@ namespace picongpu::fields::incidentField::profiles
                 // Adding units to Gaussian-specific parameters
                 gaussianMetadata["W0"] = {{"value", My::W0_SI}, {"unit", "m"}};
                 gaussianMetadata["PULSE_INIT"] = {{"value", My::PULSE_INIT}, {"unit", "none"}};
-                gaussianMetadata["Mode number"] = {{"value", My::MODENUMBER}, {"unit", "none"}};
+                gaussianMetadata["Mode number"] = {{"value", My::numModes}, {"unit", "none"}};
 
                 // Adding Laguerre modes and phases
                 nlohmann::json laguerreModesJson = nlohmann::json::array();
                 nlohmann::json laguerrePhasesJson = nlohmann::json::array();
 
-                for(uint32_t i = 0; i <= MODENUMBER; ++i)
+                for(uint32_t i = 0; i <= numModes; ++i)
                 {
-                    laguerreModesJson.push_back(LAGUERREMODES_t{}[i]);
-                    laguerrePhasesJson.push_back(LAGUERREPHASES_t{}[i]);
+                    laguerreModesJson.push_back(laguerreModes[i]);
+                    laguerrePhasesJson.push_back(laguerrePhases[i]);
                 }
 
                 gaussianMetadata["Laguerre modes"] = {{"value", laguerreModesJson}, {"unit", "none"}};

--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -1,6 +1,6 @@
-/* Copyright 2013-2024 Axel Huebl, Heiko Burau, Anton Helm, Rene Widera,
- *                     Richard Pausch, Alexander Debus, Sergei Bastrakov,
-                       Julian Lenz
+/* Copyright 2013-2024 Axel Huebl, Heiko Burau, Anton Helm,
+ *                     Rene Widera, Richard Pausch, Alexander Debus,
+ *                     Sergei Bastrakov, Julian Lenz
  *
  * This file is part of PIConGPU.
  *
@@ -24,7 +24,6 @@
 #include "picongpu/fields/incidentField/profiles/BaseParam.def"
 
 #include <nlohmann/json.hpp>
-
 
 namespace picongpu::fields::incidentField::profiles
 {
@@ -76,8 +75,25 @@ namespace picongpu::fields::incidentField::profiles
             {
                 auto baseMetadata = BaseParam::metadata<My>();
                 auto gaussianMetadata = nlohmann::json::object();
-                gaussianMetadata["W0"] = W0_SI;
-                gaussianMetadata["PULSE_INIT"] = PULSE_INIT;
+
+                // Adding units to Gaussian-specific parameters
+                gaussianMetadata["W0"] = {{"value", My::W0_SI}, {"unit", "m"}};
+                gaussianMetadata["PULSE_INIT"] = {{"value", My::PULSE_INIT}, {"unit", "none"}};
+                gaussianMetadata["Mode number"] = {{"value", My::MODENUMBER}, {"unit", "none"}};
+
+                // Adding Laguerre modes and phases
+                nlohmann::json laguerreModesJson = nlohmann::json::array();
+                nlohmann::json laguerrePhasesJson = nlohmann::json::array();
+
+                for(uint32_t i = 0; i <= MODENUMBER; ++i)
+                {
+                    laguerreModesJson.push_back(LAGUERREMODES_t{}[i]);
+                    laguerrePhasesJson.push_back(LAGUERREPHASES_t{}[i]);
+                }
+
+                gaussianMetadata["Laguerre modes"] = {{"value", laguerreModesJson}, {"unit", "none"}};
+                gaussianMetadata["Laguerre phases"] = {{"value", laguerrePhasesJson}, {"unit", "none"}};
+
                 baseMetadata["Gaussian parameters"] = gaussianMetadata;
                 return baseMetadata;
             }

--- a/share/picongpu/examples/Bunch/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/incidentField.param
@@ -73,7 +73,7 @@ namespace picongpu
              * The particular used parameter structures do not have to inherit this, but must define same members
              * with same meaning.
              */
-            struct PlaneWaveParams
+            struct PlaneWaveParams : public profiles::BaseParam
             {
                 /** Wave length along propagation direction
                  *

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/incidentField.param
@@ -78,7 +78,7 @@ namespace picongpu
              * The particular used parameter structures do not have to inherit this, but must define same members
              * with same meaning.
              */
-            struct PlaneWaveParams
+            struct PlaneWaveParams : public profiles::BaseParam
             {
                 /** Wave length along propagation direction
                  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -243,12 +243,12 @@ namespace picongpu
                 static constexpr auto laguerrePhases = floatN_X<numModes + 1>(0.0);
                 /** @} */
 
-                template<typename My = GaussianPulseParam>
+                template<typename T_Self = GaussianPulseParam>
                 static auto metadata()
                 {
                     // static member functions do not bind to the derived type when inherited, so we have to refer to
                     // our type explicitly
-                    return profiles::defaults::GaussianPulseParam::metadata<My>();
+                    return profiles::defaults::GaussianPulseParam::metadata<T_Self>();
                 };
             };
 

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -209,14 +209,6 @@ namespace picongpu
                 static constexpr float_64 POLARISATION_DIRECTION_Y = 0.0;
                 static constexpr float_64 POLARISATION_DIRECTION_Z = 0.0;
                 /** @} */
-
-                template<typename My = LwfaGaussianPulseBaseParams>
-                static auto metadata()
-                {
-                    // static member functions do not bind to the derived type when inherited, so we have to refer to
-                    // our type explicitly
-                    return profiles::BaseParam::metadata<My>();
-                };
             };
 
             /** Special structure for parameters of Gaussian laser pulses.
@@ -250,6 +242,14 @@ namespace picongpu
                 static constexpr auto laguerreModes = floatN_X<numModes + 1>(1.0);
                 static constexpr auto laguerrePhases = floatN_X<numModes + 1>(0.0);
                 /** @} */
+
+                template<typename My = GaussianPulseParam>
+                static auto metadata()
+                {
+                    // static member functions do not bind to the derived type when inherited, so we have to refer to
+                    // our type explicitly
+                    return profiles::defaults::GaussianPulseParam::metadata<My>();
+                };
             };
 
 

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -70,7 +70,7 @@ namespace picongpu::fields::incidentField
      * The particular used parameter structures do not have to inherit this, but must define same members
      * with same meaning.
      */
-    struct PyPIConGPULaserBaseParam
+    struct PyPIConGPULaserBaseParam : public profiles::BaseParam
     {
         static constexpr float_64 WAVE_LENGTH_SI = {{{wave_length_si}}}; // m
         static constexpr float_64 AMPLITUDE_SI = {{{E0_si}}}; // V/m

--- a/share/picongpu/tests/Shadowgraphy/include/picongpu/param/incidentField.param
+++ b/share/picongpu/tests/Shadowgraphy/include/picongpu/param/incidentField.param
@@ -35,7 +35,7 @@ namespace picongpu
 
             namespace profiles
             {
-                struct MyGaussianParam
+                struct MyGaussianParam : public profiles::BaseParam
                 {
                     static constexpr float_64 WAVE_LENGTH_SI = 800e-9; // TIME_PERIOD_SI * sim.si.getSpeedOfLight();
                     static constexpr float_64 TIME_PERIOD_SI = WAVE_LENGTH_SI / sim.si.getSpeedOfLight();

--- a/share/picongpu/tests/metadataFromLaserWakefield/picongpu-metadata.json.reference
+++ b/share/picongpu/tests/metadataFromLaserWakefield/picongpu-metadata.json.reference
@@ -11,6 +11,32 @@
     ],
     "YMin": [
       {
+        "Gaussian parameters": {
+          "Laguerre modes": {
+            "unit": "none",
+            "value": [
+              1.0
+            ]
+          },
+          "Laguerre phases": {
+            "unit": "none",
+            "value": [
+              0.0
+            ]
+          },
+          "Mode number": {
+            "unit": "none",
+            "value": 0
+          },
+          "PULSE_INIT": {
+            "unit": "none",
+            "value": 15.0
+          },
+          "W0": {
+            "unit": "m",
+            "value": 4.246609082647506e-06
+          }
+        },
         "amplitude": {
           "unit": "V/m",
           "value": 32107010989706.094

--- a/share/picongpu/tests/metadataFromLaserWakefield/picongpu-metadata.json.reference
+++ b/share/picongpu/tests/metadataFromLaserWakefield/picongpu-metadata.json.reference
@@ -11,6 +11,37 @@
     ],
     "YMin": [
       {
+        "amplitude": {
+          "unit": "V/m",
+          "value": 32107010989706.094
+        },
+        "direction": {
+          "unit": "none",
+          "value": [
+            0.0,
+            1.0,
+            0.0
+          ]
+        },
+        "focus_origin": {
+          "type": [
+            "center",
+            "zero",
+            "center"
+          ]
+        },
+        "focus_position": {
+          "unit": "m",
+          "value": [
+            0.0,
+            4.62e-05,
+            0.0
+          ]
+        },
+        "laser_phase": {
+          "unit": "rad",
+          "value": 0.0
+        },
         "polarisation": {
           "direction": [
             1.0,
@@ -18,6 +49,18 @@
             0.0
           ],
           "type": "circular"
+        },
+        "pulse_duration": {
+          "unit": "s",
+          "value": 5e-15
+        },
+        "time_delay": {
+          "unit": "s",
+          "value": 0.0
+        },
+        "wavelength": {
+          "unit": "m",
+          "value": 8e-07
         }
       }
     ],


### PR DESCRIPTION
This pull request adds laser parameter output in the `BaseParam.def` and `GaussianPulse.def` files, based on the new parameter output [feature](https://github.com/ComputationalRadiationPhysics/picongpu/pull/4812) from @chillenzer .

In the `picongpu-metadata.json` file the standard laser parameters from `incidentField.param` are displayed with units, for example:

```
"W0": {
    "unit": "m",
    "value": 4.246609082647506e-06
}
```
or
```
"direction": {
    "unit": "none",
    "value": [
      0.0,
      1.0,
      0.0
    ]
},

```

The next things on my list are:

- [x] ~~adding README~~ [EDIT/REMOVED by @PrometheusPi]

- [x] invest deeper in the problem, that Laguerremodes and -phases in the incidentField.param file are not correctly displayed if there are several Laguerremodes (seems like its falling back to the default 0th Laguerre mode for a standard Gaussian)