### PR TITLE
Updating alpha centauri profiles at TUD-ZIH

### DIFF
--- a/etc/picongpu/taurus-tud/A100.tpl
+++ b/etc/picongpu/taurus-tud/A100.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2023 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+# Copyright 2013-2024 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #
@@ -19,7 +19,7 @@
 #
 
 
-# PIConGPU batch script for taurus' SLURM batch system
+# PIConGPU batch script for alpha centauri's SLURM batch system
 
 #SBATCH --partition=!TBG_queue
 #SBATCH --time=!TBG_wallTime
@@ -54,16 +54,11 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 6 gpus per node
-# Taurus does not have enough node memory to hold data of all GPUs in node memory during ADIOS output.
-# If you experience crashes with memory allocation errors or get killed by the batch system's
-# resource watch dog, reduce the number of GPUs used per node to four here for debugging.
-# That is, replace in the following line the two appearances of 8 with 4.
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
-
 # number of CPU cores to block per GPU
 # we got 6 CPU cores per GPU (48cores/8gpus ~ 6cores)
 .TBG_coresPerGPU=6
+.TBG_numHostedGPUPerNode=8
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi)
 
 # We only start 1 MPI task per GPU
 .TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"

--- a/etc/picongpu/taurus-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/A100_picongpu.profile.example
@@ -15,22 +15,15 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Modules #####################################################################
 #
-module switch modenv/hiera
-
-# load GCC/10.3.0, zlib 1.2.11, OpenMPI/4.1.1 and others
-module load foss/2021a
-module load CUDA/11.6.0
-module load HDF5/1.10.7
-module load CMake
+# load GCC/11.3.0, zlib 1.2.12, OpenMPI/4.1.4 and others
+module load release/23.04
+module load foss/2022a
+module load CUDA/12.0.0
+module load HDF5/1.13.2
+module load CMake/3.24.3
 module load libpng/1.6.37
-module load freetype/2.10.4
-
-printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
-printf "@ Note: You need to compile picongpu on a node. @\n"
-printf "@       Likewise for building the libraries.    @\n"
-printf "@       Get a node with the getNode command.    @\n"
-printf "@       Then source %s again.@\n" "$(basename $PIC_PROFILE)"
-printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
+module load freetype/2.12.1
+module load git/2.36.0-nodocs
 
 # Self-Build Software #########################################################
 #
@@ -39,21 +32,11 @@ printf "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n"
 # https://gist.github.com/BeyondEspresso/c8f9e07224e2844db299b664a32ceab7#file-taurus-a100-build-picongpu-dependencies-sh
 #
 export PIC_LIBS=$HOME/lib/alpha
-export BOOST_ROOT=$PIC_LIBS/boost-1.68.0
-export PNGwriter_DIR=$PIC_LIBS/pngwriter-0.7.0
-export BLOSC_ROOT=$PIC_LIBS/blosc-1.21.0
-export ADIOS2_ROOT=$PIC_LIBS/adios2-2.7.1
-export OPENPMD_ROOT=$PIC_LIBS/openpmd-0.14.3
-
-export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
-export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$PNGwriter_DIR/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
-
-export PATH=$ADIOS2_ROOT/bin:$PATH
-
+export CMAKE_PREFIX_PATH=$PIC_LIBS/boost:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS/pngwriter:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS/c-blosc2:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS/adios2:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS/openPMD-api:$CMAKE_PREFIX_PATH
 
 export PICSRC=$HOME/src/picongpu
 export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
@@ -88,7 +71,7 @@ function getNode() {
         numNodes=$1
     fi
     export OMP_NUM_THREADS=6
-    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((8 * $numNodes)) --ntasks-per-node=8 --cpus-per-task=6 --mem=0 --exclusive --gres=gpu:8 -p alpha-interactive --pty bash
+    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((8 * $numNodes)) --ntasks-per-node=8 --cpus-per-task=6 --mem=0 --exclusive --gres=gpu:8 -p alpha --pty bash
 }
 
 # allocate an interactive shell for two hours
@@ -105,7 +88,7 @@ function getDevice() {
         fi
     fi
     export OMP_NUM_THREADS=6
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha-interactive --pty bash
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha --pty bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/taurus-tud/A100_restart.tpl
+++ b/etc/picongpu/taurus-tud/A100_restart.tpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2013-2023 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+# Copyright 2013-2024 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
 #
 # This file is part of PIConGPU.
 #
@@ -19,7 +19,7 @@
 #
 
 
-# PIConGPU batch script for taurus' SLURM batch system
+# PIConGPU batch script for alpha centauri's SLURM batch system
 # This tpl for automated restarts is older than the actual
 # V100.tpl.
 # It uses a machine file for parallel job execution,
@@ -64,12 +64,11 @@
 .TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
-# 8 gpus per node
-.TBG_gpusPerNode=`if [ $TBG_tasks -gt 8 ] ; then echo 8; else echo $TBG_tasks; fi`
-
 # number of CPU cores to block per GPU
 # we got 6 CPU cores per GPU (48cores/8gpus ~ 6cores)
 .TBG_coresPerGPU=6
+.TBG_numHostedGPUPerNode=8
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi)
 
 # We only start 1 MPI task per GPU
 .TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"


### PR DESCRIPTION
This PR updates the A100 profiles of the old Taurus system at TUD/ZIH for its successor cluster alpha centauri.