### PR TITLE
fix MaxwellJuettner functor

### DIFF
--- a/include/picongpu/particles/manipulators/unary/MaxwellJuettner.def
+++ b/include/picongpu/particles/manipulators/unary/MaxwellJuettner.def
@@ -20,8 +20,7 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
-
+#include "picongpu/defines.hpp"
 #include "picongpu/particles/manipulators/generic/FreeRng.def"
 #include "picongpu/particles/manipulators/unary/FreeTotalCellOffsetRng.def"
 

--- a/include/picongpu/particles/manipulators/unary/MaxwellJuettner.hpp
+++ b/include/picongpu/particles/manipulators/unary/MaxwellJuettner.hpp
@@ -20,9 +20,9 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
-
+#include "picongpu/defines.hpp"
 #include "picongpu/particles/functor/User.hpp"
+#include "picongpu/traits/attribute/GetMass.hpp"
 
 namespace picongpu::particles::manipulators::unary::acc
 {
@@ -58,10 +58,10 @@ namespace picongpu::particles::manipulators::unary::acc
                 T_Particle& particle,
                 T_MaxwellJuettner temperatureKeV) const
             {
-                float_X const energy = (temperatureKeV * sim.si.conv.ev2Joule(1.0e3)) / sim.unit.energy();
+                float_X const energy = (temperatureKeV * sim.si.conv().eV2Joule(1.0e3)) / sim.unit.energy();
 
                 float_X const macroWeighting = particle[weighting_];
-                float_X const macroMass = attribute::getMass(macroWeighting, particle);
+                float_X const macroMass = picongpu::traits::attribute::getMass(macroWeighting, particle);
                 float_X const mass = macroMass / macroWeighting;
                 float_X const theta = energy / (mass * sim.pic.getSpeedOfLight() * sim.pic.getSpeedOfLight());
 


### PR DESCRIPTION
The PR #5133 and #5142 got merged together with #4826. Removed files and renamings for the unit systems collide therefore.