### PR TITLE
remove local name qualifier from FLYonPIC(AtomicPhysics) helper fields

### DIFF
--- a/include/picongpu/particles/atomicPhysics/AtomicPhysicsSuperCellFields.hpp
+++ b/include/picongpu/particles/atomicPhysics/AtomicPhysicsSuperCellFields.hpp
@@ -22,12 +22,12 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ParticleType.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalElectronHistogramOverSubscribedField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalFoundUnboundIonField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRejectionProbabilityCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeStepField.hpp"
-#include "picongpu/particles/atomicPhysics/stage/CreateLocalRateCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/ElectronHistogramOverSubscribedField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/FoundUnboundIonField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/stage/CreateRateCacheField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/meta/ForEach.hpp>
@@ -55,35 +55,36 @@ namespace picongpu::particles::atomicPhysics
             // local rate cache, create in pre-stage call for each species
             pmacc::meta::ForEach<
                 ListAtomicPhysicsSpecies,
-                particles::atomicPhysics::stage::CreateLocalRateCacheField<boost::mpl::_1>>
-                ForEachIonSpeciesCreateLocalRateCacheField;
-            ForEachIonSpeciesCreateLocalRateCacheField(dataConnector, mappingDesc);
+                particles::atomicPhysics::stage::CreateRateCacheField<boost::mpl::_1>>
+                ForEachIonSpeciesCreateRateCacheField;
+            ForEachIonSpeciesCreateRateCacheField(dataConnector, mappingDesc);
 
             // local time remaining field
-            auto localSuperCellTimeRemainingField
-                = std::make_unique<localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(mappingDesc);
-            dataConnector.consume(std::move(localSuperCellTimeRemainingField));
+            auto superCellTimeRemainingField
+                = std::make_unique<localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(mappingDesc);
+            dataConnector.consume(std::move(superCellTimeRemainingField));
 
             // local time step field
-            auto localSuperCellTimeStepField
-                = std::make_unique<localHelperFields::LocalTimeStepField<picongpu::MappingDesc>>(mappingDesc);
-            dataConnector.consume(std::move(localSuperCellTimeStepField));
+            auto superCellTimeStepField
+                = std::make_unique<localHelperFields::TimeStepField<picongpu::MappingDesc>>(mappingDesc);
+            dataConnector.consume(std::move(superCellTimeStepField));
 
             // local electron histogram over subscribed switch
-            auto localSuperCellElectronHistogramOverSubscribedField = std::make_unique<
-                localHelperFields::LocalElectronHistogramOverSubscribedField<picongpu::MappingDesc>>(mappingDesc);
-            dataConnector.consume(std::move(localSuperCellElectronHistogramOverSubscribedField));
-
-            // local storage for FoundUnboundIonField
-            auto localFoundUnboundIonField
-                = std::make_unique<localHelperFields::LocalFoundUnboundIonField<picongpu::MappingDesc>>(mappingDesc);
-            dataConnector.consume(std::move(localFoundUnboundIonField));
-
-            // rejection probability for each over-subscribed bin of the local electron histogram
-            auto localSuperCellRejectionProbabilityCacheField
-                = std::make_unique<localHelperFields::LocalRejectionProbabilityCacheField<picongpu::MappingDesc>>(
+            auto superCellElectronHistogramOverSubscribedField
+                = std::make_unique<localHelperFields::ElectronHistogramOverSubscribedField<picongpu::MappingDesc>>(
                     mappingDesc);
-            dataConnector.consume(std::move(localSuperCellRejectionProbabilityCacheField));
+            dataConnector.consume(std::move(superCellElectronHistogramOverSubscribedField));
+
+            // local storage for foundUnboundIon switch
+            auto foundUnboundIonField
+                = std::make_unique<localHelperFields::FoundUnboundIonField<picongpu::MappingDesc>>(mappingDesc);
+            dataConnector.consume(std::move(foundUnboundIonField));
+
+            // rejection probability for each over-subscribed bin of the electron histogram
+            auto superCellRejectionProbabilityCacheField
+                = std::make_unique<localHelperFields::RejectionProbabilityCacheField<picongpu::MappingDesc>>(
+                    mappingDesc);
+            dataConnector.consume(std::move(superCellRejectionProbabilityCacheField));
         }
     };
 } // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/debug/kernel/DumpRateCacheToConsole.kernel
+++ b/include/picongpu/particles/atomicPhysics/debug/kernel/DumpRateCacheToConsole.kernel
@@ -40,21 +40,21 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localRateCacheBox deviceDataBox giving access to the local rate cache of
+         * @param rateCacheBox deviceDataBox giving access to the local rate cache of
          *  all local superCells
          */
-        template<typename T_Worker, typename T_AreaMapping, typename T_LocalRateCacheBox>
+        template<typename T_Worker, typename T_AreaMapping, typename T_RateCacheBox>
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalRateCacheBox const localRateCacheBox) const
+            T_RateCacheBox const rateCacheBox) const
         {
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
 
             rateCache.printToConsole(worker.getAcc(), superCellFieldIdx);
         }

--- a/include/picongpu/particles/atomicPhysics/debug/stage/DumpRateCacheToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/stage/DumpRateCacheToConsole.hpp
@@ -24,7 +24,7 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/debug/kernel/DumpRateCacheToConsole.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRateCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -55,14 +55,14 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localRateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
-                                                    LocalRateCacheField<picongpu::MappingDesc, IonSpecies>>(
-                IonSpecies::FrameType::getName() + "_localRateCacheField");
+            auto& rateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
+                                               RateCacheField<picongpu::MappingDesc, IonSpecies>>(
+                IonSpecies::FrameType::getName() + "_rateCacheField");
 
             using DumpToConsole = picongpu::particles::atomicPhysics::kernel::DumpRateCacheToConsoleKernel;
 
             PMACC_LOCKSTEP_KERNEL(DumpToConsole())
-                .template config<1u>(mapper.getGridDim())(mapper, localRateCacheField.getDeviceDataBox());
+                .template config<1u>(mapper.getGridDim())(mapper, rateCacheField.getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp
@@ -17,7 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file implements the local electron histogram field for each superCell
+/** @file implements a local histogram field for each superCell
  *
  */
 
@@ -99,7 +99,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
         }
     };
 
-    /** holds a gridBuffer of the per-superCell localHistograms for atomicPhysics
+    /** holds a gridBuffer of the per-superCell histograms for atomicPhysics
      *
      * @attention histograms are uninitialized upon creation of the field, use .getDeviceBuffer().setValue() to init
      */
@@ -122,7 +122,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
         //! required by ISimulationData
         std::string getUniqueId() override
         {
-            return histogramType + "_localHistogramField";
+            return histogramType + "_HistogramField";
         }
     };
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/LocalIPDInputFields.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/LocalIPDInputFields.hpp
@@ -27,6 +27,6 @@
 
 #pragma once
 
-#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/LocalDebyeLengthField.hpp"
-#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/LocalTemperatureEnergyField.hpp"
-#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/LocalZStarField.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/DebyeLengthField.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/TemperatureEnergyField.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/ZStarField.hpp"

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -53,7 +53,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             // T_AdditionalData:
             //@{
             typename T_LocalTimeRemainingBox,
-            typename T_LocalFoundUnboundIonBox,
+            typename T_FoundUnboundIonBox,
             typename T_ChargeStateDataBox,
             typename T_AtomicStateDataBox,
             typename T_IPDIonizationStateDataBox,
@@ -64,7 +64,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             pmacc::DataSpace<picongpu::simDim> const superCellIndex,
             pmacc::DataSpace<picongpu::simDim> const,
             T_LocalTimeRemainingBox const,
-            T_LocalFoundUnboundIonBox const,
+            T_FoundUnboundIonBox const,
             T_ChargeStateDataBox const,
             T_AtomicStateDataBox const,
             T_IPDIonizationStateDataBox const,
@@ -99,10 +99,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         HDINLINE static bool skipSuperCell(
             pmacc::DataSpace<picongpu::simDim> const,
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_AdditionalStuff...)
         {
-            return (localTimeRemainingBox[superCellFieldIndex] <= 0._X);
+            return (timeRemainingBox[superCellFieldIndex] <= 0._X);
         }
     };
 
@@ -119,7 +119,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         template<
             typename T_KernelState,
             typename T_LocalTimeRemainingBox,
-            typename T_LocalFoundUnboundIonBox,
+            typename T_FoundUnboundIonBox,
             typename T_ChargeStateDataBox,
             typename T_AtomicStateDataBox,
             typename T_IPDIonizationStateDataBox,
@@ -129,7 +129,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_KernelState& kernelState,
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
             T_LocalTimeRemainingBox const,
-            T_LocalFoundUnboundIonBox const,
+            T_FoundUnboundIonBox const,
             T_ChargeStateDataBox const,
             T_AtomicStateDataBox const,
             T_IPDIonizationStateDataBox const,
@@ -152,7 +152,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_Worker,
             typename T_Ion,
             typename T_LocalTimeRemainingBox,
-            typename T_LocalFoundUnboundIonBox,
+            typename T_FoundUnboundIonBox,
             typename T_AtomicStateDataBox,
             typename T_ChargeStateDataBox,
             typename T_IPDIonizationStateDataBox,
@@ -163,7 +163,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             KernelState& kernelState,
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
             T_LocalTimeRemainingBox const,
-            T_LocalFoundUnboundIonBox const,
+            T_FoundUnboundIonBox const,
             T_ChargeStateDataBox const chargeStateBox,
             T_AtomicStateDataBox const atomicStateBox,
             T_IPDIonizationStateDataBox const ipdIonizationStateBox,
@@ -251,7 +251,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         template<
             typename T_KernelState,
             typename T_LocalTimeRemainingBox,
-            typename T_LocalFoundUnboundIonBox,
+            typename T_FoundUnboundIonBox,
             typename T_ChargeStateDataBox,
             typename T_AtomicStateDataBox,
             typename T_IPDIonizationStateDataBox,
@@ -261,13 +261,13 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_KernelState const kernelState,
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
             T_LocalTimeRemainingBox const,
-            T_LocalFoundUnboundIonBox localFoundUnboundIonBox,
+            T_FoundUnboundIonBox foundUnboundIonBox,
             T_ChargeStateDataBox const,
             T_AtomicStateDataBox const,
             T_IPDIonizationStateDataBox const,
             T_IPDInputBoxes const...)
         {
-            uint32_t& foundUnbound = localFoundUnboundIonBox(superCellFieldIndex);
+            uint32_t& foundUnbound = foundUnboundIonBox(superCellFieldIndex);
             foundUnbound = foundUnbound || u32(kernelState.foundUnbound);
         }
     };

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -50,7 +50,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox containing local atomicPhysics step
+         * @param timeRemainingBox deviceDataBox containing local atomicPhysics step
          *  time remaining for every superCell
          * @param localSumWeightAllBox deviceDataBox giving access to the sum of weights of macro particles for all
          *  local superCells
@@ -62,11 +62,11 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
          *  macro particles for all local superCells
          * @param localSumChargeNumberSquaredBox deviceDataBox giving access to the weighted sum of the charge number
          *  squared of ion macro particles for all local superCells
-         * @param localTemperatureEnergyBox deviceDataBox giving access to the local temperature * k_Boltzman for all
+         * @param temperatureEnergyBox deviceDataBox giving access to the local temperature * k_Boltzman for all
          *  local superCells, in sim.unit.mass() * sim.unit.length()^2 / sim.unit.time()^2, not weighted
-         * @param localZStarBox deviceDataBox giving access to the local z^Star value, = average(q^2) / average(q),
+         * @param zStarBox deviceDataBox giving access to the local z^Star value, = average(q^2) / average(q),
          *  for all local superCells, unitless, not weighted
-         * @param localDebyeLengthBox deviceDataBox giving access to the local debye length for all local superCells,
+         * @param debyeLengthBox deviceDataBox giving access to the local debye length for all local superCells,
          *  sim.unit.length(), not weighted
          */
         template<
@@ -79,20 +79,20 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_SumChargeNumberIonsFieldDataBox,
             typename T_SumChargeNumberSquaredIonsFieldDataBox,
             typename T_LocalTemperatureFieldDataBox,
-            typename T_LocalZStarFieldDataBox,
+            typename T_ZStarFieldDataBox,
             typename T_LocaDebyeLengthFieldDataBox>
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingDataBox const localTimeRemainingBox,
+            T_LocalTimeRemainingDataBox const timeRemainingBox,
             T_SumWeightAllFieldDataBox const localSumWeightAllBox,
             T_SumTemperatureFunctionalFieldDataBox const localSumTemperatureFunctionalBox,
             T_SumWeightElectronFieldBox const localSumWeightElectronBox,
             T_SumChargeNumberIonsFieldDataBox const localSumChargeNumberBox,
             T_SumChargeNumberSquaredIonsFieldDataBox const localSumChargeNumberSquaredBox,
