### PR TITLE
Metadata optimization: Only write ADIOS2 attributes from rank 0 in openPMD-api >= 0.16

### DIFF
--- a/include/picongpu/plugins/openPMD/Json.cpp
+++ b/include/picongpu/plugins/openPMD/Json.cpp
@@ -339,6 +339,37 @@ The key 'select' must point to either a single string or an array of strings.)EN
          * careful memory configuration is necessary anyway, so the
          * defaults don't matter.
          */
+#    if OPENPMDAPI_VERSION_GE(0, 16, 0)
+        /*
+         * In openPMD >= 0.16, additionally ignore all attribute metadata
+         * that comes from a rank other than rank 0.
+         * The openPMD plugin of PIConGPU writes attributes synchronously
+         * (since this is required in common configurations of HDF5).
+         * For ADIOS2 however, it's better to write attributes from single
+         * ranks only and avoid metadata duplication across ranks.
+         * This option tells the ADIOS2 backend of openPMD that it can
+         * safely ignore any attribute write if the current MPI rank is
+         * not 0.
+         */
+        std::string const& defaultValues = R"(
+{
+  "hdf5": {
+    "dataset": {
+      "chunks": "none"
+    }
+  },
+  "adios2": {
+    "attribute_writing_ranks": 0,
+    "engine": {
+      "preferred_flush_target": "buffer",
+      "parameters": {
+        "BufferChunkSize": 2147381248
+      }
+    }
+  }
+}
+        )";
+#    else
         std::string const& defaultValues = R"(
 {
   "hdf5": {
@@ -356,6 +387,7 @@ The key 'select' must point to either a single string or an array of strings.)EN
   }
 }
         )";
+#    endif
         std::stringstream json_to_string;
         json_to_string << config;
         auto merged = openPMD::json::merge(defaultValues, json_to_string.str());


### PR DESCRIPTION
We were thinking about using this as the default option generally in openPMD, but [our documentation](https://openpmd-api.readthedocs.io/en/0.15.2/details/mpi.html) specifies that attribute writing is collective only in HDF5, and attributes can be written independently in ADIOS2. So it would have broken the API contract to assume that attributes outside of rank 0 can be ignored.
In PIConGPU, however, they can.