### PR TITLE
fix pic-configure: CMake architecture setup

### DIFF
--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -99,7 +99,7 @@ get_backend_flags()
     elif [ "${backend_cfg[0]}" == "hip" ] ; then
         result+=" -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_ACC_GPU_HIP_ONLY_MODE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DGPU_TARGETS=${backend_cfg[1]}"
+            result+=" -DCMAKE_HIP_ARCHITECTURES=${backend_cfg[1]}"
         fi
     else
         echo "unsupported backend given '$1'" >&2

--- a/share/ci/backendFlags.sh
+++ b/share/ci/backendFlags.sh
@@ -42,10 +42,10 @@ get_backend_flags()
     elif [ "${backend_cfg[0]}" == "hip" ] ; then
         result+=" -Dalpaka_ACC_GPU_HIP_ENABLE=ON -Dalpaka_ACC_GPU_HIP_ONLY_MODE=ON"
         if [ $num_options -eq 2 ] ; then
-            result+=" -DGPU_TARGETS=${backend_cfg[1]}"
+            result+=" -DCMAKE_HIP_ARCHITECTURES=${backend_cfg[1]}"
         else
             # If no architecture is given build for Radeon VII or MI50/60.
-            result+=" -DGPU_TARGETS=gfx906"
+            result+=" -DCMAKE_HIP_ARCHITECTURES=gfx906"
         fi
     else
         echo "unsupported backend given '$1'" >&2

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -33,7 +33,7 @@ if [[ "$PIC_BACKEND" =~ hip.* ]] ; then
         # to Radeon VII or MI50/60.
         export GPU_TARGETS="gfx906"
     fi
-    export PIC_CMAKE_ARGS="$PIC_CMAKE_ARGS -DGPU_TARGETS=$GPU_TARGETS"
+    export PIC_CMAKE_ARGS="$PIC_CMAKE_ARGS -DCMAKE_HIP_ARCHITECTURES=$GPU_TARGETS"
 fi
 
 ###################################################


### PR DESCRIPTION
With CMake 3.21 the CMake variable `CMAKE_HIP_ARCHITECTURES` must be used to setup the target architecture.