### PR TITLE
cleanup `particlesFunctors.hpp`

### DIFF
--- a/include/picongpu/particles/ParticlesFunctors.hpp
+++ b/include/picongpu/particles/ParticlesFunctors.hpp
@@ -23,14 +23,8 @@
 
 #include "picongpu/simulation_defines.hpp"
 
-#include "picongpu/fields/Fields.def"
-#include "picongpu/particles/boundary/RemoveOuterParticles.hpp"
-#include "picongpu/particles/creation/creation.hpp"
-#include "picongpu/particles/traits/GetIonizerList.hpp"
-
 #include <pmacc/Environment.hpp>
 #include <pmacc/communication/AsyncCommunication.hpp>
-#include <pmacc/memory/buffers/HostDeviceBuffer.hpp>
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/particles/traits/ResolveAliasFromSpecies.hpp>
@@ -149,26 +143,6 @@ namespace picongpu
             }
         };
 
-        /** Remove all particles of the species that are outside the respective boundaries
-         *
-         * Must be called only for species with a pusher
-         *
-         * @tparam T_SpeciesType type or name as PMACC_CSTRING of particle species that is checked
-         */
-        template<typename T_SpeciesType>
-        struct RemoveOuterParticles
-        {
-            using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
-            using FrameType = typename SpeciesType::FrameType;
-
-            HINLINE void operator()(const uint32_t currentStep) const
-            {
-                DataConnector& dc = Environment<>::get().DataConnector();
-                auto species = dc.get<SpeciesType>(FrameType::getName());
-                boundary::removeOuterParticles(*species, currentStep);
-            }
-        };
-
         /** Communicate a species
          *
          * communication is only triggered for species with a pusher
@@ -234,104 +208,6 @@ namespace picongpu
                 for(auto iter = commEventList.begin(); iter != commEventList.end(); ++iter)
                 {
                     commEvent += *iter;
-                }
-            }
-        };
-
-        //! Remove all particles of all species with pusher flag that are outside the respective boundaries
-        struct RemoveOuterParticlesAllSpecies
-        {
-            /** Remove all external particles
-             *
-             * @param currentStep current simulation step
-             */
-            HINLINE void operator()(const uint32_t currentStep) const
-            {
-                using VectorSpeciesWithPusher =
-                    typename pmacc::particles::traits::FilterByFlag<VectorAllSpecies, particlePusher<>>::type;
-                meta::ForEach<VectorSpeciesWithPusher, RemoveOuterParticles<boost::mpl::_1>> removeOuterParticles;
-                removeOuterParticles(currentStep);
-            }
-        };
-
-        /** Call an ionization method upon an ion species
-         *
-         * @tparam T_SpeciesType type or name as PMACC_CSTRING of particle species that is going to be ionized
-         * with ionization scheme T_SelectIonizer
-         */
-        template<typename T_SpeciesType, typename T_SelectIonizer>
-        struct CallIonizationScheme
-        {
-            using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
-            using SelectIonizer = T_SelectIonizer;
-            using FrameType = typename SpeciesType::FrameType;
-
-            /* define the type of the species to be created
-             * from inside the ionization model specialization
-             */
-            using DestSpecies = typename SelectIonizer::DestSpecies;
-            using DestFrameType = typename DestSpecies::FrameType;
-
-            /** Functor implementation
-             *
-             * @tparam T_CellDescription contains the number of blocks and blocksize
-             *                           that is later passed to the kernel
-             * @param cellDesc logical block information like dimension and cell sizes
-             * @param currentStep The current time step
-             */
-            template<typename T_CellDescription>
-            HINLINE void operator()(T_CellDescription cellDesc, const uint32_t currentStep) const
-            {
-                DataConnector& dc = Environment<>::get().DataConnector();
-
-                // alias for pointer on source species
-                auto srcSpeciesPtr = dc.get<SpeciesType>(FrameType::getName());
-                // alias for pointer on destination species
-                auto electronsPtr = dc.get<DestSpecies>(DestFrameType::getName());
-
-                SelectIonizer selectIonizer(currentStep);
-
-                creation::createParticlesFromSpecies(*srcSpeciesPtr, *electronsPtr, selectIonizer, cellDesc);
-
-                /* fill the gaps in the created species' particle frames to ensure that only
-                 * the last frame is not completely filled but every other before is full
-                 */
-                electronsPtr->fillAllGaps();
-            }
-        };
-
-        /** Call all ionization schemes of an ion species
-         *
-         * Tests if species can be ionized and calls the kernels to do that
-         *
-         * @tparam T_SpeciesType type or name as PMACC_CSTRING of particle species that is checked for ionization
-         */
-        template<typename T_SpeciesType>
-        struct CallIonization
-        {
-            using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
-            using FrameType = typename SpeciesType::FrameType;
-
-            // SelectIonizer will be either the specified one or fallback: None
-            using SelectIonizerList = typename traits::GetIonizerList<SpeciesType>::type;
-
-            /** Functor implementation
-             *
-             * @tparam T_CellDescription contains the number of blocks and blocksize
-             *                           that is later passed to the kernel
-             * @param cellDesc logical block information like dimension and cell sizes
-             * @param currentStep The current time step
-             */
-            template<typename T_CellDescription>
-            HINLINE void operator()(T_CellDescription cellDesc, const uint32_t currentStep) const
-            {
-                // only if an ionizer has been specified, this is executed
-                using hasIonizers = typename HasFlag<FrameType, ionizers<>>::type;
-                if(hasIonizers::value)
-                {
-                    meta::ForEach<SelectIonizerList, CallIonizationScheme<SpeciesType, boost::mpl::_1>>
-                        particleIonization;
-                    particleIonization(cellDesc, currentStep);
                 }
             }
         };

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -25,7 +25,6 @@
 #include "picongpu/fields/FieldB.hpp"
 #include "picongpu/fields/FieldE.hpp"
 #include "picongpu/fields/FieldJ.hpp"
-#include "picongpu/particles/ParticlesFunctors.hpp"
 #include "picongpu/particles/atomicPhysics/SetChargeState.hpp"
 #include "picongpu/particles/ionization/byField/BSI/AlgorithmBSI.hpp"
 #include "picongpu/particles/ionization/byField/BSI/AlgorithmBSIEffectiveZ.hpp"

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/IonizationCurrent.hpp
@@ -22,7 +22,6 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/fields/FieldE.hpp"
-#include "picongpu/particles/ParticlesFunctors.hpp"
 #include "picongpu/particles/ionization/byField/IonizationCurrent/IonizerReturn.hpp"
 #include "picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp"
 #include "picongpu/particles/ionization/byField/IonizationCurrent/JIonizationCalc.hpp"

--- a/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
+++ b/include/picongpu/particles/ionization/byField/IonizationCurrent/JIonizationAssignment.hpp
@@ -22,7 +22,6 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/fields/FieldJ.hpp"
-#include "picongpu/particles/ParticlesFunctors.hpp"
 
 namespace picongpu
 {


### PR DESCRIPTION
To reduce the compile time for independent compile units solver calls were moved to the corresponding stages.

- [ ] PR #5090 is combining this and other PRs to reduce the CI load