### PR TITLE
refactor `value_identifier`

### DIFF
--- a/include/picongpu/param/speciesAttributes.param
+++ b/include/picongpu/param/speciesAttributes.param
@@ -60,7 +60,12 @@ namespace picongpu
     value_identifier_func(
         uint64_t,
         particleId,
-        [] ALPAKA_FN_ACC(auto const& worker, IdGenerator& idGen, auto const&) { return idGen.fetchInc(worker); });
+        /* called when particle is created */
+        ([](auto const& worker, IdGenerator& idGen) constexpr { return idGen.fetchInc(worker); }),
+        /* called when particle is copied */
+        (pmacc::particles::identifier::CallCopy{}),
+        /* called when particle is derived from other particle */
+        (pmacc::particles::identifier::CallInitValue{}));
 
     //! specialization for the relative in-cell position
     value_identifier(floatD_X, position_pic, floatD_X::create(0.));

--- a/include/picongpu/particles/Particles.kernel
+++ b/include/picongpu/particles/Particles.kernel
@@ -133,7 +133,7 @@ namespace picongpu
 
                         if(accSrcFilter(worker, parSrc))
                         {
-                            parDest.copyAndInit(worker, idGen, deselect<particleId>(parSrc));
+                            parDest.derive(worker, idGen, parSrc);
 
                             accManipulator(worker, parDest, parSrc);
                         }

--- a/include/picongpu/particles/ParticlesInit.kernel
+++ b/include/picongpu/particles/ParticlesInit.kernel
@@ -267,7 +267,7 @@ namespace picongpu
                                     using ParticleCleanedAttrList =
                                         typename ResolveAndRemoveFromSeq<ParticleAttrList, AttrToIgnore>::type;
 
-                                    meta::ForEach<ParticleCleanedAttrList, SetAttributeToDefault<boost::mpl::_1>>
+                                    meta::ForEach<ParticleCleanedAttrList, InitValueIdentifier<boost::mpl::_1>>
                                         setToDefault;
 
                                     setToDefault(worker, idGen, particle);

--- a/include/picongpu/particles/atomicPhysics/initElectrons/CloneAdditionalAttributes.hpp
+++ b/include/picongpu/particles/atomicPhysics/initElectrons/CloneAdditionalAttributes.hpp
@@ -48,7 +48,7 @@ namespace picongpu::particles::atomicPhysics::initElectrons
             auto targetElectronClone = partOp::deselect<pmacc::mp_list<multiMask, momentum>>(electron);
 
             // otherwise this deselect will create incomplete type compile error
-            targetElectronClone.copyAndInit(worker, idGen, partOp::deselect<particleId>(ion));
+            targetElectronClone.derive(worker, idGen, ion);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::initElectrons

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/ThomasFermi_Impl.hpp
@@ -300,7 +300,7 @@ namespace picongpu
                      */
                     auto targetElectronClone = partOp::deselect<pmacc::mp_list<multiMask, momentum>>(childElectron);
 
-                    targetElectronClone.copyAndInit(worker, idGen, partOp::deselect<particleId>(parentIon));
+                    targetElectronClone.derive(worker, idGen, parentIon);
 
                     const float_X massIon = attribute::getMass(weighting, parentIon);
                     const float_X massElectron = attribute::getMass(weighting, childElectron);

--- a/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/ADK/ADK_Impl.hpp
@@ -248,7 +248,7 @@ namespace picongpu
                      */
                     auto targetElectronClone = partOp::deselect<pmacc::mp_list<multiMask, momentum>>(childElectron);
 
-                    targetElectronClone.copyAndInit(worker, idGen, partOp::deselect<particleId>(parentIon));
+                    targetElectronClone.derive(worker, idGen, parentIon);
 
                     const float_X massIon = attribute::getMass(weighting, parentIon);
                     const float_X massElectron = attribute::getMass(weighting, childElectron);

--- a/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/BSI/BSI_Impl.hpp
@@ -225,7 +225,7 @@ namespace picongpu
                      */
                     auto targetElectronClone = partOp::deselect<pmacc::mp_list<multiMask, momentum>>(childElectron);
 
