### PR TITLE
add warning timestep mismatch snakemake and adjust cfg

### DIFF
--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -38,7 +38,7 @@ TBG_devices_z=1
 
 # if you change the number of cells in X and Z direction the laser will not be centered in the middle
 TBG_gridSize="192 1024 192"
-TBG_steps="2048"
+TBG_steps="2000"
 
 TBG_periodic="--periodic 0 0 1"
 

--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/README.rst
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/README.rst
@@ -115,6 +115,10 @@ Details of the individual rules:
     * The output file ("simulated/finished_{paramspace.wildcard_pattern}.txt") is created after the simulation but the shell script would be immediately done after submitting the simulation. If the task is done and the output file is not created an error occurs and the workflow fails. In order to make Snakemake wait till the simulation is finished, the status of the slurm job is checked every two minutes.
     * This control loop is set up in such a way that even if the snakemake session is aborted or fails, it will catch up with simulations already running when snakemake is restarted.
 
+  .. warning::
+
+        The simulate rule looks for ``100 % =`` in ``stdout``. If the number of time steps and the percentage of output do not match, such an output will never be created (e.g. 1024 time steps and output every 5% will not generate a ``100 % =`` output).
+
 |
 
 Using the example ``Snakefile`` and ``params.csv``, the resulting DAG looks like this.


### PR DESCRIPTION
This pull request:
- adds a warning to the README about a potential timestep output-percentage mismatch
- fixes the default `1.cfg`to not trigger the error

ToDo: 

- [x] check whether changed to `README.rst` are rendered correctly