### PR TITLE
Instant transition for states with high field ionization rate.

### DIFF
--- a/include/picongpu/param/atomicPhysics.param
+++ b/include/picongpu/param/atomicPhysics.param
@@ -55,6 +55,9 @@ namespace picongpu::atomicPhysics
         // which probability approximation to use for the acceptance step
         using ProbabilityApproximationFunctor
             = picongpu::particles::atomicPhysics::ExponentialApproximationProbability;
+
+        // maximum number of atomicPhysics sub-steps per PIC time step for fieldIonization
+        static constexpr uint32_t maximumNumberSubStepsFieldIonization = 2000;
     };
 
     /** atomicConfigNumber definition for argon ions

--- a/include/picongpu/particles/atomicPhysics/kernel/ApplyInstantFieldTransitions.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ApplyInstantFieldTransitions.kernel
@@ -1,0 +1,356 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need simulation.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/EFieldNormExtrema.hpp"
+#include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
+
+#include <pmacc/algorithms/math/PowerFunction.hpp>
+#include <pmacc/dimensions/SuperCellDescription.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/math/operation/Assign.hpp>
+#include <pmacc/memory/boxes/CachedBox.hpp>
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include <pmacc/memory/boxes/SharedBox.hpp>
+#include <pmacc/memory/shared/Allocate.hpp>
+#include <pmacc/particles/algorithm/ForEach.hpp>
+#include <pmacc/static_assert.hpp>
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics::kernel
+{
+    namespace s_enums = picongpu::particles::atomicPhysics::enums;
+
+    /** kernel for ApplyInstantFieldTransitions sub-stage
+     *
+     * @tparam T_IPDModel ionization potential depression model to use
+     * @tparam T_ADKLaserPolarization polarization direction to use in the ADK rate calculation
+     * @tparam T_EField type of EField
+     * @tparam T_numberAtomicStates number of atomic states in atomic data data base
+     * @tparam T_TransitionOrdering ordering of assumed for transition DataBox
+     */
+    template<
+        typename T_IPDModel,
+        s_enums::ADKLaserPolarization T_ADKLaserPolarization,
+        typename T_EField,
+        uint32_t T_numberAtomicStates,
+        s_enums::TransitionOrdering T_TransitionOrdering>
+    struct ApplyInstantFieldTransitionsKernel
+    {
+        template<
+            typename T_AtomicStateNumberTransitionsBox,
+            typename T_AtomicStateStartIndexBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool correctAtomicDataBoxes()
+        {
+            // check that correct databoxes are given
+            PMACC_CASSERT_MSG(
+                number_transitions_dataBox_not_bound_free_based,
+                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
+                    == u8(s_enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                transition_dataBox_not_boud_free_based,
+                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
+            // check ordering of transition dataBox
+            PMACC_CASSERT_MSG(
+                wrong_ordering_of_DataBox,
+                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+
+            return true;
+        };
+
+        /** call operator
+         *
+         * called by ApplyInstantFieldTransitions atomic physics sub-stage
+         *
+         * @param worker object containing the device and block information, passed by PMACC_KERNEL call
+         * @param areaMapping mapping of blockIndex to block superCell index
+         * @param rngFactoryFloat factory for uniformly distributed random number generator, for float_X [0,1)
+         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
+         * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
+         * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
+         * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states'
+         *  block of transitions in the up-/down-ward bound-bound transition collection
+         * @param numberTransitionsDataBox deviceDataBox giving access to the number of transitions
+         *   of each atomic state up- and down-ward
+         * @param boundFreeTransitionDataBox deviceDataBox giving access to bound-free transition property data
+         * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
+         * @param ipdInput deviceDataBoxes giving access to ionization potential depression input for each superCell
+         */
+        template<
+            typename T_Worker,
+            typename T_AreaMapping,
+            typename T_RngGeneratorFactoryFloat,
+            typename T_LocalTimeRemainingBox,
+            typename T_LocalFoundUnboundIonBox,
+            typename T_EFieldDataBox,
+            typename T_ChargeStateDataDataBox,
+            typename T_AtomicStateDataDataBox,
+            typename T_AtomicStateStartIndexBox,
+            typename T_AtomicStateNumberTransitionsBox,
+            typename T_BoundFreeTransitionDataBox,
+            typename T_IonBox,
+            typename... T_IPDInput>
+        HDINLINE void operator()(
+            T_Worker const& worker,
+            T_AreaMapping const areaMapping,
+            T_RngGeneratorFactoryFloat rngFactoryFloat,
+            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalFoundUnboundIonBox localFoundUnboundIonBox,
+            T_EFieldDataBox const eFieldBox,
+            T_ChargeStateDataDataBox const chargeStateDataDataBox,
+            T_AtomicStateDataDataBox const atomicStateDataDataBox,
+            T_AtomicStateStartIndexBox const startIndexDataBox,
+            T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
+            T_IonBox ionBox,
+            T_IPDInput... ipdInput) const
+        {
+            PMACC_CASSERT(correctAtomicDataBoxes<
+                          T_AtomicStateNumberTransitionsBox,
+                          T_AtomicStateStartIndexBox,
+                          T_BoundFreeTransitionDataBox>());
+
+            pmacc::DataSpace<picongpu::simDim> const superCellIdx
+                = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
+            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
+            //  -> must subtract guard to get correct superCellFieldIdx
+            pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
+                = superCellIdx - areaMapping.getGuardingSuperCells();
+
+            // picongpu::sim.unit.time()
+            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
+
+            // end kernel if superCell already finished or no ions
+            if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
+                return;
+
+            float_X const ionizationPotentialDepression
+                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
+                    superCellFieldIdx,
+                    ipdInput...);
+
+            // sim.unit.eField()
+            PMACC_SMEM(worker, minEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
+            // sim.unit.eField()
+            PMACC_SMEM(worker, maxEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
+
+            EFieldNormExtrema::find(worker, superCellIdx, eFieldBox, minEFieldSuperCell, maxEFieldSuperCell);
+            worker.sync();
+
+            auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
+            PMACC_SMEM(worker, fieldIonizationLossRates, pmacc::memory::Array<float_X, T_numberAtomicStates>);
+
+            // init fieldIonizationLossRates
+            forEachAtomicState([&fieldIonizationLossRates](uint32_t const atomicStateCollectionIndex)
+                               { fieldIonizationLossRates[atomicStateCollectionIndex] = -1._X; });
+            worker.sync();
+
+            // find occupied states
+            forEachLocalIonBoxEntry(
+                [&fieldIonizationLossRates](T_Worker const& worker, auto& ion)
+                {
+                    auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
+
+                    // mark slot as occupied
+                    alpaka::atomicExch(
+                        worker.getAcc(),
+                        &fieldIonizationLossRates[atomicStateCollectionIndex],
+                        0._X,
+                        ::alpaka::hierarchy::Threads{});
+                });
+            worker.sync();
+
+            // fill field ionization loss rate
+            forEachAtomicState(
+                [&ionizationPotentialDepression,
+                 &minEFieldSuperCell,
+                 &maxEFieldSuperCell,
+                 &numberTransitionsDataBox,
+                 &startIndexDataBox,
+                 &chargeStateDataDataBox,
+                 &atomicStateDataDataBox,
+                 &boundFreeTransitionDataBox,
+                 &fieldIonizationLossRates](uint32_t const atomicStateCollectionIndex)
+                {
+                    // early return on not present states
+                    if(fieldIonizationLossRates[atomicStateCollectionIndex] < 0._X)
+                        return;
+
+                    uint32_t const numberTransitionsUp
+                        = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
+                    uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
+
+                    // 1/picongpu::sim.unit.time()
+                    float_X sumRateTransitions = 0._X;
+                    for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
+                    {
+                        uint32_t const transitionCollectionIndex = offset + transitionID;
+
+                        // 1/picongpu::sim.unit.time()
+                        sumRateTransitions
+                            += atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
+                                template maximumRateADKFieldIonization(
+                                    minEFieldSuperCell,
+                                    maxEFieldSuperCell,
+                                    ionizationPotentialDepression,
+                                    transitionCollectionIndex,
+                                    chargeStateDataDataBox,
+                                    atomicStateDataDataBox,
+                                    boundFreeTransitionDataBox);
+                    }
+                    fieldIonizationLossRates[atomicStateCollectionIndex] = sumRateTransitions;
+                });
+            worker.sync();
+
+            // FLYonPIC superCells must be independent therefore we need to use a support 1 particle shape
+            using Field2Particle
+                = FieldToParticleInterpolation<particles::shapes::CIC, AssignedTrilinearInterpolation>;
+            using Margin = picongpu::traits::GetMargin<Field2Particle>;
+            using BlockArea
+                = SuperCellDescription<typename picongpu::SuperCellSize, Margin::LowerMargin, Margin::UpperMargin>;
+
+            /// create E-Field cache, @note is unique for kernel call by id and dataType, and thereby shared between
+            /// workers
+            DataBox<SharedBox<typename T_EField::ValueType, typename BlockArea::FullSuperCellSize, 0u>> eFieldCache
+                = CachedBox::create<0u, typename T_EField::ValueType>(worker, BlockArea());
+
+            //      init
+            auto const superCellSize = picongpu::SuperCellSize::toRT();
+            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * superCellSize;
+            auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
+            pmacc::math::operation::Assign assign;
+            auto collective = makeThreadCollective<BlockArea>();
+            collective(worker, assign, eFieldCache, fieldEBlockToCache);
+
+            //      wait for init to finish
+            worker.sync();
+
+            auto const fieldPosE = picongpu::traits::FieldPosition<fields::YeeCell, FieldE>();
+            auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
+
+            // accept instant transitions from state with high loss rate
+            bool foundUnbound = false;
+            forEachLocalIonBoxEntry(
+                [&fieldIonizationLossRates,
+                 &foundUnbound,
+                 &superCellSize,
+                 &eFieldCache,
+                 &fieldPosE,
+                 &numberTransitionsDataBox,
+                 &startIndexDataBox,
+                 &rngGeneratorFloat,
+                 &ionizationPotentialDepression,
+                 &chargeStateDataDataBox,
+                 &atomicStateDataDataBox,
+                 &boundFreeTransitionDataBox](T_Worker const& worker, auto& ion)
+                {
+                    auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
+
+                    float_X const stateLossRate = fieldIonizationLossRates[atomicStateCollectionIndex];
+
+                    constexpr float_X alpha = picongpu::atomicPhysics::RateSolverParam::timeStepAlpha;
+                    constexpr float_X maxNumSubSteps
+                        = float_X(picongpu::atomicPhysics::RateSolverParam::maximumNumberSubStepsFieldIonization);
+
+                    // 1/sim.pic.getDt()
+                    constexpr float_X maximumRate = alpha * maxNumSubSteps / picongpu::sim.pic.getDt();
+
+                    if(stateLossRate <= maximumRate)
+                        return;
+
+                    // set worker mark that we encountered at least one unbound ion
+                    foundUnbound = true;
+
+                    auto const ionPosition = ion[position_];
+
+                    DataSpace<picongpu::SuperCellSize::dim> const localCell
+                        = pmacc::math::mapToND(superCellSize, static_cast<int>(ion[localCellIdx_]));
+
+                    using Field2Particle
+                        = FieldToParticleInterpolation<particles::shapes::CIC, AssignedTrilinearInterpolation>;
+                    float_X const eFieldNormAtParticle = pmacc::math::l2norm(
+                        Field2Particle()(eFieldCache.shift(localCell), ionPosition, fieldPosE()));
+
+                    // get possible transitions' collectionIndices
+                    uint32_t const numberTransitions
+                        = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
+                    uint32_t const startIndexTransitionBlock
+                        = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
+
+                    // get random number
+                    float_X const r = rngGeneratorFloat();
+
+                    float_X cumSum = 0._X;
+                    for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
+                    {
+                        uint32_t const transitionCollectionIndex = transitionID + startIndexTransitionBlock;
+
+                        // 1/picongpu::sim.unit.time()
+                        float_X const rateTransition = atomicPhysics::rateCalculation::
+                            BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
+                                eFieldNormAtParticle,
+                                ionizationPotentialDepression,
+                                transitionCollectionIndex,
+                                chargeStateDataDataBox,
+                                atomicStateDataDataBox,
+                                boundFreeTransitionDataBox);
+
+                        cumSum += rateTransition / stateLossRate;
+
+                        // inclusive limit, to make sure that r==1 is assigned a transition
+                        if(r <= cumSum)
+                        {
+                            // update ion
+                            picongpu::particles::atomicPhysics::SetAtomicState::op(
+                                atomicStateDataDataBox,
+                                ion,
+                                boundFreeTransitionDataBox.upperStateCollectionIndex(transitionCollectionIndex));
+                            return;
+                        }
+                    }
+
+                    // may arrive her if particle's state loss rate < maximum loss rate for it's state
+                    // do nothing if r > cumSum
+                });
+            worker.sync();
+
+            uint32_t& foundUnboundFieldValue = localFoundUnboundIonBox(superCellFieldIdx);
+            alpaka::atomicExch(
+                worker.getAcc(),
+                &foundUnboundFieldValue,
+                u32(foundUnbound),
+                ::alpaka::hierarchy::Threads{});
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
@@ -27,12 +27,16 @@
 
 #include <pmacc/lockstep/ForEach.hpp>
 
+#include <cstdint>
+
 namespace picongpu::particles::atomicPhysics::kernel
 {
     /** find atomicPhysics time step length kernel
      *
      * will find minimum time step length from the minimum stepLength of all atomic states
      *  of all species
+     *
+     * @tparam T_numberAtomicStates number of atomic states
      */
     template<uint32_t T_numberAtomicStates>
     struct CalculateStepLengthKernel

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -176,7 +176,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             DataBox<SharedBox<typename T_EField::ValueType, typename BlockArea::FullSuperCellSize, 0u>> eFieldCache
                 = CachedBox::create<0u, typename T_EField::ValueType>(worker, BlockArea());
 
-            // init E-Field cache
+            //      init
             auto const superCellSize = picongpu::SuperCellSize::toRT();
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * superCellSize;
             auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
@@ -184,7 +184,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto collective = makeThreadCollective<BlockArea>();
             collective(worker, assign, eFieldCache, fieldEBlockToCache);
 
-            // wait for init to finish
+            //      wait for init to finish
             worker.sync();
 
             float_X const ionizationPotentialDepression

--- a/include/picongpu/particles/atomicPhysics/kernel/EFieldNormExtrema.hpp
+++ b/include/picongpu/particles/atomicPhysics/kernel/EFieldNormExtrema.hpp
@@ -1,0 +1,81 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need simulation.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+
+#include <pmacc/lockstep/ForEach.hpp>
+
+#include <limits>
+
+namespace picongpu::particles::atomicPhysics::kernel
+{
+    struct EFieldNormExtrema
+    {
+        //! find minimum and maximum value of the e E-Field Norm of the given superCell
+        template<typename T_Worker, typename T_EFieldDataBox, typename T_Type>
+        HDINLINE static void find(
+            T_Worker const& worker,
+            pmacc::DataSpace<picongpu::simDim> const superCellIdx,
+            T_EFieldDataBox const eFieldBox,
+            T_Type& minEFieldSuperCell,
+            T_Type& maxEFieldSuperCell)
+        {
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&maxEFieldSuperCell, &minEFieldSuperCell]()
+                {
+                    maxEFieldSuperCell = 0._X;
+                    minEFieldSuperCell = std::numeric_limits<float_X>::max();
+                });
+            worker.sync();
+
+            constexpr auto numberCellsInSuperCell
+                = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
+            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
+            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
+
+            /// @todo switch to shared memory reduce, Brian Marre, 2024
+            forEachCell(
+                [&worker, &superCellCellOffset, &maxEFieldSuperCell, &minEFieldSuperCell, &eFieldBox](
+                    uint32_t const linearIdx)
+                {
+                    DataSpace<picongpu::simDim> const localCellIndex
+                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearIdx));
+                    DataSpace<picongpu::simDim> const cellIndex = localCellIndex + superCellCellOffset;
+
+                    auto const eFieldNorm = pmacc::math::l2norm(eFieldBox(cellIndex));
+
+                    alpaka::atomicMax(
+                        worker.getAcc(),
+                        // sim.unit.eField()
+                        &maxEFieldSuperCell,
+                        eFieldNorm);
+
+                    alpaka::atomicMin(
+                        worker.getAcc(),
+                        // sim.unit.eField()
+                        &minEFieldSuperCell,
+                        eFieldNorm);
+                });
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -35,6 +35,7 @@
 #include <pmacc/static_assert.hpp>
 
 #include <cstdint>
+#include <limits>
 
 namespace picongpu::particles::atomicPhysics::kernel
 {
@@ -211,27 +212,28 @@ namespace picongpu::particles::atomicPhysics::kernel
             float_X const ionizationPotentialDepression)
         {
             // sim.unit.eField()
-            PMACC_SMEM(worker, maximumNormEFieldValueSuperCell, typename T_EFieldDataBox::ValueType::type);
+            PMACC_SMEM(worker, maxEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
+            // sim.unit.eField()
+            PMACC_SMEM(worker, minEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
 
-            // find maximum field strength of superCell
             auto onlyMaster = lockstep::makeMaster(worker);
             onlyMaster(
-                [&maximumNormEFieldValueSuperCell]()
+                [&maxEFieldSuperCell, &minEFieldSuperCell]()
                 {
-                    // sim.unit.eField()
-                    maximumNormEFieldValueSuperCell = 0._X;
+                    maxEFieldSuperCell = 0._X;
+                    minEFieldSuperCell = std::numeric_limits<float_X>::max();
                 });
             worker.sync();
 
             constexpr auto numberCellsInSuperCell
                 = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
-            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
-
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
+            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
 
             /// @todo switch to shared memory reduce, Brian Marre, 2024
             forEachCell(
-                [&worker, &superCellCellOffset, &maximumNormEFieldValueSuperCell, &eFieldBox](uint32_t const linearIdx)
+                [&worker, &superCellCellOffset, &maxEFieldSuperCell, &minEFieldSuperCell, &eFieldBox](
+                    uint32_t const linearIdx)
                 {
                     DataSpace<picongpu::simDim> const localCellIndex
                         = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearIdx));
@@ -242,18 +244,23 @@ namespace picongpu::particles::atomicPhysics::kernel
                     alpaka::atomicMax(
                         worker.getAcc(),
                         // sim.unit.eField()
-                        &maximumNormEFieldValueSuperCell,
+                        &maxEFieldSuperCell,
+                        eFieldNorm);
+
+                    alpaka::atomicMin(
+                        worker.getAcc(),
+                        // sim.unit.eField()
+                        &minEFieldSuperCell,
                         eFieldNorm);
                 });
             worker.sync();
 
             // calculate ADK field ionization rate, for each atomic state and maximum field value
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
-
-            //      accumulate rates of possible transitions by state
             forEachAtomicState(
                 [&ionizationPotentialDepression,
-                 &maximumNormEFieldValueSuperCell,
+                 &maxEFieldSuperCell,
+                 &minEFieldSuperCell,
                  &rateCache,
                  &numberTransitionsDataBox,
                  &startIndexDataBox,
@@ -276,14 +283,16 @@ namespace picongpu::particles::atomicPhysics::kernel
                         uint32_t const transitionCollectionIndex = offset + transitionID;
 
                         // 1/picongpu::sim.unit.time()
-                        sumRateTransitions += atomicPhysics::rateCalculation::
-                            BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
-                                maximumNormEFieldValueSuperCell,
-                                ionizationPotentialDepression,
-                                transitionCollectionIndex,
-                                chargeStateDataDataBox,
-                                atomicStateDataDataBox,
-                                boundFreeTransitionDataBox);
+                        sumRateTransitions
+                            += atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
+                                template maximumRateADKFieldIonization(
+                                    maxEFieldSuperCell,
+                                    minEFieldSuperCell,
+                                    ionizationPotentialDepression,
+                                    transitionCollectionIndex,
+                                    chargeStateDataDataBox,
+                                    atomicStateDataDataBox,
+                                    boundFreeTransitionDataBox);
                     }
 
                     rateCache.template add<s_enums::ChooseTransitionGroup::fieldBoundFreeUpward>(

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -210,12 +210,19 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
             float_X const ionizationPotentialDepression)
         {
-            // internal units
+            // sim.unit.eField()
             PMACC_SMEM(worker, maximumNormEFieldValueSuperCell, typename T_EFieldDataBox::ValueType::type);
 
             // find maximum field strength of superCell
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&maximumNormEFieldValueSuperCell]()
+                {
+                    // sim.unit.eField()
+                    maximumNormEFieldValueSuperCell = 0._X;
+                });
+            worker.sync();
 
-            /// @todo switch to shared memory reduce, Brian Marre, 2024
             constexpr auto numberCellsInSuperCell
                 = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
             auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
@@ -234,7 +241,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     alpaka::atomicMax(
                         worker.getAcc(),
-                        // internal units
+                        // sim.unit.eField()
                         &maximumNormEFieldValueSuperCell,
                         eFieldNorm);
                 });
@@ -278,6 +285,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                 atomicStateDataDataBox,
                                 boundFreeTransitionDataBox);
                     }
+
                     rateCache.template add<s_enums::ChooseTransitionGroup::fieldBoundFreeUpward>(
                         atomicStateCollectionIndex,
                         sumRateTransitions);

--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -26,6 +26,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/EFieldNormExtrema.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
@@ -212,47 +213,11 @@ namespace picongpu::particles::atomicPhysics::kernel
             float_X const ionizationPotentialDepression)
         {
             // sim.unit.eField()
-            PMACC_SMEM(worker, maxEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
-            // sim.unit.eField()
             PMACC_SMEM(worker, minEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
+            // sim.unit.eField()
+            PMACC_SMEM(worker, maxEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
 
-            auto onlyMaster = lockstep::makeMaster(worker);
-            onlyMaster(
-                [&maxEFieldSuperCell, &minEFieldSuperCell]()
-                {
-                    maxEFieldSuperCell = 0._X;
-                    minEFieldSuperCell = std::numeric_limits<float_X>::max();
-                });
-            worker.sync();
-
-            constexpr auto numberCellsInSuperCell
-                = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
-            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
-            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
-
-            /// @todo switch to shared memory reduce, Brian Marre, 2024
-            forEachCell(
-                [&worker, &superCellCellOffset, &maxEFieldSuperCell, &minEFieldSuperCell, &eFieldBox](
-                    uint32_t const linearIdx)
-                {
-                    DataSpace<picongpu::simDim> const localCellIndex
-                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearIdx));
-                    DataSpace<picongpu::simDim> const cellIndex = localCellIndex + superCellCellOffset;
-
-                    auto const eFieldNorm = pmacc::math::l2norm(eFieldBox(cellIndex));
-
-                    alpaka::atomicMax(
-                        worker.getAcc(),
-                        // sim.unit.eField()
-                        &maxEFieldSuperCell,
-                        eFieldNorm);
-
-                    alpaka::atomicMin(
-                        worker.getAcc(),
-                        // sim.unit.eField()
-                        &minEFieldSuperCell,
-                        eFieldNorm);
-                });
+            EFieldNormExtrema::find(worker, superCellIdx, eFieldBox, minEFieldSuperCell, maxEFieldSuperCell);
             worker.sync();
 
             // calculate ADK field ionization rate, for each atomic state and maximum field value
@@ -286,8 +251,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                         sumRateTransitions
                             += atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
                                 template maximumRateADKFieldIonization(
-                                    maxEFieldSuperCell,
                                     minEFieldSuperCell,
+                                    maxEFieldSuperCell,
                                     ionizationPotentialDepression,
                                     transitionCollectionIndex,
                                     chargeStateDataDataBox,

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
@@ -125,10 +125,14 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             // get histogram for current superCell
-            T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
+            [[maybe_unused]] T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
 
             // eV
             [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;
+
+            /* field ionization is not energy conserving currently
+             *-> no need to calculate energy used -> no need to calculate IPD */
+            /// @todo implement energy conservation in field ionization, Brian Marre, 2024
             if constexpr(isIonizing && isCollisional)
                 ionizationPotentialDepression
                     = ionizationPotentialDepression::PassIPDInputs::template calculateIPD<T_IPDModel>(

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -39,6 +39,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
     template<atomicPhysics::enums::ADKLaserPolarization T_ADKLaserPolarization>
     struct BoundFreeFieldTransitionRates
     {
+    private:
         /** get effective principal quantum number
          *
          * @param ionizationEnergy, in Hartree
@@ -48,17 +49,17 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          */
         HDINLINE static float_X effectivePrincipalQuantumNumber(
             float_X const screenedCharge,
-            float_x const ionizationEnergy)
+            float_X const ionizationEnergy)
         {
             return screenedCharge / math::sqrt(2._X * ionizationEnergy);
         }
 
-        /** get screened charge for ionization
+        /** get screened charge for ionization electron
          *
          * @return unit: e
          */
         template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
-        HDINLINE static float_X const screenedCharge(
+        HDINLINE static float_X screenedCharge(
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,
             T_AtomicStateDataBox const atomicStateDataBox,
@@ -74,7 +75,42 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             return chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
         }
 
+        /** actual rate rateFormula
+         *
+         * @param Z screenedCharge for ionization electron, e
+         * @param nEff effective principal quantum number, unitless
+         * @param eFieldNorm_AU norm of the E-Field strength, in sim.atomicUnit.eField()
+         */
+        HDINLINE static float_X rateFormula(float_X const Z, float_X const nEff, float_X const eFieldNorm_AU)
+        {
+            float_X const nEffCubed = pmacc::math::cPow(nEff, 3u);
+            float_X const ZCubed = pmacc::math::cPow(Z, 3u);
 
+            float_X const dBase = 4.0_X * math::exp(1._X) * ZCubed / (eFieldNorm_AU * pmacc::math::cPow(nEff, 4u));
+            float_X const dFromADK = math::pow(dBase, nEff);
+
+            constexpr float_X pi = pmacc::math::Pi<float_X>::value;
+
+            // 1/sim.atomicUnit.time()
+            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * Z)
+                * math::exp(-2._X * ZCubed / (3._X * nEffCubed * eFieldNorm_AU));
+
+            // factor from averaging over one laser cycle with LINEAR polarization
+            if constexpr(
+                u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
+                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * ZCubed));
+
+            /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
+             *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()
+             *   = (A * timeConversion) * 1/sim.unit.time()
+             *   = B * 1/sim.unit.time() */
+            constexpr float_X timeConversion = picongpu::sim.unit.time() / picongpu::sim.atomicUnit.time();
+
+            // 1/ sim.unit.time()
+            return rateADK_AU * timeConversion;
+        }
+
+    public:
         /** field ionization ADK rate for a given electric field strength
          *
          * @tparam T_ChargeStateDataBox instantiated type of dataBox
@@ -126,31 +162,79 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             // sim.atomicUnit.eField()
             float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
 
-            float_X const ZCubed = pmacc::math::cPow(Z, 3u);
+            return rateFormula(Z, nEff, eFieldNorm_AU);
+        }
 
-            float_X const dBase = 4.0_X * math::exp(1._X) * ZCubed / (eFieldNorm_AU * pmacc::math::cPow(nEff, 4u));
-            float_X const dFromADK = math::pow(dBase, nEff);
+        /** get maximum field ionization ADK rate for electric field strengths inside the given boundaries
+         *
+         * @tparam T_ChargeStateDataBox instantiated type of dataBox
+         * @tparam T_AtomicStateDataBox instantiated type of dataBox
+         * @tparam T_BoundFreeTransitionDataBox instantiated type of dataBox
+         *
+         * @param maxEFieldNorm maximum E-field vector norm, in sim.units.eField()
+         * @param minEFieldNorm minimum E-field vector norm, in sim.units.eField()
+         * @param ionizationPotentialDepression, in eV
+         * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
+         * @param atomicStateDataBox access to atomic state property data
+         * @param boundBoundTransitionDataBox access to bound-bound transition data
+         *
+         * @return unit: 1/picongpu::sim.unit.time()
+         */
+        template<
+            typename T_EFieldType,
+            typename T_ChargeStateDataBox,
+            typename T_AtomicStateDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        HDINLINE static float_X maximumRateADKFieldIonization(
+            T_EFieldType const maxEFieldNorm,
+            T_EFieldType const minEFieldNorm,
+            float_X const ionizationPotentialDepression,
+            uint32_t const transitionCollectionIndex,
+            T_ChargeStateDataBox const chargeStateDataBox,
+            T_AtomicStateDataBox const atomicStateDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
+        {
+            if(maxEFieldNorm == 0._X)
+                return 0._X;
 
-            constexpr float_X pi = pmacc::math::Pi<float_X>::value;
-            float_X const nEffCubed = pmacc::math::cPow(nEff, 3u);
+            float_X const Z = screenedCharge(
+                transitionCollectionIndex,
+                chargeStateDataBox,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox);
 
-            // 1/sim.atomicUnit.time()
-            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * Z)
-                * math::exp(-2._X * ZCubed / (3._X * nEffCubed * eFieldNorm_AU));
+            // Hartree
+            float_X const ionizationEnergy = picongpu::sim.si.conv().eV2auEnergy(DeltaEnergyTransition::get(
+                transitionCollectionIndex,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox,
+                ionizationPotentialDepression,
+                chargeStateDataBox));
 
-            // factor from averaging over one laser cycle with LINEAR polarization
-            if constexpr(
-                u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
-                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * ZCubed));
+            float_X const nEff = effectivePrincipalQuantumNumber(Z, ionizationEnergy);
+            float_X const nEffCubed = pmacc::math::cPow(nEff, u32(3u));
 
-            /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
-             *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()
-             *   = (A * timeConversion) * 1/sim.unit.time()
-             *   = B * 1/sim.unit.time() */
-            constexpr float_X timeConversion = picongpu::sim.unit.time() / picongpu::sim.atomicUnit.time();
+            float_X const maxEField_AU = picongpu::sim.pic.conv().eField2auEField(maxEFieldNorm);
+            float_X const minEField_AU = picongpu::sim.pic.conv().eField2auEField(minEFieldNorm);
 
-            // 1/ sim.unit.time()
-            return rateADK_AU * timeConversion;
+            // theoretical maximum ADK Rate, in sim.atomicUnit.eField()
+            float_X const F_max = 4._X * Z / (3 * nEffCubed * (4._X * nEff - 3._X));
+
+            // fieldStrength for maximum Rate, in sim.atomicUnit.eField(), see Notebook 2024 P.43-48
+            float_X F;
+            if(nEff <= 0.75_X || F_max > maxEField_AU)
+            {
+                F = maxEField_AU;
+            }
+            else
+            {
+                if(F_max > minEField_AU)
+                    F = F_max;
+                else
+                    F = minEField_AU;
+            }
+
+            return rateFormula(Z, nEff, F);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::rateCalculation

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -111,7 +111,14 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
                 u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
                 rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * screenedChargeCubed));
 
-            return rateADK_AU / sim.atomicUnit.time();
+            /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
+             *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()
+             *   = (A * timeConversion) * 1/sim.unit.time()
+             *   = B * 1/sim.unit.time() */
+            constexpr float_X timeConversion = picongpu::sim.unit.time() / picongpu::sim.atomicUnit.time();
+
+            // 1/ sim.unit.time()
+            return rateADK_AU * timeConversion;
         }
     };
 } // namespace picongpu::particles::atomicPhysics::rateCalculation

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -186,8 +186,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             typename T_AtomicStateDataBox,
             typename T_BoundFreeTransitionDataBox>
         HDINLINE static float_X maximumRateADKFieldIonization(
-            T_EFieldType const maxEFieldNorm,
             T_EFieldType const minEFieldNorm,
+            T_EFieldType const maxEFieldNorm,
             float_X const ionizationPotentialDepression,
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -39,14 +39,50 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
     template<atomicPhysics::enums::ADKLaserPolarization T_ADKLaserPolarization>
     struct BoundFreeFieldTransitionRates
     {
-        /** rate for bound-free field ionization transition of ion depending on the local electric field
+        /** get effective principal quantum number
+         *
+         * @param ionizationEnergy, in Hartree
+         * @param screenedCharge, in e
+         *
+         * @return unitless
+         */
+        HDINLINE static float_X effectivePrincipalQuantumNumber(
+            float_X const screenedCharge,
+            float_x const ionizationEnergy)
+        {
+            return screenedCharge / math::sqrt(2._X * ionizationEnergy);
+        }
+
+        /** get screened charge for ionization
+         *
+         * @return unit: e
+         */
+        template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
+        HDINLINE static float_X const screenedCharge(
+            uint32_t const transitionCollectionIndex,
+            T_ChargeStateDataBox const chargeStateDataBox,
+            T_AtomicStateDataBox const atomicStateDataBox,
+            T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
+        {
+            uint32_t const lowerStateClctIdx
+                = boundFreeTransitionDataBox.lowerStateCollectionIndex(transitionCollectionIndex);
+            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
+
+            using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
+            uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
+
+            return chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
+        }
+
+
+        /** field ionization ADK rate for a given electric field strength
          *
          * @tparam T_ChargeStateDataBox instantiated type of dataBox
          * @tparam T_AtomicStateDataBox instantiated type of dataBox
          * @tparam T_BoundFreeTransitionDataBox instantiated type of dataBox
          *
-         * @param eField E-field vector, in internal units
-         * @param ionizationPotentialDepression, eV
+         * @param eFieldNorm E-field vector norm, in sim.units.eField()
+         * @param ionizationPotentialDepression, in eV
          * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
          * @param atomicStateDataBox access to atomic state property data
          * @param boundBoundTransitionDataBox access to bound-bound transition data
@@ -59,9 +95,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             typename T_AtomicStateDataBox,
             typename T_BoundFreeTransitionDataBox>
         HDINLINE static float_X rateADKFieldIonization(
-            // internal units
             T_EFieldType const eFieldNorm,
-            // eV
             float_X const ionizationPotentialDepression,
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,
@@ -71,45 +105,43 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             if(eFieldNorm == 0._X)
                 return 0._X;
 
-            // get screenedCharge
-            uint32_t const lowerStateClctIdx
-                = boundFreeTransitionDataBox.lowerStateCollectionIndex(transitionCollectionIndex);
-            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
-
-            using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
-            uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
-
             // e
-            float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
+            float_X const Z = screenedCharge(
+                transitionCollectionIndex,
+                chargeStateDataBox,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox);
 
-            // ev
-            float_X const ionizationEnergy = DeltaEnergyTransition::get(
+            // Hartree
+            float_X const ionizationEnergy = picongpu::sim.si.conv().eV2auEnergy(DeltaEnergyTransition::get(
                 transitionCollectionIndex,
                 atomicStateDataBox,
                 boundFreeTransitionDataBox,
                 ionizationPotentialDepression,
-                chargeStateDataBox);
-            // unitless
-            float_X const effectivePrincipalQuantumNumber
-                = screenedCharge / math::sqrt(2._X * sim.si.conv().eV2auEnergy(ionizationEnergy));
-            float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
-            float_X const screenedChargeCubed = pmacc::math::cPow(screenedCharge, 3u);
-            float_X const dBase = 4.0_X * math::exp(1._X) * screenedChargeCubed
-                / (eFieldNorm_AU * pmacc::math::cPow(effectivePrincipalQuantumNumber, 4u));
-            float_X const dFromADK = math::pow(dBase, effectivePrincipalQuantumNumber);
+                chargeStateDataBox));
 
-            // ionization rate (for CIRCULAR polarization)
+            // unitless
+            float_X const nEff = effectivePrincipalQuantumNumber(Z, ionizationEnergy);
+
+            // sim.atomicUnit.eField()
+            float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
+
+            float_X const ZCubed = pmacc::math::cPow(Z, 3u);
+
+            float_X const dBase = 4.0_X * math::exp(1._X) * ZCubed / (eFieldNorm_AU * pmacc::math::cPow(nEff, 4u));
+            float_X const dFromADK = math::pow(dBase, nEff);
+
             constexpr float_X pi = pmacc::math::Pi<float_X>::value;
-            float_X const nEffCubed = pmacc::math::cPow(effectivePrincipalQuantumNumber, 3u);
+            float_X const nEffCubed = pmacc::math::cPow(nEff, 3u);
 
             // 1/sim.atomicUnit.time()
-            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * screenedCharge)
-                * math::exp(-2._X * screenedChargeCubed / (3._X * nEffCubed * eFieldNorm_AU));
+            float_X rateADK_AU = eFieldNorm_AU * pmacc::math::cPow(dFromADK, 2u) / (8._X * pi * Z)
+                * math::exp(-2._X * ZCubed / (3._X * nEffCubed * eFieldNorm_AU));
 
             // factor from averaging over one laser cycle with LINEAR polarization
             if constexpr(
                 u32(T_ADKLaserPolarization) == u32(atomicPhysics::enums::ADKLaserPolarization::linearPolarization))
-                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * screenedChargeCubed));
+                rateADK_AU *= math::sqrt(3._X * nEffCubed * eFieldNorm_AU / (pi * ZCubed));
 
             /* A * 1/sim.atomicUnit.time() = A * 1/sim.atomicUnit.time() * sim.unit.time() / sim.unit.time()
              *   = A * [sim.unit.time()/sim.atomicUnit.time()] * 1/sim.unit.time()

--- a/include/picongpu/particles/atomicPhysics/stage/ApplyInstantFieldTransitions.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ApplyInstantFieldTransitions.hpp
@@ -1,0 +1,127 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldE.hpp"
+#include "picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/ApplyInstantFieldTransitions.kernel"
+#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/param.hpp"
+#include "picongpu/particles/traits/GetAtomicDataType.hpp"
+#include "picongpu/particles/traits/GetNumberAtomicStates.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/lockstep/ForEach.hpp>
+#include <pmacc/particles/meta/FindByNameOrType.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace picongpu::particles::atomicPhysics::stage
+{
+    namespace enums = picongpu::particles::atomicPhysics::enums;
+
+    /** accept field ionization processes with a rate above the time resolution limit instantaneously
+     *
+     * This kernel implements a stop gap fix for field ionization lacking energy conservation.
+     *
+     * In contrast to collisional transitions field ionization rates do not reduce over consecutive atomicPhysics
+     *  subSteps due to exhaustion of the local field, since the local fields are not updated by field ionization
+     *  transitions yet.
+     * This in addition with the very high field ionization rates at laser peak field strength reduces the
+     * atomicPhysics sub step time step length below the numerical resolution limit, causing a very high number of sub
+     * steps and the accompanying performance issues.
+     *
+     * To avoid this we apply field ionization transitions instantaneously to atomic states with field ionization rates
+     *  above the user set time step resolution limit before we calculate the time step length.
+     * Thereby letting very fast transitions occur "instantaneously" in the sub-stepping and removing them from the
+     * rate solver.
+     *
+     * @tparam T_IonSpecies ion species type
+     */
+    template<typename T_IonSpecies>
+    struct ApplyInstantFieldTransitions
+    {
+        // might be alias, from here on out no more
+        //! resolved type of alias T_IonSpecies
+        using IonSpecies = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_IonSpecies>;
+
+        // ionization potential depression model to use
+        using IPDModel = picongpu::atomicPhysics::IPDModel;
+
+        using DistributionFloat = pmacc::random::distributions::Uniform<float_X>;
+        using RngFactoryFloat = particles::functor::misc::Rng<DistributionFloat>;
+
+        //! call of kernel for every superCell
+        HINLINE void operator()([[maybe_unused]] picongpu::MappingDesc const mappingDesc, uint32_t const currentStep)
+            const
+        {
+            using AtomicDataType = typename picongpu::traits::GetAtomicDataType<IonSpecies>::type;
+
+            if constexpr(AtomicDataType::switchFieldIonization)
+            {
+                // full local domain, no guards
+                pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
+                pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
+
+                constexpr uint32_t numberAtomicStatesOfSpecies
+                    = picongpu::traits::GetNumberAtomicStates<IonSpecies>::value;
+
+                auto& localTimeRemainingField
+                    = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<
+                        picongpu::MappingDesc>>("LocalTimeRemainingField");
+                auto& localFoundUnboundIonField
+                    = *dc.get<atomicPhysics::localHelperFields::LocalFoundUnboundIonField<picongpu::MappingDesc>>(
+                        "LocalFoundUnboundIonField");
+
+                using ApplyInstantFieldTransitions = kernel::ApplyInstantFieldTransitionsKernel<
+                    IPDModel,
+                    AtomicDataType::ADKLaserPolarization,
+                    FieldE,
+                    numberAtomicStatesOfSpecies,
+                    enums::TransitionOrdering::byLowerState>;
+
+                RngFactoryFloat rngFactoryFloat = RngFactoryFloat{currentStep};
+                auto eField = dc.get<FieldE>(FieldE::getName());
+                auto& atomicData = *dc.get<AtomicDataType>(IonSpecies::FrameType::getName() + "_atomicData");
+                auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
+
+                IPDModel::
+                    template callKernelWithIPDInput<ApplyInstantFieldTransitions, IonSpecies::FrameType::frameSize>(
+                        dc,
+                        mapper,
+                        rngFactoryFloat,
+                        localTimeRemainingField.getDeviceDataBox(),
+                        localFoundUnboundIonField.getDeviceDataBox(),
+                        eField->getDeviceDataBox(),
+                        atomicData.template getChargeStateDataDataBox<false>(),
+                        atomicData.template getAtomicStateDataDataBox<false>(),
+                        atomicData.template getBoundFreeStartIndexBlockDataBox<false>(),
+                        atomicData.template getBoundFreeNumberTransitionsDataBox<false>(),
+                        atomicData
+                            .template getBoundFreeTransitionDataBox<false, enums::TransitionOrdering::byLowerState>(),
+                        ions.getDeviceParticlesBox());
+            }
+        }
+    };
+
+} // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/FillLocalRateCache.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/FillLocalRateCache.hpp
@@ -29,7 +29,7 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
-#include "picongpu/fields/FieldB.hpp"
+#include "picongpu/fields/FieldE.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"

--- a/include/picongpu/particles/atomicPhysics/stage/RecordChanges.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RecordChanges.hpp
@@ -71,13 +71,13 @@ namespace picongpu::particles::atomicPhysics::stage
 
             auto& atomicData = *dc.get<AtomicDataType>(IonSpecies::FrameType::getName() + "_atomicData");
 
-            namespace enums = picongpu::particles::atomicPhysics::enums;
+            namespace s_enums = picongpu::particles::atomicPhysics::enums;
 
             if constexpr(AtomicDataType::switchElectronicExcitation)
             {
                 using RecordChanges_electronicExcitation
                     = picongpu::particles::atomicPhysics ::kernel::RecordChangesKernel<
-                        enums::ProcessClass::electronicExcitation,
+                        s_enums::ProcessClass::electronicExcitation,
                         picongpu::atomicPhysics::ElectronHistogram,
                         IPDModel>;
 
@@ -90,14 +90,14 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
-                            enums::TransitionOrdering::byLowerState>());
+                            s_enums::TransitionOrdering::byLowerState>());
             }
 
             if constexpr(AtomicDataType::switchElectronicDeexcitation)
             {
                 using RecordChanges_electronicDeexcitation
                     = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        enums::ProcessClass::electronicDeexcitation,
+                        s_enums::ProcessClass::electronicDeexcitation,
                         picongpu::atomicPhysics::ElectronHistogram,
                         IPDModel>;
 
@@ -110,14 +110,14 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
-                            enums::TransitionOrdering::byUpperState>());
+                            s_enums::TransitionOrdering::byUpperState>());
             }
 
             if constexpr(AtomicDataType::switchSpontaneousDeexcitation)
             {
                 using RecordChanges_spontaneousDeexcitation
                     = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        enums::ProcessClass::spontaneousDeexcitation,
+                        s_enums::ProcessClass::spontaneousDeexcitation,
                         picongpu::atomicPhysics::ElectronHistogram,
                         IPDModel>;
 
@@ -130,14 +130,14 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
-                            enums::TransitionOrdering::byUpperState>());
+                            s_enums::TransitionOrdering::byUpperState>());
             }
 
             if constexpr(AtomicDataType::switchElectronicIonization)
             {
                 using RecordChanges_electronicIonization
                     = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        enums::ProcessClass::electronicIonization,
+                        s_enums::ProcessClass::electronicIonization,
                         picongpu::atomicPhysics::ElectronHistogram,
                         IPDModel>;
 
@@ -151,18 +151,36 @@ namespace picongpu::particles::atomicPhysics::stage
                     localElectronHistogramField.getDeviceDataBox(),
                     atomicData.template getAtomicStateDataDataBox<false>(),
                     atomicData
-                        .template getBoundFreeTransitionDataBox<false, enums::TransitionOrdering::byLowerState>(),
+                        .template getBoundFreeTransitionDataBox<false, s_enums::TransitionOrdering::byLowerState>(),
                     atomicData.template getChargeStateDataDataBox<false>());
             }
 
