### PR TITLE
add PluginRegistry

### DIFF
--- a/include/picongpu/plugins/BinEnergyParticles.hpp
+++ b/include/picongpu/plugins/BinEnergyParticles.hpp
@@ -28,6 +28,7 @@
 #include "picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 #include "picongpu/plugins/misc/misc.hpp"
 #include "picongpu/plugins/multi/multi.hpp"
 
@@ -507,3 +508,5 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::multi::Master<picongpu::BinEnergyParticles<boost::mpl::_1>>);

--- a/include/picongpu/plugins/ChargeConservation.hpp
+++ b/include/picongpu/plugins/ChargeConservation.hpp
@@ -23,6 +23,7 @@
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 
 #include <pmacc/algorithms/GlobalReduce.hpp>
 #include <pmacc/traits/HasFlag.hpp>
@@ -97,5 +98,7 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::ChargeConservation);
 
 #include "ChargeConservation.tpp"

--- a/include/picongpu/plugins/Checkpoint.hpp
+++ b/include/picongpu/plugins/Checkpoint.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 #include "picongpu/plugins/multi/IHelp.hpp"
 #include "picongpu/plugins/output/IIOBackend.hpp"
 
@@ -217,3 +218,5 @@ namespace picongpu
     };
 
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::Checkpoint);

--- a/include/picongpu/plugins/CountParticles.hpp
+++ b/include/picongpu/plugins/CountParticles.hpp
@@ -24,6 +24,7 @@
 #include "common/txtFileHandling.hpp"
 #include "picongpu/particles/filter/filter.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/math/operation.hpp>
@@ -195,3 +196,5 @@ namespace picongpu
     };
 
 } /* namespace picongpu */
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::CountParticles<boost::mpl::_1>);

--- a/include/picongpu/plugins/Emittance.hpp
+++ b/include/picongpu/plugins/Emittance.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/algorithms/KinEnergy.hpp"
 #include "picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 #include "picongpu/plugins/common/txtFileHandling.hpp"
 #include "picongpu/plugins/misc/misc.hpp"
 #include "picongpu/plugins/multi/multi.hpp"
@@ -760,3 +761,5 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::multi::Master<picongpu::CalcEmittance<boost::mpl::_1>>);

--- a/include/picongpu/plugins/EnergyFields.hpp
+++ b/include/picongpu/plugins/EnergyFields.hpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/device/Reduce.hpp>
@@ -262,3 +263,5 @@ namespace picongpu
     };
 
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::EnergyFields);

--- a/include/picongpu/plugins/EnergyParticles.hpp
+++ b/include/picongpu/plugins/EnergyParticles.hpp
@@ -25,6 +25,7 @@
 #include "picongpu/algorithms/KinEnergy.hpp"
 #include "picongpu/particles/traits/GenerateSolversIfSpeciesEligible.hpp"
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 #include "picongpu/plugins/common/txtFileHandling.hpp"
 #include "picongpu/plugins/misc/misc.hpp"
 #include "picongpu/plugins/multi/multi.hpp"
@@ -435,3 +436,5 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::multi::Master<picongpu::EnergyParticles<boost::mpl::_1>>);

--- a/include/picongpu/plugins/IsaacPlugin.hpp
+++ b/include/picongpu/plugins/IsaacPlugin.hpp
@@ -20,27 +20,30 @@
 
 #pragma once
 
-#include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
-#include "picongpu/plugins/ILightweightPlugin.hpp"
+#if(ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
 
-#include <pmacc/alpakaHelper/acc.hpp>
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/meta/Mp11.hpp>
-#include <pmacc/static_assert.hpp>
+#    include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
+#    include "picongpu/plugins/ILightweightPlugin.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
 
-#include <boost/fusion/include/mpl.hpp>
-#include <boost/mpl/vector.hpp>
+#    include <pmacc/alpakaHelper/acc.hpp>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/meta/Mp11.hpp>
+#    include <pmacc/static_assert.hpp>
 
-#define ISAAC_IDX_TYPE pmacc::IdxType
-#include <boost/fusion/container/list.hpp>
-#include <boost/fusion/container/list/list_fwd.hpp>
-#include <boost/fusion/include/as_list.hpp>
-#include <boost/fusion/include/list.hpp>
-#include <boost/fusion/include/list_fwd.hpp>
+#    include <boost/fusion/include/mpl.hpp>
+#    include <boost/mpl/vector.hpp>
 
-#include <limits>
+#    define ISAAC_IDX_TYPE pmacc::IdxType
+#    include <boost/fusion/container/list.hpp>
+#    include <boost/fusion/container/list/list_fwd.hpp>
+#    include <boost/fusion/include/as_list.hpp>
+#    include <boost/fusion/include/list.hpp>
+#    include <boost/fusion/include/list_fwd.hpp>
 
-#include <isaac.hpp>
+#    include <limits>
+
+#    include <isaac.hpp>
 
 
 namespace picongpu
@@ -375,17 +378,17 @@ namespace picongpu
                 VectorFieldSourceList,
                 ParticleList,
                 textureDim,
-#if(ISAAC_STEREO == 0)
+#    if(ISAAC_STEREO == 0)
                 isaac::DefaultController,
                 isaac::DefaultCompositor
-#else
-                isaac::StereoController,
-#    if(ISAAC_STEREO == 1)
-                isaac::StereoCompositorSideBySide<isaac::StereoController>
 #    else
