### PR TITLE
Add per species particle filtering

### DIFF
--- a/include/picongpu/param/binningSetup.param
+++ b/include/picongpu/param/binningSetup.param
@@ -108,6 +108,14 @@ namespace picongpu
              */
             auto electronsObj = PMACC_CSTRING("e"){};
 
+            /**
+             * Optionally pass a particle filter to be used for this
+             * Simply a particle predicate functor
+             */
+            auto allParticles
+                = [] ALPAKA_FN_ACC(auto const& domainInfo, auto const& worker, auto const& particle) -> bool
+            { return true; };
+
             // type is void if species doesn't exist
             using speciesExists = typename pmacc::particles::meta::FindByNameOrType_t<
                 VectorAllSpecies,
@@ -118,7 +126,7 @@ namespace picongpu
             if constexpr(!std::is_same_v<void, speciesExists>)
             {
                 // Bring the species together in a tuple
-                auto speciesTuple = createTuple(electronsObj);
+                auto speciesTuple = createSpeciesTuple(FilteredSpecies{electronsObj, allParticles});
 
                 /**
                  * Define deposited quantity here

--- a/include/picongpu/plugins/binning/FilteredSpecies.hpp
+++ b/include/picongpu/plugins/binning/FilteredSpecies.hpp
@@ -1,0 +1,74 @@
+/* Copyright 2023-2025 Tapish Narwal
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/attribute/FunctionSpecifier.hpp>
+
+namespace picongpu
+{
+    namespace plugins::binning
+    {
+        struct AllParticles
+        {
+            HDINLINE bool operator()(auto const& domainInfo, auto const& worker, auto const& particle) const
+            {
+                return true;
+            }
+        };
+
+        template<typename TSpecies, typename TFilter = AllParticles>
+        struct FilteredSpecies
+        {
+            using species_type = TSpecies;
+            using filter_type = TFilter;
+
+            TSpecies species;
+            TFilter filter;
+
+            FilteredSpecies(TSpecies species, TFilter filter) noexcept : species(species), filter(filter)
+            {
+            }
+
+            FilteredSpecies(TSpecies species) noexcept : species(species), filter()
+            {
+            }
+        };
+
+        template<typename T>
+        concept IsFilteredSpecies = requires
+        {
+            typename T::species_type;
+            typename T::filter_type;
+        };
+
+        /**
+         * Function to create a tuple of FilteredSpecies
+         * If you pass in a type which is not a FilteredSpecies, it is assumed to be a regular Species type, and
+         * a trivial AllParticle filter is used with it, which allows all particles through without filtering
+         */
+        template<typename... Args>
+        HDINLINE auto createSpeciesTuple(Args&&... args)
+        {
+            return std::make_tuple(
+                (IsFilteredSpecies<Args> ? std::forward<Args>(args) : FilteredSpecies{std::forward<Args>(args)})...);
+        }
+
+    } // namespace plugins::binning
+} // namespace picongpu

--- a/include/picongpu/plugins/binning/binnerPlugin.hpp
+++ b/include/picongpu/plugins/binning/binnerPlugin.hpp
@@ -23,6 +23,7 @@
 #include "picongpu/plugins/binning/BinningCreator.hpp"
 #include "picongpu/plugins/binning/BinningData.hpp"
 #include "picongpu/plugins/binning/DomainInfo.hpp"
+#include "picongpu/plugins/binning/FilteredSpecies.hpp"
 #include "picongpu/plugins/binning/FunctorDescription.hpp"
 #include "picongpu/plugins/binning/UnitConversion.hpp"
 #include "picongpu/plugins/binning/axis/LinearAxis.hpp"

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/binningSetup.param
@@ -71,7 +71,7 @@ namespace picongpu::plugins::binning
         auto ions = PMACC_CSTRING("Cu"){};
 
         /// Bring the species together in a tuple
-        auto speciesTuple = createTuple(ions);
+        auto speciesTuple = createSpeciesTuple(ions);
 
         //! Define deposited quantity
         auto getParticleWeighting = [] ALPAKA_FN_ACC(auto const& worker, auto const& particle) -> float_64


### PR DESCRIPTION
Adds ability to filter particles before binning. Filters can be defined per species 
Breaks existing input sets using the binning plugin 
Users now need to use createSpeciesTuple instead of create tuple