-            // currently no bound-free based non-collisional processes exist
-            /// @todo implement field ionization, Brian Marre, 2023
+            if constexpr(AtomicDataType::switchFieldIonization)
+            {
+                using RecordChanges_fieldIonization = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
+                    s_enums::ProcessClass::fieldIonization,
+                    picongpu::atomicPhysics::ElectronHistogram,
+                    IPDModel>;
+
+                IPDModel::template callKernelWithIPDInput<
+                    RecordChanges_fieldIonization,
+                    IonSpecies::FrameType::frameSize>(
+                    dc,
+                    mapper,
+                    localTimeRemainingField.getDeviceDataBox(),
+                    ions.getDeviceParticlesBox(),
+                    localElectronHistogramField.getDeviceDataBox(),
+                    atomicData.template getAtomicStateDataDataBox<false>(),
+                    atomicData
+                        .template getBoundFreeTransitionDataBox<false, s_enums::TransitionOrdering::byLowerState>(),
+                    atomicData.template getChargeStateDataDataBox<false>());
+            }
 
             if constexpr(AtomicDataType::switchAutonomousIonization)
             {
                 using RecordChanges_autonomousIonization
                     = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        enums::ProcessClass::autonomousIonization,
+                        s_enums::ProcessClass::autonomousIonization,
                         picongpu::atomicPhysics::ElectronHistogram,
                         IPDModel>;
 
@@ -176,7 +194,7 @@ namespace picongpu::particles::atomicPhysics::stage
                     localElectronHistogramField.getDeviceDataBox(),
                     atomicData.template getAtomicStateDataDataBox<false>(),
                     atomicData
-                        .template getAutonomousTransitionDataBox<false, enums::TransitionOrdering::byUpperState>());
+                        .template getAutonomousTransitionDataBox<false, s_enums::TransitionOrdering::byUpperState>());
             }
         }
     };

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics.param
@@ -51,12 +51,15 @@ namespace picongpu::atomicPhysics
 
     struct RateSolverParam
     {
-        //      atomicPhysics timeStepLength sub-stepping of numerical limit
+        // atomicPhysics timeStepLength sub-stepping of numerical limit
         static constexpr float_X timeStepAlpha = 0.1_X;
 
-        //      which probability approximation to use for the acceptance step
+        // which probability approximation to use for the acceptance step
         using ProbabilityApproximationFunctor
             = picongpu::particles::atomicPhysics::ExponentialApproximationProbability;
+
+        // maximum number of atomicPhysics sub-steps per PIC time step for fieldIonization
+        static constexpr uint32_t maximumNumberSubStepsFieldIonization = 2000;
     };
 
     /** atomicConfigNumber definition for argon ions


### PR DESCRIPTION
Field ionization rates in AtomicPhysics(FLYonPIC) do not reduce with consecutive sub-steps since we do not update the local field yet.
These high rates require a large number o atomicPhyiscs sub steps to resolve and therefore lead to a slow down of the simulation.
To avoid this this PR adds a new sub-stage checking for states with time step lengths above a user defined limit and instantly applies field ionization transitions to ions in a state found to have a field ionization loss rate above the limit 

- [x] requires PR #5164 to be merged first
- [ ] needs to be rebased to dev

This PR will break existing setups using a custom `atomicPhysics.param`-file. To fix a setup add the following lines inside the `RateSolverParam` -struct
```c++
        // maximum number of atomicPhysics sub-steps per PIC time step for fieldIonization
        static constexpr uint32_t maximumNumberSubStepsFieldIonization = 2000;
```