### PR TITLE
Add typeinfo where typeid is used

### DIFF
--- a/include/picongpu/main.x.cpp
+++ b/include/picongpu/main.x.cpp
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <typeinfo>
 
 
 /** Run a PIConGPU simulation

--- a/include/pmacc/exec/KernelLauncher.tpp
+++ b/include/pmacc/exec/KernelLauncher.tpp
@@ -29,6 +29,7 @@
 #include "pmacc/types.hpp"
 
 #include <string>
+#include <typeinfo>
 
 
 /* No namespace in this file since we only declare macro defines */

--- a/share/picongpu/unit/radiationFormFactor.cpp
+++ b/share/picongpu/unit/radiationFormFactor.cpp
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <typeinfo>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/share/picongpu/unit/radiationWindowFunction.cpp
+++ b/share/picongpu/unit/radiationWindowFunction.cpp
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <typeinfo>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/share/picongpu/unit/shape.cpp
+++ b/share/picongpu/unit/shape.cpp
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <typeinfo>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
I somehow stumbled upon the following line (from [cppreference](https://en.cppreference.com/w/cpp/language/typeid)):

"If the standard library definition of [std::type_info](https://en.cppreference.com/w/cpp/types/type_info) is not visible when using typeid, the program is ill-formed."

A quick `grep` through our codebase revealed 0 inclusions of `<typeinfo>` but several uses of `typeid`, so there could exist a standard library implementation for which our program is ill-formed, I guess. Of course, alpaka includes it a few times which is why it's probably not an issue but just to be on the safe side, I've added the missing includes.