### PR TITLE
Topic remove cuda11.3 and g++9/CUDA support

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -136,6 +136,7 @@ Optional Libraries
 CUDA
 """"
 - `11.3.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- g++-10 or newer is required
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -135,7 +135,7 @@ Optional Libraries
 
 CUDA
 """"
-- `11.2.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- `11.3.0+ <https://developer.nvidia.com/cuda-downloads>`_
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``
 - *Arch Linux:* ``sudo pacman --sync cuda``

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -157,9 +157,10 @@ def is_valid_combination(row):
         # nvcc compatibility
         if is_cuda and is_nvcc:
             if is_gnu:
-                # for C++17 support CUDA >= 11 is required
-                if v_cuda == 11.0 and v_compiler <= 9:
-                    return True
+                # official g++ 9 and CUDA is supported but due to many
+                # compile issue we do not support this combination anymore
+                if v_compiler <= 9:
+                    return False
                 if 11.1 <= v_cuda <= 11.3 and v_compiler <= 10:
                     if v_compiler == 10:
                         # nvcc + gcc 10.3 bug see:

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -231,7 +231,6 @@ compilers.append(hip_clang_compilers)
 backends = [
     ("hip", 5.4),
     ("hip", 5.5),
-    ("cuda", 11.2),
     ("cuda", 11.3),
     ("cuda", 11.4),
     ("cuda", 11.5),

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/collision.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/collision.param
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picongpu/param/particleFilters.param"
 #include "picongpu/particles/collision/collision.def"
 #include "picongpu/plugins/misc/SpeciesFilter.hpp"
 


### PR DESCRIPTION
- Remove support for CUDA 11.2 to avoid the following compiler bug.

```
lto1: internal compiler error: in add_symbol_to_partition_1, at lto/lto-partition.c:153
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-9/README.Bugs> for instructions.
lto-wrapper: fatal error: /usr/bin/g++-9 returned 1 exit status
compilation terminated.
```

- remove support for g++9 and CUDA due to compile issues we are not able to solve e.g.
CUDA 11.3 is producing errors with message which are not related to the shown code.

```C++
/builds/hzdr/crp/picongpu/include/picongpu/../picongpu/algorithms/Gamma.def:44:37: error: 'numParticles' does not name a type; did you mean 'particles'?
2705
   44 |         HDINLINE T_PrecisionType operator()(T_MomType const& mom, T_MassType const mass) const;
2706
      |                                     ^~~~~~~~~~~~
2707
      |                                     particles
```