-            T_LocalTemperatureFieldDataBox localTemperatureEnergyBox,
-            T_LocalZStarFieldDataBox localZStarBox,
-            T_LocaDebyeLengthFieldDataBox localDebyeLengthBox) const
+            T_LocalTemperatureFieldDataBox temperatureEnergyBox,
+            T_ZStarFieldDataBox zStarBox,
+            T_LocaDebyeLengthFieldDataBox debyeLengthBox) const
         {
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
@@ -100,7 +100,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
             // sim.unit.time()
-            float_X const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            float_X const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
@@ -124,11 +124,11 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             // IPD input parameter
             //{
             // sim.unit.mass() * sim.unit.length()^2 / sim.unit.time()^2, not weighted
-            float_X& localTemperatureTimesk_Boltzman = localTemperatureEnergyBox(superCellFieldIdx);
+            float_X& localTemperatureTimesk_Boltzman = temperatureEnergyBox(superCellFieldIdx);
             // unitless, non weighted
-            float_X& localZStar = localZStarBox(superCellFieldIdx);
+            float_X& localZStar = zStarBox(superCellFieldIdx);
             // sim.unit.length(), non weighted
-            float_X& localDebyeLength = localDebyeLengthBox(superCellFieldIdx);
+            float_X& localDebyeLength = debyeLengthBox(superCellFieldIdx);
             //}
 
             const auto onlyMaster = lockstep::makeMaster(worker);

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/FillIPDSumFields_Electron.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/FillIPDSumFields_Electron.kernel
@@ -50,7 +50,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the atomic Physics step time remaining of all
+         * @param timeRemainingBox deviceDataBox giving access to the atomic Physics step time remaining of all
          *  local superCells
          * @param electronBox deviceDataBox giving access to the specie's electron frames of all local superCells
          * @param localSumWeightBox deviceDataBox giving access to the sum of weights of macro particles for all
@@ -71,7 +71,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_ElectronBox const electronBox,
             T_SumWeightFieldDataBox localSumWeightBox,
             T_SumTemperatureFunctionalFieldDataBox localSumTemperatureFunctionalBox,
@@ -84,7 +84,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalParticleBoxEntry
                 = pmacc::particles::algorithm::acc::makeForEach(worker, electronBox, superCellIdx);
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/FillIPDSumFields_Ion.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/FillIPDSumFields_Ion.kernel
@@ -50,7 +50,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the atomic Physics step time remaining of all
+         * @param timeRemainingBox deviceDataBox giving access to the atomic Physics step time remaining of all
          *  local superCells
          * @param ionBox deviceDataBox giving access to the specie's ion frames of all local superCells
          * @param localSumWeightAllBox deviceDataBox giving access to the sum of weights of macro particles for all
@@ -74,7 +74,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_IonBox const ionBox,
             T_SumWeightAllFieldDataBox localSumWeightAllBox,
             T_SumTemperatureFunctionalFieldDataBox localSumTemperatureFunctionalBox,
@@ -88,7 +88,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalParticleBoxEntry
                 = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/DebyeLengthField.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/DebyeLengthField.hpp
@@ -37,9 +37,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::loc
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalDebyeLengthField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
+    struct DebyeLengthField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
     {
-        LocalDebyeLengthField(T_MappingDescription const& mappingDesc)
+        DebyeLengthField(T_MappingDescription const& mappingDesc)
             : SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>(mappingDesc)
         {
         }
@@ -47,7 +47,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::loc
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalDebyeLengthField";
+            return "DebyeLengthField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/TemperatureEnergyField.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/TemperatureEnergyField.hpp
@@ -27,19 +27,19 @@
 
 namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields
 {
-    /**superCell field of local z^* = average(q^2)/average(q)   ;q ... charge number of ion
+    /**superCell field of local temperature * k_Boltzman
      *
-     * @details unitless, not weighted
+     * unit: eV, not weighted
      *
-     * @note required for calculating the local ionization potential depression(IPD) and filled by
+     * @details required for calculating the local ionization potential depression(IPD) and filled by
      *  calculateIPDInput kernel.
      *
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalZStarField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
+    struct TemperatureEnergyField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
     {
-        LocalZStarField(T_MappingDescription const& mappingDesc)
+        TemperatureEnergyField(T_MappingDescription const& mappingDesc)
             : SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>(mappingDesc)
         {
         }
@@ -47,7 +47,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::loc
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalZStarField";
+            return "TemperatureEnergyField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/ZStarField.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/ZStarField.hpp
@@ -27,19 +27,19 @@
 
 namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields
 {
-    /**superCell field of local temperature * k_Boltzman
+    /**superCell field of local z^* = average(q^2)/average(q)   ;q ... charge number of ion
      *
-     * unit: eV, not weighted
+     * @details unitless, not weighted
      *
-     * @details required for calculating the local ionization potential depression(IPD) and filled by
+     * @note required for calculating the local ionization potential depression(IPD) and filled by
      *  calculateIPDInput kernel.
      *
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalTemperatureEnergyField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
+    struct ZStarField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
     {
-        LocalTemperatureEnergyField(T_MappingDescription const& mappingDesc)
+        ZStarField(T_MappingDescription const& mappingDesc)
             : SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>(mappingDesc)
         {
         }
@@ -47,7 +47,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::loc
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalTemperatureEnergyField";
+            return "ZStarField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.hpp
@@ -23,8 +23,8 @@
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/LocalIPDInputFields.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.def"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalFoundUnboundIonField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/FoundUnboundIonField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 #include "picongpu/particles/traits/GetAtomicDataType.hpp"
 #include "picongpu/particles/traits/GetIonizationElectronSpecies.hpp"
@@ -54,12 +54,12 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
         pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-        auto& localTimeRemainingField
-            = *dc.get<atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
-        auto& localFoundUnboundIonField
-            = *dc.get<atomicPhysics::localHelperFields::LocalFoundUnboundIonField<picongpu::MappingDesc>>(
-                "LocalFoundUnboundIonField");
+        auto& timeRemainingField
+            = *dc.get<atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
+        auto& foundUnboundIonField
+            = *dc.get<atomicPhysics::localHelperFields::FoundUnboundIonField<picongpu::MappingDesc>>(
+                "FoundUnboundIonField");
 
         auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
         auto& electrons = *dc.get<IonizationElectronSpecies>(IonizationElectronSpecies::FrameType::getName());
@@ -67,13 +67,12 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         auto& atomicData = *dc.get<AtomicDataType>(IonSpecies::FrameType::getName() + "_atomicData");
 
         // ipd input fields
-        auto& localDebyeLengthField
-            = *dc.get<s_IPD::localHelperFields::LocalDebyeLengthField<picongpu::MappingDesc>>("LocalDebyeLengthField");
-        auto& localTemperatureEnergyField
-            = *dc.get<s_IPD::localHelperFields::LocalTemperatureEnergyField<picongpu::MappingDesc>>(
-                "LocalTemperatureEnergyField");
-        auto& localZStarField
-            = *dc.get<s_IPD::localHelperFields::LocalZStarField<picongpu::MappingDesc>>("LocalZStarField");
+        auto& debyeLengthField
+            = *dc.get<s_IPD::localHelperFields::DebyeLengthField<picongpu::MappingDesc>>("DebyeLengthField");
+        auto& temperatureEnergyField
+            = *dc.get<s_IPD::localHelperFields::TemperatureEnergyField<picongpu::MappingDesc>>(
+                "TemperatureEnergyField");
+        auto& zStarField = *dc.get<s_IPD::localHelperFields::ZStarField<picongpu::MappingDesc>>("ZStarField");
         auto idProvider = dc.get<IdProvider>("globalId");
 
         // macro for call of kernel on every superCell, see pull request #4321
@@ -83,14 +82,14 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
                 idProvider->getDeviceGenerator(),
                 ions.getDeviceParticlesBox(),
                 electrons.getDeviceParticlesBox(),
-                localTimeRemainingField.getDeviceDataBox(),
-                localFoundUnboundIonField.getDeviceDataBox(),
+                timeRemainingField.getDeviceDataBox(),
+                foundUnboundIonField.getDeviceDataBox(),
                 atomicData.template getChargeStateDataDataBox</*on device*/ false>(),
                 atomicData.template getAtomicStateDataDataBox</*on device*/ false>(),
                 atomicData.template getIPDIonizationStateDataBox</*on device*/ false>(),
-                localDebyeLengthField.getDeviceDataBox(),
-                localTemperatureEnergyField.getDeviceDataBox(),
-                localZStarField.getDeviceDataBox());
+                debyeLengthField.getDeviceDataBox(),
+                temperatureEnergyField.getDeviceDataBox(),
+                zStarField.getDeviceDataBox());
 
         // no need to call fillAllGaps, since we do not leave any gaps
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
@@ -28,7 +28,7 @@
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/LocalIPDInputFields.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/SumFields.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 
 #include <string>
 
@@ -52,9 +52,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             auto& localSumWeightAllField
                 = *dc.get<s_IPD::localHelperFields::SumWeightAllField<picongpu::MappingDesc>>("SumWeightAllField");
@@ -73,28 +73,26 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
                 = *dc.get<s_IPD::localHelperFields::SumChargeNumberSquaredIonsField<picongpu::MappingDesc>>(
                     "SumChargeNumberSquaredIonsField");
 
-            auto& localTemperatureEnergyField
-                = *dc.get<s_IPD::localHelperFields::LocalTemperatureEnergyField<picongpu::MappingDesc>>(
-                    "LocalTemperatureEnergyField");
-            auto& localZStarField
-                = *dc.get<s_IPD::localHelperFields::LocalZStarField<picongpu::MappingDesc>>("LocalZStarField");
-            auto& localDebyeLengthField
-                = *dc.get<s_IPD::localHelperFields::LocalDebyeLengthField<picongpu::MappingDesc>>(
-                    "LocalDebyeLengthField");
+            auto& temperatureEnergyField
+                = *dc.get<s_IPD::localHelperFields::TemperatureEnergyField<picongpu::MappingDesc>>(
+                    "TemperatureEnergyField");
+            auto& zStarField = *dc.get<s_IPD::localHelperFields::ZStarField<picongpu::MappingDesc>>("ZStarField");
+            auto& debyeLengthField
+                = *dc.get<s_IPD::localHelperFields::DebyeLengthField<picongpu::MappingDesc>>("DebyeLengthField");
 
             // macro for kernel call
             PMACC_LOCKSTEP_KERNEL(s_IPD::kernel::CalculateIPDInputKernel<T_numberAtomicPhysicsIonSpecies>())
                 .template config<1u>(mapper.getGridDim())(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     localSumWeightAllField.getDeviceDataBox(),
                     localSumTemperatureFunctionalField.getDeviceDataBox(),
                     localSumWeightElectronField.getDeviceDataBox(),
                     localSumChargeNumberIonsField.getDeviceDataBox(),
                     localSumChargeNumberSquaredIonsField.getDeviceDataBox(),
-                    localTemperatureEnergyField.getDeviceDataBox(),
-                    localZStarField.getDeviceDataBox(),
-                    localDebyeLengthField.getDeviceDataBox());
+                    temperatureEnergyField.getDeviceDataBox(),
+                    zStarField.getDeviceDataBox(),
+                    debyeLengthField.getDeviceDataBox());
         }
     };
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Electron.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Electron.hpp
@@ -27,7 +27,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/FillIPDSumFields_Electron.kernel"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Electron.def"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -57,9 +57,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
         pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-        auto& localTimeRemainingField = *dc.get<
-            picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-            "LocalTimeRemainingField");
+        auto& timeRemainingField = *dc.get<
+            picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+            "TimeRemainingField");
 
         // pointer to memory, we will only work on device, no sync required
         // init pointer to particles and localSumFields
@@ -79,7 +79,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         PMACC_LOCKSTEP_KERNEL(s_IPD::kernel::FillIPDSumFieldsKernel_Electron<T_TemperatureFunctional>())
             .config(mapper.getGridDim(), electrons)(
                 mapper,
-                localTimeRemainingField.getDeviceDataBox(),
+                timeRemainingField.getDeviceDataBox(),
                 electrons.getDeviceParticlesBox(),
                 localSumWeightAllField.getDeviceDataBox(),
                 localSumTemperatureFunctionalField.getDeviceDataBox(),

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Ion.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Ion.hpp
@@ -27,7 +27,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/FillIPDSumFields_Ion.kernel"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/FillIPDSumFields_Ion.def"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -56,9 +56,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
         pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-        auto& localTimeRemainingField = *dc.get<
-            picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-            "LocalTimeRemainingField");
+        auto& timeRemainingField = *dc.get<
+            picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+            "TimeRemainingField");
 
         // pointer to memory, we will only work on device, no sync required
         // init pointer to particles and localSumFields
