### PR TITLE
add missing init of maximum EField Accumulation variable

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -210,12 +210,19 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
             float_X const ionizationPotentialDepression)
         {
-            // internal units
+            // sim.unit.eField()
             PMACC_SMEM(worker, maximumNormEFieldValueSuperCell, typename T_EFieldDataBox::ValueType::type);
 
             // find maximum field strength of superCell
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&maximumNormEFieldValueSuperCell]()
+                {
+                    // sim.unit.eField()
+                    maximumNormEFieldValueSuperCell = 0._X;
+                });
+            worker.sync();
 
-            /// @todo switch to shared memory reduce, Brian Marre, 2024
             constexpr auto numberCellsInSuperCell
                 = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
             auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
@@ -234,7 +241,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     alpaka::atomicMax(
                         worker.getAcc(),
-                        // internal units
+                        // sim.unit.eField()
                         &maximumNormEFieldValueSuperCell,
                         eFieldNorm);
                 });
@@ -278,6 +285,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                 atomicStateDataDataBox,
                                 boundFreeTransitionDataBox);
                     }
+
                     rateCache.template add<s_enums::ChooseTransitionGroup::fieldBoundFreeUpward>(
                         atomicStateCollectionIndex,
                         sumRateTransitions);


### PR DESCRIPTION
Bug fix, adds missing initialization of the maximumEField storage with `0`, should not have created actual problems since we by default initialize with `0`, but an init is required to avoid relying on implicit assumptions.

ci: picongpu