### PR TITLE
CI: control via commit message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ variables:
     - apt update
     - apt install -y python3-pip
     - apt install -y curl
+    - apt install -y git
     - pip3 install allpairspy
     - $CI_PROJECT_DIR/share/ci/git_merge.sh
     - $CI_PROJECT_DIR/share/ci/generate_reduced_matrix.sh -n ${TEST_TUPLE_NUM_ELEM} -j 15 > compile.yml

--- a/docs/source/dev/ci.rst
+++ b/docs/source/dev/ci.rst
@@ -1,0 +1,54 @@
+.. _development-ci:
+
+Continuous Integration
+======================
+
+.. sectionauthor:: René Widera
+
+What is tested?
+---------------
+
+The CI is compiling tests with different compilers and boost versions.
+We compile examples, tests, and benchmark input sets from ``share/picongpu``.
+Unit tests for PMacc from ``include/pmacc/test`` and examples under ``share/pmacc`` will be compiled and executed on the corresponding compute device.
+PIConGPU unit test from ``share/picongpu/unit`` will be compiled and executed on the corresponding compute device.
+PICMI from ``share/picongpu/pypicongpu`` will be compiled too.
+
+Compiler chains
+---------------
+
+The CI is testing different version of
+
+* ``nvcc`` with ``g++`` for NVIDIA CUDA compute devices
+* ``clang`` with HIP for AMD ROCm compute devices
+* ``clang`` as NVIDIA CUDA compiler for NVIDIA CUDA devices
+* ``clang`` and ``g++`` for the serial alpaka accelerator to target x86-CPU compute devices
+
+Test PR
+-------
+
+Pull requests will perform all tests described above.
+By default PIConGPU input sets will only compile a reduced set of all setups.
+Only the first input variation from ``cmakeFlags`` will be compiled
+There is no guarantee that each setup is compiled with at least one version of the compiles chains above.
+It is guaranteed that each compiler version of all compiler chains is compiling at least one PIConGPU input set.
+
+Test dev branch
+---------------
+
+Merged PRs will perform more extensive tests compared to the PR tests.
+Each PIConGPU input set is compiled at least with one compiler version of each compiler tool chain.
+
+CI Control via Commit Message
+-----------------------------
+
+It is possible to control which compile tests will be executed for the pull request and dev branch.
+The last commit of a pull request can contain a command in form of ``ci: <command>`` which will be taken into account by the CI.
+A command must be the only text/string on a line, it is not case sensitive and can have spaces before or behind.
+
+commands:
+
+* ``ci: no-compile`` is disabling PIConGPU and PMacc compile and runtime tests
+* ``ci: full-compile`` will execute for a PR all tests the CI is performing when PRs get merged to the dev branch.
+* ``ci: picongpu`` only PIConGPU compile and runtime tests will be performed
+* ``ci: pmacc`` only PMacc compile and runtime tests will be performed

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,6 +112,7 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
 
    dev/CONTRIBUTING.md
    dev/docs/COMMIT.md
+   dev/ci
    dev/repostructure
    dev/styleguide
    dev/sphinx

--- a/share/ci/generate_reduced_matrix.sh
+++ b/share/ci/generate_reduced_matrix.sh
@@ -8,6 +8,14 @@ set -o pipefail
 export PATH=$CI_PROJECT_DIR/share/ci:$PATH
 export picongpu_DIR=$CI_PROJECT_DIR
 
+cd $picongpu_DIR
+
+# 0 == false; 1 == true
+commit_no_compile=$(git log -1 | grep -q -i "^[[:blank:]]*ci:[[:blank:]]*no-compile[[:blank:]]*$" && echo "1" || echo "0")
+commit_full_compile=$(git log -1 | grep -q -i "^[[:blank:]]*ci:[[:blank:]]*full-compile[[:blank:]]*$" && echo "1" || echo "0")
+commit_picongpu_only=$(git log -1 | grep -q -i "^[[:blank:]]*ci:[[:blank:]]*picongpu[[:blank:]]*$" && echo "1" || echo "0")
+commit_pmacc_only=$(git log -1 | grep -q -i "^[[:blank:]]*ci:[[:blank:]]*pmacc[[:blank:]]*$" && echo "1" || echo "0")
+
 cd $picongpu_DIR/share/picongpu/
 
 echo "include:"
