### PR TITLE
fix maximum ADK rate estimation

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -35,6 +35,7 @@
 #include <pmacc/static_assert.hpp>
 
 #include <cstdint>
+#include <limits>
 
 namespace picongpu::particles::atomicPhysics::kernel
 {
@@ -211,27 +212,28 @@ namespace picongpu::particles::atomicPhysics::kernel
             float_X const ionizationPotentialDepression)
         {
             // sim.unit.eField()
-            PMACC_SMEM(worker, maximumNormEFieldValueSuperCell, typename T_EFieldDataBox::ValueType::type);
+            PMACC_SMEM(worker, maxEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
+            // sim.unit.eField()
+            PMACC_SMEM(worker, minEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
 
-            // find maximum field strength of superCell
             auto onlyMaster = lockstep::makeMaster(worker);
             onlyMaster(
-                [&maximumNormEFieldValueSuperCell]()
+                [&maxEFieldSuperCell, &minEFieldSuperCell]()
                 {
-                    // sim.unit.eField()
-                    maximumNormEFieldValueSuperCell = 0._X;
+                    maxEFieldSuperCell = 0._X;
+                    minEFieldSuperCell = std::numeric_limits<float_X>::max();
                 });
             worker.sync();
 
             constexpr auto numberCellsInSuperCell
                 = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
-            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
-
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
+            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
 
             /// @todo switch to shared memory reduce, Brian Marre, 2024
             forEachCell(
-                [&worker, &superCellCellOffset, &maximumNormEFieldValueSuperCell, &eFieldBox](uint32_t const linearIdx)
+                [&worker, &superCellCellOffset, &maxEFieldSuperCell, &minEFieldSuperCell, &eFieldBox](
+                    uint32_t const linearIdx)
                 {
                     DataSpace<picongpu::simDim> const localCellIndex
                         = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearIdx));
@@ -242,18 +244,23 @@ namespace picongpu::particles::atomicPhysics::kernel
                     alpaka::atomicMax(
                         worker.getAcc(),
                         // sim.unit.eField()
-                        &maximumNormEFieldValueSuperCell,
+                        &maxEFieldSuperCell,
+                        eFieldNorm);
+
+                    alpaka::atomicMin(
+                        worker.getAcc(),
+                        // sim.unit.eField()
+                        &minEFieldSuperCell,
                         eFieldNorm);
                 });
             worker.sync();
 
             // calculate ADK field ionization rate, for each atomic state and maximum field value
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
-
-            //      accumulate rates of possible transitions by state
             forEachAtomicState(
                 [&ionizationPotentialDepression,
-                 &maximumNormEFieldValueSuperCell,
+                 &maxEFieldSuperCell,
+                 &minEFieldSuperCell,
                  &rateCache,
                  &numberTransitionsDataBox,
                  &startIndexDataBox,
@@ -276,14 +283,16 @@ namespace picongpu::particles::atomicPhysics::kernel
                         uint32_t const transitionCollectionIndex = offset + transitionID;
 
                         // 1/picongpu::sim.unit.time()
-                        sumRateTransitions += atomicPhysics::rateCalculation::
-                            BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
-                                maximumNormEFieldValueSuperCell,
-                                ionizationPotentialDepression,
-                                transitionCollectionIndex,
-                                chargeStateDataDataBox,
-                                atomicStateDataDataBox,
-                                boundFreeTransitionDataBox);
+                        sumRateTransitions
+                            += atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
+                                template maximumRateADKFieldIonization(
+                                    maxEFieldSuperCell,
+                                    minEFieldSuperCell,
+                                    ionizationPotentialDepression,
+                                    transitionCollectionIndex,
+                                    chargeStateDataDataBox,
+                                    atomicStateDataDataBox,
+                                    boundFreeTransitionDataBox);
                     }
 
                     rateCache.template add<s_enums::ChooseTransitionGroup::fieldBoundFreeUpward>(

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -221,6 +221,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                 [&maxEFieldSuperCell, &minEFieldSuperCell]()
                 {
                     maxEFieldSuperCell = 0._X;
+                    /// needs to be initialized with neutral element of Minimum
+                    /// @warning never increase the result from this variable, may be maximum representable value.
                     minEFieldSuperCell = std::numeric_limits<float_X>::max();
                 });
             worker.sync();
@@ -255,7 +257,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 });
             worker.sync();
 
