### PR TITLE
openPMD plugin: Add option for Append mode in writing

### DIFF
--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -140,6 +140,14 @@ PIConGPU command line option          description
                                       If your system host memory is small compared to the accelerator memory you should use ``--openPMD.dataPreparationStrategy mappedMemory`` to have
                                       a smaller host memory footprint.
                                       The memory footprint required to dump fields will not be affected by this parameter.
+``--openPMD.writeAccess``             openPMD Access mode for file writing. Default: ``create``. Selecting ``append`` can be useful for checkpoint-restart workflows for avoiding
+                                      truncation of data upon reopening the output Series. Note that the Append mode in openPMD-api is used for adding new Iterations to a data Series
+                                      that (possibly) already exists, but does not specify what happens when an Iteration is written for a second time.
+                                      This situation will typically occur in checkpoint-restart workflows where a handful of iterations is usually recomputed.
+                                      In this situation, the backends will pick a sensible, but unspecified implementation for proceeding. This may include:
+                                      Adding the Iteration in a new IO step, leading to data duplication (ADIOS2 non-file-based encoding);
+                                      replacing the old Iteration with the new one entirely (all file-based encodings); writing new data into the existing Iteration and leaving other
+                                      data unmodified (HDF5 in non-file-based encoding).
 ===================================== ====================================================================================================================================================
 
 .. note::

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -22,5 +22,6 @@ namespace picongpu::openPMD
         std::string jsonConfigString;
         std::string rangeString;
         std::string jsonRestartParams;
+        std::string writeModeString;
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -22,6 +22,6 @@ namespace picongpu::openPMD
         std::string jsonConfigString;
         std::string rangeString;
         std::string jsonRestartParams;
-        std::string writeModeString;
+        std::string writeAccessString;
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -92,6 +92,8 @@ namespace picongpu
 
             MappingDesc* cellDescription = nullptr;
 
+            ::openPMD::Access writeMode = ::openPMD::Access::CREATE;
+
             std::vector<char> fieldBuffer; /* temp. buffer for fields */
 
             Window window; /* window describing the volume to be dumped */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -92,7 +92,7 @@ namespace picongpu
 
             MappingDesc* cellDescription = nullptr;
 
-            ::openPMD::Access writeMode = ::openPMD::Access::CREATE;
+            ::openPMD::Access writeAccess = ::openPMD::Access::CREATE;
 
             std::vector<char> fieldBuffer; /* temp. buffer for fields */
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -263,8 +263,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                    "Particle data will be written in chunks of the given size. unit: MiB",
                    "10240"};
 
-            plugins::multi::Option<std::string> writeMode
-                = {"writeMode", "openPMD Access mode for creating output: [create|append]", "create"};
+            plugins::multi::Option<std::string> writeAccess
+                = {"writeAccess", "openPMD Access mode for creating output: [create|append]", "create"};
 
             /*
              * The openPMD plugin is used as a normal I/O plugin as well as for
@@ -357,7 +357,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                  &PluginParameters::jsonRestartParams,
                  ApplyParameter::OnlyInCheckpoint},
                 {&particleIOChunkSize, "particleIOChunkSize", &PluginParameters::particleIOChunkSizeString},
-                {&writeMode, "write_mode", &PluginParameters::writeModeString}};
+                {&writeAccess, "write_mode", &PluginParameters::writeAccessString}};
 
             std::vector<toml::TomlParameter> tomlParameters()
             {
@@ -668,23 +668,23 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             }
 
             std::transform(
-                writeModeString.begin(),
-                writeModeString.end(),
-                writeModeString.begin(),
+                writeAccessString.begin(),
+                writeAccessString.end(),
+                writeAccessString.begin(),
                 [](unsigned char c) { return std::tolower(c); });
-            if(writeModeString == "create")
+            if(writeAccessString == "create")
             {
-                writeMode = ::openPMD::Access::CREATE;
+                writeAccess = ::openPMD::Access::CREATE;
             }
-            else if(writeModeString == "append")
+            else if(writeAccessString == "append")
             {
-                writeMode = ::openPMD::Access::APPEND;
+                writeAccess = ::openPMD::Access::APPEND;
             }
             else
             {
                 // Better to crash here instead of doing wrong things to user data
                 throw std::runtime_error(
-                    "Wrong write mode specified: '" + writeModeString + "'. Pick either [create|append].");
+                    "Wrong write access mode specified: '" + writeAccessString + "'. Pick either [create|append].");
             }
 
             const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();
@@ -1817,7 +1817,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 else
                 {
                     log<picLog::INPUT_OUTPUT>("openPMD: opening Series %1%") % threadParams->fileName;
-                    threadParams->openSeries(threadParams->writeMode);
+                    threadParams->openSeries(threadParams->writeAccess);
                 }
 
                 /* attributes written here are pure meta data */

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -171,7 +171,7 @@ In case your openPMD API supports both ADIOS1 and ADIOS2,
 make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 )END");
                 }
-                if(at == ::openPMD::Access::CREATE)
+                if(at == ::openPMD::Access::CREATE || at == ::openPMD::Access::APPEND)
                 {
                     openPMDSeries->setMeshesPath(MESHES_PATH);
                     openPMDSeries->setParticlesPath(PARTICLES_PATH);
@@ -1793,7 +1793,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 else
                 {
                     log<picLog::INPUT_OUTPUT>("openPMD: opening Series %1%") % threadParams->fileName;
-                    threadParams->openSeries(::openPMD::Access::CREATE);
+                    threadParams->openSeries(::openPMD::Access::APPEND);
                 }
 
                 /* attributes written here are pure meta data */


### PR DESCRIPTION
https://openpmd-api.readthedocs.io/en/0.16.0/usage/workflow.html#access-modes
The Append mode is more secure as it protects better against accidentally overwriting data, e.g. when restarting from a checkpoint. I'm hesitant to fully replace the Create mode with Append mode, since (1) overwriting could be intended and (2) there were bugs in the past that made it impossible to create new files in Append mode with ADIOS2 on some platforms (I think mostly a Windows issue).

TODO:

- [x] What should we set as the default? (psychocoderHPC: we will not change the default do to the risk of breaking thinks because the meaning of `append` in openPM depends if you write file based or group based IO)