### PR TITLE
plugin: phaseSpace add pair implementation

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
+++ b/include/picongpu/plugins/PhaseSpace/DumpHBufferOpenPMD.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/plugins/PhaseSpace/AxisDescription.hpp"
+#include "picongpu/plugins/PhaseSpace/Pair.hpp"
 
 #include <pmacc/communication/manager_common.hpp>
 #include <pmacc/dimensions/DataSpace.hpp>
@@ -60,7 +61,7 @@ namespace picongpu
         void operator()(
             HostBuffer<T_Type, T_bufDim>& hBuffer,
             const AxisDescription axis_element,
-            const std::pair<float_X, float_X> axis_p_range,
+            const phaseSpace::Pair<float_X, float_X> axis_p_range,
             const float_64 pRange_unit,
             const float_64 unit,
             const std::string strSpecies,

--- a/include/picongpu/plugins/PhaseSpace/Pair.hpp
+++ b/include/picongpu/plugins/PhaseSpace/Pair.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2024 Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/attribute/FunctionSpecifier.hpp>
+
+namespace picongpu::phaseSpace
+{
+    /** Basic implementation of std::pair
+     *
+     * This class is guaranteeing that the the object is trivially copyable.
+     * std::pair is not giving this guarantee.
+     */
+    template<typename T_First, typename T_Second>
+    struct Pair
+    {
+        T_First first;
+        T_Second second;
+
+        HDINLINE Pair(T_First inFirst, T_Second inSecond) : first{inFirst}, second{inSecond}
+        {
+        }
+
+        Pair() = default;
+
+        Pair(Pair const&) = default;
+    };
+} // namespace picongpu::phaseSpace

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/PhaseSpace/AxisDescription.hpp"
+#include "picongpu/plugins/PhaseSpace/Pair.hpp"
 #include "picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp"
 #include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 
@@ -185,7 +186,7 @@ namespace picongpu
         /** plot to create: e.g. py, x from element_coordinate/momentum */
         AxisDescription axis_element;
         /** range [pMin : pMax] in m_e c */
-        std::pair<float_X, float_X> axis_p_range;
+        phaseSpace::Pair<float_X, float_X> axis_p_range;
         uint32_t r_bins;
 
         std::shared_ptr<Help> m_help;
@@ -226,14 +227,14 @@ namespace picongpu
             TParticlesBox particlesBox;
             pmacc::DataBox<PitchedBox<float_PS, 2>> phaseSpaceBox;
             uint32_t p_element;
-            std::pair<float_X, float_X> axis_p_range;
+            phaseSpace::Pair<float_X, float_X> axis_p_range;
             MappingDesc cellDesc;
 
             StartBlockFunctor(
                 const TParticlesBox& pb,
                 pmacc::DataBox<PitchedBox<float_PS, 2>> phaseSpaceDeviceBox,
                 const uint32_t p_dir,
-                const std::pair<float_X, float_X>& p_range,
+                const phaseSpace::Pair<float_X, float_X>& p_range,
                 MappingDesc const& cellDescription)
                 : particlesBox(pb)
                 , phaseSpaceBox(phaseSpaceDeviceBox)

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "picongpu/algorithms/Set.hpp"
+#include "picongpu/plugins/PhaseSpace/Pair.hpp"
 #include "picongpu/plugins/PhaseSpace/PhaseSpace.hpp"
 
 #include <pmacc/lockstep.hpp>
@@ -59,7 +60,7 @@ namespace picongpu
             T_Particle particle,
             T_SharedMemHist sharedMemHist,
             const uint32_t el_p,
-            const std::pair<float_X, float_X>& axis_p_range)
+            const phaseSpace::Pair<float_X, float_X>& axis_p_range)
         {
             using float_PS = typename T_SharedMemHist::ValueType;
             /** \todo this can become a functor to be even more flexible
@@ -118,7 +119,7 @@ namespace picongpu
         TParticlesBox particlesBox;
         pmacc::DataBox<PitchedBox<float_PS, 2>> globalHist;
         uint32_t p_element;
-        std::pair<const float_X, float_X> axis_p_range;
+        phaseSpace::Pair<float_X, float_X> axis_p_range;
         T_Filter particleFilter;
 
         /** Constructor to transfer params to device
@@ -134,7 +135,7 @@ namespace picongpu
             const TParticlesBox& pb,
             pmacc::DataBox<PitchedBox<float_PS, 2>> phaseSpaceHistogram,
             const uint32_t p_dir,
-            const std::pair<float_X, float_X>& p_range,
+            const phaseSpace::Pair<float_X, float_X>& p_range,
             const T_Filter& parFilter)
             : particlesBox(pb)
             , globalHist(phaseSpaceHistogram)


### PR DESCRIPTION
`std::pair` is not guaranteed to be trivially copyable therefore we can not pass an object storing a `std::pair` as a member into the device kernel. Depending on the std implementation alpaka will throw a compiletime exception.

By simply implementing a basic pair struct compile, the issue can be avoided.