+                isaac::StereoController,
+#        if(ISAAC_STEREO == 1)
+                isaac::StereoCompositorSideBySide<isaac::StereoController>
+#        else
                 isaac::StereoCompositorAnaglyph<isaac::StereoController, 0x000000FF, 0x00FFFF00>
+#        endif
 #    endif
-#endif
                 >;
 
             std::unique_ptr<VisualizationType> visualization;
@@ -847,3 +850,6 @@ namespace picongpu
 
     } // namespace isaacP
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(isaacP::IsaacPlugin);
+#endif

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.hpp
@@ -19,26 +19,28 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
+#if(ENABLE_OPENPMD == 1)
+#    include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/PhaseSpace/AxisDescription.hpp"
-#include "picongpu/plugins/PhaseSpace/Pair.hpp"
-#include "picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#    include "picongpu/plugins/PhaseSpace/AxisDescription.hpp"
+#    include "picongpu/plugins/PhaseSpace/Pair.hpp"
+#    include "picongpu/plugins/PhaseSpace/PhaseSpaceFunctors.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 
-#include <pmacc/communication/manager_common.hpp>
-#include <pmacc/lockstep/lockstep.hpp>
-#include <pmacc/math/Vector.hpp>
-#include <pmacc/pluginSystem/INotify.hpp>
-#include <pmacc/traits/HasFlag.hpp>
-#include <pmacc/traits/HasIdentifiers.hpp>
+#    include <pmacc/communication/manager_common.hpp>
+#    include <pmacc/lockstep/lockstep.hpp>
+#    include <pmacc/math/Vector.hpp>
+#    include <pmacc/pluginSystem/INotify.hpp>
+#    include <pmacc/traits/HasFlag.hpp>
+#    include <pmacc/traits/HasIdentifiers.hpp>
 
-#include <memory>
-#include <string>
-#include <utility>
+#    include <memory>
+#    include <string>
+#    include <utility>
 
-#include <mpi.h>
+#    include <mpi.h>
 
 
 namespace picongpu
@@ -306,4 +308,9 @@ namespace picongpu
     } // namespace particles
 } // namespace picongpu
 
-#include "PhaseSpace.tpp"
+#    include "PhaseSpace.tpp"
+
+PIC_REGISTER_SPECIES_PLUGIN(
+    picongpu::plugins::multi::Master<
+        picongpu::PhaseSpace<picongpu::particles::shapes::Counter::ChargeAssignment, boost::mpl::_1>>);
+#endif

--- a/include/picongpu/plugins/PluginController.hpp
+++ b/include/picongpu/plugins/PluginController.hpp
@@ -24,177 +24,61 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/BinEnergyParticles.hpp"
+#include "picongpu/plugins/ChargeConservation.hpp"
+#include "picongpu/plugins/Checkpoint.hpp"
 #include "picongpu/plugins/CountParticles.hpp"
 #include "picongpu/plugins/Emittance.hpp"
 #include "picongpu/plugins/EnergyFields.hpp"
 #include "picongpu/plugins/EnergyParticles.hpp"
+#include "picongpu/plugins/ILightweightPlugin.hpp"
+#include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/IsaacPlugin.hpp"
+#include "picongpu/plugins/PhaseSpace/PhaseSpace.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
+#include "picongpu/plugins/PngPlugin.hpp"
 #include "picongpu/plugins/SumCurrents.hpp"
+#include "picongpu/plugins/binning/BinningDispatcher.hpp"
+#include "picongpu/plugins/makroParticleCounter/PerSuperCell.hpp"
 #include "picongpu/plugins/multi/Master.hpp"
-#include "picongpu/plugins/output/images/PngCreator.hpp"
-#include "picongpu/plugins/output/images/Visualisation.hpp"
+#include "picongpu/plugins/openPMD/openPMDWriter.hpp"
+#include "picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp"
+#include "picongpu/plugins/radiation/Radiation.hpp"
+#include "picongpu/plugins/radiation/VectorTypes.hpp"
+#include "picongpu/plugins/shadowgraphy/Shadowgraphy.hpp"
 #include "picongpu/plugins/transitionRadiation/TransitionRadiation.hpp"
 
 #include <pmacc/assert.hpp>
-/* That's an abstract plugin for image output with the possibility
- * to store the image as png file or send it via a sockets to a server.
- *
- * \todo rename PngPlugin to ImagePlugin or similar
- */
-#include "picongpu/plugins/PngPlugin.hpp"
-
-#if(SIMDIM == DIM3 && PIC_ENABLE_FFTW3 == 1 && ENABLE_OPENPMD == 1)
-#    include "picongpu/plugins/shadowgraphy/Shadowgraphy.hpp"
-#endif
-
-#if(ENABLE_OPENPMD == 1)
-#    include "picongpu/plugins/PhaseSpace/PhaseSpace.hpp"
-#    include "picongpu/plugins/binning/BinningDispatcher.hpp"
-#    include "picongpu/plugins/openPMD/openPMDWriter.hpp"
-#    include "picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp"
-#endif
-
-#include "picongpu/plugins/ChargeConservation.hpp"
-#if(ENABLE_OPENPMD == 1)
-#    include "picongpu/plugins/makroParticleCounter/PerSuperCell.hpp"
-#endif
-
-#if(ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
-#    include "picongpu/plugins/IsaacPlugin.hpp"
-#endif
-
-#if ENABLE_OPENPMD
-#    include "picongpu/plugins/radiation/Radiation.hpp"
-#    include "picongpu/plugins/radiation/VectorTypes.hpp"
-#endif
-
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/Checkpoint.hpp"
-#include "picongpu/plugins/ILightweightPlugin.hpp"
-#include "picongpu/plugins/ISimulationPlugin.hpp"
-
 #include <pmacc/mappings/kernel/MappingDescription.hpp>
 #include <pmacc/meta/AllCombinations.hpp>
 
