### PR TITLE
Add ADK field ionization to FLYonPIC

### DIFF
--- a/include/picongpu/param/atomicPhysics.param
+++ b/include/picongpu/param/atomicPhysics.param
@@ -27,6 +27,7 @@
 #include "picongpu/particles/atomicPhysics/LinearApproximationProbability.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LogSpaceHistogram.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
 
 #include <cstdint>
@@ -109,5 +110,6 @@ namespace picongpu::atomicPhysics
         // T_autonomousIonization
         true,
         // T_fieldIonization
-        false>;
+        true,
+        picongpu::particles::atomicPhysics::enums::ADKLaserPolarization::linearPolarization>;
 } // namespace picongpu::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
+++ b/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
@@ -48,11 +48,11 @@
 #include "picongpu/particles/atomicPhysics/atomicData/CompareTransitionTuple.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/GetStateFromTransitionTuple.hpp"
 
-// enum of groups of processClass's
-#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
-// enum of transition ordering in dataBoxes
+// enums for configuration and meta description
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
 
 // debug only
@@ -84,7 +84,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
     namespace s_enums = picongpu::particles::atomicPhysics::enums;
     using ProcClassGroup = picongpu::particles::atomicPhysics::enums::ProcessClassGroup;
 
-    /** gathering of all atomicPhyiscs input data
+    /** gathering of all atomicPhysics input data
      *
      * @tparam T_Number dataType used for number storage, typically uint32_t
      * @tparam T_Value dataType used for value storage, typically float_X
@@ -143,6 +143,8 @@ namespace picongpu::particles::atomicPhysics::atomicData
      * Assumptions about input data are described in CheckTransitionTuple.hpp, ordering requirements of transitions in
      *  CompareTransitionTuple.hpp and all other requirements in the checkChargeStateList(), checkAtomicStateList() and
      *  checkTransitionsForEnergyInversion() methods.
+     *
+     * @todo add photonic channels, Brian Marre, 2022
      */
     template<
         typename T_Number,
@@ -155,7 +157,8 @@ namespace picongpu::particles::atomicPhysics::atomicData
         bool T_spontaneousDeexcitation,
         bool T_electronicIonization,
         bool T_autonomousIonization,
