### PR TITLE
Refactor atomic physics debug

### DIFF
--- a/include/picongpu/param/atomicPhysics_Debug.param
+++ b/include/picongpu/param/atomicPhysics_Debug.param
@@ -78,7 +78,6 @@ namespace picongpu::atomicPhysics::debug
         constexpr bool TRANSITION_DATA_SET_INDEX_RANGE_CHECKS = false;
     } // namespace rateCache
 
-
     namespace rejectionProbabilityCache
     {
         //! @attention only useful if using serial backend, no output unless compiling for cpu backend
@@ -88,20 +87,17 @@ namespace picongpu::atomicPhysics::debug
         constexpr bool BIN_INDEX_RANGE_CHECK = false;
     } // namespace rejectionProbabilityCache
 
-
     namespace timeRemaining
     {
         //! @attention no output unless compiling for cpu backend
         constexpr bool PRINT_TO_CONSOLE = false;
     } // namespace timeRemaining
 
-
     namespace timeStep
     {
         //! @attention no output unless compiling for cpu backend
         constexpr bool PRINT_TO_CONSOLE = false;
     } // namespace timeStep
-
 
     namespace initIonizationElectrons
     {
@@ -123,7 +119,6 @@ namespace picongpu::atomicPhysics::debug
         };
     } // namespace scFlyComparison
 
-
     namespace kernel::calculateTimeStep
     {
         //! @attention performance relevant
@@ -137,6 +132,12 @@ namespace picongpu::atomicPhysics::debug
         //! @attention performance relevant
         constexpr bool CHECK_FOR_OVERFLOWS_IN_ACCUMULATON = false;
     } // namespace kernel::chooseTransition