-#include <list>
 #include <memory>
+#include <vector>
 
 
 namespace picongpu
 {
-    using namespace pmacc;
-
     /**
      * Plugin management controller for user-level plugins.
      */
     class PluginController : public ILightweightPlugin
     {
     private:
-        std::list<std::shared_ptr<ISimulationPlugin>> plugins;
-
-        template<typename T_Type>
-        struct PushBack
-        {
-            template<typename T>
-            void operator()(T& list)
-            {
-                list.push_back(std::make_shared<T_Type>());
-            }
-        };
-
-        struct TupleSpeciesPlugin
-        {
-            enum Names
-            {
-                species = 0,
-                plugin = 1
-            };
-
-            /** apply the 1st vector component to the 2nd
-             *
-             * @tparam T_TupleVector vector of type
-             *                       pmacc::math::CT::vector< Species, Plugin >
-             *                       with two components
-             */
-            template<typename T_TupleVector>
-            using Apply = typename boost::mpl::
-                apply1<pmacc::mp_at_c<T_TupleVector, plugin>, pmacc::mp_at_c<T_TupleVector, species>>::type;
-
-            /** Check the combination Species+Plugin in the Tuple
-             *
-             * @tparam T_TupleVector with Species, Plugin
-             */
-            template<typename T_TupleVector>
-            struct IsEligible
-            {
-                using Species = pmacc::mp_at_c<T_TupleVector, species>;
-                using Solver = pmacc::mp_at_c<T_TupleVector, plugin>;
-
-                static constexpr bool value
-                    = particles::traits::SpeciesEligibleForSolver<Species, Solver>::type::value;
-            };
-        };
-
-        /* define stand alone plugins */
-        using StandAlonePlugins = pmacc::mp_list<
-            Checkpoint,
-            EnergyFields,
-            ChargeConservation,
-            SumCurrents
-#if(SIMDIM == DIM3 && PIC_ENABLE_FFTW3 == 1 && ENABLE_OPENPMD == 1)
-            ,
-            plugins::multi::Master<plugins::shadowgraphy::Shadowgraphy>
-#endif
-#if(ENABLE_OPENPMD == 1)
-            ,
-            plugins::binning::BinningDispatcher,
-            plugins::multi::Master<openPMD::openPMDWriter>
-#endif
-#if(ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
-            ,
-            isaacP::IsaacPlugin
-#endif
-            >;
-
-        using AllFields = pmacc::mp_list<FieldB, FieldE, FieldJ>;
-
-        /* define species plugins */
-        using UnspecializedSpeciesPlugins = pmacc::mp_list<
-            plugins::multi::Master<EnergyParticles<boost::mpl::_1>>,
-            plugins::multi::Master<CalcEmittance<boost::mpl::_1>>,
-            plugins::multi::Master<BinEnergyParticles<boost::mpl::_1>>,
-            CountParticles<boost::mpl::_1>,
-            PngPlugin<Visualisation<boost::mpl::_1, PngCreator>>,
-            plugins::transitionRadiation::TransitionRadiation<boost::mpl::_1>
-
-#if(ENABLE_OPENPMD == 1)
-            ,
-            plugins::radiation::Radiation<boost::mpl::_1>,
-            plugins::multi::Master<ParticleCalorimeter<boost::mpl::_1>>,
-            plugins::multi::Master<PhaseSpace<particles::shapes::Counter::ChargeAssignment, boost::mpl::_1>>,
-            PerSuperCell<boost::mpl::_1>
-#endif
-            >;
-
-        using CombinedUnspecializedSpeciesPlugins
-            = pmacc::AllCombinations<VectorAllSpecies, UnspecializedSpeciesPlugins>;
-
-        using CombinedUnspecializedSpeciesPluginsEligible
-            = pmacc::mp_copy_if<CombinedUnspecializedSpeciesPlugins, TupleSpeciesPlugin::IsEligible>;
-
-        using SpeciesPlugins
-            = pmacc::mp_transform<TupleSpeciesPlugin::Apply, CombinedUnspecializedSpeciesPluginsEligible>;
-
-        /* create sequence with all fully specialized plugins */
-        using AllPlugins = MakeSeq_t<StandAlonePlugins, SpeciesPlugins>;
+        std::vector<std::shared_ptr<ISimulationPlugin>> plugins;
 
         /**
          * Initializes the controller by adding all user plugins to its internal list.
          */
         virtual void init()
         {
-            meta::ForEach<AllPlugins, PushBack<boost::mpl::_1>> pushBack;
-            pushBack(plugins);
+            // get all plugins from plugin registry
+            auto const pluginFactories = PluginRegistry::get().getPluginFactories();
+            plugins.reserve(pluginFactories.size());
+            for(auto const& pluginFactory : pluginFactories)
+            {
+                plugins.emplace_back(pluginFactory->createPlugin());
+            }
         }
 
     public:
@@ -209,9 +93,9 @@ namespace picongpu
         {
             PMACC_ASSERT(cellDescription != nullptr);
 
-            for(auto iter = plugins.begin(); iter != plugins.end(); ++iter)
+            for(auto plugin : plugins)
             {
-                (*iter)->setMappingDescription(cellDescription);
+                plugin->setMappingDescription(cellDescription);
             }
         }
 

--- a/include/picongpu/plugins/PluginRegistry.hpp
+++ b/include/picongpu/plugins/PluginRegistry.hpp
@@ -1,0 +1,197 @@
+/* Copyright 2013-2024 Axel Huebl, Benjamin Schneider, Felix Schmitt,
+ *                     Heiko Burau, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz, Erik Zenker, Finn-Ole Carstens,
+ *                     Franz Poeschel
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#include "picongpu/plugins/ISimulationPlugin.hpp"
+
+#include <pmacc/meta/AllCombinations.hpp>
+#include <pmacc/ppFunctions.hpp>
+
+#include <memory>
+#include <vector>
+
+
+namespace picongpu
+{
+    using namespace pmacc;
+
+    /** plugin registry entry interface */
+    struct IRegistryEntry
+    {
+        virtual std::shared_ptr<ISimulationPlugin> createPlugin() = 0;
+    };
+
+    /** factory used to create a plugin at runtime */
+    template<typename T_Plugin>
+    struct RegistryEntry : IRegistryEntry
+    {
+        std::shared_ptr<ISimulationPlugin> createPlugin() override
+        {
+            return std::make_shared<T_Plugin>();
+        }
+    };
+
+    /** singleton to register plugins which get created by PluginController during the startup */
+    struct PluginRegistry
+    {
+        static PluginRegistry& get()
+        {
+            static PluginRegistry instance = PluginRegistry{};
+            return instance;
+        }
+
+        /** combines a plugins with all species
+         *
+         * Trait SpeciesEligibleForSolver is evaluated to check if a plugin support using a species.
+         *
+         * @tparam T_Plugin
+         */
+        template<typename T_Plugin>
+        static void registerSpeciesPlugin()
+        {
+            using CombinedUnspecializedSpeciesPlugins = pmacc::AllCombinations<VectorAllSpecies, MakeSeq_t<T_Plugin>>;
+
+            using CombinedUnspecializedSpeciesPluginsEligible
+                = pmacc::mp_copy_if<CombinedUnspecializedSpeciesPlugins, TupleSpeciesPlugin::IsEligible>;
+
+            using SpeciesPlugins
+                = pmacc::mp_transform<TupleSpeciesPlugin::Apply, CombinedUnspecializedSpeciesPluginsEligible>;
+
+
+            meta::ForEach<SpeciesPlugins, PushBack<boost::mpl::_1>> pushBack;
+            pushBack(PluginRegistry::get().pluginFactories);
+        }
+
+        template<typename T_Plugin>
+        static void registerStandAlonePlugin()
+        {
+            meta::ForEach<MakeSeq_t<T_Plugin>, PushBack<boost::mpl::_1>> pushBack;
+            pushBack(PluginRegistry::get().pluginFactories);
+        }
+
+        /** get a container with factories to create plugins
+         *
+         * @return container with factories where createPlugin() can be called on each entry
+         */
+        auto getPluginFactories() const
+        {
+            return pluginFactories;
+        }
+
+    private:
+        std::vector<std::shared_ptr<IRegistryEntry>> pluginFactories;
+
+        PluginRegistry() = default;
+
+        struct TupleSpeciesPlugin
+        {
+            enum Names
+            {
+                species = 0,
+                plugin = 1
+            };
+
+            /** apply the 1st vector component to the 2nd
+             *
+             * @tparam T_TupleVector vector of type
+             *                       pmacc::math::CT::vector< Species, Plugin >
+             *                       with two components
+             */
+            template<typename T_TupleVector>
+            using Apply = typename boost::mpl::
+                apply1<pmacc::mp_at_c<T_TupleVector, plugin>, pmacc::mp_at_c<T_TupleVector, species>>::type;
+
+            /** Check the combination Species+Plugin in the Tuple
+             *
+             * @tparam T_TupleVector with Species, Plugin
+             */
+            template<typename T_TupleVector>
+            struct IsEligible
+            {
+                using Species = pmacc::mp_at_c<T_TupleVector, species>;
+                using Solver = pmacc::mp_at_c<T_TupleVector, plugin>;
+
+                static constexpr bool value
+                    = particles::traits::SpeciesEligibleForSolver<Species, Solver>::type::value;
+            };
+        };
+
+        template<typename T_Type>
+        struct PushBack
+        {
+            template<typename T>
+            void operator()(T& pluginFactories)
+            {
+                pluginFactories.push_back(std::make_shared<RegistryEntry<T_Type>>());
+            }
+        };
+    };
+
+} // namespace picongpu
+
+/** Create a static object which registers a plugin automatically at the start of the application to the registry.
+ *
+ * @param counter compile time unique counter __COUNTER__
+ * @param registerOperation method which is called on the singleton PluginRegistry to register the plugin
+ *                          can be registerStandAlonePlugin or registerSpeciesPlugin
+ * @param ... plugin type signature
+ */
+#define PIC_REGISTER_PLUGIN_DO(counter, registerOperation, ...)                                                       \
+                                                                                                                      \
+    namespace picongpu::plugin                                                                                        \
+    {                                                                                                                 \
+        struct PMACC_JOIN(plugin_, counter)                                                                           \
+        {                                                                                                             \
+            PMACC_JOIN(plugin_, counter)()                                                                            \
+            {                                                                                                         \
+                picongpu::PluginRegistry::registerOperation<__VA_ARGS__>();                                           \
+            }                                                                                                         \
+        };                                                                                                            \
+    }                                                                                                                 \
+    static picongpu::plugin::PMACC_JOIN(plugin_, counter) PMACC_JOIN(plugin_instance, counter)                        \
+    {                                                                                                                 \
+    }
+
+/** Register a species independent plugin class to PIConGPU
+ *
+ * @param ... plugin type signature
+ *
+ *  @code{.cpp}
+ *   PIC_REGISTER_PLUGIN(picongpu::SumCurrents);
+ * @endcode
+ */
+#define PIC_REGISTER_PLUGIN(...) PIC_REGISTER_PLUGIN_DO(__COUNTER__, registerStandAlonePlugin, __VA_ARGS__)
+
+/** Register a species dependent plugin class to PIConGPU
+ *
+ * The plugin is combined with all possible species in case the checked with the trait SpeciesEligibleForSolver is
+ * evaluated to true.
+ *
+ * @param ... plugin type signature
+ *
+ * @code{.cpp}
+ *   PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::multi::Master<picongpu::BinEnergyParticles<boost::mpl::_1>>);
+ * @endcode
+ */
+#define PIC_REGISTER_SPECIES_PLUGIN(...) PIC_REGISTER_PLUGIN_DO(__COUNTER__, registerSpeciesPlugin, __VA_ARGS__)

--- a/include/picongpu/plugins/PngPlugin.hpp
+++ b/include/picongpu/plugins/PngPlugin.hpp
@@ -24,6 +24,9 @@
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/ILightweightPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
+#include "picongpu/plugins/output/images/PngCreator.hpp"
+#include "picongpu/plugins/output/images/Visualisation.hpp"
 #include "picongpu/simulation/control/MovingWindow.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
@@ -231,3 +234,5 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::PngPlugin<Visualisation<boost::mpl::_1, PngCreator>>);

