### PR TITLE
Further refactoring of AtomicPhysics to avoid code duplication

### DIFF
--- a/include/picongpu/particles/atomicPhysics/AtomicPhysicsSuperCellFields.hpp
+++ b/include/picongpu/particles/atomicPhysics/AtomicPhysicsSuperCellFields.hpp
@@ -24,7 +24,8 @@
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/FieldEnergyUseCacheField.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/FoundUnboundIonField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Bin.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Cell.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/SharedResourcesOverSubscribedField.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/TimeStepField.hpp"
@@ -81,11 +82,17 @@ namespace picongpu::particles::atomicPhysics
                 = std::make_unique<localHelperFields::FoundUnboundIonField<picongpu::MappingDesc>>(mappingDesc);
             dataConnector.consume(std::move(foundUnboundIonField));
 
-            // local rejection probability for each over-subscribed bin of the electron histogram
-            auto superCellRejectionProbabilityCacheField
-                = std::make_unique<localHelperFields::RejectionProbabilityCacheField<picongpu::MappingDesc>>(
+            // local rejection probability for each over-subscribed cell
+            auto superCellRejectionProbabilityCacheField_Cell
+                = std::make_unique<localHelperFields::RejectionProbabilityCacheField_Cell<picongpu::MappingDesc>>(
                     mappingDesc);
-            dataConnector.consume(std::move(superCellRejectionProbabilityCacheField));
+            dataConnector.consume(std::move(superCellRejectionProbabilityCacheField_Cell));
+
+            // local rejection probability for each over-subscribed electron histogram bin
+            auto superCellRejectionProbabilityCacheField_Bin
+                = std::make_unique<localHelperFields::RejectionProbabilityCacheField_Bin<picongpu::MappingDesc>>(
+                    mappingDesc);
+            dataConnector.consume(std::move(superCellRejectionProbabilityCacheField_Bin));
 
             // local field energy use cache
             auto superCellFieldEnergyUseCacheField

--- a/include/picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp
+++ b/include/picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp
@@ -22,6 +22,8 @@
 // need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
@@ -71,6 +73,35 @@ namespace picongpu::particles::atomicPhysics
                 T_AtomicStateBoundFreeStartIndexBlockDataBox,
                 T_AtomicStateBoundFreeNumberTransitionsDataBox,
                 T_BoundFreeTransitionDataBox>();
+        }
+
+        //! check that the processClass matches the TransitionDataBox passed in TransitionOrdering and TransitionType
+        template<s_enums::ProcessClass T_ProcessClass, typename T_TransitionDataBox>
+        static constexpr bool transitionDataBoxMatchesProcessClass()
+        {
+            PMACC_CASSERT_MSG(
+                transition_dataBox_and_processClass_inconsistent,
+                s_enums::IsProcess<T_TransitionDataBox::processClassGroup>::check(u8(T_ProcessClass)));
+
+            constexpr bool isUpward
+                = s_enums::IsProcess<s_enums::ProcessClassGroup::upward>::check(u8(T_ProcessClass));
+
+            /* check ordering consistent with direction of T_ProcessClass, otherwise unphysical behaviour and/or
+             * illegal memory accesses */
+            if constexpr(isUpward)
+            {
+                PMACC_CASSERT_MSG(
+                    transition_databOxOrdering_and_processClass_inconsistent,
+                    T_TransitionDataBox::transitionOrdering == s_enums::TransitionOrdering::byLowerState);
+            }
+            else
+            {
+                PMACC_CASSERT_MSG(
+                    transition_databOxOrdering_and_processClass_inconsistent,
+                    T_TransitionDataBox::transitionOrdering == s_enums::TransitionOrdering::byUpperState);
+            }
+
+            return true;
         }
     };
 } // namespace picongpu::particles::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/KernelIndexation.hpp
+++ b/include/picongpu/particles/atomicPhysics/KernelIndexation.hpp
@@ -50,7 +50,7 @@ namespace picongpu::particles::atomicPhysics
             T_Worker const& worker,
             T_AreaMapping const areaMapping)
         {
-            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
+            // atomicPhysics superCellFields have no guard, but areaMapping includes a guard
             //  -> must subtract guard to get correct superCellFieldIdx
             return getSuperCellIndex(worker, areaMapping) - areaMapping.getGuardingSuperCells();
         }

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -206,7 +206,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
 
             if(ipdIonizationEnergy < 0._X)
             {
-                // update ion
+                /* we only update the atomic state since IPDIonization is not a regular transition and does not use
+                 *   shared resources */
+
+                // update ion atomic state
                 SetAtomicState::hard(
                     ion,
                     T_ChargeStateDataBox::atomicNumber - ipdIonizationStateChargeState,

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
@@ -96,6 +96,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
         }
     };
 
