### PR TITLE
Update modules in fwkt_v100_picongpu.profile

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -22,8 +22,10 @@ module load cuda/12.1
 module load libfabric/1.17.0
 module load ucx/1.14.0-gdr
 module load openmpi/4.1.5-cuda121-gdr
+module load python/3.12.2
+module load boost/1.85.0
+# preliminary solution, because adios2/2.9.2 does not work with python/3.12.2
 module load python/3.10.4
-module load boost/1.82.0
 
 # Other Software ##############################################################
 #


### PR DESCRIPTION
Preliminary solution!

We need boost/1.85.0
This requires python/3.12.2
But adios2/2.9.2-cuda121 needs python/3.10.4 ...

I will open a ticket. Until there exists a coherent solution, this will fix the boost bug when compiling on hemera.