### PR TITLE
Bugfix in TWEAC-FOM when switching to the incidentFields-method

### DIFF
--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
@@ -196,9 +196,8 @@ namespace picongpu
                 template<uint32_t T_component>
                 HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
                 {
-                    float3_64 const invUnitField
-                        = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
-                    float3_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
+                    float_64 const invUnitField = 1.0 / m_unitField[T_component];
+                    float_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
                     return amplitude * twtsFieldBpos.getComponent<T_component>(totalCellIdx, m_currentStep);
                 }
 #endif
@@ -239,9 +238,8 @@ namespace picongpu
                 template<uint32_t T_component>
                 HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
                 {
-                    float3_64 const invUnitField
-                        = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
-                    float3_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
+                    float_64 const invUnitField = 1.0 / m_unitField[T_component];
+                    float_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
                     return amplitude * twtsFieldBneg.getComponent<T_component>(totalCellIdx, m_currentStep);
                 }
 #endif


### PR DESCRIPTION
The PR fixes a bug in the TWEAC-FOM benchmark for the incidentFields configuration. The bug was not caught before, because the recent changes to the `simulation_defines.hpp` include structure has caused an include to go missing in the benchmark. As a consequence, initial tests of the the TWEAC-FOM benchmark using the incidentFields configuration led to "empty" functors. The then resulting benchmark was faster than anticipated.