### PR TITLE
Add ability to bin particles leaving the simulation

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -162,6 +162,21 @@ Normalize by Bin Volume
 Since it is possible to have non-uniformly sized axes, it makes sense to normalize the binned quantity by the bin volume to enable a fair comparison between bins.
 
 
+Binning Particles Leaving the Simulation Volume
+-----------------------------------------------
+
+.. doxygenenum:: picongpu::plugins::binning::ParticleRegion
+
+By default, only particles within the simulation volume are binned. However, users can modify this behavior to include or exclusively bin particles that are leaving the global simulation volume.
+This can be configured using the ``enableRegion`` and ``disableRegion`` options with the regions defined by the ``ParticleRegion`` enum.
+
+.. attention::
+
+Users must carefully configure the notify period when using the binning plugin for leaving particles. The plugin bins particles leaving the global simulation volume at every timestep (except 0) after particles are pushed, regardless of the notify period. 
+If the plugin is not notified at every timestep, this can cause discrepancies between the binning process and time-averaged data or histogram dumps, which follow the notify period.
+Additionally, the binning plugin is first notified at timestep 0, allowing users to bin initial conditions. However, leaving particles are first binned at timestep 1, after the initial particle push.
+Therefore, users should consider setting the notify period’s start at timestep 1, depending on their specific needs.
+
 writeOpenPMDFunctor
 -------------------
 Users can also write out custom output to file, for example other quantites related to the simulation which the user is interested in.

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -475,7 +475,8 @@ namespace picongpu
                     FindByNameOrType_t<VectorAllSpecies, T_Species, pmacc::errorHandlerPolicies::ReturnType<void>>;
 
                 template<typename T_BinData>
