### PR TITLE
fix possible deadlock

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -510,6 +510,8 @@ namespace picongpu
                         log<picLog::INPUT_OUTPUT>("openPMD: flush particle records for %1%, dumping round %2%")
                             % T_SpeciesFilter::getName() % dumpIteration;
 
+                        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+                        eventSystem::getTransactionEvent().waitForFinished();
                         params->m_dumpTimes.now<std::chrono::milliseconds>(
                             "\tslice " + std::to_string(dumpIteration) + " flush");
                         params->openPMDSeries->flush(PreferredFlushTarget::Disk);

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -933,6 +933,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 ValueType* nativePtr = buffer.getHostBuffer().data();
                 ReinterpretedType* rawPtr = reinterpret_cast<ReinterpretedType*>(nativePtr);
                 mrc.storeChunkRaw(rawPtr, asStandardVector(recordOffsetDims), asStandardVector(recordLocalSizeDims));
+                // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+                eventSystem::getTransactionEvent().waitForFinished();
                 params->openPMDSeries->flush(PreferredFlushTarget::Disk);
             }
 
@@ -1658,6 +1660,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                     if(numDataPoints == 0)
                     {
+                        // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+                        eventSystem::getTransactionEvent().waitForFinished();
                         params->openPMDSeries->flush(PreferredFlushTarget::Disk);
                         continue;
                     }
@@ -1711,6 +1715,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         }
                     }
 
+                    // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+                    eventSystem::getTransactionEvent().waitForFinished();
                     params->m_dumpTimes.now<std::chrono::milliseconds>("\tComponent " + std::to_string(d) + " flush");
                     params->openPMDSeries->flush(PreferredFlushTarget::Disk);
                     params->m_dumpTimes.now<std::chrono::milliseconds>("\tComponent " + std::to_string(d) + " end");


### PR DESCRIPTION
PMacc's event system must be empty before global blocking methods e.g. MPI collectives are called. 
OpenPMD's flush is possibly executing blocking collectives.