### PR TITLE
add check for valid typical ppc

### DIFF
--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -99,7 +99,14 @@ class Simulation(RenderedObject):
             + "\t WARNING: custom templates are required if using custom user input.\n"
         )
 
+    def check(self):
+        """check validity of self"""
+        if self.typical_ppc < 1:
+            raise ValueError("typical_ppc must be >= 1")
+
     def _get_serialized(self) -> dict:
+        self.check()
+
         serialized = {
             "delta_t_si": self.delta_t_si,
             "time_steps": self.time_steps,


### PR DESCRIPTION
adds a check that the typical-ppc in PICMI is always 1 or larger.