### PR TITLE
refactor schema resolver

### DIFF
--- a/lib/python/picongpu/pypicongpu/requirements.txt
+++ b/lib/python/picongpu/pypicongpu/requirements.txt
@@ -1,3 +1,4 @@
 chevron >= 0.13.1
 jsonschema >= 4.23.0
 typeguard >= 4.2.1
+referencing >=0.35.1

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -345,6 +345,7 @@ PACKAGES_TO_TEST: Dict[str, Callable] = {
     "jsonschema": get_all_major_pypi_versions,
     "picmistandard": get_all_pypi_versions,
     "pydantic": get_all_major_pypi_versions,
+    "referencing": get_all_major_pypi_versions,
 }
 
 if __name__ == "__main__":

--- a/test/python/picongpu/quick/pypicongpu/runner.py
+++ b/test/python/picongpu/quick/pypicongpu/runner.py
@@ -417,7 +417,7 @@ class TestRunner(unittest.TestCase):
             testfile_template = template_path / "etc" / "picongpu" / "date.mustache"
             with open(testfile_template, "w") as tpl_file:
                 tpl_file.write("{{{_date}}}")
-            # workaround (TODO rm): add location for pypicongpu.param
+            # workaround (@todo rm): add location for pypicongpu.param
             os.makedirs(template_path / "include" / "picongpu" / "param")
 
             # create ruunner with previous tempalte dir, rest of directories


### PR DESCRIPTION
with this PR PyPIConGPU
- removes usage of the old deprecated resolver from `jsonschema`
- switches to a separate new [resolver library](https://referencing.readthedocs.io/en/stable/)

This PR also fixes Issue #4088.

- [x] requires PR #4990 to be merged first