### PR TITLE
Add FromOpenPMDPulse profile

### DIFF
--- a/docs/source/usage/workflows/addLaser.rst
+++ b/docs/source/usage/workflows/addLaser.rst
@@ -3,7 +3,7 @@
 Adding Laser
 ------------
 
-.. sectionauthor:: Sergei Bastrakov
+.. sectionauthor:: Sergei Bastrakov, Fabia Dietrich
 
 There are several alternative ways of adding an incoming laser (or any source of electromagnetic field) to a PIConGPU simulation:
 
@@ -12,6 +12,8 @@ There are several alternative ways of adding an incoming laser (or any source of
 
 These ways operate independently of one another, each has its features and limitations.
 Incident field- and laser profiles currently match one another.
+
+Please note the sign convention for plane waves propagating forward in time: :math:`e^{-i(kz + \omega t)}`
 
 Incident Field
 """"""""""""""
@@ -46,14 +48,20 @@ The differences between matching incident field- and laser profiles are:
 #. positioning of incident field is controlled for the generation plane and not via an internal member ``::initPlaneY``
 #. incident field profiles do not have an extra time delay equal to :math:`\mathrm{initPlaneY} * \Delta y / c` as lasers do (when needed, other parameters could be adjusted to accomodate for the delay)
 #. default initial phase is chosen so that the laser starts smoothly at the generation plane (for laser it is always for plane :math:`y = 0`)
-#. incident field uses generalized coordinate system and treats transversal axes and parameters generically (explained in comments of the profile parameters in question)
+#. incident field uses a generalized coordinate system and treats transversal axes and parameters generically (explained in comments of the profile parameters in question)
 
 Note that the profile itself only controls properties of the laser, but not where it will be applied to.
 It is a combination of profile and particular plane that together will produce an inward-going laser adhering to the profile.
 For pre-set profiles a proper orientation of the wave will be provided by internal implementation.
+
 With the ``Free`` profile, it is on a user to provide functors to calculate incident fields and ensure the orientation for the boundaries it is applied to (however, it does not have to work for all boundaries, only the ones in question).
 Please refer to :ref:`the detailed description <model-TFSF>` for setting up ``Free`` profile, also for the case when only one of the external fields is known in explicit form.
-For a laser profile with non zero field amplitudes on the transversal borders of the profile e.g. defined by the profile ``Free`` without a transversal envelop the trait ``MakePeriodicTransversalHuygensSurfaceContiguous`` must be specialized and returning true to handle field periodic boundaries correctly.
+For a laser profile with non zero field amplitudes on the transversal borders of the profile e.g. defined by the profile ``Free`` without a transversal envelope the trait ``MakePeriodicTransversalHuygensSurfaceContiguous`` must be specialized and returning true to handle field periodic boundaries correctly.
+
+Another special case is the ``FromOpenPMDPulse`` profile, which reads a laser pulse profile, defined in space-time domain, from an openPMD file into the simulation. Specifically this allows to read a pulse profile obtained from an (Insight) measurement, after certain preparaion steps.
+For now, it is less flexible in choosing the propagation and polarisation direction, since those are only allowed along the cell edges, but not diagonally.
+Furthermore, one has to increase the reserved GPU memory size in memory.param, because the corresponding field chunk will be stored on every used device at timestep 0 of the simulation. Otherwise, the simulation could run into memory issues.
+For a description how to obtain the ready-to-read-in field data from an Insight measurement and how to properly set up this profile, please refer to the corresponding example parameter set.
 
 Incident field is compatible to all field solvers, however using field solvers other than Yee requires a larger offset of the generating surface from absorber depending on the stencil width along the boundary axis.
 As a rule of thumb, this extra requirement is (order of FDTD solver / 2 - 1) cells.

--- a/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def
@@ -1,0 +1,145 @@
+/* Copyright 2024 Fabia Dietrich
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+
+#    pragma once
+
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace defaults
+                {
+                    struct FromOpenPMDPulseParam
+                    {
+                        /** Path to the openPMD input file containing the E-field chunk in space-time domain
+                         *
+                         * This file can be obtained from an Insight measurement with a python script located in
+                         * lib/python/picongpu/extra/input/. This script provides methods to correct the measured
+                         * data, propagate it to the desired position and transform it into the time domain before
+                         * saving the resulting E-field chunk to openPMD.
+                         *
+                         * This field chunk will be stored at timestep 0 of the simulation on every used device, which
+                         * is why one has to increase the reserved GPU memory size in memory.param. Otherwise, the
+                         * simulation could run into memory issues.
+                         *
+                         * It is recommended to use a full path to make it independent of how PIConGPU is launched.
+                         * Relative paths require consistency to the current directory when PIConGPU is started
+                         * with tbg and the standard .tpl files, relative to the resulting simOutput directory.
+                         */
+                        static constexpr char const* filename = "/path/to/file%T.h5";
+
+                        /** Iteration inside the file (where the whole field is stored in, not related to the current
+                         * simulation time iteration)
+                         *
+                         * ATTENTION!
+                         * In this iteration, the pulse's time evolution at a specific z position was transformed
+                         * to a spatial evolution along the propagation direction via z=c*t. This approximation is
+                         * only valid when the pulse length is much smaller than a Rayleign length, because otherwise
+                         * the true spatial evolution is affected by defocusing.
+                         * BUT since the FromOpenPMDPulse profile transforms this axis back to a spatial one by
+                         * division by c, this will not lead to errors also if the pulse length is of the order of a
+                         * Rayleign length.
+                         * In principle, this should be refactored by using several iterations inside the openPMD
+                         * file instead of just one, but this will complicate reading the file in the PIConGPU
+                         * initialization procedure (coding- and time wise).
+                         */
+                        static constexpr uint32_t iteration = 0;
+
+                        /** Name of the E field dataset inside the input file
+                         *
+                         * Note that only C dataOrder is supported.
+                         *
+                         * @warning it is only the dataset itself, a simple text name and not something like
+                         * "/[directories]/[iteration]/meshes/E".
+                         */
+                        static constexpr char const* datasetEName = "E";
+
+                        /** Datatype of the field record
+                         *
+                         * openPMD needs this information at compile time.
+                         */
+                        using dataType = float_64;
+
+                        //! Defining the propagation ( = time) and polarisation axes of the input data
+                        static constexpr char const* polarisationAxisOpenPMD = "x";
+                        static constexpr char const* propagationAxisOpenPMD = "z";
+
+                        /** Unit propagation direction vector in PIConGPU
+                         *
+                         * Must be either X or Y or Z, but can be different from propagationAxisOpenPMD.
+                         *
+                         * Norm of this vector must be 1.0.
+                         * (Normalization is required on a user side as internally it is awkward to do with the
+                         * static-constexpr style of using parameters.)
+                         *
+                         * unit: none
+                         */
+                        static constexpr float_64 DIRECTION_X = 0.0;
+                        static constexpr float_64 DIRECTION_Y = 1.0;
+                        static constexpr float_64 DIRECTION_Z = 0.0;
+
+                        /** Unit E polarisation direction in PIConGPU
+                         *
+                         * Must be orthogonal to the propagation direction.
+                         * Must be either X or Y or Z, but can be different from polarisationAxisOpenPMD.
+                         *
+                         * Norm of this vector must be 1.0.
+                         * (Normalization is required on a user side as internally it is awkward to do with the
+                         * static-constexpr style of using parameters.)
+                         *
+                         * Note: we use spelling 'Polarisation' for consistency with other lasers.
+                         *
+                         * unit: none
+                         */
+                        static constexpr float_64 POLARISATION_DIRECTION_X = 1.0;
+                        static constexpr float_64 POLARISATION_DIRECTION_Y = 0.0;
+                        static constexpr float_64 POLARISATION_DIRECTION_Z = 0.0;
+
+                        /** Time delay, after which the laser initialisation will be started.
+                         * The delay must be positive.
+                         *
+                         * @warning: not optional!
+                         *
+                         * unit: time
+                         */
+                        static constexpr float_64 TIME_DELAY_SI = 0.0;
+                    };
+                } // namespace defaults
+
+                /** Experimental laser profile from openPMD
+                 *
+                 * @tparam T_Params class parameter to configure the experimental laser profile,
+                 *                  see members of defaults::FromOpenPMDPulseParam
+                 *                  for required members
+                 */
+                template<typename T_Params = defaults::FromOpenPMDPulseParam>
+                struct FromOpenPMDPulse;
+            } // namespace profiles
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu
+
+#endif

