### PR TITLE
Update JURECA profile

### DIFF
--- a/etc/picongpu/jureca-jsc/gpus.tpl
+++ b/etc/picongpu/jureca-jsc/gpus.tpl
@@ -28,6 +28,7 @@
 #SBATCH --job-name=!TBG_jobName
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --exclusive
+#SBATCH --distribution=*:block
 #SBATCH --gres=gpu:!TBG_devicesPerNode
 #SBATCH --ntasks=!TBG_tasks
 #SBATCH --ntasks-per-node=!TBG_devicesPerNode

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -51,8 +51,8 @@ module load h5py/3.9.0
 # Self-Build Software #########################################################
 #
 # needs to be compiled by the user
-# Check the install description at
-# https://github.com/ComputationalRadiationPhysics/picongpu/blob/dev/INSTALL.rst
+# Check the install script at
+# https://gist.github.com/ikbuibui/e27311bcc5390f2d66ce68401f2620e9
 #
 export PIC_LIBS=$PROJECT/share/lib
 export PNG_WRITER=$PIC_LIBS/pngwriter


### PR DESCRIPTION
Use explicit block distribution for distribution of CPUs across sockets for binding as a workaround for [this](https://apps.fz-juelich.de/jsc/hps/jureca/known-issues.html#slurm-srun-options-exact-and-exclusive-change-default-pinning).
Point to new install script gist