### PR TITLE
update memory calculator

### DIFF
--- a/docs/source/usage/workflows/memoryPerDevice.rst
+++ b/docs/source/usage/workflows/memoryPerDevice.rst
@@ -8,22 +8,14 @@ Calculating the Memory Requirement per Device
 The planning of simulations for realistically sized problems requires a careful estimation of memory usage and is often a trade-off between resolution of the plasma, overall box size and the available resources.
 The file :ref:`memory_calculator.py <usage-python-utils-memory-calculator>` contains a class for this purpose.
 
-The following paragraph shows the use of the ``MemoryCalculator`` for the ``4.cfg`` setup of the :ref:`FoilLCT example <usage-examples-foilLCT>` example.
+The following example script demonstrates it's use:
 
-It is an estimate for how much memory is used per device if the whole
-target would be fully ionized but does not move much. Of course, the real
-memory usage depends on the case and the dynamics inside the simulation.
-We calculate the memory of just one device per row of GPUs in laser
-propagation direction. We hereby assume that particles are distributed
-equally in the transverse direction like it is set up in the FoilLCT example.
+.. literalinclude:: ./memoryPerDevice.py
+    :language: python3
 
 We encourage to try out this script with different settings, to see
 how they influence the distribution of the total memory requirement
 between devices.
-
-.. literalinclude:: ./memoryPerDevice.py
-    :language: python3
-    :lines: 11,12,27-
 
 This will give the following output:
 


### PR DESCRIPTION
This PR,
- refactors the memory calculator:
  - type validation using pydantic
  - function signature checks using typeguard
  - remove explicit passing of extents by dimension
  - changes particle attribute specification to be by list of names
  - updates the pml border default size to the current defaults
  - changes the pml border size specification to match the param files
- refactors the use example
  - bug-fix in the particle memory calculation, now uses sim dimension 2 instead of the old default value 3
  - update to the new interfaces
  - generalize the implementation
  - switches to per gpu output instead of per row output
- adds the memory calculation for atomic physics super cell fields and atomic physics particle attributes
