### PR TITLE
PMacc:: Vector add `size()` method

### DIFF
--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -190,6 +190,11 @@ namespace pmacc
                 return (*this)[0];
             }
 
+            static constexpr uint32_t size()
+            {
+                return dim;
+            }
+
             /**
              * Creates a Vector where all dimensions are set to the same value
              *


### PR DESCRIPTION
Add `size()` to provide the number of values at runtime and compiletime.