### PR TITLE
fix broken requirements.txt

### DIFF
--- a/lib/python/picongpu/extra/plugins/data/requirements.txt
+++ b/lib/python/picongpu/extra/plugins/data/requirements.txt
@@ -3,4 +3,4 @@ pandas>=0.21.0
 h5py
 pillow
 imageio
-openPMD-api>=0.10.3gt
+openPMD-api>=0.10.3


### PR DESCRIPTION
This pull request fixes a minor issue in one of our `requirements.txt`. Most likely, the `gt` in the end were a typo. 
With the `gt`, `pip install` fails. Without it, it works. 