### PR TITLE
fix CMake compute/cpu architecture selection

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -72,34 +72,34 @@ get_backend_flags()
         # what is not part of alpaka 0.7.0
         result+=" -Dalpaka_ACC_GPU_CUDA_ENABLE=ON -Dalpaka_ACC_GPU_CUDA_ONLY_MODE=ON -Dalpaka_CUDA_EXPT_EXTENDED_LAMBDA=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DCMAKE_CUDA_ARCHITECTURES=\"${backend_cfg[1]}\""
+            result+=" -DCMAKE_CUDA_ARCHITECTURES=${backend_cfg[1]}"
         else
             result+=" -DCMAKE_CUDA_ARCHITECTURES=52"
         fi
     elif [ "${backend_cfg[0]}" == "omp2b" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "serial" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "tbb" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "threads" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON -DPMACC_ASYNC_QUEUES=OFF"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "hip" ] ; then
         result+=" -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_ACC_GPU_HIP_ONLY_MODE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DGPU_TARGETS=\"${backend_cfg[1]}\""
+            result+=" -DGPU_TARGETS=${backend_cfg[1]}"
         fi
     else
         echo "unsupported backend given '$1'" >&2

--- a/share/ci/backendFlags.sh
+++ b/share/ci/backendFlags.sh
@@ -15,34 +15,34 @@ get_backend_flags()
     if [ "${backend_cfg[0]}" == "cuda" ] ; then
         result+=" -Dalpaka_ACC_GPU_CUDA_ENABLE=ON -Dalpaka_ACC_GPU_CUDA_ONLY_MODE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DCMAKE_CUDA_ARCHITECTURES=\"${backend_cfg[1]}\""
+            result+=" -DCMAKE_CUDA_ARCHITECTURES=${backend_cfg[1]}"
         else
             result+=" -DCMAKE_CUDA_ARCHITECTURES=52"
         fi
     elif [ "${backend_cfg[0]}" == "omp2b" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "serial" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "tbb" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "threads" ] ; then
         result+=" -Dalpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DPMACC_CPU_ARCH=\"${backend_cfg[1]}\""
+            result+=" -DPMACC_CPU_ARCH=${backend_cfg[1]}"
         fi
     elif [ "${backend_cfg[0]}" == "hip" ] ; then
         result+=" -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_ACC_GPU_HIP_ONLY_MODE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DGPU_TARGETS=\"${backend_cfg[1]}\""
+            result+=" -DGPU_TARGETS=${backend_cfg[1]}"
         else
             # If no architecture is given build for Radeon VII or MI50/60.
             result+=" -DGPU_TARGETS=gfx906"


### PR DESCRIPTION
CMake 3.25.3 is complaining about the `"` around the compute architecture. 