### PR TITLE
bug fix ApplyIPDIonization

### DIFF
--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -263,7 +263,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 atomicStateBox.configNumber(ipdIonizationStateClctIdx));
 
             // eV
-            float_X const ionizationEnergyGroundState = chargeStateBox.ionizationEnergy(currentChargeState);
+            float_X const ionizationEnergy = chargeStateBox.ionizationEnergy(currentChargeState)
+                - atomicStateBox.energy(currentAtomicStateClctIdx);
 
             // eV
             float_X ipd = kernelState.superCellConstantIPD;
@@ -287,7 +288,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             }
 
             // eV
-            float_X const ipdIonizationEnergy = ionizationEnergyGroundState - ipd;
+            float_X const ipdIonizationEnergy = ionizationEnergy - ipd;
 
             if(ipdIonizationEnergy < 0._X)
             {


### PR DESCRIPTION
The ApplyIPDIonization kernel mistakenly did not consider excitation in the ionization energy calculation.

- [x] requires PR #5204 to be merged first
- [x] requires PR #5205 to be merged first
- [x] needs to be rebased to dev