### PR TITLE
PICMI: fix wrong unit in schemas

### DIFF
--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/foil.Foil.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/foil.Foil.json
@@ -13,7 +13,7 @@
     "properties": {
         "density_si": {
             "type": "number",
-            "description": "density in kg * m^-3",
+            "description": "particle number density in m^-3",
             "exclusiveMinimum": 0
         },
         "y_value_front_foil_si" : {

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/uniform.Uniform.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/uniform.Uniform.json
@@ -9,7 +9,7 @@
     "properties": {
         "density_si": {
             "type": "number",
-            "description": "density in kg * m^-3",
+            "description": "particle number density in m^-3",
             "exclusiveMinimum": 0
         }
     }


### PR DESCRIPTION
fixes the wrong unit in density profile schema description