### PR TITLE
Update the pmacc tuple utilities and their use in the binning plugin

### DIFF
--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -186,7 +186,7 @@ namespace picongpu
                 //  Do binning for species. Writes to histBuffer
                 if(binningData.isRegionEnabled(ParticleRegion::Bounded))
                 {
-                    binning::apply(
+                    std::apply(
                         [&](auto const&... tupleArgs) { ((doBinningForSpecies(tupleArgs, currentStep)), ...); },
                         binningData.speciesTuple);
                 }
@@ -246,7 +246,7 @@ namespace picongpu
                                 this->histBuffer->getDeviceBuffer().getDataBox());
 
                         // change output dimensions
-                        binning::apply(
+                        std::apply(
                             [&](auto const&... tupleArgs)
                             { ((dimensionSubtraction(outputUnits, tupleArgs.units)), ...); },
                             binningData.axisTuple);
@@ -304,7 +304,7 @@ namespace picongpu
 
                 if(binningData.isRegionEnabled(ParticleRegion::Leaving))
                 {
-                    binning::apply(
+                    std::apply(
                         [&](auto const&... tupleArgs)
                         {
                             (misc::ExecuteIf{}(

--- a/include/picongpu/plugins/binning/Binner.hpp
+++ b/include/picongpu/plugins/binning/Binner.hpp
@@ -115,7 +115,7 @@ namespace picongpu
                         {
                             pmacc::DataSpace<nAxes> const nDIdx = pmacc::math::mapToND(extentsDataspace, linearTid);
                             float_X factor = 1.;
-                            apply(
+                            binning::apply(
                                 [&](auto const&... binWidthsKernel)
                                 {
                                     // uses bin width for axes without dimensions as well should those be ignored?
@@ -159,7 +159,7 @@ namespace picongpu
             std::optional<::openPMD::Series> m_series;
 
         public:
-            Binner(TBinningData bd, MappingDesc* cellDesc) : binningData{bd}, cellDescription{cellDesc}
+            Binner(TBinningData const& bd, MappingDesc* cellDesc) : binningData{bd}, cellDescription{cellDesc}
             {
                 this->pluginName = "binner_" + binningData.binnerOutputName;
                 /**
@@ -186,7 +186,7 @@ namespace picongpu
                 //  Do binning for species. Writes to histBuffer
                 if(binningData.isRegionEnabled(ParticleRegion::Bounded))
                 {
-                    std::apply(
+                    binning::apply(
                         [&](auto const&... tupleArgs) { ((doBinningForSpecies(tupleArgs, currentStep)), ...); },
                         binningData.speciesTuple);
                 }
@@ -246,7 +246,7 @@ namespace picongpu
                                 this->histBuffer->getDeviceBuffer().getDataBox());
 
                         // change output dimensions
-                        apply(
+                        binning::apply(
                             [&](auto const&... tupleArgs)
                             { ((dimensionSubtraction(outputUnits, tupleArgs.units)), ...); },
                             binningData.axisTuple);
@@ -304,7 +304,7 @@ namespace picongpu
 
                 if(binningData.isRegionEnabled(ParticleRegion::Leaving))
                 {
-                    std::apply(
+                    binning::apply(
                         [&](auto const&... tupleArgs)
                         {
                             (misc::ExecuteIf{}(

--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -62,11 +62,12 @@ namespace picongpu
              */
             template<typename TAxisTuple, typename TSpeciesTuple, typename TDepositionData>
             auto addBinner(
-                std::string binnerOutputName,
-                TAxisTuple axisTupleObject,
-                TSpeciesTuple speciesTupleObject,
-                TDepositionData depositionData,
-                std::function<void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)>
+                std::string const& binnerOutputName,
+                TAxisTuple const& axisTupleObject,
+                TSpeciesTuple const& speciesTupleObject,
+                TDepositionData const& depositionData,
+                std::function<
+                    void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)> const&
                     writeOpenPMDFunctor
                 = [](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) {})
                 -> BinningData<TAxisTuple, TSpeciesTuple, TDepositionData>&

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -22,7 +22,6 @@
 #if(ENABLE_OPENPMD == 1)
 
 #    include "picongpu/plugins/binning/Axis.hpp"
-#    include "picongpu/plugins/binning/utility.hpp"
 #    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 
 #    include <cstdint>
@@ -65,7 +64,7 @@ namespace picongpu
             T_DepositionData depositionData;
             std::function<void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)>
                 writeOpenPMDFunctor;
-            DataSpace<pmacc::memory::tuple::tuple_size_v<T_AxisTuple>> axisExtentsND;
+            DataSpace<std::tuple_size_v<T_AxisTuple>> axisExtentsND;
 
             /* Optional parameters not initialized by constructor.
              * Use the return value of addBinner() to modify them if needed. */
@@ -93,18 +92,19 @@ namespace picongpu
                 , depositionData{depositData}
                 , writeOpenPMDFunctor{writeOpenPMD}
             {
-                binning::applyEnumerate(
+                std::apply(
                     [&](auto const&... tupleArgs)
                     {
+                        uint32_t i = 0;
                         // This assumes getNBins() exists
-                        ((axisExtentsND[tupleArgs.first] = tupleArgs.second.getNBins()), ...);
+                        ((axisExtentsND[i++] = tupleArgs.getNBins()), ...);
                     },
                     axisTuple);
             }
 
             static constexpr uint32_t getNAxes()
             {
-                return pmacc::memory::tuple::tuple_size_v<T_AxisTuple>;
+                return std::tuple_size_v<T_AxisTuple>;
             }
 
             /** @brief Time average the accumulated data when doing the dump. Defaults to true. */

--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -53,19 +53,18 @@ namespace picongpu
 
                 auto binsDataspace = pmacc::DataSpace<T_nAxes>{};
                 bool validIdx = true;
-                apply(
+                binning::applyEnumerate(
                     [&](auto const&... tupleArgs)
                     {
-                        uint32_t i = 0;
                         // This assumes n_bins and getBinIdx exist
                         validIdx
-                            = ((
+                            = (
                                    [&]
                                    {
-                                       auto [isValid, binIdx] = tupleArgs.getBinIdx(domainInfo, worker, particle);
-                                       binsDataspace[i++] = binIdx;
+                                       auto [isValid, binIdx] = tupleArgs.second.getBinIdx(domainInfo, worker, particle);
+                                       binsDataspace[tupleArgs.first] = binIdx;
                                        return isValid;
-                                   }())
+                                   }()
                                && ...);
                     },
                     axes);

--- a/include/picongpu/plugins/binning/FilteredSpecies.hpp
+++ b/include/picongpu/plugins/binning/FilteredSpecies.hpp
@@ -66,7 +66,7 @@ namespace picongpu
          * a trivial AllParticle filter is used with it, which allows all particles through without filtering
          */
         template<typename... Args>
-        HDINLINE auto createSpeciesTuple(Args&&... args)
+        constexpr auto createSpeciesTuple(Args&&... args)
         {
             return createTuple(
                 (IsFilteredSpecies<Args> ? std::forward<Args>(args) : FilteredSpecies{std::forward<Args>(args)})...);

--- a/include/picongpu/plugins/binning/FilteredSpecies.hpp
+++ b/include/picongpu/plugins/binning/FilteredSpecies.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "picongpu/plugins/binning/utility.hpp"
+
 #include <pmacc/attribute/FunctionSpecifier.hpp>
 
 namespace picongpu
@@ -66,7 +68,7 @@ namespace picongpu
         template<typename... Args>
         HDINLINE auto createSpeciesTuple(Args&&... args)
         {
-            return std::make_tuple(
+            return createTuple(
                 (IsFilteredSpecies<Args> ? std::forward<Args>(args) : FilteredSpecies{std::forward<Args>(args)})...);
         }
 

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -138,7 +138,7 @@ namespace picongpu
                 mesh.setGeometry(::openPMD::Mesh::Geometry::cartesian);
                 mesh.setDataOrder(::openPMD::Mesh::DataOrder::C);
 
-                binning::apply(
+                std::apply(
                     [&](auto const&... tupleArgs)
                     {
                         ((mesh.setAttribute(tupleArgs.label + "_bin_edges", tupleArgs.getBinEdgesSI())), ...);

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -56,8 +56,8 @@ namespace picongpu
                 std::optional<::openPMD::Series>& maybe_series,
                 OpenPMDWriteParams params,
                 std::unique_ptr<HostBuffer<T_Type, 1u>> hReducedBuffer,
-                T_BinningData binningData,
-                const std::array<double, numUnits>& outputUnits,
+                T_BinningData const& binningData,
+                std::array<double, numUnits> const& outputUnits,
                 const uint32_t currentStep,
                 const bool isCheckpoint = false,
                 const uint32_t accumulateCounter = 0)
@@ -138,8 +138,8 @@ namespace picongpu
                 mesh.setGeometry(::openPMD::Mesh::Geometry::cartesian);
                 mesh.setDataOrder(::openPMD::Mesh::DataOrder::C);
 
-                std::apply(
-                    [&](auto&... tupleArgs)
+                binning::apply(
+                    [&](auto const&... tupleArgs)
                     {
                         ((mesh.setAttribute(tupleArgs.label + "_bin_edges", tupleArgs.getBinEdgesSI())), ...);
                         ((mesh.setAttribute(tupleArgs.label + "_units", tupleArgs.units)), ...);
@@ -148,7 +148,7 @@ namespace picongpu
                         std::reverse(labelVector.begin(), labelVector.end());
                         mesh.setAxisLabels(labelVector);
                     },
-                    binningData.axisTuple); // careful no const tupleArgs
+                    binningData.axisTuple);
 
                 std::vector<double> gridSpacingVector;
                 std::vector<double> gridOffsetVector;

--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -188,7 +188,7 @@ namespace picongpu
                 /**
                  * @return bin edges in SI units
                  */
-                std::vector<double> getBinEdgesSI()
+                std::vector<double> getBinEdgesSI() const
                 {
                     /**
                      * @TODO store edges? Compute once at the beginning and store for later to print at every

--- a/include/picongpu/plugins/binning/axis/LogAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LogAxis.hpp
@@ -249,7 +249,7 @@ namespace picongpu
                 /**
                  * @return bin edges in SI units
                  */
-                std::vector<double> getBinEdgesSI()
+                std::vector<double> getBinEdgesSI() const
                 {
                     std::vector<double> binEdges;
                     binEdges.reserve(axisSplit.nBins + 1);

--- a/include/picongpu/plugins/binning/utility.hpp
+++ b/include/picongpu/plugins/binning/utility.hpp
@@ -72,30 +72,32 @@ namespace picongpu
 
         namespace detail
         {
-            template<size_t... Is, typename TPmaccTuple, typename Functor>
-            constexpr auto tupleMapHelper(std::index_sequence<Is...>, TPmaccTuple&& tuple, Functor&& functor) noexcept
+            template<size_t... Is, typename... Args, typename Functor>
+            constexpr auto tupleMapHelper(
+                std::index_sequence<Is...>,
+                std::tuple<Args...> const& tuple,
+                Functor&& functor) noexcept
             {
-                return pmacc::memory::tuple::make_tuple(std::forward<Functor>(functor)(
-                    pmacc::memory::tuple::get<Is>(std::forward<TPmaccTuple>(tuple)))...);
+                return pmacc::memory::tuple::make_tuple(std::forward<Functor>(functor)(std::get<Is>(tuple))...);
             }
         } // namespace detail
 
         /**
          * @brief create a new tuple from the return value of a functor applied on all arguments of a tuple
          */
-        template<typename TPmaccTuple, typename Functor>
-        constexpr auto tupleMap(TPmaccTuple&& tuple, Functor&& functor) noexcept
+        template<typename... Args, typename Functor>
+        constexpr auto tupleMap(std::tuple<Args...> const& tuple, Functor&& functor) noexcept
         {
             return detail::tupleMapHelper(
-                std::make_index_sequence<pmacc::memory::tuple::tuple_size_v<TPmaccTuple>>{},
-                std::forward<TPmaccTuple>(tuple),
+                std::make_index_sequence<sizeof...(Args)>{},
+                tuple,
                 std::forward<Functor>(functor));
         }
 
         template<typename... Args>
         constexpr auto createTuple(Args&&... args) noexcept
         {
-            return pmacc::memory::tuple::make_tuple(std::forward<Args>(args)...);
+            return std::make_tuple(std::forward<Args>(args)...);
         }
 
     } // namespace plugins::binning

--- a/include/picongpu/plugins/binning/utility.hpp
+++ b/include/picongpu/plugins/binning/utility.hpp
@@ -31,51 +31,71 @@ namespace picongpu
     {
         namespace detail
         {
-            template<typename TFunc, typename... TArgs, std::size_t... Is>
-            HDINLINE constexpr auto apply_impl(
+            template<typename TFunc, typename TPmaccTuple, std::size_t... Is>
+            HDINLINE constexpr decltype(auto) applyImpl(TFunc&& f, TPmaccTuple&& t, std::index_sequence<Is...>)
+            {
+                return std::forward<TFunc>(f)(pmacc::memory::tuple::get<Is>(std::forward<TPmaccTuple>(t))...);
+            }
+
+            template<typename TFunc, typename TPmaccTuple, std::size_t... Is>
+            HDINLINE constexpr decltype(auto) applyEnumerateImpl(
                 TFunc&& f,
-                pmacc::memory::tuple::Tuple<TArgs...>&& t,
+                TPmaccTuple&& t,
                 std::index_sequence<Is...>)
             {
-                // @todo give Is as a param to f, so compiler has knowledge
-                return f(pmacc::memory::tuple::get<Is>(std::forward<pmacc::memory::tuple::Tuple<TArgs...>&&>(t))...);
+                return std::forward<TFunc>(f)(std::make_pair(
+                    std::integral_constant<std::size_t, Is>{},
+                    pmacc::memory::tuple::get<Is>(std::forward<TPmaccTuple>(t)))...);
             }
+
         } // namespace detail
 
-        template<typename TFunc, typename... TArgs>
-        HDINLINE constexpr auto apply(TFunc&& f, pmacc::memory::tuple::Tuple<TArgs...> t)
+        // takes pmacc::memory::tuple::Tuple
+        template<typename TFunc, typename TPmaccTuple>
+        HDINLINE constexpr decltype(auto) apply(TFunc&& f, TPmaccTuple&& t)
         {
-            return detail::apply_impl(
+            return detail::applyImpl(
                 std::forward<TFunc>(f),
-                std::forward<pmacc::memory::tuple::Tuple<TArgs...>&&>(t),
-                std::make_index_sequence<sizeof...(TArgs)>{});
+                std::forward<TPmaccTuple>(t),
+                std::make_index_sequence<pmacc::memory::tuple::tuple_size_v<TPmaccTuple>>{});
+        }
+
+        // takes pmacc::memory::tuple::Tuple
+        template<typename TFunc, typename TPmaccTuple>
+        HDINLINE constexpr decltype(auto) applyEnumerate(TFunc&& f, TPmaccTuple&& t)
+        {
+            return detail::applyEnumerateImpl(
+                std::forward<TFunc>(f),
+                std::forward<TPmaccTuple>(t),
+                std::make_index_sequence<pmacc::memory::tuple::tuple_size_v<TPmaccTuple>>{});
         }
 
         namespace detail
         {
-            template<size_t... Is, typename... Args, typename Functor>
-            constexpr auto tupleMapHelper(
-                std::index_sequence<Is...>,
-                const std::tuple<Args...>& tuple,
-                const Functor& functor)
+            template<size_t... Is, typename TPmaccTuple, typename Functor>
+            constexpr auto tupleMapHelper(std::index_sequence<Is...>, TPmaccTuple&& tuple, Functor&& functor) noexcept
             {
-                return pmacc::memory::tuple::make_tuple(functor(std::get<Is>(tuple))...);
+                return pmacc::memory::tuple::make_tuple(std::forward<Functor>(functor)(
+                    pmacc::memory::tuple::get<Is>(std::forward<TPmaccTuple>(tuple)))...);
             }
         } // namespace detail
 
         /**
-         * @brief create an alpaka tuple from a standard tuple by applying a functor
+         * @brief create a new tuple from the return value of a functor applied on all arguments of a tuple
          */
-        template<typename... Args, typename Functor>
-        constexpr auto tupleMap(const std::tuple<Args...>& tuple, const Functor& functor)
+        template<typename TPmaccTuple, typename Functor>
+        constexpr auto tupleMap(TPmaccTuple&& tuple, Functor&& functor) noexcept
         {
-            return detail::tupleMapHelper(std::make_index_sequence<sizeof...(Args)>{}, tuple, functor);
+            return detail::tupleMapHelper(
+                std::make_index_sequence<pmacc::memory::tuple::tuple_size_v<TPmaccTuple>>{},
+                std::forward<TPmaccTuple>(tuple),
+                std::forward<Functor>(functor));
         }
 
         template<typename... Args>
-        HDINLINE auto createTuple(Args const&... args)
+        constexpr auto createTuple(Args&&... args) noexcept
         {
-            return std::make_tuple(args...);
+            return pmacc::memory::tuple::make_tuple(std::forward<Args>(args)...);
         }
 
     } // namespace plugins::binning


### PR DESCRIPTION
Add a new function ``applyEnumerated`` which passes pairs of ``(index ,tuple)`` to the callable argument
Fix forwarding of arguments in ``binning::apply`` and ``tupleMap``
Pass the tuples around by const ref inside the binning plugin