### PR TITLE
refactor: `HBAR`, `RYDBERG_ENERGY` and `BOHR_RADIOUS`

### DIFF
--- a/docs/source/usage/workflows/synchrotronExtensionDocumentation.rst
+++ b/docs/source/usage/workflows/synchrotronExtensionDocumentation.rst
@@ -49,7 +49,7 @@ Param: ``minEnergy``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~	 
 - **Type:** `float_64`
 - **Unit:** PIC units 
-- **Default:** `HBAR / sim.pic.getDt()`
+- **Default:** `sim.pic.getHbar() / sim.pic.getDt()`
 - **Description:** Sets the minimum energy threshold for photons to be considered in the simulation. This parameter helps in filtering out low-energy photons that may be already accounted for by the PIC fields. The default value is an approximation for the maximum photon energy that can be resolved by the field grid. This parameter is dependent on the internal unit system used in PIConGPU (Please use variables defined in `/picongpu/include/picongpu/unitless/*.unitless`).
 
 Precomputation Parameters

--- a/include/picongpu/param/ionizer.param
+++ b/include/picongpu/param/ionizer.param
@@ -493,7 +493,7 @@ namespace picongpu
                  */
                 constexpr float_X CUTOFF_MAX_ENERGY_KEV = 50.0;
                 /** cutoff energy for electron "temperature" calculation in SI units*/
-                constexpr float_X CUTOFF_MAX_ENERGY = CUTOFF_MAX_ENERGY_KEV * UNITCONV_keV_to_Joule;
+                constexpr float_X CUTOFF_MAX_ENERGY = CUTOFF_MAX_ENERGY_KEV * sim.si.conv.ev2Joule(1.0e3);
 
                 /** lower ion density cutoff
                  *

--- a/include/picongpu/param/physicalConstants.param
+++ b/include/picongpu/param/physicalConstants.param
@@ -37,16 +37,9 @@ namespace picongpu
          * 2022 CODATA Value, https://physics.nist.gov/cgi-bin/cuu/Value?mu0
          */
         constexpr float_64 MUE0_SI = 1.25663706127e-6;
+
         /** unit: C / (V m) */
         constexpr float_64 EPS0_SI = 1.0 / MUE0_SI / SPEED_OF_LIGHT_SI / SPEED_OF_LIGHT_SI;
-
-        /** reduced Planck constant
-         *
-         * unit: J * s
-         *
-         * 2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?hbar
-         */
-        constexpr float_64 HBAR_SI = 1.054571817e-34;
 
         // Electron properties
         //! unit: kg,   2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?me
@@ -59,18 +52,6 @@ namespace picongpu
          */
         constexpr float_64 ATOMIC_UNIT_ENERGY = 4.36e-18;
 
-        /** Rydberg energy, unit: eV
-         *
-         * 2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?rydhcev
-         */
-        constexpr float_64 RYDBERG_ENERGY = 13.605693122990_X; // eV
-
-        /** bohr radius, unit: m
-         *
-         * 2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0
-         */
-        constexpr float_64 BOHR_RADIUS = 5.29177210544e-11;
-
         /* atomic unit for electric field in V/m:
          * field strength between electron and core in ground state hydrogen
          */
@@ -81,50 +62,7 @@ namespace picongpu
          */
         constexpr float_64 ATOMIC_UNIT_TIME = 2.4189e-17;
 
-        /** Avogadro number
-         * unit: mol^-1
-         *
-         * Y. Azuma et al. Improved measurement results for the Avogadro
-         * constant using a 28-Si-enriched crystal, Metrologie 52, 2015, 360-375
-         * doi:10.1088/0026-1394/52/2/360
-         */
-        constexpr float_64 N_AVOGADRO = 6.02214076e23;
-
-        //! Classical electron radius in SI units
-        constexpr float_64 ELECTRON_RADIUS_SI = ELECTRON_CHARGE_SI * ELECTRON_CHARGE_SI
-            / (4.0 * PI * EPS0_SI * ELECTRON_MASS_SI * SPEED_OF_LIGHT_SI * SPEED_OF_LIGHT_SI);
     } // namespace SI
