### PR TITLE
refactor PICMI/PYPIConGPU imports

### DIFF
--- a/docs/source/pypicongpu/doc_example.py
+++ b/docs/source/pypicongpu/doc_example.py
@@ -1,8 +1,8 @@
-from typeguard import typechecked
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 def my_func(a_char: str, num: int) -> typing.List[str]:
     """
     build list with "triangle" of chars

--- a/docs/source/pypicongpu/misc.rst
+++ b/docs/source/pypicongpu/misc.rst
@@ -28,7 +28,7 @@ Note that these type annotations are **not checked by python** on their own.
 
 Typechecks are enabled through
 `typeguard <https://typeguard.readthedocs.io/>`__, mostly using the
-annotation ``@typechecked`` for classes.
+annotation ``@typeguard.typechecked`` for classes.
 
 **This does not check attribute type annotations, see next section.**
 
@@ -63,13 +63,13 @@ Internally the declaration above is expanded to the equivalent of:
 
 .. code:: python
 
-   @typechecked
+   @typeguard.typechecked
    def getter(self) -> int:
        if not hasattr(self, "actual_name_for_var__attr"):
            raise AttributeError("variable is not initialized")
        return getattr(self, "actual_name_for_var__attr")
        
-   @typechecked
+   @typeguard.typechecked
    def setter(self, value: int) -> None:
        setattr(self, "actual_name_for_var__attr", value)
 

--- a/docs/source/pypicongpu/translation.rst
+++ b/docs/source/pypicongpu/translation.rst
@@ -170,7 +170,7 @@ structures to hold data. E.g. the 3D grid is defined as follows
 
 .. code:: python
 
-   @typechecked
+   @typeguard.typechecked
    class Grid3D(RenderedObject):
        cell_size_x_si = util.build_typesafe_property(float)
        cell_size_y_si = util.build_typesafe_property(float)
@@ -186,7 +186,7 @@ structures to hold data. E.g. the 3D grid is defined as follows
 
 In particular, please note:
 
--  The annotation ``@typechecked``: This is a decorator introduced by
+-  The annotation ``@typeguard.typechecked``: This is a decorator introduced by
    ``typeguard`` and it ensures that the type annotations of methods are
    respected. However, it does not perform typechecking for attributes,
    which is why the attributes are delegated to:

--- a/lib/python/picongpu/picmi/distribution/GaussianBunchDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/GaussianBunchDistribution.py
@@ -9,7 +9,7 @@ from ...pypicongpu import species
 
 import picmistandard
 
-from typeguard import typechecked
+import typeguard
 import typing
 import math
 
@@ -35,7 +35,7 @@ this method returns None.
 """
 
 
-@typechecked
+@typeguard.typechecked
 class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
     def picongpu_get_rms_velocity_si(self) -> typing.Tuple[float, float, float]:
         return tuple(self.rms_velocity)

--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -11,11 +11,11 @@ from . import constants
 import picmistandard
 import math
 
-from typeguard import typechecked
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class GaussianLaser(picmistandard.PICMI_GaussianLaser):
     """PICMI object for Gaussian Laser"""
 

--- a/lib/python/picongpu/picmi/layout.py
+++ b/lib/python/picongpu/picmi/layout.py
@@ -6,10 +6,10 @@ License: GPLv3+
 """
 
 import picmistandard
-from typeguard import typechecked
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class PseudoRandomLayout(picmistandard.PICMI_PseudoRandomLayout):
     # note: is translated from outside, does not do any checks itself
     def check(self):

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -12,14 +12,14 @@ from .species import Species as PicongpuPicmiSpecies
 
 import picmistandard
 
-from math import sqrt, isclose
-from typeguard import typechecked
+import math
+import typeguard
 import pathlib
 import logging
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class Simulation(picmistandard.PICMI_Simulation):
     """
     Simulation as defined by PICMI
@@ -70,7 +70,9 @@ class Simulation(picmistandard.PICMI_Simulation):
 
         if self.time_step_size is not None and self.solver.cfl is not None:
             # both cfl & delta_t given -> check their compatibility