+    //! specialization for no atomicPhysics ion species
     template<>
     struct CalculateIPDInput<0u>
     {

--- a/include/picongpu/particles/atomicPhysics/kernel/CalculateRejectionProbability.hpp
+++ b/include/picongpu/particles/atomicPhysics/kernel/CalculateRejectionProbability.hpp
@@ -37,11 +37,11 @@ namespace picongpu::particles::atomicPhysics::kernel
     {
         using VectorIdx = DataSpace<picongpu::simDim>;
 
-        template<typename T_Histogram, typename T_RejectionProbabilityCache>
+        template<typename T_Histogram, typename T_RejectionProbabilityCache_Bin>
         HDINLINE static void ofHistogramBin(
             uint32_t const binIndex,
             T_Histogram const& histogram,
-            T_RejectionProbabilityCache& rejectionProbabilityCache,
+            T_RejectionProbabilityCache_Bin& rejectionProbabilityCacheBin,
             bool& sharedResourcesOverSubscribed)
         {
             float_X const weight0 = histogram.getBinWeight0(binIndex);
@@ -64,16 +64,16 @@ namespace picongpu::particles::atomicPhysics::kernel
                 sharedResourcesOverSubscribed = true;
             }
 
-            rejectionProbabilityCache.(binIndex, rejectionProbability);
+            rejectionProbabilityCacheBin.setBin(binIndex, rejectionProbability);
         }
 
-        template<typename T_EFieldBox, typename T_EFieldEnergyUseCache, typename T_RejectionProbabilityCache>
+        template<typename T_EFieldBox, typename T_EFieldEnergyUseCache, typename T_RejectionProbabilityCache_Cell>
         HDINLINE static void ofCell(
             uint32_t const linearCellIndex,
             VectorIdx const& superCellCellOffset,
             T_EFieldBox const eFieldBox,
             T_EFieldEnergyUseCache& eFieldEnergyUseCache,
-            T_RejectionProbabilityCache& rejectionProbabilityCache,
+            T_RejectionProbabilityCache_Cell& rejectionProbabilityCacheCell,
             bool& sharedResourcesOverSubscribed)
         {
             VectorIdx const localCellIndex
@@ -116,7 +116,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 sharedResourcesOverSubscribed = true;
             }
 
-            rejectionProbabilityCache.setCell(linearCellIndex, rejectionProbability);
+            rejectionProbabilityCacheCell.setCell(linearCellIndex, rejectionProbability);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/CalculateRejectionProbability.hpp
+++ b/include/picongpu/particles/atomicPhysics/kernel/CalculateRejectionProbability.hpp
@@ -1,0 +1,122 @@
+/* Copyright 2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics::kernel
+{
+    /** methods for calculating the rejection probability
+     *
+     * @return sets the rejection probability cache entry for the specified entry to either
+     *  -1, no rejection probability necessary
+     *  >= 0, rejection probability
+     *
+     * also sets the flag sharedResourcesOverSubscribed to true if an over subscription is found
+     */
+    struct CalculateRejectionProbability
+    {
+        using VectorIdx = DataSpace<picongpu::simDim>;
+
+        template<typename T_Histogram, typename T_RejectionProbabilityCache>
+        HDINLINE static void ofHistogramBin(
+            uint32_t const binIndex,
+            T_Histogram const& histogram,
+            T_RejectionProbabilityCache& rejectionProbabilityCache,
+            bool& sharedResourcesOverSubscribed)
+        {
+            float_X const weight0 = histogram.getBinWeight0(binIndex);
+            float_X const deltaWeight = histogram.getBinDeltaWeight(binIndex);
+
+            float_X rejectionProbability = -1._X;
+
+            if(weight0 < deltaWeight)
+            {
+                // bin is oversubscribed by suggested changes
+
+                // calculate rejection probability
+                rejectionProbability = math::max(
+                    // proportion of weight we want to reject
+                    (deltaWeight - weight0) / deltaWeight,
+                    // but at least one average one macro ion should be rejected
+                    picongpu::sim.unit.typicalNumParticlesPerMacroParticle() / deltaWeight);
+
+                // set flag that we found at least one over subscribed resource
+                sharedResourcesOverSubscribed = true;
+            }
+
+            rejectionProbabilityCache.(binIndex, rejectionProbability);
+        }
+
+        template<typename T_EFieldBox, typename T_EFieldEnergyUseCache, typename T_RejectionProbabilityCache>
+        HDINLINE static void ofCell(
+            uint32_t const linearCellIndex,
+            VectorIdx const& superCellCellOffset,
+            T_EFieldBox const eFieldBox,
+            T_EFieldEnergyUseCache& eFieldEnergyUseCache,
+            T_RejectionProbabilityCache& rejectionProbabilityCache,
+            bool& sharedResourcesOverSubscribed)
+        {
+            VectorIdx const localCellIndex
+                = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearCellIndex));
+            VectorIdx const cellIndex = localCellIndex + superCellCellOffset;
+
+            // sim.unit.charge()^2 * sim.unit.time()^2 / (sim.unit.mass() * sim.unit.length()^3)
+            //  * sim.unit.length()^3
+            // = sim.unit.charge()^2 * sim.unit.time()^2 / sim.unit.mass()
+            constexpr float_X eps0HalfTimesCellVolume
+                = (picongpu::sim.pic.getEps0() / 2._X) * picongpu::sim.pic.getCellSize().productOfComponents();
+
+            // sim.unit.charge()^2 * sim.unit.time()^2 / sim.unit.mass()
+            //  * ((sim.unit.mass() * sim.unit.length())/(sim.unit.time()^2 * sim.unit.charge()))^2
+            // = sim.unit.charge()^2 * sim.unit.time()^2 * sim.unit.mass()^2 * sim.unit.length()^2
+            //  / (sim.unit.mass() * sim.unit.time()^4 * sim.unit.charge()^2)
+            // = sim.unit.mass() * sim.unit.length()^2/ (sim.unit.time()^2 * sim.unit.length())
+            // sim.unit.energy()
+            float_X const eFieldEnergy = eps0HalfTimesCellVolume * pmacc::math::l2norm2(eFieldBox(cellIndex));
+
+            // eV * 1 = eV * sim.unit.energy()/sim.unit.energy() = (ev / sim.unit.energy()) * sim.unit.energy()
+            // sim.unit.energy()
+            float_X const eFieldEnergyUse
+                = picongpu::sim.pic.get_eV() * eFieldEnergyUseCache.energyUsed(linearCellIndex);
+
+            float_X rejectionProbability = -1._X;
+
+            if(eFieldEnergyUse > eFieldEnergy)
+            {
+                // cell is oversubscribed by suggested changes
+
+                // calculate rejection probability
+                rejectionProbability = pmacc::math::max(
+                    // proportion of weight we want to reject
+                    (eFieldEnergyUse - eFieldEnergy) / eFieldEnergyUse,
+                    // but approximately at least one average one macro ion per cell should be rejected
+                    1._X / static_cast<float_X>(sim.getTypicalNumParticlesPerCell()));
+
+                // set flag that we found at least one over subscribed resource
+                sharedResourcesOverSubscribed = true;
+            }
+
+            rejectionProbabilityCache.setCell(linearCellIndex, rejectionProbability);
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CalculateStepLength.kernel
@@ -22,7 +22,6 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache.hpp"
 #include "picongpu/particles/atomicPhysics/param.hpp"
 
 #include <pmacc/lockstep/ForEach.hpp>

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -23,7 +23,8 @@
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/CalculateRejectionProbability.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Bin.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Cell.hpp"
 
 #include <pmacc/lockstep/ForEach.hpp>
 
@@ -56,9 +57,11 @@ namespace picongpu::particles::atomicPhysics::kernel
          * @param fieldEnergyUseCacheBox deviceDataBox giving access to the field energy use cache for each local
          * superCell
          * @param sharedResourcesOverSubscribedBox deviceDataBox giving access to the local shared resources over
-         *  subscription switch for each local superCell
-         * @param rejectionProbabilityCacheBox deviceDataBox giving access to localRejectionProbabilityCache for
-         *  all local superCells
+         *  subscription flag for each local superCell
+         * @param rejectionProbabilityCacheCellBox deviceDataBox giving access to the rejectionProbabilityCache_Cell
+         *  for all local superCells
+         * @param rejectionProbabilityCacheBinBox deviceDataBox giving access to the rejectionProbabilityCache_Bin
+         *  for all local superCells
          */
         template<
             typename T_Worker,
@@ -68,7 +71,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_EFieldBox,
             typename T_FieldEnergyUseCacheBox,
             typename T_SharedRessourcesOverSubscribedBox,
-            typename T_RejectionProbabilityCacheDataBox>
+            typename T_RejectionProbabilityCacheBinDataBox,
+            typename T_RejectionProbabilityCacheCellDataBox>
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
@@ -77,7 +81,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_EFieldBox const eFieldBox,
             T_FieldEnergyUseCacheBox const fieldEnergyUseCacheBox,
             T_SharedRessourcesOverSubscribedBox sharedResourcesOverSubscribedBox,
-            T_RejectionProbabilityCacheDataBox rejectionProbabilityCacheBox) const
+            T_RejectionProbabilityCacheBinDataBox rejectionProbabilityCacheBinBox,
+            T_RejectionProbabilityCacheCellDataBox rejectionProbabilityCacheCellBox) const
         {
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
             auto const superCellFieldIdx
@@ -87,10 +92,12 @@ namespace picongpu::particles::atomicPhysics::kernel
             if(timeRemaining <= 0._X)
                 return;
 
-            particles::atomicPhysics::localHelperFields::RejectionProbabilityCache<
-                T_HistogramDataBox::ValueType::numberBins,
-                T_FieldEnergyUseCache::numberCells>& rejectionProbabilityCache
-                = rejectionProbabilityCacheBox(superCellFieldIdx);
+            particles::atomicPhysics::localHelperFields::RejectionProbabilityCache_Cell<
+                T_FieldEnergyUseCache::numberCells>& rejectionProbabilityCacheCell
+                = rejectionProbabilityCacheCellBox(superCellFieldIdx);
+            particles::atomicPhysics::localHelperFields::RejectionProbabilityCache_Bin<
+                T_HistogramDataBox::ValueType::numberBins>& rejectionProbabilityCacheBin
+                = rejectionProbabilityCacheBinBox(superCellFieldIdx);
 
             bool sharedResourcesOverSubscribed = false;
 
@@ -98,12 +105,12 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto forEachBin
                 = pmacc::lockstep::makeForEach<T_HistogramDataBox::ValueType::numberBins, T_Worker>(worker);
             forEachBin(
-                [&histogram, &rejectionProbabilityCache, &sharedResourcesOverSubscribed](uint32_t const binIndex)
+                [&histogram, &rejectionProbabilityCacheBin, &sharedResourcesOverSubscribed](uint32_t const binIndex)
                 {
                     CalculateRejectionProbability::ofHistogramBin(
                         binIndex,
                         histogram,
-                        rejectionProbabilityCache,
+                        rejectionProbabilityCacheBin,
                         sharedResourcesOverSubscribed);
                 });
 
@@ -114,7 +121,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                 [&superCellCellOffset,
                  &eFieldBox,
                  &eFieldEnergyUseCache,
-                 &rejectionProbabilityCache,
+                 &rejectionProbabilityCacheCell,
                  &sharedResourcesOverSubscribed](uint32_t const linearCellIndex)
                 {
                     CalculateRejectionProbability::ofCell(
@@ -122,7 +129,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         superCellCellOffset,
                         eFieldBox,
                         eFieldEnergyUseCache,
-                        rejectionProbabilityCache,
+                        rejectionProbabilityCacheCell,
                         sharedResourcesOverSubscribed);
                 });
 

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -37,12 +37,10 @@ namespace picongpu::particles::atomicPhysics::kernel
      * checks each (superCell cell)/(local histogram bin) for (fieldEnergyUse > fieldEnergy)/(deltaWeight > weight0),
      *  if yes mark cell/bin as oversubscribed and stores rejection probability in rejection probability cache
      *
