### PR TITLE
fix PICMI LaserWakefield example custom user input

### DIFF
--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -190,7 +190,7 @@ if ADD_CUSTOM_INPUT:
     )
 
     output_configuration.addToCustomInput(
-        {"opnePMD_period": 100, "opnePMD_file": "simData", "opnePMD_extension": "bp"}, "openPMD plugin configuration"
+        {"openPMD_period": 100, "openPMD_file": "simData", "openPMD_extension": "bp"}, "openPMD plugin configuration"
     )
 
     output_configuration.addToCustomInput(


### PR DESCRIPTION
fixes a typo in the custom user input specification of the PICMI LaserWakefield example

ci: no-compile