-                    targetElectronClone.copyAndInit(worker, idGen, partOp::deselect<particleId>(parentIon));
+                    targetElectronClone.derive(worker, idGen, parentIon);
 
                     const float_X massIon = attribute::getMass(weighting, parentIon);
                     const float_X massElectron = attribute::getMass(weighting, childElectron);

--- a/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
+++ b/include/picongpu/particles/ionization/byField/Keldysh/Keldysh_Impl.hpp
@@ -248,7 +248,7 @@ namespace picongpu
                      */
                     auto targetElectronClone = partOp::deselect<pmacc::mp_list<multiMask, momentum>>(childElectron);
 
-                    targetElectronClone.copyAndInit(worker, idGen, partOp::deselect<particleId>(parentIon));
+                    targetElectronClone.derive(worker, idGen, parentIon);
 
                     const float_X massIon = attribute::getMass(weighting, parentIon);
                     const float_X massElectron = attribute::getMass(weighting, childElectron);

--- a/include/picongpu/particles/manipulators/binary/Copy.def
+++ b/include/picongpu/particles/manipulators/binary/Copy.def
@@ -1,0 +1,65 @@
+/* Copyright 2015-2023 Rene Widera, Axel Huebl
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/manipulators/generic/Free.def"
+
+#include <pmacc/particles/operations/Assign.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace manipulators
+        {
+            namespace binary
+            {
+                namespace acc
+                {
+                    //! assign attributes of one particle to another
+                    struct Copy
+                    {
+                        /** Copy all attributes defined in the source particle.
+                         *
+                         * @param particleDest destination particle
+                         * @param particleSrc source particle
+                         */
+                        template<typename T_Worker, typename T_DestParticle, typename T_SrcParticle>
+                        HDINLINE void operator()(
+                            T_Worker const&,
+                            T_DestParticle& particleDest,
+                            T_SrcParticle& particleSrc)
+                        {
+                            particleDest = particleSrc;
+                        }
+                    };
+                } // namespace acc
+
+                /** copy attributes of one particle to another
+                 *
+                 * The source particle must have at least the attributes the destination requires.
+                 */
+                using Copy = generic::Free<acc::Copy>;
+
+            } // namespace binary
+        } // namespace manipulators
+    } // namespace particles
+} // namespace picongpu

--- a/include/picongpu/particles/manipulators/binary/Derive.def
+++ b/include/picongpu/particles/manipulators/binary/Derive.def
@@ -35,11 +35,11 @@ namespace picongpu
                 namespace acc
                 {
                     //! assign attributes of one particle to another
-                    struct Assign
+                    struct Derive
                     {
                         IdGenerator m_idGen;
 
-                        Assign(uint32_t, IdGenerator idGenerator) : m_idGen(idGenerator)
+                        Derive(uint32_t, IdGenerator idGenerator) : m_idGen(idGenerator)
                         {
                         }
 
@@ -58,21 +58,20 @@ namespace picongpu
                             T_DestParticle& particleDest,
                             T_SrcParticle& particleSrc)
                         {
-                            particleDest.copyAndInit(worker, m_idGen, particleSrc);
+                            particleDest.derive(worker, m_idGen, particleSrc);
                         }
                     };
                 } // namespace acc
 
-                /** assign attributes of one particle to another
+                /** derive attributes of one particle to another
                  *
-                 * Can be used as binary and higher order operator but only the first two
-                 * particles are used for the assign operation.
-                 *
-                 * Assign all matching attributes of a source particle to the destination
-                 * particle. Attributes that only exist in the destination species are initialized
-                 * with the default value. Attributes that only exists in the source particle will be ignored.
+                 * Compared to Copy, this functor can be called on species with different attribute lists.
+                 * Typically common attributes are copied and unique attributes only existing in the destination
+                 * particle will set to the initial default value. Please check the definition of all the particle
+                 * attributes in speciesAttributes.param. Attributes are allowed to changes the behaviour for the
+                 * derive operation.
                  */
-                using Assign = generic::Free<acc::Assign>;
+                using Derive = generic::Free<acc::Derive>;
 
             } // namespace binary
         } // namespace manipulators

--- a/include/picongpu/particles/manipulators/manipulators.def
+++ b/include/picongpu/particles/manipulators/manipulators.def
@@ -24,8 +24,9 @@
 
 #include "picongpu/particles/manipulators/IBinary.def"
 #include "picongpu/particles/manipulators/IUnary.def"