--- a/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.hpp
@@ -1,0 +1,694 @@
+/* Copyright 2024 Fabia Dietrich
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+
+#    pragma once
+
+#    include "picongpu/defines.hpp"
+#    include "picongpu/fields/incidentField/Functors.hpp"
+#    include "picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def"
+
+#    include <pmacc/memory/buffers/HostDeviceBuffer.hpp>
+
+#    include <algorithm>
+#    include <array>
+#    include <cmath>
+#    include <cstdint>
+#    include <limits>
+#    include <memory>
+#    include <string>
+#    include <type_traits>
+#    include <vector>
+
+#    include <openPMD/openPMD.hpp>
+
+/* REFACTORING IDEAS FOR THIS INCIDENT FIELD PROFILE
+ * -------------------------------------------------
+ * - make time delay parameter optional
+ * - load openPMD file (= call the corresponding singelton) or initialize the
+ *   Laser once before timestep 0 (before particle memory allocation)
+ * - load just the necessary parts of the measured data if the tranversal
+ *   simulation window extent is smaller than the transversal field chunk size
+ * - allow diagonal laser propagation instead of just parallel to the axes
+ * - every used device will store the whole field data chunk, which consumes
+ *   quite some memory. Instead, one could push only those two time slices to
+ *   the device which are necessary for the current time step.
+ * - get rid of the 'wrong' transformation from time to space (z = c*t) of the
+ *   longitudinal axis by using several iterations inside the openPMD file
+ *   instead of just one
+ */
+
+namespace picongpu
+{
+    namespace fields
+    {
+        namespace incidentField
+        {
+            namespace profiles
+            {
+                namespace detail
+                {
+                    /** Unitless FromOpenPMDPulse parameters
+                     *
+                     * These parameters do not inherit from BaseParam, since some of them
+                     * are unneccesary for this Laser implementation. For the remaining
+                     * (necessary) base parameters, the calculations/functions/asserts are
+                     * partly copied from there.
+                     *
+                     * @tparam T_Params user (SI) parameters
+                     */
+                    template<typename T_Params>
+                    struct FromOpenPMDPulseUnitless : public T_Params
+                    {
+                        //! User SI parameters
+                        using Params = T_Params;
+
+                        //! Unit propagation direction vector in 3d
+                        static constexpr float_X DIR_X = static_cast<float_X>(Params::DIRECTION_X);
+                        static constexpr float_X DIR_Y = static_cast<float_X>(Params::DIRECTION_Y);
+                        static constexpr float_X DIR_Z = static_cast<float_X>(Params::DIRECTION_Z);
+
+                        // Check that direction is normalized
+                        static constexpr float_X dirNorm2 = DIR_X * DIR_X + DIR_Y * DIR_Y + DIR_Z * DIR_Z;
+                        PMACC_CASSERT_MSG(
+                            _error_laser_direction_vector_must_be_unit____check_your_incidentField_param_file,
+                            (dirNorm2 > 0.9999) and (dirNorm2 < 1.0001));
+
+                        // Check that just one axis is used as propagation direction
+                        PMACC_CASSERT_MSG(
+                            _error_laser_direction_vector_must_be_limited_to_one_axis____check_your_incidentField_param_file,
+                            (DIR_X * DIR_X > 0.9999) and (DIR_X * DIR_X < 1.0001)
+                                or (DIR_Y * DIR_Y > 0.9999) and (DIR_Y * DIR_Y < 1.0001)
+                                or (DIR_Z * DIR_Z > 0.9999) and (DIR_Z * DIR_Z < 1.0001));
+
+                        //! Unit polarisation direction vector
+                        static constexpr float_X POL_DIR_X = static_cast<float_X>(Params::POLARISATION_DIRECTION_X);
+                        static constexpr float_X POL_DIR_Y = static_cast<float_X>(Params::POLARISATION_DIRECTION_Y);
+                        static constexpr float_X POL_DIR_Z = static_cast<float_X>(Params::POLARISATION_DIRECTION_Z);
+
+                        // Check that polarisation direction is normalized
+                        static constexpr float_X polDirNorm2
+                            = POL_DIR_X * POL_DIR_X + POL_DIR_Y * POL_DIR_Y + POL_DIR_Z * POL_DIR_Z;
+                        PMACC_CASSERT_MSG(
+                            _error_laser_polarisation_direction_vector_must_be_unit____check_your_incidentField_param_file,
+                            (polDirNorm2 > 0.9999) && (polDirNorm2 < 1.0001));
+
+                        // Check that just one axis is used as polarisation direction
+                        PMACC_CASSERT_MSG(
+                            _error_laser_direction_vector_must_be_limited_to_one_axis____check_your_incidentField_param_file,
+                            (POL_DIR_X * POL_DIR_X > 0.9999) and (POL_DIR_X * POL_DIR_X < 1.0001)
+                                or (POL_DIR_Y * POL_DIR_Y > 0.9999) and (POL_DIR_Y * POL_DIR_Y < 1.0001)
+                                or (POL_DIR_Z * POL_DIR_Z > 0.9999) and (POL_DIR_Z * POL_DIR_Z < 1.0001));
+
+                        // Check that polarisation direction is orthogonal to propagation direction
+                        static constexpr float_X dotPropagationPolarisation
+                            = DIR_X * POL_DIR_X + DIR_Y * POL_DIR_Y + DIR_Z * POL_DIR_Z;
+                        PMACC_CASSERT_MSG(
+                            _error_laser_polarisation_direction_vector_must_be_orthogonal_to_propagation_direction____check_your_incidentField_param_file,
+                            (dotPropagationPolarisation > -0.0001) && (dotPropagationPolarisation < 0.0001));
+
+                        /** Time delay
+                         *
+                         * This parameter is *not* optional, as it is in other Laser implementations.
+                         *
+                         * unit:  sim.unit.time()
+                         */
+                        static constexpr float_X TIME_DELAY
+                            = static_cast<float_X>(Params::TIME_DELAY_SI / sim.unit.time());
+                        PMACC_CASSERT_MSG(
+                            _error_laser_time_delay_must_be_positive____check_your_incidentField_param_file,
+                            (TIME_DELAY >= 0.0));
+
+                        // check openPMD propagation direction
+                        PMACC_CASSERT_MSG(
+                            _error_propagationAxisOpenPMD_is_not_valid____check_your_parameters,
+                            (Params::propagationAxisOpenPMD == "x" or Params::propagationAxisOpenPMD == "y"
+                             or Params::propagationAxisOpenPMD == "z"));
+
+                        // check openPMD polarisation direction
+                        PMACC_CASSERT_MSG(
+                            _error_polarisationAxisOpenPMD_is_not_valid____check_your_parameters,
+                            (Params::polarisationAxisOpenPMD == "x" or Params::polarisationAxisOpenPMD == "y"
+                             or Params::polarisationAxisOpenPMD == "z"));
+
+                        PMACC_CASSERT_MSG(
+                            _error_propagationAxisOpenPMD_and_polarisationAxisOpenPMD_have_to_be_different_____check_your_parameters,
+                            (Params::polarisationAxisOpenPMD != Params::propagationAxisOpenPMD));
+                    };
+
+                    template<typename T_Params>
+                    struct FromOpenPMDPulseFunctorIncidentE;
+
+                    /** Singleton to load field data from openPMD to device
+                     *
+                     * The complete dataset will be loaded (equally) to all GPUs, as well as
+                     * the necessary attributes (extent, cell size, offset to simulation window).
+                     *
+                     * Right now, the data will be loaded at timestep 0, which means that the user
+                     * has to **increase the reserved GPU memory** in memory.param, since otherwise
+                     * the simulation will run into memory issues.
+                     *
+                     * @tparam T_Params user parameters, providing filename etc.
+                     */
+                    template<typename T_Params>
+                    struct OpenPMDdata : public FromOpenPMDPulseUnitless<T_Params>
+                    {
+                        //! Unitless parameters type
+                        using Params = FromOpenPMDPulseUnitless<T_Params>;
+                        using dataType = typename Params::dataType;
+
+                        //! FromOpenPMD pulse E functor
+                        using Functor = FromOpenPMDPulseFunctorIncidentE<T_Params>;
+
+                        //! HostDeviceBuffer to store E field data
+                        std::shared_ptr<pmacc::HostDeviceBuffer<float_X, 3u>> bufferFieldData;
+
+                        //! HostDeviceBuffer to store the necessary attributes
+                        std::shared_ptr<pmacc::HostDeviceBuffer<float_X, 1u>> bufferExtentOpenPMD;
+                        std::shared_ptr<pmacc::HostDeviceBuffer<float_X, 1u>> bufferCellSizeOpenPMD;
+                        std::shared_ptr<pmacc::HostDeviceBuffer<float_X, 1u>> bufferOffsetOpenPMD;
+
+                        //! loading data to device
+                        static OpenPMDdata& get()
+                        {
+                            static OpenPMDdata dataBuffers{};
+                            return dataBuffers;
+                        }
+
+                    private:
+                        OpenPMDdata()
+                        {
+                            /* Open a series (this does not read the dataset itself).
+                             * This is MPI collective and so has to be done by all ranks.
+                             */
+                            auto& gc = Environment<simDim>::get().GridController();
+
+                            auto series = ::openPMD::Series{
+                                Params::filename,
+                                ::openPMD::Access::READ_ONLY,
+                                gc.getCommunicator().getMPIComm()};
+                            ::openPMD::Mesh mesh = series.iterations[Params::iteration].meshes[Params::datasetEName];
+                            // check data order
+                            if(mesh.dataOrder() != ::openPMD::Mesh::DataOrder::C)
+                                throw std::runtime_error(
+                                    "Unsupported dataOrder in openPMD E-field dataset, only C is supported");
+
+                            /* Now we align the recorded field data according to the user input
+                             * = rotation into the internal coordinate system
+                             */
+                            auto const axisLabels = std::vector<std::string>{mesh.axisLabels()};
+                            DataSpace<3u> const internalAxisIndex = Functor::getInternalAxisIndex();
+
+                            // start with the second transversal direction
+                            DataSpace<3u> aligningAxisIndex = DataSpace<3u>::create(internalAxisIndex[2]);
+
+                            // go on with the propagation direction
+                            auto it_prop
+                                = std::find(axisLabels.begin(), axisLabels.end(), Params::propagationAxisOpenPMD);
+                            if(it_prop != std::end(axisLabels))
+                                aligningAxisIndex[std::distance(begin(axisLabels), it_prop)] = internalAxisIndex[0];
+                            else
+                                throw std::runtime_error(
+                                    "Error: could not find propagation axis "
+                                    + std::string(Params::propagationAxisOpenPMD) + " in OpenPMD dataset");
+
+                            // align the polarisation direction
+                            auto it_pola
+                                = std::find(axisLabels.begin(), axisLabels.end(), Params::polarisationAxisOpenPMD);
+                            if(it_pola != std::end(axisLabels))
+                                aligningAxisIndex[std::distance(begin(axisLabels), it_pola)] = internalAxisIndex[1];
+                            else
+                                throw std::runtime_error(
+                                    "Could not find polarisation axis " + std::string(Params::polarisationAxisOpenPMD)
+                                    + " in OpenPMD dataset");
+
+                            ::openPMD::MeshRecordComponent meshRecord = mesh[Params::polarisationAxisOpenPMD];
+
+                            //! necessary attributes
+                            // Raw = not yet aligned
+                            ::openPMD::Extent const extentRaw = meshRecord.getExtent();
+                            auto const cellSizeRaw = mesh.gridSpacing<dataType>();
+
+                            bufferExtentOpenPMD = std::make_shared<pmacc::HostDeviceBuffer<float_X, 1u>>(3u);
+                            bufferCellSizeOpenPMD = std::make_shared<pmacc::HostDeviceBuffer<float_X, 1u>>(3u);
+                            bufferOffsetOpenPMD = std::make_shared<pmacc::HostDeviceBuffer<float_X, 1u>>(3u);
+
+                            auto dataBoxExtent = bufferExtentOpenPMD->getHostBuffer().getDataBox();
+                            auto dataBoxCellSize = bufferCellSizeOpenPMD->getHostBuffer().getDataBox();
+                            auto dataBoxOffset = bufferOffsetOpenPMD->getHostBuffer().getDataBox();
+
+                            const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
+                            const auto extentPIC(subGrid.getGlobalDomain().size);
+                            DataSpace<3u> extentOpenPMD;
+
+                            for(uint32_t d = 0u; d < 3u; d++)
+                            {
+                                // axis alignment and type conversion
+                                extentOpenPMD[aligningAxisIndex[d]] = static_cast<int>(extentRaw[d]);
+                                dataBoxExtent(aligningAxisIndex[d]) = static_cast<float_X>(extentRaw[d]);
+                                dataBoxCellSize(aligningAxisIndex[d])
+                                    = static_cast<float_X>(cellSizeRaw[d] * mesh.gridUnitSI()) / sim.unit.length();
+                                dataBoxOffset(aligningAxisIndex[d]) = 0.5_X
+                                    * (static_cast<float_X>(extentPIC[aligningAxisIndex[d]] - 1)
+                                           * sim.pic.getCellSize()[aligningAxisIndex[d]]
+                                       - (dataBoxExtent(aligningAxisIndex[d]) - 1.0_X)
+                                           * dataBoxCellSize(aligningAxisIndex[d]));
+                            }
+
+                            // push attribute data to device
+                            bufferExtentOpenPMD->hostToDevice();
+                            bufferCellSizeOpenPMD->hostToDevice();
+                            bufferOffsetOpenPMD->hostToDevice();
+                            eventSystem::getTransactionEvent().waitForFinished();
+
+                            // field data
+                            bufferFieldData = std::make_shared<pmacc::HostDeviceBuffer<float_X, 3u>>(extentOpenPMD);
+                            auto fieldData = std::shared_ptr<dataType>{nullptr};
+                            fieldData = meshRecord.loadChunk<dataType>();
+
+                            // This is MPI collective and so has to be done by all ranks
+                            series.flush();
+
+                            auto const numElements = std::accumulate(
+                                std::begin(extentRaw),
+                                std::end(extentRaw),
+                                1u,
+                                std::multiplies<uint32_t>());
+
+                            auto hostFieldDataBox = bufferFieldData->getHostBuffer().getDataBox();
+
+                            // reshaping, aligning and type casting of recorded field data
+                            for(uint32_t linearIdx = 0u; linearIdx < numElements; linearIdx++)
+                            {
+                                DataSpace<3u> openPMDIdx;
+                                auto tmpIndex = linearIdx;
+                                for(int32_t d = 2u; d >= 0; d--)
+                                {
+                                    openPMDIdx[aligningAxisIndex[d]] = tmpIndex % extentRaw[d];
+                                    tmpIndex /= extentRaw[d];
+                                }
+                                hostFieldDataBox(openPMDIdx)
+                                    = static_cast<float_X>(fieldData.get()[linearIdx] * meshRecord.unitSI())
+                                    / sim.unit.eField();
+                            }
+
+                            /* If the transversal simulation window is smaller than the transversal DataBox extent,
+                             * data at the chunk borders will be discarded. The maximum discarded value (relative to
+                             * the maximum amplitude) will be logged.
+                             */
+                            dataType maxE(0.0);
+                            dataType maxEDiscarded(0.0);
+                            dataType valE, valRight, valLeft;
+                            bool discard = false;
+                            for(uint32_t d = 0u; d < 3u; d++)
+                            {
+                                if(d != internalAxisIndex[0] and dataBoxOffset(d) < 0)
+                                {
+                                    for(uint32_t i = 0; i < extentOpenPMD[0]; i++)
+                                    {
+                                        for(uint32_t j = 0; j < extentOpenPMD[1]; j++)
+                                        {
+                                            for(uint32_t k = 0; k < extentOpenPMD[2]; k++)
+                                            {
+                                                // look for maximum amplitude value
+                                                if(discard == false) // do this just the first time entering the loop
+                                                {
+                                                    valE = pmacc::math::abs(hostFieldDataBox(DataSpace<3u>(i, j, k)));
+                                                    if(valE > maxE)
+                                                        maxE = valE;
+                                                }
+                                                // look for maximum discarded amplitude value
+                                                if(d == 0
+                                                   and i <= static_cast<int>(
+                                                           pmacc::math::abs(dataBoxOffset(d)) / dataBoxCellSize(d)))
+                                                {
+                                                    valLeft
+                                                        = pmacc::math::abs(hostFieldDataBox(DataSpace<3u>(i, j, k)));
+                                                    if(valLeft > maxEDiscarded) // left discarded area
+                                                        maxEDiscarded = valLeft;
+                                                    valRight = pmacc::math::abs(hostFieldDataBox(
+                                                        DataSpace<3u>(extentOpenPMD[d] - 1 - i, j, k)));
+                                                    if(valRight > maxEDiscarded) // right discarded area
+                                                        maxEDiscarded = valRight;
+                                                }
+                                                if(d == 1
+                                                   and j <= static_cast<int>(
+                                                           pmacc::math::abs(dataBoxOffset(d)) / dataBoxCellSize(d)))
+                                                {
+                                                    valLeft
+                                                        = pmacc::math::abs(hostFieldDataBox(DataSpace<3u>(i, j, k)));
+                                                    if(valLeft > maxEDiscarded) // left discarded area
+                                                        maxEDiscarded = valLeft;
+                                                    valRight = pmacc::math::abs(hostFieldDataBox(
+                                                        DataSpace<3u>(i, extentOpenPMD[d] - 1 - j, k)));
+                                                    if(valRight > maxEDiscarded) // right discarded area
+                                                        maxEDiscarded = valRight;
+                                                }
+                                                if(d == 2
+                                                   and k <= static_cast<int>(
+                                                           pmacc::math::abs(dataBoxOffset(d)) / dataBoxCellSize(d)))
+                                                {
+                                                    valLeft
+                                                        = pmacc::math::abs(hostFieldDataBox(DataSpace<3u>(i, j, k)));
+                                                    if(valLeft > maxEDiscarded) // left discarded area
+                                                        maxEDiscarded = valLeft;
+                                                    valRight = pmacc::math::abs(hostFieldDataBox(
+                                                        DataSpace<3u>(i, j, extentOpenPMD[d] - 1 - k)));
+                                                    if(valRight > maxEDiscarded) // right discarded area
+                                                        maxEDiscarded = valRight;
+                                                }
+                                            } // k
+                                        } // j
+                                    } // i
+                                    discard = true;
+                                }
+                            } // d
+
+                            if(discard == true)
+                            {
+                                // show the discard warning message just for the 0th rank
+                                pmacc::GridController<simDim>& gc = pmacc::Environment<simDim>::get().GridController();
+                                pmacc::CommunicatorMPI<simDim>& comm = gc.getCommunicator();
+                                uint32_t rank = comm.getRank();
+
+                                if(rank == 0)
+                                    log<picLog::PHYSICS>(
+                                        "Warning: Transversal simulation window extent is smaller than "
+                                        "measured data, discarding data at the border.\nMax. discarded "
+                                        "amplitude relative to max. measured amplitude: %1% ")
+                                        % (maxEDiscarded / maxE);
+                            }
+
+                            //! Push field data to device
+                            bufferFieldData->hostToDevice();
+                            eventSystem::getTransactionEvent().waitForFinished();
+                        } // OpenPMDdata
+                    };
+
+                    /** FromOpenPMDPulse incident E functor
+                     *
+                     * @tparam T_Params parameters
+                     */
+                    template<typename T_Params>
+                    struct FromOpenPMDPulseFunctorIncidentE : public FromOpenPMDPulseUnitless<T_Params>
+                    {
+                        //! Unitless parameters type
+                        using Unitless = FromOpenPMDPulseUnitless<T_Params>;
+
+                        /** Create a functor on the host side for the given time step
+                         *
+                         * @param currentStep current time step index, note that it is fractional
+                         * @param unitField conversion factor from SI to internal units,
+                         *                  fieldE_internal = fieldE_SI / unitField
+                         */
+                        HINLINE FromOpenPMDPulseFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
+                            : timeOriginPIC(currentStep * sim.pic.getDt())
+                        {
+                            // load data at timestep 0
+                            auto& openPMDdata = OpenPMDdata<T_Params>::get();
+
+                            // get field data
+                            fieldDataBox = openPMDdata.bufferFieldData->getDeviceBuffer().getDataBox();
+
+                            // get field data attributes
+                            extentOpenPMDdataBox = openPMDdata.bufferExtentOpenPMD->getDeviceBuffer().getDataBox();
+                            cellSizeOpenPMDdataBox = openPMDdata.bufferCellSizeOpenPMD->getDeviceBuffer().getDataBox();
+                            offsetOpenPMDdataBox = openPMDdata.bufferOffsetOpenPMD->getDeviceBuffer().getDataBox();
+                        }
+
+                        /** Read incident field E value for the given position and time step
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         * @return incident field E value in internal units
+                         */
+                        HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+                        {
+                            return getPolarisationVector() * getValueE(totalCellIdx);
+                        }
+
+                        //! Get a unit vector with linear E polarisation
+                        HDINLINE static constexpr float3_X getPolarisationVector()
+                        {
+                            return float3_X(Unitless::POL_DIR_X, Unitless::POL_DIR_Y, Unitless::POL_DIR_Z);
+                        }
+
+                        //! Get a 3-dimensional unit direction vector
+                        HDINLINE static constexpr float3_X getDirection()
+                        {
+                            return float3_X(Unitless::DIR_X, Unitless::DIR_Y, Unitless::DIR_Z);
+                        }
+
+                        /** Get the internal axis indices w.r.t. (x, y, z)
+                         * [0] propagation axis index (longitudinal)
+                         * [1] polarisation axis index
+                         * [2] remaining transversal axis index
+                         */
+                        HDINLINE static DataSpace<3u> getInternalAxisIndex()
+                        {
+                            float3_X const xyzAxisIndex{0.0_X, 1.0_X, 2.0_X};
+                            DataSpace<3u> const internalAxisIndex{
+                                static_cast<int>(pmacc::math::abs(pmacc::math::dot(xyzAxisIndex, getDirection()))),
+                                static_cast<int>(
+                                    pmacc::math::abs(pmacc::math::dot(xyzAxisIndex, getPolarisationVector()))),
+                                static_cast<int>(pmacc::math::abs(pmacc::math::dot(
+                                    xyzAxisIndex,
+                                    pmacc::math::cross(getDirection(), getPolarisationVector()))))};
+
+                            return internalAxisIndex;
+                        }
+
+                    private:
+                        /** Get value of E field for the given position
+                         * Linear interpolation of measured field data, which is aligned centered at the chosen
+                         * incident field plane. If the simulation window extent is greater than the field data chunk,
+                         * zero will be returned. In the other case, the field data chunk will be (transversally)
+                         * cropped.
+                         *
+                         * @param totalCellIdx cell index in the total domain (including all moving window slides)
+                         */
+                        HDINLINE float_X getValueE(floatD_X const& totalCellIdx) const
+                        {
+                            auto const posPIC = totalCellIdx * sim.pic.getCellSize(); // position in simulation volume
+
+                            DataSpace<3u> internalAxisIndex = getInternalAxisIndex();
+
+                            // check whether we are outside the field chunk extent
+                            for(uint32_t d = 0u; d < simDim; d++)
+                            {
+                                // return zero if transversal simulation window exceeds chunk extent
+                                if(d != internalAxisIndex[0])
+                                {
+                                    if(posPIC[d] < offsetOpenPMDdataBox(d)
+                                       or posPIC[d] > offsetOpenPMDdataBox(d)
+                                               + (extentOpenPMDdataBox(d) - 1.0_X) * cellSizeOpenPMDdataBox(d))
+                                        return 0.0_X;
+                                }
+                                // return zero if simulation timestep exceeds chunk extent
+                                else // d == internalAxisIndex[0]
+                                {
+                                    if((timeOriginPIC - Unitless::TIME_DELAY) < 0.0_X
+                                       or (timeOriginPIC - Unitless::TIME_DELAY) > (extentOpenPMDdataBox(d) - 1.0_X)
+                                               * cellSizeOpenPMDdataBox(d) / sim.pic.getSpeedOfLight())
+                                        return 0.0_X;
+                                }
+                            }
+
+                            // check whether the (openPMD) system is right handed, i.e. direction x polarisation > 0
+                            bool rh = true; // > 0
+                            if(Unitless::propagationAxisOpenPMD == "x" and Unitless::polarisationAxisOpenPMD == "z"
+                               or Unitless::propagationAxisOpenPMD == "y" and Unitless::polarisationAxisOpenPMD == "x"
+                               or Unitless::propagationAxisOpenPMD == "z" and Unitless::polarisationAxisOpenPMD == "y")
+                                rh = false; // < 0
+
+                            // transversal axis directions (internal)
+                            float_X const polAxisDirection = getPolarisationVector().sumOfComponents();
+                            float_X const transvAxisDirection
+                                = pmacc::math::cross(getDirection(), getPolarisationVector()).sumOfComponents();
+
+                            // find the position in the field data chunk corresponding to totalCellIdx and
+                            // timeOriginPIC
+                            float3_X idxClosestRaw; // raw = not yet rounded to integers
+
+                            for(uint32_t d = 0u; d < simDim; d++)
+                            {
+                                /* Now we check whether we have to invert the transversal (internal) axis directions
+                                 * in order to keep the handiness of the (openPMD) system
+                                 */
+                                if(d != internalAxisIndex[0])
+                                {
+                                    if(d == internalAxisIndex[1] and polAxisDirection < 0
+                                       or d == internalAxisIndex[2]
+                                           and (transvAxisDirection < 0 and rh or transvAxisDirection > 0 and !rh))
+                                    {
+                                        // we have to invert
+                                        idxClosestRaw[d] = extentOpenPMDdataBox(d) - 1.0_X
+                                            - (posPIC[d] - offsetOpenPMDdataBox(d)) / cellSizeOpenPMDdataBox(d);
+                                    }
+                                    else
+                                    {
+                                        // we can keep the original direction
+                                        idxClosestRaw[d]
+                                            = (posPIC[d] - offsetOpenPMDdataBox(d)) / cellSizeOpenPMDdataBox(d);
+                                    }
+                                } // d != internalAxisIndex[0]
+
+                                else // d == internalAxisIndex[0]
+                                {
+                                    // the longitudinal (time) axis is never inverted
+                                    idxClosestRaw[d] = (timeOriginPIC - Unitless::TIME_DELAY)
+                                        / cellSizeOpenPMDdataBox(d) * sim.pic.getSpeedOfLight();
+                                }
+                            } // for(uint32_t d = 0u; d < simDim; d++)
+
+                            // linear interpolation
+                            return linInterpol(fieldDataBox, idxClosestRaw);
+                        } // getValueE
+
+                        /** Linear interpolation routine
+                         *
+                         * @param dataBox 3D (Device) data box containing the data to be interpolated.
+                         *        The spacing between the values is assumed to be one and the origin is located in the
+                         *        (lower left) corner, i.e. the scales describing the data box == the cell indices
+                         * @param pos position at which to evaluate; has to be inside the data box.
+                         *
+                         * returns the interpolated value of dataBox at pos.
+                         */
+                        HDINLINE float_X linInterpol(
+                            typename pmacc::Buffer<float_X, 3u>::DataBoxType const& dataBox,
+                            float3_X const& pos) const
+                        {
+                            // find the index in the data box which is nearest to pos
+                            DataSpace<3u> const idxClosest
+                                = static_cast<pmacc::math::Vector<int, 3u>>(pos + float3_X::create(0.5_X));
+
+                            // the other 7 nearest neighbour indices still have to be found
+                            DataSpace<3u> idxShift; // shift to the other nearest neighbour indices
+                            DataSpace<3u> idxNext; // nearest neighbour index
+                            float3_X weight;
+                            for(uint32_t d = 0u; d < 3u; d++)
+                            {
+                                if(idxClosest[d] == 0) // to avoid border problems
+                                    idxShift[d] = 1;
+                                else if(pos[d] - static_cast<float_X>(idxClosest[d]) <= 0.0_X)
+                                    idxShift[d] = -1;
+                                else
+                                    idxShift[d] = 1;
+
+                                weight[d] = pmacc::math::abs(static_cast<float_X>(idxClosest[d]) - pos[d]);
+                            }
+
+                            // linear interpolation routine
+                            float_X dataInterp = 0.0_X;
+
+                            dataInterp
+                                += dataBox(idxClosest) * (float3_X::create(1.0_X) - weight).productOfComponents();
+                            for(uint32_t d = 0u; d < 3u; d++)
+                            {
+                                idxNext = idxClosest;
+                                float3_X ones = float3_X::create(1.0_X);
+                                idxNext[d] = idxClosest[d] + idxShift[d];
+                                ones[d] = 0.0_X;
+                                dataInterp -= dataBox(idxNext) * (ones - weight).productOfComponents();
+                                if(d == 2)
+                                {
+                                    idxNext[0] = idxClosest[0] + idxShift[0];
+                                    ones[0] = 0.0_X;
+                                }
+                                else
+                                {
+                                    idxNext[d + 1] = idxClosest[d + 1] + idxShift[d + 1];
+                                    ones[d + 1] = 0.0_X;
+                                }
+                                dataInterp += dataBox(idxNext) * (ones - weight).productOfComponents();
+                            }
+                            dataInterp += dataBox(idxClosest + idxShift) * weight.productOfComponents();
+
+                            return dataInterp;
+                        } // linInterpol
+
+                    protected:
+                        float_X const timeOriginPIC; // current time at incident plane
+                        PMACC_ALIGN(fieldDataBox, typename pmacc::Buffer<float_X, 3u>::DataBoxType);
+                        typename pmacc::Buffer<float_X, 1u>::DataBoxType extentOpenPMDdataBox;
+                        typename pmacc::Buffer<float_X, 1u>::DataBoxType cellSizeOpenPMDdataBox;
+                        typename pmacc::Buffer<float_X, 1u>::DataBoxType offsetOpenPMDdataBox;
+
+                    }; // FromOpenPMDPulseFunctorIncidentE
+                } // namespace detail
+
+                template<typename T_Params>
+                struct FromOpenPMDPulse
+                {
+                    //! Get text name of the incident field profile
+                    HINLINE static std::string getName()
+                    {
+                        return "FromOpenPMDPulse";
+                    }
+                };
+            } // namespace profiles
+
+            namespace traits
+            {
+                namespace detail
+                {
+                    /** Get type of incident field E functor for the experimental laser profile type
+                     *
+                     * @tparam T_Params parameters
+                     */
+                    template<typename T_Params>
+                    struct GetFunctorIncidentE<profiles::FromOpenPMDPulse<T_Params>>
+                    {
+                        using type = profiles::detail::FromOpenPMDPulseFunctorIncidentE<T_Params>;
+                    };
+
+                    /** Get type of incident field B functor for the experimental laser profile type
+                     *
+                     * @tparam T_Params parameters
+                     */
+                    template<typename T_Params>
+                    struct GetFunctorIncidentB<profiles::FromOpenPMDPulse<T_Params>>
+                    {
+                        using type = incidentField::detail::ApproximateIncidentB<
+                            typename GetFunctorIncidentE<profiles::FromOpenPMDPulse<T_Params>>::type>;
+                    };
+
+                    //! FromOpenPMDPulse profile has an unknown phase velocity, use c as a default value
+                    template<typename T_Params>
+                    struct GetPhaseVelocity<profiles::FromOpenPMDPulse<T_Params>>
+                    {
+                        HINLINE float_X operator()() const
+                        {
+                            return sim.pic.getSpeedOfLight();
+                        }
+                    };
+                } // namespace detail
+
+                //! Specialization for FromOpenPMDPulse profile which has unknown amplitude
+                template<typename T_Params>
+                struct GetAmplitude<profiles::FromOpenPMDPulse<T_Params>>
+                {
+                    static constexpr float_X value = 0.0_X;
+                };
+            } // namespace traits
+        } // namespace incidentField
+    } // namespace fields
+} // namespace picongpu
+
+#endif

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -23,6 +23,9 @@
 #include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def"
 #include "picongpu/fields/incidentField/profiles/Free.def"
 #include "picongpu/fields/incidentField/profiles/GaussianPulse.def"