-     * @tparam T_Histogram histogram type
-     * @tparam T_FieldEnergyUseCache field energy use cache type
      * @tparam T_numberAtomicPhysicsIonSpecies specialization template parameter used to prevent compilation of all
      *  atomicPhysics kernels if no atomic physics species is present.
      */
-    template<typename T_Histogram, typename T_FieldEnergyUseCache, uint32_t T_numberAtomicPhysicsIonSpecies>
+    template<uint32_t T_numberAtomicPhysicsIonSpecies>
     struct CheckForOverSubscriptionKernel
     {
         /** call operator
@@ -92,18 +90,20 @@ namespace picongpu::particles::atomicPhysics::kernel
             if(timeRemaining <= 0._X)
                 return;
 
+            using Histogram = typename T_HistogramDataBox::ValueType;
+            using FieldEnergyUseCache = typename T_FieldEnergyUseCacheBox::ValueType;
+
             particles::atomicPhysics::localHelperFields::RejectionProbabilityCache_Cell<
-                T_FieldEnergyUseCache::numberCells>& rejectionProbabilityCacheCell
+                FieldEnergyUseCache::numberCells>& rejectionProbabilityCacheCell
                 = rejectionProbabilityCacheCellBox(superCellFieldIdx);
-            particles::atomicPhysics::localHelperFields::RejectionProbabilityCache_Bin<
-                T_HistogramDataBox::ValueType::numberBins>& rejectionProbabilityCacheBin
+            particles::atomicPhysics::localHelperFields::RejectionProbabilityCache_Bin<Histogram::numberBins>&
+                rejectionProbabilityCacheBin
                 = rejectionProbabilityCacheBinBox(superCellFieldIdx);
 
             bool sharedResourcesOverSubscribed = false;
 
-            T_HistogramDataBox::ValueType const& histogram = histogramBox(superCellFieldIdx);
-            auto forEachBin
-                = pmacc::lockstep::makeForEach<T_HistogramDataBox::ValueType::numberBins, T_Worker>(worker);
+            Histogram const& histogram = histogramBox(superCellFieldIdx);
+            auto forEachBin = pmacc::lockstep::makeForEach<Histogram::numberBins, T_Worker>(worker);
             forEachBin(
                 [&histogram, &rejectionProbabilityCacheBin, &sharedResourcesOverSubscribed](uint32_t const binIndex)
                 {
@@ -114,9 +114,9 @@ namespace picongpu::particles::atomicPhysics::kernel
                         sharedResourcesOverSubscribed);
                 });
 
-            T_FieldEnergyUseCache const& eFieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
+            FieldEnergyUseCache const& eFieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
-            auto forEachCell = pmacc::lockstep::makeForEach<T_FieldEnergyUseCache::numberCells, T_Worker>(worker);
+            auto forEachCell = pmacc::lockstep::makeForEach<FieldEnergyUseCache::numberCells, T_Worker>(worker);
             forEachCell(
                 [&superCellCellOffset,
                  &eFieldBox,

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -107,11 +107,11 @@ namespace picongpu::particles::atomicPhysics::kernel
             forEachBin(
                 [&histogram, &rejectionProbabilityCacheBin, &sharedResourcesOverSubscribed](uint32_t const binIndex)
                 {
-                    CalculateRejectionProbability::ofHistogramBin(
-                        binIndex,
-                        histogram,
-                        rejectionProbabilityCacheBin,
-                        sharedResourcesOverSubscribed);
+                    if(CalculateRejectionProbability::ofHistogramBin(
+                           binIndex,
+                           histogram,
+                           rejectionProbabilityCacheBin))
+                        sharedResourcesOverSubscribed = true;
                 });
 
             FieldEnergyUseCache const& eFieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
@@ -124,13 +124,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                  &rejectionProbabilityCacheCell,
                  &sharedResourcesOverSubscribed](uint32_t const linearCellIndex)
                 {
-                    CalculateRejectionProbability::ofCell(
-                        linearCellIndex,
-                        superCellCellOffset,
-                        eFieldBox,
-                        eFieldEnergyUseCache,
-                        rejectionProbabilityCacheCell,
-                        sharedResourcesOverSubscribed);
+                    if(CalculateRejectionProbability::ofCell(
+                           linearCellIndex,
+                           superCellCellOffset,
+                           eFieldBox,
+                           eFieldEnergyUseCache,
+                           rejectionProbabilityCacheCell))
+                        sharedResourcesOverSubscribed = true;
                 });
 
             uint32_t& flagField = sharedResourcesOverSubscribedBox(superCellFieldIdx);

--- a/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel
@@ -22,6 +22,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/CalculateRejectionProbability.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache.hpp"
 
 #include <pmacc/lockstep/ForEach.hpp>
@@ -32,8 +33,8 @@ namespace picongpu::particles::atomicPhysics::kernel
 {
     /** check all bins and cells for overSubscription
      *
-     * checks each (superCell cell)/(local histogram bin) for (deltaWeight > weight0)/(fieldEnergyUse > fieldEnergy),
-     *  if yes mark cell/bin as oversubscribed and store rejection probability in rejection probability cache
+     * checks each (superCell cell)/(local histogram bin) for (fieldEnergyUse > fieldEnergy)/(deltaWeight > weight0),
+     *  if yes mark cell/bin as oversubscribed and stores rejection probability in rejection probability cache
      *
      * @tparam T_Histogram histogram type
      * @tparam T_FieldEnergyUseCache field energy use cache type
@@ -63,7 +64,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_Worker,
             typename T_AreaMapping,
             typename T_LocalTimeRemainingBox,
-            typename T_LocalHistogramDataBox,
+            typename T_HistogramDataBox,
             typename T_EFieldBox,
             typename T_FieldEnergyUseCacheBox,
             typename T_SharedRessourcesOverSubscribedBox,
@@ -72,7 +73,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
             T_LocalTimeRemainingBox const timeRemainingBox,
-            T_LocalHistogramDataBox const histogramBox,
+            T_HistogramDataBox const histogramBox,
             T_EFieldBox const eFieldBox,
             T_FieldEnergyUseCacheBox const fieldEnergyUseCacheBox,
             T_SharedRessourcesOverSubscribedBox sharedResourcesOverSubscribedBox,
@@ -87,98 +88,42 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             particles::atomicPhysics::localHelperFields::RejectionProbabilityCache<
-                T_Histogram::numberBins,
+                T_HistogramDataBox::ValueType::numberBins,
                 T_FieldEnergyUseCache::numberCells>& rejectionProbabilityCache
                 = rejectionProbabilityCacheBox(superCellFieldIdx);
 
             bool sharedResourcesOverSubscribed = false;
 
-            T_Histogram const& histogram = histogramBox(superCellFieldIdx);
-            auto forEachBin = pmacc::lockstep::makeForEach<T_Histogram::numberBins, T_Worker>(worker);
+            T_HistogramDataBox::ValueType const& histogram = histogramBox(superCellFieldIdx);
+            auto forEachBin
+                = pmacc::lockstep::makeForEach<T_HistogramDataBox::ValueType::numberBins, T_Worker>(worker);
             forEachBin(
-                [&worker, &histogram, &sharedResourcesOverSubscribed, &rejectionProbabilityCache](
-                    uint32_t const binIndex)
+                [&histogram, &rejectionProbabilityCache, &sharedResourcesOverSubscribed](uint32_t const binIndex)
                 {
-                    float_X const weight0 = histogram.getBinWeight0(binIndex);
-                    float_X const deltaWeight = histogram.getBinDeltaWeight(binIndex);
-
-                    float_X rejectionProbability;
-
-                    if(weight0 < deltaWeight)
-                    {
-                        // bin is oversubscribed by suggested changes
-
-                        // calculate rejection probability
-                        rejectionProbability = math::max(
-                            // proportion of weight we want to reject
-                            (deltaWeight - weight0) / deltaWeight,
-                            // but at least one average one macro ion should be rejected
-                            sim.unit.typicalNumParticlesPerMacroParticle() / deltaWeight);
-
-                        // set flag that we found at least one over subscribed resource
-                        sharedResourcesOverSubscribed = true;
-                    }
-                    else
-                        rejectionProbability = -1._X;
-
-                    rejectionProbabilityCache.setBin(binIndex, rejectionProbability);
+                    CalculateRejectionProbability::ofHistogramBin(
+                        binIndex,
+                        histogram,
+                        rejectionProbabilityCache,
+                        sharedResourcesOverSubscribed);
                 });
-
 
             T_FieldEnergyUseCache const& eFieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
             auto forEachCell = pmacc::lockstep::makeForEach<T_FieldEnergyUseCache::numberCells, T_Worker>(worker);
             forEachCell(
-                [&worker,
-                 &superCellCellOffset,
+                [&superCellCellOffset,
                  &eFieldBox,
                  &eFieldEnergyUseCache,
-                 &sharedResourcesOverSubscribed,
-                 &rejectionProbabilityCache](uint32_t const linearCellIndex)
+                 &rejectionProbabilityCache,
+                 &sharedResourcesOverSubscribed](uint32_t const linearCellIndex)
                 {
-                    DataSpace<picongpu::simDim> const localCellIndex
-                        = pmacc::math::mapToND(picongpu::SuperCellSize::toRT(), static_cast<int>(linearCellIndex));
-                    DataSpace<picongpu::simDim> const cellIndex = localCellIndex + superCellCellOffset;
-
-                    // sim.unit.charge()^2 * sim.unit.time()^2 / (sim.unit.mass() * sim.unit.length()^3)
-                    //  * sim.unit.length()^3
-                    // = sim.unit.charge()^2 * sim.unit.time()^2 / sim.unit.mass()
-                    constexpr float_X eps0HalfTimesCellVolume
-                        = (picongpu::sim.pic.getEps0() / 2._X) * picongpu::sim.pic.getCellSize().productOfComponents();
-
-                    // sim.unit.charge()^2 * sim.unit.time()^2 / sim.unit.mass()
-                    //  * ((sim.unit.mass() * sim.unit.length())/(sim.unit.time()^2 * sim.unit.charge()))^2
-                    // = sim.unit.charge()^2 * sim.unit.time()^2 * sim.unit.mass()^2 * sim.unit.length()^2
-                    //  / (sim.unit.mass() * sim.unit.time()^4 * sim.unit.charge()^2)
-                    // = sim.unit.mass() * sim.unit.length()^2/ (sim.unit.time()^2 * sim.unit.length())
-                    // sim.unit.energy()
-                    float_X const eFieldEnergy = eps0HalfTimesCellVolume * pmacc::math::l2norm2(eFieldBox(cellIndex));
-
-                    // eV * 1 = eV * sim.unit.energy()/sim.unit.energy() = (ev / sim.unit.energy()) * sim.unit.energy()
-                    // sim.unit.energy()
-                    float_X const eFieldEnergyUse
-                        = picongpu::sim.pic.get_eV() * eFieldEnergyUseCache.energyUsed(linearCellIndex);
-
-                    float_X rejectionProbability;
-
-                    if(eFieldEnergyUse > eFieldEnergy)
-                    {
-                        // cell is oversubscribed by suggested changes
-
-                        // calculate rejection probability
-                        rejectionProbability = pmacc::math::max(
-                            // proportion of weight we want to reject
-                            (eFieldEnergyUse - eFieldEnergy) / eFieldEnergyUse,
-                            // but approximately at least one average one macro ion per cell should be rejected
-                            1._X / static_cast<float_X>(sim.getTypicalNumParticlesPerCell()));
-
-                        // set flag that we found at least one over subscribed resource
-                        sharedResourcesOverSubscribed = true;
-                    }
-                    else
-                        rejectionProbability = -1._X;
-
-                    rejectionProbabilityCache.setCell(linearCellIndex, rejectionProbability);
+                    CalculateRejectionProbability::ofCell(
+                        linearCellIndex,
+                        superCellCellOffset,
+                        eFieldBox,
+                        eFieldEnergyUseCache,
+                        rejectionProbabilityCache,
+                        sharedResourcesOverSubscribed);
                 });
 
             uint32_t& flagField = sharedResourcesOverSubscribedBox(superCellFieldIdx);

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -172,7 +172,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     {
                         uint32_t const transitionCollectionIndex = transitionID + startIndexTransitionBlock;
 
-                        // 1/picongpu::sim.unit.time()
+                        // unit: 1/unit_time
                         float_X const rateTransition
                             = atomicPhysics::rateCalculation::BoundFreeFieldTransitionRates<T_ADKLaserPolarization>::
                                 template rateADKFieldIonization<float_X>(

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
@@ -20,13 +20,14 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/CheckSetOfAtomicDataBoxes.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
+#include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/SetAtomicState.hpp"
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
-#include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/PassIPDInputs.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
@@ -42,12 +43,13 @@ namespace picongpu::particles::atomicPhysics::kernel
      *  to used electron histogram bin
      *
      * @tparam T_ProcessClass processClass for which to execute this kernel
-     * @tparam T_Histogram type of the histogram
      * @tparam T_IPDModel ionization potential depression model to use for energy calculation
      */
-    template<s_enums::ProcessClass T_ProcessClass, typename T_Histogram, typename T_IPDModel>
+    template<s_enums::ProcessClass T_ProcessClass, typename T_IPDModel>
     struct RecordChangesKernel
     {
+        using VectorIdx = pmacc::DataSpace<picongpu::simDim>;
+
         /** call operator
          *
          * called by RecordChanges atomicPhysics sub-stage for each active processClass
@@ -61,8 +63,8 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  electron histograms of all local superCells
          * @param atomicStateBox deviceDataBox giving access to atomic state property data
          * @param transitionBox deviceDataBox giving access to transition property data,
-         * @param chargeStateBox optional deviceDataBox giving access to charge state property data
-         *  required for T_ProcessClassGroup = boundFreeBased
+         * @param chargeStateBoxAndIPDInput optional deviceDataBoxes giving access to charge state property data
+         *  and the IPD input data, required for T_ProcessClassGroup = boundFreeBased
          */
         template<
             typename T_Worker,
@@ -83,11 +85,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_TransitionDataBox const transitionBox,
             T_ChargeStateBoxAndIPDInput... chargeStateBoxAndIPDInput) const
         {
-            // check transition dataBox consistent with T_ProcessClass
-            //  otherwise unphysical behaviour and/or illegal memory accesses
-            PMACC_CASSERT_MSG(
-                transition_dataBox_and_processClass_inconsistent,
-                s_enums::IsProcess<T_TransitionDataBox::processClassGroup>::check(u8(T_ProcessClass)));
+            PMACC_CASSERT(CheckSetOfAtomicDataBoxes::
+                              transitionDataBoxMatchesProcessClass<T_ProcessClass, T_TransitionDataBox>());
 
             constexpr bool isCollisional
                 = s_enums::IsProcess<s_enums::ProcessClassGroup::electronicCollisional>::check(u8(T_ProcessClass));
@@ -96,45 +95,27 @@ namespace picongpu::particles::atomicPhysics::kernel
             constexpr bool isUpward
                 = s_enums::IsProcess<s_enums::ProcessClassGroup::upward>::check(u8(T_ProcessClass));
 
-            // check ordering consistent with direction of T_ProcessClass
-            //  otherwise unphysical behaviour and/or illegal memory accesses
-            if constexpr(isUpward)
-            {
-                PMACC_CASSERT_MSG(
-                    transition_databOxOrdering_and_processClass_inconsistent,
-                    T_TransitionDataBox::transitionOrdering == s_enums::TransitionOrdering::byLowerState);
-            }
-            else
-            {
-                PMACC_CASSERT_MSG(
-                    transition_databOxOrdering_and_processClass_inconsistent,
-                    T_TransitionDataBox::transitionOrdering == s_enums::TransitionOrdering::byUpperState);
-            }
-
-            pmacc::DataSpace<simDim> const superCellIdx = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
-
-            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
-            //  -> must subtract guard to get correct superCellFieldIdx
-            pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
-                = superCellIdx - areaMapping.getGuardingSuperCells();
+            VectorIdx const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
+            VectorIdx const superCellFieldIdx
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto const timeRemaining = timeRemainingBox(superCellFieldIdx);
-
             auto forEachLocalIonBoxEntry = pmacc::particles::algorithm::acc::makeForEach(worker, ionBox, superCellIdx);
 
-            // end kernel if no particles or if superCell already finished
-            if((timeRemaining <= 0._X) || (!forEachLocalIonBoxEntry.hasParticles()))
+            bool const superCellAlreadyFinished = (timeRemaining <= 0._X);
+            bool const superCellHasIons = forEachLocalIonBoxEntry.hasParticles();
+            if(superCellAlreadyFinished || !superCellHasIons)
                 return;
 
-            // get histogram for current superCell
-            [[maybe_unused]] T_Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
+            using Histogram = typename T_LocalElectronHistogramDataBox::ValueType;
 
+            // get histogram for current superCell
+            [[maybe_unused]] Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
             // eV
             [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;
 
-            /* field ionization is not energy conserving currently
-             *-> no need to calculate energy used -> no need to calculate IPD */
-            /// @todo implement energy conservation in field ionization, Brian Marre, 2024
+            /* field energy use is directly deposited to the field energy cache -> no need to calculate energy used
+             *  -> no need to calculate IPD for non collisional processClasses*/
             if constexpr(isIonizing && isCollisional)
                 ionizationPotentialDepression
                     = ionizationPotentialDepression::PassIPDInputs::template calculateIPD<T_IPDModel>(
@@ -180,10 +161,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                     }
 
                     uint32_t newAtomicStateCollectionIndex;
-
                     if constexpr(isUpward)
                     {
-                        // upward process
                         if constexpr(isCollisional)
                             deltaEnergy = -deltaEnergy;
 
@@ -210,6 +189,6 @@ namespace picongpu::particles::atomicPhysics::kernel
     };
 
     // no change physical transition never changes anything
-    template<typename T_Histogram, typename T_IPDModel>
-    struct RecordChangesKernel<s_enums::ProcessClass::noChange, T_Histogram, T_IPDModel>;
+    template<typename T_IPDModel>
+    struct RecordChangesKernel<s_enums::ProcessClass::noChange, T_IPDModel>;
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
@@ -31,7 +31,8 @@
 
 namespace picongpu::particles::atomicPhysics::kernel
 {
-    /** record used weight from bin of electron histogram for each accepted transition
+    /** record used weight from bins of electron histogram and used field energy of cells for each accepted transition
+     *  of an macro ion
      *
      * @tparam T_IPDModel ionization potential depression model to use
      * @tparam T_atLeastOneElectronicCollisionalProcessActive is channel at least one electronic collisional channel

--- a/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
@@ -40,10 +40,11 @@ namespace picongpu::particles::atomicPhysics::kernel
      *  - the accepted transition is a collisional transition and whether the interaction bin is over subscribed
      * or
      *  - the accepted transition is a field based transition and whether the macro ions' cell is over subscribed
+     *
      * If yes roll for rejection of the transition.
      *
-     * Rejection probability stored for each bin in rejectionProbabilityCache_Bin
-     *  and for each cell in rejectionProbabilityCache_Cell.
+     * Rejection probability stored for each bin in rejectionProbabilityCache_Bin and for each cell in
+     *   rejectionProbabilityCache_Cell.
      */
     struct RollForOverSubscriptionKernel
     {

--- a/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RollForOverSubscription.kernel
@@ -25,7 +25,8 @@
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Bin.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Cell.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
@@ -35,12 +36,15 @@ namespace picongpu::particles::atomicPhysics::kernel
 {
     /** roll for over subscription kernel
      *
-     * check for each macro ion, whether the ion accepted a transition, the accepted
-     *  transition is a collisional transition and whether the interaction bin is over
-     *  subscribed. If yes roll for rejection of the transition.
-     * Rejection probability stored for each bin in localRejectionProbabilityCache.
+     * check for each macro ion with an accepted a transition, whether:
+     *  - the accepted transition is a collisional transition and whether the interaction bin is over subscribed
+     * or
+     *  - the accepted transition is a field based transition and whether the macro ions' cell is over subscribed
+     * If yes roll for rejection of the transition.
+     *
+     * Rejection probability stored for each bin in rejectionProbabilityCache_Bin
+     *  and for each cell in rejectionProbabilityCache_Cell.
      */
-    template<typename T_RejectionProbabilityCache>
     struct RollForOverSubscriptionKernel
     {
         /** call operator
@@ -51,13 +55,14 @@ namespace picongpu::particles::atomicPhysics::kernel
          *  passed by PMACC_KERNEL call
          * @param areMapping mapping of blockIndex to block superCell index
          * @param rngFactory random number generator factory
-         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local super
-         * cells
-         * @param sharedResourceOverSubscribedBox deviceDataBox giving access to
-         *  the histogram oversubscribed switch of all local superCells
+         * @param timeRemainingBox deviceDataBox giving access to the local time remaining of all local superCells
+         * @param sharedResourceOverSubscribedBox deviceDataBox giving access to the shared resources oversubscribed
+         *  flag of all local superCells
          * @param ionBox deviceDataBox giving access to the particle frames of all local superCells
-         * @param rejectionProbabilityCacheBox deviceDataBox giving access to the
-         *  local RejectionProbabilityCache of each local superCells
+         * @param rejectionProbabilityCacheBinBox deviceDataBox giving access to the rejectionProbabilityCache_Bin
+         *  of each local superCell
+         * @param rejectionProbabilityCacheCellBox deviceDataBox giving access to the rejectionProbabilityCache_Cell
+         *  of each local superCell
          */
         template<
             typename T_Worker,
@@ -66,7 +71,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             typename T_TimeRemainingBox,
             typename T_SharedResourceOverSubscribedBox,
             typename T_IonBox,
-            typename T_RejectionProbabilityCacheDataBox>
+            typename T_RejectionProbabilityCacheBinDataBox,
+            typename T_RejectionProbabilityCacheCellDataBox>
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
@@ -75,7 +81,8 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_TimeRemainingBox const timeRemainingBox,
             T_SharedResourceOverSubscribedBox const sharedResourceOverSubscribedBox,
             T_IonBox ionBox,
-            T_RejectionProbabilityCacheDataBox rejectionProbabilityCacheBox) const
+            T_RejectionProbabilityCacheBinDataBox rejectionProbabilityCacheBinBox,
+            T_RejectionProbabilityCacheCellDataBox rejectionProbabilityCacheCellBox) const
         {
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
             auto const superCellFieldIdx
@@ -94,8 +101,14 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             /// @todo cache in shared memory, Brian Marre, 2024
-            T_RejectionProbabilityCache const& rejectionProbabilityCache
-                = rejectionProbabilityCacheBox(superCellFieldIdx);
+            using RejectionProbabilityCache_Bin = typename T_RejectionProbabilityCacheBinDataBox::ValueType;
+            RejectionProbabilityCache_Bin const& rejectionProbabilityCache_Bin
+                = rejectionProbabilityCacheBinBox(superCellFieldIdx);
+
+            using RejectionProbabilityCache_Cell = typename T_RejectionProbabilityCacheCellDataBox::ValueType;
+            RejectionProbabilityCache_Cell const& rejectionProbabilityCache_Cell
+                = rejectionProbabilityCacheCellBox(superCellFieldIdx);
+
             auto rngGenerator = rngFactory(worker, superCellFieldIdx);
 
             // try to reject each accepted macro-ion, which takes from an oversubscribed bin
@@ -122,12 +135,12 @@ namespace picongpu::particles::atomicPhysics::kernel
                     float_X rejectionProbability;
                     if(usesElectronHistogramWeight)
                     {
-                        rejectionProbability = rejectionProbabilityCache.getRejectionProbabilityBin(binIndex);
+                        rejectionProbability = rejectionProbabilityCache_Bin.getRejectionProbabilityBin(binIndex);
                     }
                     else
                     {
                         /// @note (usesElectricFieldEnergy == true)
-                        rejectionProbability = rejectionProbabilityCache.getRejectionProbabilityCell(cellIndex);
+                        rejectionProbability = rejectionProbabilityCache_Cell.getRejectionProbabilityCell(cellIndex);
                     }
                     bool const usesOverSubscribedResource = (rejectionProbability > 0._X);
 

--- a/include/picongpu/particles/atomicPhysics/kernel/UpdateElectricField.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/UpdateElectricField.kernel
@@ -30,11 +30,10 @@ namespace picongpu::particles::atomicPhysics::kernel
 {
     /** update electric field due to field ionization energy use
      *
-     * @tparam T_FieldEnergyUseCache FieldEnergyCache type
      * @tparam T_numberAtomicPhysicsIonSpecies specialization template parameter used to prevent compilation of all
      *  atomicPhysics kernels if no atomic physics species is present.
      */
-    template<typename T_FieldEnergyUseCache, uint32_t T_numberAtomicPhysicsIonSpecies>
+    template<uint32_t T_numberAtomicPhysicsIonSpecies>
     struct UpdateElectricFieldKernel
     {
         /** call operator
@@ -70,10 +69,11 @@ namespace picongpu::particles::atomicPhysics::kernel
             if(timeRemaining <= 0._X)
                 return;
 
-            T_FieldEnergyUseCache const& eFieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
+            using FieldEnergyUseCache = typename T_FieldEnergyUseCacheBox::ValueType;
+            FieldEnergyUseCache const& eFieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
             DataSpace<picongpu::simDim> const superCellCellOffset = superCellIdx * picongpu::SuperCellSize::toRT();
 
-            auto forEachCell = pmacc::lockstep::makeForEach<T_FieldEnergyUseCache::numberCells, T_Worker>(worker);
+            auto forEachCell = pmacc::lockstep::makeForEach<FieldEnergyUseCache::numberCells, T_Worker>(worker);
             forEachCell(
                 [&worker, &superCellCellOffset, &eFieldBox, &eFieldEnergyUseCache](uint32_t const linearCellIndex)
                 {

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/FieldEnergyUseCacheField.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/FieldEnergyUseCacheField.hpp
@@ -82,7 +82,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
     {
         using Extent = picongpu::SuperCellSize;
         using StorageType = float_X;
-        using ElementType = FieldEnergyUseCache<Extent, StorageType>;
+        using ValueType = FieldEnergyUseCache<Extent, StorageType>;
 
         FieldEnergyUseCacheField(T_MappingDescription const& mappingDesc)
             : SuperCellField<FieldEnergyUseCache<Extent, StorageType>, T_MappingDescription, false /*no guards*/>(

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Bin.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Bin.hpp
@@ -1,0 +1,62 @@
+/* Copyright 2023-2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file implements a super cell local cache of of each electron histogram bin's
+ *   rejectionProbability due to over subscription
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/SuperCellField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Bin.hpp"
+#include "picongpu/particles/atomicPhysics/param.hpp"
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics::localHelperFields
+{
+    /** superCell field of the rejectionProbabilityCache for all electron histogram bins
+     *
+     * @tparam T_MappingDescription description of local mapping from device to grid
+     */
+    template<typename T_MappingDescription>
+    struct RejectionProbabilityCacheField_Bin
+        : public SuperCellField<
+              RejectionProbabilityCache_Bin<picongpu::atomicPhysics::ElectronHistogram::numberBins>,
+              T_MappingDescription,
+              false /*no guards*/>
+    {
+        using ElementType = RejectionProbabilityCache_Bin<picongpu::atomicPhysics::ElectronHistogram::numberBins>;
+
+        RejectionProbabilityCacheField_Bin(T_MappingDescription const& mappingDesc)
+            : SuperCellField<
+                RejectionProbabilityCache_Bin<picongpu::atomicPhysics::ElectronHistogram::numberBins>,
+                T_MappingDescription,
+                false /*no guards*/>(mappingDesc)
+        {
+        }
+
+        // required by ISimulationData
+        std::string getUniqueId() override
+        {
+            return "RejectionProbabilityCacheField_Bin";
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Cell.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Cell.hpp
@@ -25,35 +25,30 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/SuperCellField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Cell.hpp"
 #include "picongpu/particles/atomicPhysics/param.hpp"
 
 #include <cstdint>
 
 namespace picongpu::particles::atomicPhysics::localHelperFields
 {
-    /**@class superCell field of the rejectionProbabilityCache
+    /** superCell field of the rejectionProbabilityCache for all cells
      *
      * @tparam T_MappingDescription description of local mapping from device to grid
      */
     template<typename T_MappingDescription>
-    struct RejectionProbabilityCacheField
+    struct RejectionProbabilityCacheField_Cell
         : public SuperCellField<
-              RejectionProbabilityCache<
-                  picongpu::atomicPhysics::ElectronHistogram::numberBins,
-                  pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value>,
+              RejectionProbabilityCache_Cell<pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value>,
               T_MappingDescription,
               false /*no guards*/>
     {
-        using ElementType = RejectionProbabilityCache<
-            picongpu::atomicPhysics::ElectronHistogram::numberBins,
-            pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value>;
+        using ElementType
+            = RejectionProbabilityCache_Cell<pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value>;
 
-        RejectionProbabilityCacheField(T_MappingDescription const& mappingDesc)
+        RejectionProbabilityCacheField_Cell(T_MappingDescription const& mappingDesc)
             : SuperCellField<
-                RejectionProbabilityCache<
-                    picongpu::atomicPhysics::ElectronHistogram::numberBins,
-                    pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value>,
+                RejectionProbabilityCache_Cell<pmacc::math::CT::volume<picongpu::SuperCellSize>::type::value>,
                 T_MappingDescription,
                 false /*no guards*/>(mappingDesc)
         {
@@ -62,7 +57,7 @@ namespace picongpu::particles::atomicPhysics::localHelperFields
         // required by ISimulationData
         std::string getUniqueId() override
         {
-            return "RejectionProbabilityCacheField";
+            return "RejectionProbabilityCacheField_Cell";
         }
     };
 } // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Cell.hpp
+++ b/include/picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCache_Cell.hpp
@@ -1,0 +1,148 @@
+/* Copyright 2023-2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/debug/param.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+
+namespace picongpu::particles::atomicPhysics::localHelperFields
+{
+    /** debug only, write content of rate cache to console
+     *
+     * @attention only useful of compiling for serial backend, otherwise different RejectionProbabilityCache's outputs
+     *  will interleave
+     */
+    template<bool printOnlyOversubscribed>
+    struct PrintRejectionProbabilityCacheCellToConsole
+    {
+        template<typename T_Acc, typename T_RejectionProbabilityCache_Cell>
+        HDINLINE auto operator()(
+            T_Acc const&,
+            T_RejectionProbabilityCache_Cell const& rejectionProbabilityCache,
+            pmacc::DataSpace<picongpu::simDim> superCellIdx) const
+            -> std::enable_if_t<std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
+        {
+            constexpr uint32_t numCells = T_RejectionProbabilityCache_Cell::numberCells;
+
+            // check if overSubscribed
+            bool overSubscription = false;
+            for(uint32_t i = 0u; i < numCells; i++)
+            {
+                if(rejectionProbabilityCache.getRejectionProbabilityCell(i) > 0._X)
+                    overSubscription = true;
+            }
+
+            // print content
+            std::cout << "rejectionProbabilityCache_Cell " << superCellIdx.toString(",", "[]");
+            std::cout << " oversubcribed: " << ((overSubscription) ? "true" : "false") << std::endl;
+            std::cout << "Cells:" << std::endl;
+            for(uint32_t i = 0u; i < numCells; i++)
+            {
+                if constexpr(printOnlyOversubscribed)
+                {
+                    if(rejectionProbabilityCache.getRejectionProbabilityCell(i) < 0._X)
+                        continue;
+                }
+
+                std::cout << "\t\t" << i << ":[ " << std::setw(10) << std::scientific
+                          << rejectionProbabilityCache.getRejectionProbabilityCell(i) << std::defaultfloat << " ]"
+                          << std::endl;
+            }
+        }
+
+        template<typename T_Acc, typename T_RejectionProbabilityCache_Cell>
+        HDINLINE auto operator()(
+            T_Acc const&,
+            T_RejectionProbabilityCache_Cell const& rejectionProbabilityCache,
+            pmacc::DataSpace<picongpu::simDim> superCellIdx) const
+            -> std::enable_if_t<!std::is_same_v<alpaka::Dev<T_Acc>, alpaka::DevCpu>>
+        {
+        }
+    };
+
+    /** cache of rejection probability of p_cell for over subscribed cells,
+     *
+     * p_Cell = (cellEnergy - cellEnergyUsed)/cellDeltaEnergy
+     *
+     * @tparam T_numberCells number of cell entries in cache
+     *
+     * @attention invalidated every time the FieldEnergyUse changes
+     */
+    template<uint32_t T_numberCells>
+    class RejectionProbabilityCache_Cell
+    {
+    public:
+        static constexpr uint32_t numberCells = T_numberCells;
+
+    private:
+        float_X rejectionProbabilityCell[numberCells] = {-1._X}; // unitless
+
+        //! @attention only active by debug setting
+        HDINLINE static bool outOfRangeLinearCellIndex(uint32_t const linearCellIndex)
+        {
+            if constexpr(picongpu::atomicPhysics::debug::rejectionProbabilityCache::BIN_INDEX_RANGE_CHECK)
+                if(linearCellIndex >= numberCells)
+                {
+                    printf("atomicPhysics ERROR: out of range linear cell index in call to "
+                           "RejectionProbabilityCache_Cell\n");
+                    return true;
+                }
+            return false;
+        }
+
+    public:
+        /** set cache entry
+         *
+         * @param linearCellIndex linearized index of cell
+         * @param rejectionProbability rejectionProbability of cell
+         *
+         * @attention no range checks outside a debug compile, invalid memory write on failure
+         * @attention only use if only ever one thread accesses each rate cache entry!
+         */
+        HDINLINE void setCell(uint32_t const linearCellIndex, float_X const rejectionProbability)
+        {
+            if(outOfRangeLinearCellIndex(linearCellIndex))
+                return;
+
+            rejectionProbabilityCell[linearCellIndex] = rejectionProbability;
+        }
+
+        /** get cached rejectionProbability for a cell
+         *
+         * @param linearCellIndex
+         * @return rejectionProbability rejectionProbability of bin
+         *
+         * @attention no range checks outside a debug compile, invalid memory access on failure
+         */
+        HDINLINE float_X getRejectionProbabilityCell(uint32_t const linearCellIndex) const
+        {
+            if(outOfRangeLinearCellIndex(linearCellIndex))
+                return -1._X;
+
+            return rejectionProbabilityCell[linearCellIndex];
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
@@ -86,8 +86,6 @@ namespace picongpu::particles::atomicPhysics::stage
 
             // macro for call of kernel for every superCell, see pull request #4321
             PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::CheckForOverSubscriptionKernel<
-                                      picongpu::atomicPhysics::ElectronHistogram,
-                                      FieldEnergyUseCacheField::ElementType,
                                       T_numberAtomicPhysicsIonSpecies>())
                 .template config<picongpu::atomicPhysics::ElectronHistogram::numberBins>(mapper.getGridDim())(
                     mapper,
@@ -107,7 +105,7 @@ namespace picongpu::particles::atomicPhysics::stage
     template<>
     struct CheckForOverSubscription<0u>
     {
-        HINLINE void operator()(picongpu::MappingDesc const mappingDesc) const
+        HINLINE void operator()([[maybe_unused]] picongpu::MappingDesc const mappingDesc) const
         {
         }
     };

--- a/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
@@ -102,4 +102,13 @@ namespace picongpu::particles::atomicPhysics::stage
             /// @todo implement photon histogram, Brian Marre, 2023
         }
     };
+
+    //! specialization for no atomicPhysics ion species
+    template<>
+    struct CheckForOverSubscription<0u>
+    {
+        HINLINE void operator()(picongpu::MappingDesc const mappingDesc) const
+        {
+        }
+    };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/CheckForOverSubscription.hpp
@@ -27,7 +27,8 @@
 #include "picongpu/particles/atomicPhysics/electronDistribution/LocalHistogramField.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/CheckForOverSubscription.kernel"
 #include "picongpu/particles/atomicPhysics/localHelperFields/FieldEnergyUseCacheField.hpp"
-#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Bin.hpp"
+#include "picongpu/particles/atomicPhysics/localHelperFields/RejectionProbabilityCacheField_Cell.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/SharedResourcesOverSubscribedField.hpp"
 #include "picongpu/particles/atomicPhysics/localHelperFields/TimeRemainingField.hpp"
 
@@ -69,9 +70,12 @@ namespace picongpu::particles::atomicPhysics::stage
                 = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::SharedResourcesOverSubscribedField<
                     picongpu::MappingDesc>>("SharedResourcesOverSubscribedField");
 
-            auto& rejectionProbabilityCacheField
-                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::RejectionProbabilityCacheField<
-                    picongpu::MappingDesc>>("RejectionProbabilityCacheField");
+            auto& rejectionProbabilityCacheField_Bin
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::RejectionProbabilityCacheField_Bin<
+                    picongpu::MappingDesc>>("RejectionProbabilityCacheField_Bin");
+            auto& rejectionProbabilityCacheField_Cell
+                = *dc.get<picongpu::particles::atomicPhysics::localHelperFields::RejectionProbabilityCacheField_Cell<
+                    picongpu::MappingDesc>>("RejectionProbabilityCacheField_Cell");
 
             auto& eField = *dc.get<FieldE>(FieldE::getName());
 
@@ -92,7 +96,8 @@ namespace picongpu::particles::atomicPhysics::stage
                     eField.getDeviceDataBox(),
                     fieldEnergyUseCacheField.getDeviceDataBox(),
                     sharedResourcesOverSubscribedField.getDeviceDataBox(),
-                    rejectionProbabilityCacheField.getDeviceDataBox());
+                    rejectionProbabilityCacheField_Bin.getDeviceDataBox(),
+                    rejectionProbabilityCacheField_Cell.getDeviceDataBox());
 
             /// @todo implement photon histogram, Brian Marre, 2023
         }

--- a/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/ChooseTransition.hpp
@@ -17,7 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! @file deduceTransitionCollectionIndex sub-stage of atomicPhysics
+//! @file chooseTransition sub-stage of atomicPhysics
 
 #pragma once
 

--- a/include/picongpu/particles/atomicPhysics/stage/RecordChanges.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RecordChanges.hpp
@@ -35,7 +35,10 @@
 
 namespace picongpu::particles::atomicPhysics::stage
 {
-    /** atomicPhysics sub-stage recording deltaEnergy usage by all transitions
+    /** atomicPhysics sub-stage updating atomic state of ions and recording electron histogram energy usage of
+     *  transitions
+     *
+     * @attention assumes that all ions accepted a transition, no check for acceptance outside of a debug compile.
      *
      * @tparam T_IonSpecies ion species type
      */
@@ -75,11 +78,8 @@ namespace picongpu::particles::atomicPhysics::stage
 
             if constexpr(AtomicDataType::switchElectronicExcitation)
             {
-                using RecordChanges_electronicExcitation
-                    = picongpu::particles::atomicPhysics ::kernel::RecordChangesKernel<
-                        s_enums::ProcessClass::electronicExcitation,
-                        picongpu::atomicPhysics::ElectronHistogram,
-                        IPDModel>;
+                using RecordChanges_electronicExcitation = picongpu::particles::atomicPhysics ::kernel::
+                    RecordChangesKernel<s_enums::ProcessClass::electronicExcitation, IPDModel>;
 
                 PMACC_LOCKSTEP_KERNEL(RecordChanges_electronicExcitation())
                     .config(mapper.getGridDim(), ions)(
@@ -95,11 +95,8 @@ namespace picongpu::particles::atomicPhysics::stage
 
             if constexpr(AtomicDataType::switchElectronicDeexcitation)
             {
-                using RecordChanges_electronicDeexcitation
-                    = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        s_enums::ProcessClass::electronicDeexcitation,
-                        picongpu::atomicPhysics::ElectronHistogram,
-                        IPDModel>;
+                using RecordChanges_electronicDeexcitation = picongpu::particles::atomicPhysics::kernel::
+                    RecordChangesKernel<s_enums::ProcessClass::electronicDeexcitation, IPDModel>;
 
                 PMACC_LOCKSTEP_KERNEL(RecordChanges_electronicDeexcitation())
                     .config(mapper.getGridDim(), ions)(
@@ -115,11 +112,8 @@ namespace picongpu::particles::atomicPhysics::stage
 
             if constexpr(AtomicDataType::switchSpontaneousDeexcitation)
             {
-                using RecordChanges_spontaneousDeexcitation
-                    = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        s_enums::ProcessClass::spontaneousDeexcitation,
-                        picongpu::atomicPhysics::ElectronHistogram,
-                        IPDModel>;
+                using RecordChanges_spontaneousDeexcitation = picongpu::particles::atomicPhysics::kernel::
+                    RecordChangesKernel<s_enums::ProcessClass::spontaneousDeexcitation, IPDModel>;
 
                 PMACC_LOCKSTEP_KERNEL(RecordChanges_spontaneousDeexcitation())
                     .config(mapper.getGridDim(), ions)(
@@ -135,11 +129,8 @@ namespace picongpu::particles::atomicPhysics::stage
 
             if constexpr(AtomicDataType::switchElectronicIonization)
             {
-                using RecordChanges_electronicIonization
-                    = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        s_enums::ProcessClass::electronicIonization,
-                        picongpu::atomicPhysics::ElectronHistogram,
-                        IPDModel>;
+                using RecordChanges_electronicIonization = picongpu::particles::atomicPhysics::kernel::
+                    RecordChangesKernel<s_enums::ProcessClass::electronicIonization, IPDModel>;
 
                 IPDModel::template callKernelWithIPDInput<
                     RecordChanges_electronicIonization,
@@ -157,10 +148,8 @@ namespace picongpu::particles::atomicPhysics::stage
 
             if constexpr(AtomicDataType::switchFieldIonization)
             {
-                using RecordChanges_fieldIonization = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                    s_enums::ProcessClass::fieldIonization,
-                    picongpu::atomicPhysics::ElectronHistogram,
-                    IPDModel>;
+                using RecordChanges_fieldIonization = picongpu::particles::atomicPhysics::kernel::
+                    RecordChangesKernel<s_enums::ProcessClass::fieldIonization, IPDModel>;
 
                 IPDModel::template callKernelWithIPDInput<
                     RecordChanges_fieldIonization,
@@ -178,11 +167,8 @@ namespace picongpu::particles::atomicPhysics::stage
 
             if constexpr(AtomicDataType::switchAutonomousIonization)
             {
-                using RecordChanges_autonomousIonization
-                    = picongpu::particles::atomicPhysics::kernel::RecordChangesKernel<
-                        s_enums::ProcessClass::autonomousIonization,
-                        picongpu::atomicPhysics::ElectronHistogram,
-                        IPDModel>;
+                using RecordChanges_autonomousIonization = picongpu::particles::atomicPhysics::kernel::
+                    RecordChangesKernel<s_enums::ProcessClass::autonomousIonization, IPDModel>;
 
                 IPDModel::template callKernelWithIPDInput<
                     RecordChanges_autonomousIonization,

--- a/include/picongpu/particles/atomicPhysics/stage/RollForOverSubscription.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/RollForOverSubscription.hpp
@@ -68,34 +68,34 @@ namespace picongpu::particles::atomicPhysics::stage
             pmacc::AreaMapping<CORE + BORDER, MappingDesc> mapper(mappingDesc);
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
 
-            auto& timeRemainingField
-                = *dc.get<localHelperFields::TimeRemainingField<picongpu::MappingDesc>>("TimeRemainingField");
+            auto timeRemainingField
+                = dc.get<localHelperFields::TimeRemainingField<picongpu::MappingDesc>>("TimeRemainingField");
 
-            auto& ions = *dc.get<IonSpecies>(IonSpecies::FrameType::getName());
+            auto ions = dc.get<IonSpecies>(IonSpecies::FrameType::getName());
 
-            auto& rejectionProbabilityCacheField_Bin
-                = *dc.get<localHelperFields::RejectionProbabilityCacheField_Bin<picongpu::MappingDesc>>(
+            auto rejectionProbabilityCacheField_Bin
+                = dc.get<localHelperFields::RejectionProbabilityCacheField_Bin<picongpu::MappingDesc>>(
                     "RejectionProbabilityCacheField_Bin");
-            auto& rejectionProbabilityCacheField_Cell
-                = *dc.get<localHelperFields::RejectionProbabilityCacheField_Cell<picongpu::MappingDesc>>(
+            auto rejectionProbabilityCacheField_Cell
+                = dc.get<localHelperFields::RejectionProbabilityCacheField_Cell<picongpu::MappingDesc>>(
                     "RejectionProbabilityCacheField_Cell");
 
-            auto& sharedResourcesOverSubscribedField
-                = *dc.get<localHelperFields::SharedResourcesOverSubscribedField<picongpu::MappingDesc>>(
+            auto sharedResourcesOverSubscribedField
+                = dc.get<localHelperFields::SharedResourcesOverSubscribedField<picongpu::MappingDesc>>(
                     "SharedResourcesOverSubscribedField");
 
             RngFactoryFloat rngFactory = RngFactoryFloat{currentStep};
 
             // macro for call of kernel for every superCell
-            PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::RollForOverSubscriptionKernel())
-                .config(mapper.getGridDim(), ions)(
+            PMACC_LOCKSTEP_KERNEL(particles::atomicPhysics::kernel::RollForOverSubscriptionKernel())
+                .config(mapper.getGridDim(), *ions)(
                     mapper,
                     rngFactory,
-                    timeRemainingField.getDeviceDataBox(),
-                    sharedResourcesOverSubscribedField.getDeviceDataBox(),
-                    ions.getDeviceParticlesBox(),
-                    rejectionProbabilityCacheField_Bin.getDeviceDataBox(),
-                    rejectionProbabilityCacheField_Cell.getDeviceDataBox());
+                    timeRemainingField->getDeviceDataBox(),
+                    sharedResourcesOverSubscribedField->getDeviceDataBox(),
+                    ions->getDeviceParticlesBox(),
+                    rejectionProbabilityCacheField_Bin->getDeviceDataBox(),
+                    rejectionProbabilityCacheField_Cell->getDeviceDataBox());
         }
     };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/UpdateElectricField.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/UpdateElectricField.hpp
@@ -66,10 +66,9 @@ namespace picongpu::particles::atomicPhysics::stage
             auto& fieldEnergyUseCacheField = *dc.get<FieldEnergyUseCacheField>("FieldEnergyUseCacheField");
 
             // macro for call of kernel for every superCell, see pull request #4321
-            PMACC_LOCKSTEP_KERNEL(picongpu::particles::atomicPhysics::kernel::UpdateElectricFieldKernel<
-                                      FieldEnergyUseCacheField::ElementType,
-                                      T_numberAtomicPhysicsIonSpecies>())
-                .template config<FieldEnergyUseCacheField::ElementType::numberCells>(mapper.getGridDim())(
+            PMACC_LOCKSTEP_KERNEL(
+                particles::atomicPhysics::kernel::UpdateElectricFieldKernel<T_numberAtomicPhysicsIonSpecies>())
+                .template config<FieldEnergyUseCacheField::ValueType::numberCells>(mapper.getGridDim())(
                     mapper,
                     timeRemainingField.getDeviceDataBox(),
                     eField.getDeviceDataBox(),

--- a/include/picongpu/particles/atomicPhysics/stage/UpdateElectricField.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/UpdateElectricField.hpp
@@ -76,4 +76,13 @@ namespace picongpu::particles::atomicPhysics::stage
                     fieldEnergyUseCacheField.getDeviceDataBox());
         }
     };
+
+    //! specialization for no atomicPhysics ion species
+    template<>
+    struct UpdateElectricField<0u>
+    {
+        HINLINE void operator()(picongpu::MappingDesc const mappingDesc) const
+        {
+        }
+    };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/particles/atomicPhysics/stage/UpdateTimeRemaining.hpp
+++ b/include/picongpu/particles/atomicPhysics/stage/UpdateTimeRemaining.hpp
@@ -66,4 +66,13 @@ namespace picongpu::particles::atomicPhysics::stage
                     timeStepField.getDeviceDataBox());
         }
     };
+
+    //! specialization for no atomic Physics ion specie sin simulation
+    template<>
+    struct UpdateTimeRemaining<0u>
+    {
+        HINLINE void operator()(picongpu::MappingDesc const mappingDesc) const
+        {
+        }
+    };
 } // namespace picongpu::particles::atomicPhysics::stage

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -184,10 +184,15 @@ namespace picongpu::simulation::stage
                 if constexpr(debug::rejectionProbabilityCache::PRINT_TO_CONSOLE)
                 {
                     picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
-                        localHelperFields::RejectionProbabilityCacheField<picongpu::MappingDesc>,
-                        localHelperFields::PrintRejectionProbabilityCacheToConsole<true>>{}(
+                        localHelperFields::RejectionProbabilityCacheField_Bin<picongpu::MappingDesc>,
+                        localHelperFields::PrintRejectionProbabilityCacheBinToConsole<true>>{}(
                         mappingDesc,
-                        "RejectionProbabilityCacheField");
+                        "RejectionProbabilityCacheField_Bin");
+                    picongpu::particles::atomicPhysics::stage::DumpSuperCellDataToConsole<
+                        localHelperFields::RejectionProbabilityCacheField_Cell<picongpu::MappingDesc>,
+                        localHelperFields::PrintRejectionProbabilityCacheCellToConsole<true>>{}(
+                        mappingDesc,
+                        "RejectionProbabilityCacheField_Cell");
                 }
             }
 


### PR DESCRIPTION
combination of different refactors in AtomicPhysics(FLYonPIC) to avoid code duplication, in preparation for PR #5218.
 
each separate feature refactor is contained in its own commit, and it would probably be helpful to also review commit wise.