### PR TITLE
fix C++20 compiler

### DIFF
--- a/include/picongpu/particles/functor/User.hpp
+++ b/include/picongpu/particles/functor/User.hpp
@@ -49,7 +49,9 @@ namespace picongpu
                 template<typename DeferFunctor = Functor>
                 HINLINE User(
                     uint32_t currentStep,
-                    std::enable_if_t<std::is_constructible_v<DeferFunctor, uint32_t>>* = 0)
+                    std::enable_if_t<
+                        !std::is_default_constructible_v<
+                            DeferFunctor> && std::is_constructible_v<DeferFunctor, uint32_t>>* = 0)
                     : Functor(currentStep)
                 {
                 }
@@ -64,7 +66,8 @@ namespace picongpu
                  * @param is used to enable/disable the constructor (do not pass any value to this parameter)
                  */
                 template<typename DeferFunctor = Functor>
-                HINLINE User(uint32_t, std::enable_if_t<std::is_constructible_v<DeferFunctor>>* = nullptr) : Functor()
+                HINLINE User(uint32_t, std::enable_if_t<std::is_default_constructible_v<DeferFunctor>>* = nullptr)
+                    : Functor()
                 {
                 }
             };

--- a/include/picongpu/plugins/misc/concatenateToString.hpp
+++ b/include/picongpu/plugins/misc/concatenateToString.hpp
@@ -43,7 +43,7 @@ namespace picongpu
                     container.begin(),
                     container.end(),
                     std::string(),
-                    [&](std::string& result, std::string& inString)
+                    [&](std::string const& result, std::string const& inString)
                     { return result.empty() ? inString : result + separator + inString; });
             }
         } // namespace misc


### PR DESCRIPTION
- fix using reference to possible temporary
- `is_constructible_v` in C++20 is returning true if a member can be explicit initialized even if there is no constructor available.