### PR TITLE
PMacc: refactor `FileSystem.hpp`

### DIFF
--- a/include/picongpu/plugins/PhaseSpace/PhaseSpace.x.cpp
+++ b/include/picongpu/plugins/PhaseSpace/PhaseSpace.x.cpp
@@ -34,6 +34,7 @@
 
 #    include <pmacc/communication/manager_common.hpp>
 #    include <pmacc/lockstep/lockstep.hpp>
+#    include <pmacc/mappings/simulation/Filesystem.hpp>
 #    include <pmacc/math/Vector.hpp>
 #    include <pmacc/mpi/MPIReduce.hpp>
 #    include <pmacc/mpi/reduceMethods/Reduce.hpp>
@@ -319,7 +320,7 @@ namespace picongpu
             if(activatePlugin)
             {
                 /** create dir */
-                Environment<simDim>::get().Filesystem().createDirectoryWithPermissions("phaseSpace");
+                pmacc::Filesystem::get().createDirectoryWithPermissions("phaseSpace");
 
                 const uint32_t r_element = axis_element.space;
 

--- a/include/picongpu/plugins/makroParticleCounter/PerSuperCell.x.cpp
+++ b/include/picongpu/plugins/makroParticleCounter/PerSuperCell.x.cpp
@@ -30,6 +30,7 @@
 
 #    include <pmacc/dataManagement/DataConnector.hpp>
 #    include <pmacc/mappings/kernel/AreaMapping.hpp>
+#    include <pmacc/mappings/simulation/Filesystem.hpp>
 #    include <pmacc/memory/buffers/GridBuffer.hpp>
 #    include <pmacc/memory/shared/Allocate.hpp>
 #    include <pmacc/mpi/MPIReduce.hpp>
@@ -186,7 +187,7 @@ namespace picongpu
                 localResult = std::make_unique<GridBufferType>(localSuperCells);
 
                 /* create folder for hdf5 files*/
-                Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(foldername);
+                pmacc::Filesystem::get().createDirectoryWithPermissions(foldername);
             }
         }
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -65,6 +65,7 @@
 #    include <pmacc/dataManagement/DataConnector.hpp>
 #    include <pmacc/dimensions/GridLayout.hpp>
 #    include <pmacc/filesystem.hpp>
+#    include <pmacc/mappings/simulation/Filesystem.hpp>
 #    include <pmacc/mappings/simulation/GridController.hpp>
 #    include <pmacc/mappings/simulation/SubGrid.hpp>
 #    include <pmacc/math/Vector.hpp>
@@ -1116,16 +1117,16 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                         Environment<>::get().PluginConnector().setNotificationPeriod(this, emplaced->second.periods());
 
