### PR TITLE
remove clang extension usage

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -49,6 +49,7 @@
 
 #include <algorithm>
 #include <type_traits> // std::remove_reference_t
+#include <vector>
 
 namespace picongpu
 {
@@ -399,7 +400,7 @@ namespace picongpu
                         % (particleIoChunkInfo.largestChunk * particleSizeInByte);
 
                     myNumParticles = particleIoChunkInfo.totalNumParticles;
-                    uint64_t allNumParticles[mpiSize];
+                    std::vector<uint64_t> allNumParticles(mpiSize);
 
                     // avoid deadlock between not finished pmacc tasks and mpi blocking
                     // collectives
@@ -408,7 +409,7 @@ namespace picongpu
                         &myNumParticles,
                         1,
                         MPI_UNSIGNED_LONG_LONG,
-                        allNumParticles,
+                        allNumParticles.data(),
                         1,
                         MPI_UNSIGNED_LONG_LONG,
                         gc.getCommunicator().getMPIComm()));


### PR DESCRIPTION
fix warning

```
/builds/hzdr/crp/picongpu/include/picongpu/../picongpu/plugins/openPMD/WriteSpecies.hpp:424:40: note: read of non-const variable 'mpiSize' is not allowed in a constant expression
/builds/hzdr/crp/picongpu/include/picongpu/../picongpu/plugins/openPMD/WriteSpecies.hpp:337:26: note: declared here
  337 |                 uint64_t mpiSize = gc.getGlobalSize();
      |                          ^
/builds/hzdr/crp/picongpu/include/picongpu/../picongpu/plugins/openPMD/WriteSpecies.hpp:402:46: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  402 |                     uint64_t allNumParticles[mpiSize];
```