### PR TITLE
remove infiniband config file

### DIFF
--- a/etc/picongpu/openib.conf
+++ b/etc/picongpu/openib.conf
@@ -1,5 +1,0 @@
-#this file handels openib configuration for pic
-#we have problems with large data over 1MB
-#thus we create bigger openib buffer (100MB)
-btl_openib_rdma_pipeline_send_length = 100000000
-btl_openib_rdma_pipeline_frag_size = 100000000

--- a/etc/picongpu/submitAction.sh
+++ b/etc/picongpu/submitAction.sh
@@ -50,7 +50,6 @@ if [ -f $TBG_projectPath/cmakeFlagsSetup ]
 then
   cp -a $TBG_projectPath/cmakeFlagsSetup input
 fi
-cp -a $TBG_cfgPath/openib.conf tbg
 cp -a $0 tbg
 if [ -f $TBG_cfgPath/cpuNumaStarter.sh ]
 then


### PR DESCRIPTION
fix #5222

The ibconfig is not compatible with all MPI versions. I added this file 10 years ago as a workaround for Infiniband issues. If for any reason ib configuration is required the variables should be set in the corresponding tpl file.