### PR TITLE
fix python copyright doc string

### DIFF
--- a/docs/source/models/field_ionization_charge_state_prediction.py
+++ b/docs/source/models/field_ionization_charge_state_prediction.py
@@ -1,6 +1,6 @@
 """Ionization prediction module and example.
 
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2019-2023 PIConGPU contributors
 Authors: Marco Garten
 License: GPLv3+

--- a/lib/python/picongpu/extra/plugins/data/base_reader.py
+++ b/lib/python/picongpu/extra/plugins/data/base_reader.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/data/emittance.py
+++ b/lib/python/picongpu/extra/plugins/data/emittance.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sophie Rudat, Axel Huebl

--- a/lib/python/picongpu/extra/plugins/data/energy_histogram.py
+++ b/lib/python/picongpu/extra/plugins/data/energy_histogram.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Axel Huebl

--- a/lib/python/picongpu/extra/plugins/data/phase_space.py
+++ b/lib/python/picongpu/extra/plugins/data/phase_space.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Axel Huebl

--- a/lib/python/picongpu/extra/plugins/data/png.py
+++ b/lib/python/picongpu/extra/plugins/data/png.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/data/transitionradiation.py
+++ b/lib/python/picongpu/extra/plugins/data/transitionradiation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Axel Huebl, Finn-Ole Carstens

--- a/lib/python/picongpu/extra/plugins/jupyter_widgets/base_widget.py
+++ b/lib/python/picongpu/extra/plugins/jupyter_widgets/base_widget.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/jupyter_widgets/energy_histogram_widget.py
+++ b/lib/python/picongpu/extra/plugins/jupyter_widgets/energy_histogram_widget.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/jupyter_widgets/phase_space_widget.py
+++ b/lib/python/picongpu/extra/plugins/jupyter_widgets/phase_space_widget.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/jupyter_widgets/png_widget.py
+++ b/lib/python/picongpu/extra/plugins/jupyter_widgets/png_widget.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/jupyter_widgets/utils.py
+++ b/lib/python/picongpu/extra/plugins/jupyter_widgets/utils.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/base_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/base_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/emittance_evolution_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/emittance_evolution_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/energy_histogram_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/energy_histogram_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/energy_waterfall_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/energy_waterfall_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/phase_space_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/phase_space_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/png_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/png_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/slice_emittance_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/slice_emittance_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke

--- a/lib/python/picongpu/extra/plugins/plot_mpl/slice_emittance_waterfall_visualizer.py
+++ b/lib/python/picongpu/extra/plugins/plot_mpl/slice_emittance_waterfall_visualizer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sophie Rudat, Sebastian Starke

--- a/lib/python/picongpu/extra/utils/field_ionization.py
+++ b/lib/python/picongpu/extra/utils/field_ionization.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Field ionization models implemented in PIConGPU.
 
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2019-2023 PIConGPU contributors
 Authors: Marco Garten, Brian Marre
 License: GPLv3+

--- a/lib/python/picongpu/extra/utils/find_time.py
+++ b/lib/python/picongpu/extra/utils/find_time.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Axel Huebl

--- a/lib/python/picongpu/extra/utils/param_parser.py
+++ b/lib/python/picongpu/extra/utils/param_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Sebastian Starke

--- a/lib/python/picongpu/picmi/constants.py
+++ b/lib/python/picongpu/picmi/constants.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/distribution/Distribution.py
+++ b/lib/python/picongpu/picmi/distribution/Distribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/distribution/FoilDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/FoilDistribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/distribution/GaussianBunchDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/GaussianBunchDistribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/distribution/GaussianDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/GaussianDistribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/distribution/UniformDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/UniformDistribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus
 License: GPLv3+

--- a/lib/python/picongpu/picmi/grid.py
+++ b/lib/python/picongpu/picmi/grid.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+

--- a/lib/python/picongpu/picmi/layout.py
+++ b/lib/python/picongpu/picmi/layout.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/solver.py
+++ b/lib/python/picongpu/picmi/solver.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/customuserinput.py
+++ b/lib/python/picongpu/pypicongpu/customuserinput.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/grid.py
+++ b/lib/python/picongpu/pypicongpu/grid.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/output/auto.py
+++ b/lib/python/picongpu/pypicongpu/output/auto.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/rendering/renderedobject.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderedobject.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/rendering/renderer.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/solver.py
+++ b/lib/python/picongpu/pypicongpu/solver.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/attribute/attribute.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/attribute.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/attribute/boundelectrons.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/boundelectrons.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/attribute/momentum.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/momentum.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/attribute/position.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/position.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/attribute/weighting.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/weighting.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/constant/charge.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/charge.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/constant/constant.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/constant.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/constant/densityratio.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/densityratio.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/constant/elementproperties.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/elementproperties.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizers.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizers.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/constant/mass.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/mass.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/initmanager.py
+++ b/lib/python/picongpu/pypicongpu/species/initmanager.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityoperation.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityoperation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023-2023 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/densityprofile.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/densityprofile.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/foil.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/foil.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023 PIConGPU contributors
 Authors: Kristin Tippey, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
 Authors: Brian Edward Marre, Masoud Afshari
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/exponential.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/exponential.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023 PIConGPU contributors
 Authors: Kristin Tippey, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/none.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/none.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023 PIConGPU contributors
 Authors: Kristin Tippey, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/plasmaramp.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/plasmaramp.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/uniform.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/uniform.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/momentum/drift.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/momentum/drift.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/momentum/temperature.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/momentum/temperature.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/noboundelectrons.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/noboundelectrons.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/notplaced.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/notplaced.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/operation.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/operation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/setboundelectrons.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/setboundelectrons.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/operation/simplemomentum.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simplemomentum.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/species.py
+++ b/lib/python/picongpu/pypicongpu/species/species.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/species/util/element.py
+++ b/lib/python/picongpu/pypicongpu/species/util/element.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/picongpu/pypicongpu/util.py
+++ b/lib/python/picongpu/pypicongpu/util.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/lib/python/test/setups/ESKHI/config.py
+++ b/lib/python/test/setups/ESKHI/config.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/setups/ESKHI/main.py
+++ b/lib/python/test/setups/ESKHI/main.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/setups/MI/config.py
+++ b/lib/python/test/setups/MI/config.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/setups/MI/main.py
+++ b/lib/python/test/setups/MI/main.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Math/__init__.py
+++ b/lib/python/test/testsuite/Math/__init__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Math/_manager.py
+++ b/lib/python/test/testsuite/Math/_manager.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Math/_searchData.py
+++ b/lib/python/test/testsuite/Math/_searchData.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Math/deviation.py
+++ b/lib/python/test/testsuite/Math/deviation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Math/math.py
+++ b/lib/python/test/testsuite/Math/math.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Math/physics.py
+++ b/lib/python/test/testsuite/Math/physics.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Output/Log.py
+++ b/lib/python/test/testsuite/Output/Log.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Output/__init__.py
+++ b/lib/python/test/testsuite/Output/__init__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Output/_manager.py
+++ b/lib/python/test/testsuite/Output/_manager.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/__init__.py
+++ b/lib/python/test/testsuite/Reader/__init__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/_manager.py
+++ b/lib/python/test/testsuite/Reader/_manager.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/cmakeFlagReader.py
+++ b/lib/python/test/testsuite/Reader/cmakeFlagReader.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/dataReader.py
+++ b/lib/python/test/testsuite/Reader/dataReader.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/jsonReader.py
+++ b/lib/python/test/testsuite/Reader/jsonReader.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/paramReader.py
+++ b/lib/python/test/testsuite/Reader/paramReader.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Reader/readFiles.py
+++ b/lib/python/test/testsuite/Reader/readFiles.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/Template/config.py
+++ b/lib/python/test/testsuite/Template/config.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/__init__.py
+++ b/lib/python/test/testsuite/__init__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/_checkData.py
+++ b/lib/python/test/testsuite/_checkData.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/lib/python/test/testsuite/_manager.py
+++ b/lib/python/test/testsuite/_manager.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023-2023 PIConGPU contributors
 Authors: Mika Soren Voss

--- a/share/ci/install/pypicongpu.sh
+++ b/share/ci/install/pypicongpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This file is part of the PIConGPU.
+# This file is part of PIConGPU.
 # Copyright 2023-2023 PIConGPU contributors
 # Authors: Simeon Ehrig
 # License: GPLv3+

--- a/share/ci/install/requirements_txt_modifier.py
+++ b/share/ci/install/requirements_txt_modifier.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023-2023 PIConGPU contributors
 Authors: Simeon Ehrig
 License: GPLv3+

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Callable
 import pkg_resources
 
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2023-2023 PIConGPU contributors
 Authors: Simeon Ehrig
 License: GPLv3+

--- a/share/picongpu/examples/FoilLCT/bin/plot_charge_density.py
+++ b/share/picongpu/examples/FoilLCT/bin/plot_charge_density.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2017-2023 PIConGPU contributors
 Authors: Axel Huebl

--- a/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/BeamRelaxationVerifier.py
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/BeamRelaxationVerifier.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/SmileiBeamRelaxation.py
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/SmileiBeamRelaxation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/__init__.py
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/__init__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/generate_plots.py
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/lib/python/picongpu/beam_relaxation_verifier/generate_plots.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/SmileiThermalization.py
+++ b/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/SmileiThermalization.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/ThermalizationVerifier.py
+++ b/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/ThermalizationVerifier.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/__init__.py
+++ b/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/__init__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/generate_plots.py
+++ b/share/picongpu/tests/CollisionsThermalisation/lib/python/picongpu/thermalization_verifier/generate_plots.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2022-2023 PIConGPU contributors
 Authors: Pawel Ordyna

--- a/share/picongpu/tests/CurrentDeposition/lib/python/test/CurrentDeposition/MainTest.py
+++ b/share/picongpu/tests/CurrentDeposition/lib/python/test/CurrentDeposition/MainTest.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023 PIConGPU contributors
 Authors: Hannes Wolf

--- a/share/picongpu/tests/CurrentDeposition/lib/python/test/CurrentDeposition/assignment_and_W_func.py
+++ b/share/picongpu/tests/CurrentDeposition/lib/python/test/CurrentDeposition/assignment_and_W_func.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023 PIConGPU contributors
 Authors: Hannes Wolf

--- a/share/picongpu/tests/CurrentDeposition/lib/python/test/CurrentDeposition/grid_class.py
+++ b/share/picongpu/tests/CurrentDeposition/lib/python/test/CurrentDeposition/grid_class.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023 PIConGPU contributors
 Authors: Hannes Wolf

--- a/share/picongpu/tests/Pusher/lib/python/test/Pusher/MainTest.py
+++ b/share/picongpu/tests/Pusher/lib/python/test/Pusher/MainTest.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 
 Copyright 2023 PIConGPU contributors
 Authors: Hannes Wolf

--- a/test/python/picongpu/__main__.py
+++ b/test/python/picongpu/__main__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/compiling/__main__.py
+++ b/test/python/picongpu/compiling/__main__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/compiling/distribution.py
+++ b/test/python/picongpu/compiling/distribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/compiling/runner.py
+++ b/test/python/picongpu/compiling/runner.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Simeon Ehrig
 License: GPLv3+

--- a/test/python/picongpu/compiling/species.py
+++ b/test/python/picongpu/compiling/species.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/__main__.py
+++ b/test/python/picongpu/quick/__main__.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/picmi/distribution.py
+++ b/test/python/picongpu/quick/picmi/distribution.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/picmi/gaussian_laser.py
+++ b/test/python/picongpu/quick/picmi/gaussian_laser.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+

--- a/test/python/picongpu/quick/picmi/grid.py
+++ b/test/python/picongpu/quick/picmi/grid.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Richard Pausch, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/picmi/layout.py
+++ b/test/python/picongpu/quick/picmi/layout.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/picmi/simulation.py
+++ b/test/python/picongpu/quick/picmi/simulation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+

--- a/test/python/picongpu/quick/picmi/species.py
+++ b/test/python/picongpu/quick/picmi/species.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/customuserinput.py
+++ b/test/python/picongpu/quick/pypicongpu/customuserinput.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/grid.py
+++ b/test/python/picongpu/quick/pypicongpu/grid.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/laser.py
+++ b/test/python/picongpu/quick/pypicongpu/laser.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/output/auto.py
+++ b/test/python/picongpu/quick/pypicongpu/output/auto.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/rendering/renderedobject.py
+++ b/test/python/picongpu/quick/pypicongpu/rendering/renderedobject.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/rendering/renderer.py
+++ b/test/python/picongpu/quick/pypicongpu/rendering/renderer.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/runner.py
+++ b/test/python/picongpu/quick/pypicongpu/runner.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/solver.py
+++ b/test/python/picongpu/quick/pypicongpu/solver.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/attribute/attribute.py
+++ b/test/python/picongpu/quick/pypicongpu/species/attribute/attribute.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/attribute/boundelectrons.py
+++ b/test/python/picongpu/quick/pypicongpu/species/attribute/boundelectrons.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/attribute/momentum.py
+++ b/test/python/picongpu/quick/pypicongpu/species/attribute/momentum.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/attribute/position.py
+++ b/test/python/picongpu/quick/pypicongpu/species/attribute/position.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/attribute/weighting.py
+++ b/test/python/picongpu/quick/pypicongpu/species/attribute/weighting.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/constant/charge.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/charge.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/constant/constant.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/constant.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/constant/densityratio.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/densityratio.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/constant/elementproperties.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/elementproperties.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/constant/ionizers.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/ionizers.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/constant/mass.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/mass.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/initmanager.py
+++ b/test/python/picongpu/quick/pypicongpu/species/initmanager.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/densityprofile.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/densityprofile.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/foil.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/foil.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/uniform.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/uniform.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/momentum/drift.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/momentum/drift.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/momentum/temperature.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/momentum/temperature.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/noboundelectrons.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/noboundelectrons.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/notplaced.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/notplaced.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/operation.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/operation.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/setboundelectrons.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/setboundelectrons.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/simpledensity.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/simpledensity.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/operation/simplemomentum.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/simplemomentum.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/species.py
+++ b/test/python/picongpu/quick/pypicongpu/species/species.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+

--- a/test/python/picongpu/quick/pypicongpu/species/util/element.py
+++ b/test/python/picongpu/quick/pypicongpu/species/util/element.py
@@ -1,5 +1,5 @@
 """
-This file is part of the PIConGPU.
+This file is part of PIConGPU.
 Copyright 2021-2023 PIConGPU contributors
 Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+


### PR DESCRIPTION
removes the superflous ~~the~~ PIConGPU from our python doc strings.