### PR TITLE
Topic switch to static cast short hands in atomic physics

### DIFF
--- a/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
+++ b/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
@@ -361,14 +361,14 @@ namespace picongpu::particles::atomicPhysics::atomicData
 
             while(file >> chargeState >> ionizationEnergy >> screenedCharge)
             {
-                if(chargeState == static_cast<uint32_t>(T_ConfigNumber::atomicNumber))
+                if(chargeState == u32(T_ConfigNumber::atomicNumber))
                     throw std::runtime_error(
                         "charge state " + std::to_string(chargeState)
                         + " should not be included in input file for Z = "
                         + std::to_string(T_ConfigNumber::atomicNumber));
 
                 S_ChargeStateTuple item = std::make_tuple(
-                    static_cast<uint8_t>(chargeState),
+                    u8(chargeState),
                     ionizationEnergy, // [eV]
                     screenedCharge); // [e]
 
@@ -868,8 +868,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
 
             uint32_t const numberTransitions = transitionHostBox.getNumberOfTransitionsTotal();
 
-            for(uint32_t collectionIndex = static_cast<uint32_t>(0u); collectionIndex < numberTransitions;
-                collectionIndex++)
+            for(uint32_t collectionIndex = u32(0u); collectionIndex < numberTransitions; collectionIndex++)
             {
                 float_X const deltaEnergy = picongpu::particles::atomicPhysics::DeltaEnergyTransition::get(
                     collectionIndex,

--- a/include/picongpu/particles/atomicPhysics/atomicData/ChargeStateData.hpp
+++ b/include/picongpu/particles/atomicPhysics/atomicData/ChargeStateData.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 // need: picongpu/param/atomicPhysics_Debug.param and picongpu/param/atomicPhysics.param
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicTuples.def"
 #include "picongpu/particles/atomicPhysics/atomicData/DataBox.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/DataBuffer.hpp"
@@ -92,11 +93,11 @@ namespace picongpu::particles::atomicPhysics::atomicData
          */
         HINLINE void store(uint32_t const collectionIndex, S_ChargeStateTuple& tuple)
         {
-            uint8_t chargeState = static_cast<uint8_t>(std::get<0>(tuple));
+            uint8_t chargeState = u8(std::get<0>(tuple));
 
             if constexpr(picongpu::atomicPhysics::debug::atomicData::RANGE_CHECKS_IN_DATA_LOAD)
             {
-                if(collectionIndex >= static_cast<uint32_t>(T_atomicNumber))
+                if(collectionIndex >= u32(T_atomicNumber))
                 {
                     throw std::runtime_error(
                         "atomicPhysics ERROR: out of range call store() chargeState property data");
@@ -134,7 +135,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
         HDINLINE T_Value ionizationEnergy(uint8_t const chargeState) const
         {
             if constexpr(picongpu::atomicPhysics::debug::atomicData::RANGE_CHECKS_IN_DATA_QUERIES)
-                if(chargeState >= static_cast<uint32_t>(T_atomicNumber))
+                if(chargeState >= u32(T_atomicNumber))
                 {
                     printf("atomicPhysics ERROR: out of range ionizationEnergy() call\n");
                     return static_cast<T_Value>(0.);
@@ -147,7 +148,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
         HDINLINE T_Value screenedCharge(uint8_t const chargeState) const
         {
             if constexpr(picongpu::atomicPhysics::debug::atomicData::RANGE_CHECKS_IN_DATA_QUERIES)
-                if(chargeState >= static_cast<uint32_t>(T_atomicNumber))
+                if(chargeState >= u32(T_atomicNumber))
                 {
                     printf("atomicPhysics ERROR: out of range ionizationEnergy() call\n");
                     return static_cast<T_Value>(0.);

--- a/include/picongpu/particles/atomicPhysics/atomicData/ChargeStateOrgaData.hpp
+++ b/include/picongpu/particles/atomicPhysics/atomicData/ChargeStateOrgaData.hpp
@@ -95,7 +95,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
         HINLINE void store(uint32_t const collectionIndex, T_Number numberAtomicStates, T_Number startIndex)
         {
             if constexpr(picongpu::atomicPhysics::debug::atomicData::RANGE_CHECKS_IN_DATA_LOAD)
-                if(collectionIndex > static_cast<uint32_t>(T_atomicNumber))
+                if(collectionIndex > u32(T_atomicNumber))
                 {
                     throw std::runtime_error("atomicPhysics ERROR: out of range call store() chargeState orga data");
                     return;
@@ -109,7 +109,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
         HDINLINE T_Number numberAtomicStates(uint8_t chargeState) const
         {
             if constexpr(picongpu::atomicPhysics::debug::atomicData::RANGE_CHECKS_IN_DATA_QUERIES)
-                if(chargeState > static_cast<uint32_t>(T_atomicNumber))
+                if(chargeState > u32(T_atomicNumber))
                 {
                     printf("atomicPhysics ERROR: out of range chargeStateOrgaData.numberAtomicStates() call\n");
                     return static_cast<T_Number>(0._X);
@@ -122,7 +122,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
         HDINLINE T_Number startIndexBlockAtomicStates(uint8_t chargeState) const
         {
             if constexpr(picongpu::atomicPhysics::debug::atomicData::RANGE_CHECKS_IN_DATA_QUERIES)
-                if(chargeState > static_cast<uint32_t>(T_atomicNumber))
+                if(chargeState > u32(T_atomicNumber))
                 {
                     printf(
                         "atomicPhysics ERROR: out of range chargeStateOrgaData.startIndexBlockAtomicStates() call\n");

--- a/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
@@ -31,6 +31,7 @@
 #include "picongpu/simulation_defines.hpp"
 // need unit.param
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicTuples.def"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp"
@@ -123,11 +124,11 @@ namespace picongpu::particles::atomicPhysics::debug
             // charge states
             S_ChargeStateBox chargeStateHostBox = chargeStateBuffer->getHostDataBox();
             //      ionizationEnergy = 100 eV, screened charge = 5 e
-            auto tupleChargeState_1 = std::make_tuple(static_cast<uint8_t>(0u), 100._X, 5._X);
-            chargeStateHostBox.store(static_cast<uint8_t>(0u), tupleChargeState_1);
+            auto tupleChargeState_1 = std::make_tuple(u8(0u), 100._X, 5._X);
+            chargeStateHostBox.store(u8(0u), tupleChargeState_1);
             //      only target charge state, states do not matter
-            auto tupleChargeState_2 = std::make_tuple(static_cast<uint8_t>(1u), 100._X, 5._X);
-            chargeStateHostBox.store(static_cast<uint8_t>(1u), tupleChargeState_2);
+            auto tupleChargeState_2 = std::make_tuple(u8(1u), 100._X, 5._X);
+            chargeStateHostBox.store(u8(1u), tupleChargeState_2);
             chargeStateBuffer->hostToDevice();
 
             /// atomic states, @attention caution all atomic state must differ in configNumber
@@ -135,17 +136,17 @@ namespace picongpu::particles::atomicPhysics::debug
 
             // 1:(1,1,0,0,0,0,1,0,1,0) lowerStateBoundFree
             auto tupleAtomicState_1 = std::make_tuple(static_cast<uint64_t>(243754u), 0._X);
-            atomicStateHostBox.store(static_cast<uint8_t>(1u), tupleAtomicState_1);
+            atomicStateHostBox.store(u8(1u), tupleAtomicState_1);
             // 2:(1,1,0,0,0,0,1,0,0,0) upperStateBoundFree, excitationEnergyDifference = 5 eV
             auto tupleAtomicState_2 = std::make_tuple(static_cast<uint64_t>(9379u), 5._X);
-            atomicStateHostBox.store(static_cast<uint8_t>(3u), tupleAtomicState_2);
+            atomicStateHostBox.store(u8(3u), tupleAtomicState_2);
 
             // 1:(1,0,2,0,0,0,1,0,0,0) lowerStateBoundBound
             auto tupleAtomicState_3 = std::make_tuple(static_cast<uint64_t>(9406u), 0._X);
-            atomicStateHostBox.store(static_cast<uint8_t>(0u), tupleAtomicState_3);
+            atomicStateHostBox.store(u8(0u), tupleAtomicState_3);
             // 1:(1,0,1,0,0,0,1,0,1,0) upperStateBoundBound, energyDiffLowerUpper = 5 eV
             auto tupleAtomicState_4 = std::make_tuple(static_cast<uint64_t>(243766u), 5._X);
-            atomicStateHostBox.store(static_cast<uint8_t>(2u), tupleAtomicState_4);
+            atomicStateHostBox.store(u8(2u), tupleAtomicState_4);
             atomicStateBuffer->hostToDevice();
 
             // bound-bound transitions
@@ -243,7 +244,7 @@ namespace picongpu::particles::atomicPhysics::debug
             float_X const crossSection = rateCalculation::BoundBoundTransitionRates<T_n_max>::
                 template collisionalBoundBoundCrossSection<S_AtomicStateBox, S_BoundBoundBox, true>(
                     energyElectron,
-                    static_cast<uint32_t>(0u),
+                    u32(0u),
                     atomicStateBuffer->getHostDataBox(),
                     boundBoundBuffer->getHostDataBox()); // 1e6b
 

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/LogSpaceHistogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/LogSpaceHistogram.hpp
@@ -121,7 +121,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
             if(energy >= 1._X)
             {
                 // standard bin
-                return static_cast<uint32_t>(math::log(energy) / math::log(computeBase())) + 1u;
+                return u32(math::log(energy) / math::log(computeBase())) + 1u;
             }
             else
                 return 0u; // first bin

--- a/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <cstdint>
 #include <string>
 
@@ -59,25 +61,15 @@ namespace picongpu::particles::atomicPhysics
     template<enums::ChooseTransitionGroup T_ChooseTransitionGroup>
     ALPAKA_FN_HOST std::string enumToString()
     {
-        if constexpr(
-            static_cast<uint8_t>(T_ChooseTransitionGroup)
-            == static_cast<uint8_t>(enums::ChooseTransitionGroup::boundBoundUpward))
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::boundBoundUpward))
             return "bound-bound(upward)";
-        if constexpr(
-            static_cast<uint8_t>(T_ChooseTransitionGroup)
-            == static_cast<uint8_t>(enums::ChooseTransitionGroup::boundBoundDownward))
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::boundBoundDownward))
             return "bound-bound(downward)";
-        if constexpr(
-            static_cast<uint8_t>(T_ChooseTransitionGroup)
-            == static_cast<uint8_t>(enums::ChooseTransitionGroup::boundFreeUpward))
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::boundFreeUpward))
             return "bound-free(upward)";
-        if constexpr(
-            static_cast<uint8_t>(T_ChooseTransitionGroup)
-            == static_cast<uint8_t>(enums::ChooseTransitionGroup::autonomousDownward))
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::autonomousDownward))
             return "autonomous(downward)";
-        if constexpr(
-            static_cast<uint8_t>(T_ChooseTransitionGroup)
-            == static_cast<uint8_t>(enums::ChooseTransitionGroup::noChange))
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::noChange))
             return "noChange";
         return "unknown";
     }

--- a/include/picongpu/particles/atomicPhysics/enums/IsProcess.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/IsProcess.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 
@@ -84,9 +85,9 @@ namespace picongpu::particles::atomicPhysics::enums
     {
         HDINLINE static constexpr bool check(uint8_t processClass)
         {
-            if((processClass == static_cast<uint8_t>(ProcessClass::electronicIonization))
-               || (processClass == static_cast<uint8_t>(ProcessClass::autonomousIonization))
-               || (processClass == static_cast<uint8_t>(ProcessClass::fieldIonization)))
+            if((processClass == u8(ProcessClass::electronicIonization))
+               || (processClass == u8(ProcessClass::autonomousIonization))
+               || (processClass == u8(ProcessClass::fieldIonization)))
                 return true;
             return false;
         }

--- a/include/picongpu/particles/atomicPhysics/enums/LastResortProcessClass.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/LastResortProcessClass.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 

--- a/include/picongpu/particles/atomicPhysics/enums/ProcessClass.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ProcessClass.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <cstdint>
 #include <string>
 
@@ -44,28 +46,21 @@ namespace picongpu::particles::atomicPhysics
     template<enums::ProcessClass T_ProcessClass>
     ALPAKA_FN_HOST std::string enumToString()
     {
-        if constexpr(static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::noChange))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::noChange))
             return "noChange";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::spontaneousDeexcitation))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::spontaneousDeexcitation))
             return "spontaneousDeexcitation";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::electronicExcitation))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::electronicExcitation))
             return "electronicExcitation";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::electronicDeexcitation))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::electronicDeexcitation))
             return "electronicDeexcitation";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::electronicIonization))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::electronicIonization))
             return "electronicIonization";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::autonomousIonization))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::autonomousIonization))
             return "autonomousIonization";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::fieldIonization))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::fieldIonization))
             return "fieldIonization";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClass) == static_cast<uint8_t>(enums::ProcessClass::pressureIonization))
