### PR TITLE
refactor requirements.txt of PICMI and PyPIConGPU

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,9 +152,9 @@ pypicongpu-generate-full-matrix:
   script:
     - apt update
     - apt install -y python3 python3-pip
-    - pip3 install pyyaml requests
+    - pip3 install pyyaml requests typeguard
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
-    - python3 $CI_PROJECT_DIR/share/ci/pypicongpu_generator.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt > compile.yml
+    - python3 $CI_PROJECT_DIR/share/ci/pypicongpu_generator.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt $CI_PROJECT_DIR/lib/python/picongpu/pypicongpu/requirements.txt > compile.yml
     - cat compile.yml
   artifacts:
     paths:

--- a/lib/python/picongpu/picmi/requirements.txt
+++ b/lib/python/picongpu/picmi/requirements.txt
@@ -1,7 +1,6 @@
-typeguard >= 4.2.1
-pydantic
-sympy >= 1.9
-chevron >= 0.13.1
-jsonschema == 4.17.3
 scipy >= 1.7.1
 picmistandard >= 0.27.0
+typeguard >= 4.2.1
+sympy >= 1.9
+pydantic >= 2.6.4
+-r ../pypicongpu/requirements.txt

--- a/lib/python/picongpu/pypicongpu/requirements.txt
+++ b/lib/python/picongpu/pypicongpu/requirements.txt
@@ -1,0 +1,3 @@
+chevron >= 0.13.1
+jsonschema >= 4.23.0
+typeguard >= 4.2.1

--- a/lib/python/picongpu/requirements.txt
+++ b/lib/python/picongpu/requirements.txt
@@ -1,2 +1,3 @@
--r picmi/requirements.txt
 -r extra/requirements.txt
+-r pypicongpu/requirements.txt
+-r picmi/requirements.txt

--- a/share/ci/install/pypicongpu.sh
+++ b/share/ci/install/pypicongpu.sh
@@ -39,15 +39,19 @@ cd $CI_PROJECT_DIR
 conda create -n pypicongpu python=${PYTHON_VERSION}
 conda activate pypicongpu
 python3 --version
-MODIFIED_REQUIREMENT_TXT=$CI_PROJECT_DIR/lib/python/picongpu/modified_requirements.txt
-python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt $MODIFIED_REQUIREMENT_TXT
+MODIFIED_REQUIREMENT_TXT_PICMI=$CI_PROJECT_DIR/lib/python/picongpu/picmi/modified_requirements.txt
+MODIFIED_REQUIREMENT_TXT_PYPICONGPU=$CI_PROJECT_DIR/lib/python/picongpu/pypicongpu/modified_requirements.txt
+python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt $MODIFIED_REQUIREMENT_TXT_PICMI
+python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/pypicongpu/requirements.txt $MODIFIED_REQUIREMENT_TXT_PYPICONGPU
 
 echo "modified_requirements.txt: "
-cat $MODIFIED_REQUIREMENT_TXT
+cat $MODIFIED_REQUIREMENT_TXT_PICMI
+cat $MODIFIED_REQUIREMENT_TXT_PYPICONGPU
 echo ""
 
 # run quick tests
-pip3 install -r $MODIFIED_REQUIREMENT_TXT
+pip3 install -r $MODIFIED_REQUIREMENT_TXT_PICMI
+pip3 install -r $MODIFIED_REQUIREMENT_TXT_PYPICONGPU
 cd $CI_PROJECT_DIR/test/python/picongpu
 python3 -m quick
 


### PR DESCRIPTION
this PR:
- creates separate `requirements.txt` for PICMI and PyPIConGPU
- reverts the earlier fix of the dependency `jsonschema` in PR #4628
- updates the `jsonschema` to the current version
- updates the pypicongpu ci to allow more than one `requirements.txt`
- updates the CI to use both the PICMI and the PyPIConGPU `requirements.txt`
- adds python 3.12 and pydantic to the CI