### PR TITLE
Fix juwels booster profile to make use of all cores in a node.

### DIFF
--- a/etc/picongpu/juwels-jsc/booster.tpl
+++ b/etc/picongpu/juwels-jsc/booster.tpl
@@ -29,6 +29,7 @@
 #SBATCH --nodes=!TBG_nodes
 #SBATCH --ntasks=!TBG_tasks
 #SBATCH --ntasks-per-node=!TBG_devicesPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerTask
 #SBATCH --mincpus=!TBG_mpiTasksPerNode
 #SBATCH --mem=!TBG_memPerNode
 #SBATCH --gres=gpu:!TBG_devicesPerNode
@@ -58,6 +59,10 @@ export UCX_RC_TIMEOUT=3000000.00us # 3s instead of 1s
 
 # required GPUs per node for the current job
 .TBG_devicesPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedDevicesPerNode ] ; then echo $TBG_numHostedDevicesPerNode; else echo $TBG_tasks; fi)
+
+# Cores per task. Theoretically we have 48 cores, we might leave one per task for the OS but then we would need to
+# hope that srun will do the pinning of cores to memory correctly in order to performantly read from memory.
+.TBG_coresPerTask=12
 
 # host memory per device
 .TBG_memPerDevice="$((499712 / $TBG_numHostedDevicesPerNode))"

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -103,7 +103,7 @@ function getNode() {
         return 1
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=488G -A $account -p develbooster bash
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=12 --gres=gpu:4 --mem=488G -A $account -p develbooster bash
 }
 
 # allocate an interactive shell for one hour
@@ -119,7 +119,7 @@ function getDevice() {
             numDevices=$1
         fi
     fi
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p develbooster --pty bash
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
For example, compiling on nodes took ages because only a single core was utilized. Fixed this in `getDevice`, `getNode` and the `booster.tpl`.