### PR TITLE
add missing space to PlantUMl documentation

### DIFF
--- a/docs/source/dev/PlantUML.rst
+++ b/docs/source/dev/PlantUML.rst
@@ -9,7 +9,7 @@ For each UML diagram generated using PlantUML we also provide the source file ``
 Install PlantUML
 ----------------
 
-See `PlantUML documentation<https://plantuml.com/starting>`_ for detailed instructions.
+See `PlantUML documentation <https://plantuml.com/starting>`_ for detailed instructions.
 
 TLDR:
 ^^^^^


### PR DESCRIPTION
adds a missing space in the PlantUML link to the installation instructions