--- a/include/picongpu/plugins/SumCurrents.hpp
+++ b/include/picongpu/plugins/SumCurrents.hpp
@@ -24,6 +24,7 @@
 
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/plugins/ILightweightPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/lockstep/lockstep.hpp>
@@ -174,5 +175,6 @@ namespace picongpu
             return sumcurrents->getHostBuffer().getDataBox()[0];
         }
     };
-
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::SumCurrents);

--- a/include/picongpu/plugins/binning/BinningDispatcher.hpp
+++ b/include/picongpu/plugins/binning/BinningDispatcher.hpp
@@ -19,17 +19,20 @@
 
 #pragma once
 
-#include "picongpu/param/binningSetup.param"
-#include "picongpu/plugins/ISimulationPlugin.hpp"
-#include "picongpu/plugins/binning/BinningCreator.hpp"
+#if(ENABLE_OPENPMD == 1)
 
-#include <boost/program_options.hpp>
-#include <boost/program_options/options_description.hpp>
+#    include "picongpu/param/binningSetup.param"
+#    include "picongpu/plugins/ISimulationPlugin.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/binning/BinningCreator.hpp"
 
-#include <cstdint>
-#include <memory>
-#include <string>
-#include <vector>
+#    include <boost/program_options.hpp>
+#    include <boost/program_options/options_description.hpp>
+
+#    include <cstdint>
+#    include <memory>
+#    include <string>
+#    include <vector>
 
 namespace picongpu
 {
@@ -115,3 +118,6 @@ namespace picongpu
         };
     } // namespace plugins::binning
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::plugins::binning::BinningDispatcher);
+#endif

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.hpp
@@ -19,26 +19,29 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
+#if(ENABLE_OPENPMD == 1)
 