-                        /** create notify directory */
-                        Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(outputDirectory);
+                        /** create output directory */
+                        pmacc::Filesystem::get().createDirectoryWithPermissions(outputDirectory);
                     }
                     else if(not tomlSourcesSpecified && notifyPeriodSpecified)
                     {
                         std::string const& notifyPeriod = m_help->notifyPeriod.get(id);
                         Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
 
-                        /** create notify directory */
-                        Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(outputDirectory);
+                        /** create output directory */
+                        pmacc::Filesystem::get().createDirectoryWithPermissions(outputDirectory);
                     }
                     else
                     {

--- a/include/picongpu/plugins/output/images/PngCreator.tpp
+++ b/include/picongpu/plugins/output/images/PngCreator.tpp
@@ -24,6 +24,7 @@
 #include "picongpu/plugins/output/header/MessageHeader.hpp"
 #include "picongpu/plugins/output/images/PngCreator.hpp"
 
+#include <pmacc/mappings/simulation/Filesystem.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/types.hpp>
 #include <pmacc/verify.hpp>
@@ -50,7 +51,7 @@ namespace picongpu
 #if(PIC_ENABLE_PNG == 1)
         if(m_createFolder)
         {
-            Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(m_folder);
+            pmacc::Filesystem::get().createDirectoryWithPermissions(m_folder);
             m_createFolder = false;
         }
 

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.x.cpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.x.cpp
@@ -37,6 +37,7 @@
 #    include <pmacc/dataManagement/DataConnector.hpp>
 #    include <pmacc/lockstep/lockstep.hpp>
 #    include <pmacc/mappings/kernel/AreaMapping.hpp>
+#    include <pmacc/mappings/simulation/Filesystem.hpp>
 #    include <pmacc/math/Vector.hpp>
 #    include <pmacc/mpi/MPIReduce.hpp>
 #    include <pmacc/mpi/reduceMethods/Reduce.hpp>
@@ -214,8 +215,7 @@ namespace picongpu
              * Create folder for openPMD checkpoint files.
              * openPMD would also do it automatically, but let's keep things explicit.
              */
-            Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(
-                checkpointDirectory + "/" + this->foldername);
+            pmacc::Filesystem::get().createDirectoryWithPermissions(checkpointDirectory + "/" + this->foldername);
             auto dataSize = this->dBufLeftParsCalorimeter->capacityND();
             HBufCalorimeter hBufLeftParsCalorimeter(dataSize);
             HBufCalorimeter hBufTotal(dataSize);
@@ -358,7 +358,7 @@ namespace picongpu
                 this->calorimeterFrameVecZ);
 
             /* create folder for openPMD files*/
-            Environment<simDim>::get().Filesystem().createDirectoryWithPermissions(this->foldername);
+            pmacc::Filesystem::get().createDirectoryWithPermissions(this->foldername);
 
             // set how often the plugin should be executed while PIConGPU is running
             Environment<>::get().PluginConnector().setNotificationPeriod(this, m_help->notifyPeriod.get(m_id));

--- a/include/picongpu/plugins/radiation/Radiation.x.cpp
+++ b/include/picongpu/plugins/radiation/Radiation.x.cpp
@@ -41,6 +41,7 @@
 #    include <pmacc/dataManagement/DataConnector.hpp>
 #    include <pmacc/filesystem.hpp>
 #    include <pmacc/lockstep/lockstep.hpp>
+#    include <pmacc/mappings/simulation/Filesystem.hpp>
 #    include <pmacc/math/operation.hpp>
 #    include <pmacc/mpi/MPIReduce.hpp>
 #    include <pmacc/mpi/reduceMethods/Reduce.hpp>
@@ -357,7 +358,7 @@ namespace picongpu
                         freqFkt = freqInit.getFunctor();
 
                         Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