-#include "picongpu/particles/manipulators/binary/Assign.def"
+#include "picongpu/particles/manipulators/binary/Copy.def"
 #include "picongpu/particles/manipulators/binary/DensityWeighting.def"
+#include "picongpu/particles/manipulators/binary/Derive.def"
 #include "picongpu/particles/manipulators/binary/ProtonTimesWeighting.def"
 #include "picongpu/particles/manipulators/binary/UnboundElectronsTimesWeighting.def"
 #include "picongpu/particles/manipulators/generic/Free.def"

--- a/include/picongpu/particles/synchrotron/AlgorithmSynchrotron.hpp
+++ b/include/picongpu/particles/synchrotron/AlgorithmSynchrotron.hpp
@@ -415,7 +415,7 @@ namespace picongpu
                      */
                     auto targetPhotonClone = partOp::deselect<pmacc::mp_list<multiMask, momentum>>(childPhoton);
 
-                    targetPhotonClone.copyAndInit(worker, idGen, partOp::deselect<particleId>(parentElectron));
+                    targetPhotonClone.derive(worker, idGen, parentElectron);
 
                     childPhoton[momentum_] = m_PhotonMomentum;
 

--- a/include/pmacc/identifier/value_identifier.hpp
+++ b/include/pmacc/identifier/value_identifier.hpp
@@ -23,11 +23,68 @@
 
 #include "pmacc/identifier/identifier.hpp"
 #include "pmacc/particles/IdProvider.hpp"
+#include "pmacc/ppFunctions.hpp"
+#include "pmacc/traits/HasIdentifier.hpp"
 #include "pmacc/types.hpp"
 
 #include <string>
 
-/* No namespace is needed because we only have defines*/
+
+namespace pmacc::particles::identifier
+{
+    /** copy value from the source particle
+     *
+     * This class can be used as copyFunctor for value_identifier_func.
+     */
+    struct CallCopy
+    {
+        template<typename T_Identifier, typename T_ParticleType>
+        constexpr auto operator()(T_Identifier const identifier, T_ParticleType const& srcParticle) const
+        {
+            return srcParticle[identifier];
+        }
+    };
+
+    /** copy value or init from default value
+     *
+     * If the source particle contains the identifier the method copyValue() from the
+     * identifier will be called else initValue() is called.
+     *
+     * This class can be used as deriveFunctor for value_identifier_func.
+     */
+    struct CallCopyOrInit
+    {
+        template<typename T_Worker, typename T_Identifier, typename T_ParticleType>
+        constexpr auto operator()(
+            T_Worker const& worker,
+            IdGenerator& idGen,
+            T_Identifier const identifier,
+            T_ParticleType const& srcParticle) const
+        {
+            if constexpr(pmacc::traits::HasIdentifier<T_ParticleType, T_Identifier>::type::value)
+                return identifier.copyValue(identifier, srcParticle);
+            else
+                return identifier.initValue(worker, idGen);
+        }
+    };
+
+    /** calls the method initValue() from the identifier
+     *
+     * This class can be used as deriveFunctor for value_identifier_func.
+     */
+    struct CallInitValue
+    {
+        template<typename T_Worker, typename T_Identifier, typename T_ParticleType>
+        constexpr auto operator()(
+            T_Worker const& worker,
+            IdGenerator& idGen,
+            T_Identifier const identifier,
+            T_ParticleType const&) const
+        {
+            return identifier.initValue(worker, idGen);
+        }
+    };
+} // namespace pmacc::particles::identifier
 
 /** define a unique identifier with name, type and a default value
  * @param in_type type of the value
@@ -35,36 +92,69 @@
  *
  * The created identifier has the following options:
  *      getValue()        - return the user defined value of value_identifier
- *      getValue(worker,IdGenerator) - return the user defined value of value_identifier_func
+ *      initValue(worker,IdGenerator) - return the user defined value of value_identifier_func
+ *      copyValue(identifier, SourceParticle) - return the identifier from the source particle
+ *      deriveValue(worker,IdGenerator, identifier, SourceParticle)
+ *                        - return the derived identifier value from the source particle
  *      getName()         - return the name of the identifier
  *      ::type            - get type of the value
  *
- * e.g. value_identifier(float,length,0.0f)
+ * @code{.cpp}
+ *      value_identifier(float,length,0.0f)
  *      typedef length::type value_type; // is float
  *      value_type x = length::getValue(); //set x to 0.f
  *      printf("Identifier name: %s",length::getName()); //print Identifier name: length
+ * @endcode
  *
  * to create a instance of this value_identifier you can use:
  *      `length()` or `length_`
  * @{
  */
 
