### PR TITLE
Support for toml11 library version 4.0 (adapt to breaking changes)

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -346,8 +346,15 @@ if(PIC_SEARCH_openPMD)
                     # explicitly.
                     EXCLUDE_FROM_ALL)
             else()
-                find_package(toml11 3.7.0 CONFIG REQUIRED)
-                message(STATUS "toml11: Found version '${toml11_VERSION}'")
+                find_package(toml11 CONFIG REQUIRED)
+                # Need to check the version manually. toml11 4.0 was a breaking change, so
+                # find_package(toml11 3.7.1) would not accept versions 4.0+.
+                # We support both 3.* and 4.*.
+                if(${toml11_VERSION} VERSION_LESS 3.7.1)
+                    message(FATAL_ERROR "toml11: Found version '${toml11_VERSION}', but requires version '3.7.1' at least.")
+                else()
+                    message(STATUS "toml11: Found version '${toml11_VERSION}'")
+                endif()
             endif()
             list(PREPEND HOST_LIBS openPMD::openPMD)
         else()

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -346,15 +346,13 @@ if(PIC_SEARCH_openPMD)
                     # explicitly.
                     EXCLUDE_FROM_ALL)
             else()
-                find_package(toml11 CONFIG REQUIRED)
-                # Need to check the version manually. toml11 4.0 was a breaking change, so
-                # find_package(toml11 3.7.1) would not accept versions 4.0+.
-                # We support both 3.* and 4.*.
-                if(${toml11_VERSION} VERSION_LESS 3.7.1)
-                    message(FATAL_ERROR "toml11: Found version '${toml11_VERSION}', but requires version '3.7.1' at least.")
-                else()
-                    message(STATUS "toml11: Found version '${toml11_VERSION}'")
+                # Since toml11 4.0 was a breaking change,
+                # it needs separate find_package() calls
+                find_package(toml11 3.7.0 CONFIG QUIET)
+                if(NOT toml11_FOUND)
+                    find_package(toml11 4.0 CONFIG REQUIRED)
                 endif()
+                message(STATUS "toml11: Found version '${toml11_VERSION}'")
             endif()
             list(PREPEND HOST_LIBS openPMD::openPMD)
         else()

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -88,30 +88,36 @@ namespace
                 // 1. option: dataSources is an array:
                 for(auto& value : *dataSourcesInToml.as_ok())
                 {
-                    auto dataSource
-                        = toml::expect<std::string>(value)
-                              .or_else(
-                                  [](auto const&) -> toml::success<std::string>
-                                  {
-                                      throw std::runtime_error("[openPMD plugin] Data sources in TOML "
-                                                               "file must be a string or a vector of strings.");
-                                  })
-                              .value;
+                    auto dataSource = [&]()
+                    {
+                        try
+                        {
+                            return toml::get<std::string>(value);
+                        }
+                        catch(toml::type_error const&)
+                        {
+                            throw std::runtime_error("[openPMD plugin] Data sources in TOML "
+                                                     "file must be a string or a vector of strings.");
+                        }
+                    }();
                     dataSources.push_back(std::move(dataSource));
                 }
             }
             else
             {
                 // 2. option: dataSources is no array, check if it is a simple string
-                auto dataSource
-                    = toml::expect<std::string>(pair.second)
-                          .or_else(
-                              [](auto const&) -> toml::success<std::string>
-                              {
-                                  throw std::runtime_error("[openPMD plugin] Data sources in TOML "
-                                                           "file must be a string or a vector of strings.");
-                              })
-                          .value;
+                auto dataSource = [&]()
+                {
+                    try
+                    {
+                        return toml::get<std::string>(pair.second);
+                    }
+                    catch(toml::type_error const&)
+                    {
+                        throw std::runtime_error("[openPMD plugin] Data sources in TOML "
+                                                 "file must be a string or a vector of strings.");
+                    }
+                }();
                 dataSources.push_back(std::move(dataSource));
             }
 


### PR DESCRIPTION
Two changes needed:

1. Update `CMakeLists.txt`, `find_package(toml11 3.7.0 CONFIG REQUIRED)` does not accept toml11 4.0 as it's a breaking change
2. They removed `toml::expect`, so rewrite two little expressions

TODO:

- [x] Better logic for CMake, this currently entirely evades these breaking version checks