### PR TITLE
Extract caching e field

### DIFF
--- a/include/picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp
+++ b/include/picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp
@@ -1,0 +1,72 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
+
+#include <pmacc/static_assert.hpp>
+
+namespace picongpu::particles::atomicPhysics
+{
+    struct CheckSetOfAtomicDataBoxes
+    {
+        template<
+            typename T_TransitionOrdering,
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool areBoundFreeAndOrdering()
+        {
+            PMACC_CASSERT_MSG(
+                number_transition_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                startIndex_dataBox_not_bound_free_based,
+                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
+                    == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                boundFreeTransitiondataBox_not_bound_free_based,
+                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
+            PMACC_CASSERT_MSG(
+                wrong_transition_ordering_boundFreeTransitionDataBox,
+                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
+            return true;
+        }
+
+        template<
+            typename T_TransitionDirection,
+            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
+            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
+            typename T_BoundFreeTransitionDataBox>
+        static constexpr bool areBoundFreeAndDirection()
+        {
+            return areBoundFreeAndOrdering<
+                s_enums::TransitionOrderingFor<T_TransitionDirection>::ordering,
+                T_AtomicStateBoundFreeStartIndexBlockDataBox,
+                T_AtomicStateBoundFreeNumberTransitionsDataBox,
+                T_BoundFreeTransitionDataBox>();
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/EFieldCache.hpp
+++ b/include/picongpu/particles/atomicPhysics/EFieldCache.hpp
@@ -22,12 +22,18 @@
 // need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
 #include "picongpu/defines.hpp"
 
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/dimensions/SuperCellDescription.hpp>
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/math/operation/Assign.hpp>
+#include <pmacc/memory/boxes/CachedBox.hpp>
+
 namespace picongpu::particles::atomicPhysics
 {
     struct EFieldCache
     {
         //! @attention collective Method, before first access of cache values a thread synchronize is required!
-        template<typename T_Worker, typename T_EFieldDataBox>
+        template<uint32_t T_id, typename T_Worker, typename T_EFieldDataBox>
         HDINLINE static auto get(
             T_Worker const& worker,
             pmacc::DataSpace<picongpu::simDim> const superCellIndex,
@@ -36,7 +42,7 @@ namespace picongpu::particles::atomicPhysics
             using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
             /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
             auto eFieldCache
-                = CachedBox::create<__COUNTER__, typename T_EFieldDataBox::ValueType::type>(worker, SuperCellBlock());
+                = CachedBox::create<T_id, typename T_EFieldDataBox::ValueType::type>(worker, SuperCellBlock());
 
             pmacc::DataSpace<picongpu::simDim> const superCellCellOffset
                 = superCellIndex * picongpu::SuperCellSize::toRT();

--- a/include/picongpu/particles/atomicPhysics/EFieldCache.hpp
+++ b/include/picongpu/particles/atomicPhysics/EFieldCache.hpp
@@ -1,0 +1,54 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+
+namespace picongpu::particles::atomicPhysics
+{
+    struct EFieldCache
+    {
+        //! @attention collective Method, before first access of cache values a thread synchronize is required!
+        template<typename T_Worker, typename T_EFieldDataBox>
+        HDINLINE static auto get(
+            T_Worker const& worker,
+            pmacc::DataSpace<picongpu::simDim> const superCellIndex,
+            T_EFieldDataBox const eFieldBox)
+        {
+            using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
+            /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
+            auto eFieldCache
+                = CachedBox::create<__COUNTER__, typename T_EFieldDataBox::ValueType::type>(worker, SuperCellBlock());
+
+            pmacc::DataSpace<picongpu::simDim> const superCellCellOffset
+                = superCellIndex * picongpu::SuperCellSize::toRT();
+
+            auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
+
+            pmacc::math::operation::Assign assign;
+            auto collective = makeThreadCollective<SuperCellBlock>();
+
+            collective(worker, assign, eFieldCache, fieldEBlockToCache);
+
+            return eFieldCache;
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/KernelIndexation.hpp
+++ b/include/picongpu/particles/atomicPhysics/KernelIndexation.hpp
@@ -60,9 +60,8 @@ namespace picongpu::particles::atomicPhysics
          * @details version for already known superCellIndex
          * @attention assumes that the kernel was launched for CORE+BORDER Region
          */
-        template<typename T_Worker, typename T_AreaMapping>
-        HDINLINE static pmacc::DataSpace<picongpu::simDim> getSuperCellFieldIndex(
-            T_Worker const& worker,
+        template<typename T_AreaMapping>
+        HDINLINE static pmacc::DataSpace<picongpu::simDim> getSuperCellFieldIndexFromSuperCellIndex(
             T_AreaMapping const areaMapping,
             pmacc::DataSpace<picongpu::simDim> const superCellIndex)
         {

--- a/include/picongpu/particles/atomicPhysics/MinimumAndMaximumEFieldNormOfSuperCell.hpp
+++ b/include/picongpu/particles/atomicPhysics/MinimumAndMaximumEFieldNormOfSuperCell.hpp
@@ -1,0 +1,84 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/MinimumAndMaximumEFieldNormOfSuperCell.hpp"
+
+#include <pmacc/lockstep/ForEach.hpp>
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics
+{
+    struct MinimumAndMaximumEFieldNormOfSuperCell
+    {
+        using VectorIdx = DataSpace<picongpu::simDim>;
+
+        template<typename T_Worker, typename T_EFieldDataBox>
+        HDINLINE static void find(
+            T_Worker const& worker,
+            VectorIdx const superCellIdx,
+            T_EFieldDataBox const eFieldBox,
+            float_X& minEFieldNormSuperCell,
+            float_X& maxEFieldNormSuperCell)
+        {
+            auto initAccumulationVariables = lockstep::makeMaster(worker);
+            initAccumulationVariables(
+                [&minEFieldNormSuperCell, &maxEFieldNormSuperCell]()
+                {
+                    /// needs to be initialized with neutral element of Minimum
+                    /// @warning never increase the result from this variable, may be maximum representable value.
+                    minEFieldNormSuperCell = std::numeric_limits<float_X>::max();
+                    maxEFieldNormSuperCell = 0._X;
+                });
+            worker.sync();
+
+            constexpr auto numberCellsInSuperCell
+                = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
+            VectorIdx const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
+            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell>(worker);
+
+            /// @todo switch to shared memory reduce, Brian Marre, 2024
+            forEachCell(
+                [&worker, &superCellCellOffset, &maxEFieldNormSuperCell, &minEFieldNormSuperCell, &eFieldBox](
+                    uint32_t const linearCellIdx)
+                {
+                    VectorIdx const localCellIndex
+                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearCellIdx));
+                    VectorIdx const cellIndex = localCellIndex + superCellCellOffset;
+
+                    auto const eFieldNorm = pmacc::math::l2norm(eFieldBox(cellIndex));
+
+                    alpaka::atomicMin(
+                        worker.getAcc(),
+                        // unit: unit_eField
+                        &minEFieldNormSuperCell,
+                        eFieldNorm);
+
+                    alpaka::atomicMax(
+                        worker.getAcc(),
+                        // unit: unit_eField
+                        &maxEFieldNormSuperCell,
+                        eFieldNorm);
+                });
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
@@ -420,7 +420,8 @@ namespace picongpu::particles::atomicPhysics::debug
             // 1/s
             float_64 const rate
                 = static_cast<float_64>(
-                      rateCalculation::BoundFreeFieldTransitionRates<laserPolarization>::rateADKFieldIonization(
+                      rateCalculation::BoundFreeFieldTransitionRates<laserPolarization>::rateADKFieldIonization<
+                          float_X>(
                           eFieldNorm,
                           ipd,
                           u32(1u),

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -263,7 +263,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 atomicStateBox.configNumber(ipdIonizationStateClctIdx));
 
             // eV
-            float_X const ionizationEnergyGroundState = chargeStateBox.ionizationEnergy(currentChargeState);
+            float_X const ionizationEnergy = chargeStateBox.ionizationEnergy(currentChargeState)
+                - atomicStateBox.energy(currentAtomicStateClctIdx);
 
             // eV
             float_X ipd = kernelState.superCellConstantIPD;
@@ -287,7 +288,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             }
 
             // eV
-            float_X const ipdIonizationEnergy = ionizationEnergyGroundState - ipd;
+            float_X const ipdIonizationEnergy = ionizationEnergy - ipd;
 
             if(ipdIonizationEnergy < 0._X)
             {

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -58,11 +58,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         typename T_IonBox,
         typename T_IonizationElectronBox,
         typename T_IPDModel,
-        typename T_EField,
         typename T_fieldIonizationActive>
     struct ApplyIPDIonizationSanityCheckInputs
         : public s_interfaces::
-              SanityCheckInputs<T_IonBox, T_IonizationElectronBox, T_IPDModel, T_EField, T_fieldIonizationActive>
+              SanityCheckInputs<T_IonBox, T_IonizationElectronBox, T_IPDModel, T_fieldIonizationActive>
     {
         template<
             // T_AdditionalData:
@@ -130,9 +129,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         uint32_t foundUnbound;
     };
 
-    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
-    struct CalculateIPDValue
-        : public s_interfaces::InitKernelStateFunctor<T_IPDModel, T_EField, T_fieldIonizationActive>
+    template<typename T_IPDModel, typename T_fieldIonizationActive>
+    struct CalculateIPDValue : public s_interfaces::InitKernelStateFunctor<T_IPDModel, T_fieldIonizationActive>
     {
         template<
             typename T_KernelState,
@@ -163,10 +161,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
-    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    template<typename T_IPDModel, typename T_fieldIonizationActive>
     struct CacheEFieldForSuperCell
         : public s_interfaces::
-              InitCacheFunctor<pmacc::DataSpace<picongpu::simDim>, T_IPDModel, T_EField, T_fieldIonizationActive>
+              InitCacheFunctor<pmacc::DataSpace<picongpu::simDim>, T_IPDModel, T_fieldIonizationActive>
     {
         template<
             typename T_Worker,
@@ -192,8 +190,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             {
                 using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
                 /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
-                auto eFieldCache
-                    = CachedBox::create<__COUNTER__, typename T_EField::ValueType>(worker, SuperCellBlock());
+                auto eFieldCache = CachedBox::create<__COUNTER__, typename T_EFieldDataBox::ValueType::type>(
+                    worker,
+                    SuperCellBlock());
 
                 pmacc::DataSpace<picongpu::simDim> const superCellCellOffset
                     = superCellIndex * picongpu::SuperCellSize::toRT();
@@ -215,9 +214,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
     };
 
     //! predict number pressure ionization electrons for one pressure ionization step and update ion atomic state
-    template<typename T_Number, typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    template<typename T_Number, typename T_IPDModel, typename T_fieldIonizationActive>
     struct IPDIonizationPredictor
-        : public s_interfaces::PredictorFunctor<T_Number, T_IPDModel, T_EField, T_fieldIonizationActive>
+        : public s_interfaces::PredictorFunctor<T_Number, T_IPDModel, T_fieldIonizationActive>
     {
         template<
             typename T_Worker,
@@ -342,9 +341,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
-    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    template<typename T_IPDModel, typename T_fieldIonizationActive>
     struct WriteFoundUnboundToSuperCellField
-        : public s_interfaces::WriteOutKernelStateFunctor<T_IPDModel, T_EField, T_fieldIonizationActive>
+        : public s_interfaces::WriteOutKernelStateFunctor<T_IPDModel, T_fieldIonizationActive>
     {
         template<
             typename T_KernelState,
@@ -385,12 +384,11 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         WriteFoundUnboundToSuperCellField>;
 
     //! actual definition of ApplyIPDIonizationKernel
-    template<typename T_IPDModel, typename T_EField, typename T_fieldIonizationActive>
+    template<typename T_IPDModel, typename T_fieldIonizationActive>
     using ApplyIPDIonizationKernel = picongpu::particles::creation::SpawnFromSourceSpeciesKernelFramework<
         // T_TypeNumber
         uint8_t,
         ApplyIPDIonizationModulConfig,
         T_IPDModel,
-        T_EField,
         T_fieldIonizationActive>;
 } // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::kernel

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -265,7 +265,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         spawnFromSourceSpeciesModules::InitAsCoMoving,
         KernelState,
         CalculateIPDValue,
-        spawnFromSourceSpeciesModules::CacheEFieldForSuperCell,
+        template<typename T_Worker, typename T_IPDModel, typename T_fieldIonizationActive>
+        spawnFromSourceSpeciesModules::
+            CacheEFieldForSuperCell<__COUNTER__, T_Worker, T_IPDModel, T_fieldIonizationActive>,
         spawnFromSourceSpeciesModules::SuperCellFieldIndexFunctor,
         WriteFoundUnboundToSuperCellField>;
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -33,18 +33,15 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/SetAtomicState.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
-#include "picongpu/particles/atomicPhysics/initElectrons/CoMoving.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/BarrierSupressionIonization.hpp"
+#include "picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/CacheEFieldForSuperCell.hpp"
+#include "picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/InitAsCoMoving.hpp"
+#include "picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/SkipFinishedSuperCells.hpp"
+#include "picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/SuperCellFieldIndexFunctor.hpp"
 #include "picongpu/particles/creation/SpawnFromSourceSpecies.kernel"
 #include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
-#include <pmacc/dimensions/SuperCellDescription.hpp>
-#include <pmacc/mappings/threads/ThreadCollective.hpp>
-#include <pmacc/math/operation/Assign.hpp>
-#include <pmacc/memory/boxes/CachedBox.hpp>
-#include <pmacc/memory/boxes/DataBox.hpp>
-#include <pmacc/memory/boxes/SharedBox.hpp>
 
 #include <cstdint>
 
@@ -92,36 +89,6 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
-    //! functor to get superCellFieldIdx
-    template<typename... T_KernelConfigOptions>
-    struct SuperCellFieldIndexFunctor : public s_interfaces::AdditionalDataIndexFunctor<T_KernelConfigOptions...>
-    {
-        template<typename T_AreaMapping>
-        HDINLINE static pmacc::DataSpace<picongpu::simDim> getIndex(
-            T_AreaMapping const areaMapping,
-            pmacc::DataSpace<picongpu::simDim> const superCellIdx)
-        {
-            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
-            //  -> must subtract guard to get correct superCellFieldIdx
-            return superCellIdx - areaMapping.getGuardingSuperCells();
-        }
-    };
-
-    //! test for local time remaining <= 0 for superCell
-    template<typename... T_KernelConfigOptions>
-    struct SkipFinishedSuperCellsAtomicPhysics : public s_interfaces::SuperCellFilterFunctor<T_KernelConfigOptions...>
-    {
-        template<typename T_LocalTimeRemainingBox, typename... T_AdditionalStuff>
-        HDINLINE static bool skipSuperCell(
-            pmacc::DataSpace<picongpu::simDim> const,
-            pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
-            T_LocalTimeRemainingBox const timeRemainingBox,
-            T_AdditionalStuff...)
-        {
-            return (timeRemainingBox[superCellFieldIndex] <= 0._X);
-        }
-    };
-
     struct KernelState
     {
         // eV
@@ -158,58 +125,6 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 superCellFieldIndex,
                 ipdInputBoxes...);
             kernelState.foundUnbound = u32(false);
-        }
-    };
-
-    template<typename T_IPDModel, typename T_fieldIonizationActive>
-    struct CacheEFieldForSuperCell
-        : public s_interfaces::
-              InitCacheFunctor<pmacc::DataSpace<picongpu::simDim>, T_IPDModel, T_fieldIonizationActive>
-    {
-        template<
-            typename T_Worker,
-            typename T_LocalTimeRemainingBox,
-            typename T_FoundUnboundIonBox,
-            typename T_ChargeStateDataBox,
-            typename T_AtomicStateDataBox,
-            typename T_IPDIonizationStateDataBox,
-            typename T_EFieldDataBox,
-            typename... T_IPDInputBoxes>
-        HDINLINE static auto getCache(
-            T_Worker const& worker,
-            pmacc::DataSpace<picongpu::simDim> const superCellIndex,
-            T_LocalTimeRemainingBox const,
-            T_FoundUnboundIonBox const,
-            T_ChargeStateDataBox const,
-            T_AtomicStateDataBox const,
-            T_IPDIonizationStateDataBox const,
-            T_EFieldDataBox const eFieldBox,
-            T_IPDInputBoxes const... ipdInputBoxes)
-        {
-            if constexpr(T_fieldIonizationActive::value)
-            {
-                using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
-                /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
-                auto eFieldCache = CachedBox::create<__COUNTER__, typename T_EFieldDataBox::ValueType::type>(
-                    worker,
-                    SuperCellBlock());
-
-                pmacc::DataSpace<picongpu::simDim> const superCellCellOffset
-                    = superCellIndex * picongpu::SuperCellSize::toRT();
-
-                auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
-
-                pmacc::math::operation::Assign assign;
-                auto collective = makeThreadCollective<SuperCellBlock>();
-
-                collective(worker, assign, eFieldCache, fieldEBlockToCache);
-
-                return eFieldCache;
-            }
-            else
-            {
-                return 0._X;
-            }
         }
     };
 
@@ -312,35 +227,6 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
-    template<typename... T_KernelConfigOptions>
-    struct InitAsCoMoving : public s_interfaces::ParticlePairUpdateFunctor<T_KernelConfigOptions...>
-    {
-        template<
-            typename T_Worker,
-            typename T_SourceParticle,
-            typename T_ProductParticle,
-            typename T_Number,
-            typename T_KernelStateType,
-            typename T_Index,
-            typename... T_AdditionalData>
-        HDINLINE static void update(
-            T_Worker const& worker,
-            T_SourceParticle& sourceParticle,
-            T_ProductParticle& productParticle,
-            IdGenerator& idGen,
-            T_Number const,
-            T_KernelStateType&,
-            T_Index const,
-            T_AdditionalData...)
-        {
-            particles::atomicPhysics::initElectrons::CoMoving::initElectron(
-                worker,
-                sourceParticle,
-                productParticle,
-                idGen);
-        }
-    };
-
     template<typename T_IPDModel, typename T_fieldIonizationActive>
     struct WriteFoundUnboundToSuperCellField
         : public s_interfaces::WriteOutKernelStateFunctor<T_IPDModel, T_fieldIonizationActive>
@@ -374,13 +260,13 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
     //! moduleConfig of the ApplyIPDIonizationKernel
     using ApplyIPDIonizationModulConfig = particles::creation::ModuleConfig<
         ApplyIPDIonizationSanityCheckInputs,
-        SkipFinishedSuperCellsAtomicPhysics,
+        spawnFromSourceSpeciesModules::SkipFinishedSuperCells,
         IPDIonizationPredictor,
-        InitAsCoMoving,
+        spawnFromSourceSpeciesModules::InitAsCoMoving,
         KernelState,
         CalculateIPDValue,
-        CacheEFieldForSuperCell,
-        SuperCellFieldIndexFunctor,
+        spawnFromSourceSpeciesModules::CacheEFieldForSuperCell,
+        spawnFromSourceSpeciesModules::SuperCellFieldIndexFunctor,
         WriteFoundUnboundToSuperCellField>;
 
     //! actual definition of ApplyIPDIonizationKernel

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.hpp
@@ -83,7 +83,6 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         // macro for call of kernel on every superCell, see pull request #4321
         PMACC_LOCKSTEP_KERNEL(s_IPD::kernel::ApplyIPDIonizationKernel<
                                   T_IPDModel,
-                                  FieldE,
                                   std::integral_constant<bool, AtomicDataType::switchFieldIonization>>())
             .config(mapper.getGridDim(), ions)(
                 mapper,

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -79,7 +79,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_RejectionProbabilityCacheDataBox rejectionProbabilityCacheBox) const
         {
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
-            auto const superCellFieldIdx = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
+            auto const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             if(timeRemaining <= 0._X)

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -200,14 +200,15 @@ namespace picongpu::particles::atomicPhysics::kernel
                         uint32_t const transitionCollectionIndex = transitionID + startIndexTransitionBlock;
 
                         // 1/picongpu::sim.unit.time()
-                        float_X const rateTransition = atomicPhysics::rateCalculation::
-                            BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::template rateADKFieldIonization(
-                                eFieldNormCell,
-                                ionizationPotentialDepression,
-                                transitionCollectionIndex,
-                                chargeStateDataDataBox,
-                                atomicStateDataDataBox,
-                                transitionDataBox);
+                        float_X const rateTransition
+                            = atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
+                                template rateADKFieldIonization<float_X>(
+                                    eFieldNormCell,
+                                    ionizationPotentialDepression,
+                                    transitionCollectionIndex,
+                                    chargeStateDataDataBox,
+                                    atomicStateDataDataBox,
+                                    transitionDataBox);
 
                         cumSum += rateTransition
                             / rateCache.rate(

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -138,7 +138,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
             VectorIdx const superCellFieldIdx
-                = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -21,13 +21,12 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/CheckForInvalidChooseTransitionGroup.hpp"
+#include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
-#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
-#include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
@@ -86,30 +85,6 @@ namespace picongpu::particles::atomicPhysics::kernel
             worker.sync();
         }
 
-        template<
-            typename T_AtomicStateBoundFreeStartIndexBlockDataBox,
-            typename T_AtomicStateBoundFreeNumberTransitionsDataBox,
-            typename T_BoundFreeTransitionDataBox>
-        static constexpr bool checkCorrectAtomicDataBoxesPassed()
-        {
-            PMACC_CASSERT_MSG(
-                number_transition_dataBox_not_bound_free_based,
-                u8(T_AtomicStateBoundFreeNumberTransitionsDataBox::processClassGroup)
-                    == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateBoundFreeStartIndexBlockDataBox::processClassGroup)
-                    == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                boundFreeTransitiondataBox_not_bound_free_based,
-                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                wrong_transition_ordering_boundFreeTransitionDataBox,
-                u8(T_BoundFreeTransitionDataBox::transitionOrdering)
-                    == u8(s_enums::TransitionOrderingFor<s_enums::TransitionDirection::upward>::ordering));
-            return true;
-        }
-
     public:
         /** call operator
          *
@@ -126,7 +101,7 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param startIndexBox deviceDataBox giving access to the start index of each
          * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
          * cells
-         * @param eFieldBox deviceDataBox giving access to the device local eField Values
+         * @param eFieldBox deviceDataBox giving access to the device local E-Field values
          * @param ionBox deviceDataBox giving access to the ion frames of all local superCells
          * @param ipdInput everything required by T_IPDModel to calculate the IonizationPotentialDepression,
          *  passed by T_IPDModel::callKernelWithIPDInput
@@ -160,7 +135,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_IonBox ionBox,
             T_IPDInput const... ipdInput) const
         {
-            PMACC_CASSERT(checkCorrectAtomicDataBoxesPassed<
+            PMACC_CASSERT(CheckSetOfAtomicDataBoxes::areBoundFreeAndDirection<
+                          s_enums::TransitionDirection::upward,
                           T_AtomicStateBoundFreeStartIndexBlockDataBox,
                           T_AtomicStateBoundFreeNumberTransitionsDataBox,
                           T_BoundFreeTransitionDataBox>());

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -23,6 +23,7 @@
 #include "picongpu/particles/atomicPhysics/CheckForInvalidChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/EFieldCache.hpp"
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
@@ -62,25 +63,6 @@ namespace picongpu::particles::atomicPhysics::kernel
     {
         using VectorIdx = pmacc::DataSpace<picongpu::simDim>;
 
-    private:
-        //! @attention this is a collective method and implicitly synchronises
-        template<typename BlockDescription, typename T_Worker, typename T_EFieldBox, typename T_EfieldCache>
-        HDINLINE void initEFieldCache(
-            T_Worker const& worker,
-            VectorIdx const& superCellCellOffset,
-            T_EFieldBox const eFieldBox,
-            T_EfieldCache& eFieldCache) const
-        {
-            auto fieldEBlockToCache = eFieldBox.shift(superCellCellOffset);
-
-            pmacc::math::operation::Assign assign;
-            auto collective = makeThreadCollective<BlockDescription>();
-
-            collective(worker, assign, eFieldCache, fieldEBlockToCache);
-            worker.sync();
-        }
-
-    public:
         /** call operator
          *
          * called by ChooseTransition atomic physics sub-stage
@@ -146,15 +128,11 @@ namespace picongpu::particles::atomicPhysics::kernel
             if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
                 return;
 
-            using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
-            VectorIdx const superCellSize = picongpu::SuperCellSize::toRT();
-            /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
-            auto eFieldCache
-                = CachedBox::create</* Id */ 0u, typename T_EFieldBox::ValueType::type>(worker, SuperCellBlock());
-            VectorIdx const superCellCellOffset = superCellIdx * superCellSize;
-            initEFieldCache<SuperCellBlock>(worker, superCellCellOffset, eFieldBox, eFieldCache);
+            auto eFieldCache = EFieldCache::get<__COUNTER__>(worker, superCellIdx, eFieldBox);
+            worker.sync()
 
-            auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
+                auto rngGeneratorFloat
+                = rngFactoryFloat(worker, superCellFieldIdx);
             auto& rateCache = rateCacheBox(superCellFieldIdx);
 
             float_X const ionizationPotentialDepression

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -54,15 +54,10 @@ namespace picongpu::particles::atomicPhysics::kernel
      * The transition corresponding to the interval containing r is the chosen and accepted.
      *
      * @tparam T_ADKLaserPolarization polarization direction to use in the ADK rate calculation
-     * @tparam T_EField type of EField
      * @tparam T_n_max number of levels of atomic states in input
      * @tparam T_IPDModel ionization potential depression model to use
      */
-    template<
-        s_enums::ADKLaserPolarization T_ADKLaserPolarization,
-        typename T_EField,
-        uint8_t T_n_max,
-        typename T_IPDModel>
+    template<s_enums::ADKLaserPolarization T_ADKLaserPolarization, uint8_t T_n_max, typename T_IPDModel>
     struct ChooseTransitionKernel_FieldBoundFree
     {
         using VectorIdx = pmacc::DataSpace<picongpu::simDim>;
@@ -154,7 +149,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             using SuperCellBlock = pmacc::SuperCellDescription<typename picongpu::SuperCellSize>;
             VectorIdx const superCellSize = picongpu::SuperCellSize::toRT();
             /// @note cache is unique for kernel call by id and dataType, and thereby shared between workers
-            auto eFieldCache = CachedBox::create</* Id */ 0u, typename T_EField::ValueType>(worker, SuperCellBlock());
+            auto eFieldCache
+                = CachedBox::create</* Id */ 0u, typename T_EFieldBox::ValueType::type>(worker, SuperCellBlock());
             VectorIdx const superCellCellOffset = superCellIdx * superCellSize;
             initEFieldCache<SuperCellBlock>(worker, superCellCellOffset, eFieldBox, eFieldCache);
 

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
@@ -21,6 +21,7 @@
 
 // need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
 #include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/CachedHistogram.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
@@ -62,7 +63,7 @@ namespace picongpu::particles::atomicPhysics::kernel
      *
      * @tparam T_electronicIonization is collisional electronic ionization channel active?
      * @tparam T_fieldIonization is field ionization channel active?
-     * @tparam T_TransitionOrdering ordering of assumed for transition DataBox
+     * @tparam T_TransitionOrdering ordering assumed for transition DataBox
      */
     template<
         typename T_IPDModel,
@@ -75,31 +76,6 @@ namespace picongpu::particles::atomicPhysics::kernel
         s_enums::TransitionOrdering T_TransitionOrdering>
     struct FillRateCacheKernel_BoundFree
     {
-        template<
-            typename T_AtomicStateNumberTransitionsBox,
-            typename T_AtomicStateStartIndexBox,
-            typename T_BoundFreeTransitionDataBox>
-        static constexpr bool correctAtomicDataBoxes()
-        {
-            // check that correct databoxes are given
-            PMACC_CASSERT_MSG(
-                number_transitions_dataBox_not_bound_free_based,
-                u8(T_AtomicStateNumberTransitionsBox::processClassGroup)
-                    == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                startIndex_dataBox_not_bound_free_based,
-                u8(T_AtomicStateStartIndexBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            PMACC_CASSERT_MSG(
-                transition_dataBox_not_bound_free_based,
-                u8(T_BoundFreeTransitionDataBox::processClassGroup) == u8(s_enums::ProcessClassGroup::boundFreeBased));
-            // check ordering of transition dataBox
-            PMACC_CASSERT_MSG(
-                wrong_ordering_of_DataBox,
-                u8(T_BoundFreeTransitionDataBox::transitionOrdering) == u8(T_TransitionOrdering));
-
-            return true;
-        };
-
         template<
             typename T_Worker,
             typename T_RateCache,
@@ -309,18 +285,17 @@ namespace picongpu::particles::atomicPhysics::kernel
          *
          * @param worker object containing the device and block information, passed by PMACC_KERNEL call
          * @param areaMapping mapping of blockIndex to block superCell index
-         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
-         * cells
-         * @param rateCacheBox deviceDataBox giving access to the local rate cache of
-         *  all local superCells
-         * @param electronHistogramDataBox giving access to the local electron histograms
-         *  of all local superCells
+         * @param timeRemainingBox deviceDataBox giving access to the time remaining of all local superCells
+         * @param rateCacheBox deviceDataBox giving access to the rate cache of all local superCells
+         * @param electronHistogramDataBox deviceDataBox giving access to the electron histograms of all local
+         *  superCells
+         * @param eFieldBox deviceDataBox giving access to the E-Field values of all local cells
          * @param chargeStateDataDataBox deviceDataBox giving access to charge state property data
          * @param atomicStateDataDataBox deviceDataBox giving access to atomic state property data
-         * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states'
-         *  block of transitions in the up-/down-ward bound-bound transition collection
-         * @param numberTransitionsDataBox deviceDataBox giving access to the number of transitions
-         *   of each atomic state up- and down-ward
+         * @param startIndexDataBox deviceDataBox giving access to the start index of each atomic states' block of
+         *  transitions in the up-/down-ward bound-bound transition collection
+         * @param numberTransitionsDataBox deviceDataBox giving access to the number of transitions of each atomic
+         *  state up- and down-ward
          * @param boundFreeTransitionDataBox deviceDataBox giving access to bound-free transition property data
          * @param ipdInput deviceDataBoxes giving access to ionization potential depression input for each superCell
          *
@@ -359,7 +334,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             // This last is always used:
             T_IPDInput... ipdInput) const
         {
-            PMACC_CASSERT(correctAtomicDataBoxes<
+            PMACC_CASSERT(CheckSetOfAtomicDataBoxes::areBoundFreeAndOrdering<
+                          T_TransitionOrdering,
                           T_AtomicStateNumberTransitionsBox,
                           T_AtomicStateStartIndexBox,
                           T_BoundFreeTransitionDataBox>());

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
@@ -313,7 +313,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
             VectorIdx const superCellFieldIdx
-                = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             // unit: unit_time
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
@@ -23,6 +23,8 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
+#include "picongpu/particles/atomicPhysics/MinimumAndMaximumEFieldNormOfSuperCell.hpp"
 #include "picongpu/particles/atomicPhysics/electronDistribution/CachedHistogram.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
@@ -76,6 +78,8 @@ namespace picongpu::particles::atomicPhysics::kernel
         s_enums::TransitionOrdering T_TransitionOrdering>
     struct FillRateCacheKernel_BoundFree
     {
+        using VectorIdx = pmacc::DataSpace<picongpu::simDim>;
+
         template<
             typename T_Worker,
             typename T_RateCache,
@@ -87,7 +91,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_BoundFreeTransitionDataBox>
         HDINLINE static void fillWithCollisonalIonization(
             T_Worker const& worker,
-            pmacc::DataSpace<picongpu::simDim> superCellFieldIdx,
+            VectorIdx superCellFieldIdx,
             T_RateCache& rateCache,
             T_LocalElectronHistogramDataBox const electronHistogramDataBox,
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
@@ -177,7 +181,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_BoundFreeTransitionDataBox>
         HDINLINE static void fillWithFieldIonization(
             T_Worker const& worker,
-            pmacc::DataSpace<picongpu::simDim> superCellIdx,
+            VectorIdx superCellIdx,
             T_RateCache& rateCache,
             T_EFieldDataBox const eFieldBox,
             T_ChargeStateDataDataBox const chargeStateDataDataBox,
@@ -187,50 +191,17 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
             float_X const ionizationPotentialDepression)
         {
-            // sim.unit.eField()
-            PMACC_SMEM(worker, maxEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
-            // sim.unit.eField()
-            PMACC_SMEM(worker, minEFieldSuperCell, typename T_EFieldDataBox::ValueType::type);
+            // unit: unit_eField
+            PMACC_SMEM(worker, minEFieldNormSuperCell, typename T_EFieldDataBox::ValueType::type);
+            // unit: unit_eField
+            PMACC_SMEM(worker, maxEFieldNormSuperCell, typename T_EFieldDataBox::ValueType::type);
 
-            auto onlyMaster = lockstep::makeMaster(worker);
-            onlyMaster(
-                [&maxEFieldSuperCell, &minEFieldSuperCell]()
-                {
-                    maxEFieldSuperCell = 0._X;
-                    /// needs to be initialized with neutral element of Minimum
-                    /// @warning never increase the result from this variable, may be maximum representable value.
-                    minEFieldSuperCell = std::numeric_limits<float_X>::max();
-                });
-            worker.sync();
-
-            constexpr auto numberCellsInSuperCell
-                = pmacc::math::CT::volume<typename picongpu::SuperCellSize>::type::value;
-            DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
-            auto forEachCell = pmacc::lockstep::makeForEach<numberCellsInSuperCell, T_Worker>(worker);
-
-            /// @todo switch to shared memory reduce, Brian Marre, 2024
-            forEachCell(
-                [&worker, &superCellCellOffset, &maxEFieldSuperCell, &minEFieldSuperCell, &eFieldBox](
-                    uint32_t const linearIdx)
-                {
-                    DataSpace<picongpu::simDim> const localCellIndex
-                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearIdx));
-                    DataSpace<picongpu::simDim> const cellIndex = localCellIndex + superCellCellOffset;
-
-                    auto const eFieldNorm = pmacc::math::l2norm(eFieldBox(cellIndex));
-
-                    alpaka::atomicMax(
-                        worker.getAcc(),
-                        // sim.unit.eField()
-                        &maxEFieldSuperCell,
-                        eFieldNorm);
-
-                    alpaka::atomicMin(
-                        worker.getAcc(),
-                        // sim.unit.eField()
-                        &minEFieldSuperCell,
-                        eFieldNorm);
-                });
+            MinimumAndMaximumEFieldNormOfSuperCell::find(
+                worker,
+                superCellIdx,
+                eFieldBox,
+                minEFieldNormSuperCell,
+                maxEFieldNormSuperCell);
             worker.sync();
 
             // calculate maximum ADK field ionization rate for each atomic state
@@ -254,18 +225,18 @@ namespace picongpu::particles::atomicPhysics::kernel
                         = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
                     uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
 
-                    // 1/picongpu::sim.unit.time()
+                    // unit: 1/unit_time
                     float_X sumRateTransitions = 0._X;
                     for(uint32_t transitionID = u32(0u); transitionID < numberTransitionsUp; ++transitionID)
                     {
                         uint32_t const transitionCollectionIndex = offset + transitionID;
 
-                        // 1/picongpu::sim.unit.time()
+                        // unit: 1/unit_time
                         sumRateTransitions
                             += atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
-                                template maximumRateADKFieldIonization(
-                                    maxEFieldSuperCell,
+                                template maximumRateADKFieldIonization<float_X>(
                                     minEFieldSuperCell,
+                                    maxEFieldSuperCell,
                                     ionizationPotentialDepression,
                                     transitionCollectionIndex,
                                     chargeStateDataDataBox,
@@ -340,14 +311,11 @@ namespace picongpu::particles::atomicPhysics::kernel
                           T_AtomicStateStartIndexBox,
                           T_BoundFreeTransitionDataBox>());
 
-            pmacc::DataSpace<picongpu::simDim> const superCellIdx
-                = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
-            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
-            //  -> must subtract guard to get correct superCellFieldIdx
-            pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
-                = superCellIdx - areaMapping.getGuardingSuperCells();
+            VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
+            VectorIdx const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
 
-            // picongpu::sim.unit.time()
+            // unit: unit_time
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
 
             // end kernel if superCell already finished

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
@@ -83,7 +83,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_IPDInput const... ipdInput) const
         {
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
-            auto const superCellFieldIdx = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
+            auto const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);

--- a/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
@@ -78,7 +78,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_RejectionProbabilityCacheDataBox rejectionProbabilityCacheBox) const
         {
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
-            auto const superCellFieldIdx = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
+            auto const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             bool const sharedResourcesOverSubscribed

--- a/include/picongpu/particles/atomicPhysics/kernel/UpdateElectricField.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/UpdateElectricField.kernel
@@ -63,7 +63,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_FieldEnergyUseCacheBox const fieldEnergyUseCacheBox) const
         {
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
-            auto const superCellFieldIdx = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping, superCellIdx);
+            auto const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
             if(timeRemaining <= 0._X)

--- a/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/CacheEFieldForSuperCell.hpp
+++ b/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/CacheEFieldForSuperCell.hpp
@@ -25,19 +25,13 @@
 #include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
-#include <pmacc/dimensions/SuperCellDescription.hpp>
-#include <pmacc/mappings/threads/ThreadCollective.hpp>
-#include <pmacc/math/operation/Assign.hpp>
-#include <pmacc/memory/boxes/CachedBox.hpp>
-#include <pmacc/memory/boxes/DataBox.hpp>
-#include <pmacc/memory/boxes/SharedBox.hpp>
 
 namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
 {
     namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
 
     //! definition of Modul
-    template<typename T_IPDModel, typename T_fieldIonizationActive>
+    template<uint32_t T_id, typename T_IPDModel, typename T_fieldIonizationActive>
     struct CacheEFieldForSuperCell
         : public s_interfaces::
               InitCacheFunctor<pmacc::DataSpace<picongpu::simDim>, T_IPDModel, T_fieldIonizationActive>
@@ -65,7 +59,7 @@ namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
         {
             if constexpr(T_fieldIonizationActive::value)
             {
-                return EFieldCache::get(worker, superCellIndex, eFieldBox);
+                return EFieldCache::get<T_id>(worker, superCellIndex, eFieldBox);
             }
             else
             {

--- a/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/CacheEFieldForSuperCell.hpp
+++ b/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/CacheEFieldForSuperCell.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software you can redistribute it and or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need simDim from dim.param
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/EFieldCache.hpp"
+#include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/dimensions/SuperCellDescription.hpp>
+#include <pmacc/mappings/threads/ThreadCollective.hpp>
+#include <pmacc/math/operation/Assign.hpp>
+#include <pmacc/memory/boxes/CachedBox.hpp>
+#include <pmacc/memory/boxes/DataBox.hpp>
+#include <pmacc/memory/boxes/SharedBox.hpp>
+
+namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
+{
+    namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
+
+    //! definition of Modul
+    template<typename T_IPDModel, typename T_fieldIonizationActive>
+    struct CacheEFieldForSuperCell
+        : public s_interfaces::
+              InitCacheFunctor<pmacc::DataSpace<picongpu::simDim>, T_IPDModel, T_fieldIonizationActive>
+    {
+        //! @attention this is a collective method, needs a thread synchronize before first access of cache values
+        template<
+            typename T_Worker,
+            typename T_LocalTimeRemainingBox,
+            typename T_FoundUnboundIonBox,
+            typename T_ChargeStateDataBox,
+            typename T_AtomicStateDataBox,
+            typename T_IPDIonizationStateDataBox,
+            typename T_EFieldDataBox,
+            typename... T_IPDInputBoxes>
+        HDINLINE static auto getCache(
+            T_Worker const& worker,
+            pmacc::DataSpace<picongpu::simDim> const superCellIndex,
+            T_LocalTimeRemainingBox const,
+            T_FoundUnboundIonBox const,
+            T_ChargeStateDataBox const,
+            T_AtomicStateDataBox const,
+            T_IPDIonizationStateDataBox const,
+            T_EFieldDataBox const eFieldBox,
+            T_IPDInputBoxes const...)
+        {
+            if constexpr(T_fieldIonizationActive::value)
+            {
+                return EFieldCache::get(worker, superCellIndex, eFieldBox);
+            }
+            else
+            {
+                return 0._X;
+            }
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules

--- a/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/InitAsCoMoving.hpp
+++ b/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/InitAsCoMoving.hpp
@@ -1,0 +1,61 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/initElectrons/CoMoving.hpp"
+#include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
+{
+    namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
+
+    template<typename... T_KernelConfigOptions>
+    struct InitAsCoMoving : public s_interfaces::ParticlePairUpdateFunctor<T_KernelConfigOptions...>
+    {
+        template<
+            typename T_Worker,
+            typename T_SourceParticle,
+            typename T_ProductParticle,
+            typename T_Number,
+            typename T_KernelStateType,
+            typename T_Index,
+            typename... T_AdditionalData>
+        HDINLINE static void update(
+            T_Worker const& worker,
+            T_SourceParticle& sourceParticle,
+            T_ProductParticle& productParticle,
+            IdGenerator& idGen,
+            T_Number const,
+            T_KernelStateType&,
+            T_Index const,
+            T_AdditionalData...)
+        {
+            particles::atomicPhysics::initElectrons::CoMoving::initElectron(
+                worker,
+                sourceParticle,
+                productParticle,
+                idGen);
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules

--- a/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/SkipFinishedSuperCell.hpp
+++ b/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/SkipFinishedSuperCell.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
+{
+    namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
+
+    //! test for local time remaining <= 0 for superCell
+    template<typename... T_KernelConfigOptions>
+    struct SkipFinishedSuperCellsAtomicPhysics : public s_interfaces::SuperCellFilterFunctor<T_KernelConfigOptions...>
+    {
+        template<typename T_LocalTimeRemainingBox, typename... T_AdditionalStuff>
+        HDINLINE static bool skipSuperCell(
+            pmacc::DataSpace<picongpu::simDim> const,
+            pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
+            T_LocalTimeRemainingBox const timeRemainingBox,
+            T_AdditionalStuff const...)
+        {
+            return (timeRemainingBox[superCellFieldIndex] <= 0._X);
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules

--- a/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/SuperCellFieldIndexFunctor.hpp
+++ b/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/SuperCellFieldIndexFunctor.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need simDim from dimensions.param
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
+#include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
+{
+    namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
+
+    template<typename... T_KernelConfigOptions>
+    struct SuperCellFieldIndexFunctor : public s_interfaces::AdditionalDataIndexFunctor<T_KernelConfigOptions...>
+    {
+        template<typename T_AreaMapping>
+        HDINLINE static pmacc::DataSpace<picongpu::simDim> getIndex(
+            T_AreaMapping const areaMapping,
+            pmacc::DataSpace<picongpu::simDim> const superCellIdx)
+        {
+            return particles::atomicPhysics::KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(
+                areaMapping,
+                superCellIdx);
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules

--- a/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
@@ -172,7 +172,6 @@ namespace picongpu::particles::atomicPhysics::stage
                 using ChooseTransitionKernel_FieldBoundFree
                     = picongpu::particles::atomicPhysics::kernel::ChooseTransitionKernel_FieldBoundFree<
                         AtomicDataType::ADKLaserPolarization,
-                        FieldE,
                         AtomicDataType::ConfigNumber::numberLevels,
                         IPDModel>;
 

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -464,10 +464,7 @@ namespace picongpu::simulation::stage
                 do
                 {
                     resetFoundUnboundIon();
-                    picongpu::atomicPhysics::IPDModel::
-                        template calculateIPDInput<T_numberAtomicPhysicsIonSpecies, IPDIonSpecies, IPDElectronSpecies>(
-                            mappingDesc,
-                            currentStep);
+                    calculateIPDInput(mappingDesc, currentStep);
                     picongpu::atomicPhysics::IPDModel::template applyIPDIonization<AtomicPhysicsIonSpecies>(
                         mappingDesc,
                         currentStep);
@@ -540,8 +537,8 @@ namespace picongpu::simulation::stage
                     resetAcceptStatus(mappingDesc);
                     resetElectronEnergyHistogram();
                     debugForceConstantElectronTemperature(currentStep);
+                    doIPDIonization(mappingDesc, currentStep, deviceLocalReduce);
                     binElectronsToEnergyHistogram(mappingDesc);
-                    calculateIPDInput(mappingDesc, currentStep);
                     resetTimeStep(mappingDesc);
                     resetRateCache();
                     checkPresence(mappingDesc);
@@ -584,10 +581,12 @@ namespace picongpu::simulation::stage
                     recordChanges(mappingDesc);
                     updateElectrons(mappingDesc, currentStep);
                     updateElectricField(mappingDesc);
-                    doIPDIonization(mappingDesc, currentStep, deviceLocalReduce);
                     updateTimeRemaining(mappingDesc);
                     isSubSteppingComplete = isSubSteppingFinished(mappingDesc, deviceLocalReduce);
                 } // end atomicPhysics sub-stepping loop
+
+                // ensure no unbound states are visible to the rest of the loop
+                doIPDIonization(mappingDesc, currentStep, deviceLocalReduce);
             }
         };
 


### PR DESCRIPTION
Extract the creation of an superCell E-Field Cache to remove code duplication.

This is done in preparation for the implementation of the instant field ionization transitions.

- [x] requires PR #5207 to b merged first
- [ ] requires PR #5206 to be merged first
- [ ] requires PR #5212 to be merged first
- [ ] requires PR #5213 to be merged first
- [ ] requires PR #5214 to be merged first
- [ ] requires PR #5215 to be merged first
- [ ] requires PR #5216 to be merged first
- [ ] needs to be rebased to the dev

every but the last commit belongs to the base PRs