### PR TITLE
add mpiexec to picongpu call of metadata test

### DIFF
--- a/share/picongpu/tests/metadataFromLaserWakefield/bin/ci.sh
+++ b/share/picongpu/tests/metadataFromLaserWakefield/bin/ci.sh
@@ -83,7 +83,7 @@ pic-create -f . "${TMPDIR}" &&
     cd "${TMPDIR}" &&
     pic-build
 
-EXECUTABLE="bin/picongpu"
+EXECUTABLE="mpiexec -n 1 bin/picongpu"
 ARGS="-d 1 1 1 -g 24 24 24 "
 
 # doc-include-start: cmdline


### PR DESCRIPTION
The current CI test `metadataFromLaserWakefield` did not use `mipexec` and thus failed e.g. on hemera with the following error:
```
OPAL ERROR: Unreachable in file pmix3x_client.c at line 112
--------------------------------------------------------------------------
The application appears to have been direct launched using "srun",
but OMPI was not built with SLURM's PMI support and therefore cannot
execute. There are several options for building PMI support under
SLURM, depending upon the SLURM version you are using:

  version 16.05 or later: you can use SLURM's PMIx support. This
  requires that you configure and build SLURM --with-pmix.

  Versions earlier than 16.05: you must use either SLURM's PMI-1 or
  PMI-2 support. SLURM builds PMI-1 by default, or you can manually
  install PMI-2. You must then build Open MPI using --with-pmi pointing
  to the SLURM PMI library location.

Please configure as appropriate and try again.
--------------------------------------------------------------------------
*** An error occurred in MPI_Init
*** on a NULL communicator
*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
***    and potentially your MPI job)
```

This pull request should fix that. 

Thanks @max-lehman14 for discovering this bug. 