@@ -81,7 +81,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         PMACC_LOCKSTEP_KERNEL(s_IPD::kernel::FillIPDSumFieldsKernel_Ion<T_TemperatureFunctional>())
             .config(mapper.getGridDim(), ions)(
                 mapper,
-                localTimeRemainingField.getDeviceDataBox(),
+                timeRemainingField.getDeviceDataBox(),
                 ions.getDeviceParticlesBox(),
                 localSumWeightAllField.getDeviceDataBox(),
                 localSumTemperatureFunctionalField.getDeviceDataBox(),

--- a/include/picongpu/particles/atomicPhysics/kernel/BinElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/BinElectrons.kernel
@@ -51,12 +51,12 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the atomic Physics step time remaining of all
-         *  local superCells
-         * @param electronBox deviceDataBox giving access to the electron specie's particle frames
-         *   of all local superCells
-         * @param localElectronHistogramDataBox deviceDataBox giving access to the
-         *  local electron histograms of all local superCells
+         * @param timeRemainingBox deviceDataBox giving access to the atomic Physics step time remaining of all local
+         *  superCells
+         * @param electronBox deviceDataBox giving access to the electron specie's particle frames of all local
+         *  superCells
+         * @param electronHistogramDataBox deviceDataBox giving access to the electron histograms of all local
+         *  superCells
          */
         template<
             typename T_Worker,
@@ -67,9 +67,9 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_ElectronBox const electronBox,
-            T_LocalElectronHistogramDataBox localElectronHistogramDataBox) const
+            T_LocalElectronHistogramDataBox electronHistogramDataBox) const
         {
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
 
@@ -78,7 +78,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalElectronBoxEntry
                 = pmacc::particles::algorithm::acc::makeForEach(worker, electronBox, superCellIdx);
 
@@ -87,7 +87,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             // get histogram for current superCell
-            T_Histogram& histogram = localElectronHistogramDataBox(superCellFieldIdx);
+            T_Histogram& histogram = electronHistogramDataBox(superCellFieldIdx);
             // bin electrons
             forEachLocalElectronBoxEntry(
                 [&histogram](T_Worker const& worker, auto& particle)

--- a/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
@@ -46,9 +46,9 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeStepBox deviceDataBox giving access to localTimeStep superCellField values
+         * @param timeStepBox deviceDataBox giving access to localTimeStep superCellField values
          *  of all local superCells
-         * @param localTimeStepBox deviceDataBox giving access to superCell local rateCaches
+         * @param timeStepBox deviceDataBox giving access to superCell local rateCaches
          *  of all local superCells
          */
         template<
@@ -60,23 +60,23 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalTimeStepBox localTimeStepBox,
-            T_LocalRateCache localRateCacheBox) const
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalTimeStepBox timeStepBox,
+            T_LocalRateCache rateCacheBox) const
         {
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;
 
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
             // sim.unit.time()
-            float_X& timeStep = localTimeStepBox(superCellFieldIdx);
+            float_X& timeStep = timeStepBox(superCellFieldIdx);
 
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
 

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -47,7 +47,7 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
          * @param rngFactory factory for uniformly distributed random number generator
-         * @param localHistogramBox deviceDataBox giving access to localHistograms for
+         * @param histogramBox deviceDataBox giving access to localHistograms for
          *  all local superCells
          * @param localElectronHistogramOverSubscribed deviceDataBox giving access to
          *  histogram over subscription switch for each local superCell
@@ -64,8 +64,8 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalHistogramDataBox localHistogramBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalHistogramDataBox histogramBox,
             T_LocalElectronHistogramOverSubscribedDataBox localElectronHistogramOverSubscribedBox,
             T_LocalRejectionProbabilityCacheDataBox localRejectionProbabilityCacheBox) const
         {
@@ -76,7 +76,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;
@@ -84,7 +84,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto forEachBin = pmacc::lockstep::makeForEach<T_Histogram::numberBins, T_Worker>(worker);
             auto onlyMaster = pmacc::lockstep::makeMaster<T_Worker>(worker);
 
-            T_Histogram& histogram = localHistogramBox(superCellFieldIdx);
+            T_Histogram& histogram = histogramBox(superCellFieldIdx);
 
             uint32_t& histogramOverSubscribed = localElectronHistogramOverSubscribedBox(superCellFieldIdx);
 

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckPresence.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckPresence.kernel
@@ -36,10 +36,11 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
+         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param ionBox deviceDataBox giving access to all ion frames of a species of all local
          *  superCells
-         * @param localTimeStepBox deviceDataBox giving access to superCell local rateCaches
-         *  of all local superCells
+         * @param rateCacheBox deviceDataBox giving access to superCell local rateCaches of all local superCells
          */
         template<
             typename T_Worker,
@@ -50,9 +51,9 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_IonBox const ionBox,
-            T_LocalRateCache localRateCacheBox) const
+            T_LocalRateCache rateCacheBox) const
         {
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
@@ -60,14 +61,14 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if superCell already finished or no ions
             if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
                 return;
 
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
 
             forEachLocalIonBoxEntry([&rateCache](T_Worker const& worker, auto& ion)
                                     { rateCache.setPresent(worker, ion[atomicStateCollectionIndex_], true); });

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
@@ -96,10 +96,10 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
          * @param rngFactoryFloat factory for uniformly distributed random number generator for float_X in [0,1)
-         * @param localTimeStepBox deviceDataBox giving access to the atomic physics time
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeStepBox deviceDataBox giving access to the atomic physics time
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localRateCacheBox deviceDataBox giving access the local rate cache of all local super cells
+         * @param rateCacheBox deviceDataBox giving access the local rate cache of all local super cells
          * @param ionBox deviceDataBox giving access to all ion frames of a species of all local superCells
          */
         template<
@@ -114,9 +114,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
             T_RngGeneratorFactoryFloat rngFactoryFloat,
-            T_TimeStepDataBox const localTimeStepBox,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalRateCacheBox localRateCacheBox,
+            T_TimeStepDataBox const timeStepBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalRateCacheBox rateCacheBox,
             T_IonBox ionBox) const
         {
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
@@ -125,15 +125,15 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if superCell already finished or if contains no ions
             if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
                 return;
 
-            auto const timeStep = localTimeStepBox(superCellFieldIdx);
-            T_RateCache& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto const timeStep = timeStepBox(superCellFieldIdx);
+            T_RateCache& rateCache = rateCacheBox(superCellFieldIdx);
             auto rngGenerator = rngFactoryFloat(worker, superCellFieldIdx);
 
             // choose transition type randomly

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
@@ -85,9 +85,9 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  atomic states block of transitions
          * @param transitionDataBox deviceDataBox giving access to autonomous
          *  transition property data
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localRateCacheBox deviceDataBox giving access the local rate cache of all local super cells
+         * @param rateCacheBox deviceDataBox giving access the local rate cache of all local super cells
          * @param ionBox deviceDataBox giving access to the species particle frames of all local super cells
          */
         template<
@@ -108,8 +108,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AtomicStateAutonomousNumberTransitionsDataBox const numberTransitionsBox,
             T_AtomicStateAutonomousStartIndexBlockDataBox const startIndexBox,
             T_AutonomousTransitionDataBox const transitionDataBox,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalRateCacheBox const localRateCacheBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalRateCacheBox const rateCacheBox,
             T_IonBox ionBox) const
         {
             PMACC_CASSERT(checkAtomicDataBoxes<
@@ -123,7 +123,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if superCell already finished or no ions
@@ -131,7 +131,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
 
             forEachLocalIonBoxEntry(
                 [&rngGeneratorFloat, &numberTransitionsBox, &startIndexBox, &transitionDataBox, &rateCache](

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
@@ -108,16 +108,16 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
          * @param rngFactoryFloat factory for uniformly distributed random number generator, for float_X [0,1)
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localElectronHistogramDataBox deviceDataBox giving access to the local
+         * @param electronHistogramDataBox deviceDataBox giving access to the local
          *  electron histograms of all local superCells
          * @param numberTransitionsBox deviceDataBox giving access to the number of
          *  bound-free transitions for each atomic state
          * @param startIndexBox deviceDataBox giving access to the start index of each
          *  atomic states block of transitions
          * @param transitionDataBox deviceDataBox giving access to bound-bound transition data
-         * @param localRateCacheBox deviceDataBox giving access the local rate cache of all local super cells
+         * @param rateCacheBox deviceDataBox giving access the local rate cache of all local super cells
          * @param ionBox deviceDataBox giving access to the species particle frames of all local super cells
          */
         template<
@@ -140,9 +140,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AtomicStateBoundBoundNumberTransitionsDataBox const numberTransitionsBox,
             T_AtomicStateBoundBoundStartIndexBlockDataBox const startIndexBox,
             T_BoundBoundTransitionDataBox const transitionDataBox,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalElectronHistogramDataBox localElectronHistogramDataBox,
-            T_LocalRateCacheBox localRateCacheBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalElectronHistogramDataBox electronHistogramDataBox,
+            T_LocalRateCacheBox rateCacheBox,
             T_IonBox ionBox) const
         {
             // check that correct databoxes are given
@@ -157,7 +157,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if superCell already finished or no particles
@@ -165,8 +165,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
-            T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
+            T_Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
 
             // sim.unit.length()^3
             constexpr float_X volumeScalingFactor

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
@@ -92,12 +92,12 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param startIndexBox deviceDataBox giving access to the start index of each
          *  bound-free transitions for each atomic state
          * @param transitionDataBox deviceDataBox giving access to bound-free transition data
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localElectronHistogramDataBox deviceDataBox giving access to the local
+         * @param electronHistogramDataBox deviceDataBox giving access to the local
          *  electron histograms of all local superCells
-         * @param localRateCacheBox deviceDataBox giving access to the sum of all transitions rates for each
-         *  chooseTransitionGroup cache previously filled by the FillLocalRateCache sub-stage
+         * @param rateCacheBox deviceDataBox giving access to the sum of all transitions rates for each
+         *  chooseTransitionGroup cache previously filled by the FillRateCache sub-stage
          * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
          * @param ipdInput everything required by T_IPDModel to calculate the IonizationPotentialDepression,
          *  passed by T_IPDModel::callKernelWithIPDInput
@@ -125,9 +125,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AtomicStateBoundFreeNumberTransitionsDataBox const numberTransitionsBox,
             T_AtomicStateBoundFreeStartIndexBlockDataBox const startIndexBox,
             T_BoundFreeTransitionDataBox const transitionDataBox,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalElectronHistogramDataBox localElectronHistogramDataBox,
-            T_LocalRateCacheBox localRateCacheBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalElectronHistogramDataBox electronHistogramDataBox,
+            T_LocalRateCacheBox rateCacheBox,
             T_IonBox ionBox,
             T_IPDInput const... ipdInput) const
         {
@@ -142,7 +142,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if superCell already finished or no particles
@@ -150,8 +150,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
-            T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
+            T_Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
 
             // sim.unit.length()^3
             constexpr float_X volumeScalingFactor

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -107,7 +107,7 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param numberTransitionsBox deviceDataBox giving access to the number of
          *  bound-free transitions for each atomic state
          * @param startIndexBox deviceDataBox giving access to the start index of each
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
          * @param eFieldBox deviceDataBox giving access to the device local eField Values
          * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
@@ -123,9 +123,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
             typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
             typename T_BoundFreeTransitionDataBox,
-            typename T_LocalTimeRemainingBox,
+            typename T_TimeRemainingBox,
             typename T_EFieldBox,
-            typename T_LocalRateCacheBox,
+            typename T_RateCacheBox,
             typename T_IonBox,
             typename... T_IPDInput>
         HDINLINE void operator()(
@@ -137,9 +137,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AtomicStateBoundFreeNumberTransitionsDataBox const numberTransitionsBox,
             T_AtomicStateBoundFreeStartIndexBlockDataBox const startIndexBox,
             T_BoundFreeTransitionDataBox const transitionDataBox,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_EFieldBox const eFieldBox,
-            T_LocalRateCacheBox localRateCacheBox,
+            T_TimeRemainingBox const timeRemainingBox,
+            T_EFieldBox eFieldBox,
+            T_RateCacheBox const rateCacheBox,
             T_IonBox ionBox,
             T_IPDInput const... ipdInput) const
         {
@@ -154,7 +154,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if superCell already finished or no particles
@@ -162,7 +162,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
 
             // FLYonPIC superCells must be independent therefore we need to use a support 1 particle shape
             using Field2Particle

--- a/include/picongpu/particles/atomicPhysics/kernel/DecelerateElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/DecelerateElectrons.kernel
@@ -51,9 +51,11 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
+         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param electronBox deviceDataBox giving access to the ion species particle frames
          *   of all local superCells
-         * @param localElectronHistogramDataBox deviceDataBox giving access to the
+         * @param electronHistogramDataBox deviceDataBox giving access to the
          *  local electron histograms of all local superCells
          */
         template<
@@ -65,9 +67,9 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_ElectronBox electronBox,
-            T_LocalElectronHistogramDataBox localElectronHistogramDataBox) const
+            T_LocalElectronHistogramDataBox electronHistogramDataBox) const
         {
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
 
@@ -76,7 +78,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             auto forEachLocalElectronBoxEntry
                 = pmacc::particles::algorithm::acc::makeForEach(worker, electronBox, superCellIdx);
@@ -86,7 +88,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             // get histogram for current superCell
-            T_Histogram& histogram = localElectronHistogramDataBox(superCellFieldIdx);
+            T_Histogram& histogram = electronHistogramDataBox(superCellFieldIdx);
 
             // decelerate electrons
             forEachLocalElectronBoxEntry(

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_Autonomous.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_Autonomous.kernel
@@ -51,17 +51,17 @@ namespace picongpu::particles::atomicPhysics::kernel
         uint32_t T_numberAtomicStates,
         bool T_autonomousIonization,
         enums::TransitionOrdering T_TransitionOrdering>
-    struct FillLocalRateCacheKernel_Autonomous
+    struct FillRateCacheKernel_Autonomous
     {
         /** call operator
          *
-         * called by FillLocalRateCache atomic physics sub-stage
+         * called by FillRateCache atomic physics sub-stage
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localRateCacheBox deviceDataBox giving access the local rate cache of all local super cells
+         * @param rateCacheBox deviceDataBox giving access the local rate cache of all local super cells
          * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states'
          *  block of transitions in the up-/down-ward bound-bound transition collection
          * @param numberTransitionsDataBox deviceDataBox giving access to the number of transitions
@@ -82,8 +82,8 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalRateCacheBox localRateCacheBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalRateCacheBox rateCacheBox,
             T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
             T_AutonomousTransitionDataBox const autonomousTransitionDataBox) const
@@ -109,7 +109,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;
@@ -117,7 +117,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             if constexpr(T_autonomousIonization)
             {
                 auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
-                auto& rateCache = localRateCacheBox(superCellFieldIdx);
+                auto& rateCache = rateCacheBox(superCellFieldIdx);
 
                 forEachAtomicState(
                     [&worker, &rateCache, &startIndexDataBox, &numberTransitionsDataBox, &autonomousTransitionDataBox](

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundBound.kernel
@@ -66,7 +66,7 @@ namespace picongpu::particles::atomicPhysics::kernel
         bool T_electronicDeexcitation,
         bool T_spontaneousDeexcitation,
         s_enums::TransitionOrdering T_TransitionOrdering>
-    struct FillLocalRateCacheKernel_BoundBound
+    struct FillRateCacheKernel_BoundBound
     {
         template<
             typename T_AtomicStateStartIndexBox,
@@ -95,15 +95,15 @@ namespace picongpu::particles::atomicPhysics::kernel
 
         /** call operator
          *
-         * called by FillLocalRateCache atomic physics sub-stage
+         * called by FillRateCache atomic physics sub-stage
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localRateCacheBox deviceDataBox giving access to the local rate cache of
+         * @param rateCacheBox deviceDataBox giving access to the local rate cache of
          *  all local superCells
-         * @param localElectronHistogramDataBox giving access to the local electron histograms
+         * @param electronHistogramDataBox giving access to the local electron histograms
          *  of all local superCells
          * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
          * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states'
@@ -125,9 +125,9 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalRateCacheBox localRateCacheBox,
-            T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalRateCacheBox rateCacheBox,
+            T_LocalElectronHistogramDataBox const electronHistogramDataBox,
             T_AtomicStateDataDataBox const atomicStateDataDataBox,
             T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
@@ -146,7 +146,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             // end kernelif superCell already finished
             if(timeRemaining <= 0._X)
@@ -155,8 +155,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto forEachAtomicStateAndBin
                 = pmacc::lockstep::makeForEach<T_numberAtomicStates * T_numberBins, T_Worker>(worker);
 
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
-            auto& histogram = localElectronHistogramDataBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
+            auto& histogram = electronHistogramDataBox(superCellFieldIdx);
 
 
             // sim.unit.length()^3

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
@@ -73,7 +73,7 @@ namespace picongpu::particles::atomicPhysics::kernel
         bool T_electronicIonization,
         bool T_fieldIonization,
         s_enums::TransitionOrdering T_TransitionOrdering>
-    struct FillLocalRateCacheKernel_BoundFree
+    struct FillRateCacheKernel_BoundFree
     {
         template<
             typename T_AtomicStateNumberTransitionsBox,
@@ -113,7 +113,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_Worker const& worker,
             pmacc::DataSpace<picongpu::simDim> superCellFieldIdx,
             T_RateCache& rateCache,
-            T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
+            T_LocalElectronHistogramDataBox const electronHistogramDataBox,
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
             T_AtomicStateDataDataBox const atomicStateDataDataBox,
             T_AtomicStateStartIndexBox const startIndexDataBox,
@@ -124,7 +124,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto forEachAtomicStateAndBin
                 = pmacc::lockstep::makeForEach<T_numberAtomicStates * T_numberBins, T_Worker>(worker);
 
-            auto& histogram = localElectronHistogramDataBox(superCellFieldIdx);
+            auto& histogram = electronHistogramDataBox(superCellFieldIdx);
 
             // picongpu::sim.unit.length()^3
             constexpr float_X volumeScalingFactor = pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value
@@ -305,15 +305,15 @@ namespace picongpu::particles::atomicPhysics::kernel
 
         /** call operator
          *
-         * called by FillLocalRateCache atomic physics sub-stage
+         * called by FillRateCache atomic physics sub-stage
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param localRateCacheBox deviceDataBox giving access to the local rate cache of
+         * @param rateCacheBox deviceDataBox giving access to the local rate cache of
          *  all local superCells
-         * @param localElectronHistogramDataBox giving access to the local electron histograms
+         * @param electronHistogramDataBox giving access to the local electron histograms
          *  of all local superCells
          * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
          * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
@@ -342,10 +342,10 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalRateCacheBox localRateCacheBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalRateCacheBox rateCacheBox,
             // Only used when electronic ionization is active:
-            [[maybe_unused]] T_LocalElectronHistogramDataBox const localElectronHistogramDataBox,
+            [[maybe_unused]] T_LocalElectronHistogramDataBox const electronHistogramDataBox,
             // Only used when field ionization is active:
             [[maybe_unused]] T_EFieldDataBox const eFieldBox,
             // The rest is only used when at least one form of ionization is activated but I'd argue that NOT having
@@ -372,7 +372,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
             // picongpu::sim.unit.time()
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
@@ -383,14 +383,14 @@ namespace picongpu::particles::atomicPhysics::kernel
                     superCellFieldIdx,
                     ipdInput...);
 
-            auto& rateCache = localRateCacheBox(superCellFieldIdx);
+            auto& rateCache = rateCacheBox(superCellFieldIdx);
 
             if constexpr(T_electronicIonization)
                 fillWithCollisonalIonization(
                     worker,
                     superCellFieldIdx,
                     rateCache,
-                    localElectronHistogramDataBox,
+                    electronHistogramDataBox,
                     chargeStateDataDataBox,
                     atomicStateDataDataBox,
                     startIndexDataBox,

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
@@ -54,8 +54,10 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param ionBox deviceDataBox giving access to the particle frames of all local superCells
-         * @param localElectronHistogramDataBox deviceDataBox giving access to the local
+         * @param electronHistogramDataBox deviceDataBox giving access to the local
          *  electron histograms of all local superCells
          * @param atomicStateBox deviceDataBox giving access to atomic state property data
          * @param transitionBox deviceDataBox giving access to transition property data,
@@ -74,9 +76,9 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_IonBox ionBox,
-            T_LocalElectronHistogramDataBox localElectronHistogramDataBox,
+            T_LocalElectronHistogramDataBox electronHistogramDataBox,
             T_AtomicStateDataBox const atomicStateBox,
             T_TransitionDataBox const transitionBox,
             T_ChargeStateBoxAndIPDInput... chargeStateBoxAndIPDInput) const
@@ -116,7 +118,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
@@ -125,7 +127,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             // get histogram for current superCell
-            [[maybe_unused]] T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
+            [[maybe_unused]] T_Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
 
             // eV
             [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordUsedElectronHistogramWeight.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordUsedElectronHistogramWeight.kernel
@@ -43,8 +43,10 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param ionBox deviceDataBox giving access to the particle frames of all local superCells
-         * @param localElectronHistogramDataBox deviceDataBox giving access to the local
+         * @param electronHistogramDataBox deviceDataBox giving access to the local
          *  electron histograms of all local superCells
          */
         template<
@@ -56,9 +58,9 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_IonBox const ionBox,
-            T_LocalElectronHistogramDataBox localElectronHistogramDataBox) const
+            T_LocalElectronHistogramDataBox electronHistogramDataBox) const
         {
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
 
@@ -67,7 +69,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
             // end kernel if no particles or superCell already finished
@@ -75,7 +77,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             // get histogram for current superCell
-            T_Histogram& electronHistogram = localElectronHistogramDataBox(superCellFieldIdx);
+            T_Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
 
             forEachLocalIonBoxEntry(
                 [&electronHistogram](T_Worker const& worker, auto& ion)

--- a/include/picongpu/particles/atomicPhysics/kernel/ResetAcceptedStatus.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ResetAcceptedStatus.kernel
@@ -45,6 +45,8 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block
          *  information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param ionBox deviceDataBox pointing to the particle frames of the species
          *   T_IonSpecies of all local superCells
          */
@@ -52,7 +54,7 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_IonBox const ionBox) const
         {
             pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
@@ -61,7 +63,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;

--- a/include/picongpu/particles/atomicPhysics/kernel/ResetDeltaWeightElectronHistogram.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ResetDeltaWeightElectronHistogram.kernel
@@ -42,8 +42,9 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param rngFactory factory for uniformly distributed random number generator
-         * @param localHistogramBox deviceDataBox giving access to localHistograms for
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
+         * @param histogramBox deviceDataBox giving access to localHistograms for
          *  all local superCells
          */
         template<
@@ -54,22 +55,22 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalHistogramDataBox localHistogramBox) const
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalHistogramDataBox histogramBox) const
         {
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;
 
             auto forEachBin = pmacc::lockstep::makeForEach<T_Histogram::numberBins, T_Worker>(worker);
 
-            T_Histogram& histogram = localHistogramBox(superCellFieldIdx);
+            T_Histogram& histogram = histogramBox(superCellFieldIdx);
 
             forEachBin([&worker, &histogram](uint32_t const binIndex) { histogram.setDeltaWeight(binIndex, 0._X); });
         }

--- a/include/picongpu/particles/atomicPhysics/kernel/ResetTimeStepField.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ResetTimeStepField.kernel
@@ -33,7 +33,7 @@ namespace picongpu::particles::atomicPhysics::kernel
      *  atomicPhysics kernels if no atomic physics species is present.
      */
     template<uint32_t T_numberAtomicPhysicsIonSpecies>
-    struct ResetLocalTimeStepFieldKernel
+    struct ResetTimeStepFieldKernel
     {
         /** call operator
          *
@@ -41,9 +41,9 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox containing local atomicPhysics step
+         * @param timeRemainingBox deviceDataBox containing local atomicPhysics step
          *  time remaining for every superCell
-         * @param localTimeStepBox deviceDataBox containing local atomicPhysics time step
+         * @param timeStepBox deviceDataBox containing local atomicPhysics time step
          *  length for every superCell
          */
         template<
@@ -54,20 +54,20 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalTimeStepBox localTimeStepBox) const
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalTimeStepBox timeStepBox) const
         {
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;
 
-            auto& timeStep = localTimeStepBox(superCellFieldIdx);
+            auto& timeStep = timeStepBox(superCellFieldIdx);
 
             auto onlyMaster = lockstep::makeMaster(worker);
 
@@ -76,7 +76,7 @@ namespace picongpu::particles::atomicPhysics::kernel
     };
 
     template<>
-    struct ResetLocalTimeStepFieldKernel<0u>
+    struct ResetTimeStepFieldKernel<0u>
     {
         template<
             typename T_Worker,
@@ -86,8 +86,8 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
-            T_LocalTimeStepBox localTimeStepBox) const
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_LocalTimeStepBox timeStepBox) const
         {
         }
     };

--- a/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
@@ -50,6 +50,8 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
          * @param rngFactory random number generator factory
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param localElectronHistogramOverSubscribedBox deviceDataBox giving access to
          *  the histogram oversubscribed switch of all local superCells
          * @param ionBox deviceDataBox giving access to the particle frames of all local superCells
@@ -69,7 +71,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AreaMapping const areaMapping,
             /// const?, @todo Brian Marre, 2023
             T_RngGeneratorFactoryFloat rngFactory,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_LocalElectronHistogramOverSubscribedDataBox const localElectronHistogramOverSubscribedBox,
             T_IonBox ionBox,
             T_LocalRejectionProbabilityCacheDataBox localRejectionProbabilityCacheBox) const