-            delta_t_from_cfl = self.solver.cfl / (constants.c * sqrt(1 / delta_x**2 + 1 / delta_y**2 + 1 / delta_z**2))
+            delta_t_from_cfl = self.solver.cfl / (
+                constants.c * math.sqrt(1 / delta_x**2 + 1 / delta_y**2 + 1 / delta_z**2)
+            )
 
             if delta_t_from_cfl != self.time_step_size:
                 raise ValueError(
@@ -82,12 +84,12 @@ class Simulation(picmistandard.PICMI_Simulation):
             if self.time_step_size is not None:
                 # calculate cfl
                 self.solver.cfl = self.time_step_size * (
-                    constants.c * sqrt(1 / delta_x**2 + 1 / delta_y**2 + 1 / delta_z**2)
+                    constants.c * math.sqrt(1 / delta_x**2 + 1 / delta_y**2 + 1 / delta_z**2)
                 )
             elif self.solver.cfl is not None:
                 # calculate delta_t
                 self.time_step_size = self.solver.cfl / (
-                    constants.c * sqrt(1 / delta_x**2 + 1 / delta_y**2 + 1 / delta_z**2)
+                    constants.c * math.sqrt(1 / delta_x**2 + 1 / delta_y**2 + 1 / delta_z**2)
                 )
 
             # if neither delta_t nor cfl are given simply silently pass
@@ -353,9 +355,9 @@ class Simulation(picmistandard.PICMI_Simulation):
                 all_electrons.append(picmi_species)
             elif (
                 picmi_species.mass is not None
-                and isclose(picmi_species.mass, constants.m_e)
+                and math.isclose(picmi_species.mass, constants.m_e)
                 and picmi_species.charge is not None
-                and isclose(picmi_species.charge, -constants.q_e)
+                and math.isclose(picmi_species.charge, -constants.q_e)
             ):
                 all_electrons.append(picmi_species)
 

--- a/lib/python/picongpu/picmi/solver.py
+++ b/lib/python/picongpu/picmi/solver.py
@@ -8,11 +8,10 @@ License: GPLv3+
 from ..pypicongpu import util, solver
 
 import picmistandard
+import typeguard
 
-from typeguard import typechecked
 
-
-@typechecked
+@typeguard.typechecked
 class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
     """
     PICMI Electromagnic Solver

--- a/lib/python/picongpu/pypicongpu/grid.py
+++ b/lib/python/picongpu/pypicongpu/grid.py
@@ -6,13 +6,13 @@ License: GPLv3+
 """
 
 from . import util
-from typeguard import typechecked
+import typeguard
 import typing
 import enum
 from .rendering import RenderedObject
 
 
-@typechecked
+@typeguard.typechecked
 class BoundaryCondition(enum.Enum):
     """
     Boundary Condition of PIConGPU
@@ -38,7 +38,7 @@ class BoundaryCondition(enum.Enum):
         return literal_by_boundarycondition[self]
 
 
-@typechecked
+@typeguard.typechecked
 class Grid3D(RenderedObject):
     """
     PIConGPU 3 dimensional (cartesian) grid

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -6,14 +6,15 @@ License: GPLv3+
 """
 
 from . import util
-from typeguard import typechecked
-from enum import Enum
 from .rendering import RenderedObject
+
+import enum
 import typing
+import typeguard
 import logging
 
 
-@typechecked
+@typeguard.typechecked
 class GaussianLaser(RenderedObject):
     """
     PIConGPU Gaussian Laser
@@ -21,7 +22,7 @@ class GaussianLaser(RenderedObject):
     Holds Parameters to specify a gaussian laser
     """
 
-    class PolarizationType(Enum):
+    class PolarizationType(enum.Enum):
         """represents a polarization of a laser (for PIConGPU)"""
 
         LINEAR = 1

--- a/lib/python/picongpu/pypicongpu/output/auto.py
+++ b/lib/python/picongpu/pypicongpu/output/auto.py
@@ -7,10 +7,11 @@ License: GPLv3+
 
 from .. import util
 from ..rendering import RenderedObject
-from typeguard import typechecked
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class Auto(RenderedObject):
     """
     Class to provide output **without further configuration**.

--- a/lib/python/picongpu/pypicongpu/rendering/renderedobject.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderedobject.py
@@ -6,7 +6,8 @@ License: GPLv3+
 """
 
 from .. import util
-from typeguard import typechecked
+
+import typeguard
 import typing
 import jsonschema
 import logging
@@ -15,7 +16,7 @@ import re
 import json
 
 
-@typechecked
+@typeguard.typechecked
 class RenderedObject:
     """
     Class to be inherited from for rendering context generation

--- a/lib/python/picongpu/pypicongpu/rendering/renderer.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderer.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 import typing
-from typeguard import typechecked
+import typeguard
 import math
 import datetime
 import sympy
@@ -17,7 +17,7 @@ import pathlib
 import functools
 
 
-@typechecked
+@typeguard.typechecked
 class Renderer:
     """
     helper class to render Mustache templates

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -10,8 +10,9 @@ from . import util
 from .rendering import Renderer
 
 from os import path, environ, chdir
-import typeguard
 from functools import reduce
+
+import typeguard
 import tempfile
 import subprocess
 import logging

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -14,11 +14,11 @@ from . import output
 from .rendering import RenderedObject
 
 import typing
-from typeguard import typechecked
+import typeguard
 import logging
 
 
-@typechecked
+@typeguard.typechecked
 class Simulation(RenderedObject):
     """
     Represents all parameters required to build & run a PIConGPU simulation.

--- a/lib/python/picongpu/pypicongpu/solver.py
+++ b/lib/python/picongpu/pypicongpu/solver.py
@@ -5,11 +5,12 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from typeguard import typechecked
 from .rendering import RenderedObject
 
+import typeguard
 
-@typechecked
+
+@typeguard.typechecked
 class Solver:
     """
     represents a field solver
@@ -20,7 +21,7 @@ class Solver:
     pass
 
 
-@typechecked
+@typeguard.typechecked
 class YeeSolver(Solver, RenderedObject):
     """
     Yee solver as defined by PIConGPU

--- a/lib/python/picongpu/pypicongpu/species/constant/charge.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/charge.py
@@ -7,11 +7,11 @@ License: GPLv3+
 
 from .constant import Constant
 from ... import util
-from typeguard import typechecked
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class Charge(Constant):
     """
     charge of a physical particle

--- a/lib/python/picongpu/pypicongpu/species/constant/densityratio.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/densityratio.py
@@ -7,11 +7,12 @@ License: GPLv3+
 
 from .constant import Constant
 from ... import util
-from typeguard import typechecked
+
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class DensityRatio(Constant):
     """
     factor for weighting when using profiles/deriving

--- a/lib/python/picongpu/pypicongpu/species/constant/elementproperties.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/elementproperties.py
@@ -8,11 +8,12 @@ License: GPLv3+
 from .constant import Constant
 from ... import util
 from ..util import Element
-from typeguard import typechecked
+
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class ElementProperties(Constant):
     """
     represents constants associated to a chemical element

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizers.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizers.py
@@ -8,11 +8,12 @@ License: GPLv3+
 from .constant import Constant
 from ..attribute import BoundElectrons
 from .elementproperties import ElementProperties
-from typeguard import typechecked
+
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class Ionizers(Constant):
     """
     ionizers describing the ionization methods

--- a/lib/python/picongpu/pypicongpu/species/constant/mass.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/mass.py
@@ -7,11 +7,12 @@ License: GPLv3+
 
 from .constant import Constant
 from ... import util
-from typeguard import typechecked
+
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class Mass(Constant):
     """
     mass of a physical particle

--- a/lib/python/picongpu/pypicongpu/species/operation/densityoperation.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityoperation.py
@@ -6,10 +6,11 @@ License: GPLv3+
 """
 
 from .operation import Operation
-from typeguard import typechecked
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class DensityOperation(Operation):
     """
     common interface for all operations that create density

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/densityprofile.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/densityprofile.py
@@ -5,12 +5,12 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from typeguard import typechecked
-
 from ....rendering import RenderedObject
 
+import typeguard
 
-@typechecked
+
+@typeguard.typechecked
 class DensityProfile(RenderedObject):
     """
     (abstract) parent class of all density profiles

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/foil.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/foil.py
@@ -6,13 +6,13 @@ License: GPLv3+
 """
 
 from .densityprofile import DensityProfile
-from .... import util
-from typeguard import typechecked
-
 from .plasmaramp import PlasmaRamp
+from .... import util
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class Foil(DensityProfile):
     """
     Directional density profile with thickness and pre- and

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/uniform.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/uniform.py
@@ -7,10 +7,11 @@ License: GPLv3+
 
 from .densityprofile import DensityProfile
 from .... import util
-from typeguard import typechecked
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class Uniform(DensityProfile):
     """
     globally constant density

--- a/lib/python/picongpu/pypicongpu/species/operation/momentum/drift.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/momentum/drift.py
@@ -5,12 +5,13 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from typeguard import typechecked
+from ....rendering import RenderedObject
 from .... import util
+
+import typeguard
 import typing
 import math
 from scipy import constants
-from ....rendering import RenderedObject
 
 # Note to the future maintainer:
 # If you want to add another way to specify the drift, please turn
@@ -18,7 +19,7 @@ from ....rendering import RenderedObject
 # method.
 
 
-@typechecked
+@typeguard.typechecked
 class Drift(RenderedObject):
     """
     Add drift to a species (momentum)

--- a/lib/python/picongpu/pypicongpu/species/operation/momentum/temperature.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/momentum/temperature.py
@@ -5,7 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from typeguard import typechecked
+import typeguard
 from .... import util
 from ....rendering import RenderedObject
 
@@ -16,7 +16,7 @@ from ....rendering import RenderedObject
 # supported, so such a structure would be overkill.)
 
 
-@typechecked
+@typeguard.typechecked
 class Temperature(RenderedObject):
     """
     Initialize momentum from temperature

--- a/lib/python/picongpu/pypicongpu/species/operation/noboundelectrons.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/noboundelectrons.py
@@ -10,10 +10,11 @@ from ..species import Species
 from ..attribute import BoundElectrons
 from ..constant import Ionizers
 from ... import util
-from typeguard import typechecked
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class NoBoundElectrons(Operation):
     """
     assigns a BoundElectrons attribute, but leaves it a 0

--- a/lib/python/picongpu/pypicongpu/species/operation/notplaced.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/notplaced.py
@@ -9,10 +9,11 @@ from .densityoperation import DensityOperation
 from ..species import Species
 from ..attribute import Position, Weighting
 from ... import util
-from typeguard import typechecked
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class NotPlaced(DensityOperation):
     """
     assigns a position attribute, but does not place a species

--- a/lib/python/picongpu/pypicongpu/species/operation/operation.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/operation.py
@@ -7,14 +7,15 @@ License: GPLv3+
 
 from ...rendering import RenderedObject
 from ... import util
-import typing
-from typeguard import typechecked
 from ..attribute import Attribute
 from ..species import Species
+
+import typeguard
+import typing
 from functools import reduce
 
 
-@typechecked
+@typeguard.typechecked
 class Operation(RenderedObject):
     """
     Defines the initialization of a set of attributes across multiple species

--- a/lib/python/picongpu/pypicongpu/species/operation/setboundelectrons.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/setboundelectrons.py
@@ -10,10 +10,11 @@ from ..species import Species
 from ..attribute import BoundElectrons
 from ..constant import Ionizers
 from ... import util
-from typeguard import typechecked
+
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class SetBoundElectrons(Operation):
     """
     assigns and set the boundElectrons attribute

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -6,16 +6,17 @@ License: GPLv3+
 """
 
 from .densityoperation import DensityOperation
-from typeguard import typechecked
-from ... import util
-from ..species import Species
 from .densityprofile import DensityProfile
-import typing
+from ..species import Species
 from ..attribute import Position, Weighting
 from ..constant import DensityRatio
+from ... import util
+
+import typeguard
+import typing
 
 
-@typechecked
+@typeguard.typechecked
 class SimpleDensity(DensityOperation):
     """
     Place a set of species together, using the same density profile

--- a/lib/python/picongpu/pypicongpu/species/operation/simplemomentum.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simplemomentum.py
@@ -10,11 +10,12 @@ from .momentum import Temperature, Drift
 from ..species import Species
 from ..attribute import Momentum
 from ... import util
-from typeguard import typechecked
+
+import typeguard
 import typing
 
 
-@typechecked
+@typeguard.typechecked
 class SimpleMomentum(Operation):
     """
     provides momentum to a species

--- a/lib/python/picongpu/pypicongpu/species/species.py
+++ b/lib/python/picongpu/pypicongpu/species/species.py
@@ -5,17 +5,17 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from typeguard import typechecked
-from .. import util
 from ..rendering import RenderedObject
+from .attribute import Attribute, Position, Momentum
+from .constant import Constant, Charge, Mass, DensityRatio, Ionizers, ElementProperties
+from .. import util
+
+import typeguard
 import typing
 import re
 
-from .attribute import Attribute, Position, Momentum
-from .constant import Constant, Charge, Mass, DensityRatio, Ionizers, ElementProperties
 
-
-@typechecked
+@typeguard.typechecked
 class Species(RenderedObject):
     """
     PyPIConGPU species definition

--- a/lib/python/picongpu/pypicongpu/species/util/element.py
+++ b/lib/python/picongpu/pypicongpu/species/util/element.py
@@ -6,12 +6,13 @@ License: GPLv3+
 """
 
 from ...rendering import RenderedObject
+
+import typeguard
 import enum
 import scipy
-from typeguard import typechecked
 
 
-@typechecked
+@typeguard.typechecked
 class Element(RenderedObject, enum.Enum):
     """
     Denotes an element from the periodic table of elements

--- a/lib/python/picongpu/pypicongpu/util.py
+++ b/lib/python/picongpu/pypicongpu/util.py
@@ -5,7 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from typeguard import typechecked
+import typeguard
 import typing
 import logging
 
@@ -15,7 +15,7 @@ attr_cnt = 0
 # note: type_ may be either a type, or a definition by typing
 # depending on the python version the type of typing.XXXX is different
 # (_GenericMeta vs. GenericMeta) -- so we compute it on the fly
-@typechecked
+@typeguard.typechecked
 def build_typesafe_property(
     type_: typing.Union[type, type(typing.List[int])], name: typing.Optional[str] = None
 ) -> property:
@@ -26,20 +26,20 @@ def build_typesafe_property(
     # don't use private prefix '__' to avoid name mangling
     actual_var_name = "magic_string_private_____{}".format(name)
 
-    @typechecked
+    @typeguard.typechecked
     def getter(self) -> type_:
         if not hasattr(self, actual_var_name):
             raise AttributeError("variable is not initialized")
         return getattr(self, actual_var_name)
 
-    @typechecked
+    @typeguard.typechecked
     def setter(self, value: type_):
         setattr(self, actual_var_name, value)
 
     return property(getter, setter)
 
 
-@typechecked
+@typeguard.typechecked
 def unsupported(name: str, value: typing.Any = 1, default: typing.Any = None) -> None:
     """
     Print a msg that the feature/parameter/thing is unsupported.

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 from picongpu import pypicongpu, picmi
 
-from typeguard import typechecked
+import typeguard
 
 import unittest
 import tempfile
@@ -15,7 +15,7 @@ import os
 import logging
 
 
-@typechecked
+@typeguard.typechecked
 def get_grid(delta_x: float, delta_y: float, delta_z: float, n: int):
     # sets delta_[x,y,z] implicitly by providing bounding box+cell count
     return picmi.Cartesian3DGrid(

--- a/test/python/picongpu/quick/picmi/distribution.py
+++ b/test/python/picongpu/quick/picmi/distribution.py
@@ -11,10 +11,10 @@ import unittest
 
 from picongpu.pypicongpu import species
 import math
-from typeguard import typechecked
+import typeguard
 
 
-@typechecked
+@typeguard.typechecked
 class HelperTestPicmiBoundaries:
     """
     provides test functions to check proper handling of boundaries
@@ -115,7 +115,7 @@ class TestPicmiUniformDistribution(unittest.TestCase, HelperTestPicmiBoundaries)
 
 
 @unittest.skip("not implemented")
-@typechecked
+@typeguard.typechecked
 class TestPicmiAnalyticDistriution(unittest.TestCase, HelperTestPicmiBoundaries):
     def _get_distribution(self, lower_bound, upper_bound):
         return picmi.AnalyticDistribution(density_expression="x+y+z", lower_bound=lower_bound, upper_bound=upper_bound)
@@ -197,7 +197,7 @@ class TestPicmiAnalyticDistriution(unittest.TestCase, HelperTestPicmiBoundaries)
 
 
 @unittest.skip("not implemented")
-@typechecked
+@typeguard.typechecked
 class TestPicmiGaussianBunchDistribution(unittest.TestCase):
     def test_full(self):
         """check for all possible params"""

--- a/test/python/picongpu/quick/pypicongpu/species/species.py
+++ b/test/python/picongpu/quick/pypicongpu/species/species.py
@@ -7,9 +7,6 @@ License: GPLv3+
 
 from picongpu.pypicongpu.species import Species
 
-import unittest
-import typeguard
-
 from picongpu.pypicongpu.species.attribute import Position, Weighting, Momentum
 from picongpu.pypicongpu.species.constant import (
     Mass,
@@ -24,6 +21,8 @@ from .attribute import DummyAttribute
 from .constant import DummyConstant
 
 import itertools
+import unittest
+import typeguard
 
 
 class TestSpecies(unittest.TestCase):


### PR DESCRIPTION
harmonizes imports of PICMI and PyPIConGPU:
- avoid importing features into the PICMI/PyPIConGPU namespace
- separate external and internal dependency imports