+        if constexpr(u8(T_ProcessClass) == u8(enums::ProcessClass::pressureIonization))
             return "pressureIonization";
         return "unknown";
     }

--- a/include/picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <cstdint>
 #include <string>
 
@@ -43,30 +45,19 @@ namespace picongpu::particles::atomicPhysics
     template<enums::ProcessClassGroup T_ProcessClassGroup>
     ALPAKA_FN_HOST std::string enumToString()
     {
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup)
-            == static_cast<uint8_t>(enums::ProcessClassGroup::boundBoundBased))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::boundBoundBased))
             return "boundBound";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup)
-            == static_cast<uint8_t>(enums::ProcessClassGroup::boundFreeBased))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased))
             return "boundFree";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup)
-            == static_cast<uint8_t>(enums::ProcessClassGroup::autonomousBased))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::autonomousBased))
             return "autonomous";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup) == static_cast<uint8_t>(enums::ProcessClassGroup::ionizing))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::ionizing))
             return "ionizing";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup)
-            == static_cast<uint8_t>(enums::ProcessClassGroup::electronicCollisional))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::electronicCollisional))
             return "electronicCollisional";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup) == static_cast<uint8_t>(enums::ProcessClassGroup::upward))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::upward))
             return "upward";
-        if constexpr(
-            static_cast<uint8_t>(T_ProcessClassGroup) == static_cast<uint8_t>(enums::ProcessClassGroup::downward))
+        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::downward))
             return "downard";
         return "unknown";
     }

