### PR TITLE
update picmi user documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,7 @@ pypicongpu-generate-full-matrix:
     - apt install -y python3 python3-pip
     - pip3 install pyyaml requests
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - python3 $CI_PROJECT_DIR/share/ci/pypicongpu_generator.py $CI_PROJECT_DIR/lib/python/picongpu/requirements.txt > compile.yml
+    - python3 $CI_PROJECT_DIR/share/ci/pypicongpu_generator.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt > compile.yml
     - cat compile.yml
   artifacts:
     paths:

--- a/docs/source/usage/picmi/intro.rst
+++ b/docs/source/usage/picmi/intro.rst
@@ -11,6 +11,22 @@ Example
 
 Creates a directory ``generated_input``, where you can run ``pic-build`` and subsequently ``tbg``.
 
+.. note::
+
+   Note that in order to run the python script, you need to set up a Python environment that
+   includes all the dependencies listed in  ``$PICSRC/lib/python/picongpu/picmi/requirements.txt``.
+   This can be done by e.g. ``pip install -r $PICSRC/lib/python/picongpu/picmi/requirements.txt``.
+   You will also need to set your ``$PYTHONPATH`` to include PIConGPU's Python libraries.
+   This can be done by ``export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH``.
+   (Updating the ``PYTHONPATH`` is automatically done when you source your PIConGPU environment, see below.)
+   For ``pic-build`` and ``tbg`` you need to setup a working PIConGPU environment.
+   This is documented in :ref:`the Setup part of PIConGPU in 5 Minutes on Hemera <hemeraIn5min>`.
+
+   Above, we used:
+
+   -  ``$PICSRC`` as shell variable providing the path to picongpu's source code directory.
+
+
 Generation Results
 ------------------
 

--- a/lib/python/picongpu/picmi/requirements.txt
+++ b/lib/python/picongpu/picmi/requirements.txt
@@ -1,0 +1,6 @@
+typeguard >= 4.2.1
+sympy >= 1.9
+chevron >= 0.13.1
+jsonschema == 4.17.3
+scipy >= 1.7.1
+picmistandard >= 0.27.0

--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,8 +1,2 @@
-typeguard >= 4.2.1
-sympy >= 1.9
-chevron >= 0.13.1
-jsonschema == 4.17.3
-scipy >= 1.7.1
-picmistandard >= 0.27.0
-
+-r picmi/requirements.txt
 -r extra/requirements.txt

--- a/share/ci/install/pypicongpu.sh
+++ b/share/ci/install/pypicongpu.sh
@@ -40,7 +40,7 @@ conda create -n pypicongpu python=${PYTHON_VERSION}
 conda activate pypicongpu
 python3 --version
 MODIFIED_REQUIREMENT_TXT=$CI_PROJECT_DIR/lib/python/picongpu/modified_requirements.txt
-python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/requirements.txt $MODIFIED_REQUIREMENT_TXT
+python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt $MODIFIED_REQUIREMENT_TXT
 
 echo "modified_requirements.txt: "
 cat $MODIFIED_REQUIREMENT_TXT


### PR DESCRIPTION
This pull request
- separates the PICMI python dependencies out of the global space and into a local `picmi/requirements.txt`
- updates the introduction to picmi to include what setup is needed to actually run the python example code

- [x] I need to check, whether the read the docs file is actually rendered correctly 