@@ -82,7 +84,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 = superCellIdx - areaMapping.getGuardingSuperCells();
 
 
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             bool const histogramOverSubscribed
                 = static_cast<bool>(localElectronHistogramOverSubscribedBox(superCellFieldIdx));
 

--- a/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
@@ -76,6 +76,8 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param worker object containing the device and block information,
          *  passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
+         * cells
          * @param ionBox deviceDataBox giving access to the particle frames of T_IonSpecies
          *  of all local superCells
          * @param ionizationElectronBox deviceDataBox giving access to the particle frames
@@ -100,7 +102,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
             IdGenerator idGen,
-            T_LocalTimeRemainingBox const localTimeRemainingBox,
+            T_LocalTimeRemainingBox const timeRemainingBox,
             T_IonBox ionBox,
             T_IonizationElectronBox ionizationElectronBox,
             T_AtomicStateDataBox atomicStateBox,
@@ -128,7 +130,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto onlyMaster = pmacc::lockstep::makeMaster(worker);
 
             IonFramePtr ionFrame = ionBox.getLastFrame(superCellIdx);
-            auto const timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             // end kernel if superCell already finished or no ions in superCell --> no bound electrons to ionize
             if((timeRemaining <= 0._X) || (!ionFrame.isValid()))

--- a/include/picongpu/particles/atomicPhysics/kernel/UpdateTimeRemaining.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/UpdateTimeRemaining.kernel
@@ -35,9 +35,9 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
-         * @param localTimeRemainingBox deviceDataBox giving access to the local atomicPhysics time remaining for every
+         * @param timeRemainingBox deviceDataBox giving access to the local atomicPhysics time remaining for every
          *  superCell