--- a/include/picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <cstdint>
 #include <string>
 
@@ -38,11 +40,9 @@ namespace picongpu::particles::atomicPhysics
     template<enums::TransitionDirection T_TransitionDirection>
     ALPAKA_FN_HOST std::string enumToString()
     {
-        if constexpr(
-            static_cast<uint8_t>(T_TransitionDirection) == static_cast<uint8_t>(enums::TransitionDirection::upward))
+        if constexpr(u8(T_TransitionDirection) == u8(enums::TransitionDirection::upward))
             return "upward";
-        if constexpr(
-            static_cast<uint8_t>(T_TransitionDirection) == static_cast<uint8_t>(enums::TransitionDirection::downward))
+        if constexpr(u8(T_TransitionDirection) == u8(enums::TransitionDirection::downward))
             return "downward";
         return "unknown";
     }

--- a/include/picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <cstdint>
 #include <string>
 
@@ -39,13 +41,9 @@ namespace picongpu::particles::atomicPhysics
     template<enums::TransitionOrdering T_TransitionOrdering>
     ALPAKA_FN_HOST std::string enumToString()
     {
-        if constexpr(
-            static_cast<uint8_t>(T_TransitionOrdering)
-            == static_cast<uint8_t>(enums::TransitionOrdering::byLowerState))
+        if constexpr(u8(T_TransitionOrdering) == u8(enums::TransitionOrdering::byLowerState))
             return "byLowerState";
-        if constexpr(
-            static_cast<uint8_t>(T_TransitionOrdering)
-            == static_cast<uint8_t>(enums::TransitionOrdering::byUpperState))
+        if constexpr(u8(T_TransitionOrdering) == u8(enums::TransitionOrdering::byUpperState))
             return "byUpperState";
     }
 } // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/enums/TransitionType.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/TransitionType.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <cstdint>
 #include <string>
 
