### PR TITLE
CI: fix filter rules

### DIFF
--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -373,7 +373,7 @@ namespace picongpu
         T_MapperFactory const& mapperFactory,
         bool const onlyProcessMustShiftSupercells)
     {
-        ParticlesBaseType::template shiftParticles(mapperFactory, onlyProcessMustShiftSupercells);
+        ParticlesBaseType::shiftParticles(mapperFactory, onlyProcessMustShiftSupercells);
     }
 
     template<typename T_Name, typename T_Flags, typename T_Attributes>

--- a/include/pmacc/particles/ParticlesBase.hpp
+++ b/include/pmacc/particles/ParticlesBase.hpp
@@ -120,7 +120,7 @@ namespace pmacc
         template<typename T_MapperFactory>
         void shiftParticles(T_MapperFactory const& mapperFactory, bool onlyProcessMustShiftSupercells)
         {
-            this->template shiftParticlesImpl(
+            this->shiftParticlesImpl(
                 StrideMapperFactory<T_MapperFactory, 3>{mapperFactory},
                 onlyProcessMustShiftSupercells);
         }

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -80,7 +80,7 @@ def get_base_image(compiler, backend):
 def is_valid_combination(row):
     n = len(row)
 
-    if n >= 2:
+    if n >= 3:
         v_compiler = get_version(row[0])
 
         is_clang_cuda = True if len(row[0]) == 3 and row[0][2] == "clangCuda" else False

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -186,9 +186,9 @@ def is_valid_combination(row):
 
         # clang as host compiler
         if is_clang:
-            if os_name == "ubuntu" and os_version == 22.04 and v_compiler <= 12:
+            if os_name == "ubuntu" and os_version == 22.04 and v_compiler <= 13:
                 return True
-            if os_name == "ubuntu" and os_version == 24.04 and v_compiler >= 13:
+            if os_name == "ubuntu" and os_version == 24.04 and v_compiler >= 14:
                 return True
             return False
 

--- a/share/ci/n_wise_generator.py
+++ b/share/ci/n_wise_generator.py
@@ -188,6 +188,12 @@ def is_valid_combination(row):
         if is_clang:
             if os_name == "ubuntu" and os_version == 22.04 and v_compiler <= 13:
                 return True
+            # disabled due to compile issue
+            #  chrono:2360:48: error: call to consteval function
+            #  'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
+            #        static constexpr unsigned fractional_width = {_S_fractional_width()};
+            if v_compiler == 14:
+                return False
             if os_name == "ubuntu" and os_version == 24.04 and v_compiler >= 14:
                 return True
             return False

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -56,9 +56,15 @@ if [[ "$PIC_TEST_CASE_FOLDER" =~ .*Empty.* ]] ; then
     # where all dependencies are disabled.
     CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF -DPIC_USE_openPMD=OFF -DPIC_USE_PNGwriter=OFF -DPIC_USE_FFTW3=OFF"
 else
-    # enforce optional dependencies
-    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON -DPIC_USE_FFTW3=ON"
-
+    if [[ "${CXX_VERSION}" =~ ^g++-12 ]] ; then
+        # disable openPMD for g++-12 due to std::variant compile issues
+        # error: function "std::__detail::__variant::_Variadic_union<_First, _Rest...>::~_Variadic_union()
+        # ... cannot be referenced -- it is a deleted function
+        CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=OFF -DPIC_USE_PNGwriter=ON -DPIC_USE_FFTW3=ON"
+    else
+        # enforce optional dependencies
+        CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON -DPIC_USE_FFTW3=ON"
+    fi
     # ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
     # ISAAC is disabled until someone adds support for alpaka 1.2.0
     # re-enable tho following code if somene fixes the ISAAC issues.

--- a/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/Scatter.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/Scatter.hpp
@@ -1364,7 +1364,7 @@ namespace mallocMC
                 // printf("Block %d, id %d: activeThreads=%d
                 // linearId=%d\n",blockIdx.x,threadIdx.x,activeThreads,linearId);
                 unsigned const temp
-                    = this->template getAvailaibleSlotsDeviceFunction(acc, slotSize, linearId, activeThreads);
+                    = this->getAvailaibleSlotsDeviceFunction(acc, slotSize, linearId, activeThreads);
                 if(temp)
                     alpaka::atomicOp<alpaka::AtomicAdd>(acc, &warpResults[wId], temp);
 


### PR DESCRIPTION
Only CUDA was tested in the CI because the new filter rules from #5255 used the OS version which was not available during the execution of the filter.