### PR TITLE
fix warning in PyPIConGPU version tests

### DIFF
--- a/share/ci/install/pypicongpu.sh
+++ b/share/ci/install/pypicongpu.sh
@@ -43,8 +43,17 @@ micromamba activate pypicongpu
 python3 --version
 MODIFIED_REQUIREMENT_TXT_PICMI=$CI_PROJECT_DIR/lib/python/picongpu/picmi/modified_requirements.txt
 MODIFIED_REQUIREMENT_TXT_PYPICONGPU=$CI_PROJECT_DIR/lib/python/picongpu/pypicongpu/modified_requirements.txt
-python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt $MODIFIED_REQUIREMENT_TXT_PICMI
-python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py $CI_PROJECT_DIR/lib/python/picongpu/pypicongpu/requirements.txt $MODIFIED_REQUIREMENT_TXT_PYPICONGPU
+# The environment variables for changing the version of a dependency package are set globally.
+# Therefore, all calls of the requirements_txt_modfifier.py script are affected.
+# To avoid unexpected changes to dependencies, the list of ignored environment variables.
+python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py \
+    -i $CI_PROJECT_DIR/lib/python/picongpu/picmi/requirements.txt \
+    -o $MODIFIED_REQUIREMENT_TXT_PICMI \
+    --ignore_env_args PYPIC_DEP_VERSION_referencing PYPIC_DEP_VERSION_jsonschema
+python3 $CI_PROJECT_DIR/share/ci/install/requirements_txt_modifier.py \
+    -i $CI_PROJECT_DIR/lib/python/picongpu/pypicongpu/requirements.txt \
+    -o $MODIFIED_REQUIREMENT_TXT_PYPICONGPU \
+    --ignore_env_args PYPIC_DEP_VERSION_pydantic PYPIC_DEP_VERSION_picmistandard
 
 echo "modified_requirements.txt: "
 cat $MODIFIED_REQUIREMENT_TXT_PICMI


### PR DESCRIPTION
- If the script `requirements_txt_modifier.py` should modify a dependency in a requirements.txt, which does not exist, it throws a warning because this is unexpected behavior. Because warnings are hard to detect in the CI, change it to an error.
- Implement a function to ignore specific environment variables which are set to change the version in a requirements.txt.

Example: https://gitlab.com/hzdr/crp/picongpu/-/jobs/7789974598