### PR TITLE
use lumi as default cluster directory 

### DIFF
--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -84,7 +84,7 @@ export PIC_BACKEND="hip:gfx90a"
 
 # Path to the required templates of the system,
 # relative to the PIConGPU source code of the tool bin/pic-create.
-export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/frontier-ornl"}
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/lumi-eurohpc"}
 
 export PATH=$PICSRC/bin:$PATH
 export PATH=$PICSRC/src/tools/bin:$PATH


### PR DESCRIPTION
Another fix for LUMI setup: the default cluster directory was still frontier 