### PR TITLE
bug fixes atomicPhysics(FLYonPIC) RateCalculationReference

### DIFF
--- a/lib/python/picongpu/extra/__init__.py
+++ b/lib/python/picongpu/extra/__init__.py
@@ -1,3 +1,9 @@
+from . import input
+from . import plugins
+from . import utils
+
+__all__ = ["input", "plugins", "utils"]
+
 """
 auxiliary tools not directly related to PIConGPU execution
 

--- a/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/__init__.py
+++ b/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/__init__.py
@@ -1,0 +1,5 @@
+from .BoundBoundTransitions import BoundBoundTransitions
+from .BoundFreeFieldTransitions import BoundFreeFieldTransitions
+from .BoundFreeCollisionalTransitions import BoundFreeCollisionalTransitions
+
+__all__ = ["BoundBoundTransitions", "BoundFreeCollisionalTransitions", "BoundFreeFieldTransitions"]

--- a/lib/python/picongpu/extra/utils/__init__.py
+++ b/lib/python/picongpu/extra/utils/__init__.py
@@ -1,7 +1,6 @@
 from .find_time import FindTime
 from .memory_calculator import MemoryCalculator
 from .field_ionization import FieldIonization
-from . import FLYonPICRateCalcualtionReference
+from . import FLYonPICRateCalculationReference
 
-
-__all__ = ["FindTime", "MemoryCalculator", "FieldIonization", "FLYonPICRateCalcualtionReference"]
+__all__ = ["FindTime", "MemoryCalculator", "FieldIonization", "FLYonPICRateCalculationReference"]


### PR DESCRIPTION
fix typo in `lib/python/picongpu/extra/utils/__init__.py` and adds an `__init__.py` to FLYonPICRateCalculationReference for faster import and easier use.

ci: no-compile