### PR TITLE
change pulse laguerre mode definition

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/GaussianPulse.def
@@ -30,21 +30,6 @@ namespace picongpu::fields::incidentField::profiles
 {
     namespace defaults
     {
-        namespace gaussianPulse
-        {
-            //! Use only the 0th Laguerremode for a standard Gaussian
-            static constexpr uint32_t MODENUMBER = 0;
-            PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
-            PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
-            // This is just an example for a more complicated set of Laguerre modes
-            // constexpr uint32_t MODENUMBER = 12;
-            // PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, -1.0, 0.0300519, 0.319461,
-            // -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038,
-            // -0.00896321, -0.0160788); PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES,
-            // 0.0, 1.0344594, -0.9384701, -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303,
-            // -0.8039839, 3.0055385, -0.1503778, -9.6980362, -2.8122287);
-        } // namespace gaussianPulse
-
         struct GaussianPulseParam : public BaseParam
         {
             /** Beam waist: distance from the axis where the pulse intensity (E^2)
@@ -65,13 +50,25 @@ namespace picongpu::fields::incidentField::profiles
             static constexpr float_64 PULSE_INIT = 20.0;
 
 
-            /** Laguerre mode parameters
+            /** Use only the 0th Laguerremode for a standard Gaussian
              *
              * @{
              */
-            using LAGUERREMODES_t = gaussianPulse::LAGUERREMODES_t;
-            using LAGUERREPHASES_t = gaussianPulse::LAGUERREPHASES_t;
-            static constexpr uint32_t MODENUMBER = gaussianPulse::MODENUMBER;
+            static constexpr uint32_t numModes = 0;
+            static constexpr auto laguerreModes = floatN_X<numModes + 1>(1.0);
+            static constexpr auto laguerrePhases = floatN_X<numModes + 1>(0.0);
+            /** This is just an example for a more complicated set of Laguerre modes
+             *
+             * @code{.cpp}
+             * static constexpr uint32_t numModes = 12;
+             * static constexpr auto laguerreModes = floatN_X<numModes+1>( -1.0, 0.0300519, 0.319461,
+             * -0.23783, 0.0954839, 0.0318653, -0.144547, 0.0249208, -0.111989, 0.0434385, -0.030038,
+             * -0.00896321, -0.0160788);
+             * static constexpr auto laguerrePhases = floatN_X<numModes+1>(
+             * 0.0, 1.0344594, -0.9384701, -2.7384883, 0.0016872, 2.4563653, -0.312892, -1.7298303,
+             * -0.8039839, 3.0055385, -0.1503778, -9.6980362, -2.8122287);
+             * @endcode
+             */
             /** @} */
 
             template<typename My = GaussianPulseParam>

--- a/include/picongpu/unitless/precision.unitless
+++ b/include/picongpu/unitless/precision.unitless
@@ -31,20 +31,26 @@ namespace picongpu
     {
         using float_X = precisionType;
         /* 32 Bit defines */
-        using float1_X = ::pmacc::math::Vector<float_X, 1u>;
-        using float2_X = ::pmacc::math::Vector<float_X, 2u>;
-        using float3_X = ::pmacc::math::Vector<float_X, 3u>;
-        using floatD_X = ::pmacc::math::Vector<float_X, simDim>;
+        template<uint32_t T_n>
+        using floatN_X = ::pmacc::math::Vector<float_X, T_n>;
+
+        using float1_X = floatN_X<1u>;
+        using float2_X = floatN_X<2u>;
+        using float3_X = floatN_X<3u>;
+        using floatD_X = floatN_X<simDim>;
     } // namespace precision32Bit
 
     namespace precision64Bit
     {
         using float_X = precisionType;
         /* 64 Bit defines */
-        using float1_X = ::pmacc::math::Vector<float_X, 1u>;
-        using float2_X = ::pmacc::math::Vector<float_X, 2u>;
-        using float3_X = ::pmacc::math::Vector<float_X, 3u>;
-        using floatD_X = ::pmacc::math::Vector<float_X, simDim>;
+        template<uint32_t T_n>
+        using floatN_X = ::pmacc::math::Vector<float_X, T_n>;
+
+        using float1_X = floatN_X<1u>;
+        using float2_X = floatN_X<2u>;
+        using float3_X = floatN_X<3u>;
+        using floatD_X = floatN_X<simDim>;
     } // namespace precision64Bit
 
     using float_32 = precision32Bit::float_X;
@@ -55,16 +61,23 @@ namespace picongpu
     using float2_X = ::pmacc::math::Vector<float_X, 2u>;
     using float3_X = ::pmacc::math::Vector<float_X, 3u>;
     using floatD_X = ::pmacc::math::Vector<float_X, simDim>;
+    template<uint32_t T_n>
+    using floatN_X = ::pmacc::math::Vector<float_X, T_n>;
+
     /* 32 Bit defines */
     using float1_32 = precision32Bit::float1_X;
     using float2_32 = precision32Bit::float2_X;
     using float3_32 = precision32Bit::float3_X;
     using floatD_32 = precision32Bit::floatD_X;
+    template<uint32_t T_n>
+    using floatN_32 = precision32Bit::floatN_X<T_n>;
     /* 64 Bit defines */
     using float1_64 = precision64Bit::float1_X;
     using float2_64 = precision64Bit::float2_X;
     using float3_64 = precision64Bit::float3_X;
     using floatD_64 = precision64Bit::floatD_X;
+    template<uint32_t T_n>
+    using floatN_64 = precision64Bit::floatN_X<T_n>;
 
     // literals for short-hand notations
     constexpr float_X operator""_X(long double x)

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -190,6 +190,11 @@ namespace pmacc
                 return (*this)[0];
             }
 
+            static constexpr uint32_t size()
+            {
+                return dim;
+            }
+
             /**
              * Creates a Vector where all dimensions are set to the same value
              *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -219,14 +219,6 @@ namespace picongpu
                 };
             };
 
-            namespace lwfaGaussianPulse
-            {
-                //! Use only the 0th Laguerremode for a standard Gaussian
-                static constexpr uint32_t MODENUMBER = 0;
-                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES, 1.0);
-                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES, 0.0);
-            } // namespace lwfaGaussianPulse
-
             /** Special structure for parameters of Gaussian laser pulses.
              *
              * Inherits from LwfaGaussianPulseBaseParams in order to combine all Gaussian pulse parameters.
@@ -253,9 +245,10 @@ namespace picongpu
                  *
                  * @{
                  */
-                using LAGUERREMODES_t = lwfaGaussianPulse::LAGUERREMODES_t;
-                using LAGUERREPHASES_t = lwfaGaussianPulse::LAGUERREPHASES_t;
-                static constexpr uint32_t MODENUMBER = lwfaGaussianPulse::MODENUMBER;
+                //! Use only the 0th Laguerremode for a standard Gaussian
+                static constexpr uint32_t numModes = 0;
+                static constexpr auto laguerreModes = floatN_X<numModes + 1>(1.0);
+                static constexpr auto laguerrePhases = floatN_X<numModes + 1>(0.0);
                 /** @} */
             };
 

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -107,22 +107,6 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
     };
 