-
-    /** conversions
-     *
-     * UNIT_A to UNIT_B
-     *
-     * CONVENTION: WE DO NOT CONVERT FROM ANY STRANGE UNIT TO UNITLESS UNITS DIRECTLY!
-     *             convert steps: INPUT -> float_64_convert to SI -> float_64_convert to unitless
-     *                                  -> cast to float
-     * WE DO NOT define "sim.unit.energy()_keV" or something similar! Never!
-     * Stay SI, stay free ;-)
-     *
-     * example:
-     *   // some particle physicist beloved input:
-     *   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
-     *
-     *   // first convert to SI (because SI stays our standard Unit System!)
-     *   constexpr float_64 An_Arbitrary_Energy_Input_SI = An_Arbitrary_Energy_Input_keV * UNITCONV_keV_to_Joule //
-     *   unit: Joule
-     *
-     *   // now the "real" convert to our internal unitless system
-     *   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI / sim.unit.energy()) //
-     * unit: none
-     *
-     * As a convention, we DO NOT use the short track:
-     *   constexpr float_64 An_Arbitrary_Energy_Input_keV = 30.0; // unit: keV
-     *   constexpr float_X An_Arbitrary_Energy_Input = float_X(An_Arbitrary_Energy_Input_SI * UNITCONV_keV_to_Joule /
-     *   sim.unit.energy()) // unit: none
-     */
-    constexpr float_64 UNITCONV_keV_to_Joule = 1.602176634e-16;
-    constexpr float_64 UNITCONV_eV_to_Joule = UNITCONV_keV_to_Joule * 1e-3;
-    constexpr float_64 UNITCONV_Joule_to_keV = (1.0 / UNITCONV_keV_to_Joule);
 
     /* 1 atomic unit of energy is equal to 1 Hartree or 2 Rydberg
      * which is twice the ground state binding energy of atomic hydrogen */

--- a/include/picongpu/param/synchrotron.param
+++ b/include/picongpu/param/synchrotron.param
@@ -37,9 +37,8 @@ namespace picongpu
                 //! @todo bool for turning on or off the photon generation
 
                 /* energy HiPass filter: accept only photons with energy higher than this value
-                 * in PIC units: use HBAR, sim.pic.getDt() etc. from /picongpu/include/picongpu/unitless/?.unitless
                  */
-                constexpr float_64 minEnergy = HBAR / sim.pic.getDt();
+                constexpr float_64 minEnergy = sim.pic.getHbar<float_64>() / sim.pic.getDt<float_64>();
 
                 //! Parameters how to compute first synhrotron function
                 struct FirstSynchrotronFunctionParams

--- a/include/picongpu/particles/atomicPhysics/GetPhysicalEnergy.hpp
+++ b/include/picongpu/particles/atomicPhysics/GetPhysicalEnergy.hpp
@@ -69,7 +69,7 @@ namespace picongpu::particles::atomicPhysics
             // unit conversion factor for eV
             constexpr float_X eV = static_cast<float_X>(
                 picongpu::sim.unit.mass() * picongpu::sim.si.getSpeedOfLight() * picongpu::sim.si.getSpeedOfLight()
-                * picongpu::UNITCONV_Joule_to_keV * 1e3);
+                * sim.si.conv.joule2ev(1.0));
 
             // eV
             return energy * eV;

--- a/include/picongpu/particles/atomicPhysics/initElectrons/Inelastic2BodyCollisionFromCoMoving.hpp
+++ b/include/picongpu/particles/atomicPhysics/initElectrons/Inelastic2BodyCollisionFromCoMoving.hpp
@@ -199,7 +199,7 @@ namespace picongpu::particles::atomicPhysics::initElectrons
             float_64 const mE_mI = static_cast<float_64>(massElectron / massIon);
             // kg * m^2/s^2 * keV/J * 1e3 = J/J * eV = eV
             float_64 const mc2_Ion = static_cast<float_64>(massIon) * sim.unit.mass()
