### PR TITLE
fix import statements for plugins

### DIFF
--- a/docs/source/usage/plugins/energyHistogram.rst
+++ b/docs/source/usage/plugins/energyHistogram.rst
@@ -93,7 +93,7 @@ You can quickly load and interact with the data in Python with:
 
 .. code:: python
 
-   from picongpu.plugins.data import EnergyHistogramData
+   from picongpu.extra.plugins.data import EnergyHistogramData
 
    eh_data = EnergyHistogramData('path/to/run_dir') # the directory in which simOutput is located
 
@@ -120,7 +120,7 @@ You can quickly plot the data in Python with:
 
 .. code:: python
 
-   from picongpu.plugins.plot_mpl import EnergyHistogramMPL
+   from picongpu.extra.plugins.plot_mpl import EnergyHistogramMPL
    import matplotlib.pyplot as plt
 
 
@@ -202,7 +202,7 @@ After starting the notebook server write the following
    plt.ioff()
 
    from IPython.display import display
-   from picongpu.plugins.jupyter_widgets import EnergyHistogramWidget
+   from picongpu.extra.plugins.jupyter_widgets import EnergyHistogramWidget
 
    # provide the paths to the simulations you want to be able to choose from
    # together with labels that will be used in the plot legends so you still know

--- a/docs/source/usage/plugins/phaseSpace.rst
+++ b/docs/source/usage/plugins/phaseSpace.rst
@@ -211,7 +211,7 @@ The final script snippet then reads:
    plt.ioff()
 
    from IPython.display import display
-   from picongpu.plugins.jupyter_widgets import PhaseSpaceWidget
+   from picongpu.extra.plugins.jupyter_widgets import PhaseSpaceWidget
 
    # provide the paths to the simulations you want to be able to choose from
    # together with labels that will be used in the plot legends so you still know

--- a/docs/source/usage/plugins/png.rst
+++ b/docs/source/usage/plugins/png.rst
@@ -274,7 +274,7 @@ You can quickly load and interact with the data in Python with:
 
 .. code:: python
 
-   from picongpu.plugins.data import PNGData
+   from picongpu.extra.plugins.data import PNGData
 
 
    png_data = PNGData('path/to/run_dir')
@@ -299,7 +299,7 @@ even easier since you don't have to load the data manually.
 
 .. code:: python
 
-   from picongpu.plugins.plot_mpl import PNGMPL
+   from picongpu.extra.plugins.plot_mpl import PNGMPL
    import matplotlib.pyplot as plt
 
 
@@ -350,7 +350,7 @@ After starting the notebook server write the following
    plt.ioff()
 
    from IPython.display import display
-   from picongpu.plugins.jupyter_widgets import PNGWidget
+   from picongpu.extra.plugins.jupyter_widgets import PNGWidget
 
    # provide the paths to the simulations you want to be able to choose from
    # together with labels that will be used in the plot legends so you still know

--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -489,7 +489,7 @@ This currently assumes adios output but any openPMD output, such as hdf5, will w
     import matplotlib.pyplot as plt
     from matplotlib.colors import LogNorm
 
-    from picongpu.plugins.data import RadiationData
+    from picongpu.extra.plugins.data import RadiationData
 
     # access openPMD radiation file for specific time step
     radData = RadiationData("./simOutput/radiationOpenPMD/e_radAmplitudes_%T.bp", 2820)


### PR DESCRIPTION
Since quite a while (since PICMI), our plugin example codes snippets were outdated.  This pull request updates that. 