### PR TITLE
allow multiple gaussian density profiles with differing density

### DIFF
--- a/include/picongpu/param/density.param
+++ b/include/picongpu/param/density.param
@@ -69,12 +69,17 @@ namespace picongpu
     namespace densityProfiles
     {
         /** Profile Formula:
-         *   `const float_X exponent = abs((y - gasCenter_SI) / gasSigma_SI);`
-         *   `const float_X density = exp(gasFactor * pow(exponent, gasPower));`
          *
-         *   takes `gasCenterLeft_SI      for y < gasCenterLeft_SI`,
-         *         `gasCenterRight_SI     for y > gasCenterRight_SI`,
-         *   and `exponent = 0.0 for gasCenterLeft_SI < y < gasCenterRight_SI`
+         * for `y < gasCenterLeft_SI`:
+         * `density = densityFactor * exp(gasFactor * pow(abs((y - gasCenterLeft_SI) / gasSigmaLeft_SI), gasPower))
+         *            * BASE_DENSITY_SI;`
+         *
+         * for `gasCenterLeft_SI <= y <= gasCenterRight_SI`:
+         *  `density = densityFactor * BASE_DENSITY_SI;`
+         *
+         * for `y > gasCenterRight_SI`:
+         *  `density = densityFactor * exp(gasFactor * pow(abs((y - gasCenterRight_SI) / gasSigmaRight_SI), gasPower))
+         *             * BASE_DENSITY_SI;`
          */
         struct GaussianParam
         {
@@ -101,6 +106,9 @@ namespace picongpu
              */
             static constexpr float_64 gasSigmaLeft_SI = 4.62e-5;
             static constexpr float_64 gasSigmaRight_SI = 4.62e-5;
+
+            //! factor to multiply BASE_DENSITY_SI by to get density
+            static constexpr float_X densityFactor = 1._X;
         };
 
         /* definition of density profile with gaussian profile */

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -57,10 +57,11 @@ namespace picongpu
                     return 0._X;
                 }
 
-                constexpr float_X gasCenterLeft = ParamClass::gasCenterLeft_SI / UNIT_LENGTH;
-                constexpr float_X gasCenterRight = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
-                constexpr float_X gasSigmaLeft = ParamClass::gasSigmaLeft_SI / UNIT_LENGTH;
-                constexpr float_X gasSigmaRight = ParamClass::gasSigmaRight_SI / UNIT_LENGTH;
+                constexpr float_X gasCenterLeft = static_cast<float_X>(ParamClass::gasCenterLeft_SI / UNIT_LENGTH);
+                constexpr float_X gasCenterRight = static_cast<float_X>(ParamClass::gasCenterRight_SI / UNIT_LENGTH);
+                constexpr float_X gasSigmaLeft = static_cast<float_X>(ParamClass::gasSigmaLeft_SI / UNIT_LENGTH);
+                constexpr float_X gasSigmaRight = static_cast<float_X>(ParamClass::gasSigmaRight_SI / UNIT_LENGTH);
+
                 auto exponent = 0._X;
                 if(globalCellPos.y() < gasCenterLeft)
                 {
@@ -73,7 +74,9 @@ namespace picongpu
 
                 constexpr float_X gasPower = ParamClass::gasPower;
                 constexpr float_X gasFactor = ParamClass::gasFactor;
-                float_X const density = math::exp(gasFactor * math::pow(exponent, gasPower));
+                constexpr float_X densityFunctor = ParamClass::densityFactor;
+
+                float_X const density = densityFunctor * math::exp(gasFactor * math::pow(exponent, gasPower));
                 return density;
             }
         };

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -50,30 +50,31 @@ namespace picongpu
             HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
             {
                 const float_X vacuum_y = float_X(ParamClass::vacuumCellsY) * cellSize.y();
-                const float_X gas_center_left = ParamClass::gasCenterLeft_SI / UNIT_LENGTH;
-                const float_X gas_center_right = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
-                const float_X gas_sigma_left = ParamClass::gasSigmaLeft_SI / UNIT_LENGTH;
-                const float_X gas_sigma_right = ParamClass::gasSigmaRight_SI / UNIT_LENGTH;
+                const float_X gasCenterLeft = ParamClass::gasCenterLeft_SI / UNIT_LENGTH;
+                const float_X gasCenterRight = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
+                const float_X gasSigmaLeft = ParamClass::gasSigmaLeft_SI / UNIT_LENGTH;
+                const float_X gasSigmaRight = ParamClass::gasSigmaRight_SI / UNIT_LENGTH;
 
                 const floatD_X globalCellPos(precisionCast<float_X>(totalCellOffset) * cellSize.shrink<simDim>());
 
                 if(globalCellPos.y() * cellSize.y() < vacuum_y)
                 {
-                    return float_X(0.0);
+                    return 0._X;
                 }
 
-                auto exponent = float_X(0.0);
-                if(globalCellPos.y() < gas_center_left)
+                auto exponent = 0._X;
+                if(globalCellPos.y() < gasCenterLeft)
                 {
-                    exponent = math::abs((globalCellPos.y() - gas_center_left) / gas_sigma_left);
+                    exponent = math::abs((globalCellPos.y() - gasCenterLeft) / gasSigmaLeft);
                 }
-                else if(globalCellPos.y() >= gas_center_right)
+                else if(globalCellPos.y() >= gasCenterRight)
                 {
-                    exponent = math::abs((globalCellPos.y() - gas_center_right) / gas_sigma_right);
+                    exponent = math::abs((globalCellPos.y() - gasCenterRight) / gasSigmaRight);
                 }
 
-                const float_X gas_power = ParamClass::gasPower;
-                const float_X density = math::exp(float_X(ParamClass::gasFactor) * math::pow(exponent, gas_power));
+                const float_X gasPower = ParamClass::gasPower;
+                const float_X gasFactor = ParamClass::gasFactor;
+                const float_X density = math::exp(gasFactor * math::pow(exponent, gasPower));
                 return density;
             }
         };

