### PR TITLE
shift AtomicConfigNumber to standard unit tests

### DIFF
--- a/include/picongpu/param/atomicPhysics_Debug.param
+++ b/include/picongpu/param/atomicPhysics_Debug.param
@@ -27,11 +27,6 @@
 
 namespace picongpu::atomicPhysics::debug
 {
-    namespace configNumber
-    {
-        constexpr bool RUN_UNIT_TESTS = false;
-    } // namespace configNumber
-
     namespace atomicData
     {
         constexpr bool PRINT_TO_CONSOLE = false;

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -61,7 +61,6 @@
 #include <string>
 
 // debug only
-#include "picongpu/particles/atomicPhysics/debug/TestAtomicConfigNumber.hpp"
 #include "picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp"
 
 #include <iostream>
@@ -588,13 +587,6 @@ namespace picongpu::simulation::stage
         {
             auto test = particles::atomicPhysics::debug::TestRateCalculation<10u>();
             std::cout << "TestRateCalculation:" << std::endl;
-            test.testAll();
-        }
-
-        if constexpr(picongpu::atomicPhysics::debug::configNumber::RUN_UNIT_TESTS)
-        {
-            auto test = particles::atomicPhysics::debug::TestAtomicConfigNumber();
-            std::cout << "TestAtomicConfigNumber:" << std::endl;
             test.testAll();
         }
     }

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
@@ -27,11 +27,6 @@
 
 namespace picongpu::atomicPhysics::debug
 {
-    namespace configNumber
-    {
-        constexpr bool RUN_UNIT_TESTS = false;
-    } // namespace configNumber
-
     namespace atomicData
     {
         constexpr bool PRINT_TO_CONSOLE = false;

--- a/share/picongpu/unit/atomicPhysics/TestAtomicConfigNumber.cpp
+++ b/share/picongpu/unit/atomicPhysics/TestAtomicConfigNumber.cpp
@@ -17,8 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
 
@@ -31,12 +29,13 @@
 #include <string>
 #include <utility>
 
+#include <catch2/catch_test_macros.hpp>
+
 namespace picongpu::particles::atomicPhysics::debug
 {
     /** Tests of configNumber conversion methods
      *
      * @tparam T_ConsoleOutput true =^= write results and correct value to console
-     * @attention must be called on cpu only, if T_ConsoleOutput==true
      *
      * @return true =^= all tests passed
      */
@@ -162,3 +161,8 @@ namespace picongpu::particles::atomicPhysics::debug
         }
     };
 } // namespace picongpu::particles::atomicPhysics::debug
+
+TEST_CASE("unit::atomicPhysics atomicConfigNumber", "[atomic physics]")
+{
+    CHECK(picongpu::particles::atomicPhysics::debug::TestAtomicConfigNumber{}.testAll());
+};


### PR DESCRIPTION
moves the atomicConfigNumber unit test of FLYonPIC from it's custom location to the standard unit test folder of PIConGPU and makes it part of the the unit test suite of PIConGPU.

@attention This PR removes the `picongpu::configNumber::RUN_UNIT_TEST` option in the `atomicPhysics_Debug.param` file. Old setups setting with this option will still work, but any setting of the option will be ignored.

If you want to run this test, use the PIConGPU unit test framework instead.

ci: picongpu