@@ -45,13 +47,13 @@ namespace picongpu::particles::atomicPhysics
     template<enums::TransitionType T_TransitionType>
     ALPAKA_FN_HOST std::string enumToString()
     {
-        if constexpr(static_cast<uint8_t>(T_TransitionType) == static_cast<uint8_t>(enums::TransitionType::boundBound))
+        if constexpr(u8(T_TransitionType) == u8(enums::TransitionType::boundBound))
             return "bound-bound";
-        if constexpr(static_cast<uint8_t>(T_TransitionType) == static_cast<uint8_t>(enums::TransitionType::boundFree))
+        if constexpr(u8(T_TransitionType) == u8(enums::TransitionType::boundFree))
             return "bound-free";
-        if constexpr(static_cast<uint8_t>(T_TransitionType) == static_cast<uint8_t>(enums::TransitionType::autonomous))
+        if constexpr(u8(T_TransitionType) == u8(enums::TransitionType::autonomous))
             return "autonomous";
-        if constexpr(static_cast<uint8_t>(T_TransitionType) == static_cast<uint8_t>(enums::TransitionType::noChange))
+        if constexpr(u8(T_TransitionType) == u8(enums::TransitionType::noChange))
             return "noChange";
         return "unknown";
     }

--- a/include/picongpu/particles/atomicPhysics/initElectrons/Inelastic2BodyCollisionFromCoMoving.hpp
+++ b/include/picongpu/particles/atomicPhysics/initElectrons/Inelastic2BodyCollisionFromCoMoving.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/simulation_defines.hpp"
 // need physicalConstants.param
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/initElectrons/CloneAdditionalAttributes.hpp"
 
 #include <pmacc/algorithms/math/PowerFunction.hpp>