--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -49,19 +49,18 @@ namespace picongpu
              */
             HDINLINE float_X operator()(const DataSpace<simDim>& totalCellOffset)
             {
-                const float_X vacuum_y = float_X(ParamClass::vacuumCellsY) * cellSize.y();
-                const float_X gasCenterLeft = ParamClass::gasCenterLeft_SI / UNIT_LENGTH;
-                const float_X gasCenterRight = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
-                const float_X gasSigmaLeft = ParamClass::gasSigmaLeft_SI / UNIT_LENGTH;
-                const float_X gasSigmaRight = ParamClass::gasSigmaRight_SI / UNIT_LENGTH;
+                floatD_X const globalCellPos(precisionCast<float_X>(totalCellOffset) * cellSize.shrink<simDim>());
 
-                const floatD_X globalCellPos(precisionCast<float_X>(totalCellOffset) * cellSize.shrink<simDim>());
-
+                float_X const vacuum_y = float_X(ParamClass::vacuumCellsY) * cellSize.y();
                 if(globalCellPos.y() * cellSize.y() < vacuum_y)
                 {
                     return 0._X;
                 }
 
+                constexpr float_X gasCenterLeft = ParamClass::gasCenterLeft_SI / UNIT_LENGTH;
+                constexpr float_X gasCenterRight = ParamClass::gasCenterRight_SI / UNIT_LENGTH;
+                constexpr float_X gasSigmaLeft = ParamClass::gasSigmaLeft_SI / UNIT_LENGTH;
+                constexpr float_X gasSigmaRight = ParamClass::gasSigmaRight_SI / UNIT_LENGTH;
                 auto exponent = 0._X;
                 if(globalCellPos.y() < gasCenterLeft)
                 {
@@ -72,9 +71,9 @@ namespace picongpu
                     exponent = math::abs((globalCellPos.y() - gasCenterRight) / gasSigmaRight);
                 }
 
-                const float_X gasPower = ParamClass::gasPower;
-                const float_X gasFactor = ParamClass::gasFactor;
-                const float_X density = math::exp(gasFactor * math::pow(exponent, gasPower));
+                constexpr float_X gasPower = ParamClass::gasPower;
+                constexpr float_X gasFactor = ParamClass::gasFactor;
+                float_X const density = math::exp(gasFactor * math::pow(exponent, gasPower));
                 return density;
             }
         };

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/density.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/density.param
@@ -75,6 +75,9 @@ namespace picongpu
              */
             static constexpr float_64 gasSigmaLeft_SI = 8.0e-5;
             static constexpr float_64 gasSigmaRight_SI = 8.0e-5;
+
+            //! factor to multiply BASE_DENSITY_SI by to get density
+            static constexpr float_X densityFactor = 1._X;
         };
 
         /* definition of density with Gaussian profile */


### PR DESCRIPTION
adds the new parameter `densityFactor` to the `GaussianImpl` Param-struct allowing the user to scale the density profile relative to BASE_DENSITY_SI.

This allows using more than one Gaussian density profile at the same with different densities.

@attention This is a **breaking change** of the GaussianImpl interface, this will break old setups.

To fix an old setup you need to add the following line
```c++
static constexpr float_X densityFactor = 1._X;
```
to your `GaussianImpl` Param-Struct