-    namespace PyPIConGPUGaussianPulse
-    {
-                //! Use only the 0th Laguerremode for a standard Gaussian
-                static constexpr uint32_t MODENUMBER = {{{modenumber}}};
-                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREMODES,
-                {{#laguerre_modes}}
-                {{{single_laguerre_mode}}}{{^_last}},{{/_last}}
-                {{/laguerre_modes}}
-                );
-                PMACC_CONST_VECTOR(float_X, MODENUMBER + 1, LAGUERREPHASES,
-                {{#laguerre_phases}}
-                {{{single_laguerre_phase}}}{{^_last}},{{/_last}}
-                {{/laguerre_phases}}
-                );
-    } // namespace PyPIConGPUGaussianPulse
-
     struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
     {
         /** Beam waist: distance from the axis where the pulse intensity (E^2)
@@ -145,9 +129,17 @@ namespace picongpu::fields::incidentField
          *
          * @{
          */
-        using LAGUERREMODES_t = PyPIConGPUGaussianPulse::LAGUERREMODES_t;
-        using LAGUERREPHASES_t = PyPIConGPUGaussianPulse::LAGUERREPHASES_t;
-        static constexpr uint32_t MODENUMBER = PyPIConGPUGaussianPulse::MODENUMBER;
+        static constexpr uint32_t numModes = {{{modenumber}}};
+        static constexpr auto laguerreModes = floatN_X<numModes+1>(
+            {{#laguerre_modes}}
+            {{{single_laguerre_mode}}}{{^_last}},{{/_last}}
+            {{/laguerre_modes}}
+            );
+        static constexpr auto laguerrePhases = floatN_X<numModes+1>(
+            {{#laguerre_phases}}
+            {{{single_laguerre_phase}}}{{^_last}},{{/_last}}
+            {{/laguerre_phases}}
+            );
         /** @} */
     };
 

--- a/share/picongpu/tests/Shadowgraphy/include/picongpu/param/incidentField.param
+++ b/share/picongpu/tests/Shadowgraphy/include/picongpu/param/incidentField.param
@@ -71,9 +71,8 @@ namespace picongpu
 
                     static constexpr float_64 PULSE_INIT = 16.0;
 
-                    using LAGUERREMODES_t = defaults::gaussianPulse::LAGUERREMODES_t;
-                    using LAGUERREPHASES_t = defaults::gaussianPulse::LAGUERREPHASES_t;
-                    static constexpr uint32_t MODENUMBER = defaults::gaussianPulse::MODENUMBER;
+                    static constexpr auto laguerreModes = defaults::GaussianPulseParam::laguerreModes;
+                    static constexpr auto laguerrePhases = defaults::GaussianPulseParam::laguerrePhases;
                     /** @} */
                 };
             } // namespace profiles


### PR DESCRIPTION
Use `floatN_X<>` to configure laguerre modes instead of `PMACC_CONST_VECTOR`.
This comes with the advantage that the modes are now part of the configuration struct and there is no need for a namespace we reference within the struct.

**ATTENTION** This PR makes older setups incompatible. Change the laguerre modes to solve issue.

```
static constexpr uint32_t numModes = 0;
static constexpr auto laguerreModes = floatN_X<numModes + 1>(1.0);
static constexpr auto laguerrePhases = floatN_X<numModes + 1>(0.0);
```

New shorthand notations to create `pmacc::math::Vector<floatX,dim>` are introduced.
  - `floatN_X<n>`
  - `floatN_64<n>`
  - `floatN_32<n>`

- [x] merge after #4965 (first commit of this PR can be ignored because it is from #4965)