@@ -77,10 +78,10 @@ namespace picongpu::particles::atomicPhysics::initElectrons
                 // standard case
                 for(uint32_t j = 0u; j < 3u; j++)
                 {
-                    auto const jTerm = (gamma - 1.) * beta(j, static_cast<uint32_t>(0u)) / normBetaSquared;
+                    auto const jTerm = (gamma - 1.) * beta(j, u32(0u)) / normBetaSquared;
                     for(uint32_t i = 0u; i < 3u; i++)
                     {
-                        lorentzMatrix(i, j) = jTerm * beta(i, static_cast<uint32_t>(0u));
+                        lorentzMatrix(i, j) = jTerm * beta(i, u32(0u));
                     }
                 }
             }
@@ -213,8 +214,7 @@ namespace picongpu::particles::atomicPhysics::initElectrons
             // weight * (unitless^2 - unitless) * (UNIT_MASS * UNIT_LENGTH/UNIT_TIME)
             // = UNIT_MASS * UNIT_LENGTH / UNIT_TIME, weighted
             float_64 const normMomentumStarElectron_IonSystem = static_cast<float_64>(electron[weighting_])
-                * mc_Electron
-                * math::sqrt(pmacc::math::cPow(gammaStarElectron_IonSystem, static_cast<uint8_t>(2u)) - 1.);
+                * mc_Electron * math::sqrt(pmacc::math::cPow(gammaStarElectron_IonSystem, u8(2u)) - 1.);
             ///@}
 
             /// choose scattering direction @{

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyPressureIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyPressureIonization.kernel
@@ -136,7 +136,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 = T_IPDModel::template calculateIPD<T_ChargeStateDataBox::atomicNumber>(
                     superCellFieldIndex,
                     ipdInputBoxes...);
-            kernelState.foundUnbound = static_cast<uint32_t>(false);
+            kernelState.foundUnbound = u32(false);
         }
     };
 
@@ -205,7 +205,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 alpaka::atomicExch(
                     worker.getAcc(),
                     &kernelState.foundUnbound,
-                    static_cast<uint32_t>(true),
+                    u32(true),
                     ::alpaka::hierarchy::Threads{});
             }
 
@@ -265,7 +265,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_IPDInputBoxes const...)
         {
             uint32_t& foundUnbound = localFoundUnboundIonBox(superCellFieldIndex);
-            foundUnbound = foundUnbound || static_cast<uint32_t>(kernelState.foundUnbound);
+            foundUnbound = foundUnbound || u32(kernelState.foundUnbound);
         }
     };
 

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -91,7 +91,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 = localRejectionProbabilityCacheBox(superCellFieldIdx);
 
             // reset to initial value