-                        pmacc::Filesystem<simDim>& fs = Environment<simDim>::get().Filesystem();
+                        auto& fs = pmacc::Filesystem::get();
 
                         if(isMaster)
                         {

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
@@ -42,6 +42,7 @@
 
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/lockstep/lockstep.hpp>
+#include <pmacc/mappings/simulation/Filesystem.hpp>
 #include <pmacc/math/Complex.hpp>
 #include <pmacc/math/operation.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
@@ -235,7 +236,7 @@ namespace picongpu
 
                         /*only rank 0 create a file*/
                         isMaster = reduce.hasResult(mpi::reduceMethods::Reduce());
-                        pmacc::Filesystem<simDim>& fs = Environment<simDim>::get().Filesystem();
+                        auto& fs = pmacc::Filesystem::get();
 
                         Environment<>::get().PluginConnector().setNotificationPeriod(this, notifyPeriod);
 

--- a/include/pmacc/Environment.hpp
+++ b/include/pmacc/Environment.hpp
@@ -31,7 +31,6 @@
 #include "pmacc/eventSystem/events/EventPool.hpp"
 #include "pmacc/eventSystem/queues/QueueController.hpp"
 #include "pmacc/eventSystem/tasks/Factory.hpp"
-#include "pmacc/mappings/simulation/Filesystem.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
 #include "pmacc/mappings/simulation/SubGrid.hpp"
 #include "pmacc/particles/tasks/ParticleFactory.hpp"
@@ -135,12 +134,6 @@ namespace pmacc
          * @return instance of SubGrid
          */
         HINLINE pmacc::SubGrid<T_dim>& SubGrid();
-
-        /** get the singleton Filesystem
-         *
-         * @return instance of Filesystem
-         */
-        HINLINE pmacc::Filesystem<T_dim>& Filesystem();
 
         /** get the singleton Environment< DIM >
          *

--- a/include/pmacc/Environment.tpp
+++ b/include/pmacc/Environment.tpp
@@ -108,7 +108,6 @@ namespace pmacc
             return device::MemoryInfo::getInstance();
         }
 
-
         simulationControl::SimulationDescription& Environment::SimulationDescription()
         {
             return simulationControl::SimulationDescription::getInstance();
@@ -147,13 +146,6 @@ namespace pmacc
     }
 
     template<uint32_t T_dim>
-    pmacc::Filesystem<T_dim>& Environment<T_dim>::Filesystem()
-    {
-        return pmacc::Filesystem<T_dim>::getInstance();
-    }
-
-
-    template<uint32_t T_dim>
     void Environment<T_dim>::initDevices(DataSpace<T_dim> devices, DataSpace<T_dim> periodic)
     {
         // initialize the MPI context
@@ -163,8 +155,6 @@ namespace pmacc
         GridController().init(devices, periodic);
 
         EnvironmentController();
-
-        Filesystem();
 
         detail::EnvironmentContext::getInstance().setDevice(static_cast<int>(GridController().getHostRank()));
 

--- a/include/pmacc/mappings/simulation/Filesystem.hpp
+++ b/include/pmacc/mappings/simulation/Filesystem.hpp
@@ -30,10 +30,7 @@ namespace pmacc
 {
     /**
      * Singleton class providing common filesystem operations.
-     *
-     * @tparam DIM number of dimensions of the simulation
      */
-    template<unsigned DIM>
     class Filesystem
     {
     public:
@@ -64,9 +61,20 @@ namespace pmacc
          */
         std::string basename(const std::string pathFilename) const;
 
-    private:
-        friend class Environment<DIM>;
+        /**
+         * Returns the instance of the filesystem class.
+         *
+         * This class is a singleton class.
+         *
+         * @return a filesystem instance
+         */
+        static Filesystem& get()
+        {
+            static Filesystem instance;
+            return instance;
+        }
 
+    private:
         /**
          * Constructor
          */
@@ -76,19 +84,6 @@ namespace pmacc
          * Constructor
          */
         Filesystem(const Filesystem& fs) = default;
-
-        /**
-         * Returns the instance of the filesystem class.
-         *
-         * This class is a singleton class.
-         *
-         * @return a filesystem instance
-         */
-        static Filesystem<DIM>& getInstance()
-        {
-            static Filesystem<DIM> instance;
-            return instance;
-        }
     };
 
 } // namespace pmacc

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -28,6 +28,7 @@
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/eventSystem/Manager.hpp"
 #include "pmacc/filesystem.hpp"
+#include "pmacc/mappings/simulation/Filesystem.hpp"
 #include "pmacc/mappings/simulation/GridController.hpp"
 #include "pmacc/particles/IdProvider.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
@@ -113,7 +114,7 @@ namespace pmacc
             /* create directory containing checkpoints  */
             if(numCheckpoints == 0)
             {
-                Environment<DIM>::get().Filesystem().createDirectoryWithPermissions(checkpointDirectory);
+                pmacc::Filesystem::get().createDirectoryWithPermissions(checkpointDirectory);
             }
 
             Environment<DIM>::get().PluginConnector().checkpointPlugins(currentStep, checkpointDirectory);


### PR DESCRIPTION
- remove dimension from the filesystem class
- remove Filesystem from pmacc::Environment<>

In the past, we thought that it was good to get access to all singletons from a single object, the Environment.
This introduces many issues, e.g. cyclic includes. Additionally, we templated all objects with the simulation dimension.

This PR removes the dimension from the Filesystem object and allows the creation of the filesystem singleton from everywhere.