+
+    namespace kernel::recordSuggestedChanges
+    {
+        //! @attention only useful if using serial backend, no output unless compiling for cpu backend
+        constexpr bool PRINT_DEBUG_TO_CONSOLE = false;
+    } // namespace kernel::recordSuggestedChanges
 
     namespace kernel::rollForOverSubscription
     {

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp
@@ -33,14 +33,24 @@
 
 namespace picongpu::particles::atomicPhysics::electronDistribution
 {
-    /** debug only, print content and bins of histogram to console
-     *
-     * @attention only creates output if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
-     * @attention only useful if compiling for serial backend, otherwise output for different histograms will
-     * interleave
-     */
-    template<bool printOnlyOverSubscribed>
-    struct PrintHistogramToConsole
+    namespace enums
+    {
+        enum struct BinSelection : uint8_t
+        {
+            onlyOverSubscribedBins,
+            allBins
+        };
+    } // namespace enums
+    namespace enums
+
+        /** debug only, print content and bins of histogram to console
+         *
+         * @attention only creates output if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
+         * @attention only useful if compiling for serial backend, otherwise output for different histograms will
+         * interleave
+         */
+        template<BinSelection T_BinSelection>
+        struct PrintHistogramToConsole
     {
         //! cpu version
         template<typename T_Acc, typename T_Histogram>
@@ -63,7 +73,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
 
             for(uint32_t i = 0u; i < numBins; i++)
             {
-                if constexpr(printOnlyOverSubscribed)
+                if constexpr(u8(T_BinSelection) == u8(enums::BinSelection::onlyOverSubscribed))
                 {
                     if(histogram.getBinWeight0(i) >= histogram.getBinDeltaWeight(i))
                         continue;
@@ -97,7 +107,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
             -> std::enable_if_t<!std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
         }
-    };
+    }; // namespace PrintHistogramToConsole
 
     /** holds a gridBuffer of the per-superCell histograms for atomicPhysics
      *

--- a/include/picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp
+++ b/include/picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp
@@ -37,20 +37,19 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
     {
         enum struct BinSelection : uint8_t
         {
-            onlyOverSubscribedBins,
-            allBins
+            OnlyOverSubscribed,
+            All
         };
     } // namespace enums
-    namespace enums
 
-        /** debug only, print content and bins of histogram to console
-         *
-         * @attention only creates output if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
-         * @attention only useful if compiling for serial backend, otherwise output for different histograms will
-         * interleave
-         */
-        template<BinSelection T_BinSelection>
-        struct PrintHistogramToConsole
+    /** debug only, print content and bins of histogram to console
+     *
+     * @attention only creates output if atomicPhysics debug setting CPU_OUTPUT_ACTIVE == True
+     * @attention only useful if compiling for serial backend, otherwise output for different histograms will
+     * interleave
+     */
+    template<enums::BinSelection T_BinSelection>
+    struct PrintHistogramToConsole
     {
         //! cpu version
         template<typename T_Acc, typename T_Histogram>
@@ -73,7 +72,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
 
             for(uint32_t i = 0u; i < numBins; i++)
             {
-                if constexpr(u8(T_BinSelection) == u8(enums::BinSelection::onlyOverSubscribed))
+                if constexpr(T_BinSelection == enums::BinSelection::OnlyOverSubscribed)
                 {
                     if(histogram.getBinWeight0(i) >= histogram.getBinDeltaWeight(i))
                         continue;
@@ -107,7 +106,7 @@ namespace picongpu::particles::atomicPhysics::electronDistribution
             -> std::enable_if_t<!std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
         {
         }
-    }; // namespace PrintHistogramToConsole
+    };
 
     /** holds a gridBuffer of the per-superCell histograms for atomicPhysics
      *

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -70,6 +70,18 @@ namespace picongpu::simulation::stage
 {
     namespace detail
     {
+        namespace enums
+        {
+            enum struct Loop : uint8_t
+            {
+                SubStep,
+                ChooseTransition,
+                RejectOverSubscription
+            };
+        } // namespace enums
+
+        namespace debug = picongpu::atomicPhysics::debug;
+
         /** atomic physics stage
          *
          * models excited atomic state and ionization dynamics
@@ -96,15 +108,17 @@ namespace picongpu::simulation::stage
         private:
             // linearized dataBox of SuperCellField
             template<typename T_Field>
-            using S_LinearizedBox = DataBoxDim1Access<typename T_Field::DataBoxType>;
+            using LinearizedBox = DataBoxDim1Access<typename T_Field::DataBoxType>;
 
-            using S_OverSubscribedField
+            using OverSubscribedField
                 = picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
                     picongpu::MappingDesc>;
-            using S_TimeRemainingField
+            using TimeRemainingField
                 = particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>;
-            using S_FoundUnboundField
+            using FoundUnboundField
                 = particles::atomicPhysics::localHelperFields::FoundUnboundIonField<picongpu::MappingDesc>;
+
+            using BinSelection = picongpu::particles::atomicPhysics::electronDistribution::enums::BinSelection;
 
             //! species lists
             //!@{
@@ -122,67 +136,87 @@ namespace picongpu::simulation::stage
             //! debug print to console
             //!@{
 
-            //! print electron histogram to console, debug only
-            template<picongpu::particles::atomicPhysics::electronDistribution::enums::BinSelection T_BinSelection>
-            HINLINE static void printHistogramToConsole(picongpu::MappingDesc const& mappingDesc)
+            //! control multiple location debug prints depending on debug output setting
+            template<enums::Loop T_Loop>
+            static constexpr bool debugPrintActive()
             {
-                picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::electronDistribution::
-                        LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>,
-                    picongpu::particles::atomicPhysics::electronDistribution::PrintHistogramToConsole<
-                        T_BinSelection>>{}(mappingDesc, "Electron_HistogramField");
+                constexpr bool isSubStepLoop = (T_Loop == enums::Loop::SubStep);
+                constexpr bool isChooseTransition = (T_Loop == enums::Loop::ChooseTransition);
+                constexpr bool isRejectOverSubscription = (T_Loop == enums::Loop::RejectOverSubscription);
+
+                constexpr bool isActive = (isSubStepLoop)
+                    || (isChooseTransition && debug::kernel::recordSuggestedChanges::PRINT_DEBUG_TO_CONSOLE)
+                    || (isRejectOverSubscription && debug::kernel::rollForOverSubscription::PRINT_DEBUG_TO_CONSOLE);
+
+                return isActive;
+            }
+
+            //! print electron histogram to console, debug only
+            template<BinSelection T_BinSelection, enums::Loop T_Loop>
+            HINLINE static void printHistogramToConsole(picongpu::MappingDesc const& mappingDesc, std::string name)
+            {
+                constexpr bool printActive = debug::electronHistogram::PRINT_TO_CONSOLE && debugPrintActive<T_Loop>();
+                if constexpr(printActive)
+                {
+                    std::cout << name << std::endl;
+                    picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
+                        picongpu::particles::atomicPhysics::electronDistribution::
+                            LocalHistogramField<picongpu::atomicPhysics::ElectronHistogram, picongpu::MappingDesc>,
+                        picongpu::particles::atomicPhysics::electronDistribution::PrintHistogramToConsole<
+                            T_BinSelection>>{}(mappingDesc, "Electron_HistogramField");
+                }
             }
 
             //! print ElectronHistogramOverSubscribedField to console, debug only
             HINLINE static void printOverSubscriptionFieldToConsole(picongpu::MappingDesc const& mappingDesc)
             {
-                picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
-                        picongpu::MappingDesc>,
-                    picongpu::particles::atomicPhysics::localHelperFields::PrintOverSubcriptionFieldToConsole>{}(
-                    mappingDesc,
-                    "ElectronHistogramOverSubscribedField");
+                if constexpr(debug::rejectionProbabilityCache::PRINT_TO_CONSOLE)
+                    picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
+                        picongpu::particles::atomicPhysics::localHelperFields::ElectronHistogramOverSubscribedField<
+                            picongpu::MappingDesc>,
+                        picongpu::particles::atomicPhysics::localHelperFields::PrintOverSubcriptionFieldToConsole>{}(
+                        mappingDesc,
+                        "ElectronHistogramOverSubscribedField");
             }
 
             //! print rejectionProbabilityCache to console, debug only
             HINLINE static void printRejectionProbabilityCacheToConsole(picongpu::MappingDesc const& mappingDesc)
             {
-                picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields ::RejectionProbabilityCacheField<
-                        picongpu::MappingDesc>,
-                    picongpu::particles::atomicPhysics::localHelperFields ::PrintRejectionProbabilityCacheToConsole<
-                        true>>{}(mappingDesc, "RejectionProbabilityCacheField");
+                if constexpr(debug::rejectionProbabilityCache::PRINT_TO_CONSOLE)
+                {
+                    picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
+                        picongpu::particles::atomicPhysics::localHelperFields ::RejectionProbabilityCacheField<
+                            picongpu::MappingDesc>,
+                        picongpu::particles::atomicPhysics::localHelperFields ::
+                            PrintRejectionProbabilityCacheToConsole<true>>{}(
+                        mappingDesc,
+                        "RejectionProbabilityCacheField");
+                }
             }
 
             //! print local time remaining to console, debug only
             HINLINE static void printTimeRemainingToConsole(picongpu::MappingDesc const& mappingDesc)
             {
-                picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<picongpu::MappingDesc>,
-                    picongpu::particles::atomicPhysics::localHelperFields::PrintTimeRemaingToConsole>{}(
-                    mappingDesc,
-                    "TimeRemainingField");
+                if constexpr(debug::timeRemaining::PRINT_TO_CONSOLE)
+                {
+                    picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
+                        picongpu::particles::atomicPhysics::localHelperFields::TimeRemainingField<
+                            picongpu::MappingDesc>,
+                        picongpu::particles::atomicPhysics::localHelperFields::PrintTimeRemaingToConsole>{}(
+                        mappingDesc,
+                        "TimeRemainingField");
+                }
             }
 
             //! print local time step to console, debug only
             HINLINE static void printTimeStepToConsole(picongpu::MappingDesc const& mappingDesc)
             {
-                picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>,
-                    picongpu::particles::atomicPhysics::localHelperFields::PrintTimeStepToConsole>{}(
-                    mappingDesc,
-                    "TimeStepField");
-            }
-
-            //! print local fieldEnergyUseCache to console, debug only
-            HINLINE static void printFieldEnergyUseCacheToConsole(picongpu::MappingDesc const& mappingDesc)
-            {
-                picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                    picongpu::particles::atomicPhysics::localHelperFields::FieldEnergyUseCacheField<
-                        picongpu::MappingDesc>,
-                    picongpu::particles::atomicPhysics::localHelperFields::PrintFieldEnergyUseCacheToConsole>{}(
-                    mappingDesc,
-                    "FieldEnergyUseCacheField");
+                if constexpr(debug::timeStep::PRINT_TO_CONSOLE)
+                    picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
+                        picongpu::particles::atomicPhysics::localHelperFields::TimeStepField<picongpu::MappingDesc>,
+                        picongpu::particles::atomicPhysics::localHelperFields::PrintTimeStepToConsole>{}(
+                        mappingDesc,
+                        "TimeStepField");
             }
             //!@}
 
@@ -190,7 +224,7 @@ namespace picongpu::simulation::stage
             HINLINE static void setTimeRemaining()
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& localTimeRemainingField = *dc.get<S_TimeRemainingField>("TimeRemainingField");
+                auto& localTimeRemainingField = *dc.get<TimeRemainingField>("TimeRemainingField");
                 localTimeRemainingField.getDeviceBuffer().setValue(picongpu::sim.pic.getDt()); // sim.unit.time()
             }
 
@@ -209,7 +243,7 @@ namespace picongpu::simulation::stage
             HINLINE static void resetFoundUnboundIon()
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& foundUnboundIonField = *dc.get<S_FoundUnboundField>("FoundUnboundIonField");
+                auto& foundUnboundIonField = *dc.get<FoundUnboundField>("FoundUnboundIonField");
                 foundUnboundIonField.getDeviceBuffer().setValue(0._X);
             };
 
@@ -224,7 +258,7 @@ namespace picongpu::simulation::stage
 
             HINLINE static void debugForceConstantElectronTemperature([[maybe_unused]] uint32_t const currentStep)
             {
-                if constexpr(picongpu::atomicPhysics::debug::scFlyComparison::FORCE_CONSTANT_ELECTRON_TEMPERATURE)
+                if constexpr(debug::scFlyComparison::FORCE_CONSTANT_ELECTRON_TEMPERATURE)
                 {
                     using ForEachElectronSpeciesSetTemperature = pmacc::meta::ForEach<
                         AtomicPhysicsElectronSpecies,
@@ -241,11 +275,7 @@ namespace picongpu::simulation::stage
                     particles::atomicPhysics::stage::BinElectrons<boost::mpl::_1>>;
                 ForEachElectronSpeciesBinElectrons{}(mappingDesc);
 
-                if constexpr(picongpu::atomicPhysics::debug::electronHistogram::PRINT_TO_CONSOLE)
-                {
-                    using BinSelection = picongpu::particles::atomicPhysics::electronDistribution::BinSelection;
-                    printHistogramToConsole<BinSelection::allBins>(mappingDesc);
-                }
+                printHistogramToConsole<BinSelection::All, enums::Loop::SubStep>(mappingDesc, "[after binning]");
             }
 
             //! calculate ionization potential depression parameters for every superCell
@@ -292,7 +322,7 @@ namespace picongpu::simulation::stage
                     AtomicPhysicsIonSpecies,
                     particles::atomicPhysics::stage::DumpRateCacheToConsole<boost::mpl::_1>>;
 
-                if constexpr(picongpu::atomicPhysics::debug::rateCache::PRINT_TO_CONSOLE)
+                if constexpr(debug::rateCache::PRINT_TO_CONSOLE)
                     ForEachIonSpeciesDumpRateCacheToConsole{}(mappingDesc);
             }
 
@@ -331,7 +361,7 @@ namespace picongpu::simulation::stage
             }
 
             // check if an electron histogram bin () is over subscription --> superCellOversubScriptionField
-            template<typename T_SuperCellOversubScriptionField, typename T_DeviceReduce>
+            template<enums::Loop T_Loop, typename T_SuperCellOversubScriptionField, typename T_DeviceReduce>
             HINLINE static bool isAnElectronHistogramOverSubscribed(
                 picongpu::MappingDesc const& mappingDesc,
                 T_SuperCellOversubScriptionField& perSuperCellElectronHistogramOverSubscribedField,
@@ -343,7 +373,7 @@ namespace picongpu::simulation::stage
                 picongpu::particles::atomicPhysics::stage::CheckForOverSubscription<T_numberAtomicPhysicsIonSpecies>{}(
                     mappingDesc);
 
-                auto linearizedOverSubscribedBox = S_LinearizedBox<S_OverSubscribedField>(
+                auto linearizedOverSubscribedBox = LinearizedBox<OverSubscribedField>(
                     perSuperCellElectronHistogramOverSubscribedField.getDeviceDataBox(),
                     fieldGridLayoutOverSubscription);
 
@@ -351,17 +381,17 @@ namespace picongpu::simulation::stage
                     pmacc::math::operation::Or(),
                     linearizedOverSubscribedBox,
                     fieldGridLayoutOverSubscription.productOfComponents()));
-                // debug only
-                if constexpr(picongpu::atomicPhysics::debug::rejectionProbabilityCache::PRINT_TO_CONSOLE)
-                {
-                    std::cout << "\t\t a histogram oversubscribed?: " << (isOverSubscribed ? "true" : "false")
-                              << std::endl;
 
-                    printOverSubscriptionFieldToConsole(mappingDesc);
-                    printRejectionProbabilityCacheToConsole(mappingDesc);
-                    using BinSelection = picongpu::particles::atomicPhysics::electronDistribution::BinSelection;
-                    printHistogramToConsole<BinSelection::onlyOverSubscribedBins>(mappingDesc);
+                // debug only
+                std::string message;
+                if constexpr(debugPrintActive<T_Loop>())
+                {
+                    message += "[histogram oversubscribed?]: ";
+                    message += (isOverSubscribed ? "true" : "false");
                 }
+                printHistogramToConsole<BinSelection::OnlyOverSubscribed, T_Loop>(mappingDesc, message);
+                printOverSubscriptionFieldToConsole(mappingDesc);
+                printRejectionProbabilityCacheToConsole(mappingDesc);
 
                 // check whether a least one histogram is oversubscribed
                 return isOverSubscribed;
@@ -411,7 +441,7 @@ namespace picongpu::simulation::stage
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-                auto& foundUnboundIonField = *dc.get<S_FoundUnboundField>("FoundUnboundIonField");
+                auto& foundUnboundIonField = *dc.get<FoundUnboundField>("FoundUnboundIonField");
                 DataSpace<picongpu::simDim> const fieldGridLayoutFoundUnbound
                     = foundUnboundIonField.getGridLayout().sizeWithoutGuardND();
 
@@ -428,7 +458,7 @@ namespace picongpu::simulation::stage
                         mappingDesc,
                         currentStep);
 
-                    auto linearizedFoundUnboundIonBox = S_LinearizedBox<S_FoundUnboundField>(
+                    auto linearizedFoundUnboundIonBox = LinearizedBox<FoundUnboundField>(
                         foundUnboundIonField.getDeviceDataBox(),
                         fieldGridLayoutFoundUnbound);
 
@@ -453,11 +483,11 @@ namespace picongpu::simulation::stage
                 T_DeviceReduce& deviceReduce)
             {
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
-                auto& localTimeRemainingField = *dc.get<S_TimeRemainingField>("TimeRemainingField");
+                auto& localTimeRemainingField = *dc.get<TimeRemainingField>("TimeRemainingField");
                 DataSpace<picongpu::simDim> const fieldGridLayoutTimeRemaining
                     = localTimeRemainingField.getGridLayout().sizeWithoutGuardND();
 
-                auto linearizedTimeRemainingBox = S_LinearizedBox<S_TimeRemainingField>(
+                auto linearizedTimeRemainingBox = LinearizedBox<TimeRemainingField>(
                     localTimeRemainingField.getDeviceDataBox(),
                     fieldGridLayoutTimeRemaining);
 
@@ -477,7 +507,7 @@ namespace picongpu::simulation::stage
                 pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
                 auto& perSuperCellElectronHistogramOverSubscribedField
-                    = *dc.get<S_OverSubscribedField>("ElectronHistogramOverSubscribedField");
+                    = *dc.get<OverSubscribedField>("ElectronHistogramOverSubscribedField");
 
                 /// @todo find better way than hard code old value, Brian Marre, 2023
                 // `static` avoids that reduce is allocating each time step memory, which will reduce the performance.
@@ -511,7 +541,7 @@ namespace picongpu::simulation::stage
                         chooseTransition(mappingDesc, currentStep);
                         recordSuggestedChanges(mappingDesc);
 
-                        bool isOverSubscribed = isAnElectronHistogramOverSubscribed(
+                        bool isOverSubscribed = isAnElectronHistogramOverSubscribed<enums::Loop::ChooseTransition>(
                             mappingDesc,
                             perSuperCellElectronHistogramOverSubscribedField,
                             deviceLocalReduce);
@@ -520,33 +550,22 @@ namespace picongpu::simulation::stage
                         while(isOverSubscribed)
                         {
                             // at least one superCell electron histogram over-subscribed
-
-                            // debug only
-                            if constexpr(picongpu::atomicPhysics::debug::kernel::rollForOverSubscription::
-                                             PRINT_DEBUG_TO_CONSOLE)
-                            {
-                                printOverSubscriptionFieldToConsole(mappingDesc);
-                                printHistogramToConsole<onlyOverSubscribedBins>(mappingDesc);
-
-                                if constexpr(picongpu::atomicPhysics::debug::rejectionProbabilityCache::
-                                                 PRINT_TO_CONSOLE)
-                                    printRejectionProbabilityCacheToConsole(mappingDesc);
-                            }
-
                             randomlyRejectTransitionFromOverSubscribedBins(mappingDesc, currentStep);
                             recordSuggestedChanges(mappingDesc);
 
-                            isOverSubscribed = isAnElectronHistogramOverSubscribed(
-                                mappingDesc,
-                                perSuperCellElectronHistogramOverSubscribedField,
-                                deviceLocalReduce);
+                            isOverSubscribed
+                                = isAnElectronHistogramOverSubscribed<enums::Loop::RejectOverSubscription>(
+                                    mappingDesc,
+                                    perSuperCellElectronHistogramOverSubscribedField,
+                                    deviceLocalReduce);
                         } // end remove over subscription loop
+
+                        if constexpr(debug::kernel::rollForOverSubscription::PRINT_DEBUG_TO_CONSOLE)
+                            std::cout << "[rejection loop complete]" << std::endl;
                     } // end choose transition loop
 
-                    if constexpr(picongpu::atomicPhysics::debug::timeRemaining::PRINT_TO_CONSOLE)
-                        printTimeRemainingToConsole(mappingDesc);
-                    if constexpr(picongpu::atomicPhysics::debug::timeStep::PRINT_TO_CONSOLE)
-                        printTimeStepToConsole(mappingDesc);
+                    printTimeRemainingToConsole(mappingDesc);
+                    printTimeStepToConsole(mappingDesc);
 
                     recordChanges(mappingDesc);
                     updateElectrons(mappingDesc, currentStep);

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
@@ -78,7 +78,6 @@ namespace picongpu::atomicPhysics::debug
         constexpr bool TRANSITION_DATA_SET_INDEX_RANGE_CHECKS = false;
     } // namespace rateCache
 
-
     namespace rejectionProbabilityCache
     {
         //! @attention only useful if using serial backend, no output unless compiling for cpu backend
@@ -140,6 +139,12 @@ namespace picongpu::atomicPhysics::debug
         //! @attention performance relevant
         constexpr bool CHECK_FOR_OVERFLOWS_IN_ACCUMULATON = false;
     } // namespace kernel::chooseTransition
+
+    namespace kernel::recordSuggestedChanges
+    {
+        //! @attention only useful if using serial backend, no output unless compiling for cpu backend
+        constexpr bool PRINT_DEBUG_TO_CONSOLE = false;
+    } // namespace kernel::recordSuggestedChanges
 
     namespace kernel::rollForOverSubscription
     {


### PR DESCRIPTION
refactor of the debug printing options of AtomicPhysics(FLYonPIC) to allow selectively activating debug prints depending on the sub-loop of the atomicPhysics stage.

This PR prepares the implementation of energy conservation for field ionization.

ATTENTION: This PR will break setups using a custom `atomicPhysics_Debug.param`-file. To Update them add the following,

```c++
namespace picongpu::atomicPhysics::debug::kernel::recordSuggestedChanges
{
    //! @attention only useful if using serial backend, no output unless compiling for cpu backend
    constexpr bool PRINT_DEBUG_TO_CONSOLE = false;
} // namespace picongpu::atomicPhysics::debug::kernel::recordSuggestedChanges
```

ci: picongpu