-                * pmacc::math::cPow(picongpu::sim.si.getSpeedOfLight(), 2u) * picongpu::UNITCONV_Joule_to_keV * 1.e3;
+                * pmacc::math::cPow(picongpu::sim.si.getSpeedOfLight(), 2u) * sim.si.conv.joule2ev(1.0);
 
             //  eV / eV + sim.unit.mass() / sim.unit.mass() = unitless
             float_64 const A_E = deltaEnergy / mc2_Ion + mE_mI;
@@ -248,7 +248,7 @@ namespace picongpu::particles::atomicPhysics::initElectrons
             float_64 const mI_mE = static_cast<float_64>(massIon / massElectron);
             // kg * m^2/s^2 * keV/J * 1e3 = J/J * eV = eV
             float_64 const mc2_Electron = static_cast<float_64>(massElectron) * sim.unit.mass()
-                * pmacc::math::cPow(picongpu::sim.si.getSpeedOfLight(), 2u) * picongpu::UNITCONV_Joule_to_keV * 1.e3;
+                * pmacc::math::cPow(picongpu::sim.si.getSpeedOfLight(), 2u) * sim.si.conv.joule2ev(1.0);
 
             float_64 const A_I = deltaEnergy / mc2_Electron + mI_mE;
             float_64 const gammaStarIon_IonSystem = (A_I * (A_I + 2.) + (mI_mE * mI_mE)) / ((A_I + 1.) * 2. * mI_mE);

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
@@ -211,7 +211,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
             // eV/(sim.unit.mass() * sim.unit.length()^2 / sim.unit.time()^2)
             constexpr float_X eV = static_cast<float_X>(
                 picongpu::sim.unit.mass() * pmacc::math::cPow(picongpu::sim.unit.length(), 2u)
-                / pmacc::math::cPow(picongpu::sim.unit.time(), 2u) * picongpu::UNITCONV_Joule_to_keV * 1e3);
+                / pmacc::math::cPow(picongpu::sim.unit.time(), 2u) * sim.si.conv.joule2ev(1.0));
 
             // eV/(sim.unit.mass() * sim.unit.length()^2 / sim.unit.time()^2) * unitless * sim.unit.charge()^2
             //  / ( unitless * sim.unit.charge()^2 * sim.unit.time()^2 / (sim.unit.length()^3 * sim.unit.mass()))

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -152,7 +152,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                     // eV/(sim.unit.mass() * sim.unit.length()^2 / sim.unit.time()^2)
                     constexpr float_X eV = static_cast<float_X>(
                         picongpu::sim.unit.mass() * pmacc::math::cPow(picongpu::sim.unit.length(), 2u)
-                        / pmacc::math::cPow(picongpu::sim.unit.time(), 2u) * picongpu::UNITCONV_Joule_to_keV * 1e3);
+                        / pmacc::math::cPow(picongpu::sim.unit.time(), 2u) * sim.si.conv.joule2ev(1.0));
 
                     // eV/(sim.unit.mass() * sim.unit.length()^2 / sim.unit.time()^2) * sim.unit.mass() *
                     // sim.unit.length()^2 / sim.unit.time()^2

--- a/include/picongpu/particles/atomicPhysics/kernel/DecelerateElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/DecelerateElectrons.kernel
@@ -115,7 +115,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     float_X const mcSquaredElectron = static_cast<float_X>(
                         static_cast<float_64>(picongpu::traits::frame::getMass<typename T_Electron::FrameType>())
                         * sim.unit.mass() * pmacc::math::cPow(picongpu::sim.si.getSpeedOfLight(), 2u)
-                        * UNITCONV_Joule_to_keV * 1.e3);
+                        * sim.si.conv.joule2ev(1.0));
                     // eV, not weighted
 
                     // distribute energy change as mean by weight on all electrons in bin
@@ -134,7 +134,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // usually ~1, internal units
 
                     constexpr float_X conversionEnergy
