### PR TITLE
add Comment to definition of l2Norm

### DIFF
--- a/include/pmacc/algorithms/math/defines/l2norm.hpp
+++ b/include/pmacc/algorithms/math/defines/l2norm.hpp
@@ -27,6 +27,7 @@ namespace pmacc
 {
     namespace math
     {
+        /// definition must be provided by Type
         template<typename Type>
         struct L2norm;
 


### PR DESCRIPTION
adds a small comment to the definition of l2Norm for future developers

ci: no-compile