### PR TITLE
Set main rank correctly in the binning plugin

### DIFF
--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -160,7 +160,7 @@ namespace picongpu
                  */
                 this->histBuffer = std::make_unique<HostDeviceBuffer<TDepositedQuantity, 1>>(
                     binningData.axisExtentsND.productOfComponents());
-                isMain = reduce.hasResult();
+                isMain = reduce.hasResult(mpi::reduceMethods::Reduce());
             }
 
             ~Binner() override


### PR DESCRIPTION
The binning plugin does an MPI reduce across all MPI ranks and then outputs openPMD from the main rank. 
It was currently setting the main rank incorrectly as it was using ``hasResult()``  with no parameters which defaults to checking if a rank has the result when an ``AllReduce`` operation is performed. 
All ranks have the ``AllReduce`` result, so the output created was from the last rank which writes the openPMD. This was sometimes coincidentally the "main rank" of reduction so it sometimes gave the correct result and other times the output was zeros.