-                        = static_cast<float_X>(UNITCONV_eV_to_Joule * 1. / sim.unit.energy());
+                        = static_cast<float_X>(sim.si.conv.ev2Joule(1.0) / sim.unit.energy());
                     // J/(eV) * sim.unit.energy()/J  = J/J * sim.unit.energy()/(eV)
 
                     constexpr float_X scalingFactor = 1._X / c_internal * conversionEnergy;

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
@@ -246,11 +246,11 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
 
             // (unitless * m)^2 / (unitless * m^2/1e6b) = m^2 / m^2 * 1e6b = 1e6b
             constexpr float_X scalingConstant = static_cast<float_X>(
-                8. * pmacc::math::cPow(picongpu::PI * picongpu::SI::BOHR_RADIUS, u8(2u))
+                8. * pmacc::math::cPow(picongpu::PI * sim.si.getBohrRadius(), u8(2u))
                 / (1.e-22)); // [1e6b], ~ 2211,01 * 1e6b
             // 1e6b
             constexpr float_X constantPart
-                = scalingConstant * static_cast<float_X>(pmacc::math::cPow(picongpu::SI::RYDBERG_ENERGY, u8(2u)));
+                = scalingConstant * static_cast<float_X>(pmacc::math::cPow(sim.si.getRydbergEnergy(), u8(2u)));
             // [1e6b * (eV)^2]
 
             // 1e6b*(eV)^2 / (eV)^2 * unitless * (eV)/(eV) * unitless = 1e6b
@@ -377,7 +377,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             // unitless
             constexpr float_64 pi = picongpu::PI;
             // Js
-            constexpr float_64 hbar_SI = picongpu::SI::HBAR_SI;
+            constexpr float_64 hbar_SI = sim.si.getHbar();
 
             uint32_t const upperStateClctIdx
                 = boundBoundTransitionDataBox.upperStateCollectionIndex(transitionCollectionIndex);
@@ -389,8 +389,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
                 atomicStateDataBox.energy(upperStateClctIdx) - atomicStateDataBox.energy(lowerStateClctIdx));
 
             // J/(eV) / (Js) * s/sim.unit.time() = J/J * s/s * 1/(eV * sim.unit.time())
