### PR TITLE
Switch AtomicPhysics(FLYonPIC) to constant field in Cell

### DIFF
--- a/include/picongpu/particles/atomicPhysics/KernelIndexation.hpp
+++ b/include/picongpu/particles/atomicPhysics/KernelIndexation.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need dimensions.param
+#include "picongpu/defines.hpp"
+
+namespace picongpu::particles::atomicPhysics
+{
+    //! short hand methods for getting dataBox access indices in atomicPhysics from kernels
+    struct KernelIndexation
+    {
+        /** get index of superCell corresponding of the worker
+         *
+         * @attention assumes that the kernel was launched for CORE+BORDER Region
+         */
+        template<typename T_Worker, typename T_AreaMapping>
+        HDINLINE static pmacc::DataSpace<picongpu::simDim> getSuperCellIndex(
+            T_Worker const& worker,
+            T_AreaMapping const areaMapping)
+        {
+            static_assert(T_AreaMapping::AreaType == CORE + BORDER, "kernel area needs to be CORE+BORDER");
+
+            return areaMapping.getSuperCellIndex(worker.blockDomIdxND());
+        }
+
+        /** get index of SuperCellField entry corresponding to the worker
+         *
+         * @attention assumes that the kernel was launched for CORE+BORDER Region
+         */
+        template<typename T_Worker, typename T_AreaMapping>
+        HDINLINE static pmacc::DataSpace<picongpu::simDim> getSuperCellFieldIndex(
+            T_Worker const& worker,
+            T_AreaMapping const areaMapping)
+        {
+            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
+            //  -> must subtract guard to get correct superCellFieldIdx
+            return getSuperCellIndex(worker, areaMapping) - areaMapping.getGuardingSuperCells();
+        }
+
+        /** get index of SuperCellField entry corresponding to the worker
+         *
+         * @details version for already known superCellIndex
+         * @attention assumes that the kernel was launched for CORE+BORDER Region
+         */
+        template<typename T_Worker, typename T_AreaMapping>
+        HDINLINE static pmacc::DataSpace<picongpu::simDim> getSuperCellFieldIndex(
+            T_Worker const& worker,
+            T_AreaMapping const areaMapping,
+            pmacc::DataSpace<picongpu::simDim> const superCellIndex)
+        {
+            static_assert(T_AreaMapping::AreaType == CORE + BORDER, "kernel area needs to be CORE+BORDER");
+
+            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
+            //  -> must subtract guard to get correct superCellFieldIdx
+            return superCellIndex - areaMapping.getGuardingSuperCells();
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -19,22 +19,18 @@
 
 #pragma once
 
-#include "picongpu/algorithms/AssignedTrilinearInterpolation.hpp"
-#include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
 #include "picongpu/defines.hpp"
-#include "picongpu/fields/YeeCell.hpp"
 #include "picongpu/particles/atomicPhysics/CheckForInvalidChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
-#include "picongpu/particles/shapes.hpp"
-#include "picongpu/traits/FieldPosition.hpp"
-#include "picongpu/traits/GetMargin.hpp"
 
+#include <pmacc/dimensions/DataSpace.hpp>
 #include <pmacc/dimensions/SuperCellDescription.hpp>
 #include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/mappings/threads/ThreadCollective.hpp>
@@ -46,6 +42,7 @@
 #include <pmacc/static_assert.hpp>
 
 #include <cstdint>
+#include <limits>
 
 namespace picongpu::particles::atomicPhysics::kernel
 {
@@ -69,6 +66,29 @@ namespace picongpu::particles::atomicPhysics::kernel
         typename T_IPDModel>
     struct ChooseTransitionKernel_FieldBoundFree
     {
+        using S_VectorIdx = pmacc::DataSpace<picongpu::simDim>;
+
+    private:
+        //! @attention this is a collective method and implicitly synchronises
+        template<typename BlockDescription, typename T_Worker, typename T_EFieldBox, typename T_EfieldCache>
+        HDINLINE void initEFieldCache(
+            T_Worker const& worker,
+            S_VectorIdx const superCellIdx,
+            S_VectorIdx const superCellSize,
+            T_EFieldBox const eFieldBox,
+            T_EfieldCache& eFieldCache) const
+        {
+            S_VectorIdx const superCellCellOffset = superCellIdx * superCellSize;
+
+            auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
+
+            pmacc::math::operation::Assign assign;
+            auto collective = makeThreadCollective<BlockDescription>();
+
+            collective(worker, assign, eFieldCache, fieldEBlockToCache);
+            worker.sync();
+        }
+
         template<
             typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
             typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
@@ -93,6 +113,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             return true;
         }
 
+    public:
         /** call operator
          *
          * called by ChooseTransition atomic physics sub-stage
@@ -148,65 +169,32 @@ namespace picongpu::particles::atomicPhysics::kernel
                           T_AtomicStateBoundFreeNumberTransitionsDataBox,
                           T_BoundFreeTransitionDataBox>());
 
-            pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
-            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
-            //  -> must subtract guard to get correct superCellFieldIdx
-            pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
-                = superCellIdx - areaMapping.getGuardingSuperCells();
+            S_VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
+            S_VectorIdx const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
-            // end kernel if superCell already finished or no particles
             if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
                 return;
 
+            using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
+            S_VectorIdx const superCellSize = picongpu::SuperCellSize::toRT();
+            /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
+            auto eFieldCache = CachedBox::create</* Id */ 0u, typename T_EField::ValueType>(worker, SuperCellBlock());
+            initEFieldCache<SuperCellBlock>(worker, superCellIdx, superCellSize, eFieldBox, eFieldCache);
+
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
             auto& rateCache = rateCacheBox(superCellFieldIdx);
-
-            // FLYonPIC superCells must be independent therefore we need to use a support 1 particle shape
-            using Field2Particle
-                = FieldToParticleInterpolation<particles::shapes::CIC, AssignedTrilinearInterpolation>;
-            using Margin = picongpu::traits::GetMargin<Field2Particle>;
-            using BlockArea
-                = SuperCellDescription<typename picongpu::SuperCellSize, Margin::LowerMargin, Margin::UpperMargin>;
-
-            /// create E-Field cache, @note is unique for kernel call by id and dataType, and thereby shared between
-            /// workers
-            DataBox<SharedBox<typename T_EField::ValueType, typename BlockArea::FullSuperCellSize, 0u>> eFieldCache
-                = CachedBox::create<0u, typename T_EField::ValueType>(worker, BlockArea());
-
-            // init E-Field cache
-            auto const superCellSize = picongpu::SuperCellSize::toRT();
-            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * superCellSize;
-            auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
-            pmacc::math::operation::Assign assign;
-            auto collective = makeThreadCollective<BlockArea>();
-            collective(worker, assign, eFieldCache, fieldEBlockToCache);
-
-            // wait for init to finish
-            worker.sync();
 
             float_X const ionizationPotentialDepression
                 = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
                     superCellFieldIdx,
                     ipdInput...);
 
-            auto const fieldPosE = picongpu::traits::FieldPosition<fields::YeeCell, FieldE>();
-
-            // check whether field bound-free transition and if yes, roll specific transition
             forEachLocalIonBoxEntry(
-                [&superCellSize,
-                 &fieldPosE,
-                 &rngGeneratorFloat,
-                 &chargeStateDataDataBox,
-                 &atomicStateDataDataBox,
-                 &numberTransitionsBox,
-                 &startIndexBox,
-                 &transitionDataBox,
-                 &eFieldCache,
-                 &rateCache,
-                 &ionizationPotentialDepression](T_Worker const& worker, auto& ion)
+                [&](T_Worker const& worker, auto& ion)
                 {
                     // debug
                     checkForInvalidChooseTransitionGroup(ion);
@@ -217,13 +205,11 @@ namespace picongpu::particles::atomicPhysics::kernel
                     if(ion[accepted_] || !selectedFieldBoundFreeUpwardTransition)
                         return;
 
-                    auto const ionPosition = ion[position_];
                     auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
 
-                    DataSpace<picongpu::SuperCellSize::dim> const localCell
+                    S_VectorIdx const localCellIndex
                         = pmacc::math::mapToND(superCellSize, static_cast<int>(ion[localCellIdx_]));
-                    float_X const eFieldNormAtParticle = pmacc::math::l2norm(
-                        Field2Particle()(eFieldCache.shift(localCell), ionPosition, fieldPosE()));
+                    float_X const eFieldNormCell = pmacc::math::l2norm(eFieldCache(localCellIndex));
 
                     // get possible transitions' collectionIndices
                     uint32_t const numberTransitions
@@ -242,7 +228,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         // 1/picongpu::sim.unit.time()
                         float_X const rateTransition = atomicPhysics::rateCalculation::
                             BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
-                                eFieldNormAtParticle,
+                                eFieldNormCell,
                                 ionizationPotentialDepression,
                                 transitionCollectionIndex,
                                 chargeStateDataDataBox,
@@ -268,8 +254,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     }
 
                     /* particle position maximum rate below superCell maximum -> need to do noChange Transition for
-                     *  correct division into other channels.
-                     */
+                     *  correct division into other channels. */
                     ion[processClass_] = u8(s_enums::ProcessClass::noChange);
                     // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
                     //  and accepted_ = true prevents it being worked on by ChooseTransitionKernels

--- a/include/pmacc/memory/boxes/SharedBox.hpp
+++ b/include/pmacc/memory/boxes/SharedBox.hpp
@@ -90,7 +90,7 @@ namespace pmacc
         /** get value at the given index
          *
          * @tparam T_MemoryIdxType Index type
-         * @param idx n-dimansional offset relative to the origin pointer
+         * @param idx n-dimensional offset relative to the origin pointer
          * @return reference to the value
          * @{
          */
@@ -111,7 +111,7 @@ namespace pmacc
         /** create a shared memory box
          *
          * This call synchronizes a block and must be called from all threads and
-         * not inside a if clauses
+         * not inside if clauses
          */
         template<typename T_Worker>
         DINLINE static SharedBox init(T_Worker const& worker)


### PR DESCRIPTION
Switches the ChooseTransition kernel to the constant E-Field in a cell approximation.

This PR is necessary for the for the implementation of energy conservation in AtomicPhysics(FLYonPIC) field ionization.

- [x] requires PR #5194 to be merged first
- [x] requires PR #5196 to be merged first
- [x] must be rebased to dev