-            onlyMaster([&histogramOverSubscribed]() { histogramOverSubscribed = static_cast<uint32_t>(false); });
+            onlyMaster([&histogramOverSubscribed]() { histogramOverSubscribed = u32(false); });
             worker.sync();
 
             /* check all bins for overSubscription
@@ -120,7 +120,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         alpaka::atomicExch(
                             worker.getAcc(),
                             &histogramOverSubscribed,
-                            static_cast<uint32_t>(true),
+                            u32(true),
                             ::alpaka::hierarchy::Threads{});
                     }
                     else

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_Autonomous.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_Autonomous.kernel
@@ -131,7 +131,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                             = numberTransitionsDataBox.numberOfTransitionsDown(atomicStateCollectionIndex);
                         uint32_t offset = startIndexDataBox.startIndexBlockTransitionsDown(atomicStateCollectionIndex);
 
-                        for(uint32_t i = static_cast<uint32_t>(0u); i < numberTransitionsDown; i++)
+                        for(uint32_t i = u32(0u); i < numberTransitionsDown; i++)
                         {
                             // 1/UNIT_TIME
                             rateCache.template add<atomicPhysics::enums::ChooseTransitionGroup::autonomousDownward>(

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundBound.kernel
@@ -188,8 +188,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         auto const binWidth = cachedHistogram.binWidth[binIndex];
                         auto const density = cachedHistogram.density[binIndex];
 
-                        for(uint32_t transitionID = static_cast<uint32_t>(0u); transitionID < numberTransitions;
-                            ++transitionID)
+                        for(uint32_t transitionID = u32(0u); transitionID < numberTransitions; ++transitionID)
                         {
                             // electronic excitation
                             if constexpr(isUpward)
@@ -256,8 +255,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         uint32_t const offset
                             = startIndexDataBox.startIndexBlockTransitionsDown(atomicStateCollectionIndex);
 
-                        for(uint32_t transitionID = static_cast<uint32_t>(0u); transitionID < numberTransitions;
-                            ++transitionID)
+                        for(uint32_t transitionID = u32(0u); transitionID < numberTransitions; ++transitionID)
                         {
                             rateCache.template add<s_enums::ChooseTransitionGroup::boundBoundDownward>(
                                 atomicStateCollectionIndex,

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -188,8 +188,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     [[maybe_unused]] auto const binWidth = cachedHistogram.binWidth[binIndex];
                     [[maybe_unused]] auto const density = cachedHistogram.density[binIndex];
 
-                    for(uint32_t transitionID = static_cast<uint32_t>(0u); transitionID < numberTransitionsUp;
-                        ++transitionID)
+                    for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
                     {
                         if constexpr(T_electronicIonization)
                         {

--- a/include/picongpu/particles/atomicPhysics/kernel/FixAtomicState.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FixAtomicState.kernel
@@ -21,6 +21,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
 #include <cstdint>
@@ -64,7 +66,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 {
                     using ConfigNumber = typename T_AtomicStateDataDataBox::ConfigNumber;
 
-                    uint8_t const boundElectrons = static_cast<uint8_t>(ion[boundElectrons_]);
+                    uint8_t const boundElectrons = u8(ion[boundElectrons_]);
                     typename ConfigNumber::DataType const configNumber
                         = atomicStateDataBox.configNumber(ion[atomicStateCollectionIndex_]);
 

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp"
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
 #include "picongpu/particles/atomicPhysics/SetAtomicState.hpp"
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"

--- a/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
@@ -129,15 +129,14 @@ namespace picongpu::particles::atomicPhysics::kernel
             if((timeRemaining <= 0._X) || (!ionFrame.isValid()))
                 return;
 
-            using FrameArray = memory::Array<ElectronFramePtr, static_cast<uint32_t>(2u)>;
+            using FrameArray = memory::Array<ElectronFramePtr, u32(2u)>;
             PMACC_SMEM(worker, electronFrameArray, FrameArray);
 
             PMACC_SMEM(worker, offsetLowFrame, int32_t);
             PMACC_SMEM(worker, totalNumberMacroElectronsToSpawn, uint32_t);
             PMACC_SMEM(worker, spawnCounter, uint32_t);
 
-            auto numberIonizationElectronsCtxArr
-                = lockstep::makeVar<uint8_t>(forEachFrameSlot, static_cast<uint8_t>(0u));
+            auto numberIonizationElectronsCtxArr = lockstep::makeVar<uint8_t>(forEachFrameSlot, u8(0u));
 
             [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;
             if constexpr(T_ProcessClassGroup == enums::ProcessClassGroup::autonomousBased)
@@ -158,8 +157,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                     offsetLowFrame
                         = static_cast<int32_t>(ionizationElectronBox.getSuperCell(superCellIdx).getSizeLastFrame());
 
-                    totalNumberMacroElectronsToSpawn = static_cast<uint32_t>(0u);
-                    spawnCounter = static_cast<uint32_t>(0u);
+                    totalNumberMacroElectronsToSpawn = u32(0u);
+                    spawnCounter = u32(0u);
 
                     // might be nullptr if no electrons in superCell
                     electronFrameArray[u32(detail::Access::low)] = ionizationElectronBox.getLastFrame(superCellIdx);
@@ -184,7 +183,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                             // no bound-free based ionizing process
                             || !(enums::IsProcess<T_ProcessClassGroup>::check(ion[processClass_])))
                         {
-                            numberIonizationElectrons = static_cast<uint8_t>(0u);
+                            numberIonizationElectrons = u8(0u);
                             return;
                         }
 
@@ -292,13 +291,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                             auto ion = ionFrame[frameSlotIdx];
 
                             // not occupied or does not want to spawn an electron
-                            if(numberIonizationElectrons == static_cast<uint32_t>(0u))
+                            if(numberIonizationElectrons == u32(0u))
                                 return;
 
                             uint32_t const globalSlotIndex = alpaka::atomicAdd(
                                 worker.getAcc(),
                                 &spawnCounter,
-                                static_cast<uint32_t>(1u),
+                                u32(1u),
                                 ::alpaka::hierarchy::Threads{});
 
                             uint32_t const electronFrameIndex = (globalSlotIndex + offsetLowFrame) / frameSize;
@@ -343,7 +342,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                             // update frame slot counter
                             //      will never underflow since we check for 0 above
-                            numberIonizationElectrons -= static_cast<uint8_t>(1u);
+                            numberIonizationElectrons -= u8(1u);
                         },
                         numberIonizationElectronsCtxArr);
                     worker.sync();
@@ -388,11 +387,11 @@ namespace picongpu::particles::atomicPhysics::kernel
                             // update numParticles in superCell for electrons
                             superCell.setNumParticles(superCell.getNumParticles() + spawnCounter);
 
-                            spawnCounter = static_cast<uint32_t>(0u);
+                            spawnCounter = u32(0u);
                         });
                     worker.sync();
 
-                    if(totalNumberMacroElectronsToSpawn == static_cast<uint32_t>(0u))
+                    if(totalNumberMacroElectronsToSpawn == u32(0u))
                         break;
                 }
 

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BinomialCoefficient.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BinomialCoefficient.hpp
@@ -17,7 +17,11 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "picongpu/simulation_defines.hpp" // need: picongpu/param/atomicPhysics_Debug.param
+
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 
 namespace picongpu::particles::atomicPhysics::rateCalculation
 {
@@ -42,7 +46,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
 
         /// @todo beneficial?, Brian Marre, 2022
         // reduce necessary steps using symmetry in k
-        if(k > (n / static_cast<uint8_t>(2u)))
+        if(k > (n / u8(2u)))
         {
             k = n - k;
         }

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
@@ -26,6 +26,7 @@
  *  - unit.param                      unit of time for normalization
  */
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/CollisionalRate.hpp"
@@ -245,16 +246,16 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
 
             // (unitless * m)^2 / (unitless * m^2/1e6b) = m^2 / m^2 * 1e6b = 1e6b
             constexpr float_X scalingConstant = static_cast<float_X>(
-                8. * pmacc::math::cPow(picongpu::PI * picongpu::SI::BOHR_RADIUS, static_cast<uint8_t>(2u))
+                8. * pmacc::math::cPow(picongpu::PI * picongpu::SI::BOHR_RADIUS, u8(2u))
                 / (1.e-22)); // [1e6b], ~ 2211,01 * 1e6b
             // 1e6b
