### PR TITLE
fix FixAtomicState Kernel

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/FixAtomicState.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FixAtomicState.kernel
@@ -22,6 +22,7 @@
 #include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/traits/GetNumberAtomicStates.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
@@ -31,7 +32,10 @@ namespace picongpu::particles::atomicPhysics::kernel
 {
     /** search for mismatch between atomic state charge state and boundElectrons and fix them by setting the
      *  atomic state to the ground state of the charge state if mismatched.
+     *
+     * @param T_IonSpecies resolved type of the Ion Species
      */
+    template<typename T_IonSpecies>
     struct FixAtomicStateKernel
     {
         /** call operator
@@ -65,21 +69,32 @@ namespace picongpu::particles::atomicPhysics::kernel
                 [&chargeStateOrgaBox, &atomicStateDataBox](T_Worker const& worker, auto& ion)
                 {
                     using ConfigNumber = typename T_AtomicStateDataDataBox::ConfigNumber;
-
                     uint8_t const boundElectrons = u8(ion[boundElectrons_]);
-                    typename ConfigNumber::DataType const configNumber
-                        = atomicStateDataBox.configNumber(ion[atomicStateCollectionIndex_]);
+                    uint8_t const targetChargeState = ConfigNumber::atomicNumber - boundElectrons;
 
-                    uint8_t const atomicPhysicsBoundElectrons = ConfigNumber::getBoundElectrons(configNumber);
+                    constexpr uint32_t numberAtomicStates
+                        = u32(picongpu::traits::GetNumberAtomicStates<T_IonSpecies>::value);
+                    uint32_t const collectionIndex = ion[atomicStateCollectionIndex_];
 
-                    if(boundElectrons != atomicPhysicsBoundElectrons)
+                    // check for default and out of range values
+                    if(collectionIndex >= numberAtomicStates)
                     {
-                        // set atomic state to ground state
-                        uint8_t const targetChargeState = ConfigNumber::atomicNumber - boundElectrons;
-
                         ion[atomicStateCollectionIndex_] = atomicStateDataBox.findGroundState(
                             chargeStateOrgaBox.numberAtomicStates(targetChargeState),
                             chargeStateOrgaBox.startIndexBlockAtomicStates(targetChargeState));
+                    }
+                    else
+                    {
+                        typename ConfigNumber::DataType const configNumber
+                            = atomicStateDataBox.configNumber(collectionIndex);
+                        uint8_t const atomicPhysicsBoundElectrons = ConfigNumber::getBoundElectrons(configNumber);
+
+                        if(boundElectrons != atomicPhysicsBoundElectrons)
+                        {
+                            ion[atomicStateCollectionIndex_] = atomicStateDataBox.findGroundState(
+                                chargeStateOrgaBox.numberAtomicStates(targetChargeState),
+                                chargeStateOrgaBox.startIndexBlockAtomicStates(targetChargeState));
+                        }
                     }
                 });
         }

--- a/include/picongpu/particles/atomicPhysics/stage/FixAtomicState.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/FixAtomicState.hpp
@@ -77,7 +77,7 @@ namespace picongpu::particles::atomicPhysics::stage
 
             auto& atomicData = *dc.get<AtomicDataType>(IonSpecies::FrameType::getName() + "_atomicData");
 
-            PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::FixAtomicStateKernel())
+            PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::FixAtomicStateKernel<IonSpecies>())
                 .config(mapper.getGridDim(), ions)(
                     mapper,
                     ions.getDeviceParticlesBox(),


### PR DESCRIPTION
Fixes an out of bounds memory access in the FixAtomicStateKernel outisde a debug compile caused by uninitialized atomicPhysics ions.

Due to the new default values introduced in PR #5079, the `atomicStateCollectionIndex` of uninitialized ions is no longer within the bounds of allowed atomic state collection indices.
Since the FixAtomicState kernel did not check for bounds access this caused an out of bounds memory access.