### PR TITLE
Fix atomic physics example docs

### DIFF
--- a/share/picongpu/examples/AtomicPhysics/README.md
+++ b/share/picongpu/examples/AtomicPhysics/README.md
@@ -54,8 +54,7 @@ Run Locally
 ___________
 
 From the root directory
-1.) run picongpu by hand using `./bin/picongpu -g 1 1 1 -d 1 1 1 -s 25 --periodic 1 1 1`
-2.) run `./validate/validateLocally.sh` to validate the simulation results
+Run `./validate/validateLocally.sh` to run and validate the simulation results
 
 Run Using TBG
 _____________

--- a/share/picongpu/examples/AtomicPhysics/validation/validateLocally.sh
+++ b/share/picongpu/examples/AtomicPhysics/validation/validateLocally.sh
@@ -21,7 +21,7 @@
 # assume working picongpu with atomic physics environment
 
 # build setup
-pic-build 2>&1 | tee compile.result
+pic-build -c "-DPARAM_FORCE_CONSTANT_ELECTRON_TEMPERATURE" 2>&1 | tee compile.result
 
 # run test simulation
 ./bin/picongpu -r 4 -g 32 32 32 -d 1 1 1 --periodic 1 1 1 -s 25 --progressPeriod 1 --versionOnce 2>&1 | tee ../output.result


### PR DESCRIPTION
`validateLocally` already includes a call to execute PIConGPU, fix to not run twice
Fixes the pic-build call in validate script