### PR TITLE
fix missing error message

### DIFF
--- a/include/pmacc/alpakaHelper/ValidateCall.hpp
+++ b/include/pmacc/alpakaHelper/ValidateCall.hpp
@@ -81,7 +81,7 @@
         }                                                                                                             \
         catch(std::exception const& e)                                                                                \
         {                                                                                                             \
-            PMACC_PRINT_ALPAKA_ERROR(e.what());                                                                       \
+            PMACC_PRINT_ALPAKA_ERROR(std::string(e.what()) + "\n" + msg);                                             \
         }                                                                                                             \
     } while(false)
 


### PR DESCRIPTION
`PMACC_CHECK_ALPAKA_CALL_MSG` missed to forward the error message.