### PR TITLE
pypicongpu: reduce compile paralism

### DIFF
--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -320,7 +320,7 @@ class Runner:
     def __build(self):
         """launch build of PIConGPU"""
         chdir(self.setup_dir)
-        runArgs("pic-build", ["pic-build"])
+        runArgs("pic-build", ["pic-build", "-j", "4"])
 
     def __run(self):
         """


### PR DESCRIPTION
Reduce the compile to 4 parallel threads to avoid that the CI is running out of memory.