### PR TITLE
seperate atomic data box checks

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
@@ -47,6 +47,31 @@ namespace picongpu::particles::atomicPhysics::kernel
      */
     struct ChooseTransitionKernel_Autonomous
     {
+        template<
+            typename T_AtomicStateAutonomousStartIndexBlockDataBox,
+            typename T_AtomicStateAutonomousNumberTransitionsDataBox,
+            typename T_AutonomousTransitionDataBox>
+        static constexpr bool checkAtomicDataBoxes()
+        {
+            PMACC_CASSERT_MSG(
+                numberTransitionBox_not_autonomous_based,
+                u8(T_AtomicStateAutonomousNumberTransitionsDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::autonomousBased));
+            PMACC_CASSERT_MSG(
+                startIndexBox_not_autonomous_based,
+                u8(T_AtomicStateAutonomousStartIndexBlockDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::autonomousBased));
+            PMACC_CASSERT_MSG(
+                transitiondataBox_not_autonomous_based,
+                u8(T_AutonomousTransitionDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::autonomousBased));
+            PMACC_CASSERT_MSG(
+                wrong_transition_ordering_AutonomousTransitionDataBox,
+                u8(T_AutonomousTransitionDataBox::transitionOrdering)
+                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::downward>::ordering));
+            return true;
+        }
+
         /** call operator
          *
          * called by ChooseTransition atomic physics sub-stage
@@ -88,23 +113,10 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_LocalRateCacheBox const localRateCacheBox,
             T_IonBox ionBox) const
         {
-            // check that correct atomicPhysics databoxes are given
-            PMACC_CASSERT_MSG(
-                numberTransitionBox_not_autonomous_based,
-                u8(T_AtomicStateAutonomousNumberTransitionsDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::autonomousBased));
-            PMACC_CASSERT_MSG(
-                startIndexBox_not_autonomous_based,
-                u8(T_AtomicStateAutonomousStartIndexBlockDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::autonomousBased));
-            PMACC_CASSERT_MSG(
-                transitiondataBox_not_autonomous_based,
-                u8(T_AutonomousTransitionDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::autonomousBased));
-            PMACC_CASSERT_MSG(
-                wrong_transition_ordering_AutonomousTransitionDataBox,
-                u8(T_AutonomousTransitionDataBox::transitionOrdering)
-                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::downward>::ordering));
+            PMACC_CASSERT(checkAtomicDataBoxes<
+                          T_AtomicStateAutonomousStartIndexBlockDataBox,
+                          T_AtomicStateAutonomousNumberTransitionsDataBox,
+                          T_AutonomousTransitionDataBox>());
 
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
@@ -74,6 +74,31 @@ namespace picongpu::particles::atomicPhysics::kernel
         static constexpr bool electronicChannelActive
             = (T_electronicDeexcitation && !isUpward) || ((T_electronicExcitation && isUpward));
 
+        template<
+            typename T_AtomicStateBoundBoundStartIndexBlockDataBox,
+            typename T_AtomicStateBoundBoundNumberTransitionsDataBox,
+            typename T_BoundBoundTransitionDataBox>
+        static constexpr bool checkAtomicDataBoxes()
+        {
+            PMACC_CASSERT_MSG(
+                number_transition_dataBox_not_bound_bound_based,
+                u8(T_AtomicStateBoundBoundNumberTransitionsDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_bound_based,
+                u8(T_AtomicStateBoundBoundStartIndexBlockDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
+            PMACC_CASSERT_MSG(
+                transitiondataBox_not_bound_bound_based,
+                u8(T_BoundBoundTransitionDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
+            PMACC_CASSERT_MSG(
+                wrong_transition_ordering_for_T_transitionDirection,
+                u8(T_BoundBoundTransitionDataBox::transitionOrdering)
+                    == u8(s_enums::TransitionOrderingFor<T_TransitionDirection>::ordering));
+            return true;
+        }
+
         /** call operator
          *
          * called by ChooseTransition atomic physics sub-stage
@@ -120,22 +145,10 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_IonBox ionBox) const
         {
             // check that correct databoxes are given
-            PMACC_CASSERT_MSG(
-                number_transition_dataBox_not_bound_bound_based,
-                u8(T_AtomicStateBoundBoundNumberTransitionsDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_bound_based,
-                u8(T_AtomicStateBoundBoundStartIndexBlockDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
-            PMACC_CASSERT_MSG(
-                transitiondataBox_not_bound_bound_based,
-                u8(T_BoundBoundTransitionDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
-            PMACC_CASSERT_MSG(
-                wrong_transition_ordering_for_T_transitionDirection,
-                u8(T_BoundBoundTransitionDataBox::transitionOrdering)
-                    == u8(s_enums::TransitionOrderingFor<T_TransitionDirection>::ordering));
+            PMACC_CASSERT(checkAtomicDataBoxes<
+                          T_AtomicStateBoundBoundStartIndexBlockDataBox,
+                          T_AtomicStateBoundBoundNumberTransitionsDataBox,
+                          T_BoundBoundTransitionDataBox>());
 
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundBound.kernel
@@ -67,6 +67,31 @@ namespace picongpu::particles::atomicPhysics::kernel
         s_enums::TransitionOrdering T_TransitionOrdering>
     struct FillLocalRateCacheKernel_BoundBound
     {
+        template<
+            typename T_AtomicStateStartIndexBox,
+            typename T_AtomicStateNumberTransitionsBox,
+            typename T_BoundBoundTransitionDataBox>
+        static constexpr bool checkAtomicDataBoxes()
+        {
+            PMACC_CASSERT_MSG(
+                number_transitions_dataBox_not_bound_bound_based,
+                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundBoundBased));
+            PMACC_CASSERT_MSG(
+                transition_dataBox_not_boud_bound_based,
+                u8(T_BoundBoundTransitionDataBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
+            // check ordering of transition dataBox
+            PMACC_CASSERT_MSG(
+                wrong_ordering_of_DataBox,
+                u8(T_BoundBoundTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+
+            return true;
+        }
+
         /** call operator
          *
          * called by FillLocalRateCache atomic physics sub-stage
@@ -108,21 +133,10 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_BoundBoundTransitionDataBox const boundBoundTransitionDataBox) const
         {
             // check that correct databoxes are given
-            PMACC_CASSERT_MSG(
-                number_transitions_dataBox_not_bound_bound_based,
-                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundBoundBased));
-            PMACC_CASSERT_MSG(
-                transition_dataBox_not_boud_bound_based,
-                u8(T_BoundBoundTransitionDataBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundBoundBased));
-            // check ordering of transition dataBox
-            PMACC_CASSERT_MSG(
-                wrong_ordering_of_DataBox,
-                u8(T_BoundBoundTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+            PMACC_CASSERT(checkAtomicDataBoxes<
+                          T_AtomicStateStartIndexBox,
+                          T_AtomicStateNumberTransitionsBox,
+                          T_BoundBoundTransitionDataBox>());
 
             constexpr bool isUpward = (u8(T_TransitionOrdering) == u8(s_enums::TransitionOrdering::byLowerState));
 

--- a/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
@@ -57,6 +57,19 @@ namespace picongpu::particles::atomicPhysics::kernel
     template<typename T_IPDModel, picongpu::particles::atomicPhysics::enums::ProcessClassGroup T_ProcessClassGroup>
     struct SpawnIonizationMacroElectronsKernel
     {
+        template<typename T_TransitionDataBox, typename T_IonBox, typename T_IonizationElectronBox>
+        static constexpr bool checkPassedDataBoxes()
+        {
+            PMACC_CASSERT_MSG(
+                processClassGroup_and_transition_dataBox_not_consistent,
+                u8(T_ProcessClassGroup) == u8(T_TransitionDataBox::processClassGroup));
+            PMACC_CASSERT_MSG(
+                ion_and_electron_framesize_must_be_equal,
+                T_IonBox::frameSize == T_IonizationElectronBox::frameSize);
+
+            return true;
+        }
+
         /** call operator
          *
          * called by SpawnIonizationMacroElectrons atomic physics sub-stage
@@ -100,14 +113,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             using ElectronFramePtr = typename T_IonizationElectronBox::FramePtr;
             using IonFramePtr = typename T_IonBox::FramePtr;
 
-            // check transition data box content consistent with processClassGroup,
-            //  otherwise unpyhsical behaviour and/or illegal memory access
-            PMACC_CASSERT_MSG(
-                processClassGroup_and_transition_dataBox_not_consistent,
-                u8(T_ProcessClassGroup) == u8(T_TransitionDataBox::processClassGroup));
-            PMACC_CASSERT_MSG(
-                ion_and_electron_framesize_must_be_equal,
-                T_IonBox::frameSize == T_IonizationElectronBox::frameSize);
+            PMACC_CASSERT(checkPassedDataBoxes<T_TransitionDataBox, T_IonBox, T_IonizationElectronBox>());
 
             constexpr uint32_t frameSize = T_IonBox::frameSize;
 


### PR DESCRIPTION
moves the compile time checks of passed databoxes in FLYonPIC kernel into separate functions to improve code readability.

- [x] requires PR #5098 to be merged first