@@ -23,7 +31,12 @@ has_label=$($CI_PROJECT_DIR/share/ci/pr_has_label.sh "CI:no-compile" && echo "0"
 if [ "$has_label" == "0" ] ; then
   echo "skip-compile:"
   echo "  script:"
-  echo "    - echo \"CI action - 'CI:no-compile' -> skip compile/runtime tests\""
+  echo "    - echo \"CI label action - 'CI:no-compile' -> skip compile/runtime tests\""
+  exit 0
+elif [ $commit_no_compile -eq 1 ]; then
+  echo "skip-compile:"
+  echo "  script:"
+  echo "    - echo \"Commit CI control action - 'CI:no-compile' -> skip compile/runtime tests\""
   exit 0
 else
   echo "Label 'CI:no-compile' for the current CI job not set." >&2
@@ -33,33 +46,56 @@ if [ -n "$QUICK_CI_TESTS" ] ; then
   # For user PRs only run reduced set of tests.
   # If a PR is merged to the `dev` branch a non-reduced test will be executed.
   is_pr=$(echo "$CI_COMMIT_REF_NAME" | grep -q "^pr-" && echo 1 || echo 0)
-  if [ $is_pr -eq 1 ] ; then
-      ADDITIONAL_GENRATOR_FLAGS="--quick"
+  if [ $is_pr -eq 1 ] && [ $commit_full_compile -ne 1 ] ; then
+      ADDITIONAL_GENRATOR_FLAGS="$ADDITIONAL_GENRATOR_FLAGS --quick"
   fi
 fi
 
+add_empty_job=0
+
 folders=()
 if [ "$PIC_INPUTS" == "pmacc" ] ; then
-  # create test cases for PMacc
-  echo "pmacc" | tr " " "\n" | n_wise_generator.py $@ --limit_boost_version $ADDITIONAL_GENRATOR_FLAGS
+  if [ $commit_picongpu_only -ne 1 ] ; then
+    # create unit tests for PMacc
+    echo "pmacc" | tr " " "\n" | n_wise_generator.py $@ --limit_boost_version $ADDITIONAL_GENRATOR_FLAGS
+  else
+    add_empty_job=1
+  fi
 elif [ "$PIC_INPUTS" == "pmacc_header" ] ; then
-    # create test cases for PMacc
+  if [ $commit_picongpu_only -ne 1 ] ; then
+    # create header validation test for PMacc
     echo "pmacc_header" | tr " " "\n" | n_wise_generator.py $@ --limit_boost_version $ADDITIONAL_GENRATOR_FLAGS
+  fi
 elif [ "$PIC_INPUTS" == "unit" ] ; then
-   # create test cases for PMacc
-   echo "unit" | tr " " "\n" | n_wise_generator.py $@ --limit_boost_version $ADDITIONAL_GENRATOR_FLAGS
+  if [ $commit_pmacc_only -ne 1 ] ; then
+    # create unit tests for PIConGPU
+    echo "unit" | tr " " "\n" | n_wise_generator.py $@ --limit_boost_version $ADDITIONAL_GENRATOR_FLAGS
+  else
+    add_empty_job=1
+  fi
 else
-  # create test cases for PIConGPU
-  for CASE in ${PIC_INPUTS}; do
-    if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] || [  "$CASE" == "benchmarks"  ] ; then
-        all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
-    else
-        all_cases=$(find $CASE -maxdepth 0 -type d)
-    fi
-    for test_case_folder in $all_cases ; do
-        folders+=($test_case_folder)
+  if [ $commit_pmacc_only -ne 1 ] ; then
+    # create input set test cases for PIConGPU
+    for CASE in ${PIC_INPUTS}; do
+      if [ "$CASE" == "examples" ] || [  "$CASE" == "tests"  ] || [  "$CASE" == "benchmarks"  ] ; then
+          all_cases=$(find ${CASE}/* -maxdepth 0 -type d)
+      else
+          all_cases=$(find $CASE -maxdepth 0 -type d)
+      fi
+      for test_case_folder in $all_cases ; do
+          folders+=($test_case_folder)
+      done
     done
-  done
 
-  echo "${folders[@]}" | tr " " "\n" | n_wise_generator.py $@ $ADDITIONAL_GENRATOR_FLAGS
+    echo "${folders[@]}" | tr " " "\n" | n_wise_generator.py $@ $ADDITIONAL_GENRATOR_FLAGS
+  else
+      add_empty_job=1
+  fi
+fi
+
+if [ $add_empty_job -eq 1 ] ; then
+  echo "skip-compile:"
+  echo "  script:"
+  echo "    - echo \"Commit CI control action - skip compile/runtime tests\""
+  exit 0
 fi


### PR DESCRIPTION
- add possibility to control the CI via commit messages
- add basic documentation

This feature is required in case CI tests for PR merges to the dev branch are failing.

- [x] PR is currently a draft because I need to test all commands first
