### PR TITLE
fix out of bounds memory access in RollForOverSubscription

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
@@ -110,14 +110,15 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     bool const processUsesElectronHistogramWeight
                         = enums::IsProcess<enums::ProcessClassGroup::electronicCollisional>::check(processClass);
+                    bool usesNotOverSubcribedBin = false;
 
-                    bool const usesNotOverSubcribedBin
-                        = (rejectionProbabilityCache.rejectionProbability(binIndex) <= 0._X);
+                    if(processUsesElectronHistogramWeight)
+                        usesNotOverSubcribedBin = (rejectionProbabilityCache.rejectionProbability(binIndex) <= 0._X);
 
                     if constexpr(picongpu::atomicPhysics::debug::kernel::rollForOverSubscription::
                                      PRINT_DEBUG_TO_CONSOLE)
                     {
-                        if(!usesNotOverSubcribedBin && processUsesElectronHistogramWeight && ion[accepted_])
+                        if(ion[accepted_] && processUsesElectronHistogramWeight && !usesNotOverSubcribedBin)
                         {
                             picongpu::particles::atomicPhysics::debug::PrintAtomicPhysicsIonToConsole{}(
                                 worker.getAcc(),


### PR DESCRIPTION
Fixes an out of bound memory access in the RollForOversubscription caused by the change of the default value of the `binIndex` particle attribute introduced in PR #5079.

Previously it was safe to do a lockup in the `RejectionProbabilityCache` independent of the `processClass` since, the ion `binIndex` attribute was guaranteed to always be a valid value, independent of the previously selected process class.
If the `processClass` did not belong to a histogram using process this value was simply ignored.

Now only ions with a histogram using `processClass` are guaranteed to have a valid `binIndex` since we do not set a binIndex unless required for performance reasons. With the new invalid default values this causes an illegal memory access error.