-            constexpr float_X constantPart = scalingConstant
-                * static_cast<float_X>(pmacc::math::cPow(picongpu::SI::RYDBERG_ENERGY, static_cast<uint8_t>(2u)));
+            constexpr float_X constantPart
+                = scalingConstant * static_cast<float_X>(pmacc::math::cPow(picongpu::SI::RYDBERG_ENERGY, u8(2u)));
             // [1e6b * (eV)^2]
 
             // 1e6b*(eV)^2 / (eV)^2 * unitless * (eV)/(eV) * unitless = 1e6b
             float_X crossSection_butGaunt = constantPart / math::sqrt(3._X)
-                / pmacc::math::cPow(energyDifference, static_cast<uint8_t>(2u)) * collisionalOscillatorStrength
+                / pmacc::math::cPow(energyDifference, u8(2u)) * collisionalOscillatorStrength
                 * (energyDifference / energyElectron);
             // [1e6b]
 

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeTransitionRates.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp" // need atomicPhysics_Debug.param
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/CollisionalRate.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/Multiplicities.hpp"
@@ -286,9 +287,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
         //    LevelVector diffLevelVector = lowerStateLevelVector - upperStateLevelVector;
         //
         //    uint8_t shellIonizedElectron;
-        //    for (uint8_t i = static_cast<uint8_t>(0u); i < T_numberLevels; i++ )
+        //    for (uint8_t i = u8(0u); i < T_numberLevels; i++ )
         //    {
-        //        if (diffLevelVector[i] != static_cast<uint8_t>(0u))
+        //        if (diffLevelVector[i] != u8(0u))
         //        {
         //            shellIonizedElectron = i;
         //            break;
@@ -296,7 +297,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
         //    }
         //
         //    if constexpr (ATOMIC_PYHSICS_RATE_CALCULATION_HOT_DEBUG)
-        //        if (diffLevelVector.sumOfComponents() != static_cast<uint8_t>(1u))
+        //        if (diffLevelVector.sumOfComponents() != u8(1u))
         //        {
         //            printf("atomicPhysics ERROR: rateADK assumption single electron ionization broken\n");
         //            return 0._X;
@@ -314,26 +315,26 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
         //    electron)`*/ float_X effectiveCharge = chargeStateDataBox.effectiveCharge(lowerStateChargeState) -
         //    upperStateLevelVector[shellIonizedElectron]; // e
         //
-        //    uint8_t n = shellIonizedElectron + static_cast<uint8_t>(1u);
+        //    uint8_t n = shellIonizedElectron + u8(1u);
         //    /* nameless variable for convenience dFromADK*/
