### PR TITLE
remove superfluous cast from ChooseTransitionKernel

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundFree.kernel
@@ -257,7 +257,7 @@ namespace picongpu::particles::atomicPhysics::kernel
         {
             ion[processClass_] = selectedProcessClass;
             ion[transitionIndex_] = selectedTransitionIndex;
-            ion[binIndex_] = u32(selectedBinIndex);
+            ion[binIndex_] = selectedBinIndex;
             ion[accepted_] = true;
         }
     };


### PR DESCRIPTION
removes a superfluous cast from the ChooseTransitionKernel_BoundFree