### PR TITLE
avoid using SIMDIM for controlflow

### DIFF
--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -18,6 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+// required for SIMDIM definition
+#include "picongpu/defines.hpp"
 
 #if(ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
 

--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.x.cpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.x.cpp
@@ -414,10 +414,10 @@ namespace picongpu
                 calcPhaseSpace<AxisDescription::x>(currentStep);
             else if(this->axis_element.space == AxisDescription::y)
                 calcPhaseSpace<AxisDescription::y>(currentStep);
-#    if(SIMDIM == DIM3)
-            else
-                calcPhaseSpace<AxisDescription::z>(currentStep);
-#    endif
+
+            if constexpr(simDim == DIM3)
+                if(this->axis_element.space == AxisDescription::z)
+                    calcPhaseSpace<AxisDescription::z>(currentStep);
 
             /* transfer to host */
             this->dBuffer->deviceToHost();

--- a/include/picongpu/unitless/simulation.unitless
+++ b/include/picongpu/unitless/simulation.unitless
@@ -199,6 +199,9 @@ namespace picongpu
 
         static constexpr uint32_t dim()
         {
+            static_assert(
+                simDim == SIMDIM,
+                "Preprocessor define SIMDIM and simDim must be equal! see file dimension.param");
             return simDim;
         }
 


### PR DESCRIPTION
fix #5062

Avoid using the macro SIMDIM for program control-flow. SIMDIM should only be used for include guards.
Fix missing include in untested code IsaacPlugin.x.cpp.