### PR TITLE
refactor `value_identifier_func`

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -60,7 +60,7 @@ namespace picongpu
     value_identifier_func(
         uint64_t,
         particleId,
-        [] ALPAKA_FN_ACC(auto const& worker, IdGenerator& idGen) { return idGen.fetchInc(worker); });
+        [] ALPAKA_FN_ACC(auto const& worker, IdGenerator& idGen, auto const&) { return idGen.fetchInc(worker); });
 
     //! specialization for the relative in-cell position
     value_identifier(floatD_X, position_pic, floatD_X::create(0.));

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -30,7 +30,6 @@
 #include <pmacc/memory/boxes/PitchedBox.hpp>
 #include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/meta/conversion/ResolveAndRemoveFromSeq.hpp>
-#include <pmacc/particles/operations/SetAttributeToDefault.hpp>
 
 namespace picongpu
 {

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -94,10 +94,10 @@ namespace pmacc
          * ATTENTION: The pointer must be the last member to avoid local memory usage
          *            https://github.com/ComputationalRadiationPhysics/picongpu/pull/762
          */
-        PMACC_ALIGN(frame, FrameType*);
+        PMACC_ALIGN(frame, FrameType*) = nullptr;
 
         /** index of particle inside the Frame*/
-        PMACC_ALIGN(idx, uint32_t);
+        PMACC_ALIGN(idx, uint32_t) = std::numeric_limits<uint32_t>::max();
 
         /** set particle handle to invalid
          *
@@ -123,6 +123,8 @@ namespace pmacc
         {
             return frame != nullptr;
         }
+
+        HDINLINE Particle() = default;
 
         /** create particle
          *
@@ -169,8 +171,7 @@ namespace pmacc
          *
          * The common subset of the attribute lists from both particles is
          * used to set the attributes in this particle with the corresponding ones from source particle.
-         * The remaining attributes that only exist in this particle
-         * is simply set to their default values.
+         * The remaining attributes that only exist in this particle is simply set to their default values.
          */
         template<typename T_Worker, typename T_OtherFrameType, typename T_OtherValueTypeSeq>
         HDINLINE void copyAndInit(
@@ -199,7 +200,7 @@ namespace pmacc
 
             /* set all attributes which are not in src to their default value*/
             ForEach<UniqueInDestTypeSeq, SetAttributeToDefault<boost::mpl::_1>> setAttributeToDefault;
-            setAttributeToDefault(worker, idGen, *this);
+            setAttributeToDefault(worker, idGen, *this, srcParticle);
         }
 
         /** Assign common attributes of one particle to another

--- a/include/pmacc/particles/operations/SetAttributeToDefault.hpp
+++ b/include/pmacc/particles/operations/SetAttributeToDefault.hpp
@@ -38,15 +38,32 @@ namespace pmacc
 
         /** set an attribute to their default value
          *
-         * @tparam T_Partcile particle type
+         * Check value_identifier and value_identifier_func for special behaviours on how defaults get derived.
+         *
+         * @tparam T_DestParticleType particle type
+         *
+         * @{
          */
-        template<typename T_Worker, typename T_Particle>
-        HDINLINE void operator()(T_Worker const& worker, IdGenerator idGen, T_Particle& particle)
+        template<typename T_Worker, typename T_DestParticleType>
+        HDINLINE void operator()(T_Worker const& worker, IdGenerator idGen, T_DestParticleType& destParticle)
         {
             using ResolvedAttr = typename pmacc::traits::Resolve<Attribute>::type;
-            /* set attribute to it's user defined default value */
-            particle[Attribute()] = ResolvedAttr::getValue(worker, idGen);
+            /* set attribute to its user defined default value */
+            destParticle[Attribute()] = ResolvedAttr::getValue(worker, idGen, T_DestParticleType{});
         }
+
+        template<typename T_Worker, typename T_DestParticleType, typename T_SrcParticleType>
+        HDINLINE void operator()(
+            T_Worker const& worker,
+            IdGenerator idGen,
+            T_DestParticleType& destParticle,
+            T_SrcParticleType const& srcParticle)
+        {
+            using ResolvedAttr = typename pmacc::traits::Resolve<Attribute>::type;
+            /* set attribute to its user defined default value */
+            destParticle[Attribute()] = ResolvedAttr::getValue(worker, idGen, srcParticle);
+        }
+        /** @} */
     };
 
 


### PR DESCRIPTION
Refactor `value_identifier_func` and `SetAttributeToDefault` to allow deriving any kind of attribute from the source particle.
The refactoring required adding a default constructor for `Particle`.