### PR TITLE
fix gcc 13 compile issue

### DIFF
--- a/include/picongpu/particles/Particles.hpp
+++ b/include/picongpu/particles/Particles.hpp
@@ -189,6 +189,8 @@ namespace picongpu
             for(auto exchange : particles::boundary::getAllAxisAlignedExchanges())
             {
                 auto const axis = pmacc::boundary::getAxis(exchange);
+                if(axis >= simDim)
+                    throw std::runtime_error("The used exchange results into an invalid selected axis.");
                 auto const temperature = boundaryDescription()[axis].temperature;
 
                 const std::string directionName = ExchangeTypeNames()[exchange];

--- a/include/picongpu/particles/boundary/Absorbing.hpp
+++ b/include/picongpu/particles/boundary/Absorbing.hpp
@@ -84,6 +84,8 @@ namespace picongpu
                     pmacc::DataSpace<simDim> beginInternalCellsTotal, endInternalCellsTotal;
                     getInternalCellsTotal(species, exchangeType, &beginInternalCellsTotal, &endInternalCellsTotal);
                     auto const axis = pmacc::boundary::getAxis(exchangeType);
+                    if(axis >= simDim)
+                        throw std::runtime_error("The used exchange results into an invalid selected axis.");
                     AbsorbParticleIfOutside::parameters().axis = axis;
                     AbsorbParticleIfOutside::parameters().beginInternalCellsTotal = beginInternalCellsTotal[axis];
                     AbsorbParticleIfOutside::parameters().endInternalCellsTotal = endInternalCellsTotal[axis];
@@ -192,6 +194,8 @@ namespace picongpu
 
                     // Our active area is between particle boundary offset and inner PML boundary
                     auto const axis = pmacc::boundary::getAxis(exchangeType);
+                    if(axis >= simDim)
+                        throw std::runtime_error("The used exchange results into an invalid selected axis.");
                     auto const offsetCells = getOffsetCells(species, exchangeType);
                     auto const isMinSide = pmacc::boundary::isMinSide(exchangeType);
                     auto const& pmlImpl = absorberImpl.asPmlImpl();

--- a/include/picongpu/particles/boundary/Apply.hpp
+++ b/include/picongpu/particles/boundary/Apply.hpp
@@ -93,6 +93,8 @@ namespace picongpu
 
                     // Call boundary condition implementation
                     auto axis = pmacc::boundary::getAxis(exchange);
+                    if(axis >= simDim)
+                        throw std::runtime_error("The used exchange results into an invalid selected axis.");
                     auto boundaryDescription = species.boundaryDescription()[axis];
                     switch(boundaryDescription.kind)
                     {

--- a/include/picongpu/particles/boundary/Reflecting.hpp
+++ b/include/picongpu/particles/boundary/Reflecting.hpp
@@ -98,6 +98,8 @@ namespace picongpu
                     pmacc::DataSpace<simDim> beginInternalCellsTotal, endInternalCellsTotal;
                     getInternalCellsTotal(species, exchangeType, &beginInternalCellsTotal, &endInternalCellsTotal);
                     auto const axis = pmacc::boundary::getAxis(exchangeType);
+                    if(axis >= simDim)
+                        throw std::runtime_error("The used exchange results into an invalid selected axis.");
                     ReflectParticleIfOutside::parameters().axis = axis;
                     ReflectParticleIfOutside::parameters().beginInternalCellsTotal = beginInternalCellsTotal[axis];
                     ReflectParticleIfOutside::parameters().endInternalCellsTotal = endInternalCellsTotal[axis];

--- a/include/picongpu/particles/boundary/Utility.hpp
+++ b/include/picongpu/particles/boundary/Utility.hpp
@@ -65,6 +65,8 @@ namespace picongpu
             HINLINE uint32_t getOffsetCells(T_Species const& species, uint32_t exchangeType)
             {
                 uint32_t axis = pmacc::boundary::getAxis(exchangeType);
+                if(axis >= simDim)
+                    throw std::runtime_error("The used exchange results into an invalid selected axis.");
                 return species.boundaryDescription()[axis].offset;
             }
 
@@ -79,6 +81,8 @@ namespace picongpu
             HINLINE float_X getTemperature(T_Species const& species, uint32_t exchangeType)
             {
                 uint32_t axis = pmacc::boundary::getAxis(exchangeType);
+                if(axis >= simDim)
+                    throw std::runtime_error("The used exchange results into an invalid selected axis.");
                 return species.boundaryDescription()[axis].temperature;
             }
 
@@ -105,6 +109,8 @@ namespace picongpu
                 pmacc::DataSpace<simDim>* end)
             {
                 auto axis = pmacc::boundary::getAxis(exchangeType);
+                if(axis >= simDim)
+                    throw std::runtime_error("The used exchange results into an invalid selected axis.");
                 auto offsetCells = getOffsetCells(species, exchangeType);
                 SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
                 // For non-axis directions, we take all cells including the guards
@@ -142,6 +148,8 @@ namespace picongpu
                 pmacc::DataSpace<simDim>* end)
             {
                 auto axis = pmacc::boundary::getAxis(exchangeType);
+                if(axis >= simDim)
+                    throw std::runtime_error("The used exchange results into an invalid selected axis.");
                 auto offsetCells = getOffsetCells(species, exchangeType);
                 SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
                 // For non-axis directions, we take all cells including the guards
@@ -179,6 +187,8 @@ namespace picongpu
                 for(auto exchangeType : getAllAxisAlignedExchanges())
                 {
                     auto axis = pmacc::boundary::getAxis(exchangeType);
+                    if(axis >= simDim)
+                        throw std::runtime_error("The used exchange results into an invalid selected axis.");
                     auto offsetCells = getOffsetCells(species, exchangeType);
                     if(pmacc::boundary::isMinSide(exchangeType))
                         (*begin)[axis] += offsetCells;
@@ -211,6 +221,8 @@ namespace picongpu
 
                 // Change to a single supercell along the active axis
                 uint32_t const axis = pmacc::boundary::getAxis(exchangeType);
+                if(axis >= simDim)
+                    throw std::runtime_error("The used exchange results into an invalid selected axis.");
                 numSupercells[axis] = 1;
                 auto const offsetCells = getOffsetCells(species, exchangeType);
                 auto const offsetSupercells


### PR DESCRIPTION
Add check to silence gcc 13 arrays bound check.
The error showed up after https://github.com/ComputationalRadiationPhysics/picongpu/pull/5114 was merged to the develop branch.
IMO it is a false positive but the additional check should not introduce performance issues therefore I decided to not disable the array bounds checks to avoid that we miss real issues.

```
In member function 'constexpr std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = int; long unsigned int _Nm = 2]',
    inlined from 'constexpr pmacc::math::Vector<T_Type, T_dim, T_Storage>::type& pmacc::math::Vector<T_Type, T_dim, T_Storage>::operator[](uint32_t) [with T_Type = int; unsigned int T_dim = 2; T_Storage = pmacc::math::ArrayStorage<int, 2>]' at /pmacc/math/vector/Vector.hpp:219:43,
    inlined from 'auto picongpu::particles::boundary::getMapperFactory(T_Species&, uint32_t) [with T_Species = picongpu::Particles<pmacc::meta::String<'e'>, boost::mp11::mp_list<picongpu::particlePusher<picongpu::particles::pusher::Composite<picongpu::particles::pusher::Vay, picongpu::particles::pusher::Boris, picongpu::particles::pusher::CompositeBinarySwitchActivationFunctor<10> >, pmacc::pmacc_isAlias>, picongpu::shape<picongpu::particles::shapes::CIC, pmacc::pmacc_isAlias>, picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::CIC, picongpu::AssignedTrilinearInterpolation>, pmacc::pmacc_isAlias>, picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::CIC, picongpu::currentSolver::strategy::StridedCachedSupercells>, pmacc::pmacc_isAlias>, picongpu::massRatio<picongpu::MassRatioElectrons, pmacc::pmacc_isAlias>, picongpu::chargeRatio<picongpu::ChargeRatioElectrons, pmacc::pmacc_isAlias> >, boost::mp11::mp_list<picongpu::position<picongpu::position_pic, pmacc::pmacc_isAlias>, picongpu::momentum, picongpu::weighting, picongpu::probeE, picongpu::probeB> >]' at picongpu/include/picongpu/../picongpu/particles/boundary/Utility.hpp:214:30,
    inlined from 'void picongpu::ParticleCalorimeter<ParticlesType>::onParticleLeave(const std::string&, int32_t) [with ParticlesType = picongpu::Particles<pmacc::meta::String<'e'>, boost::mp11::mp_list<picongpu::particlePusher<picongpu::particles::pusher::Composite<picongpu::particles::pusher::Vay, picongpu::particles::pusher::Boris, picongpu::particles::pusher::CompositeBinarySwitchActivationFunctor<10> >, pmacc::pmacc_isAlias>, picongpu::shape<picongpu::particles::shapes::CIC, pmacc::pmacc_isAlias>, picongpu::interpolation<picongpu::FieldToParticleInterpolation<picongpu::particles::shapes::CIC, picongpu::AssignedTrilinearInterpolation>, pmacc::pmacc_isAlias>, picongpu::current<picongpu::currentSolver::EmZ<picongpu::particles::shapes::CIC, picongpu::currentSolver::strategy::StridedCachedSupercells>, pmacc::pmacc_isAlias>, picongpu::massRatio<picongpu::MassRatioElectrons, pmacc::pmacc_isAlias>, picongpu::chargeRatio<picongpu::ChargeRatioElectrons, pmacc::pmacc_isAlias> >, boost::mp11::mp_list<picongpu::position<picongpu::position_pic, pmacc::pmacc_isAlias>, picongpu::momentum, picongpu::weighting, picongpu::probeE, picongpu::probeB> >]' at picongpu/include/picongpu/plugins/particleCalorimeter/ParticleCalorimeter.x.cpp:621:71:
include/c++/13.1.0/array:203:24: error: array subscript 2 is above array bounds of 'std::__array_traits<int, 2>::_Type' {aka 'int [2]'} [-Werror=array-bounds=]
  203 |         return _M_elems[__n];
```