-/** @param ... Must be a device function/lambda with arguments worker, IdGenerator and source particle.
- *             @attention source particle can be invalid, isHandleValid() can be used to check the status.
- *             To stay generic the lambda should be guarded against deriving from a particle which does not provide the
- *             required attributes to initialize the value.
+/**
+ * @param initFunctor Should be a constexpr function/lambda with arguments worker, IdGenerator. Functor must be
+ * surrounded by round brackets. The functor is called at the moment where a particle is the first time created.
+ * @param copyFunctor Should be a constexpr function/lambda with arguments identifier, source particle. Functor must be
+ * surrounded by round brackets. The functor is called if the same particle type is copied. The identifier can be used
+ * without checking the source particle type.
+ * @param deriveFunctor Should be a constexpr function/lambda with arguments worker, IdGenerator, identifier, source
+ * particle. Functor must be surrounded by round brackets. The functor is called when a particle is derived from
+ * another. It is not guaranteed that the source particle has each identifier given into the functor.
  *
  * @code{.cpp}
- * [] ALPAKA_FN_ACC(auto const& worker, IdGenerator& idGen, auto const& srcParticle) { return idGen.fetchInc(worker) };
+ * # possible functor for initFunctor
+ * [] ALPAKA_FN_ACC(auto const& worker, IdGenerator& idGen, auto const& srcParticle) { return idGen.fetchInc(worker);
+ * };
+ *
+ * # possible functor for copyFunctor
+ * [] ALPAKA_FN_ACC(auto const identifier, auto const& srcParticle) { return srcParticle[identifier]; };
+ *
+ * # possible functor for deriveFunctor, see pmacc::particles::identifier::CopyOrInit
  * @endcode
  */