-#include "picongpu/plugins/ILightweightPlugin.hpp"
-#include "picongpu/plugins/common/openPMDAttributes.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-#include "picongpu/plugins/common/openPMDWriteMeta.hpp"
+#    include "picongpu/simulation_defines.hpp"
 
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
-#include <pmacc/memory/buffers/GridBuffer.hpp>
-#include <pmacc/memory/shared/Allocate.hpp>
-#include <pmacc/particles/algorithm/ForEach.hpp>
+#    include "picongpu/plugins/ILightweightPlugin.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/common/openPMDAttributes.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/plugins/common/openPMDWriteMeta.hpp"
 
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <memory>
-#include <string>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/mappings/kernel/AreaMapping.hpp>
+#    include <pmacc/memory/buffers/GridBuffer.hpp>
+#    include <pmacc/memory/shared/Allocate.hpp>
+#    include <pmacc/particles/algorithm/ForEach.hpp>
 
-#include <openPMD/openPMD.hpp>
+#    include <fstream>
+#    include <iomanip>
+#    include <iostream>
+#    include <memory>
+#    include <string>
+
+#    include <openPMD/openPMD.hpp>
 
 
 namespace picongpu
@@ -297,3 +300,7 @@ namespace picongpu
     };
 
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::PerSuperCell<boost::mpl::_1>);
+
+#endif

--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -21,80 +21,83 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
+#if(ENABLE_OPENPMD == 1)
 
