### PR TITLE
CI: reduce number of pusher test combindations

### DIFF
--- a/share/picongpu/tests/Pusher/cmakeFlags
+++ b/share/picongpu/tests/Pusher/cmakeFlags
@@ -33,17 +33,20 @@
 # Boris Pusher
 flags[0]=""
 flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_DIMENSION=DIM2'"
-# Vay Pusher
-flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Vay'"
-flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Vay;-DPARAM_DIMENSION=DIM2'"
-# Photon Pusher
-flags[4]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Photon'"
-flags[5]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Photon;-DPARAM_DIMENSION=DIM2'"
-# does not support 2D
-# Reduced Landau Lifshitz Pusher
-flags[6]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz'"
-flags[7]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz;-DPARAM_DIMENSION=DIM2'"
 
+# limit examles if we run CI tests
+if [ -z  "$CI_PROJECT_DIR" ] ; then
+  # Vay Pusher
+  flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Vay'"
+  flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Vay;-DPARAM_DIMENSION=DIM2'"
+  # Photon Pusher
+  flags[4]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Photon'"
+  flags[5]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=Photon;-DPARAM_DIMENSION=DIM2'"
+  # does not support 2D
+  # Reduced Landau Lifshitz Pusher
+  flags[6]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz'"
+  flags[7]="-DPARAM_OVERWRITES:LIST='-DPARAM_PARTICLEPUSHER=ReducedLandauLifshitz;-DPARAM_DIMENSION=DIM2'"
+fi
 
 ################################################################################
 # execution


### PR DESCRIPTION
All combinations of pusher are compiled in `compileParticlePusher` therefore the number of compile tests can be reduced for CI runs.