### PR TITLE
remove python from snakemake requirements.txt

### DIFF
--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/requirements.txt
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/requirements.txt
@@ -1,7 +1,6 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
-python
 pandas
 snakemake>=8.11.3
 snakemake-executor-plugin-slurm>=0.5.1


### PR DESCRIPTION
This pull request fixes a little bug I oversaw when merging #4949. There should  be no `python` in `requirements.txt` since it is not itself a python package. 