### PR TITLE
BSI minimal implementation

### DIFF
--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/BarrierSupressionIonization.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/BarrierSupressionIonization.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+
+namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
+{
+    struct BarrierSupressionIonization
+    {
+        /** get ionization potential depression(IPD) due to electric field according to the barrier suppression
+         *  ionization model
+         *
+         * @param screenedCharge, in e
+         * @param electricFieldNormAU, in sim.atomicUnit.eField()
+         *
+         * @return unit: eV
+         */
+        HDINLINE static float_X getIPD(float_X const screenedCharge, float_X const electricFieldNormAU)
+        {
+            // Hartree = sim.atomicUnit.energy()
+            return picongpu::sim.si.conv().auEnergy2eV(2._X * math::sqrt(screenedCharge * electricFieldNormAU));
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -28,14 +28,23 @@
  *      framework
  */
 
-
 #pragma once
 
+#include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/SetAtomicState.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/initElectrons/CoMoving.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/BarrierSupressionIonization.hpp"
 #include "picongpu/particles/creation/SpawnFromSourceSpecies.kernel"
 #include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/dimensions/SuperCellDescription.hpp>
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/math/operation/Assign.hpp>
+#include <pmacc/memory/boxes/CachedBox.hpp>
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include <pmacc/memory/boxes/SharedBox.hpp>
 
 #include <cstdint>
 
@@ -45,9 +54,15 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
     namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
 
     //! sanity checks for apply ApplyIPDIonizationKernel
-    template<typename T_IonBox, typename T_IonizationElectronBox, typename T_IPDModel>
+    template<
+        typename T_IonBox,
+        typename T_IonizationElectronBox,
+        typename T_IPDModel,
+        typename T_EField,
+        typename T_fieldIonizationActive>
     struct ApplyIPDIonizationSanityCheckInputs
-        : public s_interfaces::SanityCheckInputs<T_IonBox, T_IonizationElectronBox, T_IPDModel>
+        : public s_interfaces::
+              SanityCheckInputs<T_IonBox, T_IonizationElectronBox, T_IPDModel, T_EField, T_fieldIonizationActive>
     {
         template<
             // T_AdditionalData:
@@ -57,6 +72,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_ChargeStateDataBox,
             typename T_AtomicStateDataBox,
             typename T_IPDIonizationStateDataBox,
+            typename T_EFieldDataBox,
             typename... T_IPDInputBoxes
             //@}
             >
@@ -68,6 +84,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_ChargeStateDataBox const,
             T_AtomicStateDataBox const,
             T_IPDIonizationStateDataBox const,
+            T_EFieldDataBox const,
             T_IPDInputBoxes const...)
         {
             PMACC_CASSERT_MSG(
@@ -109,12 +126,13 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
     struct KernelState
     {
         // eV
-        float_X ionizationPotentialDepression;
+        float_X superCellConstantIPD;
         uint32_t foundUnbound;
     };
 
-    template<typename T_IPDModel>
-    struct CalculateIPDValue : public s_interfaces::InitKernelStateFunctor<T_IPDModel>
+    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    struct CalculateIPDValue
+        : public s_interfaces::InitKernelStateFunctor<T_IPDModel, T_EField, T_fieldIonizationActive>
     {
         template<
             typename T_KernelState,
@@ -123,6 +141,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_ChargeStateDataBox,
             typename T_AtomicStateDataBox,
             typename T_IPDIonizationStateDataBox,
+            typename T_EFieldDataBox,
             typename... T_IPDInputBoxes>
         HDINLINE static void init(
             pmacc::DataSpace<picongpu::simDim> const,
@@ -133,40 +152,96 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_ChargeStateDataBox const,
             T_AtomicStateDataBox const,
             T_IPDIonizationStateDataBox const,
+            T_EFieldDataBox const,
             T_IPDInputBoxes const... ipdInputBoxes)
         {
             // eV
-            kernelState.ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataBox::atomicNumber>(
-                    superCellFieldIndex,
-                    ipdInputBoxes...);
+            kernelState.superCellConstantIPD = T_IPDModel::template calculateIPD<T_ChargeStateDataBox::atomicNumber>(
+                superCellFieldIndex,
+                ipdInputBoxes...);
             kernelState.foundUnbound = u32(false);
         }
     };
 
-    //! predict number pressure ionization electrons for one pressure ionization step and update ion atomic state
-    template<typename T_Number, typename T_IPDModel>
-    struct IPDIonizationPredictor : public s_interfaces::PredictorFunctor<T_Number, T_IPDModel>
+    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    struct CacheEFieldForSuperCell
+        : public s_interfaces::
+              InitCacheFunctor<pmacc::DataSpace<picongpu::simDim>, T_IPDModel, T_EField, T_fieldIonizationActive>
     {
         template<
             typename T_Worker,
+            typename T_LocalTimeRemainingBox,
+            typename T_FoundUnboundIonBox,
+            typename T_ChargeStateDataBox,
+            typename T_AtomicStateDataBox,
+            typename T_IPDIonizationStateDataBox,
+            typename T_EFieldDataBox,
+            typename... T_IPDInputBoxes>
+        HDINLINE static auto getCache(
+            T_Worker const& worker,
+            pmacc::DataSpace<picongpu::simDim> const superCellIndex,
+            T_LocalTimeRemainingBox const,
+            T_FoundUnboundIonBox const,
+            T_ChargeStateDataBox const,
+            T_AtomicStateDataBox const,
+            T_IPDIonizationStateDataBox const,
+            T_EFieldDataBox const eFieldBox,
+            T_IPDInputBoxes const... ipdInputBoxes)
+        {
+            if constexpr(T_fieldIonizationActive::value)
+            {
+                using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
+                /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
+                auto eFieldCache
+                    = CachedBox::create<__COUNTER__, typename T_EField::ValueType>(worker, SuperCellBlock());
+
+                pmacc::DataSpace<picongpu::simDim> const superCellCellOffset
+                    = superCellIndex * picongpu::SuperCellSize::toRT();
+
+                auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
+
+                pmacc::math::operation::Assign assign;
+                auto collective = makeThreadCollective<SuperCellBlock>();
+
+                collective(worker, assign, eFieldCache, fieldEBlockToCache);
+
+                return eFieldCache;
+            }
+            else
+            {
+                return 0._X;
+            }
+        }
+    };
+
+    //! predict number pressure ionization electrons for one pressure ionization step and update ion atomic state
+    template<typename T_Number, typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    struct IPDIonizationPredictor
+        : public s_interfaces::PredictorFunctor<T_Number, T_IPDModel, T_EField, T_fieldIonizationActive>
+    {
+        template<
+            typename T_Worker,
+            typename T_EFieldCache,
             typename T_Ion,
             typename T_LocalTimeRemainingBox,
             typename T_FoundUnboundIonBox,
             typename T_AtomicStateDataBox,
             typename T_ChargeStateDataBox,
             typename T_IPDIonizationStateDataBox,
+            typename T_EFieldDataBox,
             typename... T_IPDInputBoxes>
         HDINLINE static T_Number getNumberNewParticles(
             T_Worker const& worker,
             T_Ion& ion,
             KernelState& kernelState,
+            T_EFieldCache const& eFieldCache,
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
             T_LocalTimeRemainingBox const,
             T_FoundUnboundIonBox const,
             T_ChargeStateDataBox const chargeStateBox,
             T_AtomicStateDataBox const atomicStateBox,
             T_IPDIonizationStateDataBox const ipdIonizationStateBox,
+            T_EFieldDataBox const,
             T_IPDInputBoxes const...)
         {
             auto const currentAtomicStateClctIdx = ion[atomicStateCollectionIndex_];
@@ -189,9 +264,30 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
 
             // eV
             float_X const ionizationEnergyGroundState = chargeStateBox.ionizationEnergy(currentChargeState);
+
             // eV
-            float_X const ipdIonizationEnergy
-                = ionizationEnergyGroundState - kernelState.ionizationPotentialDepression;
+            float_X ipd = kernelState.superCellConstantIPD;
+
+            if constexpr(T_fieldIonizationActive::value)
+            {
+                using VectorIdx = pmacc::DataSpace<picongpu::simDim>;
+
+                VectorIdx const superCellSize = picongpu::SuperCellSize::toRT();
+                VectorIdx const localCellIndex
+                    = pmacc::math::mapToND(superCellSize, static_cast<int>(ion[localCellIdx_]));
+
+                // sim.unit.eField()
+                float_X const eFieldNormCell = pmacc::math::l2norm(eFieldCache(localCellIndex));
+
+                float_X const eFieldNormAU = sim.pic.conv().eField2auEField(eFieldNormCell);
+                float_X const screenedCharge = chargeStateBox.screenedCharge(currentChargeState) - 1._X;
+
+                // eV
+                ipd += BarrierSupressionIonization::getIPD(screenedCharge, eFieldNormAU);
+            }
+
+            // eV
+            float_X const ipdIonizationEnergy = ionizationEnergyGroundState - ipd;
 
             if(ipdIonizationEnergy < 0._X)
             {
@@ -245,8 +341,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
-    template<typename T_IPDModel>
-    struct WriteFoundUnboundToSuperCellField : public s_interfaces::WriteOutKernelStateFunctor<T_IPDModel>
+    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    struct WriteFoundUnboundToSuperCellField
+        : public s_interfaces::WriteOutKernelStateFunctor<T_IPDModel, T_EField, T_fieldIonizationActive>
     {
         template<
             typename T_KernelState,
@@ -255,6 +352,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_ChargeStateDataBox,
             typename T_AtomicStateDataBox,
             typename T_IPDIonizationStateDataBox,
+            typename T_EFieldDataBox,
             typename... T_IPDInputBoxes>
         HDINLINE static void postProcess(
             pmacc::DataSpace<picongpu::simDim> const,
@@ -265,6 +363,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_ChargeStateDataBox const,
             T_AtomicStateDataBox const,
             T_IPDIonizationStateDataBox const,
+            T_EFieldDataBox const,
             T_IPDInputBoxes const...)
         {
             uint32_t& foundUnbound = foundUnboundIonBox(superCellFieldIndex);
@@ -280,14 +379,17 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         InitAsCoMoving,
         KernelState,
         CalculateIPDValue,
+        CacheEFieldForSuperCell,
         SuperCellFieldIndexFunctor,
         WriteFoundUnboundToSuperCellField>;
 
     //! actual definition of ApplyIPDIonizationKernel
-    template<typename T_IPDModel>
+    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
     using ApplyIPDIonizationKernel = picongpu::particles::creation::SpawnFromSourceSpeciesKernelFramework<
         // T_TypeNumber
         uint8_t,
         ApplyIPDIonizationModulConfig,
-        T_IPDModel>;
+        T_IPDModel,
+        T_EField,
+        T_fieldIonizationActive>;
 } // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -66,20 +66,17 @@ namespace picongpu::particles::atomicPhysics::kernel
         typename T_IPDModel>
     struct ChooseTransitionKernel_FieldBoundFree
     {
-        using S_VectorIdx = pmacc::DataSpace<picongpu::simDim>;
+        using VectorIdx = pmacc::DataSpace<picongpu::simDim>;
 
     private:
         //! @attention this is a collective method and implicitly synchronises
         template<typename BlockDescription, typename T_Worker, typename T_EFieldBox, typename T_EfieldCache>
         HDINLINE void initEFieldCache(
             T_Worker const& worker,
-            S_VectorIdx const superCellIdx,
-            S_VectorIdx const superCellSize,
+            VectorIdx const& superCellCellOffset,
             T_EFieldBox const eFieldBox,
             T_EfieldCache& eFieldCache) const
         {
-            S_VectorIdx const superCellCellOffset = superCellIdx * superCellSize;
-
             auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
 
             pmacc::math::operation::Assign assign;
@@ -168,8 +165,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                           T_AtomicStateBoundFreeNumberTransitionsDataBox,
                           T_BoundFreeTransitionDataBox>());
 
-            S_VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
-            S_VectorIdx const superCellFieldIdx
+            VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
+            VectorIdx const superCellFieldIdx
                 = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
@@ -179,10 +176,11 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
-            S_VectorIdx const superCellSize = picongpu::SuperCellSize::toRT();
+            VectorIdx const superCellSize = picongpu::SuperCellSize::toRT();
             /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
             auto eFieldCache = CachedBox::create</* Id */ 0u, typename T_EField::ValueType>(worker, SuperCellBlock());
-            initEFieldCache<SuperCellBlock>(worker, superCellIdx, superCellSize, eFieldBox, eFieldCache);
+            VectorIdx const superCellCellOffset = superCellIdx * superCellSize;
+            initEFieldCache<SuperCellBlock>(worker, superCellCellOffset, eFieldBox, eFieldCache);
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
             auto& rateCache = rateCacheBox(superCellFieldIdx);
@@ -206,8 +204,9 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     auto const atomicStateCollectionIndex = ion[atomicStateCollectionIndex_];
 
-                    S_VectorIdx const localCellIndex
+                    VectorIdx const localCellIndex
                         = pmacc::math::mapToND(superCellSize, static_cast<int>(ion[localCellIdx_]));
+                    // sim.unit.eField()
                     float_X const eFieldNormCell = pmacc::math::l2norm(eFieldCache(localCellIndex));
 
                     // get possible transitions' collectionIndices

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -170,13 +170,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          *
          * @return unit: 1/picongpu::sim.unit.time()
          */
-        template<
-            typename T_EFieldType,
-            typename T_ChargeStateDataBox,
-            typename T_AtomicStateDataBox,
-            typename T_BoundFreeTransitionDataBox>
+        template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
         HDINLINE static float_X rateADKFieldIonization(
-            T_EFieldType const eFieldNorm,
+            float_X const eFieldNorm,
             float_X const ionizationPotentialDepression,
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,
@@ -215,14 +211,10 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          *
          * @return unit: 1/picongpu::sim.unit.time()
          */
-        template<
-            typename T_EFieldType,
-            typename T_ChargeStateDataBox,
-            typename T_AtomicStateDataBox,
-            typename T_BoundFreeTransitionDataBox>
+        template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
         HDINLINE static float_X maximumRateADKFieldIonization(
-            T_EFieldType const maxEFieldNorm,
-            T_EFieldType const minEFieldNorm,
+            float_X const maxEFieldNorm,
+            float_X const minEFieldNorm,
             float_X const ionizationPotentialDepression,
             uint32_t const transitionCollectionIndex,
             T_ChargeStateDataBox const chargeStateDataBox,

--- a/include/picongpu/particles/creation/ModuleConfig.hpp
+++ b/include/picongpu/particles/creation/ModuleConfig.hpp
@@ -44,6 +44,7 @@ namespace picongpu::particles::creation
      * additionalData and sourceSpecies particle
      * @tparam T_KernelStateType type of kernelState, one instance for each superCell
      * @tparam T_InitKernelStateFunctor functor initialising T_KernelStateType variable
+     * @tparam T_CollectiveInitFunctor functor handling collective init of cache boxes and similar
      * @tparam T_AdditionalDataIndexFunctor functor returning index to access additionalData by
      *  @note only one is supported for all additionalData
      *  @note dimension is configurable
@@ -65,6 +66,8 @@ namespace picongpu::particles::creation
         typename T_KernelStateType,
         template<typename... T_KernelConfigOptions>
         typename T_InitKernelStateFunctor,
+        template<typename... T_KernelConfigOptions>
+        typename T_InitCacheFunctor,
         template<typename... T_KernelConfigOptions>
         typename T_AdditionalDataIndexFunctor,
         template<typename... T_KernelConfigOptions>
@@ -96,6 +99,9 @@ namespace picongpu::particles::creation
 
         template<typename... T_KernelConfigOptions>
         using InitKernelStateFunctor = T_InitKernelStateFunctor<T_KernelConfigOptions...>;
+
+        template<typename... T_KernelConfigOptions>
+        using InitCacheFunctor = T_InitCacheFunctor<T_KernelConfigOptions...>;
 
         template<typename... T_KernelConfigOptions>
         using WriteOutKernelStateFunctor = T_WriteOutKernelStateFunctor<T_KernelConfigOptions...>;

--- a/include/picongpu/particles/creation/SpawnFromSourceSpecies.kernel
+++ b/include/picongpu/particles/creation/SpawnFromSourceSpecies.kernel
@@ -156,6 +156,13 @@ namespace picongpu::particles::creation
             // create shared memory variable for kernel state
             PMACC_SMEM(worker, sharedKernelState, typename Modules::KernelStateType);
 
+            // create cache
+            auto cache = Modules::template InitCacheFunctor<T_KernelConfigOptions...>::getCache(
+                worker,
+                superCellIndex,
+                std::forward<T_AdditionalData>(additonalData)...);
+            // thread sync not necessary since we sync all threads later anyway, after completing shared memory init
+
             auto numberProductParticlesCtxArr
                 = lockstep::makeVar<TypeNumber>(forEachFrameSlot, static_cast<TypeNumber>(0u));
 
@@ -179,6 +186,7 @@ namespace picongpu::particles::creation
                         = productBox.getLastFrame(superCellIndex);
                     productSpeciesFrameArray[s_conv::u32(detail::Access::high)] = nullptr;
                 });
+            /// @attention thread sync for **both** shared memory init and InitCacheFunctor call
             worker.sync();
 
             // go over frames until all processed
@@ -204,6 +212,7 @@ namespace picongpu::particles::creation
                                 worker,
                                 sourceParticle,
                                 sharedKernelState,
+                                cache,
                                 additionalDataIndex,
                                 std::forward<T_AdditionalData>(additonalData)...);
 

--- a/include/picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp
+++ b/include/picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "picongpu/particles/creation/moduleInterfaces/AdditionalDataIndexFunctor.hpp"
+#include "picongpu/particles/creation/moduleInterfaces/InitCacheFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/InitKernelStateFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/ParticlePairUpdateFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/PredictorFunctor.hpp"

--- a/include/picongpu/particles/creation/moduleInterfaces/InitCacheFunctor.hpp
+++ b/include/picongpu/particles/creation/moduleInterfaces/InitCacheFunctor.hpp
@@ -23,29 +23,17 @@
 
 namespace picongpu::particles::creation::moduleInterfaces
 {
-    /** interface of PredictorFunctor
+    /** interface of CollectiveInitFunctor
      *
-     * functor predicting number of product species particles to spawn for a given source species particle,
-     * depending on passed kernelState and additionalData
-     *
-     * @note may update source particle!
+     * functor handling collective init of a cached data box, for example field caches
      */
-    template<typename T_Number, typename... T_KernelConfigOptions>
-    struct PredictorFunctor
+    template<typename T_Index, typename... T_KernelConfigOptions>
+    struct InitCacheFunctor
     {
-        template<
-            typename T_Worker,
-            typename T_SourceParticle,
-            typename T_KernelState,
-            typename T_Cache,
-            typename T_Index,
-            typename... T_AdditionalData>
-        HDINLINE static T_Number getNumberNewParticles(
-            T_Worker const& worker,
-            T_SourceParticle& sourceParticle,
-            T_KernelState& kernelState,
-            T_Cache const& cache,
-            T_Index const addtionalDataIndex,
-            T_AdditionalData... additionalData);
+        template<typename T_Worker, typename... T_AdditionalData>
+        HDINLINE static auto getCache(
+            T_Worker worker,
+            T_Index const superCellIndex,
+            T_AdditionalData&&... additonalData);
     };
 } // namespace picongpu::particles::creation::moduleInterfaces


### PR DESCRIPTION
Implements barrier suppression ionization(BSI) in AtomicPhysics(FLYonPIC) as an ionization potential depression(IPD) contribution in the `ApplyIPDIonization`-kernel.

**ATTENTION:** The BSI IPD contribution is only considered in IPDIonization.

Other ionizing transition only consider particle based IPD contributions, like Stewart-Pyatt, when determining the ionization energy.

This is due to Field-based IPD contributions requiring the electric field at the particle position, therefore necessitating access to every superCell cell's field value, which currently is not available in all ChooseTransitionKernels.

A future rework of the IPD implementation is planed that will fix this, but this will take some time.

- [x] requires PR #5204  to be merged first
- [x] needs to be rebased to the dev