-        bool T_fieldIonization> /// @todo add photonic channels, Brian Marre, 2022
+        bool T_fieldIonization,
+        atomicPhysics::enums::ADKLaserPolarization T_ADKLaserPolarization>
     class AtomicData : public pmacc::ISimulationData
     {
     public:
@@ -172,6 +175,7 @@ namespace picongpu::particles::atomicPhysics::atomicData
         static constexpr bool switchElectronicIonization = T_electronicIonization;
         static constexpr bool switchAutonomousIonization = T_autonomousIonization;
         static constexpr bool switchFieldIonization = T_fieldIonization;
+        static constexpr s_enums::ADKLaserPolarization ADKLaserPolarization = T_ADKLaserPolarization;
 
         /// type shorthand definitions
         //@{

--- a/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
@@ -35,7 +35,7 @@
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicTuples.def"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp"
-#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeTransitionRates.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
 
 #include <pmacc/algorithms/math.hpp>
@@ -278,8 +278,8 @@ namespace picongpu::particles::atomicPhysics::debug
         ALPAKA_FN_HOST bool testCollisionalIonizationCrossSection()
         {
             float_X const correctCrossSection = 8.051678880120e-01; // 1e6b
-            float_X const crossSection
-                = rateCalculation::BoundFreeTransitionRates<T_n_max, true>::collisionalIonizationCrossSection(
+            float_X const crossSection = rateCalculation::BoundFreeCollisionalTransitionRates<T_n_max, true>::
+                collisionalIonizationCrossSection(
                     // eV
                     energyElectron,
                     // ionization potential depression, eV
@@ -359,16 +359,18 @@ namespace picongpu::particles::atomicPhysics::debug
             float_64 const correctRate = 1.507910098065e+14; // 1/s
             float_64 const rate
                 = static_cast<float_64>(
-                      rateCalculation::BoundFreeTransitionRates<T_n_max, true>::rateCollisionalIonizationTransition(
-                          energyElectron,
-                          energyElectronBinWidth,
-                          static_cast<float_X>(densityElectrons * pmacc::math::cPow(picongpu::sim.unit.length(), 3u)),
-                          // ionization potential depression
-                          0._X,
-                          0u,
-                          chargeStateBuffer->getHostDataBox(),
-                          atomicStateBuffer->getHostDataBox(),
-                          boundFreeBuffer->getHostDataBox()))
+                      rateCalculation::BoundFreeCollisionalTransitionRates<T_n_max, true>::
+                          rateCollisionalIonizationTransition(
+                              energyElectron,
+                              energyElectronBinWidth,
+                              static_cast<float_X>(
+                                  densityElectrons * pmacc::math::cPow(picongpu::sim.unit.length(), 3u)),
+                              // ionization potential depression
+                              0._X,
+                              0u,
+                              chargeStateBuffer->getHostDataBox(),
+                              atomicStateBuffer->getHostDataBox(),
+                              boundFreeBuffer->getHostDataBox()))
                 * 1. / sim.unit.time(); // 1/s
 
             return testRelativeError(

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/LogSpaceHistogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/LogSpaceHistogram.hpp
@@ -24,6 +24,7 @@
 
 #include "picongpu/simulation_defines.hpp" // need: picongpu/param/atomicPhysics_Debug.param
 
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/HistogramInterface.hpp"
 
 #include <pmacc/static_assert.hpp>

--- a/include/picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp
@@ -1,0 +1,49 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! @file ADKLaserPolarization, enum of laser polarization directions
+
+#pragma once
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics::enums
+{
+    enum struct ADKLaserPolarization
+    {
+        linearPolarization = 0,
+        circularPolarization = 1
+    };
+} // namespace picongpu::particles::atomicPhysics::enums
+
+namespace picongpu::particles::atomicPhysics
+{
+    template<enums::ADKLaserPolarization T_ADKLaserPolarization>
+    ALPAKA_FN_HOST std::string enumToString()
+    {
+        if constexpr(
+            static_cast<uint8_t>(T_ADKLaserPolarization)
+            == static_cast<uint8_t>(enums::ADKLaserPolarization::linearPolarization))
+            return "linear polarization";
+        if constexpr(
+            static_cast<uint8_t>(T_ADKLaserPolarization)
+            == static_cast<uint8_t>(enums::ADKLaserPolarization::circularPolarization))
+            return "circular polarization";
+    }
+} // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp
@@ -56,7 +56,7 @@ namespace picongpu::particles::atomicPhysics::enums
         noChange, // = 5
         FINAL_NUMBER_ENTRIES // = 6
     };
-    constexpr uint32_t numberChooseTransitionGroups = u32(ChooseTransitionGroup::FINAL_NUMBER_BY_STATE_GROUPS);
+    constexpr uint32_t numberChooseTransitionGroups = u32(ChooseTransitionGroup::FINAL_NUMBER_ENTRIES);
 } // namespace picongpu::particles::atomicPhysics::enums
 
 namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp
@@ -39,6 +39,9 @@ namespace picongpu::particles::atomicPhysics::enums
 {
     /** enum of used ChooseTransitionGroups
      *
+     * for every entry before FINAL_NUMBER_DATE_CACHE_DATA_SETS the rate cache will have one per state rate data set,
+     *  while everything after excluding the second last entry will, get one entry for all states.
+     *
      * @attention noChange must always be second last entry!
      * @attention do not use custom values here, ChooseTransitionGroupKernel logic depends on continuous value
      * assignment starting at 0!
@@ -47,13 +50,13 @@ namespace picongpu::particles::atomicPhysics::enums
     {
         boundBoundUpward, // = 0
         boundBoundDownward, // = 1
-        boundFreeUpward, // = 2
+        collisionalBoundFreeUpward, // = 2
         autonomousDownward, // = 3
-        noChange, // = 4
-        FINAL_NUMBER_ENTRIES // = 5
+        fieldBoundFreeUpward, // = 4
+        noChange, // = 5
+        FINAL_NUMBER_ENTRIES // = 6
     };
-    constexpr uint32_t numberChooseTransitionGroups = u32(ChooseTransitionGroup::FINAL_NUMBER_ENTRIES);
-
+    constexpr uint32_t numberChooseTransitionGroups = u32(ChooseTransitionGroup::FINAL_NUMBER_BY_STATE_GROUPS);
 } // namespace picongpu::particles::atomicPhysics::enums
 
 namespace picongpu::particles::atomicPhysics
@@ -65,8 +68,10 @@ namespace picongpu::particles::atomicPhysics
             return "bound-bound(upward)";
         if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::boundBoundDownward))
             return "bound-bound(downward)";
-        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::boundFreeUpward))
-            return "bound-free(upward)";
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::collisionalBoundFreeUpward))
+            return "collisional bound-free(upward)";
+        if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::fieldBoundFreeUpward))
+            return "field bound-free(upward)";
         if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::autonomousDownward))
             return "autonomous(downward)";
         if constexpr(u32(T_ChooseTransitionGroup) == u32(enums::ChooseTransitionGroup::noChange))

--- a/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroupFor.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroupFor.hpp
@@ -45,12 +45,7 @@ namespace picongpu::particles::atomicPhysics::enums
         static constexpr ChooseTransitionGroup chooseTransitionGroup = ChooseTransitionGroup::boundBoundDownward;
     };
 
-    //! bound-free(upward)
-    template<>
-    struct ChooseTransitionGroupFor<TransitionType::boundFree, TransitionDirection::upward>
-    {
-        static constexpr ChooseTransitionGroup chooseTransitionGroup = ChooseTransitionGroup::boundFreeUpward;
-    };
+    //! bound-free(upward) may be either collisionalBoundFreeUpward or fieldBoundFreeUpward -> error to ask
 
     //! autonomous(downward)
     template<>

--- a/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroupFor.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/ChooseTransitionGroupFor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Brian Marre
+/* Copyright 2023-2024 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -17,7 +17,15 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! @file get ChooseTransitionGroup from TransitionDirection and TransitionType
+/** @file get ChooseTransitionGroup token from TransitionDirection token and TransitionType token
+ *
+ * File contains one specialisation of ChooseTransitionGroupFor for every combination of TransitionType and
+ *  TransitionDirection, giving access to the corresponding ChooseTransitionGroup,
+ *
+ * @attention no ChooseTransitionGroupFor specialization exists for **bound-free(upward)**, since the
+ *  ChooseTransitionGroup for bound-free(upward) may be either collisionalBoundFreeUpward or fieldBoundFreeUpward and
+ *  therefore no single ChooseTransitionGroup may be defined.
+ */
 
 #pragma once
 
@@ -44,8 +52,6 @@ namespace picongpu::particles::atomicPhysics::enums
     {
         static constexpr ChooseTransitionGroup chooseTransitionGroup = ChooseTransitionGroup::boundBoundDownward;
     };
-
-    //! bound-free(upward) may be either collisionalBoundFreeUpward or fieldBoundFreeUpward -> error to ask
 
     //! autonomous(downward)
     template<>

--- a/include/picongpu/particles/atomicPhysics/enums/LastResortProcessClass.hpp
+++ b/include/picongpu/particles/atomicPhysics/enums/LastResortProcessClass.hpp
@@ -56,7 +56,7 @@ namespace picongpu::particles::atomicPhysics::enums
     };
 
     template<>
-    struct LastResort<ChooseTransitionGroup::boundFreeUpward>
+    struct LastResort<ChooseTransitionGroup::collisionalBoundFreeUpward>
     {
         static constexpr uint8_t processClass()
         {

--- a/include/picongpu/particles/atomicPhysics/initElectrons/InitIonizationElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/initElectrons/InitIonizationElectrons.hpp
@@ -59,7 +59,7 @@ namespace picongpu::particles::atomicPhysics::initElectrons
             T_DataBox const... dataBoxes) const;
     };
 
-    /** specialisation for electronicIonization
+    /** specialisation for electronic collisional ionization
      *
      * @attention not momentum conserving! We do not model a three body inelastic
      *  collision, since interacting free electron momentum vector is unknown without
@@ -78,7 +78,29 @@ namespace picongpu::particles::atomicPhysics::initElectrons
             T_ElectronParticle& electron,
             IdGenerator& idGen) const
         {
-            /// @todo sample three body inelastic collision for ionization, Brian Marre, 2023
+            CoMoving::initElectron(worker, ion, electron, idGen);
+        }
+    };
+
+    /** specialisation for field ionization
+     *
+     * @attention not momentum conserving! We do not model a three body inelastic
+     *  collision, since interacting free electron momentum vector is unknown without
+     *  binary pairing
+     *
+     * @todo implement three body inelastic collision, Brian Marre, 2023
+     */
+    template<>
+    struct InitIonizationElectron<s_enums::ProcessClass::fieldIonization>
+    {
+        //! call operator
+        template<typename T_Worker, typename T_IonParticle, typename T_ElectronParticle>
+        HDINLINE void operator()(
+            T_Worker const& worker,
+            T_IonParticle& ion,
+            T_ElectronParticle& electron,
+            IdGenerator& idGen) const
+        {
             CoMoving::initElectron(worker, ion, electron, idGen);
         }
     };

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
@@ -30,7 +30,6 @@
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Electron.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Ion.hpp"
-#include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundFree.kernel"
 #include "picongpu/particles/atomicPhysics/localHelperFields/LocalFoundUnboundIonField.hpp"
 
 #include <pmacc/meta/ForEach.hpp>

--- a/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
@@ -80,6 +80,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
 
+            /// @todo switch to shared memory reduce, Brian Marre, 2024
             forEachAtomicState(
                 [&](uint32_t const atomicStateCollectionIndex)
                 {

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2023 Brian Marre
+/* Copyright 2023-2024 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -21,8 +21,11 @@
 
 #pragma once
 
+#include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
+#include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
+#include "picongpu/particles/shapes.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
@@ -35,15 +38,18 @@ namespace picongpu::particles::atomicPhysics::kernel
     /** choose transitionType
      *
      * @tparam T_RateCache dataType if RateCache
+     * @tparam T_IPDModel ionization potential depression model to use
      * @tparam T_electronicExcitation is channel active?
      * @tparam T_electronicDeexcitation is channel active?
      * @tparam T_spontaneousDeexcitation is channel active?
      * @tparam T_autonomousIonization is channel active?
-     * @tparam T_electonicIonization is channel active?
+     * @tparam T_electronicIonization is channel active?
      * @tparam T_fieldIonization is channel active?
      */
     template<
         typename T_RateCache,
+        typename T_IPDModel,
+        uint8_t T_numberLevels,
         bool T_electronicExcitation,
         bool T_electronicDeexcitation,
         bool T_spontaneousDeexcitation,
@@ -59,7 +65,7 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @returns true if active, false otherwise
          */
-        HDINLINE static constexpr bool transitionTypeActive(uint32_t const transitionTypeIndex)
+        static constexpr bool transitionTypeActive(uint32_t const transitionTypeIndex)
         {
             if(transitionTypeIndex == u32(s_enums::ChooseTransitionGroup::noChange))
                 return true;
@@ -69,8 +75,11 @@ namespace picongpu::particles::atomicPhysics::kernel
             if constexpr(T_electronicDeexcitation || T_spontaneousDeexcitation)
                 if(transitionTypeIndex == u32(s_enums::ChooseTransitionGroup::boundBoundDownward))
                     return true;
-            if constexpr(T_electronicIonization || T_fieldIonization)
-                if(transitionTypeIndex == u32(s_enums::ChooseTransitionGroup::boundFreeUpward))
+            if constexpr(T_electronicIonization)
+                if(transitionTypeIndex == u32(s_enums::ChooseTransitionGroup::collisionalBoundFreeUpward))
+                    return true;
+            if constexpr(T_fieldIonization)
+                if(transitionTypeIndex == u32(s_enums::ChooseTransitionGroup::fieldBoundFreeUpward))
                     return true;
             if constexpr(T_autonomousIonization)
                 if(transitionTypeIndex == u32(s_enums::ChooseTransitionGroup::autonomousDownward))
@@ -129,37 +138,56 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_RateCache& rateCache = localRateCacheBox(superCellFieldIdx);
             auto rngGenerator = rngFactoryFloat(worker, superCellFieldIdx);
 
+            float_X const ionizationPotentialDepression
+                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
+                    superCellFieldIdx,
+                    ipdInput...);
+
             // choose transition type randomly
             forEachLocalIonBoxEntry(
-                [&rngGenerator, &rateCache, &timeStep](T_Worker const& worker, auto& ion)
+                [&rngGenerator,
+                 &rateCache,
+                 &timeStep,
+                 &ionizationPotentialDepression,
+                 &chargeStateDataDataBox,
+                 &atomicStateDataDataBox,
+                 &numberTransitionsDataBox,
+                 &startIndexDataBox,
+                 &boundFreeTransitionDataBox](T_Worker const& worker, auto& ion)
                 {
                     constexpr uint32_t numberRateCacheTransitionTypes = T_RateCache::numberStoredDataSets;
 
                     if(ion[accepted_])
                         return;
-                    auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
 
                     float_X const r = rngGenerator();
 
+                    auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
+
+                    // per dataSet transition rates
                     /// @todo change to compile time loop, Brian Marre, 2023
                     float_X cumSum = 0._X;
-                    for(uint32_t transitionTypeID = 0u; transitionTypeID < numberRateCacheTransitionTypes;
-                        ++transitionTypeID)
+                    for(uint32_t chooseTransitionGroupID = 0u;
+                        chooseTransitionGroupID < numberRateCacheTransitionTypes;
+                        ++chooseTransitionGroupID)
                     {
                         // check whether user activated at least one process from the transitionType
-                        if(transitionTypeActive(transitionTypeID))
+                        /// @todo convert to compile time for loop?, Brian Marre, 2024
+                        if(transitionTypeActive(chooseTransitionGroupID))
                         {
-                            cumSum += timeStep * rateCache.rate(transitionTypeID, atomicStateCollectionIndex);
+                            cumSum += timeStep * rateCache.rate(chooseTransitionGroupID, atomicStateCollectionIndex);
                             if(r < cumSum)
                             {
                                 // only in between storage
-                                ion[transitionIndex_] = transitionTypeID;
+                                ion[transitionIndex_] = chooseTransitionGroupID;
                                 break;
                             }
                         }
                     }
+
                     // noChange transition as last resort transition, never stored in RateCache
-                    if(r >= cumSum) // and <= 1
+                    /// @todo test for no change first, since with default setting ~90% will take this branch anyway
+                    if(r >= cumSum) // and <= 1 by definition of timeStep
                     {
                         ion[processClass_] = u8(s_enums::ProcessClass::noChange);
                         // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
@@ -38,7 +38,6 @@ namespace picongpu::particles::atomicPhysics::kernel
     /** choose transitionType
      *
      * @tparam T_RateCache dataType if RateCache
-     * @tparam T_IPDModel ionization potential depression model to use
      * @tparam T_electronicExcitation is channel active?
      * @tparam T_electronicDeexcitation is channel active?
      * @tparam T_spontaneousDeexcitation is channel active?
@@ -48,8 +47,6 @@ namespace picongpu::particles::atomicPhysics::kernel
      */
     template<
         typename T_RateCache,
-        typename T_IPDModel,
-        uint8_t T_numberLevels,
         bool T_electronicExcitation,
         bool T_electronicDeexcitation,
         bool T_spontaneousDeexcitation,
@@ -138,22 +135,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_RateCache& rateCache = localRateCacheBox(superCellFieldIdx);
             auto rngGenerator = rngFactoryFloat(worker, superCellFieldIdx);
 
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
-
             // choose transition type randomly
             forEachLocalIonBoxEntry(
-                [&rngGenerator,
-                 &rateCache,
-                 &timeStep,
-                 &ionizationPotentialDepression,
-                 &chargeStateDataDataBox,
-                 &atomicStateDataDataBox,
-                 &numberTransitionsDataBox,
-                 &startIndexDataBox,
-                 &boundFreeTransitionDataBox](T_Worker const& worker, auto& ion)
+                [&rngGenerator, &rateCache, &timeStep](T_Worker const& worker, auto& ion)
                 {
                     constexpr uint32_t numberRateCacheTransitionTypes = T_RateCache::numberStoredDataSets;
 
@@ -179,6 +163,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                             if(r < cumSum)
                             {
                                 // only in between storage
+                                // printf("ID: %lu, %i\n", ion[particleId_], chooseTransitionGroupID);
                                 ion[transitionIndex_] = chooseTransitionGroupID;
                                 break;
                             }
@@ -189,6 +174,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     /// @todo test for no change first, since with default setting ~90% will take this branch anyway
                     if(r >= cumSum) // and <= 1 by definition of timeStep
                     {
+                        // printf("ID: %lu, %i\n", ion[particleId_], u32(s_enums::ProcessClass::noChange));
                         ion[processClass_] = u8(s_enums::ProcessClass::noChange);
                         // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
                         //  and accepted_ = true prevents it being worked on by ChooseTransitionKernels

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
@@ -170,11 +170,11 @@ namespace picongpu::particles::atomicPhysics::kernel
                         }
                     }
 
-                    // noChange transition as last resort transition, never stored in RateCache
                     /// @todo test for no change first, since with default setting ~90% will take this branch anyway
-                    if(r >= cumSum) // and <= 1 by definition of timeStep
+                    // noChange transition as last resort transition, never stored in RateCache
+                    // definition of time step guarantees that cumSum is always <= 1
+                    if(r >= cumSum)
                     {
-                        // printf("ID: %lu, %i\n", ion[particleId_], u32(s_enums::ProcessClass::noChange));
                         ion[processClass_] = u8(s_enums::ProcessClass::noChange);
                         // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
                         //  and accepted_ = true prevents it being worked on by ChooseTransitionKernels

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
@@ -29,7 +29,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
-#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeTransitionRates.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/static_assert.hpp>
@@ -40,7 +40,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 {
     namespace s_enums = picongpu::particles::atomicPhysics::enums;
 
-    /** choose specific transition from previously selected transitionType for bound-free transitions
+    /** choose specific transition from previously selected transitionType for bound-free collisional transitions
      *
      * A transition is selected by rolling a random number r, [0,1) and comparing it to the cumulative sums of the
      *  normalized rates of the physical transitions of the transitionType.
@@ -49,17 +49,34 @@ namespace picongpu::particles::atomicPhysics::kernel
      * @tparam T_Histogram type of the histogram
      * @tparam T_n_max number of levels of atomic states in input
      * @tparam T_IPDModel ionization potential depression model to use
-     * @tparam T_electronicIonization is channel active?
-     * @tparam T_fieldIonization is channel active?
      */
-    template<
-        typename T_Histogram,
-        uint8_t T_n_max,
-        typename T_IPDModel,
-        bool T_electronicIonization,
-        bool T_fieldIonization>
-    struct ChooseTransitionKernel_BoundFree
+    template<typename T_Histogram, uint8_t T_n_max, typename T_IPDModel>
+    struct ChooseTransitionKernel_CollisionalBoundFree
     {
+        template<
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool checkCorrectAtomicDataBoxesPassed()
+        {
+            PMACC_CASSERT_MSG(
+                number_transition_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                boundFreeTransitiondataBox_not_bound_free_based,
+                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                wrong_transition_ordering_boundFreeTransitionDataBox,
+                u8(T_BoundFreeTransitionDataBox::transitionOrdering)
+                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::upward>::ordering));
+            return true;
+        }
+
         /** call operator
          *
          * called by ChooseTransition atomic physics sub-stage
@@ -68,17 +85,22 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
          * @param rngFactoryFloat factory for uniformly distributed random number generator, for float_X [0,1)
+         * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
+         * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
+         * @param numberTransitionsBox deviceDataBox giving access to the number of
+         *  bound-free transitions for each atomic state
+         * @param startIndexBox deviceDataBox giving access to the start index of each
+         *  bound-free transitions for each atomic state
+         * @param transitionDataBox deviceDataBox giving access to bound-free transition data
          * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
          * @param localElectronHistogramDataBox deviceDataBox giving access to the local
          *  electron histograms of all local superCells
-         * @param numberTransitionsBox deviceDataBox giving access to the number of
-         *  bound-free transitions for each atomic state
-         * @param startIndexBox deviceDataBox giving access to the start index of each
-         * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
-         * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
-         * @param boundFreeTransitionDataBox deviceDataBox giving access to bound free transition data
+         * @param localRateCacheBox deviceDataBox giving access to the sum of all transitions rates for each
+         *  chooseTransitionGroup cache previously filled by the FillLocalRateCache sub-stage
          * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
+         * @param ipdInput everything required by T_IPDModel to calculate the IonizationPotentialDepression,
+         *  passed by T_IPDModel::callKernelWithIPDInput
          */
         template<
             typename T_Worker,
@@ -109,22 +131,10 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_IonBox ionBox,
             T_IPDInput const... ipdInput) const
         {
-            // check that correct databoxes are given
-            PMACC_CASSERT_MSG(
-                number_transition_dataBox_not_bound_free_based,
-                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
-                    == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
-                    == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                boundFreeTransitiondataBox_not_bound_free_based,
-                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                wrong_transition_ordering_boundFreeTransitionDataBox,
-                u8(T_BoundFreeTransitionDataBox::transitionOrdering)
-                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::upward>::ordering));
+            PMACC_CASSERT(checkCorrectAtomicDataBoxesPassed<
+                          T_AtomicStateBoundFreeStartIndexBlockDataBox,
+                          T_AtomicStateBoundFreeNumberTransitionsDataBox,
+                          T_BoundFreeTransitionDataBox>());
 
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
@@ -155,8 +165,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     superCellFieldIdx,
                     ipdInput...);
 
-            // check whether bound-free transition and if yes,
-            //      roll specific transition and bin
+            // check whether collisional bound-free transition and if yes, roll specific transition and bin
             forEachLocalIonBoxEntry(
                 [&rngGeneratorFloat,
                  &chargeStateDataDataBox,
@@ -172,9 +181,9 @@ namespace picongpu::particles::atomicPhysics::kernel
                     checkForInvalidChooseTransitionGroup(ion);
 
                     // reject already accepted macro-ions and other transitionTypes
-                    bool const selectedBoundFreeUpwardTransition
-                        = (ion[transitionIndex_] == u32(s_enums::ChooseTransitionGroup::boundFreeUpward));
-                    if(ion[accepted_] || !selectedBoundFreeUpwardTransition)
+                    bool const selectedCollisionalBoundFreeUpwardTransition
+                        = (ion[transitionIndex_] == u32(s_enums::ChooseTransitionGroup::collisionalBoundFreeUpward));
+                    if(ion[accepted_] || !selectedCollisionalBoundFreeUpwardTransition)
                         return;
 
                     auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
@@ -192,16 +201,16 @@ namespace picongpu::particles::atomicPhysics::kernel
                     constexpr uint32_t numberBins = T_Histogram::numberBins;
 
                     float_X cumSum = 0._X;
-                    // electronic Ionization
-                    if constexpr(T_electronicIonization)
+                    for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
                     {
-                        for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
+                        uint32_t const transitionIndex = transitionID + startIndexTransitionBlock;
+
+                        for(uint32_t binIndex = 0u; binIndex < numberBins; ++binIndex)
                         {
-                            for(uint32_t binIndex = 0u; binIndex < numberBins; ++binIndex)
-                            {
-                                // 1/sim.unit.time()
-                                float_X const rateTransition = picongpu::particles::atomicPhysics::rateCalculation::
-                                    BoundFreeTransitionRates<T_n_max>::template rateCollisionalIonizationTransition<
+                            // 1/sim.unit.time()
+                            float_X const rateTransition = picongpu::particles::atomicPhysics::rateCalculation::
+                                BoundFreeCollisionalTransitionRates<T_n_max>::
+                                    template rateCollisionalIonizationTransition<
                                         T_ChargeStateDataDataBox,
                                         T_AtomicStateDataDataBox,
                                         T_BoundFreeTransitionDataBox>(
@@ -209,36 +218,32 @@ namespace picongpu::particles::atomicPhysics::kernel
                                         cachedHistogram.binWidth[binIndex],
                                         cachedHistogram.density[binIndex],
                                         ionizationPotentialDepression,
-                                        transitionID + startIndexTransitionBlock,
+                                        transitionIndex,
                                         chargeStateDataDataBox,
                                         atomicStateDataDataBox,
                                         transitionDataBox);
 
-                                cumSum += rateTransition
-                                    / rateCache.rate(
-                                        u32(s_enums::ChooseTransitionGroup::boundFreeUpward),
-                                        atomicStateCollectionIndex);
+                            cumSum += rateTransition
+                                / rateCache.rate(
+                                    u32(s_enums::ChooseTransitionGroup::collisionalBoundFreeUpward),
+                                    atomicStateCollectionIndex);
 
-                                // inclusive limit, to make sure that r==1 is assigned a transition
-                                if(r <= cumSum)
-                                {
-                                    // found chosen transition
-                                    updateIon(
-                                        ion,
-                                        u8(picongpu::particles::atomicPhysics::enums::ProcessClass::
-                                               electronicIonization),
-                                        transitionID + startIndexTransitionBlock,
-                                        binIndex);
-                                    return;
-                                }
+                            // inclusive limit, to make sure that r==1 is assigned a transition
+                            if(r <= cumSum)
+                            {
+                                // found chosen transition
+                                updateIon(
+                                    ion,
+                                    u8(picongpu::particles::atomicPhysics::enums::ProcessClass::electronicIonization),
+                                    transitionIndex,
+                                    binIndex);
+                                return;
                             }
                         }
                     }
-                    // field ionization
-                    /// @todo filed ionization, Brian Marre, 2023
-                    // down-ward bound-free transition
-                    /// @todo implement recombination, Brian Marre, 2023
 
+                    /// @todo not calculate the last transitions rate, instead directly skip to last resort, Brian
+                    /// Marre, 2024
                     // select last resort, choose last possible transition
                     updateIon(
                         ion,
@@ -248,6 +253,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 });
         }
 
+        //! update ion with selected transition data
         template<typename T_Ion>
         HDINLINE static void updateIon(
             T_Ion& ion,

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -1,0 +1,264 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp"
+
+#include "picongpu/particles/atomicPhysics/CheckForInvalidChooseTransitionGroup.hpp"
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
+#include "picongpu/traits/FieldPosition.hpp"
+
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
+#include <pmacc/static_assert.hpp>
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics::kernel
+{
+    namespace s_enums = picongpu::particles::atomicPhysics::enums;
+
+    /** choose specific transition from previously selected transitionType for bound-free field transitions
+     *
+     * A transition is selected by rolling a random number r, [0,1) and comparing it to the cumulative sums of the
+     *  normalized rates of the physical transitions of the transitionType.
+     * The transition corresponding to the interval containing r is the chosen and accepted.
+     *
+     * @tparam T_ADKLaserPolarization polarization direction to use in the ADK rate calculation
+     * @tparam T_EField type of EField
+     * @tparam T_n_max number of levels of atomic states in input
+     * @tparam T_IPDModel ionization potential depression model to use
+     */
+    template<
+        s_enums::ADKLaserPolarization T_ADKLaserPolarization,
+        typename T_EField,
+        uint8_t T_n_max,
+        typename T_IPDModel>
+    struct ChooseTransitionKernel_FieldBoundFree
+    {
+        template<
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool checkCorrectAtomicDataBoxesPassed()
+        {
+            PMACC_CASSERT_MSG(
+                number_transition_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                boundFreeTransitiondataBox_not_bound_free_based,
+                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                wrong_transition_ordering_boundFreeTransitionDataBox,
+                u8(T_BoundFreeTransitionDataBox::transitionOrdering)
+                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::upward>::ordering));
+            return true;
+        }
+
+        /** call operator
+         *
+         * called by ChooseTransition atomic physics sub-stage
+         *
+         * @param worker object containing the device and block
+         *  information, passed by PMACC_KERNEL call
+         * @param areMapping mapping of blockIndex to block superCell index
+         * @param rngFactoryFloat factory for uniformly distributed random number generator, for float_X [0,1)
+         * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
+         * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
+         * @param boundFreeTransitionDataBox deviceDataBox giving access to bound free transition data
+         * @param numberTransitionsBox deviceDataBox giving access to the number of
+         *  bound-free transitions for each atomic state
+         * @param startIndexBox deviceDataBox giving access to the start index of each
+         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
+         * @param eFieldBox deviceDataBox giving access to the device local eField Values
+         * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
+         * @param ipdInput everything required by T_IPDModel to calculate the IonizationPotentialDepression,
+         *  passed by T_IPDModel::callKernelWithIPDInput
+         */
+        template<
+            typename T_Worker,
+            typename T_AreaMapping,
+            typename T_RngGeneratorFactoryFloat,
+            typename T_ChargeStateDataDataBox,
+            typename T_AtomicStateDataDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_BoundFreeTransitionDataBox,
+            typename T_LocalTimeRemainingBox,
+            typename T_LocalRateCacheBox,
+            typename T_IonBox,
+            typename... T_IPDInput>
+        HDINLINE void operator()(
+            T_Worker const& worker,
+            T_AreaMapping const areaMapping,
+            T_RngGeneratorFactoryFloat rngFactoryFloat,
+            T_ChargeStateDataDataBox const chargeStateDataDataBox,
+            T_AtomicStateDataDataBox const atomicStateDataDataBox,
+            T_AtomicStateBoundFreeNumberTransitionsDataBox const numberTransitionsBox,
+            T_AtomicStateBoundFreeStartIndexBlockDataBox const startIndexBox,
+            T_BoundFreeTransitionDataBox const transitionDataBox,
+            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_EFieldBox const eFieldBox,
+            T_LocalRateCacheBox localRateCacheBox,
+            T_IonBox ionBox,
+            T_IPDInput const... ipdInput) const
+        {
+            PMACC_CASSERT(checkCorrectAtomicDataBoxesPassed<
+                          T_AtomicStateBoundFreeStartIndexBlockDataBox,
+                          T_AtomicStateBoundFreeNumberTransitionsDataBox,
+                          T_BoundFreeTransitionDataBox>());
+
+            pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
+            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
+            //  -> must subtract guard to get correct superCellFieldIdx
+            pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
+                = superCellIdx - areaMapping.getGuardingSuperCells();
+
+            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
+
+            // end kernel if superCell already finished or no particles
+            if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
+                return;
+
+            auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
+            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+
+            // FLYonPIC superCells must be independent therefore we need to use a support 1 particle shape
+            using Field2Particle
+                = FieldToParticleInterpolation<particles::shape::Counter, AssignedTrilinearInterpolation>;
+            using Margin = GetMargin<Field2Particle>;
+            using BlockArea
+                = SuperCellDescription<typename picongpu::SuperCellSize, Margin::LowerMargin, Margin::UpperMargin>;
+
+            /// create E-Field cache, @note is unique for kernel call by id and dataType, and thereby shared between
+            /// workers
+            DataBox<SharedBox<T_EField::ValueType, typename BlockArea::FullSuperCellSize, 0u>> eFieldCache
+                = CachedBox::create<0u, T_EField::ValueType>(worker, BlockArea());
+
+            // init E-Field cache
+            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
+            auto fieldEBlockToCache = eBox.shift(superCellCellOffset);
+            pmacc::math::operation::Assign assign;
+            collective(worker, assign, eFieldCache, fieldEBlockToCache);
+
+            // wait for init to finish
+            worker.sync();
+
+            float_X const ionizationPotentialDepression
+                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
+                    superCellFieldIdx,
+                    ipdInput...);
+
+            // check whether field bound-free transition and if yes, roll specific transition
+            forEachLocalIonBoxEntry(
+                [&rngGeneratorFloat,
+                 &chargeStateDataDataBox,
+                 &atomicStateDataDataBox,
+                 &numberTransitionsBox,
+                 &startIndexBox,
+                 &transitionDataBox,
+                 &eFieldCache,
+                 &rateCache,
+                 &ionizationPotentialDepression](T_Worker const& worker, auto& ion)
+                {
+                    // debug
+                    checkForInvalidChooseTransitionGroup(ion);
+
+                    // reject already accepted macro-ions and other transitionTypes
+                    bool const selectedFieldBoundFreeUpwardTransition
+                        = (ion[transitionIndex_] == u32(s_enums::ChooseTransitionGroup::fieldBoundFreeUpward));
+                    if(ion[accepted_] || !selectedFieldBoundFreeUpwardTransition)
+                        return;
+
+                    auto const ionPosition = ion[position_];
+                    auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
+
+                    DataSpace<picongpu::SuperCellSize::dim> const localCell
+                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), particle[localCellIdx_]);
+                    auto const fieldPosE = picongpu::traits::FieldPosition<fields::CellType, FieldE>();
+                    float_X const eFieldNormAtParticle = pmacc::math::l2norm(
+                        Field2Particle()(eFieldCache.shift(localCell), ionPosition, fieldPosE()));
+
+                    // get possible transitions' collectionIndices
+                    uint32_t const numberTransitions
+                        = numberTransitionsBox.numberOfTransitionsUp(atomicStateCollectionIndex);
+                    uint32_t const startIndexTransitionBlock
+                        = startIndexBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
+
+                    // get random number
+                    float_X const r = rngGeneratorFloat();
+
+                    float_X cumSum = 0._X;
+                    for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
+                    {
+                        uint32_t const transitionIndex = transitionID + startIndexTransitionBlock;
+
+                        // 1/picongpu::sim.unit.time()
+                        sumRateTransitions += atomicPhysics::rateCalculation::
+                            BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
+                                eFieldNormAtParticle,
+                                ionizationPotentialDepression,
+                                transitionCollectionIndex,
+                                chargeStateDataDataBox,
+                                atomicStateDataDataBox,
+                                boundFreeTransitionDataBox);
+
+                        cumSum += rateTransition
+                            / rateCache.rate(
+                                u32(s_enums::ChooseTransitionGroup::fieldBoundFreeUpward),
+                                atomicStateCollectionIndex);
+
+                        // inclusive limit, to make sure that r==1 is assigned a transition
+                        if(r <= cumSum)
+                        {
+                            // found chosen transition
+                            ion[processClass_] = u8(s_enums::ProcessClass::fieldIonization);
+                            ion[transitionIndex_] = transitionIndex;
+                            // field ionizations are not bin based therefore we do not set a bin, and old values are
+                            // ignored
+                            ion[accepted_] = true;
+                            return;
+                        }
+                    }
+
+                    /* particle position maximum rate below superCell maximum -> need to do noChange Transition for
+                     *  correct division into other channels.
+                     */
+                    ion[processClass_] = u8(s_enums::ProcessClass::noChange);
+                    // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
+                    //  and accepted_ = true prevents it being worked on by ChooseTransitionKernels
+                    ion[accepted_] = true;
+                });
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -30,7 +30,9 @@
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 #include "picongpu/traits/FieldPosition.hpp"
+#include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/static_assert.hpp>
@@ -114,6 +116,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
             typename T_BoundFreeTransitionDataBox,
             typename T_LocalTimeRemainingBox,
+            typename T_EFieldBox,
             typename T_LocalRateCacheBox,
             typename T_IonBox,
             typename... T_IPDInput>
@@ -155,20 +158,22 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             // FLYonPIC superCells must be independent therefore we need to use a support 1 particle shape
             using Field2Particle
-                = FieldToParticleInterpolation<particles::shape::Counter, AssignedTrilinearInterpolation>;
+                = FieldToParticleInterpolation<particles::shapes::CIC, AssignedTrilinearInterpolation>;
             using Margin = GetMargin<Field2Particle>;
             using BlockArea
                 = SuperCellDescription<typename picongpu::SuperCellSize, Margin::LowerMargin, Margin::UpperMargin>;
 
             /// create E-Field cache, @note is unique for kernel call by id and dataType, and thereby shared between
             /// workers
-            DataBox<SharedBox<T_EField::ValueType, typename BlockArea::FullSuperCellSize, 0u>> eFieldCache
-                = CachedBox::create<0u, T_EField::ValueType>(worker, BlockArea());
+            DataBox<SharedBox<typename T_EField::ValueType, typename BlockArea::FullSuperCellSize, 0u>> eFieldCache
+                = CachedBox::create<0u, typename T_EField::ValueType>(worker, BlockArea());
 
             // init E-Field cache
-            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
-            auto fieldEBlockToCache = eBox.shift(superCellCellOffset);
+            auto const superCellSize = picongpu::SuperCellSize::toRT();
+            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * superCellSize;
+            auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
             pmacc::math::operation::Assign assign;
+            auto collective = makeThreadCollective<BlockArea>();
             collective(worker, assign, eFieldCache, fieldEBlockToCache);
 
             // wait for init to finish
@@ -179,9 +184,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     superCellFieldIdx,
                     ipdInput...);
 
+            auto const fieldPosE = picongpu::traits::FieldPosition<fields::YeeCell, FieldE>();
+
             // check whether field bound-free transition and if yes, roll specific transition
             forEachLocalIonBoxEntry(
-                [&rngGeneratorFloat,
+                [&superCellSize,
+                 &fieldPosE,
+                 &rngGeneratorFloat,
                  &chargeStateDataDataBox,
                  &atomicStateDataDataBox,
                  &numberTransitionsBox,
@@ -204,8 +213,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
 
                     DataSpace<picongpu::SuperCellSize::dim> const localCell
-                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), particle[localCellIdx_]);
-                    auto const fieldPosE = picongpu::traits::FieldPosition<fields::CellType, FieldE>();
+                        = pmacc::math::mapToND(superCellSize, static_cast<int>(ion[localCellIdx_]));
                     float_X const eFieldNormAtParticle = pmacc::math::l2norm(
                         Field2Particle()(eFieldCache.shift(localCell), ionPosition, fieldPosE()));
 
@@ -221,17 +229,17 @@ namespace picongpu::particles::atomicPhysics::kernel
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
                     {
-                        uint32_t const transitionIndex = transitionID + startIndexTransitionBlock;
+                        uint32_t const transitionCollectionIndex = transitionID + startIndexTransitionBlock;
 
                         // 1/picongpu::sim.unit.time()
-                        sumRateTransitions += atomicPhysics::rateCalculation::
+                        float_X const rateTransition = atomicPhysics::rateCalculation::
                             BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
                                 eFieldNormAtParticle,
                                 ionizationPotentialDepression,
                                 transitionCollectionIndex,
                                 chargeStateDataDataBox,
                                 atomicStateDataDataBox,
-                                boundFreeTransitionDataBox);
+                                transitionDataBox);
 
                         cumSum += rateTransition
                             / rateCache.rate(
@@ -243,7 +251,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         {
                             // found chosen transition
                             ion[processClass_] = u8(s_enums::ProcessClass::fieldIonization);
-                            ion[transitionIndex_] = transitionIndex;
+                            ion[transitionIndex_] = transitionCollectionIndex;
                             // field ionizations are not bin based therefore we do not set a bin, and old values are
                             // ignored
                             ion[accepted_] = true;

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -123,7 +123,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             auto& histogram = localElectronHistogramDataBox(superCellFieldIdx);
 
-            // UNIT_LENGTH^3
+            // picongpu::sim.unit.length()^3
             constexpr float_X volumeScalingFactor
                 = pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value * picongpu::CELL_VOLUME;
 

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -19,9 +19,8 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
-// need unit.param, sim.unit.length() for normalisation and memory.param for SuperCellSize, simDim from dim.param
-
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/CachedHistogram.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
@@ -102,6 +101,7 @@ namespace picongpu::particles::atomicPhysics::kernel
         template<
             typename T_Worker,
             typename T_RateCache,
+            typename T_LocalElectronHistogramDataBox,
             typename T_ChargeStateDataDataBox,
             typename T_AtomicStateDataDataBox,
             typename T_AtomicStateStartIndexBox,
@@ -111,9 +111,10 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_Worker const& worker,
             pmacc::DataSpace<picongpu::simDim> superCellFieldIdx,
             T_RateCache& rateCache,
+            T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
             T_AtomicStateDataDataBox const atomicStateDataDataBox,
-            T_AtomicStateStartIndexBox const startIndexBlockTransitionsUp,
+            T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
             float_X const ionizationPotentialDepression)
@@ -124,8 +125,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto& histogram = localElectronHistogramDataBox(superCellFieldIdx);
 
             // picongpu::sim.unit.length()^3
-            constexpr float_X volumeScalingFactor
-                = pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value * picongpu::CELL_VOLUME;
+            constexpr float_X volumeScalingFactor = pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value
+                * picongpu::sim.pic.getCellSize().productOfComponents();
 
             PMACC_SMEM(worker, cachedHistogram, CachedHistogram<T_numberBins>);
             cachedHistogram.fill(worker, histogram, volumeScalingFactor);
@@ -158,7 +159,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     float_X const density = cachedHistogram.density[binIndex];
 
                     // 1/picongpu::sim.unit.time()
-                    float_X const sumRateTransitions = 0._X;
+                    float_X sumRateTransitions = 0._X;
                     for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
                     {
                         uint32_t const transitionCollectionIndex = offset + transitionID;
@@ -198,12 +199,12 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_BoundFreeTransitionDataBox>
         HDINLINE static void fillWithFieldIonization(
             T_Worker const& worker,
-            pmacc::DataSpace<picongpu::simDim> superCellFieldIdx,
+            pmacc::DataSpace<picongpu::simDim> superCellIdx,
             T_RateCache& rateCache,
             T_EFieldDataBox const eFieldBox,
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
             T_AtomicStateDataDataBox const atomicStateDataDataBox,
-            T_AtomicStateStartIndexBox const startIndexBlockTransitionsUp,
+            T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
             float_X const ionizationPotentialDepression)
@@ -218,40 +219,23 @@ namespace picongpu::particles::atomicPhysics::kernel
                 = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
             auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
 
-            DataSpace<picongpu::simDim> cellIndex;
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
 
             /// @todo switch to shared memory reduce, Brian Marre, 2024
             forEachCell(
-                [&worker, &cellIndex, &superCellCellOffset, &maximumNormEFieldValueSuperCell, &eFieldBox](
-                    uint32_t const linearIdx)
+                [&worker, &superCellCellOffset, &maximumNormEFieldValueSuperCell, &eFieldBox](uint32_t const linearIdx)
                 {
-                    if constexpr(T_EFieldDataBox::Dim == 3u)
-                    {
-                        constexpr auto strideY = picongpu::SuperCellSize::at<0u>::type::value;
-                        constexpr auto strideZ = picongpu::SuperCellSize::at<0u>::type::value
-                            * picongpu::SuperCellSize::at<1u>::type::value;
-
-                        cellIndex = supercellCellOffset;
-                        cellIndex.x() += linearIdx % picongpu::SuperCellSize::at<0u>::type::value;
-                        cellIndex.y() += (linearIdx / strideY) % picongpu::SuperCellSize::at<1u>::type::value;
-                        cellIndex.z() += linearIdx / strideZ;
-                    }
-                    else
-                    {
-                        constexpr auto strideY = picongpu::SuperCellSize::at<0u>::type::value;
-
-                        cellIndex = supercellCellOffset;
-                        cellIndex.x() += linearIdx % picongpu::SuperCellSize::at<0u>::type::value;
-                        cellIndex.y() += linearIdx / strideY;
-                    }
+                    DataSpace<picongpu::simDim> const localCellIndex
+                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearIdx));
+                    DataSpace<picongpu::simDim> const cellIndex = localCellIndex + superCellCellOffset;
 
                     auto const eFieldNorm = pmacc::math::l2norm(eFieldBox(cellIndex));
+
                     alpaka::atomicMax(
                         worker.getAcc(),
                         // internal units
                         &maximumNormEFieldValueSuperCell,
-                        eFieldNorm));
+                        eFieldNorm);
                 });
             worker.sync();
 
@@ -267,7 +251,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                  &startIndexDataBox,
                  &chargeStateDataDataBox,
                  &atomicStateDataDataBox,
-                 &boundFreeTransitionDataBox](uint32_t const atomicStateCollectionIndex, float_X& fieldIonizationRate)
+                 &boundFreeTransitionDataBox](uint32_t const atomicStateCollectionIndex)
                 {
                     // check if atomic state present at all
                     if(!rateCache.present(atomicStateCollectionIndex))
@@ -278,7 +262,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
 
                     // 1/picongpu::sim.unit.time()
-                    float_X const sumRateTransitions = 0._X;
+                    float_X sumRateTransitions = 0._X;
                     for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
                     {
                         uint32_t const transitionCollectionIndex = offset + transitionID;
@@ -380,9 +364,10 @@ namespace picongpu::particles::atomicPhysics::kernel
                     worker,
                     superCellFieldIdx,
                     rateCache,
+                    localElectronHistogramDataBox,
                     chargeStateDataDataBox,
                     atomicStateDataDataBox,
-                    startIndexBlockTransitionsUp,
+                    startIndexDataBox,
                     numberTransitionsDataBox,
                     boundFreeTransitionDataBox,
                     ionizationPotentialDepression);
@@ -390,12 +375,12 @@ namespace picongpu::particles::atomicPhysics::kernel
             if constexpr(T_fieldIonization)
                 fillWithFieldIonization(
                     worker,
-                    superCellFieldIdx,
+                    superCellIdx,
                     rateCache,
                     eFieldBox,
                     chargeStateDataDataBox,
                     atomicStateDataDataBox,
-                    startIndexBlockTransitionsUp,
+                    startIndexDataBox,
                     numberTransitionsDataBox,
                     boundFreeTransitionDataBox,
                     ionizationPotentialDepression);

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2023 Brian Marre
+/* Copyright 2023-2024 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -20,13 +20,15 @@
 #pragma once
 
 #include "picongpu/simulation_defines.hpp"
-// need unit.param, sim.unit.length() for normalisation
+// need unit.param, sim.unit.length() for normalisation and memory.param for SuperCellSize, simDim from dim.param
 
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/CachedHistogram.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
-#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeTransitionRates.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
 #include <pmacc/algorithms/math/PowerFunction.hpp>
 #include <pmacc/lockstep/ForEach.hpp>
@@ -51,23 +53,250 @@ namespace picongpu::particles::atomicPhysics::kernel
      *  fillLocalRateChacheKernel call this atomicPhysics step
      *
      * @tparam T_IPDModel ionization potential depression model to use
+     * @tparam T_ADKLaserPolarization polarization direction to use in the ADK rate calculation
      *
      * @tparam T_numberLevels maximum principal quantum number of atomic states of ion species
      * @tparam T_numberAtomicStates number of atomic states in atomic data data base
      * @tparam T_numberBins number of regular bins in histogram
      *
-     * @tparam electronicIonization is channel active?
+     * @tparam T_electronicIonization is collisional electronic ionization channel active?
+     * @tparam T_fieldIonization is field ionization channel active?
      * @tparam T_TransitionOrdering ordering of assumed for transition DataBox
      */
     template<
         typename T_IPDModel,
+        s_enums::ADKLaserPolarization T_ADKLaserPolarization,
         uint8_t T_numberLevels,
         uint32_t T_numberAtomicStates,
         uint32_t T_numberBins,
         bool T_electronicIonization,
+        bool T_fieldIonization,
         s_enums::TransitionOrdering T_TransitionOrdering>
     struct FillLocalRateCacheKernel_BoundFree
     {
+        template<
+            typename T_AtomicStateNumberTransitionsBox,
+            typename T_AtomicStateStartIndexBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool correctAtomicDataBoxes()
+        {
+            // check that correct databoxes are given
+            PMACC_CASSERT_MSG(
+                number_transitions_dataBox_not_bound_free_based,
+                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                transition_dataBox_not_boud_free_based,
+                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
+            // check ordering of transition dataBox
+            PMACC_CASSERT_MSG(
+                wrong_ordering_of_DataBox,
+                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+
+            return true;
+        };
+
+        template<
+            typename T_Worker,
+            typename T_RateCache,
+            typename T_ChargeStateDataDataBox,
+            typename T_AtomicStateDataDataBox,
+            typename T_AtomicStateStartIndexBox,
+            typename T_AtomicStateNumberTransitionsBox,
+            typename T_BoundFreeTransitionDataBox>
+        HDINLINE static void fillWithCollisonalIonization(
+            T_Worker const& worker,
+            pmacc::DataSpace<picongpu::simDim> superCellFieldIdx,
+            T_RateCache& rateCache,
+            T_ChargeStateDataDataBox const chargeStateDataDataBox,
+            T_AtomicStateDataDataBox const atomicStateDataDataBox,
+            T_AtomicStateStartIndexBox const startIndexBlockTransitionsUp,
+            T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
+            float_X const ionizationPotentialDepression)
+        {
+            auto forEachAtomicStateAndBin
+                = pmacc::lockstep::makeForEach<T_numberAtomicStates * T_numberBins, T_Worker>(worker);
+
+            auto& histogram = localElectronHistogramDataBox(superCellFieldIdx);
+
+            // UNIT_LENGTH^3
+            constexpr float_X volumeScalingFactor
+                = pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value * picongpu::CELL_VOLUME;
+
+            PMACC_SMEM(worker, cachedHistogram, CachedHistogram<T_numberBins>);
+            cachedHistogram.fill(worker, histogram, volumeScalingFactor);
+
+            /// @todo maybe cache transition data instead of electron histogram, Brian Marre, 2024
+            forEachAtomicStateAndBin(
+                [&worker,
+                 &rateCache,
+                 &cachedHistogram,
+                 &chargeStateDataDataBox,
+                 &atomicStateDataDataBox,
+                 &startIndexDataBox,
+                 &numberTransitionsDataBox,
+                 &boundFreeTransitionDataBox,
+                 &ionizationPotentialDepression](uint32_t const linearIdx)
+                {
+                    uint32_t const binIndex = linearIdx / T_numberAtomicStates;
+                    uint32_t const atomicStateCollectionIndex = linearIdx % T_numberAtomicStates;
+
+                    // check if atomic state present at all
+                    if(!rateCache.present(atomicStateCollectionIndex))
+                        return;
+
+                    uint32_t const numberTransitionsUp
+                        = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
+                    uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
+
+                    float_X const energy = cachedHistogram.energy[binIndex];
+                    float_X const binWidth = cachedHistogram.binWidth[binIndex];
+                    float_X const density = cachedHistogram.density[binIndex];
+
+                    // 1/UNIT_TIME
+                    float_X const sumRateTransitions = 0._X;
+                    for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
+                    {
+                        uint32_t const transitionCollectionIndex = offset + transitionID;
+
+                        // 1/UNIT_TIME
+                        sumRateTransitions
+                            += atomicPhysics::rateCalculation::BoundFreeCollisionalTransitionRates<T_numberLevels>::
+                                template rateCollisionalIonizationTransition<
+                                    T_ChargeStateDataDataBox,
+                                    T_AtomicStateDataDataBox,
+                                    T_BoundFreeTransitionDataBox>(
+                                    energy,
+                                    binWidth,
+                                    density,
+                                    ionizationPotentialDepression,
+                                    transitionCollectionIndex,
+                                    chargeStateDataDataBox,
+                                    atomicStateDataDataBox,
+                                    boundFreeTransitionDataBox);
+                    }
+
+                    rateCache.template add<T_Worker, s_enums::ChooseTransitionGroup::collisionalBoundFreeUpward>(
+                        worker,
+                        atomicStateCollectionIndex,
+                        sumRateTransitions);
+                });
+        }
+
+        template<
+            typename T_Worker,
+            typename T_RateCache,
+            typename T_EFieldDataBox,
+            typename T_ChargeStateDataDataBox,
+            typename T_AtomicStateDataDataBox,
+            typename T_AtomicStateStartIndexBox,
+            typename T_AtomicStateNumberTransitionsBox,
+            typename T_BoundFreeTransitionDataBox>
+        HDINLINE static void fillWithFieldIonization(
+            T_Worker const& worker,
+            pmacc::DataSpace<picongpu::simDim> superCellFieldIdx,
+            T_RateCache& rateCache,
+            T_EFieldDataBox const eFieldBox,
+            T_ChargeStateDataDataBox const chargeStateDataDataBox,
+            T_AtomicStateDataDataBox const atomicStateDataDataBox,
+            T_AtomicStateStartIndexBox const startIndexBlockTransitionsUp,
+            T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
+            float_X const ionizationPotentialDepression)
+        {
+            // internal units
+            PMACC_SMEM(worker, maximumNormEFieldValueSuperCell, typename T_EFieldDataBox::ValueType::type);
+
+            // find maximum field strength of superCell
+
+            /// @todo switch to shared memory reduce, Brian Marre, 2024
+            constexpr auto numberCellsInSuperCell
+                = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
+            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
+
+            DataSpace<picongpu::simDim> cellIndex;
+            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
+
+            /// @todo switch to shared memory reduce, Brian Marre, 2024
+            forEachCell(
+                [&worker, &cellIndex, &superCellCellOffset, &maximumNormEFieldValueSuperCell, &eFieldBox](
+                    uint32_t const linearIdx)
+                {
+                    if constexpr(T_EFieldDataBox::Dim == 3u)
+                    {
+                        constexpr auto strideY = picongpu::SuperCellSize::at<0u>::type::value;
+                        constexpr auto strideZ = picongpu::SuperCellSize::at<0u>::type::value
+                            * picongpu::SuperCellSize::at<1u>::type::value;
+
+                        cellIndex = supercellCellOffset;
+                        cellIndex.x() += linearIdx % picongpu::SuperCellSize::at<0u>::type::value;
+                        cellIndex.y() += (linearIdx / strideY) % picongpu::SuperCellSize::at<1u>::type::value;
+                        cellIndex.z() += linearIdx / strideZ;
+                    }
+                    else
+                    {
+                        constexpr auto strideY = picongpu::SuperCellSize::at<0u>::type::value;
+
+                        cellIndex = supercellCellOffset;
+                        cellIndex.x() += linearIdx % picongpu::SuperCellSize::at<0u>::type::value;
+                        cellIndex.y() += linearIdx / strideY;
+                    }
+
+                    auto const eFieldNorm = pmacc::math::l2norm(eFieldBox(cellIndex));
+                    alpaka::atomicMax(
+                        worker.getAcc(),
+                        // internal units
+                        &maximumNormEFieldValueSuperCell,
+                        eFieldNorm));
+                });
+            worker.sync();
+
+            // calculate ADK field ionization rate, for each atomic state and maximum field value
+            auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
+
+            //      accumulate rates of possible transitions by state
+            forEachAtomicState(
+                [&ionizationPotentialDepression,
+                 &maximumNormEFieldValueSuperCell,
+                 &rateCache,
+                 &numberTransitionsDataBox,
+                 &startIndexDataBox,
+                 &chargeStateDataDataBox,
+                 &atomicStateDataDataBox,
+                 &boundFreeTransitionDataBox](uint32_t const atomicStateCollectionIndex, float_X& fieldIonizationRate)
+                {
+                    // check if atomic state present at all
+                    if(!rateCache.present(atomicStateCollectionIndex))
+                        return;
+
+                    uint32_t const numberTransitionsUp
+                        = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
+                    uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
+
+                    float_X const sumRateTransitions = 0._X;
+                    for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
+                    {
+                        // 1/UNIT_TIME
+                        sumRateTransitions += atomicPhysics::rateCalculation::
+                            BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
+                                maximumNormEFieldValueSuperCell,
+                                ionizationPotentialDepression,
+                                // transitionCollectionIndex
+                                offset + transitionID,
+                                chargeStateDataDataBox,
+                                atomicStateDataDataBox,
+                                boundFreeTransitionDataBox);
+                    }
+                    rateCache.template add<s_enums::ChooseTransitionGroup::fieldBoundFreeUpward>(
+                        atomicStateCollectionIndex,
+                        sumRateTransitions);
+                });
+        }
+
         /** call operator
          *
          * called by FillLocalRateCache atomic physics sub-stage
@@ -97,6 +326,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_LocalTimeRemainingBox,
             typename T_LocalRateCacheBox,
             typename T_LocalElectronHistogramDataBox,
+            typename T_EFieldDataBox,
             typename T_ChargeStateDataDataBox,
             typename T_AtomicStateDataDataBox,
             typename T_AtomicStateStartIndexBox,
@@ -109,6 +339,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_LocalTimeRemainingBox const localTimeRemainingBox,
             T_LocalRateCacheBox localRateCacheBox,
             T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
+            T_EFieldDataBox const eFieldBox,
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
             T_AtomicStateDataDataBox const atomicStateDataDataBox,
             T_AtomicStateStartIndexBox const startIndexDataBox,
@@ -116,26 +347,17 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
             T_IPDInput... ipdInput) const
         {
-            // check that correct databoxes are given
-            PMACC_CASSERT_MSG(
-                number_transitions_dataBox_not_bound_free_based,
-                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                transition_dataBox_not_boud_free_based,
-                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            // check ordering of transition dataBox
-            PMACC_CASSERT_MSG(
-                wrong_ordering_of_DataBox,
-                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+            PMACC_CASSERT(correctAtomicDataBoxes<
+                          T_AtomicStateNumberTransitionsBox,
+                          T_AtomicStateStartIndexBox,
+                          T_BoundFreeTransitionDataBox>());
 
+            pmacc::DataSpace<picongpu::simDim> const superCellIdx
+                = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
-                = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
+                = superCellIdx - areaMapping.getGuardingSuperCells();
 
             auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
 
@@ -143,76 +365,37 @@ namespace picongpu::particles::atomicPhysics::kernel
             if(timeRemaining <= 0._X)
                 return;
 
-            auto forEachAtomicStateAndBin
-                = pmacc::lockstep::makeForEach<T_numberAtomicStates * T_numberBins, T_Worker>(worker);
-
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
-            auto& histogram = localElectronHistogramDataBox(superCellFieldIdx);
-
-            // sim.unit.length()^3
-            constexpr float_X volumeScalingFactor
-                = pmacc::math::CT::volume<SuperCellSize>::type::value * sim.pic.getCellSize().productOfComponents();
-
-            PMACC_SMEM(worker, cachedHistogram, CachedHistogram<T_numberBins>);
-            cachedHistogram.fill(worker, histogram, volumeScalingFactor);
-
             float_X const ionizationPotentialDepression
                 = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
                     superCellFieldIdx,
                     ipdInput...);
 
-            forEachAtomicStateAndBin(
-                [&worker,
-                 &rateCache,
-                 &cachedHistogram,
-                 &chargeStateDataDataBox,
-                 &atomicStateDataDataBox,
-                 &startIndexDataBox,
-                 &numberTransitionsDataBox,
-                 &boundFreeTransitionDataBox,
-                 &ionizationPotentialDepression](uint32_t const linearIdx)
-                {
-                    uint32_t const binIndex = linearIdx / T_numberAtomicStates;
-                    uint32_t const atomicStateCollectionIndex = linearIdx % T_numberAtomicStates;
+            auto& rateCache = localRateCacheBox(superCellFieldIdx);
 
-                    // check if atomic state present at all
-                    if(!rateCache.present(atomicStateCollectionIndex))
-                        return;
+            if constexpr(T_electronicIonization)
+                fillWithCollisonalIonization(
+                    worker,
+                    superCellFieldIdx,
+                    rateCache,
+                    chargeStateDataDataBox,
+                    atomicStateDataDataBox,
+                    startIndexBlockTransitionsUp,
+                    numberTransitionsDataBox,
+                    boundFreeTransitionDataBox,
+                    ionizationPotentialDepression);
 
-                    uint32_t const numberTransitionsUp
-                        = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
-
-                    uint32_t offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
-
-                    [[maybe_unused]] auto const energy = cachedHistogram.energy[binIndex];
-                    [[maybe_unused]] auto const binWidth = cachedHistogram.binWidth[binIndex];
-                    [[maybe_unused]] auto const density = cachedHistogram.density[binIndex];
-
-                    for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
-                    {
-                        if constexpr(T_electronicIonization)
-                        {
-                            rateCache.template add<T_Worker, s_enums::ChooseTransitionGroup::boundFreeUpward>(
-                                worker,
-                                atomicStateCollectionIndex,
-                                picongpu::particles::atomicPhysics::rateCalculation::BoundFreeTransitionRates<
-                                    T_numberLevels>::
-                                    template rateCollisionalIonizationTransition<
-                                        T_ChargeStateDataDataBox,
-                                        T_AtomicStateDataDataBox,
-                                        T_BoundFreeTransitionDataBox>(
-                                        energy,
-                                        binWidth,
-                                        density,
-                                        ionizationPotentialDepression,
-                                        // transitionCollectionIndex
-                                        offset + transitionID,
-                                        chargeStateDataDataBox,
-                                        atomicStateDataDataBox,
-                                        boundFreeTransitionDataBox));
-                        }
-                    }
-                });
+            if constexpr(T_fieldIonization)
+                fillWithFieldIonization(
+                    worker,
+                    superCellFieldIdx,
+                    rateCache,
+                    eFieldBox,
+                    chargeStateDataDataBox,
+                    atomicStateDataDataBox,
+                    startIndexBlockTransitionsUp,
+                    numberTransitionsDataBox,
+                    boundFreeTransitionDataBox,
+                    ionizationPotentialDepression);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -157,13 +157,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     float_X const binWidth = cachedHistogram.binWidth[binIndex];
                     float_X const density = cachedHistogram.density[binIndex];
 
-                    // 1/UNIT_TIME
+                    // 1/picongpu::sim.unit.time()
                     float_X const sumRateTransitions = 0._X;
                     for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
                     {
                         uint32_t const transitionCollectionIndex = offset + transitionID;
 
-                        // 1/UNIT_TIME
+                        // 1/ picongpu::sim.unit.time()
                         sumRateTransitions
                             += atomicPhysics::rateCalculation::BoundFreeCollisionalTransitionRates<T_numberLevels>::
                                 template rateCollisionalIonizationTransition<
@@ -277,16 +277,18 @@ namespace picongpu::particles::atomicPhysics::kernel
                         = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
                     uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
 
+                    // 1/picongpu::sim.unit.time()
                     float_X const sumRateTransitions = 0._X;
                     for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
                     {
-                        // 1/UNIT_TIME
+                        uint32_t const transitionCollectionIndex = offset + transitionID;
+
+                        // 1/picongpu::sim.unit.time()
                         sumRateTransitions += atomicPhysics::rateCalculation::
                             BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
                                 maximumNormEFieldValueSuperCell,
                                 ionizationPotentialDepression,
-                                // transitionCollectionIndex
-                                offset + transitionID,
+                                transitionCollectionIndex,
                                 chargeStateDataDataBox,
                                 atomicStateDataDataBox,
                                 boundFreeTransitionDataBox);
@@ -359,6 +361,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
+            // picongpu::sim.unit.time()
             auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
 
             // end kernel if superCell already finished

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordUsedElectronHistogramWeight.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordUsedElectronHistogramWeight.kernel
@@ -32,8 +32,6 @@ namespace picongpu::particles::atomicPhysics::kernel
 {
     /** record used weight from bin of electron histogram for each accepted transition
      *
-     * @todo fuse into AcceptTransitionTest kernel?, Brian Marre, 2023
-     *
      * @tparam T_Histogram type of the histogram
      */
     template<typename T_Histogram>

--- a/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
@@ -95,7 +95,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_TransitionDataBox transitionBox,
             T_RNGFactoryAndChargeStateDataBoxAndIPDInput... rngFactoryAndChargeStateBoxAndIPDInput) const
         {
-            namespace enums = picongpu::particles::atomicPhysics::enums;
+            namespace s_enums = picongpu::particles::atomicPhysics::enums;
 
             using ElectronFramePtr = typename T_IonizationElectronBox::FramePtr;
             using IonFramePtr = typename T_IonBox::FramePtr;
@@ -139,7 +139,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto numberIonizationElectronsCtxArr = lockstep::makeVar<uint8_t>(forEachFrameSlot, u8(0u));
 
             [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;
-            if constexpr(T_ProcessClassGroup == enums::ProcessClassGroup::autonomousBased)
+            if constexpr(T_ProcessClassGroup == s_enums::ProcessClassGroup::autonomousBased)
                 ionizationPotentialDepression
                     = ionizationPotentialDepression::PassIPDInputs::template calculateIPD_RngFactory<T_IPDModel>(
                         superCellFieldIdx,
@@ -181,7 +181,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                             // slot is not occupied
                             !static_cast<bool>(ion[multiMask_])
                             // no bound-free based ionizing process
-                            || !(enums::IsProcess<T_ProcessClassGroup>::check(ion[processClass_])))
+                            || !(s_enums::IsProcess<T_ProcessClassGroup>::check(ion[processClass_])))
                         {
                             numberIonizationElectrons = u8(0u);
                             return;
@@ -203,14 +203,14 @@ namespace picongpu::particles::atomicPhysics::kernel
                             = T_AtomicStateDataBox::ConfigNumber::getChargeState(upperStateConfigNumber);
 
                         // set context array value
-                        if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::autonomousBased))
+                        if constexpr(u8(T_ProcessClassGroup) == u8(s_enums::ProcessClassGroup::autonomousBased))
                         {
                             // for autonomous transitions allows initialState == upperState
                             numberIonizationElectrons = lowerChargeState - upperChargeState;
                         }
                         else
                         {
-                            if constexpr(u8(T_ProcessClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased))
+                            if constexpr(u8(T_ProcessClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased))
                             {
                                 numberIonizationElectrons = upperChargeState - lowerChargeState;
                             }
@@ -309,23 +309,33 @@ namespace picongpu::particles::atomicPhysics::kernel
                             electron[multiMask_] = 1u;
 
                             // init new electron attributes
-                            if constexpr(T_ProcessClassGroup == enums::ProcessClassGroup::boundFreeBased)
+                            if constexpr(T_ProcessClassGroup == s_enums::ProcessClassGroup::boundFreeBased)
                             {
-                                // does not need chargeStateBox since we init electron as co-moving currently
+                                uint8_t const processClass = ion[processClass_];
 
-                                initElectrons::InitIonizationElectron<enums::ProcessClass::electronicIonization>{}(
-                                    worker,
-                                    ion,
-                                    electron,
-                                    idGen);
+                                /// @note do not need chargeStateBox since we init electron as co-moving currently
+                                if(processClass == u8(s_enums::ProcessClass::electronicIonization))
+                                {
+                                    initElectrons::InitIonizationElectron<
+                                        s_enums::ProcessClass::electronicIonization>{}(worker, ion, electron, idGen);
+                                }
+                                else
+                                {
+                                    // field ionization
+                                    initElectrons::InitIonizationElectron<s_enums::ProcessClass::fieldIonization>{}(
+                                        worker,
+                                        ion,
+                                        electron,
+                                        idGen);
+                                }
 
                                 /// @todo implement field ionization, Brian Marre, 2023
                             }
-                            else if constexpr(T_ProcessClassGroup == enums::ProcessClassGroup::autonomousBased)
+                            else if constexpr(T_ProcessClassGroup == s_enums::ProcessClassGroup::autonomousBased)
                             {
                                 auto const superCellLocalOffset = superCellIdx - areaMapping.getGuardingSuperCells();
 
-                                initElectrons::InitIonizationElectron<enums::ProcessClass::autonomousIonization>{}(
+                                initElectrons::InitIonizationElectron<s_enums::ProcessClass::autonomousIonization>{}(
                                     worker,
                                     ionizationPotentialDepression,
                                     ion,

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RateCache.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RateCache.hpp
@@ -45,22 +45,23 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
     {
     public:
         static constexpr uint32_t numberAtomicStates = T_numberAtomicStates;
-        // we do not store noChange since noChange is always reminder to 1
+        /// @note -1 since we never store noChange, since noChange is always reminder to 1
         static constexpr uint32_t numberStoredDataSets
             = particles::atomicPhysics::enums::numberChooseTransitionGroups - 1u;
 
     private:
         // partial sums of rates for each atomic state, one for each ChooseTransitionGroup except noChange
         // 1/sim.unit.time()
-        float_X rateEntries[T_numberAtomicStates * numberStoredDataSets] = {0};
-        uint32_t m_present[T_numberAtomicStates] = {static_cast<uint32_t>(false)}; // unitless
+        float_X rateEntries[numberAtomicStates * numberStoredDataSets] = {0._X};
+        // unitless
+        uint32_t m_present[numberAtomicStates] = {static_cast<uint32_t>(false)};
 
         /** get linear storage index
          *
          * @param collectionIndex atomic state collection index of an atomic state
          * @param dataSetIndex index of data set
          */
-        HDINLINE static constexpr uint32_t linearIndex(uint32_t const collectionIndex, uint32_t const dataSetIndex)
+        static constexpr uint32_t linearIndex(uint32_t const collectionIndex, uint32_t const dataSetIndex)
         {
             if constexpr(picongpu::atomicPhysics::debug::rateCache::COLLECTION_INDEX_RANGE_CHECKS)
             {
@@ -72,6 +73,19 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
             }
             return numberStoredDataSets * collectionIndex + dataSetIndex;
         }
+
+        template<particles::atomicPhysics::enums::ChooseTransitionGroup T_ChooseTransitionGroup>
+        static constexpr bool checkIsStoredChooseTransitionGroup()
+        {
+            PMACC_CASSERT_MSG(
+                noChange_not_allowed_as_T_ChooseTransitionGroup,
+                u32(T_ChooseTransitionGroup) != u32(atomicPhysics::enums::ChooseTransitionGroup::noChange));
+            PMACC_CASSERT_MSG(
+                not_a_by_state_choose_transition_group,
+                u32(T_ChooseTransitionGroup) < u32(atomicPhysics::enums::FINAL_NUMBER_BY_STATE_GROUPS));
+
+            return true
+        };
 
     public:
         /** add to cache entry, using atomics
@@ -85,12 +99,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         template<typename T_Worker, particles::atomicPhysics::enums::ChooseTransitionGroup T_ChooseTransitionGroup>
         HDINLINE void add(T_Worker const& worker, uint32_t const collectionIndex, float_X rate)
         {
-            PMACC_CASSERT_MSG(
-                noChange_not_allowed_as_T_ChooseTransitionGroup,
-                u32(T_ChooseTransitionGroup) != u32(particles::atomicPhysics::enums::ChooseTransitionGroup::noChange));
-            PMACC_CASSERT_MSG(
-                unknown_T_ChooseTransitionGroup,
-                u32(T_ChooseTransitionGroup) < particles::atomicPhysics::enums::numberChooseTransitionGroups);
+            PMACC_CASSERT(checkIsStoredChooseTransitionGroup<T_ChooseTransitionGroup>());
 
             if constexpr(picongpu::atomicPhysics::debug::rateCache::COLLECTION_INDEX_RANGE_CHECKS)
                 if(collectionIndex >= numberAtomicStates)
@@ -119,12 +128,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         template<particles::atomicPhysics::enums::ChooseTransitionGroup T_ChooseTransitionGroup>
         HDINLINE void add(uint32_t const collectionIndex, float_X rate)
         {
-            PMACC_CASSERT_MSG(
-                noChange_not_allowed_as_T_ChooseTransitionGroup,
-                u32(T_ChooseTransitionGroup) != u32(particles::atomicPhysics::enums::ChooseTransitionGroup::noChange));
-            PMACC_CASSERT_MSG(
-                unknown_T_ChooseTransitionGroup,
-                u32(T_ChooseTransitionGroup) < particles::atomicPhysics::enums::numberChooseTransitionGroups);
+            PMACC_CASSERT(checkIsStoredChooseTransitionGroup<T_ChooseTransitionGroup>);
 
             if constexpr(picongpu::atomicPhysics::debug::rateCache::COLLECTION_INDEX_RANGE_CHECKS)
                 if(collectionIndex >= numberAtomicStates)
@@ -171,13 +175,13 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
             if constexpr(picongpu::atomicPhysics::debug::rateCache::TRANSITION_DATA_SET_INDEX_RANGE_CHECKS)
             {
                 if(chooseTransitionGroupIndex
-                   == u8(picongpu::particles::atomicPhysics::enums::ChooseTransitionGroup::noChange))
+                   == u32(picongpu::particles::atomicPhysics::enums::ChooseTransitionGroup::noChange))
                 {
                     printf("atomicPhysics ERROR: noChange not allowed as chooseTransitionGroup in rate() call\n");
                     return 0._X;
                 }
                 if(chooseTransitionGroupIndex
-                   >= u8(picongpu::particles::atomicPhysics::enums::numberChooseTransitionGroups))
+                   >= picongpu::particles::atomicPhysics::enums::numberChooseTransitionGroups)
                 {
                     printf("atomicPhysics ERROR: unknown chooseTransitionGroup index in rate() call\n");
                     return 0._X;
@@ -187,7 +191,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
             return rateEntries[linearIndex(collectionIndex, chooseTransitionGroupIndex)];
         }
 
-        /** get cached total loss rate for an atomic state
+        /** get upper limit total loss rates for an atomic state
          *
          * @param collectionIndex collection Index of atomic state
          * @return rate of transition, [1/sim.unit.time()], by convention >0
@@ -215,7 +219,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
 
         /** get presence status for an atomic state
          *
-         * @param collectionIndex collection Index of atomic state
+         * @param collectionIndex collection index of atomic state
          * @return if state is present in superCell
          *
          * @attention no range checks outside a debug compile, invalid memory access on failure

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RateCache.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RateCache.hpp
@@ -82,9 +82,9 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
                 u32(T_ChooseTransitionGroup) != u32(atomicPhysics::enums::ChooseTransitionGroup::noChange));
             PMACC_CASSERT_MSG(
                 not_a_by_state_choose_transition_group,
-                u32(T_ChooseTransitionGroup) < u32(atomicPhysics::enums::FINAL_NUMBER_BY_STATE_GROUPS));
+                u32(T_ChooseTransitionGroup) < u32(atomicPhysics::enums::ChooseTransitionGroup::FINAL_NUMBER_ENTRIES));
 
-            return true
+            return true;
         };
 
     public:
@@ -128,7 +128,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         template<particles::atomicPhysics::enums::ChooseTransitionGroup T_ChooseTransitionGroup>
         HDINLINE void add(uint32_t const collectionIndex, float_X rate)
         {
-            PMACC_CASSERT(checkIsStoredChooseTransitionGroup<T_ChooseTransitionGroup>);
+            PMACC_CASSERT(checkIsStoredChooseTransitionGroup<T_ChooseTransitionGroup>());
 
             if constexpr(picongpu::atomicPhysics::debug::rateCache::COLLECTION_INDEX_RANGE_CHECKS)
                 if(collectionIndex >= numberAtomicStates)
@@ -247,8 +247,8 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
             -> std::enable_if_t<std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
             std::cout << "rateCache" << superCellFieldIdx.toString(",", "[]")
-                      << " atomicStateCollectionIndex [bb(up), bb(down), bf(up), a(down)]" << std::endl;
-            for(uint16_t collectionIndex = 0u; collectionIndex < numberAtomicStates; ++collectionIndex)
+                      << " atomicStateCollectionIndex [bb(up), bb(down), col.bf(up), a(down), f.bf(up)]" << std::endl;
+            for(uint32_t collectionIndex = 0u; collectionIndex < numberAtomicStates; ++collectionIndex)
             {
                 if(this->present(collectionIndex))
                 {

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/AtomicRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/AtomicRateCalculation.hpp
@@ -23,4 +23,5 @@
 
 #include "picongpu/particles/atomicPhysics/rateCalculation/AutonomousTransitionRates.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp"
-#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeTransitionRates.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -69,13 +69,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
         {
-            // eV
-            float_X const ionizationEnergy = DeltaEnergyTransition::get(
-                transitionCollectionIndex,
-                atomicStateDataBox,
-                boundFreeTransitionDataBox,
-                ionizationPotentialDepression,
-                chargeStateDataBox);
+            if(eFieldNorm == 0._X)
+                return 0._X;
 
             // get screenedCharge
             uint32_t const lowerStateClctIdx
@@ -88,13 +83,17 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             // e
             float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
 
+            // ev
+            float_X const ionizationEnergy = DeltaEnergyTransition::get(
+                transitionCollectionIndex,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox,
+                ionizationPotentialDepression,
+                chargeStateDataBox);
             // unitless
             float_X const effectivePrincipalQuantumNumber
-                = screenedCharge / math::sqrt(float_X(2.0) * ionizationEnergy);
-
-            // electric field in atomic units
+                = screenedCharge / math::sqrt(2._X * ionizationEnergy * picongpu::UNITCONV_eV_to_AU);
             float_X const eFieldNorm_AU = eFieldNorm / ATOMIC_UNIT_EFIELD;
-
             float_X const screenedChargeCubed = pmacc::math::cPow(screenedCharge, 3u);
             float_X const dBase = 4.0_X * math::exp(1._X) * screenedChargeCubed
                 / (eFieldNorm_AU * pmacc::math::cPow(effectivePrincipalQuantumNumber, 4u));

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -52,7 +52,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          * @param atomicStateDataBox access to atomic state property data
          * @param boundBoundTransitionDataBox access to bound-bound transition data
          *
-         * @return unit: 1/UNIT_TIME
+         * @return unit: 1/picongpu::sim.unit.time()
          */
         template<
             typename T_EFieldType,

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -1,0 +1,119 @@
+/* Copyright 2023 Brian Marre, Marco Garten
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/simulation_defines.hpp" // needs ?
+
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
+#include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
+
+#include <pmacc/algorithms/math.hpp>
+
+#include <cstdint>
+
+/** @file implements calculation of rates for bound-free field ionization atomic physics transitions
+ *
+ * based on the ADK ionization implementation by Marco Garten
+ */
+
+namespace picongpu::particles::atomicPhysics::rateCalculation
+{
+    template<atomicPhysics::enums::ADKLaserPolarization T_ADKLaserPolarization>
+    struct BoundFreeFieldTransitionRates
+    {
+        /** rate for bound-free field ionization transition of ion depending on the local electric field
+         *
+         * @tparam T_ChargeStateDataBox instantiated type of dataBox
+         * @tparam T_AtomicStateDataBox instantiated type of dataBox
+         * @tparam T_BoundFreeTransitionDataBox instantiated type of dataBox
+         *
+         * @param eField E-field vector, in internal units
+         * @param ionizationPotentialDepression, eV
+         * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
+         * @param atomicStateDataBox access to atomic state property data
+         * @param boundBoundTransitionDataBox access to bound-bound transition data
+         *
+         * @return unit: 1/UNIT_TIME
+         */
+        template<
+            typename T_EFieldType,
+            typename T_ChargeStateDataBox,
+            typename T_AtomicStateDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        HDINLINE static float_X rateADKFieldIonization(
+            // internal units
+            T_EFieldType const eFieldNorm,
+            // eV
+            float_X const ionizationPotentialDepression,
+            uint32_t const transitionCollectionIndex,
+            T_ChargeStateDataBox const chargeStateDataBox,
+            T_AtomicStateDataBox const atomicStateDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
+        {
+            // eV
+            float_X const ionizationEnergy = DeltaEnergyTransition::get(
+                transitionCollectionIndex,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox,
+                ionizationPotentialDepression,
+                chargeStateDataBox);
+
+            // get screenedCharge
+            uint32_t const lowerStateClctIdx
+                = boundFreeTransitionDataBox.lowerStateCollectionIndex(transitionCollectionIndex);
+            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
+
+            using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
+            uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
+
+            // e
+            float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
+
+            // unitless
+            float_X const effectivePrincipalQuantumNumber
+                = screenedCharge / math::sqrt(float_X(2.0) * ionizationEnergy);
+
+            // electric field in atomic units
+            float_X const eFieldNorm_AU = eFieldNorm / ATOMIC_UNIT_EFIELD;
+
+            float_X const screenedChargeCubed = pmacc::math::cPow(screenedCharge, 3u);
+            float_X const dBase = 4.0_X * math::exp(1._X) * screenedChargeCubed
+                / (eFieldNorm_AU * pmacc::math::cPow(effectivePrincipalQuantumNumber, 4u));
+            float_X const dFromADK = math::pow(dBase, effectivePrincipalQuantumNumber);
+
+            // ionization rate (for CIRCULAR polarization)
+            constexpr float_X pi = pmacc::math::Pi<float_X>::value;
+            float_X const nEffCubed = pmacc::math::cPow(effectivePrincipalQuantumNumber, 3u);
+
+            // 1/ATOMIC_UNIT_TIME
+            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * screenedCharge)
+                * math::exp(-2._X * screenedChargeCubed / (3._X * nEffCubed * eFieldNorm_AU));
+
+            // factor from averaging over one laser cycle with LINEAR polarization
+            if constexpr(
+                u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
+                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * screenedChargeCubed));
+
+            return rateADK_AU / ATOMIC_UNIT_TIME;
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::rateCalculation

--- a/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
@@ -28,6 +28,8 @@
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel"
 #include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel"
+#include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel"
+#include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel"
 #include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
 
 namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/DecelerateElectrons.hpp
@@ -46,8 +46,6 @@ namespace picongpu::particles::atomicPhysics::stage
      *
      * @attention assumes RecordChanges atomicPhysics sub-stage to have been executed previously
      *
-     * @todo iterate this kernel call until all deltaEnergy is accounted for, Brian Marre, 2023
-     *
      * @tparam T_ElectronSpecies species for which to call the functor
      */
     template<typename T_ElectronSpecies>

--- a/include/picongpu/particles/atomicPhysics/stage/RecordSuggestedChanges.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RecordSuggestedChanges.hpp
@@ -42,8 +42,6 @@ namespace picongpu::particles::atomicPhysics::stage
      *  and AcceptTransitionTest stages have been executed previously in the current
      *  atomicPhysics time step.
      *
-     * @todo fuse kernels into AcceptTransitionTest kernel?, Brian Marre, 2023
-     *
      * @tparam T_IonSpecies ion species type
      */
     template<typename T_IonSpecies>

--- a/include/picongpu/particles/atomicPhysics/stage/SpawnIonizationElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/SpawnIonizationElectrons.hpp
@@ -93,9 +93,8 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData
                             .template getBoundFreeTransitionDataBox<false, enums::TransitionOrdering::byLowerState>());
-
-                /// @todo field ionization, Brian Marre, 2023
             }
+
             //      autonomous based transitions
             if constexpr(AtomicDataType::switchAutonomousIonization)
             {

--- a/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/atomicPhysics.param
+++ b/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/atomicPhysics.param
@@ -28,6 +28,7 @@
 #include "picongpu/particles/atomicPhysics/LinearApproximationProbability.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LogSpaceHistogram.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
 
 #include <cstdint>
@@ -99,5 +100,6 @@ namespace picongpu::atomicPhysics
         true, // T_spontaneousDeexcitation
         true, // T_electronicIonization
         true, // T_autonomousIonization
-        false>; // T_fieldIonization
+        true, // T_fieldIonization
+        picongpu::particles::atomicPhysics::enums::ADKLaserPolarization::linearPolarization>;
 } // namespace picongpu::atomicPhysics


### PR DESCRIPTION
adds ADK based field ionization to FLYonPIC/AtomicPhysics

- [x] rebase against https://github.com/ComputationalRadiationPhysics/picongpu/pull/5081 before merging