+#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+#    include "picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def"
+#endif
 #include "picongpu/fields/incidentField/profiles/None.def"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
 #include "picongpu/fields/incidentField/profiles/Polynom.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -23,6 +23,9 @@
 #include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp"
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
 #include "picongpu/fields/incidentField/profiles/GaussianPulse.hpp"
+#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+#    include "picongpu/fields/incidentField/profiles/FromOpenPMDPulse.hpp"
+#endif
 #include "picongpu/fields/incidentField/profiles/None.hpp"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.hpp"
 #include "picongpu/fields/incidentField/profiles/Polynom.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -26,6 +26,8 @@
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::FromOpenPMDPulse<>    : reads an experimental pulse chunk defined in space-time domain into the
+ * simulation; requires openPMD API dependency and a 3D simulation
  *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters

--- a/lib/python/picongpu/extra/input/preparingInsightData.py
+++ b/lib/python/picongpu/extra/input/preparingInsightData.py
@@ -1,0 +1,837 @@
+"""
+This file is part of PIConGPU.
+
+Copyright 2024 Fabia Dietrich
+"""
+
+import openpmd_api as openpmd
+import numpy as np
+import h5py
+from scipy.interpolate import RegularGridInterpolator
+from scipy.optimize import curve_fit
+
+"""
+ATTENTION!
+----------
+When saving the pulse data to openPMD, the pulse's time evolution at a specific
+z position will be transformed to a spatial evolution along the propagation
+direction via z=c*t. This approximation is only valid when the pulse length is
+much smaller than a Rayleign length, because otherwise the true spatial
+evolution is affected by defocusing.
+BUT since the FromOpenPMDPulse profile transforms this axis back to a spatial
+one by division by c, this will not lead to errors also if the pulse length is
+of the order of a Rayleign length.
+So for now, this transformation should be considered as "meaningless"; it is
+only done to fulfil the openPMD requirements for field storage.
+In principle, this should be refactored by using several iterations in the
+openPMD file instead of just one, but this will complicate reading the file in
+the PIConGPU initialization procedure (coding- and time wise).
+"""
+
+# please correct if other units than mm and fs are used!
+c = 2.99792e-4  # speed of light in mm/fs
+
+
+def gauss2D(xy, amp, x0, y0, w):
+    """
+    2D gaussian distribution
+
+    Arguments:
+    xy: coordinates (numpy meshgrid)
+    amp: amplitude
+    x0, y0: center coordinates
+    w: waist size
+    """
+    x, y = xy
+    g = amp * np.exp(-((x - x0) ** 2 / (w**2) + (y - y0) ** 2 / (w**2)))
+    return g.ravel()
+
+
+def supergauss2D(xy, amp, x0, y0, w, n=4):
+    """
+    2D supergaussian distribution
+
+    Arguments:
+    xy: coordinates (numpy meshgrid)
+    amp: amplitude
+    x0, y0: center coordinates
+    w: waist size
+    n: superpower (default is 4)
+    """
+    assert n > 2, "n > 2 required"
+    x, y = xy
+    g = amp * np.exp(-(((x - x0) ** 2 / (w**2) + (y - y0) ** 2 / (w**2)) ** (n - 2)))
+    return g.ravel()
+
+
+def gauss(t, amp, t0, tau):
+    """
+    1D gaussian distribution to fit the temporal envelope of the pulse in the time domain
+    Definition of the pulse duration according to the GaussianPulse profile
+
+    Arguments:
+    t: time
+    amp: amplitude
+    t0: central time
+    tau: pulse duration
+    """
+    return amp * np.exp(-((t - t0) ** 2) / (2 * tau) ** 2)
+
+
+def lin(x, a, b):
+    """
+    linear function f(x) = a * x + b
+
+    Arguments:
+    x: function arguments
+    a: slope
+    b: offset
+    """
+    return a * x + b
+
+
+class PrepRoutines:
+    """
+    class to manipulate and prepare Insight data for usage as FromOpenPMDPulse profile in PIConGPU:
+        - phase corrections
+        - artifact corrections in the near field
+        - propagation
+        - transformation into the time domain
+
+    Members:
+    --------
+    Ew: measured far field in dependence of x, y, w
+    x, y: transversal far field scales in mm
+    xc, yc: far field center coordinates
+    dx, dy: far field coordinate spacing
+    waist: waist size in focus (w0)
+    zR: Rayleigh length estimated from w0
+
+    w: frequency scale in rad/fs
+    wc_idx: central frequency index
+    dw: frequency spacing
+
+    Ew_NF: reconstructed near field
+    x_NF, y_NF: transversal near field scales
+    xc_NF, yc_NF: near field center coordinates
+    dx_NF, dy_NF: coordinate spacing
+    waist_NF: waist size in near field
+
+    Et: field in the time domain
+    t, dt: time axis and spacing
+    """
+
+    def __init__(self, path, name, foc):
+        """
+        Load Insight data (in focus = far field), propagate to near field
+        and extract (gaussian) fit parameters.
+        The far field has to be measured in dependence of the transverse coordinates "x", "y" (in mm) and
+        frequency "w" (in rad/fs). If the scales are named differently or measured in another unit, they
+        have to be adjusted manually here.
+
+        Arguments:
+        path: path to Insight data file
+        name: name of Insight data file (.h5)
+        foc:  focal length in mm
+        """
+
+        self.path = path
+        self.name = name
+        self.foc = foc
+
+        # read Insight far field data
+        f = h5py.File(self.path + self.name, "r")
+        groups = list(f.keys())
+        self.Ew = np.asarray(f["data/{}".format(*f["/{}".format(groups[0])].keys())])  # 3D array (x, y, w)
+        # rescale the amplitude to 1
+        self.Ew /= np.abs(self.Ew).max()
+        # change scale name here if necessary
+        self.x = np.asarray(f["scales/x"])  # mm
+        self.y = np.asarray(f["scales/y"])  # mm
+        self.w = np.asarray(f["scales/w"])  # rad/fs
+        f.close()
+
+        self.lamb = 2 * np.pi * c / self.w  # wavelength in mm
+        self.dx = np.diff(self.x)[0]  # transverse spacing
+        self.dy = np.diff(self.y)[0]  # transverse spacing
+        self.dw = np.diff(self.w)[0]  # frequency spacing
+        self.wc_idx = int(len(self.w) / 2)  # central freq. index
+
+        # fit far field data with gaussian
+        # use intensity instead of amplitude to minimize possible halo influence
+        popt, pcov = curve_fit(
+            gauss2D,
+            (np.meshgrid(self.x, self.y)),
+            (np.abs(self.Ew[:, :, self.wc_idx]) ** 2).ravel(),
+            p0=(1, 0, 0, 0.05),
+        )
+        self.xc = popt[1]  # x center coordinate
+        self.yc = popt[2]  # y center coordinate
+        self.waist = popt[3] * np.sqrt(2)  # waist size
+        self.zR = self.waist**2 / (2 * c) * self.w[self.wc_idx]  # rayleigh length
+
+        # spectral intensity FWHM indices
+        spec_int = np.sum(np.sum(np.abs(self.Ew) ** 2, axis=0), axis=0)
+        spec_int = spec_int / spec_int.max()
+        idx_in_FWHM = np.where(spec_int > 0.5)[0]
+        self.spectFWHMIdx = np.array([idx_in_FWHM[0], idx_in_FWHM[-1]])
+
+        # propagate to near field (right before the lens, i.e. d=0)
+        self.ff_to_nf()
+        self.dx_NF = np.diff(self.x_NF)[0]
+        self.dy_NF = np.diff(self.y_NF)[0]
+
+        # fit near field data with supergaussian
+        popt_NF, pcov_NF = curve_fit(
+            supergauss2D,
+            (np.meshgrid(self.x_NF, self.y_NF)),
+            np.abs(self.Ew_NF[:, :, self.wc_idx]).ravel(),
+            p0=(1, 0, 0, 10),
+        )
+        self.xc_NF = popt_NF[1]  # x center coordinate
+        self.yc_NF = popt_NF[2]  # y center coordinate
+        self.waist_NF = popt_NF[3]  # waist size
+
+        self.is_phase_corrected = False  # phase has not been corrected yet
+        self.is_masked = False  # no aperture has been applied (yet)
+
+        # print fit parameters etc.
+        print("Central wavelength: %.f nm" % (self.lamb[self.wc_idx] * 10**6))
+        print("Rayleigh length: zR = %.2f mm" % (self.zR))
+        print("Far field center coordinates: xc = %.2f um, yc = %.2f um" % (self.xc * 1000, self.yc * 1000))
+        print("Far field waist size: w = %.2f um" % (self.waist * 1000))
+        print("Near field center coordinates: xc = %.2f mm, yc = %.2f mm" % (self.xc_NF, self.yc_NF))
+        print("Near field waist size: w = %.2f mm" % (self.waist_NF))
+
+    def ff_to_nf(self, d=0, method="linear"):
+        """
+        Propagate far field (in frequency domain) to near field at distance d in front of lens
+
+        Arguments:
+        d: distance of near field to lens, default is 0
+        method: interpolation method of RegularGridInterpolator, default is 'linear'
+        """
+        X, Y, W = np.meshgrid(self.x, self.y, self.w)
+        fac = (
+            -1j * 2 * np.pi * c / W * self.foc * np.exp(1j * W / c / 2 / self.foc * (X**2 + Y**2) * (1 - d / self.foc))
+        )
+        NF = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(self.Ew * fac, axes=(0, 1)), axes=(0, 1)), axes=(0, 1))
+        a = np.fft.fftshift(np.fft.fftfreq(self.x.size, self.dx))
+        b = np.fft.fftshift(np.fft.fftfreq(self.y.size, self.dy))
+        # rescaling from spatial frequency to x/y for every lambda (x = a * lamb * f)
+        scale = self.lamb * self.foc
+        self.x_NF = np.linspace(a[0] * scale[-1], a[-1] * scale[-1], a.size)
+        self.y_NF = np.linspace(b[0] * scale[-1], b[-1] * scale[-1], b.size)
+        self.dx_NF = np.diff(self.x_NF)[0]
+        self.dy_NF = np.diff(self.y_NF)[0]
+        Y_NF, X_NF = np.meshgrid(self.y_NF, self.x_NF, indexing="ij")
+        self.Ew_NF = np.empty_like(NF, dtype=complex)
+        for i in range(self.w.size):
+            interp_NF = RegularGridInterpolator((b * scale[i], a * scale[i]), NF[:, :, i], method=method)
+            self.Ew_NF[:, :, i] = interp_NF((Y_NF, X_NF))
+
+        # rescale the amplitude to 1
+        self.Ew_NF /= np.abs(self.Ew_NF).max()
+
+    def nf_to_ff(self, d=0, method="linear"):
+        """
+        Propagate near field (in frequency domain) to far field from distance d in front of lens
+
+        Arguments:
+        d: distance to lens, default is 0
+        method: interpolation method of RegularGridInterpolator, default is 'linear'
+        """
+        a = np.fft.fftshift(np.fft.fftfreq(self.x_NF.size, self.dx_NF))
+        b = np.fft.fftshift(np.fft.fftfreq(self.y_NF.size, self.dy_NF))
+        A, B, W = np.meshgrid(a, b, self.w)
+        fac = (
+            -W
+            / (1j * c * 2 * np.pi * self.foc)
+            * np.exp(-1j * 2 * np.pi**2 * self.foc * c / W * (A**2 + B**2) * (1 - d / self.foc))
+        )
+        FF = np.fft.fftshift(np.fft.ifft2(np.fft.ifftshift(self.Ew_NF, axes=(0, 1)), axes=(0, 1)), axes=(0, 1)) * fac
+        # rescaling from spatial frequency to space for every lambda
+        scale = self.lamb * self.foc
+        Y, X = np.meshgrid(self.y, self.x, indexing="ij")
+        for i in range(self.w.size):
+            interp_FF = RegularGridInterpolator(
+                (b * scale[i], a * scale[i]), FF[:, :, i], method=method, bounds_error=False, fill_value=0
+            )
+            self.Ew[:, :, i] = interp_FF((Y, X))
+
+        # rescale the amplitude to 1
+        self.Ew /= np.abs(self.Ew).max()
+
+    def correct_phase(self, GVD=0, TOD=0):
+        """
+        Since there is no information about the global phase of every wavelength measured with Insight,
+        there has to be a phase correction.
+        For that, we assume perfect compression of the beam center in the near field, thus we subtract a
+        frequency's phase value at the beam center from every phase value in the frequency's transverse
+        distribution in the near field.
+        Furthermore, there is the possibility to add dispersion parameters (GVD, TOD) to the data.
+
+        Arguments:
+        GVD : Group velocity disperison in fs**2/rad,  optional. The default is 0.
+        TOD : Third order dispersion in fs**3/rad**2, optional. The default is 0.
+        """
+        # phase in near field beam center
+        phase_centr = np.unwrap(
+            np.angle(self.Ew_NF[np.abs(self.y_NF - self.yc_NF).argmin(), np.abs(self.x_NF - self.xc_NF).argmin(), :])
+        )
+        dispersion = -GVD / 2 * (self.w - self.w[self.wc_idx]) ** 2 - TOD / 6 * (self.w - self.w[self.wc_idx]) ** 3
+
+        # correcting near field
+        self.Ew_NF = np.abs(self.Ew_NF) * np.exp(1j * (np.angle(self.Ew_NF) - phase_centr + dispersion))
+        # correcting far field
+        self.Ew = np.abs(self.Ew) * np.exp(1j * (np.angle(self.Ew) - phase_centr + dispersion))
+        self.is_phase_corrected = True
+        print(
+            "Phase has been corrected. \nApplied dispersion parameters: GVD = %.f fs**2/rad, TOD = %.f fs**3/rad**2"
+            % (GVD, TOD)
+        )
+
+    def correct_ugly_spot_in_nf(self, x_ugly, y_ugly, uglybins=3, method="linear"):
+        """
+        In case there is an ugly spot in the near field (such as an unnatural peak), it can be smoothened out with this function.
+        It automatically also corrects the far field by propagating the corrected near field back into the focus.
+
+        Arguments:
+        x_ugly: (near field) x coordinate of the ugly spot
+        y_ugly: (near field) y coordinate of the ugly spot
+        uglybins: number of bins surrounding the ugly spot which will be cut away / smoothened out (default is 3)
+        method: RegularGridInterpolator interpolation method,
+                default is 'linear' (since 'cubic' can cause some bumps in amplitude or phase)
+        """
+        # index borders of hole
+        x_ugly_idx = np.abs(self.x_NF - x_ugly).argmin()
+        y_ugly_idx = np.abs(self.y_NF - y_ugly).argmin()
+        xidx_low = x_ugly_idx - uglybins
+        xidx_upp = x_ugly_idx + uglybins
+        yidx_low = y_ugly_idx - uglybins
+        yidx_upp = y_ugly_idx + uglybins
+
+        # safety check: are we still in the volume?
+        assert xidx_low >= 0, "Sorry, too close to the left border!"
+        assert yidx_low >= 0, "Sorry, too close to the lower border!"
+        assert xidx_upp < len(self.x_NF), "Sorry, too close to the right border!"
+        assert yidx_upp < len(self.y_NF), "Sorry, too close to the upper border!"
+
+        # thickness of border surrounding the hole (number of bins)
+        # for linear interpolation, 1 would be sufficient; but 3 is chosen so that cubic interpolation is still possible
+        border_thickn = 3
+        # safety check: are we still in the volume?
+        assert xidx_low - border_thickn >= 0, "Sorry, too close to the left border!"
+        assert xidx_upp + border_thickn < len(self.x_NF), "Sorry, too close to the right border!"
+
+        # since it is pretty messy to work with meshgrids when there is a hole in the middle, we do the
+        # interpolation only along the x direction (but any other direction would have been just as valid)
+        x_surr = np.concatenate(
+            (
+                self.x_NF[xidx_low - border_thickn : xidx_low],
+                self.x_NF[x_ugly_idx + uglybins : xidx_upp + border_thickn],
+            )
+        )
+        Ew_surr = np.concatenate(
+            (
+                self.Ew_NF[yidx_low:yidx_upp, xidx_low - border_thickn : xidx_low, :],
+                self.Ew_NF[yidx_low:yidx_upp, xidx_upp : xidx_upp + border_thickn, :],
+            ),
+            axis=1,
+        )
+        interp = RegularGridInterpolator((self.y_NF[yidx_low:yidx_upp], x_surr, self.w), Ew_surr, method=method)
+        Y_hole, X_hole, W_hole = np.meshgrid(
+            self.y_NF[yidx_low:yidx_upp], self.x_NF[xidx_low:xidx_upp], self.w, indexing="ij"
+        )
+        self.Ew_NF[yidx_low:yidx_upp, xidx_low:xidx_upp, :] = interp((Y_hole, X_hole, W_hole))
+
+        # correct the far field
+        self.nf_to_ff()
+
+        print("corrected ugly spot in near field at x = %.2f mm, y = %.2f mm" % (x_ugly, y_ugly))
+
+    def shift_nf_to_center(self):
+        """
+        If the near field is not centered around (0, 0), it can be done with this function.
+        It automatically also corrects the far field by propagating the centered near field back into the focus.
+        """
+        # number of pixels to shift in x-direction
+        nx = int(self.xc_NF / self.dx_NF + 0.5)
+        # number of pixels to shift in y-direction
+        ny = int(self.yc_NF / self.dy_NF + 0.5)
+
+        # check shift for validity: should be less than half the size of the data extent
+        assert (
+            nx < len(self.x_NF) / 2 and ny < len(self.y_NF) / 2
+        ), "Something's off, can't shift more than half the size of the data extent!"
+
+        if nx == 0 and ny == 0:
+            print("already centered, no corrections necessary")
+            return None
+
+        if nx != 0:
+            if nx > 0:
+                self.Ew_NF[:, :-nx, :] = self.Ew_NF[:, nx:, :]
+            else:
+                self.Ew_NF[:, -nx:, :] = self.Ew_NF[:, :nx, :]
+        if ny != 0:
+            if ny > 0:
+                self.Ew_NF[:-ny, :, :] = self.Ew_NF[ny:, :, :]
+            else:
+                self.Ew_NF[-ny:, :, :] = self.Ew_NF[:ny, :, :]
+
+        # new fit of near field data with supergaussian
+        popt_NF, pcov_NF = curve_fit(
+            supergauss2D,
+            (np.meshgrid(self.x_NF, self.y_NF)),
+            np.abs(self.Ew_NF[:, :, self.wc_idx]).ravel(),
+            p0=(1, 0, 0, 10),
+        )
+        self.xc_NF = popt_NF[1]
+        self.yc_NF = popt_NF[2]
+        self.waist_NF = popt_NF[3]
+        print("new near field center coordinates: xc = %.2f mm, yc = %.2f mm" % (self.xc_NF, self.yc_NF))
+
+        # correct the far field
+        self.nf_to_ff()
+
+    def aperture_in_mf(self, d, R, xc=0, yc=0):
+        """
+        Put an aperture in the mid field.
+        This function propagates far field to mid field, applies an aperture there, propagates back and updates
+        the (far field) group member Ew.
+
+        Arguments:
+        d: distance of aperture to focal plane (same unit as the transverse scales)
+        R: radius of aperture (same unit as the transverse scales)
+        xc, yc: center coordinates of aperture in mid field (w.r.t. the transverse scales)
+        """
+        if self.is_masked:
+            print("Aperture has already been applied!")
+            return None
+
+        else:
+            # original field integral (needed for field ratio calculation)
+            int_orig = np.sum(np.abs(self.Ew))
+
+            # propagation FF to MF
+            X, Y, W = np.meshgrid(self.x, self.y, self.w)
+            fac = -1j * 2 * np.pi * c / W * d**2 / self.foc * np.exp(1j * W / c / 2 / d * (X**2 + Y**2))
+            MF = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(self.Ew * fac, axes=(0, 1)), axes=(0, 1)), axes=(0, 1))
+            # transversal scales in mid field, but still as spatial frequencies
+            a = np.fft.fftshift(np.fft.fftfreq(self.x.size, self.dx))  # = x / (lamb * d)
+            b = np.fft.fftshift(np.fft.fftfreq(self.y.size, self.dy))  # = y / (lamb * d)
+
+            # aperture = cropping MF content
+            MF_cropped = np.zeros_like(MF, dtype=complex)
+            for i in range(a.size):
+                for j in range(b.size):
+                    for k in range(self.w.size):
+                        if np.abs(a[i] * self.lamb[k] * d - xc) < R:
+                            if np.abs(b[j] * self.lamb[k] * d - yc) < np.sqrt(
+                                R**2 - (a[i] * self.lamb[k] * d - xc) ** 2
+                            ):
+                                MF_cropped[j, i, k] = MF[j, i, k]
+
+            # propagation MF to FF
+            self.Ew = np.fft.fftshift(np.fft.ifft2(np.fft.ifftshift(MF_cropped, axes=(0, 1)), axes=(0, 1)), axes=(0, 1))
+            self.Ew /= fac
+            self.is_masked = True
+            print("Aperture of radius %.2f mm at distance %.2e mm has been applied." % (R, d))
+
+            # we need the ratio of the masked far field data to the original one to calculate the correct beam energy later
+            self.field_ratio = np.sum(np.abs(self.Ew)) / int_orig
+
+    def measure_ad_in_nf(self):
+        """
+        measure angular dispersion in the near field
+        """
+        # (transverse) indices of main beam spot area (xmin, xmax, ymin, ymax)
+        # this will result in a square area covering the beam spot
+        waist_part = 0.7  # size of the square w.r.t waist size; should be < 1
+        mainSpotIdx_NF = np.array(
+            [
+                np.abs(self.x_NF - self.xc_NF + waist_part * self.waist_NF).argmin(),
+                np.abs(self.x_NF - self.xc_NF - waist_part * self.waist_NF).argmin(),
+                np.abs(self.y_NF - self.yc_NF + waist_part * self.waist_NF).argmin(),
+                np.abs(self.y_NF - self.yc_NF - waist_part * self.waist_NF).argmin(),
+            ]
+        )
+        # unwrapped phase in near field main beam spot area
+        angle_AD = np.unwrap(
+            np.unwrap(
+                np.angle(self.Ew_NF[mainSpotIdx_NF[2] : mainSpotIdx_NF[3], mainSpotIdx_NF[0] : mainSpotIdx_NF[1], :]),
+                axis=0,
+            ),
+            axis=1,
+        )
+
+        # calculating phase slope
+        mx = []
+        my = []
+        for j in range(self.w.size):
+            mx_j = []
+            my_j = []
+            for i in range(min(angle_AD.shape[0], angle_AD.shape[1])):
+                # linear fit of every row and column of main beam spot area
+                popt_x, pcov_x = curve_fit(
+                    lin, self.x_NF[mainSpotIdx_NF[0] : mainSpotIdx_NF[1]], angle_AD[i, :, j], p0=(1, 0)
+                )
+                mx_j.append(popt_x[0])
+                popt_y, pcov_y = curve_fit(
+                    lin, self.y_NF[mainSpotIdx_NF[2] : mainSpotIdx_NF[3]], angle_AD[:, i, j], p0=(1, 0)
+                )
+                my_j.append(popt_y[0])
+            # average phase slope for every lambda
+            mx.append(np.average(mx_j))
+            my.append(np.average(my_j))
+
+        # calculating wavefront tilt angle
+        alpha_x = np.arcsin(self.lamb * mx / (2 * np.pi))
+        alpha_y = np.arcsin(self.lamb * my / (2 * np.pi))
+
+        # AD = change of wavefront tilt angle with lambda
+        # fitting just values inside the spectral intensity FHWM
+        popt_x, pcov_x = curve_fit(
+            lin,
+            self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6,
+            alpha_x[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]],
+        )
+        perr_x = np.diag(pcov_x)
+        AD_x = popt_x[0]
+        e_AD_x = perr_x[0]
+
+        popt_y, pcov_y = curve_fit(
+            lin,
+            self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6,
+            alpha_y[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]],
+        )
+        perr_y = np.diag(pcov_y)
+        AD_y = popt_y[0]
+        e_AD_y = perr_y[0]
+
+        print("measured AD in NF in x direction: %.2e +- %.2e rad/nm" % (AD_x, e_AD_x))
+        print("measured AD in NF in y direction: %.2e +- %.2e rad/nm" % (AD_y, e_AD_y))
+
+    def measure_ad_in_ff(self):
+        """
+        measure angular dispersion in the far field
+        """
+        # (transverse) indices of main beam spot area (xmin, xmax, ymin, ymax)
+        # this will result in a square area covering the beam spot
+        waist_part = 0.7  # size of the square w.r.t waist size; should be < 1
+        mainSpotIdx = np.array(
+            [
+                np.abs(self.x - self.xc + waist_part * self.waist).argmin(),
+                np.abs(self.x - self.xc - waist_part * self.waist).argmin(),
+                np.abs(self.y - self.yc + waist_part * self.waist).argmin(),
+                np.abs(self.y - self.yc - waist_part * self.waist).argmin(),
+            ]
+        )
+        # unwrapped phase in far field main beam spot area
+        angle_AD = np.unwrap(
+            np.unwrap(np.angle(self.Ew[mainSpotIdx[2] : mainSpotIdx[3], mainSpotIdx[0] : mainSpotIdx[1], :]), axis=0),
+            axis=1,
+        )
+
+        # calculating phase slope
+        mx = []
+        my = []
+        for j in range(self.w.size):
+            mx_j = []
+            my_j = []
+            for i in range(min(angle_AD.shape[0], angle_AD.shape[1])):
+                # linear fit of every row and column of main beam spot area
+                popt_x, pcov_x = curve_fit(
+                    lin, self.x[mainSpotIdx[0] : mainSpotIdx[1]], angle_AD[i, :, j], p0=(-200, 0)
+                )
+                mx_j.append(popt_x[0])
+                popt_y, pcov_y = curve_fit(
+                    lin, self.y[mainSpotIdx[2] : mainSpotIdx[3]], angle_AD[:, i, j], p0=(-200, 0)
+                )
+                my_j.append(popt_y[0])
+            # average phase slope for every lambda
+            mx.append(np.average(mx_j))
+            my.append(np.average(my_j))
+
+        # calculating wavefront tilt angle
+        alpha_x = np.arcsin(self.lamb * mx / (2 * np.pi))
+        alpha_y = np.arcsin(self.lamb * my / (2 * np.pi))
+
+        # AD = change of wavefront tilt angle with lambda
+        # fitting just values inside the spectral intensity FHWM
+        popt_x, pcov_x = curve_fit(
+            lin,
+            self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6,
+            alpha_x[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]],
+        )
+        perr_x = np.diag(pcov_x)
+        AD_x = popt_x[0]
+        e_AD_x = perr_x[0]
+
+        popt_y, pcov_y = curve_fit(
+            lin,
+            self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6,
+            alpha_y[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]],
+        )
+        perr_y = np.diag(pcov_y)
+        AD_y = popt_y[0]
+        e_AD_y = perr_y[0]
+
+        print("measured AD in FF in x direction: %.2e +- %.2e rad/nm" % (AD_x, e_AD_x))
+        print("measured AD in FF in y direction: %.2e +- %.2e rad/nm" % (AD_y, e_AD_y))
+
+    def measure_sd_in_nf(self):
+        """
+        measure spatial dispersion in the near field
+        """
+        # lists to store center coordinates
+        xc_SD = []
+        yc_SD = []
+
+        X_NF, Y_NF = np.meshgrid(self.x_NF, self.y_NF)
+
+        # supergaussian fit to near field amplitude to extract center coordinates
+        # only inside the spectral intensity FWHM
+        for i in range(self.spectFWHMIdx[1] - self.spectFWHMIdx[0]):
+            popt, pcov = curve_fit(
+                supergauss2D,
+                (X_NF, Y_NF),
+                (np.abs(self.Ew_NF[:, :, self.spectFWHMIdx[0] + i])).ravel(),
+                p0=(1, self.xc_NF, self.yc_NF, self.waist_NF),
+            )
+            xc_SD.append(popt[1])
+            yc_SD.append(popt[2])
+
+        # linear fit to central x coordinate
+        popt, pcov = curve_fit(lin, self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6, xc_SD)
+        perr = np.diag(pcov)
+        SDx = popt[0]
+        eSDx = perr[0]
+        print("measured SD in NF in x direction: %.2e +- %.2e mm / nm" % (SDx, eSDx))
+
+        popt, pcov = curve_fit(lin, self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6, yc_SD)
+        perr = np.diag(pcov)
+        SDy = popt[0]
+        eSDy = perr[0]
+        print("measured SD in NF in y direction: %.2e +- %.2e mm / nm" % (SDy, eSDy))
+
+    def measure_sd_in_ff(self):
+        """
+        measure spatial dispersion in the far field
+        """
+        # lists to store center coordinates
+        xc_SD = []
+        yc_SD = []
+
+        X, Y = np.meshgrid(self.x, self.y)
+
+        # supergaussian fit to near field amplitude to extract center coordinates
+        # only inside the spectral intensity FWHM
+        for i in range(self.spectFWHMIdx[1] - self.spectFWHMIdx[0]):
+            popt, pcov = curve_fit(
+                gauss2D,
+                (X, Y),
+                (np.abs(self.Ew[:, :, self.spectFWHMIdx[0] + i]) ** 2).ravel(),
+                p0=(1, self.xc, self.yc, self.waist),
+            )
+            xc_SD.append(popt[1])
+            yc_SD.append(popt[2])
+
+        # linear fit to central x coordinate
+        popt, pcov = curve_fit(lin, self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6, xc_SD)
+        perr = np.diag(pcov)
+        SDx = popt[0]
+        eSDx = perr[0]
+        print("measured SD in FF in x direction:  %.2e +- %.2e mm / nm" % (SDx, eSDx))
+
+        popt, pcov = curve_fit(lin, self.lamb[self.spectFWHMIdx[0] : self.spectFWHMIdx[1]] * 10**6, yc_SD)
+        perr = np.diag(pcov)
+        SDy = popt[0]
+        eSDy = perr[0]
+        print("measured SD in FF in y direction:  %.2e +- %.2e mm / nm" % (SDy, eSDy))
+
+    def propagate(self, z):
+        """
+        Propagate the far field (in frequency domain) using the angular spectrum method.
+        Should be called after correcting the phase.
+        Propagation leads to a linear phase term resulting in a time shift (by t = z/c). This linear phase term
+        will be removed since it
+            1. probably cannot be resolved by the w spacing anway and
+            2. thus shifts the intensity maximum in the time domain to unexpected places,
+               maybe even to the border of the sampling interval.
+
+        Arguments:
+        z: propagation distance in mm
+
+        Returns:
+        propagated (complex) field data; the corresponding scales are self.x, self.y and self.w.
+        """
+        assert self.is_phase_corrected, "Oops, you forgot to correct the phase!"
+
+        # check that propagated beam will still fit into the window
+        w_exp = self.waist * np.sqrt(1 + (z / self.zR) ** 2)
+        assert w_exp < 0.2 * min(
+            self.dx * self.Ew.shape[0], self.dy * self.Ew.shape[1]
+        ), "Oops, you wanted to propagate too far! The pulse will not fit in the transverse window."
+
+        a = 2 * np.pi * c * np.fft.fftfreq(self.x.size, d=np.diff(self.x)[0])
+        b = 2 * np.pi * c * np.fft.fftfreq(self.y.size, d=np.diff(self.y)[0])
+        A, B, W = np.meshgrid(a, b, self.w)
+
+        # depending on the following mask, the wavenumber k_z (= spatial frequency in propagation direction)
+        # is either complex or real, resulting in plane or evanescent waves, respectively. For a detailed
+        # derivation, please refer to Godmans "Introduction to Fourier Optics". Please note that sign of the
+        # (propagating) complex phase is chosen opposite to there.
+        cond = (A**2 + B**2) / W**2
+        idx_in = np.where(cond < 1)
+        idx_out = np.where(cond > 1)
+        F_Ew = np.fft.ifft2(self.Ew, axes=(0, 1))
+        F_Ew[idx_in] *= np.exp(-1j * W[idx_in] / c * np.sqrt(1 - cond[idx_in]) * z)  # plane waves
+        F_Ew[idx_out] *= np.exp(-W[idx_out] / c * np.sqrt(cond[idx_out] - 1) * np.abs(z))  # evanescent waves
+        lin_phase = np.exp(1j * W * z / c)  # cancel out the time shift
+
+        print("far field propagated to z = %.2f mm" % (z))
+        return np.fft.fft2(F_Ew, axes=(0, 1)) * lin_phase
+
+    def to_time_domain(self, Ew, lamb_supp=10):
+        """
+        Transform far field from frequency to time domain
+
+        Arguments:
+        Ew: far field data in frequency domain (at the focus or propagated)
+        lamb_supp: number of sampling points on one wavelength;
+                   from this, the number of zeros to be padded will be derived. Default is 10.
+        """
+        assert self.is_phase_corrected, "Oops, you forgot to correct the phase!"
+
+        # calculate the number of zeros to be padded at the right side of the spectrum
+        # longitudinal axis length N_tot = 2 * pi / (dw * dt)
+        # necessary time spacing dt = lamb / (c * lamb_supp)
+        zeros = int(self.w[self.wc_idx] * lamb_supp / self.dw / 2 - self.w[-1] / self.dw)
+
+        # the data has to be sorted according to fft requirements:  w = dw * (0, 1, ... n/2, -n/2, ... -1)
+        # so we have to extent (and interpolate) first the positive side of the spectrum
+        w_fft = np.arange(0, self.w[-1] + zeros * self.dw, self.dw)
+        Y_fft, X_fft, W_fft = np.meshgrid(self.y, self.x, w_fft, indexing="ij")
+        fft_interp = RegularGridInterpolator(
+            (self.y, self.x, self.w), Ew, bounds_error=False, fill_value=0, method="linear"
+        )
+        Ew_fft = fft_interp((Y_fft, X_fft, W_fft))
+        # set the negative frequency part to 0 (instead of the complex conjugate) and neglect the imaginary part afterwards
+        w_fft = np.concatenate((w_fft, -np.flip(w_fft[1:])))
+        Ew_fft = np.concatenate((Ew_fft, np.zeros_like(Ew_fft[:, :, :-1])), axis=-1)
+
+        # transform to time domain
+        self.Et = np.fft.fftshift(np.fft.ifft(Ew_fft), axes=-1)
+        # rescale the amplitude to one
+        self.Et = self.Et / np.abs(self.Et).max()
+        self.t = np.fft.fftshift(np.fft.fftfreq(w_fft.size, self.dw / (2 * np.pi)))  # fs
+        self.dt = np.diff(self.t)[0]
+
+        # estimate the pulse length
+        popt, pcov = curve_fit(
+            gauss,
+            self.t,
+            np.abs(self.Et[np.abs(self.y - self.yc).argmin(), np.abs(self.x - self.xc).argmin(), :]),
+            p0=(1, 0, 15),
+        )
+        print("Pulse duration: %.f fs / FHWM intensity: %.f fs" % (popt[2], 2 * np.sqrt(2 * np.log(2)) * popt[2]))
+
+        print("field data size: %.1f GB" % (np.prod(self.Et.shape) * 8 * 10**-9))  # assumes datatype double
+
+    def save_to_openPMD(self, outputpath, outputname, energy, pol="y", crop_x=0, crop_y=0, crop_t=0):
+        """
+        Save the field data in time domain to an openPMD file. This output will be used for the
+        FromOpenPMDPulse profile.
+        The pulse's time evolution at a specific z position will be transformed to a spatial evolution along
+        the propagation direction via z=c*t. ATTENTION: This approximation is only valid when the pulse length
+        is much smaller than a Rayleign length, because otherwise the true spatial evolution is affected by
+        defocusing. BUT since the FromOpenPMDPulse profile transforms this axis back to a spatial one by division
+        by c, this will not lead to errors also if the pulse length is of the order of a Rayleign length.
+        So this transformation should be considered as "meaningless"; it is only done to fulfil the openPMD
+        requirements for field storage.
+        In principle, this can be refactored by using several iterations in the openPMD file instead of just
+        the 0th, but this will complicate reading the file in the PIConGPU initialization procedure.
+
+        Arguments:
+        outputpath: path to the openPMD file
+        outputname: name of the output file, e.g. "insightData%T.h5"
+        energy: beam energy in Joule. Is used to determine the correct amplitude in the time domain.
+                For that, the approximation z = c*t is used, which holds only for tau << zR/c!
+        pol: polarisation direction, either "x" or "y". Default is "y" (the long axis).
+        crop_x/y/t: if the field data chunk is too big, one can crop the borders from both sides by the length
+                    given with these values (same unit as the corresponding scales). Default is 0.
+        """
+        assert pol == "x" or pol == "y", "Oops, invalid polarisation direction!"
+        idx_x = int(crop_x / self.dx + 0.5)
+        idx_y = int(crop_y / self.dy + 0.5)
+        idx_t = int(crop_t / self.dt + 0.5)
+        Nx, Ny, Nt = np.shape(self.Et)
+        # we only need the real part of the field
+        E_save = np.array(np.real(self.Et[idx_y : Ny - idx_y, idx_x : Nx - idx_x, idx_t : Nt - idx_t]))
+
+        series = openpmd.Series(outputpath + outputname, openpmd.Access.create)
+        ite = series.iterations[0]  # use the 0th iteration
+        ite.time = 0.0
+        ite.dt = self.dt
+        ite.time_unit_SI = 1.0e-15
+
+        # record E-field in 2+1 spatial dimensions with 3 components
+        E = ite.meshes["E"]
+        E.geometry = openpmd.Geometry.cartesian
+        E.grid_spacing = [self.dy, self.dx, c * self.dt]  # mm
+        E.grid_global_offset = [0, 0, 0]  # mm
+        E.grid_unit_SI = 1e-3  # mm to m
+        E.axis_labels = ["y", "x", "z"]
+        E.data_order = "C"
+        E_pol = E[pol]
+        if pol == "x":
+            E_trans = E["y"]
+        else:
+            E_trans = E["x"]
+        E_z = E["z"]
+        data_E = openpmd.Dataset(E_save.dtype, E_save.shape)
+        E_pol.reset_dataset(data_E)
+        E_trans.reset_dataset(data_E)
+        E_z.reset_dataset(data_E)
+
+        # unit system agnostic dimension
+        E.unit_dimension = {
+            openpmd.Unit_Dimension.M: 1,
+            openpmd.Unit_Dimension.L: 1,
+            openpmd.Unit_Dimension.I: -1,
+            openpmd.Unit_Dimension.T: -3,
+        }
+
+        # conversion of field data to SI
+        # total field energy: W = dV * eps0/2 * sum(E**2 + c**2 * B**2) in Joule
+        # B_trans = +- E_pol / c
+        # B_pol = 0
+        # B_z = -+ i/w * d/d_trans E_pol; but neglectable since B_z << B_trans
+        # 1st sign for pol = "x", 2nd for "y"
+        dV = self.dx * self.dy * self.dt * c * 10**-9  # m**3
+        W = dV * 8.854e-12 * np.sum(E_save**2)
+        # correct the value if working with an applied aperture
+        if self.is_masked:
+            energy *= self.field_ratio**2
+            print("Masked pulse energy: %.3f J" % (energy))
+        # scaling to actual beam energy
+        amp_fac = np.sqrt(energy / W)
+        print("Maximum amplitude: %.2e V/m" % (amp_fac))
+
+        E_pol.unit_SI = amp_fac
+        E_trans.unit_SI = 0.0
+        E_z.unit_SI = 0.0
+
+        # register and flush chunk
+        E_pol.store_chunk(E_save)
+        E_trans.make_constant(0.0)
+        E_z.make_constant(0.0)
+        series.flush()
+
+        del series
+
+        print(
+            "data successfully saved, field data size: %.f MB" % (np.prod(E_save.shape) * 8 * 10**-6)
+        )  # assumes datatype double