-         * @param localTimeStepBox deviceDataBox giving access to local atomicPhysics time step length for every
+         * @param timeStepBox deviceDataBox giving access to local atomicPhysics time step length for every
          *  superCell
          */
         template<
@@ -48,8 +48,8 @@ namespace picongpu::particles::atomicPhysics::kernel
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
-            T_LocalTimeRemainingBox localTimeRemainingBox,
-            T_LocalTimeStepBox const localTimeStepBox) const
+            T_LocalTimeRemainingBox timeRemainingBox,
+            T_LocalTimeStepBox const timeStepBox) const
         {
             // atomicPhysics superCellFields have no guard, but areMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
@@ -57,14 +57,14 @@ namespace picongpu::particles::atomicPhysics::kernel
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND()) - areaMapping.getGuardingSuperCells();
 
             // sim.unit.time()
-            float_X& timeRemaining = localTimeRemainingBox(superCellFieldIdx);
+            float_X& timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             // end kernel if superCell already finished
             if(timeRemaining <= 0._X)
                 return;
 
             // sim.unit.time()
-            float_X const timeStep = localTimeStepBox(superCellFieldIdx);
+            float_X const timeStep = timeStepBox(superCellFieldIdx);
 
             auto onlyMaster = lockstep::makeMaster(worker);
 

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/ElectronHistogramOverSubscribedField.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/ElectronHistogramOverSubscribedField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024Brian Marre
+/* Copyright 2023 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -17,7 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! @file implements bool storage superCellField if an unbound ion was found previously
+//! @file implements bool storage superCellField if histogram overSubscribed
 
 #pragma once
 
@@ -30,55 +30,51 @@
 
 namespace picongpu::particles::atomicPhysics::localHelperFields
 {
-    /** debug only, write foundUnboundionField to console
-     *
-     * @attention only creates output if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
-     * @attention only useful if compiling for serial or cpu backend, otherwise will throw compile error if called by
-     *  DumpSuperCellDataToConsole kernel on device
-     */
-    struct PrintFoundUnboundToConsole
+    //! debug only, write electronHistogramOverSubcribed to console
+    struct PrintOverSubcriptionFieldToConsole
     {
         //! cpu version
         template<typename T_Acc>
         HDINLINE auto operator()(
             T_Acc const&,
-            uint32_t const foundUnbound,
+            uint32_t const overSubscribed,
             pmacc::DataSpace<picongpu::simDim> superCellIdx) const
             -> std::enable_if_t<std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
-            if(foundUnbound)
-                printf("foundUnbound %s: True\n", superCellIdx.toString(",", "[]").c_str());
+            if(overSubscribed)
+                printf("overSubscribed %s: True\n", superCellIdx.toString(",", "[]").c_str());
             else
-                printf("foundUnbound %s: False\n", superCellIdx.toString(",", "[]").c_str());
+                printf("overSubscribed %s: False\n", superCellIdx.toString(",", "[]").c_str());
         }
 
         //! gpu version, does nothing
         template<typename T_Acc>
         HDINLINE auto operator()(
             T_Acc const&,
-            uint32_t const foundUnbound,
+            uint32_t const overSubscribed,
             pmacc::DataSpace<picongpu::simDim> superCellIdx) const
             -> std::enable_if_t<!std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
         }
     };
 
-    /**superCell field
+    /** superCell field of the electronHistogram over subscribed state
      *
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalFoundUnboundIonField : public SuperCellField<uint32_t, T_MappingDescription, /*no guards*/ false>
+    struct ElectronHistogramOverSubscribedField
+        : public SuperCellField<uint32_t, T_MappingDescription, false /*no guards*/>
     {
-        LocalFoundUnboundIonField(T_MappingDescription const& mappingDesc)
-            : SuperCellField<uint32_t, T_MappingDescription, /*no guards*/ false>(mappingDesc)
+        ElectronHistogramOverSubscribedField(T_MappingDescription const& mappingDesc)
+            : SuperCellField<uint32_t, T_MappingDescription, false /*no guards*/>(mappingDesc)
         {
         }
 
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalFoundUnboundIonField";
+            return "ElectronHistogramOverSubscribedField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/FoundUnboundIonField.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/FoundUnboundIonField.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022-2023 Brian Marre
+/* Copyright 2024Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -17,10 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file implements the local timeRemainingField for each superCell
- *
- * timeRemaining for the current atomicPhysics step in each superCell
- */
+//! @file implements bool storage superCellField if an unbound ion was found previously
 
 #pragma once
 
@@ -33,52 +30,55 @@
 
 namespace picongpu::particles::atomicPhysics::localHelperFields
 {
-    /** debug only, write timeRemaining to console
+    /** debug only, write foundUnboundionField to console
      *
-     * @attention only creates ouptut if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
+     * @attention only creates output if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
      * @attention only useful if compiling for serial or cpu backend, otherwise will throw compile error if called by
      *  DumpSuperCellDataToConsole kernel on device
      */
-    struct PrintTimeRemaingToConsole
+    struct PrintFoundUnboundToConsole
     {
         //! cpu version
         template<typename T_Acc>
         HDINLINE auto operator()(
             T_Acc const&,
-            float_X const timeRemaining,
+            uint32_t const foundUnbound,
             pmacc::DataSpace<picongpu::simDim> superCellIdx) const
             -> std::enable_if_t<std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
-            printf("timeRemaining %s: %.8e\n", superCellIdx.toString(",", "[]").c_str(), timeRemaining);
+            if(foundUnbound)
+                printf("foundUnbound %s: True\n", superCellIdx.toString(",", "[]").c_str());
+            else
+                printf("foundUnbound %s: False\n", superCellIdx.toString(",", "[]").c_str());
         }
 
-        //! gpu version does nothing
+        //! gpu version, does nothing
         template<typename T_Acc>
         HDINLINE auto operator()(
             T_Acc const&,
-            float_X const timeRemaining,
+            uint32_t const foundUnbound,
             pmacc::DataSpace<picongpu::simDim> superCellIdx) const
             -> std::enable_if_t<!std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
         }
     };
 
-    /** holds a gridBuffer of the per-superCell timeRemaining:float_X for atomicPhysics
+    /**superCell field
      *
-     * unit: sim.unit.time()
+     * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalTimeRemainingField : public SuperCellField<float_X, T_MappingDescription, false /*no guards*/>
+    struct FoundUnboundIonField : public SuperCellField<uint32_t, T_MappingDescription, /*no guards*/ false>
     {
-        LocalTimeRemainingField(T_MappingDescription const& mappingDesc)
-            : SuperCellField<float_X, T_MappingDescription, false /*no guards*/>(mappingDesc)
+        FoundUnboundIonField(T_MappingDescription const& mappingDesc)
+            : SuperCellField<uint32_t, T_MappingDescription, /*no guards*/ false>(mappingDesc)
         {
         }
 
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalTimeRemainingField";
+            return "FoundUnboundIonField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp
@@ -50,7 +50,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
      * @tparam T_IonSpecies resolved type of ion species
      */
     template<typename T_MappingDescription, typename T_IonSpecies>
-    struct LocalRateCacheField
+    struct RateCacheField
         : public SuperCellField<
               RateCache<picongpu::traits::GetNumberAtomicStates<T_IonSpecies>::value>,
               T_MappingDescription,
@@ -58,7 +58,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
     {
         using FrameType = typename T_IonSpecies::FrameType;
 
-        LocalRateCacheField(T_MappingDescription const& mappingDesc)
+        RateCacheField(T_MappingDescription const& mappingDesc)
             : SuperCellField<
                 RateCache<picongpu::traits::GetNumberAtomicStates<T_IonSpecies>::value>,
                 T_MappingDescription,
@@ -69,7 +69,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return FrameType::getName() + "_localRateCacheField";
+            return FrameType::getName() + "_rateCacheField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp
@@ -37,13 +37,13 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalRejectionProbabilityCacheField
+    struct RejectionProbabilityCacheField
         : public SuperCellField<
               RejectionProbabilityCache<picongpu::atomicPhysics::ElectronHistogram::numberBins>,
               T_MappingDescription,
               false /*no guards*/>
     {
-        LocalRejectionProbabilityCacheField(T_MappingDescription const& mappingDesc)
+        RejectionProbabilityCacheField(T_MappingDescription const& mappingDesc)
             : SuperCellField<
                 RejectionProbabilityCache<picongpu::atomicPhysics::ElectronHistogram::numberBins>,
                 T_MappingDescription,
@@ -54,7 +54,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalRejectionProbabilityCacheField";
+            return "RejectionProbabilityCacheField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp
@@ -59,9 +59,9 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct LocalTimeStepField : public SuperCellField<float_X, T_MappingDescription, false /*no guards*/>
+    struct TimeStepField : public SuperCellField<float_X, T_MappingDescription, false /*no guards*/>
     {
-        LocalTimeStepField(T_MappingDescription const& mappingDesc)
+        TimeStepField(T_MappingDescription const& mappingDesc)
             : SuperCellField<float_X, T_MappingDescription, false /*no guards*/>(mappingDesc)
         {
         }
@@ -69,7 +69,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "LocalTimeStepField";
+            return "TimeStepField";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/stage/BinElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/BinElectrons.hpp
@@ -40,7 +40,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/BinElectrons.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -78,17 +78,17 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             // pointer to memory, we will only work on device, no sync required
-            // init pointer to electrons and localElectronHistogramField
+            // init pointer to electrons and electronHistogramField
             auto& electrons = *dc.get<ElectronSpecies>(ElectronSpecies::FrameType::getName());
-            auto& localElectronHistogramField
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
 
             using BinElectrons = picongpu::particles::atomicPhysics::kernel::BinElectronsKernel<
                 picongpu::atomicPhysics::ElectronHistogram>;
@@ -97,9 +97,9 @@ namespace picongpu::particles::atomicPhysics::stage
             PMACC_LOCKSTEP_KERNEL(BinElectrons())
                 .config(mapper.getGridDim(), electrons)(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     electrons.getDeviceParticlesBox(),
-                    localElectronHistogramField.getDeviceDataBox());
+                    electronHistogramField.getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/CalculateStepLength.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/CalculateStepLength.hpp
@@ -27,9 +27,9 @@
 #pragma once
 
 #include "picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRateCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -40,8 +40,8 @@ namespace picongpu::particles::atomicPhysics::stage
 {
     /** @class atomic physics sub-stage for finding atomic physics step length
      *
-     * @attention assumes localTimeStepField to have been reset before
-     * @attention assumes localRateCacheField to have been filled before
+     * @attention assumes timeStepField to have been reset before
+     * @attention assumes rateCacheField to have been filled before
      *
      * @tparam T_IonSpecies ion species type
      */
@@ -59,19 +59,19 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             // pointers to memory, we will only work on device, no sync required
-            //      pointer to localRateCache
-            auto& localRateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
-                                                    LocalRateCacheField<picongpu::MappingDesc, IonSpecies>>(
-                IonSpecies::FrameType::getName() + "_localRateCacheField");
-            //      pointer to localTimeStepField
-            auto& localTimeStepField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeStepField<picongpu::MappingDesc>>(
-                "LocalTimeStepField");
+            //      pointer to rateCache
+            auto& rateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
+                                               RateCacheField<picongpu::MappingDesc, IonSpecies>>(
+                IonSpecies::FrameType::getName() + "_rateCacheField");
+            //      pointer to timeStepField
+            auto& timeStepField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>>(
+                    "TimeStepField");
 
             constexpr uint32_t numberAtomicStatesOfSpecies
                 = picongpu::traits::GetNumberAtomicStates<IonSpecies>::value;
@@ -81,9 +81,9 @@ namespace picongpu::particles::atomicPhysics::stage
                 picongpu::particles::atomicPhysics::kernel::CalculateStepLengthKernel<numberAtomicStatesOfSpecies>())
                 .template config<IonSpecies::FrameType::frameSize>(mapper.getGridDim())(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localTimeStepField.getDeviceDataBox(),
-                    localRateCacheField.getDeviceDataBox());
+                    timeRemainingField.getDeviceDataBox(),
+                    timeStepField.getDeviceDataBox(),
+                    rateCacheField.getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
@@ -27,9 +27,9 @@
 
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalElectronHistogramOverSubscribedField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRejectionProbabilityCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/ElectronHistogramOverSubscribedField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
@@ -56,23 +56,22 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
-            auto& localElectronHistogramField
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
 
-            auto& localElectronHistogramOverSubscribedField
-                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
-                              LocalElectronHistogramOverSubscribedField<picongpu::MappingDesc>>(
-                    "LocalElectronHistogramOverSubscribedField");
+            auto& electronHistogramOverSubscribedField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
+                    picongpu::MappingDesc>>("ElectronHistogramOverSubscribedField");
 
-            auto& localRejectionProbabilityCacheField
-                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::LocalRejectionProbabilityCacheField<
-                    picongpu::MappingDesc>>("LocalRejectionProbabilityCacheField");
+            auto& rejectionProbabilityCacheField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::RejectionProbabilityCacheField<
+                    picongpu::MappingDesc>>("RejectionProbabilityCacheField");
 
             // macro for call of kernel for every superCell, see pull request #4321
             PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::CheckForOverSubscriptionKernel<
@@ -80,10 +79,10 @@ namespace picongpu::particles::atomicPhysics::stage
                                       T_numberAtomicPhysicsIonSpecies>())
                 .template config<picongpu::atomicPhysics::ElectronHistogram::numberBins>(mapper.getGridDim())(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localElectronHistogramField.getDeviceDataBox(),
-                    localElectronHistogramOverSubscribedField.getDeviceDataBox(),
-                    localRejectionProbabilityCacheField.getDeviceDataBox());
+                    timeRemainingField.getDeviceDataBox(),
+                    electronHistogramField.getDeviceDataBox(),
+                    electronHistogramOverSubscribedField.getDeviceDataBox(),
+                    rejectionProbabilityCacheField.getDeviceDataBox());
 
             /// @todo implement photon histogram, Brian Marre, 2023
         }

--- a/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
@@ -30,9 +30,8 @@
 #include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel"
 #include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel"
 #include "picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRateCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -71,18 +70,18 @@ namespace picongpu::particles::atomicPhysics::stage
             using AtomicDataType = typename picongpu::traits::GetAtomicDataType<IonSpecies>::type;
             auto& atomicData = *dc.get<AtomicDataType>(IonSpecies::FrameType::getName() + "_atomicData");
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
-            auto& localElectronHistogramField
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
             using RateCache = typename picongpu::particles::atomicPhysics::localHelperFields::
-                LocalRateCacheField<picongpu::MappingDesc, IonSpecies>::entryType;
-            auto& localRateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
-                                                    LocalRateCacheField<picongpu::MappingDesc, IonSpecies>>(
-                IonSpecies::FrameType::getName() + "_localRateCacheField");
+                RateCacheField<picongpu::MappingDesc, IonSpecies>::entryType;
+            auto& rateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
+                                               RateCacheField<picongpu::MappingDesc, IonSpecies>>(
+                IonSpecies::FrameType::getName() + "_rateCacheField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
 
@@ -109,9 +108,9 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
                             s_enums::TransitionOrdering::byLowerState>(),
-                        localTimeRemainingField.getDeviceDataBox(),
-                        localElectronHistogramField.getDeviceDataBox(),
-                        localRateCacheField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
+                        electronHistogramField.getDeviceDataBox(),
+                        rateCacheField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox());
             }
 
