### PR TITLE
Fix unused variable -Werror failure in FillLocalRateCache

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillLocalRateCache_BoundFree.kernel
@@ -344,13 +344,19 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AreaMapping const areaMapping,
             T_LocalTimeRemainingBox const localTimeRemainingBox,
             T_LocalRateCacheBox localRateCacheBox,
-            T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
-            T_EFieldDataBox const eFieldBox,
+            // Only used when electronic ionization is active:
+            [[maybe_unused]] T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
+            // Only used when field ionization is active:
+            [[maybe_unused]] T_EFieldDataBox const eFieldBox,
+            // The rest is only used when at least one form of ionization is activated but I'd argue that NOT having
+            // at least one active when calling this is likely enough to be a bug to not tag them with
+            // [[maybe_unused]].
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
             T_AtomicStateDataDataBox const atomicStateDataDataBox,
             T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
+            // This last is always used:
             T_IPDInput... ipdInput) const
         {
             PMACC_CASSERT(correctAtomicDataBoxes<


### PR DESCRIPTION
Immediate reaction to [this comment](https://github.com/ComputationalRadiationPhysics/picongpu/pull/5175#issuecomment-2423626573) and [this CI failure](https://gitlab.com/hzdr/crp/picongpu/-/jobs/8123427373) (not sure how long the latter link with last).

I struggled quite a bit to reproduce this until I looked it up and it's only a single, very old compiler not clever enough to understand what's going on. So, only the CI will tell us if this worked. However, I took the liberty of checking the other arguments, too, and added explanatory comments.