-#include "picongpu/fields/FieldB.hpp"
-#include "picongpu/fields/FieldE.hpp"
-#include "picongpu/fields/FieldJ.hpp"
-#include "picongpu/fields/FieldTmp.hpp"
-#include "picongpu/particles/filter/filter.hpp"
-#include "picongpu/particles/particleToGrid/CombinedDerive.def"
-#include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-#include "picongpu/plugins/common/openPMDDefinitions.def"
-#include "picongpu/plugins/common/openPMDVersion.def"
-#include "picongpu/plugins/common/openPMDWriteMeta.hpp"
-#include "picongpu/plugins/misc/ComponentNames.hpp"
-#include "picongpu/plugins/misc/SpeciesFilter.hpp"
-#include "picongpu/plugins/misc/misc.hpp"
-#include "picongpu/plugins/multi/IHelp.hpp"
-#include "picongpu/plugins/multi/Option.hpp"
-#include "picongpu/plugins/openPMD/Json.hpp"
-#include "picongpu/plugins/openPMD/NDScalars.hpp"
-#include "picongpu/plugins/openPMD/Parameters.hpp"
-#include "picongpu/plugins/openPMD/WriteSpecies.hpp"
-#include "picongpu/plugins/openPMD/openPMDWriter.def"
-#include "picongpu/plugins/openPMD/restart/LoadSpecies.hpp"
-#include "picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp"
-#include "picongpu/plugins/openPMD/toml.hpp"
-#include "picongpu/plugins/output/IIOBackend.hpp"
-#include "picongpu/simulation/control/MovingWindow.hpp"
-#include "picongpu/traits/IsFieldDomainBound.hpp"
-#include "picongpu/traits/IsFieldOutputOptional.hpp"
+#    include "picongpu/simulation_defines.hpp"
 
-#include <pmacc/Environment.hpp>
-#include <pmacc/assert.hpp>
-#include <pmacc/communication/manager_common.hpp>
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/dimensions/GridLayout.hpp>
-#include <pmacc/filesystem.hpp>
-#include <pmacc/mappings/simulation/GridController.hpp>
-#include <pmacc/mappings/simulation/SubGrid.hpp>
-#include <pmacc/math/Vector.hpp>
-#include <pmacc/meta/AllCombinations.hpp>
-#include <pmacc/particles/IdProvider.def>
-#include <pmacc/particles/frame_types.hpp>
-#include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
-#include <pmacc/particles/operations/CountParticles.hpp>
-#include <pmacc/pluginSystem/PluginConnector.hpp>
-#include <pmacc/pluginSystem/toSlice.hpp>
-#include <pmacc/simulationControl/TimeInterval.hpp>
-#include <pmacc/static_assert.hpp>
+#    include "picongpu/fields/FieldB.hpp"
+#    include "picongpu/fields/FieldE.hpp"
+#    include "picongpu/fields/FieldJ.hpp"
+#    include "picongpu/fields/FieldTmp.hpp"
+#    include "picongpu/particles/filter/filter.hpp"
+#    include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#    include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
+#    include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/plugins/common/openPMDDefinitions.def"
+#    include "picongpu/plugins/common/openPMDVersion.def"
+#    include "picongpu/plugins/common/openPMDWriteMeta.hpp"
+#    include "picongpu/plugins/misc/ComponentNames.hpp"
+#    include "picongpu/plugins/misc/SpeciesFilter.hpp"
+#    include "picongpu/plugins/misc/misc.hpp"
+#    include "picongpu/plugins/multi/IHelp.hpp"
+#    include "picongpu/plugins/multi/Option.hpp"
+#    include "picongpu/plugins/openPMD/Json.hpp"
+#    include "picongpu/plugins/openPMD/NDScalars.hpp"
+#    include "picongpu/plugins/openPMD/Parameters.hpp"
+#    include "picongpu/plugins/openPMD/WriteSpecies.hpp"
+#    include "picongpu/plugins/openPMD/openPMDWriter.def"
+#    include "picongpu/plugins/openPMD/restart/LoadSpecies.hpp"
+#    include "picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp"
+#    include "picongpu/plugins/openPMD/toml.hpp"
+#    include "picongpu/plugins/output/IIOBackend.hpp"
+#    include "picongpu/simulation/control/MovingWindow.hpp"
+#    include "picongpu/traits/IsFieldDomainBound.hpp"
+#    include "picongpu/traits/IsFieldOutputOptional.hpp"
 
-#include <boost/mpl/placeholders.hpp>
+#    include <pmacc/Environment.hpp>
+#    include <pmacc/assert.hpp>
+#    include <pmacc/communication/manager_common.hpp>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/dimensions/GridLayout.hpp>
+#    include <pmacc/filesystem.hpp>
+#    include <pmacc/mappings/simulation/GridController.hpp>
+#    include <pmacc/mappings/simulation/SubGrid.hpp>
+#    include <pmacc/math/Vector.hpp>
+#    include <pmacc/meta/AllCombinations.hpp>
+#    include <pmacc/particles/IdProvider.def>
+#    include <pmacc/particles/frame_types.hpp>
+#    include <pmacc/particles/memory/buffers/MallocMCBuffer.hpp>
+#    include <pmacc/particles/operations/CountParticles.hpp>
+#    include <pmacc/pluginSystem/PluginConnector.hpp>
+#    include <pmacc/pluginSystem/toSlice.hpp>
+#    include <pmacc/simulationControl/TimeInterval.hpp>
+#    include <pmacc/static_assert.hpp>
 
-#include <tuple>
+#    include <boost/mpl/placeholders.hpp>
 
-#include <openPMD/auxiliary/StringManip.hpp>
-#include <openPMD/openPMD.hpp>
+#    include <tuple>
 
-#if !defined(_WIN32)
-#    include <unistd.h>
-#endif
+#    include <openPMD/auxiliary/StringManip.hpp>
+#    include <openPMD/openPMD.hpp>
 