@@ -134,9 +133,9 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
                             s_enums::TransitionOrdering::byUpperState>(),
-                        localTimeRemainingField.getDeviceDataBox(),
-                        localElectronHistogramField.getDeviceDataBox(),
-                        localRateCacheField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
+                        electronHistogramField.getDeviceDataBox(),
+                        rateCacheField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox());
             }
 
@@ -161,9 +160,9 @@ namespace picongpu::particles::atomicPhysics::stage
                     atomicData.template getBoundFreeStartIndexBlockDataBox<false>(),
                     atomicData
                         .template getBoundFreeTransitionDataBox<false, s_enums::TransitionOrdering::byLowerState>(),
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localElectronHistogramField.getDeviceDataBox(),
-                    localRateCacheField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
+                    electronHistogramField.getDeviceDataBox(),
+                    rateCacheField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox());
             }
 
@@ -191,9 +190,9 @@ namespace picongpu::particles::atomicPhysics::stage
                     atomicData.template getBoundFreeStartIndexBlockDataBox<false>(),
                     atomicData
                         .template getBoundFreeTransitionDataBox<false, s_enums::TransitionOrdering::byLowerState>(),
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     fieldE.getDeviceDataBox(),
-                    localRateCacheField.getDeviceDataBox(),
+                    rateCacheField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox());
             }
 
@@ -209,8 +208,8 @@ namespace picongpu::particles::atomicPhysics::stage
                         atomicData.template getAutonomousTransitionDataBox<
                             false,
                             s_enums::TransitionOrdering::byUpperState>(),
-                        localTimeRemainingField.getDeviceDataBox(),
-                        localRateCacheField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
+                        rateCacheField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox());
             }
         }

--- a/include/picongpu/particles/atomicPhysics/stage/ChooseTransitionGroup.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ChooseTransitionGroup.hpp
@@ -26,9 +26,9 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRateCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp"
 #include "picongpu/particles/param.hpp"
 #include "picongpu/particles/traits/GetAtomicDataType.hpp"
 
@@ -64,17 +64,17 @@ namespace picongpu::particles::atomicPhysics::stage
 
             using AtomicDataType = typename picongpu::traits::GetAtomicDataType<IonSpecies>::type;
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
-            auto& localTimeStepField = *dc.get<
-                picongpu::particles::atomicPhysics ::localHelperFields::LocalTimeStepField<picongpu::MappingDesc>>(
-                "LocalTimeStepField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
+            auto& timeStepField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>>(
+                    "TimeStepField");
             using RateCacheType = typename picongpu::particles::atomicPhysics::localHelperFields::
-                LocalRateCacheField<picongpu::MappingDesc, IonSpecies>::entryType;
-            auto& localRateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
-                                                    LocalRateCacheField<picongpu::MappingDesc, IonSpecies>>(
-                IonSpecies::FrameType::getName() + "_localRateCacheField");
+                RateCacheField<picongpu::MappingDesc, IonSpecies>::entryType;
+            auto& rateCacheField = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
+                                               RateCacheField<picongpu::MappingDesc, IonSpecies>>(
+                IonSpecies::FrameType::getName() + "_rateCacheField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
             RngFactoryFloat rngFactoryFloat = RngFactoryFloat{currentStep};
@@ -92,9 +92,9 @@ namespace picongpu::particles::atomicPhysics::stage
                 .config(mapper.getGridDim(), ions)(
                     mapper,
                     rngFactoryFloat,
-                    localTimeStepField.getDeviceDataBox(),
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localRateCacheField.getDeviceDataBox(),
+                    timeStepField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
+                    rateCacheField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox());
         }
     };