-            // calculate ADK field ionization rate, for each atomic state and maximum field value
+            // calculate maximum ADK field ionization rate for each atomic state
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
             forEachAtomicState(
                 [&ionizationPotentialDepression,

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -39,6 +39,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
     template<atomicPhysics::enums::ADKLaserPolarization T_ADKLaserPolarization>
     struct BoundFreeFieldTransitionRates
     {
+    private:
         /** get effective principal quantum number
          *
          * @param ionizationEnergy, in Hartree
@@ -48,17 +49,17 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          */
         HDINLINE static float_X effectivePrincipalQuantumNumber(
             float_X const screenedCharge,
-            float_x const ionizationEnergy)
+            float_X const ionizationEnergy)
         {
             return screenedCharge / math::sqrt(2._X * ionizationEnergy);
         }
 
-        /** get screened charge for ionization
+        /** get screened charge for ionization electron
          *
          * @return unit: e
          */
         template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
-        HDINLINE static float_X const screenedCharge(
+        HDINLINE static float_X screenedCharge(
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,
             T_AtomicStateDataBox const atomicStateDataBox,
@@ -74,7 +75,42 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             return chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
         }
 
+        /** actual rate rateFormula
+         *
+         * @param Z screenedCharge for ionization electron, e
+         * @param nEff effective principal quantum number, unitless
+         * @param eFieldNorm_AU norm of the E-Field strength, in sim.atomicUnit.eField()
+         */
+        HDINLINE static float_X rateFormula(float_X const Z, float_X const nEff, float_X const eFieldNorm_AU)
+        {
+            float_X const nEffCubed = pmacc::math::cPow(nEff, 3u);
+            float_X const ZCubed = pmacc::math::cPow(Z, 3u);
 
+            float_X const dBase = 4.0_X * math::exp(1._X) * ZCubed / (eFieldNorm_AU * pmacc::math::cPow(nEff, 4u));
+            float_X const dFromADK = math::pow(dBase, nEff);
+
+            constexpr float_X pi = pmacc::math::Pi<float_X>::value;
+
+            // 1/sim.atomicUnit.time()
+            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * Z)
+                * math::exp(-2._X * ZCubed / (3._X * nEffCubed * eFieldNorm_AU));
+
+            // factor from averaging over one laser cycle with LINEAR polarization
+            if constexpr(
+                u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
+                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * ZCubed));
+
+            /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
+             *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()
+             *   = (A * timeConversion) * 1/sim.unit.time()
+             *   = B * 1/sim.unit.time() */
+            constexpr float_X timeConversion = picongpu::sim.unit.time() / picongpu::sim.atomicUnit.time();
+
+            // 1/ sim.unit.time()
+            return rateADK_AU * timeConversion;
+        }
+
+    public:
         /** field ionization ADK rate for a given electric field strength
          *
          * @tparam T_ChargeStateDataBox instantiated type of dataBox
@@ -126,31 +162,79 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             // sim.atomicUnit.eField()
             float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
 
-            float_X const ZCubed = pmacc::math::cPow(Z, 3u);
+            return rateFormula(Z, nEff, eFieldNorm_AU);
+        }
 
-            float_X const dBase = 4.0_X * math::exp(1._X) * ZCubed / (eFieldNorm_AU * pmacc::math::cPow(nEff, 4u));
-            float_X const dFromADK = math::pow(dBase, nEff);
+        /** get maximum field ionization ADK rate for electric field strengths inside the given boundaries
+         *
+         * @tparam T_ChargeStateDataBox instantiated type of dataBox
+         * @tparam T_AtomicStateDataBox instantiated type of dataBox
+         * @tparam T_BoundFreeTransitionDataBox instantiated type of dataBox
+         *
+         * @param maxEFieldNorm maximum E-field vector norm, in sim.units.eField()
+         * @param minEFieldNorm minimum E-field vector norm, in sim.units.eField()
+         * @param ionizationPotentialDepression, in eV
+         * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
+         * @param atomicStateDataBox access to atomic state property data
+         * @param boundBoundTransitionDataBox access to bound-bound transition data
+         *
+         * @return unit: 1/picongpu::sim.unit.time()
+         */
+        template<
+            typename T_EFieldType,
+            typename T_ChargeStateDataBox,
+            typename T_AtomicStateDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        HDINLINE static float_X maximumRateADKFieldIonization(
+            T_EFieldType const maxEFieldNorm,
+            T_EFieldType const minEFieldNorm,
+            float_X const ionizationPotentialDepression,
+            uint32_t const transitionCollectionIndex,
+            T_ChargeStateDataBox const chargeStateDataBox,
+            T_AtomicStateDataBox const atomicStateDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
+        {
+            if(maxEFieldNorm == 0._X)
+                return 0._X;
 
-            constexpr float_X pi = pmacc::math::Pi<float_X>::value;
-            float_X const nEffCubed = pmacc::math::cPow(nEff, 3u);
+            float_X const Z = screenedCharge(
+                transitionCollectionIndex,
+                chargeStateDataBox,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox);
 
-            // 1/sim.atomicUnit.time()
-            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * Z)
-                * math::exp(-2._X * ZCubed / (3._X * nEffCubed * eFieldNorm_AU));
+            // Hartree
+            float_X const ionizationEnergy = picongpu::sim.si.conv().eV2auEnergy(DeltaEnergyTransition::get(
+                transitionCollectionIndex,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox,
+                ionizationPotentialDepression,
+                chargeStateDataBox));
 
-            // factor from averaging over one laser cycle with LINEAR polarization
-            if constexpr(
-                u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
-                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * ZCubed));
+            float_X const nEff = effectivePrincipalQuantumNumber(Z, ionizationEnergy);
+            float_X const nEffCubed = pmacc::math::cPow(nEff, u32(3u));
 
-            /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
-             *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()
-             *   = (A * timeConversion) * 1/sim.unit.time()
-             *   = B * 1/sim.unit.time() */
-            constexpr float_X timeConversion = picongpu::sim.unit.time() / picongpu::sim.atomicUnit.time();
+            float_X const maxEField_AU = picongpu::sim.pic.conv().eField2auEField(maxEFieldNorm);
+            float_X const minEField_AU = picongpu::sim.pic.conv().eField2auEField(minEFieldNorm);
 
-            // 1/ sim.unit.time()
-            return rateADK_AU * timeConversion;
+            // theoretical maximum ADK Rate, in sim.atomicUnit.eField()
+            float_X const F_max = 4._X * Z / (3 * nEffCubed * (4._X * nEff - 3._X));
+
+            // fieldStrength for maximum Rate, in sim.atomicUnit.eField(), see Notebook 2024 P.43-48
+            float_X F;
+            if(nEff <= 0.75_X || F_max > maxEField_AU)
+            {
+                F = maxEField_AU;
+            }
+            else
+            {
+                if(F_max > minEField_AU)
+                    F = F_max;
+                else
+                    F = minEField_AU;
+            }
+
+            return rateFormula(Z, nEff, F);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::rateCalculation

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -39,14 +39,50 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
     template<atomicPhysics::enums::ADKLaserPolarization T_ADKLaserPolarization>
     struct BoundFreeFieldTransitionRates
     {
-        /** rate for bound-free field ionization transition of ion depending on the local electric field
+        /** get effective principal quantum number
+         *
+         * @param ionizationEnergy, in Hartree
+         * @param screenedCharge, in e
+         *
+         * @return unitless
+         */
+        HDINLINE static float_X effectivePrincipalQuantumNumber(
+            float_X const screenedCharge,
+            float_x const ionizationEnergy)
+        {
+            return screenedCharge / math::sqrt(2._X * ionizationEnergy);
+        }
+
+        /** get screened charge for ionization
+         *
+         * @return unit: e
+         */
+        template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
+        HDINLINE static float_X const screenedCharge(
+            uint32_t const transitionCollectionIndex,
+            T_ChargeStateDataBox const chargeStateDataBox,
+            T_AtomicStateDataBox const atomicStateDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
+        {
+            uint32_t const lowerStateClctIdx
+                = boundFreeTransitionDataBox.lowerStateCollectionIndex(transitionCollectionIndex);
+            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
+
+            using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
+            uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
+
+            return chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
+        }
+
+
+        /** field ionization ADK rate for a given electric field strength
          *
          * @tparam T_ChargeStateDataBox instantiated type of dataBox
          * @tparam T_AtomicStateDataBox instantiated type of dataBox
          * @tparam T_BoundFreeTransitionDataBox instantiated type of dataBox
          *
-         * @param eField E-field vector, in internal units
-         * @param ionizationPotentialDepression, eV
+         * @param eFieldNorm E-field vector norm, in sim.units.eField()
+         * @param ionizationPotentialDepression, in eV
          * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
          * @param atomicStateDataBox access to atomic state property data
          * @param boundBoundTransitionDataBox access to bound-bound transition data
@@ -59,9 +95,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             typename T_AtomicStateDataBox,
             typename T_BoundFreeTransitionDataBox>
         HDINLINE static float_X rateADKFieldIonization(
-            // internal units
             T_EFieldType const eFieldNorm,
-            // eV
             float_X const ionizationPotentialDepression,
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,
@@ -71,45 +105,43 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             if(eFieldNorm == 0._X)
                 return 0._X;
 
-            // get screenedCharge
-            uint32_t const lowerStateClctIdx
-                = boundFreeTransitionDataBox.lowerStateCollectionIndex(transitionCollectionIndex);
-            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
-
-            using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
-            uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
-
             // e
-            float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
+            float_X const Z = screenedCharge(
+                transitionCollectionIndex,
+                chargeStateDataBox,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox);
 
-            // ev
-            float_X const ionizationEnergy = DeltaEnergyTransition::get(
+            // Hartree
+            float_X const ionizationEnergy = picongpu::sim.si.conv().eV2auEnergy(DeltaEnergyTransition::get(
                 transitionCollectionIndex,
                 atomicStateDataBox,
                 boundFreeTransitionDataBox,
                 ionizationPotentialDepression,
-                chargeStateDataBox);
-            // unitless
-            float_X const effectivePrincipalQuantumNumber
-                = screenedCharge / math::sqrt(2._X * sim.si.conv().eV2auEnergy(ionizationEnergy));
-            float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
-            float_X const screenedChargeCubed = pmacc::math::cPow(screenedCharge, 3u);
-            float_X const dBase = 4.0_X * math::exp(1._X) * screenedChargeCubed
-                / (eFieldNorm_AU * pmacc::math::cPow(effectivePrincipalQuantumNumber, 4u));
-            float_X const dFromADK = math::pow(dBase, effectivePrincipalQuantumNumber);
+                chargeStateDataBox));
 
-            // ionization rate (for CIRCULAR polarization)
+            // unitless
+            float_X const nEff = effectivePrincipalQuantumNumber(Z, ionizationEnergy);
+
+            // sim.atomicUnit.eField()
+            float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
+
+            float_X const ZCubed = pmacc::math::cPow(Z, 3u);
+
+            float_X const dBase = 4.0_X * math::exp(1._X) * ZCubed / (eFieldNorm_AU * pmacc::math::cPow(nEff, 4u));
+            float_X const dFromADK = math::pow(dBase, nEff);
+
             constexpr float_X pi = pmacc::math::Pi<float_X>::value;
-            float_X const nEffCubed = pmacc::math::cPow(effectivePrincipalQuantumNumber, 3u);
+            float_X const nEffCubed = pmacc::math::cPow(nEff, 3u);
 
             // 1/sim.atomicUnit.time()
-            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * screenedCharge)
-                * math::exp(-2._X * screenedChargeCubed / (3._X * nEffCubed * eFieldNorm_AU));
+            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * Z)
+                * math::exp(-2._X * ZCubed / (3._X * nEffCubed * eFieldNorm_AU));
 
             // factor from averaging over one laser cycle with LINEAR polarization
             if constexpr(
                 u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
-                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * screenedChargeCubed));
+                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * ZCubed));
 
             /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
              *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()


### PR DESCRIPTION
Bug fix, AtomicPhysics(FLYonPIC) mistakenly assumed that the highes ADK rate is reached with for the highest EField.

- [x] requires PR #5163 to be merged first
- [x] requires PR #5162 to be merged first
- [x] requires PR #5159 to be merged first
- [x] needs to be rebased upon dev

ci: picongpu