### PR TITLE
fix C++20 compiler

### DIFF
--- a/include/picongpu/particles/startPosition/generic/Free.hpp
+++ b/include/picongpu/particles/startPosition/generic/Free.hpp
@@ -97,7 +97,9 @@ namespace picongpu
                     template<typename DeferFunctor = Functor>
                     HINLINE Free(
                         uint32_t currentStep,
-                        std::enable_if_t<std::is_constructible_v<DeferFunctor, uint32_t>>* = 0)
+                        std::enable_if_t<
+                            !std::is_default_constructible_v<
+                                DeferFunctor> && std::is_constructible_v<DeferFunctor, uint32_t>>* = 0)
                         : Functor(currentStep)
                     {
                     }
@@ -112,7 +114,7 @@ namespace picongpu
                      * @param is used to enable/disable the constructor (do not pass any value to this parameter)
                      */
                     template<typename DeferFunctor = Functor>
-                    HINLINE Free(uint32_t, typename std::enable_if_t<std::is_constructible_v<DeferFunctor>>* = nullptr)
+                    HINLINE Free(uint32_t, std::enable_if_t<std::is_default_constructible_v<DeferFunctor>>* = nullptr)
                         : Functor()
                     {
                     }

--- a/include/picongpu/particles/startPosition/generic/FreeRng.hpp
+++ b/include/picongpu/particles/startPosition/generic/FreeRng.hpp
@@ -107,7 +107,9 @@ namespace picongpu
                     template<typename DeferFunctor = Functor>
                     HINLINE FreeRng(
                         uint32_t currentStep,
-                        std::enable_if_t<std::is_constructible_v<DeferFunctor, uint32_t>>* = 0)
+                        std::enable_if_t<
+                            !std::is_default_constructible_v<
+                                DeferFunctor> && std::is_constructible_v<DeferFunctor, uint32_t>>* = 0)
                         : Functor(currentStep)
                         , RngGenerator(currentStep)
                     {
@@ -123,7 +125,9 @@ namespace picongpu
                      * @param is used to enable/disable the constructor (do not pass any value to this parameter)
                      */
                     template<typename DeferFunctor = Functor>
-                    HINLINE FreeRng(uint32_t currentStep, std::enable_if_t<std::is_constructible_v<DeferFunctor>>* = 0)
+                    HINLINE FreeRng(
+                        uint32_t currentStep,
+                        std::enable_if_t<std::is_default_constructible_v<DeferFunctor>>* = 0)
                         : Functor()
                         , RngGenerator(currentStep)
                     {

--- a/include/pmacc/functor/Interface.hpp
+++ b/include/pmacc/functor/Interface.hpp
@@ -122,7 +122,9 @@ namespace pmacc
             template<typename DeferFunctor = UserFunctor>
             HINLINE Interface(
                 uint32_t const currentStep,
-                std::enable_if_t<std::is_constructible_v<DeferFunctor, uint32_t>>* = nullptr)
+                std::enable_if_t<
+                    !std::is_default_constructible_v<
+                        DeferFunctor> && std::is_constructible_v<DeferFunctor, uint32_t>>* = nullptr)
                 : UserFunctor(currentStep)
             {
             }
@@ -139,7 +141,7 @@ namespace pmacc
             template<typename DeferFunctor = UserFunctor>
             HINLINE Interface(
                 uint32_t const currentStep,
-                std::enable_if_t<std::is_constructible_v<DeferFunctor>>* = nullptr)
+                std::enable_if_t<std::is_default_constructible_v<DeferFunctor>>* = nullptr)
                 : UserFunctor()
             {
                 boost::ignore_unused(currentStep);


### PR DESCRIPTION
- `is_constructible_v` in C++20 is returning true if a member can be explicit initialized even if there is no constructor available.

follow-up of #4960