-#define value_identifier_func(in_type, name, ...)                                                                     \
+#define value_identifier_func(in_type, name, initFunctor, copyFunctor, deriveFunctor)                                 \
     identifier(                                                                                                       \
-        name, using type = in_type; template<typename T_Worker, typename T_SrcParticleType> DINLINE static type       \
-            getValue(T_Worker const& worker, IdGenerator& idGen, T_SrcParticleType const& srcParticle)                \
+        name, using type = in_type;                                                                                   \
+                                                                                                                      \
+        template<typename T_Identifier, typename T_SrcParticleType>                                                   \
+        constexpr type copyValue(T_Identifier const idName, T_SrcParticleType const& srcParticle) const               \
         {                                                                                                             \
-            auto const func = __VA_ARGS__;                                                                            \
-            return func(worker, idGen, srcParticle);                                                                  \
+            auto const func = PMACC_REMOVE_BRACKETS copyFunctor;                                                      \
+            return func(idName, srcParticle);                                                                         \
+        } template<typename T_Worker, typename T_Identifier, typename T_SrcParticleType>                              \
+        constexpr type deriveValue(                                                                                   \
+            T_Worker const& worker,                                                                                   \
+            IdGenerator& idGen,                                                                                       \
+            T_Identifier const idName,                                                                                \
+            T_SrcParticleType const& srcParticle) const                                                               \
+        {                                                                                                             \
+            auto const func = PMACC_REMOVE_BRACKETS deriveFunctor;                                                    \
+            return func(worker, idGen, idName, srcParticle);                                                          \
+        } template<typename T_Worker>                                                                                 \
+        constexpr type initValue(T_Worker const& worker, IdGenerator& idGen) const                                    \
+        {                                                                                                             \
+            auto const func = PMACC_REMOVE_BRACKETS initFunctor;                                                      \
+            return func(worker, idGen);                                                                               \
         } static std::string getName() { return std::string(#name); })
 
 /** getValue() is defined constexpr
@@ -77,10 +167,15 @@
  */
 #define value_identifier(in_type, name, ...)                                                                          \
     identifier(                                                                                                       \
-        name, using type = in_type; template<typename T_Worker, typename T_SrcParticleType>                           \
-        HDINLINE static constexpr type getValue(                                                                      \
-            [[maybe_unused]] T_Worker const& acc,                                                                     \
-            [[maybe_unused]] IdGenerator& idGen,                                                                      \
-            [[maybe_unused]] T_SrcParticleType const& srcParticle)                                                    \
-        { return __VA_ARGS__; } HDINLINE static constexpr type getValue()                                             \
+        name, using type = in_type; template<typename T_Identifier, typename T_SrcParticleType>                       \
+        constexpr type copyValue(T_Identifier const idName, T_SrcParticleType const& srcParticle) const               \
+        { return srcParticle[idName]; } template<typename T_Worker>                                                   \
+        constexpr type initValue(T_Worker const&, IdGenerator&) const                                                 \
+        { return getValue(); } template<typename T_Worker, typename T_Identifier, typename T_SrcParticleType>         \
+        constexpr type deriveValue(                                                                                   \
+            T_Worker const&,                                                                                          \
+            IdGenerator&,                                                                                             \
+            T_Identifier const idName,                                                                                \
+            T_SrcParticleType const& srcParticle) const                                                               \
+        { return srcParticle[idName]; } static constexpr type getValue()                                              \
         { return __VA_ARGS__; } static std::string getName() { return std::string(#name); })

--- a/include/pmacc/particles/operations/CopyValueIdentifier.hpp
+++ b/include/pmacc/particles/operations/CopyValueIdentifier.hpp
@@ -1,0 +1,47 @@
+/* Copyright 2013-2023 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/attribute/FunctionSpecifier.hpp"
+#include "pmacc/traits/Resolve.hpp"
+
+namespace pmacc
+{
+    /** copy an attribute of a particle from another particle
+     *
+     * @tparam T_Attribute value_identifier or alias which is a value_identifier
+     *                     Attribute must be available in source and destination particle.
+     */
+    template<typename T_Attribute>
+    struct CopyValueIdentifier
+    {
+        /** derive value from source particle and assign it to the destination */
+        template<typename T_DestParticleType, typename T_SrcParticleType>
+        HDINLINE void operator()(T_DestParticleType& destParticle, T_SrcParticleType const& srcParticle) const
+        {
+            using ResolvedAttr = typename pmacc::traits::Resolve<T_Attribute>::type;
+            /* set attribute to its user defined default value */
+            destParticle[T_Attribute()] = ResolvedAttr{}.copyValue(T_Attribute{}, srcParticle);
+        }
+    };
+
+} // namespace pmacc

--- a/include/pmacc/particles/operations/DeriveValueIdentifier.hpp
+++ b/include/pmacc/particles/operations/DeriveValueIdentifier.hpp
@@ -32,38 +32,21 @@ namespace pmacc
      * @tparam  T_Attribute value_identifier or alias which is a value_identifier
      */
     template<typename T_Attribute>
-    struct SetAttributeToDefault
+    struct DeriveValueIdentifier
     {
         using Attribute = T_Attribute;
-
-        /** set an attribute to their default value
-         *
-         * Check value_identifier and value_identifier_func for special behaviours on how defaults get derived.
-         *
-         * @tparam T_DestParticleType particle type
-         *
-         * @{
-         */
-        template<typename T_Worker, typename T_DestParticleType>
-        HDINLINE void operator()(T_Worker const& worker, IdGenerator idGen, T_DestParticleType& destParticle)
-        {
-            using ResolvedAttr = typename pmacc::traits::Resolve<Attribute>::type;
-            /* set attribute to its user defined default value */
-            destParticle[Attribute()] = ResolvedAttr::getValue(worker, idGen, T_DestParticleType{});
-        }
 
         template<typename T_Worker, typename T_DestParticleType, typename T_SrcParticleType>
         HDINLINE void operator()(
             T_Worker const& worker,
             IdGenerator idGen,
             T_DestParticleType& destParticle,
-            T_SrcParticleType const& srcParticle)
+            T_SrcParticleType const& srcParticle) const
         {
             using ResolvedAttr = typename pmacc::traits::Resolve<Attribute>::type;
             /* set attribute to its user defined default value */
-            destParticle[Attribute()] = ResolvedAttr::getValue(worker, idGen, srcParticle);
+            destParticle[Attribute{}] = ResolvedAttr{}.deriveValue(worker, idGen, T_Attribute{}, srcParticle);
         }
-        /** @} */
     };
 
 

--- a/include/pmacc/particles/operations/InitValueIdentifier.hpp
+++ b/include/pmacc/particles/operations/InitValueIdentifier.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2023 Rene Widera
+/* Copyright 2014-2023 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -21,18 +21,29 @@
 
 #pragma once
 
-#include "pmacc/attribute/FunctionSpecifier.hpp"
+#include "pmacc/identifier/value_identifier.hpp"
+#include "pmacc/traits/Resolve.hpp"
+#include "pmacc/types.hpp"
 
 namespace pmacc
 {
-    template<typename T_Key>
-    struct CopyIdentifier
+    /** set an attribute of a particle to its default value
+     *
+     * @tparam  T_Attribute value_identifier or alias which is a value_identifier
+     */
+    template<typename T_Attribute>
+    struct InitValueIdentifier
     {
-        template<typename T_T1, typename T_T2>
-        HDINLINE void operator()(T_T1& dest, const T_T2& src)
+        using Attribute = T_Attribute;
+
+        template<typename T_Worker, typename T_DestParticleType>
+        HDINLINE void operator()(T_Worker const& worker, IdGenerator idGen, T_DestParticleType& destParticle) const
         {
-            dest[T_Key()] = src[T_Key()];
+            using ResolvedAttr = typename pmacc::traits::Resolve<Attribute>::type;
+            /* set attribute to its user defined default value */
+            destParticle[Attribute{}] = ResolvedAttr{}.initValue(worker, idGen);
         }
     };
+
 
 } // namespace pmacc

--- a/include/pmacc/ppFunctions.hpp
+++ b/include/pmacc/ppFunctions.hpp
@@ -80,3 +80,14 @@
                        ? 4                                                                                            \
                        : ((value) <= 8 ? 8                                                                            \
                                        : ((value) <= 16 ? 16 : ((value) <= 32 ? 32 : ((value) <= 64 ? 64 : 128)))))))
