### PR TITLE
refactor `value_identifier`

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -41,7 +41,7 @@
 #include <pmacc/identifier/identifier.hpp>
 #include <pmacc/identifier/value_identifier.hpp>
 #include <pmacc/meta/conversion/MakeSeq.hpp>
-#include <pmacc/particles/IdProvider.def>
+#include <pmacc/particles/IdProvider.hpp>
 #include <pmacc/particles/Identifier.hpp>
 
 #include <cstdint>
@@ -57,7 +57,7 @@ namespace picongpu
     alias(position);
 
     //! unique identifier for a particle
-    value_identifier(uint64_t, particleId, IdProvider<simDim>::getNewId());
+    value_identifier_func(uint64_t, particleId, [] ALPAKA_FN_ACC() { return IdProvider<simDim>::getNewId(); });
 
     //! specialization for the relative in-cell position
     value_identifier(floatD_X, position_pic, floatD_X::create(0.));
@@ -255,7 +255,8 @@ namespace picongpu
      * To set physical boundary conditions for a species, instead use <species>_boundary command-line option.
      *
      * The default behavior if this alias is not given to a species is to do nothing.
-     * The existing boundary implementations already take care of the particles leaving the global simulation volume.
+     * The existing boundary implementations already take care of the particles leaving the global simulation
+     * volume.
      */
     alias(boundaryCondition);
 

--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -31,7 +31,6 @@
 /** define a unique identifier with name, type and a default value
  * @param in_type type of the value
  * @param name name of identifier
- * @param in_value user defined value of in_type (can be a constructor of a class)
  *
  * The created identifier has the following options:
  *      getValue()        - return the user defined value
@@ -47,15 +46,32 @@
  *      `length()` or `length_`
  * @{
  */
-#define value_identifier(in_type, name, in_default)                                                                   \
+
+/** @param ... must be a device function/lambda
+ *
+ * @attention: getValue() is only callable from a pure device function e.g.
+ *
+ * @code{.cpp}
+ * [] ALPAKA_FN_ACC() { return IdProvider<simDim>::getNewId();}
+ * @endcode
+ */
+#define value_identifier_func(in_type, name, ...)                                                                     \
     identifier(                                                                                                       \
-        name, using type = in_type; HDINLINE static type getValue()                                                   \
-        { return in_default; } static std::string getName() { return std::string(#name); })
+        name, using type = in_type; DINLINE static type getValue()                                                    \
+        {                                                                                                             \
+            auto const func = __VA_ARGS__;                                                                            \
+            return func();                                                                                            \
+        } static std::string getName() { return std::string(#name); })
 
 /** getValue() is defined constexpr
+ *  @param ... user defined value of in_type (can be a constructor of a class) e.g.
+ *
+ * @code{.cpp}
+ * float3_X::create(0._X)
+ * @endcode
  * @}
  */
-#define value_identifier_constexpr(in_type, name, in_default)                                                         \
+#define value_identifier(in_type, name, ...)                                                                          \
     identifier(                                                                                                       \
         name, using type = in_type; HDINLINE static constexpr type getValue()                                         \
-        { return in_default; } static std::string getName() { return std::string(#name); })
+        { return __VA_ARGS__; } static std::string getName() { return std::string(#name); })


### PR DESCRIPTION
- remove `value_identifier_constexpr`
- `value_identifier`'s `getValue()` is now constexpr
- for device functions `value_identifier_func` should be used, `getValue()` is not constexpr and only callable from device

# breaking input change

The definition of the attribute `particleId` has changed to 

```C++
value_identifier_func(uint64_t, particleId, [] ALPAKA_FN_ACC() { return IdProvider<simDim>::getNewId(); });
```
Normally the file `speciesAttributes.param` is not part of the user input and therefore old input setups should work out of the box without changes.