### PR TITLE
update field ionization documentation

### DIFF
--- a/docs/source/models/field_ionization.rst
+++ b/docs/source/models/field_ionization.rst
@@ -158,7 +158,7 @@ You can test the implemented ionization models yourself with the corresponding m
 
     import numpy as np
     import scipy.constants as sc
-    from picongpu.utils import FieldIonization
+    from picongpu.extra.utils import FieldIonization
 
     # instantiate class object that contains functions for
     #   - ionization rates


### PR DESCRIPTION
the model documentation for field ionization still used the old python library structure.

ci: no-compile