-                auto operator()(Binner<T_BinData>* binner, int32_t direction) const -> void
+                auto operator()([[maybe_unused]] Binner<T_BinData>* binner, [[maybe_unused]] int32_t direction) const
+                    -> void
                 {
                     if constexpr(!std::is_same_v<void, Species>)
                     {

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -32,13 +32,17 @@ namespace picongpu
 {
     namespace plugins::binning
     {
-        /** @brief Bin particles in enabled region */
+        /** @brief Bin particles in enabled region
+         *
+         * All regions must be represented by a unique bit
+         */
         enum ParticleRegion : uint32_t
         {
-            /** Bounded - Particles inside the simulation volume */
-            Bounded = 1 << 0, // 01 in binary, corresponds to the first bit
-            /** Leaving - Particles that have left the simulation volume in this timestep */
-            Leaving = 1 << 1 // 10 in binary, corresponds to the second bit
+            /** Bounded - Particles inside the global simulation volume, 01 in binary, corresponds to the first bit */
+            Bounded = 1 << 0,
+            /** Leaving - Particles that have left the global simulation volume in this timestep, 10 in binary,
+             * corresponds to the second bit */
+            Leaving = 1 << 1
         };
 
         template<typename T_AxisTuple, typename T_SpeciesTuple, typename T_DepositionData>

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -32,6 +32,15 @@ namespace picongpu
 {
     namespace plugins::binning
     {
+        /** @brief Bin particles in enabled region */
+        enum ParticleRegion : uint32_t
+        {
+            /** Bounded - Particles inside the simulation volume */
+            Bounded = 1 << 0, // 01 in binary, corresponds to the first bit
+            /** Leaving - Particles that have left the simulation volume in this timestep */
+            Leaving = 1 << 1 // 10 in binary, corresponds to the second bit
+        };
+
         template<typename T_AxisTuple, typename T_SpeciesTuple, typename T_DepositionData>
         struct BinningData
         {
@@ -55,6 +64,7 @@ namespace picongpu
             bool normalizeByBinVolume = true;
             std::string notifyPeriod = "1";
             uint32_t dumpPeriod = 0u;
+            uint32_t particleRegion{ParticleRegion::Bounded};
 
             std::string openPMDInfix = "_%06T.";
             std::string openPMDExtension = openPMD::getDefaultExtension();
@@ -128,6 +138,23 @@ namespace picongpu
             {
                 this->jsonCfg = std::move(cfg);
                 return *this;
+            }
+            // enable a region in the bitmask
+            BinningData& enableRegion(ParticleRegion const region)
+            {
+                particleRegion = particleRegion | region;
+                return *this;
+            }
+            // disable a region in the bitmask
+            BinningData& disableRegion(ParticleRegion const region)
+            {
+                particleRegion = particleRegion & ~region;
+                return *this;
+            }
+            // Check if a region is enabled in the bitmask
+            bool isRegionEnabled(ParticleRegion const region) const
+            {
+                return (particleRegion & region) != 0;
             }
         };
     }; // namespace plugins::binning

--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -195,7 +195,11 @@ namespace picongpu
                 auto const superCellCellOffsetNoGuard
                     = (superCellIdx - mapper.getGuardingSuperCells()) * SuperCellSize::toRT();
 
-                auto const domainInfo = DomainInfo{currentStep, globalOffset, localOffset, superCellIdx};
+                auto const domainInfo = DomainInfo{
+                    currentStep,
+                    globalOffset,
+                    localOffset,
+                    superCellIdx - mapper.getGuardingSuperCells()};
                 auto const functorParticle = FunctorParticle{};
 
                 auto forEachParticle

--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -53,11 +53,11 @@ namespace picongpu
                 T_AxisTuple const& axes,
                 DomainInfo const& domainInfo,
                 DataSpace<T_nAxes> const& extents,
-                const T_Particle& particle) const
+                T_Particle const& particle) const
             {
                 using DepositionType = typename T_HistBox::ValueType;
 
-                auto binsDataspace = DataSpace<T_nAxes>{};
+                auto binsDataspace = pmacc::DataSpace<T_nAxes>{};
                 bool validIdx = true;
                 apply(
                     [&](auto const&... tupleArgs)
@@ -121,6 +121,10 @@ namespace picongpu
                 auto forEachParticle
                     = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
 
+                // stop kernel if we have no particles
+                if(!forEachParticle.hasParticles())
+                    return;
+
                 forEachParticle(
                     [&](auto const& lockstepWorker, auto& particle) {
                         functorParticle(
@@ -134,5 +138,96 @@ namespace picongpu
                     });
             }
         };
+
+        namespace detail
+        {
+            template<typename T1, typename T2, typename T3, std::size_t... Is>
+            DINLINE bool insideBoundsImpl(
+                T1 const& localCell,
+                T2 const& beginCellIdxLocal,
+                T3 const& endCellIdxLocal,
+                std::index_sequence<Is...>)
+            {
+                return ((localCell[Is] >= beginCellIdxLocal[Is] && localCell[Is] < endCellIdxLocal[Is]) && ...);
+            }
+
+            template<typename T1, typename T2, typename T3>
+            DINLINE bool insideBounds(T1 const& localCell, T2 const& beginCellIdxLocal, T3 const& endCellIdxLocal)
+            {
+                return insideBoundsImpl(
+                    localCell,
+                    beginCellIdxLocal,
+                    endCellIdxLocal,
+                    std::make_index_sequence<simDim>{});
+            }
+        } // namespace detail
+
+        struct BinningFunctorLeaving
+        {
+            using result_type = void;
+
+            HINLINE BinningFunctorLeaving() = default;
+
+            template<
+                typename T_Worker,
+                typename TParticlesBox,
+                typename T_HistBox,
+                typename T_DepositionFunctor,
+                typename T_AxisTuple,
+                typename T_Mapping,
+                uint32_t T_nAxes>
+            DINLINE void operator()(
+                T_Worker const& worker,
+                T_HistBox binningBox,
+                TParticlesBox particlesBox,
+                pmacc::DataSpace<simDim> const& localOffset,
+                pmacc::DataSpace<simDim> const& globalOffset,
+                T_AxisTuple const& axisTuple,
+                T_DepositionFunctor const& quantityFunctor,
+                DataSpace<T_nAxes> const& extents,
+                uint32_t const currentStep,
+                pmacc::DataSpace<simDim> const& beginCellIdxLocal,
+                pmacc::DataSpace<simDim> const& endCellIdxLocal,
+                T_Mapping const& mapper) const
+            {
+                /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
+                pmacc::DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+                auto const superCellCellOffsetNoGuard
+                    = (superCellIdx - mapper.getGuardingSuperCells()) * SuperCellSize::toRT();
+
+                auto const domainInfo = DomainInfo{currentStep, globalOffset, localOffset, superCellIdx};
+                auto const functorParticle = FunctorParticle{};
+
+                auto forEachParticle
+                    = pmacc::particles::algorithm::acc::makeForEach(worker, particlesBox, superCellIdx);
+
+                // stop kernel if we have no particles
+                if(!forEachParticle.hasParticles())
+                    return;
+
+                forEachParticle(
+                    [&](auto const& lockstepWorker, auto& particle)
+                    {
+                        // Check if it fits the internal cells range
+                        auto const cellInSuperCell
+                            = pmacc::math::mapToND(SuperCellSize::toRT(), static_cast<int>(particle[localCellIdx_]));
+                        auto const localCell = superCellCellOffsetNoGuard + cellInSuperCell;
+
+                        if(detail::insideBounds(localCell, beginCellIdxLocal, endCellIdxLocal))
+                        {
+                            functorParticle(
+                                lockstepWorker,
+                                binningBox,
+                                quantityFunctor,
+                                axisTuple,
+                                domainInfo,
+                                extents,
+                                particle);
+                        }
+                    });
+            }
+        };
+
+
     } // namespace plugins::binning
 } // namespace picongpu

--- a/include/picongpu/plugins/binning/binnerPlugin.hpp
+++ b/include/picongpu/plugins/binning/binnerPlugin.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/plugins/binning/Axis.hpp"
 #include "picongpu/plugins/binning/BinningCreator.hpp"
+#include "picongpu/plugins/binning/BinningData.hpp"
 #include "picongpu/plugins/binning/FunctorDescription.hpp"
 #include "picongpu/plugins/binning/UnitConversion.hpp"
 #include "picongpu/plugins/binning/axis/LinearAxis.hpp"

--- a/include/picongpu/plugins/misc/ExecuteIf.hpp
+++ b/include/picongpu/plugins/misc/ExecuteIf.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2024 Tapish Narwal
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include <pmacc/meta/errorHandlerPolicies/ReturnType.hpp>
+#include <pmacc/particles/meta/FindByNameOrType.hpp>
+
+#include <string>
+#include <type_traits>
+
+namespace picongpu
+{
+    namespace plugins
+    {
+        namespace misc
+        {
+            /**
+             * Predicate which checks if string argument is same as compile time species name
+             *
+             * @tparam T_Species The PMACC cstring or type of the species
+             * @param s String holding the species name
+             */
+            template<typename T_Species>
+            struct SpeciesNameIsEqual
+            {
+                using Species = pmacc::particles::meta::
+                    FindByNameOrType_t<VectorAllSpecies, T_Species, pmacc::errorHandlerPolicies::ReturnType<void>>;
+
+                bool operator()(std::string const& s) const
+                {
+                    if constexpr(std::is_same_v<void, Species>)
+                        return false;
+                    else
+                        return s == Species::FrameType::getName();
+                }
+            };
+
+            struct ExecuteIf
+            {
+                /**
+                 * Conditionally execute a nullary functor
+                 *
+                 * @param functor A nullary callable
+                 * @param predicate The predicate that determines whether to execute the functor
+                 * @param args Variable number of arguments taken by the predicate
+                 */
+                template<typename T_Callable, typename T_Predicate, typename... T_Args>
+                void operator()(T_Callable const& functor, T_Predicate const& predicate, T_Args const&... args) const
+                {
+                    if(predicate(args...))
+                        functor();
+                }
+            };
+
+        } // namespace misc
+    } // namespace plugins
+} // namespace picongpu


### PR DESCRIPTION
Adds configuration option to the binning plugin to independently bin particles inside the simulation and particles leaving the simulation. 
Care has to be taken when setting the notify period when binning particles leaving the simulation domain, as noted in the updated documentation and in code comments
Solves #4946