### PR TITLE
reduce CI compile time for atomicPhysics compile test

### DIFF
--- a/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/density.param
+++ b/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/density.param
@@ -29,39 +29,7 @@ namespace picongpu
 {
     namespace densityProfiles
     {
-        struct FreeFormulaFunctor
-        {
-            /**
-             * This formula uses SI quantities only
-             * The profile will be multiplied by BASE_DENSITY_SI.
-             *
-             * @param position_SI total offset including all slides [in meter]
-             * @param cellSize_SI cell sizes [in meter]
-             *
-             * @return float_X density [normalized to 1.0]
-             */
-            HDINLINE float_X operator()(const floatD_64& position_SI, const float3_64& cellSize_SI)
-            {
-                // get cell index for each coordinate
-                const pmacc::math::UInt64<simDim> cell_id(position_SI / cellSize_SI.shrink<simDim>());
-
-                // add particle in every cell in which all coordinates are 2,4 or 6
-                // one in every supercell of size [2,2,2]
-                bool isStartCell = true;
-                for(uint64_t d = 0; d < simDim; ++d)
-                    if((cell_id[d] != 1u) && (cell_id[d] != 3u) && (cell_id[d] != 5u))
-                        isStartCell = false;
-
-                if(isStartCell)
-                    return 1.0;
-
-                return 0.0;
-            }
-        };
-
         /* homogenous distribution */
         using Homogenous = HomogenousImpl;
-        /* definition of free formula profile */
-        using FreeFormula = FreeFormulaImpl<FreeFormulaFunctor>;
     } // namespace densityProfiles
 } // namespace picongpu

--- a/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/fileOutput.param
@@ -1,0 +1,56 @@
+/* Copyright 2013-2023 Axel Huebl, Rene Widera, Felix Schmitt,
+ *                     Benjamin Worpitz, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
+/* some forward declarations we need */
+#include "picongpu/fields/Fields.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+#include <boost/mpl/vector.hpp>
+
+
+namespace picongpu
+{
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<>;
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+
+    /** Possible native fields: FieldE, FieldB, FieldJ
+     */
+    using NativeFileOutputFields = MakeSeq_t<>;
+
+    using FileOutputFields = MakeSeq_t<>;
+
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to disable particle output set to
+     *   using FileOutputParticles = MakeSeq_t< >;
+     */
+    using FileOutputParticles = VectorAllSpecies;
+
+} // namespace picongpu

--- a/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/particle.param
@@ -46,18 +46,6 @@ namespace picongpu::particles
              */
             static constexpr uint32_t numParticlesPerCell = 10u;
         };
-
-        struct OnePositionParameter
-        {
-            /** Count of particles per cell at initial state
-             *  unit: none
-             */
-            static constexpr uint32_t numParticlesPerCell = 1u;
-            // sit directly in lower corner of the cell
-            // each x, y, z in-cell position component in range [0.0, 1.0)
-            static constexpr auto inCellOffset = float3_X(0.0, 0.0, 0.0);
-        };
-        using OnePosition = OnePositionImpl<OnePositionParameter>;
         using Random10ppc = RandomImpl<RandomParameter10ppc>;
     } // namespace startPosition
 
@@ -71,17 +59,7 @@ namespace picongpu::particles
         };
         using Assign200keVDrift = unary::Drift<Drift200keVParam, pmacc::math::operation::Assign>;
 
-        struct TemperatureParam
-        {
-            /** Initial temperature
-             *  unit: keV
-             */
-            static constexpr float_64 temperature = 1.;
-        };
-        using AddTemperature = unary::Temperature<TemperatureParam>;
-
         // definition of set initial ionization
         using SetIonization = unary::ChargeState<16u>;
-
     } // namespace manipulators
 } // namespace picongpu::particles

