### PR TITLE
add missing copyright notice to pypicongpu templates

### DIFF
--- a/share/picongpu/pypicongpu/template/include/picongpu/param/density.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/density.param.mustache
@@ -1,5 +1,6 @@
 /* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch, Marco Garten, Brian Marre, Kristin Tippey
+ *                     Hannes Troepgen
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/fieldSolver.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/fieldSolver.param.mustache
@@ -1,4 +1,5 @@
-/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov, Klaus Steiniger
+/* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov,
+ *                     Klaus Steiniger, Hannes Troepgen
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/grid.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/grid.param.mustache
@@ -1,4 +1,5 @@
 /* Copyright 2013-2023 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *                     Hannes Troepgen
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
@@ -3,7 +3,7 @@
  *
  * This file is part of PIConGPU.
  *
- * Picongpu is free software: you can redistribute it and/or modify
+ * PIConGPU is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/png.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/png.param.mustache
@@ -1,5 +1,5 @@
 /* Copyright 2013-2023 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
- *                     Benjamin Worpitz, Sergei Bastrakov
+ *                     Benjamin Worpitz, Sergei Bastrakov, Hannes Troepgen
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/speciesDefinition.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/speciesDefinition.param.mustache
@@ -1,3 +1,22 @@
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
@@ -84,5 +103,4 @@ namespace picongpu
             {{/_last}}
         {{/species_initmanager.species}}
         >;
-
 } // namespace picongpu

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/speciesDefinition.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/speciesDefinition.param.mustache
@@ -1,4 +1,5 @@
-/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau,
+ *                     Hannes Troepgen
  *
  * This file is part of PIConGPU.
  *

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/speciesInitialization.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/speciesInitialization.param.mustache
@@ -1,3 +1,22 @@
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "picongpu/particles/InitFunctors.hpp"

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/speciesInitialization.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/speciesInitialization.param.mustache
@@ -1,4 +1,5 @@
-/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau,
+ *                     Hannes Troepgen
  *
  * This file is part of PIConGPU.
  *


### PR DESCRIPTION
two pypicongpu templates were missing the copyright comment.

In addition Hannes Troepgen was not mentioned in the author section of all templates
