### PR TITLE
Fix null parameter in MPI_Init_thread

### DIFF
--- a/include/pmacc/Environment.tpp
+++ b/include/pmacc/Environment.tpp
@@ -219,7 +219,13 @@ namespace pmacc
                         "MPI_THREAD_FUNNELED, MPI_THREAD_SERIALIZED or MPI_THREAD_MULTIPLE.");
                 }
                 // MPI_Init with NULL is allowed since MPI 2.0
-                MPI_CHECK(MPI_Init_thread(nullptr, nullptr, required_level, nullptr));
+                int provided;
+                MPI_CHECK(MPI_Init_thread(nullptr, nullptr, required_level, &provided));
+                if(provided != required_level)
+                {
+                    std::cerr << "[MPI_Init_thread] Provided level '" << provided << "' differs from required level '"
+                              << required_level << "'. Will go on.\n";
+                }
             }
             else
             {


### PR DESCRIPTION
Threaded MPI can be activated in PIConGPU by `export PIC_USE_THREADED_MPI=MPI_THREAD_MULTIPLE`, necessary for some things like the HDF5 subfiling VFD or RDMA via MPI in ADIOS2 SST, introduced with #4412. However, the `MPI_Init_thread()` call was wrong and only worked with some MPI versions.