### PR TITLE
Fix filtering for plugins

### DIFF
--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -56,6 +56,10 @@ Let us select particles with momentum vector within a cone with an opening angle
           FunctorParticlesForwardPinhole
        >;
 
+.. note::
+
+    User defined filter functors must be wrapped to fit the general filter interface. This can be done using wrappers like ``generic::Free<T_UserFunctor>`` and ``generic::FreeTotalCellOffset<T_UserFunctor>``
+
 and add ``ParticlesForwardPinhole`` to the ``AllParticleFilters`` list:
 
 .. code:: cpp

--- a/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
+++ b/include/picongpu/plugins/misc/ExecuteIfNameIsEqual.hpp
@@ -41,7 +41,8 @@ namespace picongpu
                  * @param unaryFunctor any unary functor
                  */
                 template<typename T_Kernel, typename... T_Args>
-                void operator()(std::string filterName, uint32_t const currentStep, T_Kernel const unaryFunctor) const
+                void operator()(std::string const& filterName, uint32_t const currentStep, T_Kernel const unaryFunctor)
+                    const
                 {
                     if(filterName == T_Filter::getName())
                         unaryFunctor(particles::filter::IUnary<T_Filter>{currentStep});


### PR DESCRIPTION
Using filters with plugins was broken and only worked when the filter used by the user was the same as the first filter in the internal EligibleFilters type list (usually it is the filter all).
In a plugin, when ``meta::ForEach<typename Help::EligibleFilters, plugins::misc::ExecuteIfNameIsEqual<boost::mpl::_1>>{}(m_help->filter.get(m_id), currentStep, bindKernel);`` is called, the filter name string returned from ``m_help->filter.get(m_id)`` is only passed on correctly to the first expansion from the ``ForEach`` List. All other expansions were receiving an empty string.
I am not sure why this happens, I suspect that for some reason the compiler is optimizing the string being passed by value into a move and isn't dealing with the ``ForEach`` correctly. As a fix the string is now passed as a const reference, which prevents moves. This fixes the problem in my tests.
Bug found by @JessicaTiebel, and tested to be fixed by her
Duplicate of #4994 which was closed without merging, as the CI-nocompile flag couldnt be undone.
