### PR TITLE
drop HIP 5.2/5.3 and CUDA 11.0 support

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -134,7 +134,7 @@ Optional Libraries
 
 CUDA
 """"
-- `11.0.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- `11.1.0+ <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -149,7 +149,7 @@ CUDA
 
 ROCm/HIP
 """"""""
-- `5.2+ <https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html>`_
+- `5.4+ <https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html>`_
 - required if you want to run on AMD GPUs
 - *Debian/Ubuntu:*
   - ``export ROCM_VER=5.5.0``

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -226,8 +226,6 @@ compilers.append(hip_clang_compilers)
 # tuple with two components (backend name, version)
 # version is only required for the cuda backend
 backends = [
-    ("hip", 5.2),
-    ("hip", 5.3),
     ("hip", 5.4),
     ("hip", 5.5),
     ("cuda", 11.0),

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -228,7 +228,6 @@ compilers.append(hip_clang_compilers)
 backends = [
     ("hip", 5.4),
     ("hip", 5.5),
-    ("cuda", 11.0),
     ("cuda", 11.1),
     ("cuda", 11.2),
     ("cuda", 11.3),


### PR DESCRIPTION
- HIP 5.2/5.3 does not support device relocatable linking with CMake
- CUDA 11.0 produces compile issues in an upcoming PR #4935 
  - see: kokkos/kokkos#3496  
  ```
  Error #3246: Internal Compiler Error (codegen): "there was an error in verifying the lgenfe output!"
  ```

This is a preparation PR for #4935 (multiple compile units)