### PR TITLE
fix wrongly used `HDINLINE` and missing inline

### DIFF
--- a/include/picongpu/fields/absorber/pml/Field.hpp
+++ b/include/picongpu/fields/absorber/pml/Field.hpp
@@ -84,7 +84,7 @@ namespace picongpu
                      *
                      * @param idx index less than 6
                      */
-                    float_X& operator[](uint32_t const idx);
+                    HDINLINE float_X& operator[](uint32_t const idx);
 
                     /** Const element access for compatibility with pmacc vectors
                      *
@@ -95,7 +95,7 @@ namespace picongpu
                      *
                      * @param idx index less than 6
                      */
-                    float_X const& operator[](uint32_t const idx) const;
+                    HDINLINE float_X const& operator[](uint32_t const idx) const;
                 };
 
                 /** Data box type used for PML fields in kernels

--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -93,14 +93,14 @@ namespace picongpu
                     return NodeValues{initialValue};
                 }
 
-                float_X& NodeValues::operator[](uint32_t const idx)
+                HDINLINE float_X& NodeValues::operator[](uint32_t const idx)
                 {
                     // Here it is safe to call the const version
                     auto constThis = const_cast<NodeValues const*>(this);
                     return const_cast<float_X&>((*constThis)[idx]);
                 }
 
-                float_X const& NodeValues::operator[](uint32_t const idx) const
+                HDINLINE float_X const& NodeValues::operator[](uint32_t const idx) const
                 {
                     return *(&xy + idx);
                 }

--- a/include/picongpu/particles/boundary/Thermal.hpp
+++ b/include/picongpu/particles/boundary/Thermal.hpp
@@ -70,7 +70,7 @@ namespace picongpu
                 //! Name, required to be wrapped later
                 static constexpr char const* name = "reflectThermalIfOutside";
 
-                HDINLINE ReflectThermalIfOutside()
+                HINLINE ReflectThermalIfOutside()
                     : energy((m_parameters.temperature * UNITCONV_keV_to_Joule) / UNIT_ENERGY)
                 {
                 }

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -134,7 +134,7 @@ namespace picongpu
             return res;
         }
 
-        ::openPMD::Series& ThreadParams::openSeries(::openPMD::Access at)
+        inline ::openPMD::Series& ThreadParams::openSeries(::openPMD::Access at)
         {
             if(!openPMDSeries)
             {
@@ -178,7 +178,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             }
         }
 
-        void ThreadParams::closeSeries()
+        inline void ThreadParams::closeSeries()
         {
             if(openPMDSeries)
             {
@@ -582,7 +582,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             }
         };
 
-        void ThreadParams::initFromConfig(
+        inline void ThreadParams::initFromConfig(
             Help& help,
             size_t id,
             uint32_t const currentStep,
@@ -1904,7 +1904,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             DataSpace<simDim> mpi_size;
         };
 
-        std::shared_ptr<plugins::multi::IInstance> Help::create(
+        inline std::shared_ptr<plugins::multi::IInstance> Help::create(
             std::shared_ptr<plugins::multi::IHelp>& help,
             size_t const id,
             MappingDesc* cellDescription)


### PR DESCRIPTION
- `inline` is added to function where it was missed and there disallow using multiple compile units
- change wrongly used `HDINLINE`
- add missing `HDINLINE`