--- a/include/picongpu/particles/atomicPhysics/stage/CreateRateCacheField.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/CreateRateCacheField.hpp
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "picongpu/particles/atomicPhysics/debug/param.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRateCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -31,12 +31,13 @@
 
 namespace picongpu::particles::atomicPhysics::stage
 {
-    /** pre-simulation stage initiating the localRateCacheField for atomicPhysics
+    /** pre-simulation stage initiating the rateCacheField for atomicPhysics
      *
+     * is a stage to
      * @tparam T_IonSpecies species for which to call the functor
      */
     template<typename T_IonSpecies>
-    struct CreateLocalRateCacheField
+    struct CreateRateCacheField
     {
         // might be alias, from here on out no more
         //! resolved type of alias T_IonSpecies
@@ -45,10 +46,9 @@ namespace picongpu::particles::atomicPhysics::stage
         template<typename T_MappingDescription>
         HINLINE void operator()(DataConnector& dataConnector, T_MappingDescription const& mappingDesc) const
         {
-            auto localRateCacheField
-                = std::make_unique<picongpu::particles::atomicPhysics::localHelperFields::
-                                       LocalRateCacheField<picongpu::MappingDesc, IonSpecies>>(mappingDesc);
-            dataConnector.consume(std::move(localRateCacheField));
+            auto rateCacheField = std::make_unique<picongpu::particles::atomicPhysics::localHelperFields::
+                                                       RateCacheField<picongpu::MappingDesc, IonSpecies>>(mappingDesc);
+            dataConnector.consume(std::move(rateCacheField));
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/DecelerateElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/DecelerateElectrons.hpp
@@ -28,7 +28,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/DecelerateElectrons.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -63,17 +63,17 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             // pointer to memory, we will only work on device, no sync required
-            // init pointer to electrons and localElectronHistogramField
+            // init pointer to electrons and electronHistogramField
             auto& electrons = *dc.get<ElectronSpecies>(ElectronSpecies::FrameType::getName());
-            auto& localElectronHistogramField
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
 
             using DecelerateElectrons = picongpu::particles::atomicPhysics::kernel ::
                 DecelerateElectronsKernel<ElectronSpecies, picongpu::atomicPhysics::ElectronHistogram>;
@@ -82,9 +82,9 @@ namespace picongpu::particles::atomicPhysics::stage
             PMACC_LOCKSTEP_KERNEL(DecelerateElectrons())
                 .config(mapper.getGridDim(), electrons)(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     electrons.getDeviceParticlesBox(),
-                    localElectronHistogramField.getDeviceDataBox());
+                    electronHistogramField.getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/RecordChanges.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RecordChanges.hpp
@@ -25,7 +25,7 @@
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -58,16 +58,16 @@ namespace picongpu::particles::atomicPhysics::stage
 
             using AtomicDataType = typename picongpu::traits::GetAtomicDataType<IonSpecies>::type;
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
 
-            auto& localElectronHistogramField
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
 
             auto& atomicData = *dc.get<AtomicDataType>(IonSpecies::FrameType::getName() + "_atomicData");
 
@@ -84,9 +84,9 @@ namespace picongpu::particles::atomicPhysics::stage
                 PMACC_LOCKSTEP_KERNEL(RecordChanges_electronicExcitation())
                     .config(mapper.getGridDim(), ions)(
                         mapper,
-                        localTimeRemainingField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox(),
-                        localElectronHistogramField.getDeviceDataBox(),
+                        electronHistogramField.getDeviceDataBox(),
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
@@ -104,9 +104,9 @@ namespace picongpu::particles::atomicPhysics::stage
                 PMACC_LOCKSTEP_KERNEL(RecordChanges_electronicDeexcitation())
                     .config(mapper.getGridDim(), ions)(
                         mapper,
-                        localTimeRemainingField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox(),
-                        localElectronHistogramField.getDeviceDataBox(),
+                        electronHistogramField.getDeviceDataBox(),
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
@@ -124,9 +124,9 @@ namespace picongpu::particles::atomicPhysics::stage
                 PMACC_LOCKSTEP_KERNEL(RecordChanges_spontaneousDeexcitation())
                     .config(mapper.getGridDim(), ions)(
                         mapper,
-                        localTimeRemainingField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox(),
-                        localElectronHistogramField.getDeviceDataBox(),
+                        electronHistogramField.getDeviceDataBox(),
                         atomicData.template getAtomicStateDataDataBox<false>(),
                         atomicData.template getBoundBoundTransitionDataBox<
                             false,
@@ -146,9 +146,9 @@ namespace picongpu::particles::atomicPhysics::stage
                     IonSpecies::FrameType::frameSize>(
                     dc,
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox(),
-                    localElectronHistogramField.getDeviceDataBox(),
+                    electronHistogramField.getDeviceDataBox(),
                     atomicData.template getAtomicStateDataDataBox<false>(),
                     atomicData
                         .template getBoundFreeTransitionDataBox<false, s_enums::TransitionOrdering::byLowerState>(),
@@ -167,9 +167,9 @@ namespace picongpu::particles::atomicPhysics::stage
                     IonSpecies::FrameType::frameSize>(
                     dc,
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox(),
-                    localElectronHistogramField.getDeviceDataBox(),
+                    electronHistogramField.getDeviceDataBox(),
                     atomicData.template getAtomicStateDataDataBox<false>(),
                     atomicData
                         .template getBoundFreeTransitionDataBox<false, s_enums::TransitionOrdering::byLowerState>(),
@@ -189,9 +189,9 @@ namespace picongpu::particles::atomicPhysics::stage
                     IonSpecies::FrameType::frameSize>(
                     dc,
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox(),
-                    localElectronHistogramField.getDeviceDataBox(),
+                    electronHistogramField.getDeviceDataBox(),
                     atomicData.template getAtomicStateDataDataBox<false>(),
                     atomicData
                         .template getAutonomousTransitionDataBox<false, s_enums::TransitionOrdering::byUpperState>());

--- a/include/picongpu/particles/atomicPhysics/stage/RecordSuggestedChanges.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RecordSuggestedChanges.hpp
@@ -24,7 +24,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/RecordUsedElectronHistogramWeight.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -62,16 +62,16 @@ namespace picongpu::particles::atomicPhysics::stage
 
             using AtomicDataType = typename picongpu::traits::GetAtomicDataType<IonSpecies>::type;
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
 
-            auto& localElectronHistogramField
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
 
             // electronic collisional transition channel active
             if constexpr(
@@ -84,9 +84,9 @@ namespace picongpu::particles::atomicPhysics::stage
                         picongpu::atomicPhysics::ElectronHistogram>())
                     .config(mapper.getGridDim(), ions)(
                         mapper,
-                        localTimeRemainingField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox(),
-                        localElectronHistogramField.getDeviceDataBox());
+                        electronHistogramField.getDeviceDataBox());
             }
 
             /// @todo implement photonic collisional interactions, Brian Marre, 2023

--- a/include/picongpu/particles/atomicPhysics/stage/ResetAcceptedStatus.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ResetAcceptedStatus.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "picongpu/particles/atomicPhysics/kernel/ResetAcceptedStatus.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -49,16 +49,16 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
 
             PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::ResetAcceptedStatusKernel())
                 .config(
                     mapper.getGridDim(),
-                    ions)(mapper, localTimeRemainingField.getDeviceDataBox(), ions.getDeviceParticlesBox());
+                    ions)(mapper, timeRemainingField.getDeviceDataBox(), ions.getDeviceParticlesBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/ResetDeltaWeightElectronHistogram.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ResetDeltaWeightElectronHistogram.hpp
@@ -25,7 +25,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/ResetDeltaWeightElectronHistogram.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/atomicPhysics/param.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -53,14 +53,14 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
-            auto& localElectronHistogramField
+            auto& electronHistogramField
                 = *dc.get<picongpu::particles::atomicPhysics::electronDistribution::
                               LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>>(
-                    "Electron_localHistogramField");
+                    "Electron_HistogramField");
 
             // macro for call of kernel for every superCell
             PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::ResetDeltaWeightElectronHistogramKernel<
@@ -68,8 +68,8 @@ namespace picongpu::particles::atomicPhysics::stage
                                       T_numberAtomicPhysicsIonSpecies>())
                 .template config<picongpu::atomicPhysics::ElectronHistogram::numberBins>(mapper.getGridDim())(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localElectronHistogramField.getDeviceDataBox());
+                    timeRemainingField.getDeviceDataBox(),
+                    electronHistogramField.getDeviceDataBox());
 
             /// @todo implement photon histogram, Brian Marre, 2023
         }

--- a/include/picongpu/particles/atomicPhysics/stage/ResetRateCache.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ResetRateCache.hpp
@@ -25,8 +25,8 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRateCacheField.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/RateCache.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RateCacheField.hpp"
 #include "picongpu/particles/param.hpp"
 #include "picongpu/particles/traits/GetNumberAtomicStates.hpp"
 
@@ -43,7 +43,7 @@ namespace picongpu::particles::atomicPhysics::stage
      * @tparam T_IonSpecies ion species type
      */
     template<typename T_IonSpecies>
-    struct ResetLocalRateCache
+    struct ResetRateCache
     {
         // might be alias, from here on out no more
         //! resolved type of alias T_ionSpecies
@@ -54,14 +54,13 @@ namespace picongpu::particles::atomicPhysics::stage
         {
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localRateCacheField = *dc.get<
-                particles::atomicPhysics::localHelperFields::LocalRateCacheField<picongpu::MappingDesc, IonSpecies>>(
-                IonSpecies::FrameType::getName() + "_localRateCacheField");
+            auto& rateCacheField = *dc.get<
+                particles::atomicPhysics::localHelperFields::RateCacheField<picongpu::MappingDesc, IonSpecies>>(
+                IonSpecies::FrameType::getName() + "_rateCacheField");
 
             // rate cache inits to all zeros
-            localRateCacheField.getDeviceBuffer().setValue(
-                picongpu::particles::atomicPhysics::localHelperFields::RateCache<
-                    picongpu::traits::GetNumberAtomicStates<IonSpecies>::value>());
+            rateCacheField.getDeviceBuffer().setValue(picongpu::particles::atomicPhysics::localHelperFields::RateCache<
+                                                      picongpu::traits::GetNumberAtomicStates<IonSpecies>::value>());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/ResetTimeStepField.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ResetTimeStepField.hpp
@@ -17,13 +17,13 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! @file resetLocalTimeStepField sub-stage of atomicPhysics
+//! @file resetTimeStepField sub-stage of atomicPhysics
 
 #pragma once
 
-#include "picongpu/particles/atomicPhysics/kernel/ResetLocalTimeStepField.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/ResetTimeStepField.kernel"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp"
 
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 
@@ -37,7 +37,7 @@ namespace picongpu::particles::atomicPhysics::stage
      *  atomicPhysics kernels if no atomic physics species is present.
      */
     template<uint32_t T_numberAtomicPhysicsIonSpecies>
-    struct ResetLocalTimeStepField
+    struct ResetTimeStepField
     {
         //! call of kernel for every superCell
         HINLINE void operator()(picongpu::MappingDesc const mappingDesc) const
@@ -47,27 +47,27 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
             // pointers to memory, we will only work on device, no sync required
-            //      pointer to localTimeRemainingField
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
-            //      pointer to localTimeStepFieldField
-            auto& localTimeStepField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeStepField<picongpu::MappingDesc>>(
-                "LocalTimeStepField");
+            //      pointer to timeRemainingField
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
+            //      pointer to timeStepFieldField
+            auto& timeStepField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>>(
+                    "TimeStepField");
 
             // macro for call of kernel
-            PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::ResetLocalTimeStepFieldKernel<
+            PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::ResetTimeStepFieldKernel<
                                       T_numberAtomicPhysicsIonSpecies>())
                 .template config<1u>(mapper.getGridDim())(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localTimeStepField.getDeviceDataBox());
+                    timeRemainingField.getDeviceDataBox(),
+                    timeStepField.getDeviceDataBox());
         }
     };
 
     template<>