--- a/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/species.param
+++ b/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/species.param
@@ -27,62 +27,53 @@
 
 namespace picongpu
 {
-/*---------------------------- generic solver---------------------------------*/
+    /*---------------------------- generic solver---------------------------------*/
 
-/*! Particle Shape definitions -------------------------------------------------
- *  - particles::shapes::CIC : 1st order
- *  - particles::shapes::TSC : 2nd order
- *  - particles::shapes::PCS : 3rd order
- *  - particles::shapes::P4S : 4th order
- *
- *  example: using UsedParticleShape = particles::shapes::CIC;
- */
-#ifndef PARAM_PARTICLESHAPE
-#    define PARAM_PARTICLESHAPE CIC
-#endif
-    using UsedParticleShape = particles::shapes::PARAM_PARTICLESHAPE;
+    /*! Particle Shape definitions -------------------------------------------------
+     *  - particles::shapes::CIC : 1st order
+     *  - particles::shapes::TSC : 2nd order
+     *  - particles::shapes::PCS : 3rd order
+     *  - particles::shapes::P4S : 4th order
+     *
+     *  example: using UsedParticleShape = particles::shapes::CIC;
+     */
+    using UsedParticleShape = particles::shapes::CIC;
 
     /* define which interpolation method is used to interpolate fields to particle*/
     using UsedField2Particle = FieldToParticleInterpolation<UsedParticleShape, AssignedTrilinearInterpolation>;
 
-/*! select current solver method
- * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
- * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
- * - currentSolver::EZ< SHAPE, STRATEGY >        : same as EmZ (just an alias to match the currently used naming)
- *
- * STRATEGY (optional):
- * - currentSolver::strategy::StridedCachedSupercells
- * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
- * - currentSolver::strategy::CachedSupercells
- * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
- * - currentSolver::strategy::NonCachedSupercells
- * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
- */
-#ifndef PARAM_CURRENTSOLVER
-#    define PARAM_CURRENTSOLVER EmZ
-#endif
-    using UsedParticleCurrentSolver = currentSolver::PARAM_CURRENTSOLVER<UsedParticleShape>;
+    /*! select current solver method
+     * - currentSolver::Esirkepov< SHAPE, STRATEGY > : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::EmZ< SHAPE, STRATEGY >       : particle shapes - CIC, TSC, PQS, PCS (1st to 4th order)
+     * - currentSolver::EZ< SHAPE, STRATEGY >        : same as EmZ (just an alias to match the currently used naming)
+     *
+     * STRATEGY (optional):
+     * - currentSolver::strategy::StridedCachedSupercells
+     * - currentSolver::strategy::StridedCachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::CachedSupercells
+     * - currentSolver::strategy::CachedSupercellsScaled<N> with N >= 1
+     * - currentSolver::strategy::NonCachedSupercells
+     * - currentSolver::strategy::NonCachedSupercellsScaled<N> with N >= 1
+     */
+    using UsedParticleCurrentSolver = currentSolver::EmZ<UsedParticleShape>;
 
-/*! particle pusher configuration ----------------------------------------------
- *
- * Defining a pusher is optional for particles
- *
- * - particles::pusher::Vay : better suited relativistic boris pusher
- * - particles::pusher::Boris : standard boris pusher
- * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
- *                                              with classical radiation reaction
- *
- * For diagnostics & modeling: ------------------------------------------------
- * - particles::pusher::Free : free propagation, ignore fields
- *                             (= free stream model)
- * - particles::pusher::Photon : propagate with c in direction of normalized mom.
- * - particles::pusher::Probe : Probe particles that interpolate E & B
- * For development purposes: --------------------------------------------------
- * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
- */
-#ifndef PARAM_PARTICLEPUSHER
-#    define PARAM_PARTICLEPUSHER Boris
-#endif
-    using UsedParticlePusher = particles::pusher::PARAM_PARTICLEPUSHER;
+    /*! particle pusher configuration ----------------------------------------------
+     *
+     * Defining a pusher is optional for particles
+     *
+     * - particles::pusher::Vay : better suited relativistic boris pusher
+     * - particles::pusher::Boris : standard boris pusher
+     * - particles::pusher::ReducedLandauLifshitz : 4th order RungeKutta pusher
+     *                                              with classical radiation reaction
+     *
+     * For diagnostics & modeling: ------------------------------------------------
+     * - particles::pusher::Free : free propagation, ignore fields
+     *                             (= free stream model)
+     * - particles::pusher::Photon : propagate with c in direction of normalized mom.
+     * - particles::pusher::Probe : Probe particles that interpolate E & B
+     * For development purposes: --------------------------------------------------
+     * - particles::pusher::Axel : a pusher developed at HZDR during 2011 (testing)
+     */
+    using UsedParticlePusher = particles::pusher::Boris;
 
 } // namespace picongpu


### PR DESCRIPTION
- avoid compiling derived fields (added fileOutput.param)
- remove unused particle and density functors.

# Motivation

There is no need that our compile test contains functors which will be not used in the example or compiles more than required to test atomic physics compile.