### PR TITLE
change atomic physics particle attributes

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -156,16 +156,16 @@ namespace picongpu
     alias(atomicPhysicsParticle);
 
     //! particle attribute, collectionIndex of atomic state of ions
-    value_identifier(uint32_t, atomicStateCollectionIndex, 0u);
+    value_identifier(uint32_t, atomicStateCollectionIndex, std::numeric_limits<uint32_t>::max());
 
     //! particle attribute, process class of selected atomicPhysics transition
-    value_identifier(uint8_t, processClass, 0u);
+    value_identifier(uint8_t, processClass, std::numeric_limits<uint8_t>::max());
 
     //! particle attribute, index of chosen atomicPhysics transition
-    value_identifier(uint32_t, transitionIndex, 0u);
+    value_identifier(uint32_t, transitionIndex, std::numeric_limits<uint32_t>::max());
 
     //! particle attribute, index of bin chosen for atomicPhysics transition, if applicable for
-    value_identifier(uint32_t, binIndex, 0u);
+    value_identifier(uint32_t, binIndex, std::numeric_limits<uint32_t>::max());
 
     //! particle attribute, whether the selected transition was accepted
     value_identifier(bool, accepted, false);

--- a/include/picongpu/particles/atomicPhysics/SetChargeState.hpp
+++ b/include/picongpu/particles/atomicPhysics/SetChargeState.hpp
@@ -55,7 +55,7 @@ namespace picongpu::particles::atomicPhysics
                  */
 
                 // invalidate atomicStateCollectionIndex particle attribute for easier detection
-                ion[atomicStateCollectionIndex_] = 0u;
+                ion[atomicStateCollectionIndex_] = std::numeric_limits<uint32_t>::max();
             }
         }
     };


### PR DESCRIPTION
Atomic physics particle attributes was set by default to a possible valid value but in case an algorithm forget to set the value correctly we got a false valid value.
By setting it to an invalid value such errors should become visible at leat by a crash of the simulation.
An additional advantage is that we can now give an electron some of the properties which allows to track from which ion state and which transition state the electron was created.