### PR TITLE
Improve FLYonPIC documentation

### DIFF
--- a/docs/source/models/atomic_physics.rst
+++ b/docs/source/models/atomic_physics.rst
@@ -74,13 +74,13 @@ Which transitions and states are included in this update is user configurable, w
 Getting Started With FLYonPIC
 -----------------------------
 
-To use FLYonPIC in a simulation setup, you need to provide a set of atomic input data files, see :ref:`atomicPhysicsInputData` and mark at least one species as an atomic physics ion species and one species as an atomic physics electron species.
+To use FLYonPIC in a simulation setup, you need to provide a set of atomic input data files, see :ref:`Input Data For FLYonPIC <atomicPhysicsInputData>`, and mark at least one species as an atomic physics ion species and one species as an atomic physics electron species.
 
-See the the compile time tests of atomic physics, `debug compile test <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/tests/compileSparser>`_ and `compile sparser example <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/tests/compileAtomicPhysics>`_ for an example using atomic physics.
+See the `compile time test of atomic physics <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/tests/compileAtomicPhysics>`_ and the `compile sparser test <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/tests/compileSparser>`_ for examples using atomic physics.
 
 .. warning::
 
-  These setups are **tests** of FLYonPIC and are therefore activate a lot of debug options negatively impacting runtime.
+  These setups are **tests** of FLYonPIC components and therefore activate a lot of debug options negatively impacting runtime.
 
   **Do not base production simulations directly on them!**
 

--- a/docs/source/models/atomic_physics.rst
+++ b/docs/source/models/atomic_physics.rst
@@ -71,8 +71,25 @@ Changes of the PIC-simulation state by the atomic physics/FLYonPIC step are prop
 
 Which transitions and states are included in this update is user configurable, with the user providing all transition coefficients and state energies via an input file.
 
+Getting Started With FLYonPIC
+-----------------------------
+
+To use FLYonPIC in a simulation setup, you need to provide a set of atomic input data files, see :ref:`atomicPhysicsInputData` and mark at least one species as an atomic physics ion species and one species as an atomic physics electron species.
+
+See the the compile time tests of atomic physics, `debug compile test <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/tests/compileSparser>`_ and `compile sparser example <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/tests/compileAtomicPhysics>`_ for an example using atomic physics.
+
+.. warning::
+
+  These setups are **tests** of FLYonPIC and are therefore activate a lot of debug options negatively impacting runtime.
+
+  **Do not base production simulations directly on them!**
+
+  To disable all atomic physics debug options simple remove the ``atomicPhysics_Debug.param`` from the setup.
+
 Input Data for FLYonPIC
 -----------------------
+
+.. _atomicPhysicsInputData:
 
 FLYonPIC requires user provided input data describing the properties of charge- and atomic-states as well the cross section coefficients of all transitions to be modelled for all atomic Physics ions species.
 

--- a/share/picongpu/tests/compileSparser/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/tests/compileSparser/include/picongpu/param/atomicPhysics_Debug.param
@@ -42,7 +42,7 @@ namespace picongpu::atomicPhysics::debug
 
     namespace electronHistogram
     {
-        //! @attention only useful if using serial backend and requires CPU_OUTPUT_ACTIVE = true to have an effect
+        //! @attention activation only useful if using serial backend
         constexpr bool PRINT_TO_CONSOLE = false;
 
         //! @attention performance relevant, uncaught error will lead to invalid memory access
@@ -69,7 +69,7 @@ namespace picongpu::atomicPhysics::debug
 
     namespace rateCache
     {
-        //! @attention only useful if using serial backend and requires CPU_OUTPUT_ACTIVE = true to have an effect
+        //! @attention only useful if using serial backend
         constexpr bool PRINT_TO_CONSOLE = false;
 
         //! @attention performance relevant
@@ -81,7 +81,7 @@ namespace picongpu::atomicPhysics::debug
 
     namespace rejectionProbabilityCache
     {
-        //! @attention only useful if using serial backend and requires CPU_OUTPUT_ACTIVE = true to have an effect
+        //! @attention only useful if using serial backend
         constexpr bool PRINT_TO_CONSOLE = false;
 
         //! @attention performance relevant
@@ -91,14 +91,14 @@ namespace picongpu::atomicPhysics::debug
 
     namespace timeRemaining
     {
-        //! @attention only useful if using serial backend and requires CPU_OUTPUT_ACTIVE = true to have an effect
+        //! @attention only useful if using cpu backend
         constexpr bool PRINT_TO_CONSOLE = false;
     } // namespace timeRemaining
 
 
     namespace timeStep
     {
-        //! @attention only useful if using serial backend and requires CPU_OUTPUT_ACTIVE = true to have an effect
+        //! @attention only useful if using cpu backend
         constexpr bool PRINT_TO_CONSOLE = false;
     } // namespace timeStep
 
@@ -139,7 +139,7 @@ namespace picongpu::atomicPhysics::debug
 
     namespace kernel::rollForOverSubscription
     {
-        //! @attention only useful if using serial backend and requires CPU_OUTPUT_ACTIVE = true to have an effect
+        //! @attention only useful if using serial backend
         constexpr bool PRINT_DEBUG_TO_CONSOLE = false;
     } // namespace kernel::rollForOverSubscription
 


### PR DESCRIPTION
- link the compile test examples in the FLYonPIC documentation as a starting point for the user
- update the in source documentation of the `compileSparser` example