### PR TITLE
add missing get_timestep method to radiation plugin python module

### DIFF
--- a/lib/python/picongpu/extra/plugins/data/radiation.py
+++ b/lib/python/picongpu/extra/plugins/data/radiation.py
@@ -123,3 +123,7 @@ class RadiationData:
         n_vec[:, 1] = n_y * n_y_unitSI
         n_vec[:, 2] = n_z * n_z_unit_SI
         return n_vec
+
+    def get_timestep(self):
+        """return PIC iteration (timestep) at which the data was produced (unit: PIC-cycles)"""
+        return self.iteration


### PR DESCRIPTION
The [documentation of the radiation-plugin python-module](https://picongpu.readthedocs.io/en/latest/usage/plugins/radiation.html#openpmd-output) described a `get_timestep` method that was never implemented. 
Thanks to @nicowrobel for finding this error and reporting it. 
This pull request implements this method. 