-        //    float_X dBase = 4._X * pmacc::math::cPow(effectiveCharge, static_cast<uint8_t>(3u))
-        //        / (eFieldStrength_AtomicUnits * pmacc::math::cPow(n, static_cast<uint8_t>(4u)));
+        //    float_X dBase = 4._X * pmacc::math::cPow(effectiveCharge, u8(3u))
+        //        / (eFieldStrength_AtomicUnits * pmacc::math::cPow(n, u8(4u)));
         //    float_X const dFromADK = math::pow(dBase, n);
         //
         //    constexpr float_X pi = pmacc::math::Pi<float_X>::value;
         //    /* ionization rate (for CIRCULAR polarization)*/
-        //    float_X rateADK = eFieldStrength_AtomicUnits * pmacc::math::cPow(dFromADK, static_cast<uint8_t>(2u))
+        //    float_X rateADK = eFieldStrength_AtomicUnits * pmacc::math::cPow(dFromADK, u8(2u))
         //        / (8._X * pi * effectiveCharge)
-        //        * math::exp(-2._X * pmacc::math::cPow(effectiveCharge, static_cast<uint8_t>(3u))
-        //                    / (float_X(3.0) * pmacc::math::cPow(n, static_cast<uint8_t>(3u)) *
+        //        * math::exp(-2._X * pmacc::math::cPow(effectiveCharge, u8(3u))
+        //                    / (float_X(3.0) * pmacc::math::cPow(n, u8(3u)) *
         //                    eFieldStrength_AtomicUnits));
         //
         //    /* in case of linear polarization the rate is modified by an additional factor */
         //    if constexpr(T_linPol)
         //    {
         //        /* factor from averaging over one laser cycle with LINEAR polarization */
-        //        rateADK *= math::sqrt(float_X(3.0) * pmacc::math::cPow(n, static_cast<uint8_t>(3u)) *
-        //        eFieldStrength_AtomicUnits / (pi * pmacc::math::cPow(effectiveCharge, static_cast<uint8_t>(3u))));
+        //        rateADK *= math::sqrt(float_X(3.0) * pmacc::math::cPow(n, u8(3u)) *
+        //        eFieldStrength_AtomicUnits / (pi * pmacc::math::cPow(effectiveCharge, u8(3u))));
         //    }
         //
         //    return rateADK;

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/Multiplicities.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/Multiplicities.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/simulation_defines.hpp" // need: picongpu/param/atomicPhysics_Debug.param
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BinomialCoefficient.hpp"
 
 #include <pmacc/algorithms/math.hpp>
@@ -51,7 +52,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             //  number configurations over number electrons
             result *= picongpu::particles::atomicPhysics::rateCalculation::binomialCoefficient(
                 // 2*n^2, number of atomic configurations in (i+1)-th shell
-                static_cast<uint8_t>(2u) * pmacc::math::cPow(i + static_cast<uint8_t>(1u), static_cast<uint8_t>(2u)),
+                u8(2u) * pmacc::math::cPow(i + u8(1u), u8(2u)),
                 // k, number electrons in the (i+1)-th shell
                 levelVector[i]);
         }

--- a/include/picongpu/particles/atomicPhysics/stateRepresentation/DebugHelperConfigNumber.hpp
+++ b/include/picongpu/particles/atomicPhysics/stateRepresentation/DebugHelperConfigNumber.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
 
 #include <pmacc/math/Vector.hpp>
@@ -49,7 +50,7 @@ namespace picongpu::particles::atomicPhysics::stateRepresentation::debug
 
         for(uint8_t i = 0u; i < T_numberLevels; i++)
         {
-            temp = static_cast<uint8_t>(vector[i]);
+            temp = u8(vector[i]);
             levelVector[i] = temp;
         }
     }
@@ -127,7 +128,7 @@ namespace picongpu::particles::atomicPhysics::stateRepresentation::debug
             // getAtomicConfigNumber()
             for(uint8_t i = 0u; i < numberLevels; i++)
             {
-                levelVectorTemp[i] = static_cast<uint8_t>(knownLevelVector[i]); // reuse
+                levelVectorTemp[i] = u8(knownLevelVector[i]); // reuse
             }
             pass = (pass && (knownConfigNumber == Config::getAtomicConfigNumber(levelVectorTemp)));
 


### PR DESCRIPTION
- [x] This PR requires PR #5065 to be merged first

- replaces `static_cast` in atomicPhysics with the atomicPhysics short hand functions for better code readability