### PR TITLE
add ionization data for argon

### DIFF
--- a/include/picongpu/param/ionizationEnergies.param
+++ b/include/picongpu/param/ionizationEnergies.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2023 Marco Garten, Axel Huebl
+/* Copyright 2014-2024 Marco Garten, Axel Huebl, Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -162,6 +162,30 @@ namespace picongpu
                     sim.si.conv().eV2auEnergy(523.415),
                     sim.si.conv().eV2auEnergy(2437.65804),
                     sim.si.conv().eV2auEnergy(2673.1774));
+
+                /* ionization energy for argon in atomic units */
+                PMACC_CONST_VECTOR(
+                    float_X,
+                    18,
+                    Argon,
+                    sim.si.conv().eV2auEnergy(15.7596119),
+                    sim.si.conv().eV2auEnergy(27.62967),
+                    sim.si.conv().eV2auEnergy(40.735),
+                    sim.si.conv().eV2auEnergy(59.58),
+                    sim.si.conv().eV2auEnergy(74.84),
+                    sim.si.conv().eV2auEnergy(91.290),
+                    sim.si.conv().eV2auEnergy(124.41),
+                    sim.si.conv().eV2auEnergy(143.4567),
+                    sim.si.conv().eV2auEnergy(422.60),
+                    sim.si.conv().eV2auEnergy(479.76),
+                    sim.si.conv().eV2auEnergy(540.4),
+                    sim.si.conv().eV2auEnergy(619.0),
+                    sim.si.conv().eV2auEnergy(685.5),
+                    sim.si.conv().eV2auEnergy(755.13),
+                    sim.si.conv().eV2auEnergy(855.5),
+                    sim.si.conv().eV2auEnergy(918.375),
+                    sim.si.conv().eV2auEnergy(4120.6657),
+                    sim.si.conv().eV2auEnergy(4426.2229));
 
                 /* ionization energy for copper in atomic units */
                 PMACC_CONST_VECTOR(

--- a/include/picongpu/param/ionizer.param
+++ b/include/picongpu/param/ionizer.param
@@ -138,6 +138,13 @@ namespace picongpu
                 static constexpr float_X numberOfNeutrons = 14.0;
             };
 
+            /** Ar-40 ~99,6% NA */
+            struct Argon_t
+            {
+                static constexpr float_X numberOfProtons = 18.0;
+                static constexpr float_X numberOfNeutrons = 22.0;
+            };
+
             /** Cu-63 69.15% NA */
             struct Copper_t
             {
@@ -299,6 +306,34 @@ namespace picongpu
                 13.575,
                 13.575);
 
+            /* Example: argon */
+            PMACC_CONST_VECTOR(
+                float_X,
+                18,
+                Argon,
+                /* 3p^6 */
+                6.764,
+                6.764,
+                6.764,
+                6.764,
+                6.764,
+                6.764,
+                /* 3s^2 */
+                7.757,
+                7.757,
+                /* 2p^6 */
+                14.008,
+                14.008,
+                14.008,
+                14.008,
+                14.008,
+                14.008,
+                /* 2s^2 */
+                12.230,
+                12.230,
+                /* 1s^2 */
+                17.508,
+                17.508);
 
             /* Example: copper
              * Note: Copper is one of the few exceptions to the Madelung energy ordering


### PR DESCRIPTION
add all data required by ionization for Argon.
- [x] requires PR #5133 to be merged first
- [x] need to be rebased after merging PR #5133 