### PR TITLE
Disable field ionization in the atomicPhysics test case

### DIFF
--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics.param
@@ -112,6 +112,6 @@ namespace picongpu::atomicPhysics
         // T_autonomousIonization
         true,
         // T_fieldIonization
-        true,
+        false,
         picongpu::particles::atomicPhysics::enums::ADKLaserPolarization::linearPolarization>;
 } // namespace picongpu::atomicPhysics


### PR DESCRIPTION
Change needed to do the scaling tests with the atomicPhysics test case for JUREAP