--- a/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
+++ b/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
@@ -1,0 +1,544 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d25194cb-4633-4cfd-ab12-faa10f9926bc",
+   "metadata": {},
+   "source": [
+    "This file is part of PIConGPU. \\\n",
+    "Copyright 2024 Fabia Dietrich\n",
+    "\n",
+    "# Preparing Insight data for PIConGPU\n",
+    "\n",
+    "## Intro\n",
+    "This notebook allows you to manipulate Insight data and prepare it to be read via the InsightPulse profile into PIconGPU.\n",
+    "The raw Insight data cannot be used, since it (at least) has to be phase corrected and transformed into the time domain. \n",
+    "Furthermore, the field can be propagated.\n",
+    "\n",
+    "## Load modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f20b708-32b3-416e-b3d6-018884281b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# standard modules\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# modules from preparingInsightData.py\n",
+    "from preparingInsightData import PrepRoutines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e06caf1-30ea-46f9-90c9-4d691dccf127",
+   "metadata": {},
+   "source": [
+    "## Get the data\n",
+    "The far field data from an Insight measurement is stored in a h5 file and typically measured in dependence of two transversal coordinates (\"x\" and \"y\" in mm) and the frequency (\"w\" in rad/fs). If there are any deviations from this scheme, you will have to adjust the _PrepRoutines_ source code. \n",
+    "\n",
+    "Then, the first steps are:\n",
+    "1. read the far field data and store it in numpy arrays\n",
+    "2. fit the far field data intensity with a 2D gaussian to extract the beam center and waist size\n",
+    "3. propagate to the near field\n",
+    "4. fit the near field data with a 2D supergaussian to extract the beam center and waist size\n",
+    "\n",
+    "For that, you need to provide path, filename and focal distance (same unit as the transversal scales) to the init function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df9bc30d-c03b-4cb4-9621-b2aa62142f6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foc = 2000  # mm, focal distance\n",
+    "insight = PrepRoutines(\"/put/your/path/here/\", \"filename.h5\", foc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c7db135-e858-4152-9ec6-1d0358180f43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# some nice colorful pictures of your data\n",
+    "fig = plt.figure(figsize=(14, 8))\n",
+    "\n",
+    "ax1 = fig.add_subplot(231)\n",
+    "ax1.imshow(\n",
+    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+    ")\n",
+    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+    "ax1.set_xlabel(\"x [mm]\")\n",
+    "ax1.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "ax2 = fig.add_subplot(232)\n",
+    "ax2.imshow(\n",
+    "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
+    ")\n",
+    "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
+    "ax2.set_xlabel(\"x [mm]\")\n",
+    "ax2.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "ax3 = fig.add_subplot(233)\n",
+    "ax3.plot(\n",
+    "    insight.w,\n",
+    "    np.angle(\n",
+    "        insight.Ew_NF[np.abs(insight.y_NF - insight.yc_NF).argmin(), np.abs(insight.x_NF - insight.xc_NF).argmin(), :]\n",
+    "    ),\n",
+    ")\n",
+    "ax3.set_title(\"phase in near field beam center\")\n",
+    "ax3.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+    "ax3.set_ylabel(\"rad\")\n",
+    "\n",
+    "ax4 = fig.add_subplot(234)\n",
+    "ax4.imshow(\n",
+    "    np.sum(np.abs(insight.Ew), axis=0),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    aspect=\"auto\",\n",
+    "    extent=(insight.w[0], insight.w[-1], insight.x[0], insight.x[-1]),\n",
+    ")\n",
+    "ax4.set_title(r\"SD$_x$ in focus\")\n",
+    "ax4.set_ylabel(\"x [mm]\")\n",
+    "ax4.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+    "\n",
+    "ax5 = fig.add_subplot(235)\n",
+    "ax5.imshow(\n",
+    "    np.sum(np.abs(insight.Ew), axis=1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    aspect=\"auto\",\n",
+    "    extent=(insight.w[0], insight.w[-1], insight.x[0], insight.x[-1]),\n",
+    ")\n",
+    "ax5.set_title(r\"SD$_y$ in focus\")\n",
+    "ax5.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+    "ax5.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "ax6 = fig.add_subplot(236)\n",
+    "# sum just over the main beam spot to extract the spectrum\n",
+    "ax6.plot(\n",
+    "    insight.w,\n",
+    "    np.sum(\n",
+    "        np.sum(\n",
+    "            np.abs(\n",
+    "                insight.Ew[\n",
+    "                    np.abs(insight.y - insight.yc + 2 * insight.waist).argmin() : np.abs(\n",
+    "                        insight.y - insight.yc - 2 * insight.waist\n",
+    "                    ).argmin(),\n",
+    "                    np.abs(insight.x - insight.xc + 2 * insight.waist).argmin() : np.abs(\n",
+    "                        insight.x - insight.xc - 2 * insight.waist\n",
+    "                    ).argmin(),\n",
+    "                    :,\n",
+    "                ]\n",
+    "            )\n",
+    "            ** 2,\n",
+    "            axis=0,\n",
+    "        ),\n",
+    "        axis=0,\n",
+    "    ),\n",
+    ")\n",
+    "ax6.set_title(\"spectral intensity\")\n",
+    "ax6.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+    "ax6.set_ylabel(\"arb. units\")\n",
+    "\n",
+    "plt.subplots_adjust(hspace=0.3, wspace=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18bee9ee-bd16-4e28-b9a7-ac5bc12e112e",
+   "metadata": {},
+   "source": [
+    "## Correct the data\n",
+    "### Adjust beam compression and add dispersion parameters\n",
+    "Before going on with any calculations, the phase has to be corrected. Insight reconstructs the amplitude of the far field beam aswell as the phase, up to an unknown global phase for every frequency.\n",
+    "For an estimation of this global phase, perfect compression is assumed in the (near field) beam center. Thus, the phase is extracted in the beam center in dependence of the frequency and substracted globally (i.e. from the measured phase in dependence of the frequency at every space point).\n",
+    "Here, one also has the possibility to add dispersion parameters such as group velocity dispersion (`GVD`) and third order dispersion (`TOD`) (both are set to 0 by default)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db7ee493-ac2f-4c62-9121-70d270587ae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "insight.correct_phase()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe86408e-4e08-4f9a-8044-b0dfc989d408",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(\n",
+    "    insight.w,\n",
+    "    np.angle(\n",
+    "        insight.Ew_NF[np.abs(insight.y_NF - insight.yc_NF).argmin(), np.abs(insight.x_NF - insight.xc_NF).argmin(), :]\n",
+    "    ),\n",
+    ")\n",
+    "plt.title(\"corrected phase in near field beam center\")\n",
+    "plt.xlabel(r\"$\\omega$ [rad/fs]\")\n",
+    "plt.ylabel(\"rad\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11125a32-e618-40b4-aa4b-e1e51def5c3e",
+   "metadata": {},
+   "source": [
+    "### Correct ugly spots in the near field (optional)\n",
+    "Sometimes, the amplitude in the near field looks weird, showing some (unphysical) peaks or holes. These can cause artifacts in the far field and will thus be smoothened out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c772bfd-2d6b-4206-8dbd-f574d50d3931",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ugly_x = 0.0  # mm\n",
+    "ugly_y = 0.0  # mm\n",
+    "insight.correct_ugly_spot_in_nf(ugly_x, ugly_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ab764a7-979d-417f-bae4-15f19ca790e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(10, 4))\n",
+    "\n",
+    "ax1 = fig.add_subplot(121)\n",
+    "ax1.imshow(\n",
+    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+    ")\n",
+    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+    "ax1.set_xlabel(\"x [mm]\")\n",
+    "ax1.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "ax2 = fig.add_subplot(122)\n",
+    "ax2.imshow(\n",
+    "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
+    ")\n",
+    "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
+    "ax2.set_xlabel(\"x [mm]\")\n",
+    "ax2.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d63c3650-d902-4d71-8bbf-60a8c3b8bca6",
+   "metadata": {},
+   "source": [
+    "### Center the near field beam spot (optional)\n",
+    "When the near field beam spot is not centered (please check the center coordinates above), the far field will propagate obliquely instead of straight ahead. Centering the near field prevents this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b88a2410-f9ca-4ff9-ab1b-3954c38b90b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "insight.shift_nf_to_center()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfbe99d5-97b1-44b6-879c-ed97e3eae945",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(14, 4))\n",
+    "\n",
+    "ax1 = fig.add_subplot(131)\n",
+    "ax1.imshow(\n",
+    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+    ")\n",
+    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+    "ax1.set_xlabel(\"x [mm]\")\n",
+    "ax1.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "ax2 = fig.add_subplot(132)\n",
+    "ax2.imshow(\n",
+    "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
+    ")\n",
+    "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
+    "ax2.set_xlabel(\"x [mm]\")\n",
+    "ax2.set_ylabel(\"y [mm]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f6942a0-43a0-4b55-92fa-a7d6ceb9a59a",
+   "metadata": {},
+   "source": [
+    "## Measure dispersion parameters\n",
+    "You can measure angular dispersion and spatial dispersion in far- and near field.\n",
+    "For a consistency check of those values, you can check those relations: \n",
+    "\\begin{equation}\n",
+    "\\begin{aligned}\n",
+    "AD_{FF} &= - SD_{NF} / f - AD_{NF} \\\\\n",
+    "SD_{FF} &= f \\cdot AD_{NF}\n",
+    "\\end{aligned}\n",
+    "\\end{equation}\n",
+    "$f$ is the focal length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae6d2380-f5c3-4ec4-8918-23ca0fbb6ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "insight.measure_ad_in_nf()\n",
+    "insight.measure_ad_in_ff()\n",
+    "insight.measure_sd_in_nf()\n",
+    "insight.measure_sd_in_ff()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d645f08-4e8d-40ba-af73-533fdd9aa8cb",
+   "metadata": {},
+   "source": [
+    "## Add an aperture in the mid field (optional)\n",
+    "Here, you can apply an aperture to the beam, located in the mid field. The algorithm which propagates the beam to the mid field uses paraxial approximation; so please make sure to put the aperture not too close to the focal plane. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb07e460-f729-46a9-8e28-d32e968968ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = 1000  # mm, distance from focal plane to aperture\n",
+    "R = 38.5 / 2  # mm, aperture radius\n",
+    "insight.aperture_in_mf(d, R)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87430869-9a85-47b9-8127-fbea86f7bbdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure()\n",
+    "ax1 = fig.add_subplot(111)\n",
+    "ax1.imshow(\n",
+    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+    ")\n",
+    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+    "ax1.set_xlabel(\"x [mm]\")\n",
+    "ax1.set_ylabel(\"y [mm]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9988b6e5-f3e4-4395-a1ff-4159ede3b4cd",
+   "metadata": {},
+   "source": [
+    "## Propagate\n",
+    "Now the far field data is ready to be propagated. For that, the angular spectrum method is used. \n",
+    "Watch out not to propagate too far, since then the growing beam diameter could reach the transversal window borders and thus cause fourier transform artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3db3f073-cf90-48f8-a3e7-8bc220c390a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z = -2  # mm\n",
+    "Ew_prop = insight.propagate(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6ff5e59-4b93-41ec-b8a2-68d28a0f26d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(\n",
+    "    np.sum(np.abs(Ew_prop), axis=-1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+    ")\n",
+    "plt.title(\"spectrally integrated amplitude, propagated to %.2f mm\" % (z))\n",
+    "plt.xlabel(\"x [mm]\")\n",
+    "plt.ylabel(\"y [mm]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bfb7cc2-0327-43fb-8364-0dbcc62e0553",
+   "metadata": {},
+   "source": [
+    "## Transform to the time domain\n",
+    "The far field data will be transformed to the time domain via a 1D fourier transformation. This takes a while, since the spectrum has to be extended and the field data extrapolated. One can adjust the number of samples per wavelength, which is set to 10 by default. \\\n",
+    "**Attention:** it is recommeded to adjust the time sampling to the PIConGPU simulation timestep! \\\n",
+    "The real part of the resulting complex matrix `insight.Et` will be the field needed for PIConGPU and its absolute value is the envelope, which can be used for further analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f44373f9-d947-41d8-8e21-2eafe7584de8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "insight.to_time_domain(Ew_prop)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "268a89c7-4334-4906-ad16-c4536a128617",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(6, 9))\n",
+    "\n",
+    "ax1 = fig.add_subplot(311)\n",
+    "ax1.imshow(\n",
+    "    np.sum(np.abs(insight.Et), axis=0),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    aspect=\"auto\",\n",
+    "    extent=(insight.t[0], insight.t[-1], insight.x[0], insight.x[-1]),\n",
+    ")\n",
+    "ax1.set_ylabel(\"x [mm]\")\n",
+    "ax1.set_title(\"transversally integrated field\")\n",
+    "\n",
+    "ax2 = fig.add_subplot(312)\n",
+    "ax2.imshow(\n",
+    "    np.sum(np.abs(insight.Et), axis=1),\n",
+    "    cmap=\"cubehelix\",\n",
+    "    origin=\"lower\",\n",
+    "    aspect=\"auto\",\n",
+    "    extent=(insight.t[0], insight.t[-1], insight.x[0], insight.x[-1]),\n",
+    ")\n",
+    "ax2.set_ylabel(\"y [mm]\")\n",
+    "\n",
+    "ax3 = fig.add_subplot(313)\n",
+    "Et_center = insight.Et[np.abs(insight.y - insight.yc).argmin(), np.abs(insight.x - insight.xc).argmin(), :]\n",
+    "ax3.plot(insight.t, np.real(Et_center), label=\"real part\")\n",
+    "ax3.plot(insight.t, np.abs(Et_center), label=\"envelope\")\n",
+    "ax3.set_xlabel(\"t [fs]\")\n",
+    "ax3.set_ylabel(\"field strength [arb. units]\")\n",
+    "ax3.set_title(\"field in beam center\")\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.subplots_adjust(hspace=0.25)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b5e94b1-d37e-4639-ad5c-8990206df22e",
+   "metadata": {},
+   "source": [
+    "## Save data to openPMD\n",
+    "The data is now nearly ready te be used as FromOpenPMDPulse input. The amplitude of the pulse in the time domain still has to be corrected (= scaled to the actual beam energy in Joule) before saving it to an openPMD file at the provided destination path.\n",
+    "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm) and `crop_t` (in fs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5018ef1c-2696-4981-b25f-7565a3faaea6",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "E = 4.5  # J, beam energy\n",
+    "pol = \"y\"  # polarisation axis (can be 'x' or 'y')\n",
+    "crop_x = 0.3  # mm, trim transversal x axis\n",
+    "crop_y = 0.3  # mm, trim transversal y axis\n",
+    "crop_t = 100  # fs, trim time axis\n",
+    "\n",
+    "insight.save_to_openPMD(\"\", \"insightData_prepared%T.h5\", E, pol, crop_x, crop_y, crop_t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b45022ea-d79a-4ef2-b615-9ca74833e31e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
TL;DR: This is the same PR as before. I opened a new one because rebasing was a mess...

The FromOpenPMDPulse profile is an IncidentField method that reads a laser pulse in space-time domain from openPMD into PIConGPU. 

Furthermore, there are a python script provided at picongpu/lib/python/picongpu/extra/input to prepare an INSIGHT measurement as input for this laser profile. Such preparation steps are:
- restoring the missing phase relation between the measured frequencies
- propagation out of the focal plane (where the measurement took place)
- transformation from frequency to tome domain
- add group velocity / third order dispersion
- measure angular / spatial dispersion
- correct possible measurement artifacts
- save to openPMD
Further explanation and an example workflow can be found in the jupyter notebook at the same place.

Currently, there are some restrictions using the FromOpenPMDPulse profile:
- propagation and polarization only work along the axes, **not** diagonally!
- the pulse will always be aligned centered at the incident plane
- one needs to increase the reserved GPU memory size in memory.param - since the field data chunk will be stored on each used device at timestep 0 (and not during init, before allocating the particle memory), the simulation could otherwise run into memory issues.
- the Insight measurement scales have to be mm and fs, otherwise the preparation routine has to be adapted
- the time axis is read in inverted (which is wrong), but it only works this way (apparently cancelling out another error either in the preparation routine or in the incident field method). Until the bug is found, the wrong direction has to be kept.

There have been various tests to validate this new laser profile:
#### 1. Using a Gaussian pulse profile

A Gaussian pulse field chunk has been read from openPMD into the simulation. The focus was set to cell 26 (in propagation direction $y$, where $dy = \lambda/10$), where the field was read at every simulation timestep during the pulse duration. This was compared to a simulation with the already existing GaussianPulse profile with the same parameters. Since the electric field oscillates strongly in the longitudinal direction, a direct comparision is difficult (small shifts in time or of the incident field plane position can already cause quite some differences), both simulation outputs were transformed into the fourier domain:
![spectral_abs_int](https://github.com/user-attachments/assets/19c2a745-1135-473c-a102-7eb828b4f809)
![spectral_abs_int_log](https://github.com/user-attachments/assets/d50eb72d-38e0-44bc-91b6-a1899ebb8994)
![spectral_angle_center](https://github.com/user-attachments/assets/c621f3c1-6376-488e-8473-0e085041b78b)
As one can see, it fits quite nice; differences start only to appear at small intensity values and are probably caused by numerical precision. With an inverse fourier transform, the temporal envelope was reconstructed: 
![time_env_center](https://github.com/user-attachments/assets/e21daa5a-38ec-4dd3-b61f-c4832b021004)
![time_env_center_log](https://github.com/user-attachments/assets/cd10c38b-d70b-4e07-b3bd-0a42b8fcca73)
Again, the only differences appear at small intensity values; *but only* when the simulation timestep and the time sampling of the field chunk are adjusted to each other. Otherwise the temporal envelope can look wiggly, which leads to deviating results when it comes to interaction with plasma. So it is recommended to adjust those timesteps to each other.

#### 2. Using a Gauss-Laguerre pulse
According to the definition of a Gauss-Laguerre pulse in the GaussianPulse profile, a Gauss-laguerre pulse field chunk has been written to OpenPMD and read into PIConGPU. The pulse parameters were $\lambda$ = 800nm, $\tau = 30/2\sqrt{2 ln 2}$ fs, $w_0$ = 10 µm and $z$ = $-z_R$ = -0.393mm. As Laguerre coefficients, the example set in GaussianPulse.def was used. For two different positions, the simulation results ("PIC") were compared to the analytical solution ("Original"):
**a) at $z \approx -z_R$**
![xyPlaneIte1285](https://github.com/user-attachments/assets/3cb76852-3538-4070-a02c-d07335f26317)
(amplitude along the longitudinal direction)
![energyDensityIte1285](https://github.com/user-attachments/assets/7bff1c78-9354-4fe9-b588-757baa913a8e)
(energy density, definition see below)
**b) at the focus position**
![xyPlaneIte5597](https://github.com/user-attachments/assets/9998e582-3699-4eb6-bea8-8808bdd07aea)
(amplitude along the longitudinal direction,  the blue line is the focus position at this time step)
![energyDensityIte5597](https://github.com/user-attachments/assets/86ed0411-5105-45cb-b127-03055f89b350)
(energy density, definition see above)
![focusDiffIte5597](https://github.com/user-attachments/assets/9d821f14-f151-4883-8aec-0283ffe7b495)
(transversal integrated amplitude,  the black line is the focus position at this time step)
In the above mentioned simulations, the transversal simulation cell was square-shaped, as well as the transversal extent of the test pulse field chunk. To test also the asymmetrical case, the simulation cell in $x$ direction was halved in size. The results were similar: 
![energyDensityIte5649](https://github.com/user-attachments/assets/da0c589e-66de-408e-86b5-e98837e78668)
(energy density for an asymmetrical cell size; the asymmetry in amplitude shows that the energy is conserved better for a smaller cell size)
Then, the cell size was reset to original (transversal square-shaped), but the (original) field chunk was chosen to be asymmetrical:
![originalChunkExtent](https://github.com/user-attachments/assets/da0dc1ad-8faa-4856-a804-f716f1691225)
(original Gauss-Laguerre field at $z=-z_R$, before reading it into the simulation)
The resulting simulation did behave just the same as above, e.g. the pulse was still centered and not distorted after propagating it into the focus:
![yxPlaneIte5597](https://github.com/user-attachments/assets/cb033851-697a-491d-91fa-53fa3cb3808d)
![yzPlaneIte5597](https://github.com/user-attachments/assets/ba755a14-0abe-4561-a0d0-d4db99054e1f)
(amplitude in longitudinal direction, along both transversal directions; blue is the focus position)
![energyDensityIte5597](https://github.com/user-attachments/assets/dd2179ae-cc30-4d07-ac46-45cc9687d300)
( energy density)

#### 3. Using an Insight measurement

For that, the measured field data has been propagated out of the focus by one rayleigh length (-1,28 mm) during the preparation routine, saved to openPMD and then read into the simulation. The simulation ran until the pulse reached the focal plane again (in vacuum), where the simulation output was compared to the original INSIGHT measurement: 
![VacuumValidation](https://github.com/user-attachments/assets/c1db1210-5d79-4571-b2ad-0a055f1c45bc)
The shape, amplitude and extent of both pulses fit well.
A cut through both beam centers reveals the longitudinal pulse envelope:
![VacuumValidation2](https://github.com/user-attachments/assets/ed6699b9-035e-42a3-bcc6-2b6fed619520)
Here, one can see slight deviations. They are mostly caused by field solver dispersion (Yee was used with $dy = \lambda/10$ over a propagation distance of 1.28 mm) and can be improved with a finer grid. Furthermore, there is a spatial axis compared to a temporal one ("ct"), but since the pulse is short, this approximation should be valid, since pulse divergence does not play a role at that small scales.
The energy density (longitudinally integrated, $\mathcal{W} = \int dz \frac{\epsilon_0}{2} (E^2 + c^2 B^2)$ ) shows that also the transverse pulse extent in the simulation fits welll to the expected one:
![VacuumValidation_energyDensity](https://github.com/user-attachments/assets/dd84e38f-f296-4cc9-be3e-eb30dd2f2286)
Only the x axis is switched because to keep the system handiness when choosing  a different propagation and polarization direction (y, -x)  than the original measurement (z, x). Also, the pulse energy is the same, only a bit smaller in PIConGO again due to field solver dispersion. When calculating the beam energy via $W = \int dV \frac{\epsilon_0}{2} (E^2 + c^2 B^2)$, the simulation output lies slightly below the input (7% less). The loss is in the range of field solver dispersion.

Furthermore, there were tests with different propagation and polarization directions, where the field at the incident plane ("PIC") has been compared to the input ("Original") data:
![incidentPlaneIte1800](https://github.com/user-attachments/assets/62b5dc94-1d23-4b16-a61d-995fedb08e99)
(propagation in z direction, polarization in x direction, just as the original)
![incidentPlaneNegPolIte1800](https://github.com/user-attachments/assets/aede2351-2ee6-4574-b64a-4c3b5b8616b9)
(propagation in z direction, polarization in -x direction; this automatically also swaps the y axis to keep the original pulse orientation)
![xzPlaneNegPropIte1800](https://github.com/user-attachments/assets/eadcde87-654a-4e7d-8e1e-dd20ca3df3d9)
(propagation in -z direction, polarization in x direction; the time axis of the original data has been transformed to a spatial one by multiplication with $c$ to allow a better comparison)

Tests for different (transversal) simulation window extents, different transverse grid spacing ($w_0/6$ and $w_0/10$) and for a different number of devices (1, 2, 4) also lead to the expected results.