### PR TITLE
copy folder `validation` with `pic-create`

### DIFF
--- a/bin/pic-create
+++ b/bin/pic-create
@@ -27,7 +27,7 @@ picongpu_prefix=$(cd $this_dir/.. && pwd)
 default_folder_to_copy="etc/picongpu"
 
 # Folder which get recusivly copied from the source input set into the destination input set
-folder_to_clone="etc/picongpu bin include/picongpu lib"
+folder_to_clone="etc/picongpu bin include/picongpu lib validation"
 files_to_copy="cmakeFlags executeOnClone"
 
 if [ -n "$PIC_SYSTEM_TEMPLATE_PATH" ] ; then


### PR DESCRIPTION
The example AtomicPhysics provids the validation scripts and data within the folder `validation`.
Since we have currently no concept how we should handle this case we simply copy the folder.

ci: no-compile