+
+/** Removes brackets from an macro function parameter
+ *
+ *  @code{.cpp}
+ *  PMACC_REMOVE_BRACKETS (foo)
+ *
+ *  // will be transformed to:
+ *  //   foo
+ *  @endcode
+ */
+#define PMACC_REMOVE_BRACKETS(...) __VA_ARGS__


### PR DESCRIPTION
This PR provide the possibility that a value_identifier can fully describe the operation performed for the
  - first initialization -> `initValue()`
  - if a particle attribute is copied -> `copyValue()`
  - if a particle attribute is derived -> `deriveValue()`

For PIConGPU the binary manipulator `Assign` is renamed into `Derive` and a `Copy` manipulator is added.

With the new description of value identifier, there is no need to handle special attributes e.g. `particleId` explicitly in any algorithm where we derive particles.

**BREAKING** input change. In principle, this is a breaking change because `speciesAttributes.param` changed **BUT** typically this file is not part of input sets, therefore users should not be affected.

With the new attributes it is possible to implement a counter to count how often a particle is deep copied during the simulation runtime. This can be useful for code optimizations.

```C++
value_identifier_func(
    uint32_t,
    numCopies,
    ([](auto const&, IdGenerator&) constexpr { return 0u; }),
    ([](auto const idName, auto const& srcParticle) constexpr { return srcParticle[idName] + 1u; }),
    (pmacc::particles::identifier::CallInit{}));


template<>
struct Unit<numCopies>
{
    // unitless and not scaled by a factor: by convention 1.0
    static std::vector<double> get()
    {
        std::vector<double> unit(1, 1.0);
        return unit;
    }
};
template<>
struct UnitDimension<numCopies>
{
    static std::vector<float_64> get()
    {
        // numCopies is unitless
        std::vector<float_64> unitDimension(NUnitDimension, 0.0);

        return unitDimension;
    }
};
template<>
struct MacroWeighted<numCopies>
{
    // identical and can not be scaled by weightings
    static bool get()
    {
        return false;
    }
};
template<>
struct WeightingPower<numCopies>
{
    // flag * weighting^0 == flag: same for real and macro particle
    static float_64 get()
    {
        return 0.0;
    }
};
```
