### PR TITLE
fix `pic-build -c`

### DIFF
--- a/bin/pic-build
+++ b/bin/pic-build
@@ -61,7 +61,7 @@ while [[ $# -gt 0 ]] ; do
             fi
             ;;
         *)
-            cmd_line_args+=($1)
+            cmd_line_args+=("$1")
             # just ignore other options
             ;;
     esac


### PR DESCRIPTION
With #4936 we broke the option `-c`.

The CI is disabled because we do not use `pic-build` in the CI.