### PR TITLE
Short circuit axis binning if any previous axis is invalid

### DIFF
--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -94,11 +94,10 @@ namespace picongpu
                     }
 
                     template<typename T_Worker, typename T_Particle>
-                    ALPAKA_FN_ACC uint32_t getBinIdx(
+                    ALPAKA_FN_ACC std::pair<bool, uint32_t> getBinIdx(
                         const DomainInfo& domainInfo,
                         const T_Worker& worker,
-                        const T_Particle& particle,
-                        bool& validIdx) const
+                        const T_Particle& particle) const
                     {
                         auto val = getAttributeValue(domainInfo, worker, particle);
 
@@ -128,8 +127,7 @@ namespace picongpu
                             else
                                 binIdx = nBins - 1;
                         }
-                        validIdx = validIdx && enableBinning;
-                        return binIdx;
+                        return {enableBinning, binIdx};
                     }
                 };
 

--- a/include/picongpu/plugins/binning/axis/LogAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LogAxis.hpp
@@ -114,11 +114,10 @@ namespace picongpu
 
 
                     template<typename T_Worker, typename T_Particle>
-                    ALPAKA_FN_ACC uint32_t getBinIdx(
+                    ALPAKA_FN_ACC std::pair<bool, uint32_t> getBinIdx(
                         const DomainInfo& domainInfo,
                         const T_Worker& worker,
-                        const T_Particle& particle,
-                        bool& validIdx) const
+                        const T_Particle& particle) const
                     {
                         auto val = getAttributeValue(domainInfo, worker, particle);
 
@@ -155,9 +154,7 @@ namespace picongpu
                                     binIdx = nBins - 1;
                             }
                         }
-
-                        validIdx = validIdx && enableBinning;
-                        return binIdx;
+                        return {enableBinning, binIdx};
                     }
                 };
 


### PR DESCRIPTION
Optimization to not calculate axis bins after the first axis with an out of range bin is found (by using ``&&`` instead of ``,`` with the parameter pack expansion)