-            constexpr float_X scalingConstantPhotonFrequency = static_cast<float_X>(
-                picongpu::UNITCONV_eV_to_Joule / (2 * pi * hbar_SI) * picongpu::sim.unit.time());
+            constexpr float_X scalingConstantPhotonFrequency
+                = static_cast<float_X>(sim.si.conv.ev2Joule(1.0) / (2 * pi * hbar_SI) * picongpu::sim.unit.time());
 
             /// @attention actual SI frequency, NOT angular frequency
             // 1/sim.unit.time()

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
@@ -156,8 +156,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             if(energyDifference <= energyElectron)
             {
                 constexpr float_64 C = 2.3; // a fitting factor well suited for Z >= 2, unitless
-                constexpr float_64 a0 = picongpu::SI::BOHR_RADIUS; // m
-                constexpr float_64 E_R = picongpu::SI::RYDBERG_ENERGY; // eV
+                constexpr float_64 a0 = sim.si.getBohrRadius(); // m
+                constexpr float_64 E_R = sim.si.getRydbergEnergy(); // eV
                 constexpr float_64 scalingConstant
                     = C * picongpu::PI * pmacc::math::cPow(a0, 2u) / 1e-22 * pmacc::math::cPow(E_R, 2u);
                 // 10^6*b * eV^2

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/CollisionalRate.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/CollisionalRate.hpp
@@ -46,7 +46,7 @@ namespace picongpu::particles2::atomicPhysics::rateCalculation
         constexpr float_64 c_SI = picongpu::sim.si.getSpeedOfLight(); // [m/s]
         constexpr float_64 m_e_SI = picongpu::sim.si.getElectronMass(); // [kg]
 
-        constexpr float_64 electronRestMassEnergy = m_e_SI * c_SI * c_SI / picongpu::UNITCONV_eV_to_Joule;
+        constexpr float_64 electronRestMassEnergy = m_e_SI * c_SI * c_SI / sim.si.conv.ev2Joule(1.0);
         // kg * (m^2)/(s^2) * 1/(J/eV) = Nm * eV/J = J/J * eV
         // [eV] ~ 5.11e5
 

--- a/include/picongpu/particles/boundary/Thermal.hpp
+++ b/include/picongpu/particles/boundary/Thermal.hpp
@@ -71,7 +71,7 @@ namespace picongpu
                 static constexpr char const* name = "reflectThermalIfOutside";
 
                 HINLINE ReflectThermalIfOutside()
-                    : energy((m_parameters.temperature * UNITCONV_keV_to_Joule) / sim.unit.energy())
+                    : energy((m_parameters.temperature * sim.si.conv.ev2Joule(1.0e3)) / sim.unit.energy())
                 {
                 }
 

--- a/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
+++ b/include/picongpu/particles/collision/relativistic/RelativisticCollisionDynamicLog.hpp
@@ -60,7 +60,7 @@ namespace picongpu
 
                             // formula in line above eq. (22) in [Perez2012]:
                             const float_COLL minImpactParam = math::max(
-                                static_cast<float_COLL>(HBAR) * pmacc::math::Pi<float_COLL>::doubleValue
+                                sim.pic.getHbar<float_COLL>() * pmacc::math::Pi<float_COLL>::doubleValue
                                     / (2._COLL * math::sqrt(v.comsMomentum0Norm2) / precision::WEIGHT_NORM_COLL),
                                 twoRadImpactParam);
 

--- a/include/picongpu/particles/debyeLength/Estimate.kernel
+++ b/include/picongpu/particles/debyeLength/Estimate.kernel
@@ -213,7 +213,7 @@ namespace picongpu
                     using Frame = typename T_ElectronBox::FrameType;
                     auto const mass = static_cast<double>(picongpu::traits::frame::getMass<Frame>());
                     auto const kT = (momentumVariance[0] + momentumVariance[1] + momentumVariance[2]) / (3.0 * mass);
-                    auto const temperatureKeV = kT * sim.unit.energy() / UNITCONV_keV_to_Joule;
+                    auto const temperatureKeV = kT * sim.unit.energy() / sim.si.conv.ev2Joule(1.0e3);
                     auto const electronCharge = picongpu::traits::frame::getCharge<Frame>();
                     auto const debyeLength
                         = sqrt(sim.pic.getEps0() * kT / (electronDensity * electronCharge * electronCharge));

--- a/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
+++ b/include/picongpu/particles/ionization/byCollision/ThomasFermi/AlgorithmThomasFermi.hpp
@@ -161,13 +161,12 @@ namespace picongpu
                     /** convert kinetic energy in J to "temperature" in eV by assuming an ideal electron gas
                      * E_kin = 3/2 k*T
                      */
-                    constexpr float_64 convKinEnergyToTemperature
-                        = UNITCONV_Joule_to_keV * float_64(1.e3) * float_64(2. / 3.);
+                    constexpr float_64 convKinEnergyToTemperature = sim.si.conv.joule2ev(1.0) * float_64(2. / 3.);
                     /** electron "temperature" in electron volts */
                     float_64 const temperature = avgKinEnergy * convKinEnergyToTemperature;
 
                     /* conversion factors from number density to mass density */
-                    constexpr float_64 nAvogadro = SI::N_AVOGADRO;
+                    constexpr float_64 nAvogadro = sim.si.getNAvogadro();
                     constexpr float_64 convM3ToCM3 = 1.e6;
 
                     /* @TODO replace the float_64 with float_X and make sure the values are scaled to PIConGPU units */

--- a/include/picongpu/particles/manipulators/unary/Temperature.hpp
+++ b/include/picongpu/particles/manipulators/unary/Temperature.hpp
@@ -70,7 +70,8 @@ namespace picongpu
                                  * For the macroweighted momentums we store as particle[ momentum_ ],
                                  * the same relation holds, just m and E are also macroweighted
                                  */
-                                float_X const energy = (temperatureKeV * UNITCONV_keV_to_Joule) / sim.unit.energy();
+                                float_X const energy
+                                    = (temperatureKeV * sim.si.conv.ev2Joule(1.0e3)) / sim.unit.energy();
                                 float_X const macroWeighting = particle[weighting_];
                                 float_X const macroEnergy = macroWeighting * energy;
                                 float_X const macroMass = attribute::getMass(macroWeighting, particle);

--- a/include/picongpu/particles/synchrotron/AlgorithmSynchrotron.hpp
+++ b/include/picongpu/particles/synchrotron/AlgorithmSynchrotron.hpp
@@ -137,7 +137,7 @@ namespace picongpu
 
                     //! Calculate chi
                     float_X const gamma = Gamma()(parentElectron[momentum_], mass);
-                    float_X const inverse_E_Schwinger = (-sim.pic.getElectronCharge() * HBAR)
+                    float_X const inverse_E_Schwinger = (-sim.pic.getElectronCharge() * sim.pic.getHbar())
                         / (sim.pic.getElectronMass() * sim.pic.getElectronMass() * sim.pic.getSpeedOfLight()
                            * sim.pic.getSpeedOfLight() * sim.pic.getSpeedOfLight());
                     float_X const chi = HeffValue * gamma * inverse_E_Schwinger;
@@ -179,9 +179,9 @@ namespace picongpu
                      *   == dt * (e/hbar * e/hbar * m_e * c /( eps0 * 4 * np.pi)) and avoid floating point precision
                      * overflows
                      */
-                    float_X numericFactor = sim.pic.getDt() * sim.pic.getElectronCharge() / HBAR
-                        * sim.pic.getElectronCharge() / HBAR * sim.pic.getElectronMass() * sim.pic.getSpeedOfLight()
-                        / (sim.pic.getEps0() * 4._X * PI);
+                    float_X numericFactor = sim.pic.getDt() * sim.pic.getElectronCharge() / sim.pic.getHbar()
+                        * sim.pic.getElectronCharge() / sim.pic.getHbar() * sim.pic.getElectronMass()
+                        * sim.pic.getSpeedOfLight() / (sim.pic.getEps0() * 4._X * PI);
 
                     if constexpr(params::supressRequirementWarning == false)
                     {

--- a/include/picongpu/plugins/BinEnergyParticles.x.cpp
+++ b/include/picongpu/plugins/BinEnergyParticles.x.cpp
@@ -427,8 +427,8 @@ namespace picongpu
             auto idProvider = dc.get<IdProvider>("globalId");
 
             /* convert energy values from keV to PIConGPU units */
-            float_X const minEnergy = minEnergy_keV * UNITCONV_keV_to_Joule / sim.unit.energy();
-            float_X const maxEnergy = maxEnergy_keV * UNITCONV_keV_to_Joule / sim.unit.energy();
+            float_X const minEnergy = minEnergy_keV * sim.si.conv.ev2Joule(1.0e3) / sim.unit.energy();
+            float_X const maxEnergy = maxEnergy_keV * sim.si.conv.ev2Joule(1.0e3) / sim.unit.energy();
 
             auto const mapper = makeAreaMapper<AREA>(*m_cellDescription);
 

--- a/include/picongpu/plugins/binning/UnitConversion.hpp
+++ b/include/picongpu/plugins/binning/UnitConversion.hpp
@@ -36,7 +36,7 @@ namespace picongpu
             sim.unit.time(), // time
             sim.unit.charge() / sim.unit.time(), // current
             1., // thermodynamicTemperature
-            1., // amountOfSubstance add N_AVOGADRO HERE? FROM physicalConstants.param
+            1., // amountOfSubstance add sim.si.getNAvogadro() HERE? FROM physicalConstants.param
             1., // luminousIntensity
             // 1. // add weighting?
         };

--- a/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.x.cpp
+++ b/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.x.cpp
@@ -119,8 +119,8 @@ namespace picongpu
             {
                 const float_64 minEnergy_SI = this->minEnergy * sim.unit.energy();
                 const float_64 maxEnergy_SI = this->maxEnergy * sim.unit.energy();
-                const float_64 minEnergy_keV = minEnergy_SI * UNITCONV_Joule_to_keV;
-                const float_64 maxEnergy_keV = maxEnergy_SI * UNITCONV_Joule_to_keV;
+                const float_64 minEnergy_keV = minEnergy_SI * sim.si.conv.joule2ev(1.0e-3);
+                const float_64 maxEnergy_keV = maxEnergy_SI * sim.si.conv.joule2ev(1.0e-3);
 
                 dataset.setAttribute<float_64>("minEnergy[keV]", minEnergy_keV);
                 dataset.setAttribute<float_64>("maxEnergy[keV]", maxEnergy_keV);
@@ -301,8 +301,8 @@ namespace picongpu
             this->maxYaw_deg = float_X(0.5) * this->openingYaw_deg;
             this->maxPitch_deg = float_X(0.5) * this->openingPitch_deg;
             /* convert units */
-            const float_64 minEnergy_SI = this->minEnergy * UNITCONV_keV_to_Joule;
-            const float_64 maxEnergy_SI = this->maxEnergy * UNITCONV_keV_to_Joule;
+            const float_64 minEnergy_SI = this->minEnergy * sim.si.conv.ev2Joule(1.0e3);
+            const float_64 maxEnergy_SI = this->maxEnergy * sim.si.conv.ev2Joule(1.0e3);
             this->minEnergy = minEnergy_SI / sim.unit.energy();
             this->maxEnergy = maxEnergy_SI / sim.unit.energy();
 

--- a/include/picongpu/unitless/physicalConstants.unitless
+++ b/include/picongpu/unitless/physicalConstants.unitless
@@ -22,9 +22,6 @@
 
 namespace picongpu
 {
-    //! reduced Planck constant
-    constexpr float_X HBAR = (float_X) (SI::HBAR_SI / sim.unit.energy() / sim.unit.time());
-
     /* Atomic unit of electric field in PIC Efield units */
     constexpr float_X ATOMIC_UNIT_EFIELD = float_X(SI::ATOMIC_UNIT_EFIELD / sim.unit.eField());
 

--- a/include/picongpu/unitless/simulation.unitless
+++ b/include/picongpu/unitless/simulation.unitless
@@ -103,6 +103,30 @@ namespace picongpu
             {
                 return static_cast<T_Type>(pic.getMue0<T_Type>() * pic.getSpeedOfLight<T_Type>());
             }
+
+            template<typename T_Type = float_X>
+            constexpr T_Type getHbar() const
+            {
+                return static_cast<T_Type>(si.getHbar() / unit.energy() / unit.time());
+            }
+
+            template<typename T_Type = float_X>
+            constexpr T_Type getRydbergEnergy() const
+            {
+                return static_cast<T_Type>(si.getRydbergEnergy() / unit.energy());
+            }
+
+            template<typename T_Type = float_X>
+            constexpr T_Type getBohrRadius() const
+            {
+                return static_cast<T_Type>(si.getBohrRadius() / unit.length());
+            }
+
+            template<typename T_Type = float_X>
+            constexpr T_Type getClassicalElectronRadius() const
+            {
+                return static_cast<T_Type>(si.getClassicalElectronRadius() / unit.length());
+            }
         };
         struct SiUnits
         {
@@ -202,7 +226,75 @@ namespace picongpu
             {
                 return getMue0() * getSpeedOfLight();
             }
+
+            /** reduced Planck constant
+             *
+             * unit: J * s
+             *
+             * 2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?hbar
+             */
+            constexpr float_64 getHbar() const
+            {
+                return 1.054571817e-34;
+            }
+
+            /** Rydberg energy, unit: J
+             *
+             * 2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?rydhcev
+             */
+            constexpr float_64 getRydbergEnergy() const
+            {
+                // convert from  unit eV to Joule
+                return conv.ev2Joule(13.605693122990);
+            }
+
+            /** bohr radius, unit: m
+             *
+             * 2022 CODATA value, https://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0
+             */
+            constexpr float_64 getBohrRadius() const
+            {
+                return 5.29177210544e-11;
+            }
+
+            /** Avogadro number
+             * unit: mol^-1
+             *
+             * Y. Azuma et al. Improved measurement results for the Avogadro
+             * constant using a 28-Si-enriched crystal, Metrologie 52, 2015, 360-375
+             * doi:10.1088/0026-1394/52/2/360
+             */
+            constexpr float_64 getNAvogadro() const
+            {
+                return 6.02214076e23;
+            }
+
+            /** Classical electron radius, unit: m */
+            constexpr float_64 getClassicalElectronRadius() const
+            {
+                return getElectronCharge() * getElectronCharge()
+                    / (4.0 * PI * getEps0() * getElectronMass() * getSpeedOfLight() * getSpeedOfLight());
+            }
+
+            struct Convert
+            {
+                /** convert from eV into joule */
+                constexpr float_64 ev2Joule(float_64 eV = 1.0) const
+                {
+                    return eV * 1.602176634e-19;
+                }
+
+                /** convert from joule into eV */
+                constexpr float_64 joule2ev(float_64 joule = 1.0) const
+                {
+                    return joule / ev2Joule(1.0);
+                }
+            };
+
+            static constexpr Convert conv{};
         };
+
+        /** units to convert from SI into PIConGPU's SI unit system */
         struct Units
         {
             constexpr float_64 length() const

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
@@ -82,7 +82,7 @@ namespace picongpu
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = sim.si.getElectronMass() * sim.si.getSpeedOfLight()
-                    * sim.si.getSpeedOfLight() * UNITCONV_Joule_to_keV * 0.0000002;
+                    * sim.si.getSpeedOfLight() * sim.si.conv.joule2ev(1.0e-3) * 0.0000002;
             };
             /** Definition of manipulator assigning a temperature
              *  using parameters from struct TemperatureParamElectrons.
@@ -96,7 +96,7 @@ namespace picongpu
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = sim.si.getElectronMass() * sim.si.getSpeedOfLight()
-                    * sim.si.getSpeedOfLight() * UNITCONV_Joule_to_keV * 0.00002;
+                    * sim.si.getSpeedOfLight() * sim.si.conv.joule2ev(1.0e-3) * 0.00002;
             };
             /** Definition of manipulator assigning a temperature
              *  using parameters from struct TemperatureParamIons.

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
@@ -69,7 +69,7 @@ namespace picongpu
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = sim.si.getElectronMass() * sim.si.getSpeedOfLight()
-                    * sim.si.getSpeedOfLight() * UNITCONV_Joule_to_keV * 0.0002;
+                    * sim.si.getSpeedOfLight() * sim.si.conv.joule2ev(1.0e-3) * 0.0002;
             };
             /** Definition of manipulator assigning a temperature
              *  using parameters from struct TemperatureParamElectrons.
@@ -83,7 +83,7 @@ namespace picongpu
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = sim.si.getElectronMass() * sim.si.getSpeedOfLight()
-                    * sim.si.getSpeedOfLight() * UNITCONV_Joule_to_keV * 0.00018;
+                    * sim.si.getSpeedOfLight() * sim.si.conv.joule2ev(1.0e-3) * 0.00018;
             };
             /** Definition of manipulator assigning a temperature
              *  using parameters from struct TemperatureParamIons.

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/synchrotron.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/synchrotron.param
@@ -37,9 +37,8 @@ namespace picongpu
                 //! @todo bool for turning on or off the photon generation
 
                 /* energy HiPass filter: accept only photons with energy higher than this value
-                 * in PIC units: use HBAR, sim.pic.getDt() etc. from /picongpu/include/picongpu/unitless/?.unitless
                  */
-                constexpr float_64 minEnergy = HBAR / sim.pic.getDt();
+                constexpr float_64 minEnergy = sim.pic.getHbar<float_64>() / sim.pic.getDt<float_64>();
 
                 //! Parameters how to compute first synhrotron function
                 struct FirstSynchrotronFunctionParams

--- a/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/ionizer.param
+++ b/share/picongpu/tests/compileAtomicPhysics/include/picongpu/param/ionizer.param
@@ -193,7 +193,7 @@ namespace picongpu
                  */
                 constexpr float_X CUTOFF_MAX_ENERGY_KEV = 50.0;
                 /** cutoff energy for electron "temperature" calculation in SI units*/
-                constexpr float_X CUTOFF_MAX_ENERGY = CUTOFF_MAX_ENERGY_KEV * UNITCONV_keV_to_Joule;
+                constexpr float_X CUTOFF_MAX_ENERGY = CUTOFF_MAX_ENERGY_KEV * sim.si.conv.ev2Joule(1.0e3);
 
                 /** lower ion density cutoff
                  *


### PR DESCRIPTION
Move variables to the corresponding function into the PIConGPU `sim` object. 
Provide methods to convert from joule to eV and back.

The param files changed but this should not affect the user because `physicalConstants.param` is typically not part of the user setup.