### PR TITLE
unit test: fix warning

### DIFF
--- a/share/picongpu/unit/MoveParticle.cpp
+++ b/share/picongpu/unit/MoveParticle.cpp
@@ -82,7 +82,7 @@ struct ParticleStub
         return multiMaskValue;
     }
 
-    HINLINE bool operator==(ParticleStub const& other) const
+    bool operator==(ParticleStub const& other) const
     {
         return isApproxEqual(pos, other.pos) && localCellIdxValue == other.localCellIdxValue
             && multiMaskValue == other.multiMaskValue;


### PR DESCRIPTION
```
share/picongpu/unit/MoveParticle.cpp(87): warning #20011-D: calling a __host__ function("bool ::isApproxEqual< ::pmacc::math::Vector<float, (unsigned int)3u,  ::pmacc::math::ArrayStorage<float, (unsigned int)3u> > > (const T1 &, const T1 &)") from a __host__ __device__ function("ParticleStub::operator == const") is not allowed
```

Bug was already fixed with #5066 but removing the attribute is cleaner so this PR is only removing HINLINE.