### PR TITLE
CI: remove CUDA 11.1

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -135,7 +135,7 @@ Optional Libraries
 
 CUDA
 """"
-- `11.1.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- `11.2.0+ <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -228,7 +228,6 @@ compilers.append(hip_clang_compilers)
 backends = [
     ("hip", 5.4),
     ("hip", 5.5),
-    ("cuda", 11.1),
     ("cuda", 11.2),
     ("cuda", 11.3),
     ("cuda", 11.4),


### PR DESCRIPTION
- update documentation
- remove CI tests for CUDA 11.1

Currently CUDA 11.1 is producing include issues in one of our CI tests and in the upcoming refactoring #4935 it show a compiler bug (see

```
Error #3316: Internal Compiler Error (codegen): "there was an error in verifying the lgenfe output!"
```