-#include <algorithm>
-#include <cstdint>
-#include <cstdlib> // getenv
-#include <exception>
-#include <iostream>
-#include <limits>
-#include <list>
-#include <sstream>
-#include <string>
-#include <vector>
+#    if !defined(_WIN32)
+#        include <unistd.h>
+#    endif
 
-#include <pthread.h>
+#    include <algorithm>
+#    include <cstdint>
+#    include <cstdlib> // getenv
+#    include <exception>
+#    include <iostream>
+#    include <limits>
+#    include <list>
+#    include <sstream>
+#    include <string>
+#    include <vector>
+
+#    include <pthread.h>
 
 
 namespace picongpu
@@ -707,7 +710,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                 HDINLINE void operator()(ThreadParams* params, uint32_t const currentStep)
                 {
-#ifndef __CUDA_ARCH__
+#    ifndef __CUDA_ARCH__
                     DataConnector& dc = Environment<simDim>::get().DataConnector();
 
                     // Skip optional fields
@@ -743,7 +746,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         std::move(inCellPosition),
                         timeOffset,
                         isDomainBound);
-#endif
+#    endif
                 }
             };
 
@@ -1374,7 +1377,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         = std::max(0, mThreadParams.window.globalDimensions.offset[i] - localDomain.offset[i]);
                 }
 
-#if(ALPAKA_ACC_GPU_CUDA_ENABLED || ALPAKA_ACC_GPU_HIP_ENABLED)
+#    if(ALPAKA_ACC_GPU_CUDA_ENABLED || ALPAKA_ACC_GPU_HIP_ENABLED)
                 /* copy species only one time per timestep to the host */
                 if(mThreadParams.strategy == WriteSpeciesStrategy::ADIOS && lastSpeciesSyncStep != currentStep)
                 {
@@ -1394,7 +1397,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     copySpeciesToHost();
                     lastSpeciesSyncStep = currentStep;
                 }
-#endif
+#    endif
 
                 TimeIntervall timer;
                 timer.toggleStart();
@@ -1947,3 +1950,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
         }
     } // namespace toml
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::plugins::multi::Master<picongpu::openPMD::openPMDWriter>);
+#endif

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.hpp
@@ -20,37 +20,40 @@
 
 #pragma once
 
-#include "ParticleCalorimeter.kernel"
-#include "ParticleCalorimeterFunctors.hpp"
-#include "picongpu/particles/boundary/Utility.hpp"
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/common/openPMDAttributes.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-#include "picongpu/plugins/common/openPMDWriteMeta.hpp"
-#include "picongpu/plugins/misc/misc.hpp"
-#include "picongpu/plugins/multi/multi.hpp"
+#if(ENABLE_OPENPMD == 1)
 
-#include <pmacc/algorithms/math.hpp>
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/lockstep/lockstep.hpp>
-#include <pmacc/mappings/kernel/AreaMapping.hpp>
-#include <pmacc/math/Vector.hpp>
-#include <pmacc/mpi/MPIReduce.hpp>
-#include <pmacc/mpi/reduceMethods/Reduce.hpp>
-#include <pmacc/particles/policies/ExchangeParticles.hpp>
-#include <pmacc/traits/HasFlag.hpp>
-#include <pmacc/traits/HasIdentifiers.hpp>
+#    include "ParticleCalorimeter.kernel"
+#    include "ParticleCalorimeterFunctors.hpp"
+#    include "picongpu/particles/boundary/Utility.hpp"
+#    include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/common/openPMDAttributes.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/plugins/common/openPMDWriteMeta.hpp"
+#    include "picongpu/plugins/misc/misc.hpp"
+#    include "picongpu/plugins/multi/multi.hpp"
 
-#include <boost/filesystem.hpp>
+#    include <pmacc/algorithms/math.hpp>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/lockstep/lockstep.hpp>
+#    include <pmacc/mappings/kernel/AreaMapping.hpp>
+#    include <pmacc/math/Vector.hpp>
+#    include <pmacc/mpi/MPIReduce.hpp>
+#    include <pmacc/mpi/reduceMethods/Reduce.hpp>
+#    include <pmacc/particles/policies/ExchangeParticles.hpp>
+#    include <pmacc/traits/HasFlag.hpp>
+#    include <pmacc/traits/HasIdentifiers.hpp>
 
-#include <cstdlib>
-#include <fstream>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <vector>
+#    include <boost/filesystem.hpp>
 
-#include <openPMD/openPMD.hpp>
+#    include <cstdlib>
+#    include <fstream>
+#    include <iostream>
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+#    include <openPMD/openPMD.hpp>
 
 
 namespace picongpu
@@ -711,3 +714,6 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::multi::Master<picongpu::ParticleCalorimeter<boost::mpl::_1>>);
+#endif

--- a/include/picongpu/plugins/radiation/Radiation.hpp
+++ b/include/picongpu/plugins/radiation/Radiation.hpp
@@ -20,39 +20,37 @@
 
 #pragma once
 
-#if !ENABLE_OPENPMD
-#    error The activated radiation plugin (radiation.param) requires openPMD-api.
-#endif
+#if(ENABLE_OPENPMD == 1)
 
