### PR TITLE
remove conda from our documentation and scripts

### DIFF
--- a/docs/picongpu-docs-env.yml
+++ b/docs/picongpu-docs-env.yml
@@ -1,6 +1,6 @@
-# Create a separate conda environment which fulfills the package requirements
+# Create a separate Micromamba environment which fulfills the package requirements
 # for building the documentation
-# E.g. run `conda env create --file picongpu-docs-env.yml`
+# E.g. run `micromamba env create --file picongpu-docs-env.yml`
 #
 
 name: picongpu-docs-env

--- a/docs/source/dev/sphinx.rst
+++ b/docs/source/dev/sphinx.rst
@@ -32,7 +32,7 @@ The following requirements need to be installed (once) to build our documentatio
     cd docs/
 
     # doxygen is not shipped via pip, install it externally,
-    # from the homepage, your package manager, conda, etc.
+    # from the homepage, your package manager, Micromamba, etc.
     # example:
     sudo apt-get install doxygen
 
@@ -40,19 +40,19 @@ The following requirements need to be installed (once) to build our documentatio
     pip install -r requirements.txt # --user
 
 In order to not break any of your existing Python configurations, you can also create a new environment that you only use for building the documentation.
-Since it is possible to install doxygen with conda, the following demonstrates this.
+Since it is possible to install doxygen with Micromamba, the following demonstrates this.
 
 .. code-block:: bash
 
     cd docs/
 
-    # create a bare conda environment containing just all the requirements
+    # create a bare Micromamba environment containing just all the requirements
     # for building the picongpu documentation
     # note: also installs doxygen inside this environment
-    conda env create --file picongpu-docs-env.yml
+    micromamba env create --file picongpu-docs-env.yml
 
     # start up the environment as suggested during its creation e.g.
-    conda activate picongpu-docs-env
+    micromamba activate picongpu-docs-env
     # or
     source activate picongpu-docs-env
 

--- a/docs/source/postprocessing/python.rst
+++ b/docs/source/postprocessing/python.rst
@@ -11,11 +11,11 @@ If you are new to python, get your hands on the tutorials of the following impor
 - https://docs.python.org/3/tutorial/index.html
 
 An easy way to get a Python environment for analysis of PIConGPU data up and running is to download and install
-Miniconda 
+Micromamba
 
-https://docs.conda.io/en/latest/miniconda.html
+https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html
 
-and set up a conda environment with the help of this conda environment file
+and set up a Micromamba environment with the help of this Micromamba environment file
 
 https://gist.github.com/steindev/d19263d41b0964bcecdfb1f47e18a86e
 


### PR DESCRIPTION
Conda is using as default software channel the anaconda reposetory. Software in this channel is not always free to use and can require a license. Therefore we do not point the user to this possible problem.