### PR TITLE
refactor id provider

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -55,8 +55,8 @@ namespace picongpu
      */
     alias(position);
 
-    //! unique identifier for a particle
-    value_identifier(uint64_t, particleId, IdProvider<simDim>::getNewId());
+    //! unique identifier for a particle, the attribute can only be initialized on the compute device
+    value_identifier_device(uint64_t, particleId, IdProvider<simDim>::getNewId());
 
     //! specialization for the relative in-cell position
     value_identifier(floatD_X, position_pic, floatD_X::create(0.));

--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -52,10 +52,16 @@
         name, using type = in_type; HDINLINE static type getValue()                                                   \
         { return in_default; } static std::string getName() { return std::string(#name); })
 
+/** getValue is only on device callable */
+#define value_identifier_device(in_type, name, in_default)                                                            \
+    identifier(                                                                                                       \
+        name, using type = in_type; DINLINE static type getValue()                                                    \
+        { return in_default; } static std::string getName() { return std::string(#name); })
+
 /** getValue() is defined constexpr
  * @}
  */
 #define value_identifier_constexpr(in_type, name, in_default)                                                         \
     identifier(                                                                                                       \
-        name, using type = in_type; HDINLINE static constexpr type getValue()                                         \
+        name, using type = in_type; static constexpr type getValue()                                                  \
         { return in_default; } static std::string getName() { return std::string(#name); })

--- a/include/pmacc/particles/IdProvider.cpp
+++ b/include/pmacc/particles/IdProvider.cpp
@@ -1,0 +1,40 @@
+/* Copyright 2024 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+#include "pmacc/kernel/atomic.hpp"
+
+#include <cstdint>
+
+namespace pmacc::idDetail
+{
+    ALPAKA_FN_ACC uint64_t nextId;
+
+    ALPAKA_FN_ACC uint64_t fetchAddId()
+    {
+        return kernel::atomicAllInc(&nextId);
+    }
+
+    ALPAKA_FN_ACC uint64_t& getIdRef()
+    {
+        return nextId;
+    }
+} // namespace pmacc::idDetail

--- a/include/pmacc/particles/IdProvider.def
+++ b/include/pmacc/particles/IdProvider.def
@@ -61,7 +61,7 @@ namespace pmacc
          *  Modifies the state of the IdProvider */
         struct GetNewId
         {
-            HDINLINE uint64_t operator()() const
+            DINLINE uint64_t operator()() const
             {
                 return getNewId();
             }
@@ -69,7 +69,7 @@ namespace pmacc
 
         /** Function that returns a new id each time it is called
          *  Modifies the state of the IdProvider  */
-        HDINLINE static uint64_t getNewId();
+        DINLINE static uint64_t getNewId();
 
         /**
          * Return true, if an overflow of the counter is detected and hence there might be duplicate ids

--- a/include/pmacc/particles/IdProvider.hpp
+++ b/include/pmacc/particles/IdProvider.hpp
@@ -33,14 +33,16 @@ namespace pmacc
 {
     namespace idDetail
     {
-        DEVICEONLY uint64_cu nextId;
+        ALPAKA_FN_ACC ALPAKA_FN_EXTERN uint64_t fetchAddId();
+
+        ALPAKA_FN_ACC ALPAKA_FN_EXTERN uint64_t& getIdRef();
 
         struct KernelSetNextId
         {
             template<typename T_Acc>
             DINLINE void operator()(const T_Acc&, uint64_cu id) const
             {
-                nextId = id;
+                getIdRef() = id;
             }
         };
 
@@ -49,7 +51,7 @@ namespace pmacc
             template<class T_Box, typename T_Acc>
             DINLINE void operator()(const T_Acc&, T_Box boxOut) const
             {
-                boxOut(0) = nextId;
+                boxOut(0) = getIdRef();
             }
         };
 
@@ -111,9 +113,9 @@ namespace pmacc
     }
 
     template<unsigned T_dim>
-    HDINLINE uint64_t IdProvider<T_dim>::getNewId()
+    DINLINE uint64_t IdProvider<T_dim>::getNewId()
     {
-        return static_cast<uint64_t>(kernel::atomicAllInc(&idDetail::nextId));
+        return idDetail::fetchAddId();
     }
 
     template<unsigned T_dim>

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -6,7 +6,6 @@
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-${CI_CONTAINER_NAME}-cuda${CUDA_CONTAINER_VERSION}-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
-    PIC_CMAKE_ARGS: "-DCMAKE_CUDA_FLAGS=--no-cuda-version-check"
     CI_CLANG_AS_CUDA_COMPILER: "yes"
     DISABLE_ISAAC: "yes"
   script:

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -142,7 +142,7 @@ def is_valid_combination(row):
             # code with clang
             if v_compiler < 14:
                 return False
-            if 11.0 <= v_cuda < 12.0 and v_compiler == 14:
+            if 11.0 <= v_cuda < 11.6 and v_compiler == 14:
                 return True
             # currently not supported due to an error
             # __clang_cuda_texture_intrinsics.h:696:13:


### PR DESCRIPTION
- value_identifier: allows creating identifier which can only be default initiated on the compute device
- refactor IdProvider to avoid multiple definitions of the device global id counter variable
- CMake: enable link-time optimization for device code (required to avoid slowdown due to activated device relocatable code)


The change in `speciesAttributes.param` for the identifier `particleId` is required because we call this method from a pure device function. The compilers was able to resolve issues within a single compile unit but since IDProvider is now split into its own cpp file this change is required.