### PR TITLE
remove CUDA 11.2 and 11.3 support

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -135,7 +135,7 @@ Optional Libraries
 
 CUDA
 """"
-- `11.2.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- `11.4.0+ <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -231,8 +231,6 @@ compilers.append(hip_clang_compilers)
 backends = [
     ("hip", 5.4),
     ("hip", 5.5),
-    ("cuda", 11.2),
-    ("cuda", 11.3),
     ("cuda", 11.4),
     ("cuda", 11.5),
     ("cuda", 11.6),


### PR DESCRIPTION
- Remove support for CUDA 11.2 to avoid the following compiler bug.

```
lto1: internal compiler error: in add_symbol_to_partition_1, at lto/lto-partition.c:153
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-9/README.Bugs> for instructions.
lto-wrapper: fatal error: /usr/bin/g++-9 returned 1 exit status
compilation terminated.
```

- remove CUDA 11.3 support

CUDA 11.3 is producing errors with message which are not related to the shown code.

```C++
/builds/hzdr/crp/picongpu/include/picongpu/../picongpu/algorithms/Gamma.def:44:37: error: 'numParticles' does not name a type; did you mean 'particles'?
2705
   44 |         HDINLINE T_PrecisionType operator()(T_MomType const& mom, T_MassType const mass) const;
2706
      |                                     ^~~~~~~~~~~~
2707
      |                                     particles
```