-    struct ResetLocalTimeStepField<0u>
+    struct ResetTimeStepField<0u>
     {
         HINLINE void operator()(picongpu::MappingDesc const mappingDesc) const
         {

--- a/include/picongpu/particles/atomicPhysics/stage/RollForOverSubscription.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RollForOverSubscription.hpp
@@ -21,9 +21,9 @@
 
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalElectronHistogramOverSubscribedField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalRejectionProbabilityCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/ElectronHistogramOverSubscribedField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 
 #include <pmacc/particles/meta/FindByNameOrType.hpp>
@@ -61,20 +61,19 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
 
-            auto& localRejectionProbabilityCacheField
-                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::LocalRejectionProbabilityCacheField<
-                    picongpu::MappingDesc>>("LocalRejectionProbabilityCacheField");
+            auto& rejectionProbabilityCacheField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::RejectionProbabilityCacheField<
+                    picongpu::MappingDesc>>("RejectionProbabilityCacheField");
 
-            auto& localElectronHistogramOverSubscribedField
-                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::
-                              LocalElectronHistogramOverSubscribedField<picongpu::MappingDesc>>(
-                    "LocalElectronHistogramOverSubscribedField");
+            auto& electronHistogramOverSubscribedField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
+                    picongpu::MappingDesc>>("ElectronHistogramOverSubscribedField");
 
             RngFactoryFloat rngFactory = RngFactoryFloat{currentStep};
 
@@ -84,10 +83,10 @@ namespace picongpu::particles::atomicPhysics::stage
                 .config(mapper.getGridDim(), ions)(
                     mapper,
                     rngFactory,
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localElectronHistogramOverSubscribedField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
+                    electronHistogramOverSubscribedField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox(),
-                    localRejectionProbabilityCacheField.getDeviceDataBox());
+                    rejectionProbabilityCacheField.getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/SpawnIonizationElectrons.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/SpawnIonizationElectrons.hpp
@@ -30,7 +30,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/param.hpp"
 #include "picongpu/particles/traits/GetIonizationElectronSpecies.hpp"
 
@@ -68,9 +68,9 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
 
             auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
             auto& electrons = *dc.get<IonizationElectronSpecies>(IonizationElectronSpecies::FrameType::getName());
@@ -90,7 +90,7 @@ namespace picongpu::particles::atomicPhysics::stage
                     .config(mapper.getGridDim(), ions)(
                         mapper,
                         idProvider->getDeviceGenerator(),
-                        localTimeRemainingField.getDeviceDataBox(),
+                        timeRemainingField.getDeviceDataBox(),
                         ions.getDeviceParticlesBox(),
                         electrons.getDeviceParticlesBox(),
                         atomicData.template getAtomicStateDataDataBox<false>(),
@@ -110,7 +110,7 @@ namespace picongpu::particles::atomicPhysics::stage
                     dc,
                     mapper,
                     idProvider->getDeviceGenerator(),
-                    localTimeRemainingField.getDeviceDataBox(),
+                    timeRemainingField.getDeviceDataBox(),
                     ions.getDeviceParticlesBox(),
                     electrons.getDeviceParticlesBox(),
                     atomicData.template getAtomicStateDataDataBox<false>(),

--- a/include/picongpu/particles/atomicPhysics/stage/UpdateTimeRemaining.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/UpdateTimeRemaining.hpp
@@ -23,8 +23,8 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/UpdateTimeRemaining.kernel"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeRemainingField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/LocalTimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp"
 
 #include <pmacc/mappings/kernel/AreaMapping.hpp>
 
@@ -49,21 +49,21 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
             // pointers to memory, we will only work on device, no sync required
-            //      pointer to localTimeRemainingField
-            auto& localTimeRemainingField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<picongpu::MappingDesc>>(
-                "LocalTimeRemainingField");
-            //      pointer to localTimeStepFieldField
-            auto& localTimeStepField = *dc.get<
-                picongpu::particles::atomicPhysics::localHelperFields::LocalTimeStepField<picongpu::MappingDesc>>(
-                "LocalTimeStepField");
+            //      pointer to timeRemainingField
+            auto& timeRemainingField = *dc.get<
+                picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>>(
+                "TimeRemainingField");
+            //      pointer to timeStepFieldField
+            auto& timeStepField
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>>(
+                    "TimeStepField");
 
             // macro for kernel call
             PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::UpdateTimeRemainingKernel())
                 .template config<1u>(mapper.getGridDim())(
                     mapper,
-                    localTimeRemainingField.getDeviceDataBox(),
-                    localTimeStepField.getDeviceDataBox());
+                    timeRemainingField.getDeviceDataBox(),
+                    timeStepField.getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/creation/moduleInterfaces/SuperCellFilterFunctor.hpp
+++ b/include/picongpu/particles/creation/moduleInterfaces/SuperCellFilterFunctor.hpp
@@ -28,8 +28,7 @@ namespace picongpu::particles::creation::moduleInterfaces
      * @details functor returning whether entire superCell to should be skipped depending on additionalData or
      * superCell index
      *
-     * @example skip superCell if localTimeRemainingDataBox[additionalDataIndex](dataBox passed via additionalData) is
-     * > 0
+     * @example skip superCell if TimeRemainingDataBox[additionalDataIndex] is > 0, (dataBox passed via additionalData)
      *
      *  @note to skip test, use empty function
      */

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -780,13 +780,13 @@ namespace picongpu
              * - FieldJ
              * - FieldTmp
              * [atomicPhysics:]
-             * - LocalTimeRemainingField
-             * - LocalTimeStepLengthField
+             * - TimeRemainingField
+             * - TimeStepLengthField
              * - LocalHistogramField
-             * - LocalRateCacheField
-             * - LocalElectronHistogramOverSubscribedField
-             * - LocalRejectionProbabilityCacheField
-             * - LocalFoundUnboundIonField
+             * - RateCacheField
+             * - ElectronHistogramOverSubscribedField
+             * - RejectionProbabilityCacheField
+             * - FoundUnboundIonField
              * [IPD:]
              * - LocalIPDSupportField(s)
              * - LocalIPDInputField(s)

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -35,15 +35,15 @@
 #include "picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp"
 #include "picongpu/particles/atomicPhysics/stage/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/stage/DecelerateElectrons.hpp"
-#include "picongpu/particles/atomicPhysics/stage/FillLocalRateCache.hpp"
+#include "picongpu/particles/atomicPhysics/stage/FillRateCache.hpp"
 #include "picongpu/particles/atomicPhysics/stage/FixAtomicState.hpp"
 #include "picongpu/particles/atomicPhysics/stage/LoadAtomicInputData.hpp"
 #include "picongpu/particles/atomicPhysics/stage/RecordChanges.hpp"
 #include "picongpu/particles/atomicPhysics/stage/RecordSuggestedChanges.hpp"
 #include "picongpu/particles/atomicPhysics/stage/ResetAcceptedStatus.hpp"
 #include "picongpu/particles/atomicPhysics/stage/ResetDeltaWeightElectronHistogram.hpp"
-#include "picongpu/particles/atomicPhysics/stage/ResetLocalRateCache.hpp"
-#include "picongpu/particles/atomicPhysics/stage/ResetLocalTimeStepField.hpp"
+#include "picongpu/particles/atomicPhysics/stage/ResetRateCache.hpp"
+#include "picongpu/particles/atomicPhysics/stage/ResetTimeStepField.hpp"
 #include "picongpu/particles/atomicPhysics/stage/RollForOverSubscription.hpp"
 #include "picongpu/particles/atomicPhysics/stage/SpawnIonizationElectrons.hpp"
 #include "picongpu/particles/atomicPhysics/stage/UpdateTimeRemaining.hpp"
@@ -73,7 +73,7 @@ namespace picongpu::simulation::stage
         /** atomic physics stage
          *
          * models excited atomic state and ionization dynamics
-         *
+         *gi
          * @note one instance of this class is initialized and it's operator() called for every time step
          *
          * @tparam T_AtomicPhysicsIonSpecies list of all ion species to partake in the atomicPhysics step
@@ -99,12 +99,12 @@ namespace picongpu::simulation::stage
             using S_LinearizedBox = DataBoxDim1Access<typename T_Field::DataBoxType>;
 
             using S_OverSubscribedField
-                = picongpu::particles::atomicPhysics::localHelperFields::LocalElectronHistogramOverSubscribedField<
+                = picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
                     picongpu::MappingDesc>;
             using S_TimeRemainingField
-                = particles::atomicPhysics::localHelperFields ::LocalTimeRemainingField<picongpu::MappingDesc>;
+                = particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>;
             using S_FoundUnboundField
-                = particles::atomicPhysics::localHelperFields ::LocalFoundUnboundIonField<picongpu::MappingDesc>;
+                = particles::atomicPhysics::localHelperFields::FoundUnboundIonField<picongpu::MappingDesc>;
 
             // species Lists
             //{
@@ -119,11 +119,11 @@ namespace picongpu::simulation::stage
             using IPDIonSpecies = MakeSeq_t<AtomicPhysicsIonSpecies, OnlyIPDIonSpecies>;
             //}
 
-            //! set local timeRemaining to PIC-time step
+            //! set timeRemaining to PIC-time step
             HINLINE static void setTimeRemaining()
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& localTimeRemainingField = *dc.get<S_TimeRemainingField>("LocalTimeRemainingField");
+                auto& localTimeRemainingField = *dc.get<S_TimeRemainingField>("TimeRemainingField");
                 localTimeRemainingField.getDeviceBuffer().setValue(picongpu::sim.pic.getDt()); // sim.unit.time()
             }
 
@@ -131,19 +131,19 @@ namespace picongpu::simulation::stage
             HINLINE static void resetElectronEnergyHistogram()
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& localElectronHistogramField
+                auto& electronHistogramField
                     = *dc.get<particles::atomicPhysics::electronDistribution::LocalHistogramField<
                         picongpu::atomicPhysics::ElectronHistogram,
-                        picongpu::MappingDesc>>("Electron_localHistogramField");
-                localElectronHistogramField.getDeviceBuffer().setValue(picongpu::atomicPhysics::ElectronHistogram());
+                        picongpu::MappingDesc>>("Electron_HistogramField");
+                electronHistogramField.getDeviceBuffer().setValue(picongpu::atomicPhysics::ElectronHistogram());
             }
 
-            //! reset localFoundUnboundIonField on device side
+            //! reset foundUnboundIonField on device side
             HINLINE static void resetFoundUnboundIon()
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& localFoundUnboundIonField = *dc.get<S_FoundUnboundField>("LocalFoundUnboundIonField");
-                localFoundUnboundIonField.getDeviceBuffer().setValue(0._X);
+                auto& foundUnboundIonField = *dc.get<S_FoundUnboundField>("FoundUnboundIonField");
+                foundUnboundIonField.getDeviceBuffer().setValue(0._X);
             };
 
             //! print electron histogram to console, debug only
@@ -154,49 +154,48 @@ namespace picongpu::simulation::stage
                     picongpu::particles::atomicPhysics::electronDistribution::
                         LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>,
                     picongpu::particles::atomicPhysics::electronDistribution::PrintHistogramToConsole<
-                        T_printOnlyOverSubscribed>>{}(mappingDesc, "Electron_localHistogramField");
+                        T_printOnlyOverSubscribed>>{}(mappingDesc, "Electron_HistogramField");
             }
 
-            //! print LocalElectronHistogramOverSubscribedField to console, debug only
+            //! print ElectronHistogramOverSubscribedField to console, debug only
             HINLINE static void printOverSubscriptionFieldToConsole(picongpu::MappingDesc const mappingDesc)
             {
                 picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::LocalElectronHistogramOverSubscribedField<
+                    picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
                         picongpu::MappingDesc>,
                     picongpu::particles::atomicPhysics::localHelperFields::PrintOverSubcriptionFieldToConsole>{}(
                     mappingDesc,
-                    "LocalElectronHistogramOverSubscribedField");
+                    "ElectronHistogramOverSubscribedField");
             }
 
             //! print rejectionProbabilityCache to console, debug only
             HINLINE static void printRejectionProbabilityCacheToConsole(picongpu::MappingDesc const mappingDesc)
             {
                 picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields ::LocalRejectionProbabilityCacheField<
+                    picongpu::particles::atomicPhysics::localHelperFields ::RejectionProbabilityCacheField<
                         picongpu::MappingDesc>,
                     picongpu::particles::atomicPhysics::localHelperFields ::PrintRejectionProbabilityCacheToConsole<
-                        true>>{}(mappingDesc, "LocalRejectionProbabilityCacheField");
+                        true>>{}(mappingDesc, "RejectionProbabilityCacheField");
             }
 
-            //! print local time remaining to console, debug only
-            HINLINE static void printTimeRemaingToConsole(picongpu::MappingDesc const mappingDesc)
+            //! print time remaining to console, debug only
+            HINLINE static void printTimeRemaingToConsole(picongpu::MappingDesc const& mappingDesc)
             {
                 picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::LocalTimeRemainingField<
-                        picongpu::MappingDesc>,
+                    picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>,
                     picongpu::particles::atomicPhysics::localHelperFields::PrintTimeRemaingToConsole>{}(
                     mappingDesc,
-                    "LocalTimeRemainingField");
+                    "TimeRemainingField");
             }
 
             //! print local time step to console, debug only
             HINLINE static void printTimeStepToConsole(picongpu::MappingDesc const mappingDesc)
             {
                 picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::LocalTimeStepField<picongpu::MappingDesc>,
+                    picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>,
                     picongpu::particles::atomicPhysics::localHelperFields::PrintTimeStepToConsole>{}(
                     mappingDesc,
-                    "LocalTimeStepField");
+                    "TimeStepField");
             }
 
             void resetAcceptStatus(picongpu::MappingDesc const& mappingDesc) const
@@ -245,18 +244,17 @@ namespace picongpu::simulation::stage
             //! reset each superCell's time step
             void resetTimeStep(picongpu::MappingDesc const& mappingDesc) const
             {
-                // timeStep = localTimeRemaining
-                picongpu::particles::atomicPhysics::stage::ResetLocalTimeStepField<T_numberAtomicPhysicsIonSpecies>()(
+                // timeStep = timeRemaining
+                picongpu::particles::atomicPhysics::stage::ResetTimeStepField<T_numberAtomicPhysicsIonSpecies>()(
                     mappingDesc);
             }
 
             //! reset each superCell's rate cache
             void resetRateCache() const
             {
-                using ForEachIonSpeciesResetLocalRateCache = pmacc::meta::ForEach<
-                    AtomicPhysicsIonSpecies,
-                    particles::atomicPhysics::stage::ResetLocalRateCache<boost::mpl::_1>>;
-                ForEachIonSpeciesResetLocalRateCache{}();
+                using ForEachIonSpeciesResetRateCache = pmacc::meta::
+                    ForEach<AtomicPhysicsIonSpecies, particles::atomicPhysics::stage::ResetRateCache<boost::mpl::_1>>;
+                ForEachIonSpeciesResetRateCache{}();
             }
 
             //! check which atomic states are actually present in each superCell
@@ -270,10 +268,9 @@ namespace picongpu::simulation::stage
             //! fill each superCell's rate cache
             void fillRateCache(picongpu::MappingDesc const& mappingDesc) const
             {
-                using ForEachIonSpeciesFillLocalRateCache = pmacc::meta::ForEach<
-                    AtomicPhysicsIonSpecies,
-                    particles::atomicPhysics::stage::FillLocalRateCache<boost::mpl::_1>>;
-                ForEachIonSpeciesFillLocalRateCache{}(mappingDesc);
+                using ForEachIonSpeciesFillRateCache = pmacc::meta::
+                    ForEach<AtomicPhysicsIonSpecies, particles::atomicPhysics::stage::FillRateCache<boost::mpl::_1>>;
+                ForEachIonSpeciesFillRateCache{}(mappingDesc);
 
                 using ForEachIonSpeciesDumpRateCacheToConsole = pmacc::meta::ForEach<
                     AtomicPhysicsIonSpecies,
@@ -397,9 +394,9 @@ namespace picongpu::simulation::stage
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-                auto& localFoundUnboundIonField = *dc.get<S_FoundUnboundField>("LocalFoundUnboundIonField");
+                auto& foundUnboundIonField = *dc.get<S_FoundUnboundField>("FoundUnboundIonField");
                 DataSpace<picongpu::simDim> const fieldGridLayoutFoundUnbound
-                    = localFoundUnboundIonField.getGridLayout().sizeWithoutGuardND();
+                    = foundUnboundIonField.getGridLayout().sizeWithoutGuardND();
 
                 // pressure ionization loop, ends when no ion in unbound state anymore
                 bool foundUnbound = true;
@@ -415,7 +412,7 @@ namespace picongpu::simulation::stage
                         currentStep);
 
                     auto linearizedFoundUnboundIonBox = S_LinearizedBox<S_FoundUnboundField>(
-                        localFoundUnboundIonField.getDeviceDataBox(),
+                        foundUnboundIonField.getDeviceDataBox(),
                         fieldGridLayoutFoundUnbound);
 
                     foundUnbound = static_cast<bool>(deviceReduce(
@@ -437,7 +434,7 @@ namespace picongpu::simulation::stage
             bool isSubSteppingFinished(picongpu::MappingDesc const& mappingDesc, T_DeviceReduce& deviceReduce) const
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& localTimeRemainingField = *dc.get<S_TimeRemainingField>("LocalTimeRemainingField");
+                auto& localTimeRemainingField = *dc.get<S_TimeRemainingField>("TimeRemainingField");
                 DataSpace<picongpu::simDim> const fieldGridLayoutTimeRemaining
                     = localTimeRemainingField.getGridLayout().sizeWithoutGuardND();
 
@@ -461,7 +458,7 @@ namespace picongpu::simulation::stage
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
                 auto& perSuperCellElectronHistogramOverSubscribedField
-                    = *dc.get<S_OverSubscribedField>("LocalElectronHistogramOverSubscribedField");
+                    = *dc.get<S_OverSubscribedField>("ElectronHistogramOverSubscribedField");
 
                 /// @todo find better way than hard code old value, Brian Marre, 2023
                 // `static` avoids that reduce is allocating each time step memory, which will reduce the performance.


### PR DESCRIPTION
removes the `local` name qualifier from all FLYonPIC(AtomicPhysics) local helper field names.