### PR TITLE
Add a helper to get particle position

### DIFF
--- a/include/picongpu/param/binningSetup.param
+++ b/include/picongpu/param/binningSetup.param
@@ -47,10 +47,7 @@ namespace picongpu
             auto getPositionY
                 = [] ALPAKA_FN_ACC(auto const& domainInfo, auto const& worker, auto const& particle) -> int
             {
-                int const linearCellIdx = particle[localCellIdx_];
-                DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
-                auto relative_cellpos = domainInfo.globalOffset + domainInfo.localOffset + domainInfo.blockCellOffset;
-                auto posBin = cellIdx + relative_cellpos;
+                auto posBin = getParticlePosition<DomainOrigin::TOTAL>(domainInfo, particle);
                 return posBin[1];
             };
 

--- a/include/picongpu/plugins/binning/binnerPlugin.hpp
+++ b/include/picongpu/plugins/binning/binnerPlugin.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/plugins/binning/Axis.hpp"
 #include "picongpu/plugins/binning/BinningCreator.hpp"
 #include "picongpu/plugins/binning/BinningData.hpp"
+#include "picongpu/plugins/binning/DomainInfo.hpp"
 #include "picongpu/plugins/binning/FunctorDescription.hpp"
 #include "picongpu/plugins/binning/UnitConversion.hpp"
 #include "picongpu/plugins/binning/axis/LinearAxis.hpp"


### PR DESCRIPTION
Adds a helper using the domainInfo object to get the position of a particle relative to various simulation domain "origins"