### PR TITLE
Refactor passed atomic data boxes check

### DIFF
--- a/include/picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp
+++ b/include/picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp
@@ -1,0 +1,74 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
+
+#include <pmacc/static_assert.hpp>
+
+namespace picongpu::particles::atomicPhysics
+{
+    struct CheckSetOfAtomicDataBoxes
+    {
+        template<
+            enums::TransitionOrdering T_TransitionOrdering,
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool areBoundFreeAndOrdering()
+        {
+            PMACC_CASSERT_MSG(
+                number_transition_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                boundFreeTransitiondataBox_not_bound_free_based,
+                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                wrong_transition_ordering_boundFreeTransitionDataBox,
+                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+            return true;
+        }
+
+        template<
+            enums::TransitionDirection T_TransitionDirection,
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool areBoundFreeAndDirection()
+        {
+            return areBoundFreeAndOrdering<
+                s_enums::TransitionOrderingFor<T_TransitionDirection>::ordering,
+                T_AtomicStateBoundFreeStartIndexBlockDataBox,
+                T_AtomicStateBoundFreeNumberTransitionsDataBox,
+                T_BoundFreeTransitionDataBox>();
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -21,13 +21,12 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/CheckForInvalidChooseTransitionGroup.hpp"
+#include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
-#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
-#include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
@@ -86,30 +85,6 @@ namespace picongpu::particles::atomicPhysics::kernel
             worker.sync();
         }
 
-        template<
-            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
-            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
-            typename T_BoundFreeTransitionDataBox>
-        static constexpr bool checkCorrectAtomicDataBoxesPassed()
-        {
-            PMACC_CASSERT_MSG(
-                number_transition_dataBox_not_bound_free_based,
-                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
-                    == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
-                    == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                boundFreeTransitiondataBox_not_bound_free_based,
-                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                wrong_transition_ordering_boundFreeTransitionDataBox,
-                u8(T_BoundFreeTransitionDataBox::transitionOrdering)
-                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::upward>::ordering));
-            return true;
-        }
-
     public:
         /** call operator
          *
@@ -126,7 +101,7 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param startIndexBox deviceDataBox giving access to the start index of each
          * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param eFieldBox deviceDataBox giving access to the device local eField Values
+         * @param eFieldBox deviceDataBox giving access to the device local E-Field values
          * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
          * @param ipdInput everything required by T_IPDModel to calculate the IonizationPotentialDepression,
          *  passed by T_IPDModel::callKernelWithIPDInput
@@ -160,7 +135,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_IonBox ionBox,
             T_IPDInput const... ipdInput) const
         {
-            PMACC_CASSERT(checkCorrectAtomicDataBoxesPassed<
+            PMACC_CASSERT(CheckSetOfAtomicDataBoxes::areBoundFreeAndDirection<
+                          s_enums::TransitionDirection::upward,
                           T_AtomicStateBoundFreeStartIndexBlockDataBox,
                           T_AtomicStateBoundFreeNumberTransitionsDataBox,
                           T_BoundFreeTransitionDataBox>());

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
@@ -21,6 +21,7 @@
 
 // need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
 #include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/CachedHistogram.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
@@ -62,7 +63,7 @@ namespace picongpu::particles::atomicPhysics::kernel
      *
      * @tparam T_electronicIonization is collisional electronic ionization channel active?
      * @tparam T_fieldIonization is field ionization channel active?
-     * @tparam T_TransitionOrdering ordering of assumed for transition DataBox
+     * @tparam T_TransitionOrdering ordering assumed for transition DataBox
      */
     template<
         typename T_IPDModel,
@@ -75,31 +76,6 @@ namespace picongpu::particles::atomicPhysics::kernel
         s_enums::TransitionOrdering T_TransitionOrdering>
     struct FillRateCacheKernel_BoundFree
     {
-        template<
-            typename T_AtomicStateNumberTransitionsBox,
-            typename T_AtomicStateStartIndexBox,
-            typename T_BoundFreeTransitionDataBox>
-        static constexpr bool correctAtomicDataBoxes()
-        {
-            // check that correct databoxes are given
-            PMACC_CASSERT_MSG(
-                number_transitions_dataBox_not_bound_free_based,
-                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                transition_dataBox_not_bound_free_based,
-                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            // check ordering of transition dataBox
-            PMACC_CASSERT_MSG(
-                wrong_ordering_of_DataBox,
-                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
-
-            return true;
-        };
-
         template<
             typename T_Worker,
             typename T_RateCache,
@@ -309,18 +285,17 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
-         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
-         * cells
-         * @param rateCacheBox deviceDataBox giving access to the local rate cache of
-         *  all local superCells
-         * @param electronHistogramDataBox giving access to the local electron histograms
-         *  of all local superCells
+         * @param timeRemainingBox deviceDataBox giving access to the time remaining of all local superCells
+         * @param rateCacheBox deviceDataBox giving access to the rate cache of all local superCells
+         * @param electronHistogramDataBox deviceDataBox giving access to the electron histograms of all local
+         *  superCells
+         * @param eFieldBox deviceDataBox giving access to the E-Field values of all local cells
          * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
          * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
-         * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states'
-         *  block of transitions in the up-/down-ward bound-bound transition collection
-         * @param numberTransitionsDataBox deviceDataBox giving access to the number of transitions
-         *   of each atomic state up- and down-ward
+         * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states' block of
+         *  transitions in the up-/down-ward bound-bound transition collection
+         * @param numberTransitionsDataBox deviceDataBox giving access to the number of transitions of each atomic
+         *  state up- and down-ward
          * @param boundFreeTransitionDataBox deviceDataBox giving access to bound-free transition property data
          * @param ipdInput deviceDataBoxes giving access to ionization potential depression input for each superCell
          *
@@ -359,7 +334,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             // This last is always used:
             T_IPDInput... ipdInput) const
         {
-            PMACC_CASSERT(correctAtomicDataBoxes<
+            PMACC_CASSERT(CheckSetOfAtomicDataBoxes::areBoundFreeAndOrdering<
+                          T_TransitionOrdering,
                           T_AtomicStateNumberTransitionsBox,
                           T_AtomicStateStartIndexBox,
                           T_BoundFreeTransitionDataBox>());

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -464,10 +464,7 @@ namespace picongpu::simulation::stage
                 do
                 {
                     resetFoundUnboundIon();
-                    picongpu::atomicPhysics::IPDModel::
-                        template calculateIPDInput<T_numberAtomicPhysicsIonSpecies, IPDIonSpecies, IPDElectronSpecies>(
-                            mappingDesc,
-                            currentStep);
+                    calculateIPDInput(mappingDesc, currentStep);
                     picongpu::atomicPhysics::IPDModel::template applyIPDIonization<AtomicPhysicsIonSpecies>(
                         mappingDesc,
                         currentStep);
@@ -540,8 +537,8 @@ namespace picongpu::simulation::stage
                     resetAcceptStatus(mappingDesc);
                     resetElectronEnergyHistogram();
                     debugForceConstantElectronTemperature(currentStep);
+                    doIPDIonization(mappingDesc, currentStep, deviceLocalReduce);
                     binElectronsToEnergyHistogram(mappingDesc);
-                    calculateIPDInput(mappingDesc, currentStep);
                     resetTimeStep(mappingDesc);
                     resetRateCache();
                     checkPresence(mappingDesc);
@@ -584,10 +581,12 @@ namespace picongpu::simulation::stage
                     recordChanges(mappingDesc);
                     updateElectrons(mappingDesc, currentStep);
                     updateElectricField(mappingDesc);
-                    doIPDIonization(mappingDesc, currentStep, deviceLocalReduce);
                     updateTimeRemaining(mappingDesc);
                     isSubSteppingComplete = isSubSteppingFinished(mappingDesc, deviceLocalReduce);
                 } // end atomicPhysics sub-stepping loop
+
+                // ensure no unbound states are visible to the rest of the loop
+                doIPDIonization(mappingDesc, currentStep, deviceLocalReduce);
             }
         };
 


### PR DESCRIPTION
extract the check of the passed bound-free atomic data boxes to avoid code duplication 

This is done in preparation for the implementation of the instant field ionization transitions.

- [x] requires PR #5207 to be merged first
- [ ] requires PR #5206 to be merged first
- [ ] needs to be rebased to dev

every but the last commit belongs to the base PRs