-#include "picongpu/simulation_defines.hpp"
+#    include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
-#include "picongpu/plugins/ISimulationPlugin.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-#include "picongpu/plugins/common/openPMDVersion.def"
-#include "picongpu/plugins/common/stringHelpers.hpp"
-#include "picongpu/plugins/radiation/Radiation.kernel"
-#include "picongpu/plugins/radiation/executeParticleFilter.hpp"
+#    include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
+#    include "picongpu/plugins/ISimulationPlugin.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/plugins/common/openPMDVersion.def"
+#    include "picongpu/plugins/common/stringHelpers.hpp"
+#    include "picongpu/plugins/radiation/Radiation.kernel"
+#    include "picongpu/plugins/radiation/executeParticleFilter.hpp"
 
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/filesystem.hpp>
-#include <pmacc/lockstep/lockstep.hpp>
-#include <pmacc/math/operation.hpp>
-#include <pmacc/mpi/MPIReduce.hpp>
-#include <pmacc/mpi/reduceMethods/Reduce.hpp>
-#include <pmacc/traits/HasIdentifier.hpp>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/filesystem.hpp>
+#    include <pmacc/lockstep/lockstep.hpp>
+#    include <pmacc/math/operation.hpp>
+#    include <pmacc/mpi/MPIReduce.hpp>
+#    include <pmacc/mpi/reduceMethods/Reduce.hpp>
+#    include <pmacc/traits/HasIdentifier.hpp>
 
-#include <algorithm> // std::any
-#include <complex>
-#include <cstdlib>
-#include <fstream>
-#include <iostream>
-#include <memory>
-#include <optional>
-#include <string>
-#include <vector>
+#    include <algorithm> // std::any
+#    include <complex>
+#    include <cstdlib>
+#    include <fstream>
+#    include <iostream>
+#    include <memory>
+#    include <optional>
+#    include <string>
+#    include <vector>
 
-#include <openPMD/openPMD.hpp>
+#    include <openPMD/openPMD.hpp>
 
 namespace picongpu
 {
@@ -1264,3 +1262,7 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::radiation::Radiation<boost::mpl::_1>);
+
+#endif

--- a/include/picongpu/plugins/shadowgraphy/Shadowgraphy.hpp
+++ b/include/picongpu/plugins/shadowgraphy/Shadowgraphy.hpp
@@ -19,28 +19,31 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
+#if(SIMDIM == DIM3 && PIC_ENABLE_FFTW3 == 1 && ENABLE_OPENPMD == 1)
 
-#include "picongpu/fields/FieldB.hpp"
-#include "picongpu/fields/FieldE.hpp"
-#include "picongpu/plugins/common/openPMDAttributes.hpp"
-#include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
-#include "picongpu/plugins/common/openPMDVersion.def"
-#include "picongpu/plugins/common/openPMDWriteMeta.hpp"
-#include "picongpu/plugins/multi/multi.hpp"
-#include "picongpu/plugins/shadowgraphy/ShadowgraphyHelper.hpp"
+#    include "picongpu/simulation_defines.hpp"
 
-#include <pmacc/dataManagement/DataConnector.hpp>
-#include <pmacc/math/Vector.hpp>
-#include <pmacc/mpi/GatherSlice.hpp>
+#    include "picongpu/fields/FieldB.hpp"
+#    include "picongpu/fields/FieldE.hpp"
+#    include "picongpu/plugins/PluginRegistry.hpp"
+#    include "picongpu/plugins/common/openPMDAttributes.hpp"
+#    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
+#    include "picongpu/plugins/common/openPMDVersion.def"
+#    include "picongpu/plugins/common/openPMDWriteMeta.hpp"
+#    include "picongpu/plugins/multi/multi.hpp"
+#    include "picongpu/plugins/shadowgraphy/ShadowgraphyHelper.hpp"
 
-#include <iostream>
-#include <sstream>
-#include <string>
+#    include <pmacc/dataManagement/DataConnector.hpp>
+#    include <pmacc/math/Vector.hpp>
+#    include <pmacc/mpi/GatherSlice.hpp>
 
-#include <mpi.h>
-#include <openPMD/openPMD.hpp>
-#include <stdio.h>
+#    include <iostream>
+#    include <sstream>
+#    include <string>
+
+#    include <mpi.h>
+#    include <openPMD/openPMD.hpp>
+#    include <stdio.h>
 
 
 namespace picongpu
@@ -631,3 +634,7 @@ namespace picongpu
         } // namespace shadowgraphy
     } // namespace plugins
 } // namespace picongpu
+
+PIC_REGISTER_PLUGIN(picongpu::plugins::multi::Master<picongpu::plugins::shadowgraphy::Shadowgraphy>);
+
+#endif

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.hpp
@@ -25,6 +25,7 @@
 
 #include "picongpu/particles/traits/SpeciesEligibleForSolver.hpp"
 #include "picongpu/plugins/ISimulationPlugin.hpp"
+#include "picongpu/plugins/PluginRegistry.hpp"
 #include "picongpu/plugins/common/stringHelpers.hpp"
 #include "picongpu/plugins/transitionRadiation/TransitionRadiation.kernel"
 #include "picongpu/plugins/transitionRadiation/executeParticleFilter.hpp"
@@ -530,3 +531,5 @@ namespace picongpu
         } // namespace traits
     } // namespace particles
 } // namespace picongpu
+
+PIC_REGISTER_SPECIES_PLUGIN(picongpu::plugins::transitionRadiation::TransitionRadiation<boost::mpl::_1>);


### PR DESCRIPTION
Add helper construct to register the automatically plugin at the start of the application.
Guard plugin header to fulfill compile dependencies.

This PR is a pre-preparation to move each plugin into an independent compile unit. The plugin `.hpp` file needs to be renamed into `x.cpp`. Additionally the `SimulationStarter` should be separated to avoid that each compile unit is comping an instance of this class, this would only waste compile time.