### PR TITLE
Modernize trivial tuple

### DIFF
--- a/include/pmacc/memory/STLTuple.hpp
+++ b/include/pmacc/memory/STLTuple.hpp
@@ -27,12 +27,17 @@
  *    Ralph Potter  Codeplay Software Ltd.
  *    Luke Iwanski  Codeplay Software Ltd.
  *
- * This file has been modified by Tapish Narwal
+ * This file has been modified by Tapish Narwal, adding forward as tuple,
+ * tie, passing paramters by forwarding, and using stl instead of
+ * self-written metafunctions.
  **************************************************************************/
 
 #pragma once
 
 #include <alpaka/core/BoostPredef.hpp>
+
+#include <type_traits>
+#include <utility>
 
 // suppress warnings as this is third-party code
 #if BOOST_COMP_CLANG
@@ -51,294 +56,182 @@ namespace pmacc
     {
         namespace tuple
         {
-            /// @struct StaticIf
-            /// @brief The StaticIf struct is used to statically choose the type based on
-            /// the condition.
-            template<bool, typename T = void>
-            struct StaticIf;
-            /// @brief specialisation of the @ref StaticIf when the condition is true
-            template<typename T>
-            struct StaticIf<true, T>
-            {
-                typedef T type;
-            };
-
-
             /// @struct Tuple
-            /// @brief is a fixed-size collection of heterogeneous values
-            /// @tparam Ts...  - the types of the elements that the tuple stores.
-            /// Empty list is supported.
-            template<class... Ts>
+            /// @brief A fixed-size collection of heterogeneous values, implemented using recursive templates.
+            /// This structure allows accessing elements by index, and supports various utilities like concatenation
+            /// and removal of types.
+            /// @tparam Ts...  Types of the elements that the tuple stores. Empty list is supported.
+            template<typename... Ts>
             struct Tuple;
 
-            /// @brief specialisation of the @ref Tuple class when the tuple has at least
-            /// one element.
-            /// @tparam T : the type of the first element in the tuple.
-            /// @tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
-            template<class T, class... Ts>
+            /// @brief Specialization of the @ref Tuple class when the tuple has at least one element.
+            /// This recursive structure stores the first element (`head`) and delegates the rest to the `tail`.
+            /// @tparam T The type of the first element in the tuple.
+            /// @tparam Ts... The types of the remaining elements in the tuple.
+            template<typename T, typename... Ts>
             struct Tuple<T, Ts...>
             {
-                Tuple(T t, Ts... ts) : head(t), tail(ts...)
+                template<typename U, typename... Us>
+                    requires(!std::same_as<std::remove_cvref_t<U>, Tuple> && sizeof...(Us) == sizeof...(Ts))
+                constexpr Tuple(U&& u, Us&&... us) noexcept : head(std::forward<U>(u)), tail(std::forward<Us>(us)...)
                 {
                 }
+                constexpr Tuple(const Tuple&) noexcept = default;
+                constexpr Tuple(Tuple&&) noexcept = default;
+                constexpr Tuple& operator=(const Tuple&) noexcept = default;
+                constexpr Tuple& operator=(Tuple&&) noexcept = default;
+
                 T head;
                 Tuple<Ts...> tail;
             };
 
-            template<typename, typename>
-            struct concat_tuple
+            // Base case for empty tuple
+            template<>
+            struct Tuple<>
             {
             };
 
-            template<typename... Ts, typename... Us>
-            struct concat_tuple<Tuple<Ts...>, Tuple<Us...>>
-            {
-                using type = Tuple<Ts..., Us...>;
-            };
-
-            template<typename T>
-            struct remove_last_type;
-
-            template<typename T>
-            struct remove_last_type<Tuple<T>>
-            {
-                using type = Tuple<>;
-            };
-
-            template<typename T, typename... Args>
-            struct remove_last_type<Tuple<T, Args...>>
-            {
-                using type = typename concat_tuple<Tuple<T>, typename remove_last_type<Tuple<Args...>>::type>::type;
-            };
-
-            template<typename T>
-            struct remove_first_type
-            {
-            };
-
+            // Deduction guide for Tuple to contruct with values
             template<typename T, typename... Ts>
-            struct remove_first_type<Tuple<T, Ts...>>
+            Tuple(T&&, Ts&&...) -> Tuple<std::remove_cvref_t<T>, std::remove_cvref_t<Ts>...>;
+
+
+            /// @brief Extracts the Kth element from the tuple.
+            /// @tparam K The index of the element to extract (0-based).
+            /// @tparam T The type of the (sizeof...(Types) -(K+1))th element.
+            /// @tparam Ts... The types of the elements in the tuple.
+            /// @param t The tuple from which to extract the element.
+            /// @return The extracted element by reference.
+            template<size_t k, typename T, typename... Ts>
+            constexpr decltype(auto) get(Tuple<T, Ts...>& t)
             {
-                typedef Tuple<Ts...> type;
-            };
-
-            /// @struct ElemTypeHolder
-            /// @brief ElemTypeHolder class is used to specify the types of the
-            /// elements inside the tuple
-            /// @tparam size_t the number of elements inside the tuple
-            /// @tparam class the tuple class
-            template<size_t, class>
-            struct ElemTypeHolder;
-
-            /// @brief specialisation of the @ref ElemTypeHolder class when the number of
-            /// elements inside the tuple is 1
-            template<class T, class... Ts>
-            struct ElemTypeHolder<0, Tuple<T, Ts...>>
-            {
-                typedef T type;
-            };
-
-            /// @brief specialisation of the @ref ElemTypeHolder class when the number of
-            /// elements inside the tuple is bigger than 1. It recursively calls itself to
-            /// detect the type of each element in the tuple
-            /// @tparam T : the type of the first element in the tuple.
-            /// @tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
-            /// @tparam K is the Kth element in the tuple
-            template<size_t k, class T, class... Ts>
-            struct ElemTypeHolder<k, Tuple<T, Ts...>>
-            {
-                typedef typename ElemTypeHolder<k - 1, Tuple<Ts...>>::type type;
-            };
-
-            /// get
-            /// @brief Extracts the first element from the tuple.
-            /// K=0 represents the first element of the tuple. The tuple cannot be empty.
-            /// @tparam Ts... are the type of the elements in the tuple.
-            /// @param t is the tuple whose contents to extract
-            /// @return  typename ElemTypeHolder<0, Tuple<Ts...> >::type &>::type
-
-#define TERMINATE_CONDS_TUPLE_GET(CVQual)                                                                             \
-    template<size_t k, class... Ts>                                                                                   \
-    typename StaticIf<k == 0, CVQual typename ElemTypeHolder<0, Tuple<Ts...>>::type&>::type constexpr get(            \
-        CVQual Tuple<Ts...>& t)                                                                                       \
-    {                                                                                                                 \
-        static_assert(sizeof...(Ts) != 0, "The requseted value is bigger than the size of the tuple");                \
-        return t.head;                                                                                                \
-    }
-
-            TERMINATE_CONDS_TUPLE_GET(const)
-            TERMINATE_CONDS_TUPLE_GET()
-#undef TERMINATE_CONDS_TUPLE_GET
-/// get
-/// @brief Extracts the Kth element from the tuple.
-///@tparam K is an integer value in [0,sizeof...(Types)).
-/// @tparam T is the (sizeof...(Types) -(K+1)) element in the tuple
-/// @tparam Ts... are the type of the elements  in the tuple.
-/// @param t is the tuple whose contents to extract
-/// @return  typename ElemTypeHolder<K, Tuple<Ts...> >::type &>::type
-#define RECURSIVE_TUPLE_GET(CVQual)                                                                                   \
-    template<size_t k, class T, class... Ts>                                                                          \
-    typename StaticIf<k != 0, CVQual typename ElemTypeHolder<k, Tuple<T, Ts...>>::type&>::type constexpr get(         \
-        CVQual Tuple<T, Ts...>& t)                                                                                    \
-    {                                                                                                                 \
-        return pmacc::memory::tuple::get<k - 1>(t.tail);                                                              \
-    }
-            RECURSIVE_TUPLE_GET(const)
-            RECURSIVE_TUPLE_GET()
-#undef RECURSIVE_TUPLE_GET
-
-            /// make_tuple
-            /// @brief Creates a tuple object, deducing the target type from the types of
-            /// arguments.
-            /// @tparam Args the type of the arguments to construct the tuple from
-            /// @param args zero or more arguments to construct the tuple from
-            /// @return Tuple<Args...>
-            template<typename... Args>
-            Tuple<Args...> make_tuple(Args... args)
-            {
-                return Tuple<Args...>(args...);
+                if constexpr(k == 0)
+                {
+                    return t.head;
+                }
+                else
+                {
+                    return get<k - 1>(t.tail);
+                }
             }
 
-            /// size
-            /// @brief Provides access to the number of elements in a tuple as a
-            /// compile-time constant expression.
-            /// @tparam Args the type of the arguments to construct the tuple from
-            /// @return size_t
-            template<typename... Args>
-            static constexpr size_t size(Tuple<Args...>&)
+            /// Const version of `get`
+            template<size_t k, typename T, typename... Ts>
+            constexpr decltype(auto) get(const Tuple<T, Ts...>& t)
             {
-                return sizeof...(Args);
+                if constexpr(k == 0)
+                {
+                    return t.head;
+                }
+                else
+                {
+                    return get<k - 1>(t.tail);
+                }
             }
 
-            // Handles cv-qualifiers and refs
+            /// @brief Creates a tuple object by forwarding the provided arguments.
+            /// The types of the arguments are deduced from the argument types.
+            /// @tparam Args The types of the arguments to construct the tuple from.
+            /// @param args The arguments to construct the tuple.
+            /// @return A tuple containing the provided arguments.
+            template<typename... Args>
+            constexpr auto make_tuple(Args&&... args)
+            {
+                return Tuple<std::remove_cvref_t<Args>...>(std::forward<Args>(args)...);
+            }
+
+            /// @brief Creates a tuple of forwarding references to the provided arguments.
+            /// This ensures the value category (lvalue/rvalue) of each argument is preserved.
+            /// @tparam Args Types of the arguments to construct the tuple from.
+            /// @param args Zero or more arguments to construct the tuple.
+            /// @return A tuple of forwarding references to the provided arguments.
+            template<typename... Args>
+            constexpr auto forward_as_tuple(Args&&... args)
+            {
+                return Tuple<Args&&...>(std::forward<Args>(args)...);
+            }
+
+            /// @brief Creates a tuple of references to the provided variables.
+            /// This is similar to std::tie but for the custom Tuple class.
+            /// @tparam Args Types of the arguments to construct the tuple from.
+            /// @param args Variables to create the tuple of references from.
+            /// @return Tuple<Args&...> A tuple of references to the provided variables.
+            template<typename... Args>
+            constexpr auto tie(Args&... args)
+            {
+                return Tuple<Args&...>(args...);
+            }
+
+            /// @brief Creates a tuple of references to the provided const variables.
+            /// This is a const reference version for constant variables.
+            /// @tparam Args Types of the arguments to construct the tuple from.
+            /// @param args Variables to create the tuple of references from.
+            /// @return Tuple<Args&...> A tuple of references to the provided const variables.
+            template<typename... Args>
+            constexpr auto tie(const Args&... args)
+            {
+                return Tuple<const Args&...>(args...);
+            }
+
+            /// @struct tuple_size
+            /// @brief A helper structure to get the size of a tuple. Handles cv-qualifiers and refs
             template<typename T>
             struct tuple_size : tuple_size<std::remove_cvref_t<T>>
             {
             };
 
+            /// Specialization of `tuple_size` for the `Tuple` type.
             template<typename... Args>
             struct tuple_size<Tuple<Args...>> : std::integral_constant<std::size_t, sizeof...(Args)>
             {
             };
 
+            /// Helper variable template to get the size of a tuple.
             template<typename T>
             constexpr std::size_t tuple_size_v = tuple_size<T>::value;
 
-            /// @struct IndexList
-            /// @brief Creates a list of index from the elements in the tuple
-            /// @tparam Is... a list of index from [0 to sizeof...(tuple elements))
-            template<size_t... Is>
-            struct IndexList
+            template<typename Tuple, typename T, std::size_t... Is>
+            constexpr auto append_base(Tuple&& t, T&& a, std::index_sequence<Is...>)
             {
-            };
-
-            /// @struct RangeBuilder
-            /// @brief Collects internal details for generating index ranges [MIN, MAX)
-            /// Declare primary template for index range builder
-            /// @tparam MIN is the starting index in the tuple
-            /// @tparam N represents sizeof..(elemens)- sizeof...(Is)
-            /// @tparam Is... are the list of generated index so far
-            template<size_t MIN, size_t N, size_t... Is>
-            struct RangeBuilder;
-
-            /// @brief base Step: Specialisation of the @ref RangeBuilder when the
-            /// MIN==MAX. In this case the Is... is [0 to sizeof...(tuple elements))
-            /// @tparam MIN is the starting index of the tuple
-            /// @tparam Is is [0 to sizeof...(tuple elements))
-            template<size_t MIN, size_t... Is>
-            struct RangeBuilder<MIN, MIN, Is...>
-            {
-                typedef IndexList<Is...> type;
-            };
-
-            /// Induction step: Specialisation of the RangeBuilder class when N!=MIN
-            /// in this case we are recursively subtracting N by one and adding one
-            /// index to Is... list until MIN==N
-            /// @tparam MIN is the starting index in the tuple
-            /// @tparam N represents sizeof..(elemens)- sizeof...(Is)
-            /// @tparam Is... are the list of generated index so far
-            template<size_t MIN, size_t N, size_t... Is>
-            struct RangeBuilder : public RangeBuilder<MIN, N - 1, N - 1, Is...>
-            {
-            };
-
-            /// @brief IndexRange that returns a [MIN, MAX) index range
-            /// @tparam MIN is the starting index in the tuple
-            /// @tparam MAX is the size of the tuple
-            template<size_t MIN, size_t MAX>
-            struct IndexRange : RangeBuilder<MIN, MAX>::type
-            {
-            };
-
-            /// append_base
-            /// @brief unpacking the elements of the input tuple t and creating a new tuple
-            /// by adding element a at the end of it.
-            ///@tparam Args... the type of the elements inside the tuple t
-            /// @tparam T the type of the new element going to be added at the end of tuple
-            /// @tparam I... is the list of index from [0 to sizeof...(t))
-            /// @param t the tuple on which we want to append a.
-            /// @param a the new elements going to be added to the tuple
-            /// @return Tuple<Args..., T>
-            template<typename... Args, typename T, size_t... I>
-            Tuple<Args..., T> append_base(Tuple<Args...> t, T a, IndexList<I...>)
-            {
-                return pmacc::memory::tuple::make_tuple(get<I>(t)..., a);
+                return make_tuple(get<Is>(std::forward<Tuple>(t))..., std::forward<T>(a));
             }
 
-            /// append
-            /// @brief the deduction function for @ref append_base that automatically
-            /// generate the @ref IndexRange
-            ///@tparam Args... the type of the elements inside the tuple t
-            /// @tparam T the type of the new element going to be added at the end of tuple
-            /// @param t the tuple on which we want to append a.
-            /// @param a the new elements going to be added to the tuple
-            /// @return Tuple<Args..., T>
+            /// @brief A function to append a new element to the end of a tuple.
+            /// @tparam Args... The types of the elements inside the tuple.
+            /// @tparam T The type of the new element to append.
+            /// @param t The tuple to which the new element will be added.
+            /// @param a The new element to add.
+            /// @return A new tuple containing all elements from the original tuple followed by the new element.
             template<typename... Args, typename T>
-            Tuple<Args..., T> append(Tuple<Args...> t, T a)
+            constexpr auto append(Tuple<Args...>& t, T&& a)
             {
-                return pmacc::memory::tuple::append_base(t, a, IndexRange<0, sizeof...(Args)>());
+                return append_base(t, std::forward<T>(a), std::make_index_sequence<sizeof...(Args)>{});
             }
 
-            /// append_base
-            /// @brief This is a specialisation of @ref append_base when we want to
-            /// concatenate
-            /// tuple t2 at the end of the tuple t1. Here we unpack both tuples, generate
-            /// the IndexRange for each of them and create an output tuple T that contains
-            /// both elements of t1 and t2.
-            ///@tparam Args1... the type of the elements inside the tuple t1
-            ///@tparam Args2... the type of the elements inside the tuple t2
-            /// @tparam I1... is the list of index from [0 to sizeof...(t1))
-            /// @tparam I2... is the list of index from [0 to sizeof...(t2))
-            /// @param t1 is the tuple on which we want to append t2.
-            /// @param t2 is the tuple that is going to be added on t1.
-            /// @return Tuple<Args1..., Args2...>
-            template<typename... Args1, typename... Args2, size_t... I1, size_t... I2>
-            Tuple<Args1..., Args2...> append_base(
-                Tuple<Args1...> t1,
-                Tuple<Args2...> t2,
-                IndexList<I1...>,
-                IndexList<I2...>)
+            template<typename... Args1, typename... Args2, std::size_t... Is1, std::size_t... Is2>
+            constexpr auto append_base(
+                Tuple<Args1...>& t1,
+                Tuple<Args2...>& t2,
+                std::index_sequence<Is1...>,
+                std::index_sequence<Is2...>)
             {
-                return pmacc::memory::tuple::make_tuple(get<I1>(t1)..., get<I2>(t2)...);
+                return make_tuple(get<Is1>(t1)..., get<Is2>(t2)...);
             }
 
-            /// append
-            /// @brief deduction function for @ref append_base when we are appending tuple
-            /// t1 by tuple t2. In this case the @ref IndexRange for both tuple are
-            /// automatically generated.
-            ///@tparam Args1... the type of the elements inside the tuple t1
-            ///@tparam Args2... the type of the elements inside the tuple t2
-            /// @param t1 is the tuple on which we want to append t2.
-            /// @param t2 is the tuple that is going to be added on t1.
-            /// @return Tuple<Args1..., Args2...>
+            /// @brief Concatenates two tuples into one tuple.
+            /// @tparam Args1... The types of the elements inside the first tuple.
+            /// @tparam Args2... The types of the elements inside the second tuple.
+            /// @param t1 The first tuple to append.
+            /// @param t2 The second tuple to append.
+            /// @return A new tuple that contains all elements from both input tuples.
             template<typename... Args1, typename... Args2>
-            Tuple<Args1..., Args2...> append(Tuple<Args1...> t1, Tuple<Args2...> t2)
+            constexpr auto append(Tuple<Args1...>& t1, Tuple<Args2...>& t2)
             {
-                return pmacc::memory::tuple::append_base(
+                return append_base(
                     t1,
                     t2,
-                    IndexRange<0, sizeof...(Args1)>(),
-                    IndexRange<0, sizeof...(Args2)>());
+                    std::make_index_sequence<sizeof...(Args1)>{},
+                    std::make_index_sequence<sizeof...(Args2)>{});
             }
 
         } // namespace tuple

--- a/include/pmacc/memory/STLTuple.hpp
+++ b/include/pmacc/memory/STLTuple.hpp
@@ -27,132 +27,147 @@
  *    Ralph Potter  Codeplay Software Ltd.
  *    Luke Iwanski  Codeplay Software Ltd.
  *
+ * This file has been modified by Tapish Narwal
  **************************************************************************/
 
 #pragma once
-
-// clang-format off
 
 #include <alpaka/core/BoostPredef.hpp>
 
 // suppress warnings as this is third-party code
 #if BOOST_COMP_CLANG
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wdocumentation"
-#   pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdocumentation"
+#    pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #endif
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #    pragma warning(push)
 #    pragma warning(disable : 4003) // not enough arguments for function-like macro invocation
 #endif
 
-namespace pmacc {
-namespace memory {
-namespace tuple {
-/// @struct StaticIf
-/// @brief The StaticIf struct is used to statically choose the type based on
-/// the condition.
-template <bool, typename T = void>
-struct StaticIf;
-/// @brief specialisation of the @ref StaticIf when the condition is true
-template <typename T>
-struct StaticIf<true, T> {
-  typedef T type;
-};
+namespace pmacc
+{
+    namespace memory
+    {
+        namespace tuple
+        {
+            /// @struct StaticIf
+            /// @brief The StaticIf struct is used to statically choose the type based on
+            /// the condition.
+            template<bool, typename T = void>
+            struct StaticIf;
+            /// @brief specialisation of the @ref StaticIf when the condition is true
+            template<typename T>
+            struct StaticIf<true, T>
+            {
+                typedef T type;
+            };
 
-/// @struct Tuple
-/// @brief is a fixed-size collection of heterogeneous values
-/// @tparam Ts...  - the types of the elements that the tuple stores.
-/// Empty list is supported.
-template <class... Ts>
-struct Tuple {};
 
-/// @brief specialisation of the @ref Tuple class when the tuple has at least
-/// one element.
-/// @tparam T : the type of the first element in the tuple.
-/// @tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
-template <class T, class... Ts>
-struct Tuple<T, Ts...> {
-  Tuple(T t, Ts... ts) : head(t), tail(ts...) {}
-  T head;
-  Tuple<Ts...> tail;
-};
+            /// @struct Tuple
+            /// @brief is a fixed-size collection of heterogeneous values
+            /// @tparam Ts...  - the types of the elements that the tuple stores.
+            /// Empty list is supported.
+            template<class... Ts>
+            struct Tuple;
 
-template <typename, typename>
-struct concat_tuple {};
+            /// @brief specialisation of the @ref Tuple class when the tuple has at least
+            /// one element.
+            /// @tparam T : the type of the first element in the tuple.
+            /// @tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
+            template<class T, class... Ts>
+            struct Tuple<T, Ts...>
+            {
+                Tuple(T t, Ts... ts) : head(t), tail(ts...)
+                {
+                }
+                T head;
+                Tuple<Ts...> tail;
+            };
 
-template <typename... Ts, typename... Us>
-struct concat_tuple<Tuple<Ts...>, Tuple<Us...>> {
-  using type = Tuple<Ts..., Us...>;
-};
+            template<typename, typename>
+            struct concat_tuple
+            {
+            };
 
-template <typename T>
-struct remove_last_type;
+            template<typename... Ts, typename... Us>
+            struct concat_tuple<Tuple<Ts...>, Tuple<Us...>>
+            {
+                using type = Tuple<Ts..., Us...>;
+            };
 
-template <typename T>
-struct remove_last_type<Tuple<T>> {
-  using type = Tuple<>;
-};
+            template<typename T>
+            struct remove_last_type;
 
-template <typename T, typename... Args>
-struct remove_last_type<Tuple<T, Args...>> {
-  using type = typename concat_tuple<
-      Tuple<T>, typename remove_last_type<Tuple<Args...>>::type>::type;
-};
+            template<typename T>
+            struct remove_last_type<Tuple<T>>
+            {
+                using type = Tuple<>;
+            };
 
-template <typename T>
-struct remove_first_type {};
+            template<typename T, typename... Args>
+            struct remove_last_type<Tuple<T, Args...>>
+            {
+                using type = typename concat_tuple<Tuple<T>, typename remove_last_type<Tuple<Args...>>::type>::type;
+            };
 
-template <typename T, typename... Ts>
-struct remove_first_type<Tuple<T, Ts...>> {
-  typedef Tuple<Ts...> type;
-};
+            template<typename T>
+            struct remove_first_type
+            {
+            };
 
-/// @struct ElemTypeHolder
-/// @brief ElemTypeHolder class is used to specify the types of the
-/// elements inside the tuple
-/// @tparam size_t the number of elements inside the tuple
-/// @tparam class the tuple class
-template <size_t, class>
-struct ElemTypeHolder;
+            template<typename T, typename... Ts>
+            struct remove_first_type<Tuple<T, Ts...>>
+            {
+                typedef Tuple<Ts...> type;
+            };
 
-/// @brief specialisation of the @ref ElemTypeHolder class when the number of
-/// elements inside the tuple is 1
-template <class T, class... Ts>
-struct ElemTypeHolder<0, Tuple<T, Ts...>> {
-  typedef T type;
-};
+            /// @struct ElemTypeHolder
+            /// @brief ElemTypeHolder class is used to specify the types of the
+            /// elements inside the tuple
+            /// @tparam size_t the number of elements inside the tuple
+            /// @tparam class the tuple class
+            template<size_t, class>
+            struct ElemTypeHolder;
 
-/// @brief specialisation of the @ref ElemTypeHolder class when the number of
-/// elements inside the tuple is bigger than 1. It recursively calls itself to
-/// detect the type of each element in the tuple
-/// @tparam T : the type of the first element in the tuple.
-/// @tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
-/// @tparam K is the Kth element in the tuple
-template <size_t k, class T, class... Ts>
-struct ElemTypeHolder<k, Tuple<T, Ts...>> {
-  typedef typename ElemTypeHolder<k - 1, Tuple<Ts...>>::type type;
-};
+            /// @brief specialisation of the @ref ElemTypeHolder class when the number of
+            /// elements inside the tuple is 1
+            template<class T, class... Ts>
+            struct ElemTypeHolder<0, Tuple<T, Ts...>>
+            {
+                typedef T type;
+            };
 
-/// get
-/// @brief Extracts the first element from the tuple.
-/// K=0 represents the first element of the tuple. The tuple cannot be empty.
-/// @tparam Ts... are the type of the elements in the tuple.
-/// @param t is the tuple whose contents to extract
-/// @return  typename ElemTypeHolder<0, Tuple<Ts...> >::type &>::type
+            /// @brief specialisation of the @ref ElemTypeHolder class when the number of
+            /// elements inside the tuple is bigger than 1. It recursively calls itself to
+            /// detect the type of each element in the tuple
+            /// @tparam T : the type of the first element in the tuple.
+            /// @tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
+            /// @tparam K is the Kth element in the tuple
+            template<size_t k, class T, class... Ts>
+            struct ElemTypeHolder<k, Tuple<T, Ts...>>
+            {
+                typedef typename ElemTypeHolder<k - 1, Tuple<Ts...>>::type type;
+            };
 
-#define TERMINATE_CONDS_TUPLE_GET(CVQual)                                      \
-  template <size_t k, class... Ts>                                             \
-  typename StaticIf<k == 0, CVQual                                             \
-                    typename ElemTypeHolder<0, Tuple<Ts...>>::type&>::type     \
-  constexpr get(CVQual Tuple<Ts...>& t) {                                                \
-    static_assert(sizeof...(Ts) != 0,                                          \
-                  "The requseted value is bigger than the size of the tuple"); \
-    return t.head;                                                             \
-  }
+            /// get
+            /// @brief Extracts the first element from the tuple.
+            /// K=0 represents the first element of the tuple. The tuple cannot be empty.
+            /// @tparam Ts... are the type of the elements in the tuple.
+            /// @param t is the tuple whose contents to extract
+            /// @return  typename ElemTypeHolder<0, Tuple<Ts...> >::type &>::type
 
-TERMINATE_CONDS_TUPLE_GET(const)
-TERMINATE_CONDS_TUPLE_GET()
+#define TERMINATE_CONDS_TUPLE_GET(CVQual)                                                                             \
+    template<size_t k, class... Ts>                                                                                   \
+    typename StaticIf<k == 0, CVQual typename ElemTypeHolder<0, Tuple<Ts...>>::type&>::type constexpr get(            \
+        CVQual Tuple<Ts...>& t)                                                                                       \
+    {                                                                                                                 \
+        static_assert(sizeof...(Ts) != 0, "The requseted value is bigger than the size of the tuple");                \
+        return t.head;                                                                                                \
+    }
+
+            TERMINATE_CONDS_TUPLE_GET(const)
+            TERMINATE_CONDS_TUPLE_GET()
 #undef TERMINATE_CONDS_TUPLE_GET
 /// get
 /// @brief Extracts the Kth element from the tuple.
@@ -161,146 +176,178 @@ TERMINATE_CONDS_TUPLE_GET()
 /// @tparam Ts... are the type of the elements  in the tuple.
 /// @param t is the tuple whose contents to extract
 /// @return  typename ElemTypeHolder<K, Tuple<Ts...> >::type &>::type
-#define RECURSIVE_TUPLE_GET(CVQual)                                           \
-  template <size_t k, class T, class... Ts>                                   \
-  typename StaticIf<k != 0, CVQual                                            \
-                    typename ElemTypeHolder<k, Tuple<T, Ts...>>::type&>::type \
-  constexpr get(CVQual Tuple<T, Ts...>& t) {                                            \
-    return pmacc::memory::tuple::get<k - 1>(t.tail);                                \
-  }
-RECURSIVE_TUPLE_GET(const)
-RECURSIVE_TUPLE_GET()
+#define RECURSIVE_TUPLE_GET(CVQual)                                                                                   \
+    template<size_t k, class T, class... Ts>                                                                          \
+    typename StaticIf<k != 0, CVQual typename ElemTypeHolder<k, Tuple<T, Ts...>>::type&>::type constexpr get(         \
+        CVQual Tuple<T, Ts...>& t)                                                                                    \
+    {                                                                                                                 \
+        return pmacc::memory::tuple::get<k - 1>(t.tail);                                                              \
+    }
+            RECURSIVE_TUPLE_GET(const)
+            RECURSIVE_TUPLE_GET()
 #undef RECURSIVE_TUPLE_GET
 
-/// make_tuple
-/// @brief Creates a tuple object, deducing the target type from the types of
-/// arguments.
-/// @tparam Args the type of the arguments to construct the tuple from
-/// @param args zero or more arguments to construct the tuple from
-/// @return Tuple<Args...>
-template <typename... Args>
-Tuple<Args...> make_tuple(Args... args) {
-  return Tuple<Args...>(args...);
-}
+            /// make_tuple
+            /// @brief Creates a tuple object, deducing the target type from the types of
+            /// arguments.
+            /// @tparam Args the type of the arguments to construct the tuple from
+            /// @param args zero or more arguments to construct the tuple from
+            /// @return Tuple<Args...>
+            template<typename... Args>
+            Tuple<Args...> make_tuple(Args... args)
+            {
+                return Tuple<Args...>(args...);
+            }
 
-/// size
-/// @brief Provides access to the number of elements in a tuple as a
-/// compile-time constant expression.
-/// @tparam Args the type of the arguments to construct the tuple from
-/// @return size_t
-template <typename... Args>
-static constexpr size_t size(Tuple<Args...>&) {
-  return sizeof...(Args);
-}
+            /// size
+            /// @brief Provides access to the number of elements in a tuple as a
+            /// compile-time constant expression.
+            /// @tparam Args the type of the arguments to construct the tuple from
+            /// @return size_t
+            template<typename... Args>
+            static constexpr size_t size(Tuple<Args...>&)
+            {
+                return sizeof...(Args);
+            }
 
-/// @struct IndexList
-/// @brief Creates a list of index from the elements in the tuple
-/// @tparam Is... a list of index from [0 to sizeof...(tuple elements))
-template <size_t... Is>
-struct IndexList {};
+            // Handles cv-qualifiers and refs
+            template<typename T>
+            struct tuple_size : tuple_size<std::remove_cvref_t<T>>
+            {
+            };
 
-/// @struct RangeBuilder
-/// @brief Collects internal details for generating index ranges [MIN, MAX)
-/// Declare primary template for index range builder
-/// @tparam MIN is the starting index in the tuple
-/// @tparam N represents sizeof..(elemens)- sizeof...(Is)
-/// @tparam Is... are the list of generated index so far
-template <size_t MIN, size_t N, size_t... Is>
-struct RangeBuilder;
+            template<typename... Args>
+            struct tuple_size<Tuple<Args...>> : std::integral_constant<std::size_t, sizeof...(Args)>
+            {
+            };
 
-/// @brief base Step: Specialisation of the @ref RangeBuilder when the
-/// MIN==MAX. In this case the Is... is [0 to sizeof...(tuple elements))
-/// @tparam MIN is the starting index of the tuple
-/// @tparam Is is [0 to sizeof...(tuple elements))
-template <size_t MIN, size_t... Is>
-struct RangeBuilder<MIN, MIN, Is...> {
-  typedef IndexList<Is...> type;
-};
+            template<typename T>
+            constexpr std::size_t tuple_size_v = tuple_size<T>::value;
 
-/// Induction step: Specialisation of the RangeBuilder class when N!=MIN
-/// in this case we are recursively subtracting N by one and adding one
-/// index to Is... list until MIN==N
-/// @tparam MIN is the starting index in the tuple
-/// @tparam N represents sizeof..(elemens)- sizeof...(Is)
-/// @tparam Is... are the list of generated index so far
-template <size_t MIN, size_t N, size_t... Is>
-struct RangeBuilder : public RangeBuilder<MIN, N - 1, N - 1, Is...> {};
+            /// @struct IndexList
+            /// @brief Creates a list of index from the elements in the tuple
+            /// @tparam Is... a list of index from [0 to sizeof...(tuple elements))
+            template<size_t... Is>
+            struct IndexList
+            {
+            };
 
-/// @brief IndexRange that returns a [MIN, MAX) index range
-/// @tparam MIN is the starting index in the tuple
-/// @tparam MAX is the size of the tuple
-template <size_t MIN, size_t MAX>
-struct IndexRange : RangeBuilder<MIN, MAX>::type {};
+            /// @struct RangeBuilder
+            /// @brief Collects internal details for generating index ranges [MIN, MAX)
+            /// Declare primary template for index range builder
+            /// @tparam MIN is the starting index in the tuple
+            /// @tparam N represents sizeof..(elemens)- sizeof...(Is)
+            /// @tparam Is... are the list of generated index so far
+            template<size_t MIN, size_t N, size_t... Is>
+            struct RangeBuilder;
 
-/// append_base
-/// @brief unpacking the elements of the input tuple t and creating a new tuple
-/// by adding element a at the end of it.
-///@tparam Args... the type of the elements inside the tuple t
-/// @tparam T the type of the new element going to be added at the end of tuple
-/// @tparam I... is the list of index from [0 to sizeof...(t))
-/// @param t the tuple on which we want to append a.
-/// @param a the new elements going to be added to the tuple
-/// @return Tuple<Args..., T>
-template <typename... Args, typename T, size_t... I>
-Tuple<Args..., T> append_base(Tuple<Args...> t, T a, IndexList<I...>) {
-  return pmacc::memory::tuple::make_tuple(get<I>(t)..., a);
-}
+            /// @brief base Step: Specialisation of the @ref RangeBuilder when the
+            /// MIN==MAX. In this case the Is... is [0 to sizeof...(tuple elements))
+            /// @tparam MIN is the starting index of the tuple
+            /// @tparam Is is [0 to sizeof...(tuple elements))
+            template<size_t MIN, size_t... Is>
+            struct RangeBuilder<MIN, MIN, Is...>
+            {
+                typedef IndexList<Is...> type;
+            };
 
-/// append
-/// @brief the deduction function for @ref append_base that automatically
-/// generate the @ref IndexRange
-///@tparam Args... the type of the elements inside the tuple t
-/// @tparam T the type of the new element going to be added at the end of tuple
-/// @param t the tuple on which we want to append a.
-/// @param a the new elements going to be added to the tuple
-/// @return Tuple<Args..., T>
-template <typename... Args, typename T>
-Tuple<Args..., T> append(Tuple<Args...> t, T a) {
-  return pmacc::memory::tuple::append_base(t, a, IndexRange<0, sizeof...(Args)>());
-}
+            /// Induction step: Specialisation of the RangeBuilder class when N!=MIN
+            /// in this case we are recursively subtracting N by one and adding one
+            /// index to Is... list until MIN==N
+            /// @tparam MIN is the starting index in the tuple
+            /// @tparam N represents sizeof..(elemens)- sizeof...(Is)
+            /// @tparam Is... are the list of generated index so far
+            template<size_t MIN, size_t N, size_t... Is>
+            struct RangeBuilder : public RangeBuilder<MIN, N - 1, N - 1, Is...>
+            {
+            };
 
-/// append_base
-/// @brief This is a specialisation of @ref append_base when we want to
-/// concatenate
-/// tuple t2 at the end of the tuple t1. Here we unpack both tuples, generate
-/// the IndexRange for each of them and create an output tuple T that contains
-/// both elements of t1 and t2.
-///@tparam Args1... the type of the elements inside the tuple t1
-///@tparam Args2... the type of the elements inside the tuple t2
-/// @tparam I1... is the list of index from [0 to sizeof...(t1))
-/// @tparam I2... is the list of index from [0 to sizeof...(t2))
-/// @param t1 is the tuple on which we want to append t2.
-/// @param t2 is the tuple that is going to be added on t1.
-/// @return Tuple<Args1..., Args2...>
-template <typename... Args1, typename... Args2, size_t... I1, size_t... I2>
-Tuple<Args1..., Args2...> append_base(Tuple<Args1...> t1, Tuple<Args2...> t2,
-                                      IndexList<I1...>, IndexList<I2...>) {
-  return pmacc::memory::tuple::make_tuple(get<I1>(t1)..., get<I2>(t2)...);
-}
+            /// @brief IndexRange that returns a [MIN, MAX) index range
+            /// @tparam MIN is the starting index in the tuple
+            /// @tparam MAX is the size of the tuple
+            template<size_t MIN, size_t MAX>
+            struct IndexRange : RangeBuilder<MIN, MAX>::type
+            {
+            };
 
-/// append
-/// @brief deduction function for @ref append_base when we are appending tuple
-/// t1 by tuple t2. In this case the @ref IndexRange for both tuple are
-/// automatically generated.
-///@tparam Args1... the type of the elements inside the tuple t1
-///@tparam Args2... the type of the elements inside the tuple t2
-/// @param t1 is the tuple on which we want to append t2.
-/// @param t2 is the tuple that is going to be added on t1.
-/// @return Tuple<Args1..., Args2...>
-template <typename... Args1, typename... Args2>
-Tuple<Args1..., Args2...> append(Tuple<Args1...> t1, Tuple<Args2...> t2) {
-  return pmacc::memory::tuple::append_base(t1, t2, IndexRange<0, sizeof...(Args1)>(),
-                                     IndexRange<0, sizeof...(Args2)>());
-}
+            /// append_base
+            /// @brief unpacking the elements of the input tuple t and creating a new tuple
+            /// by adding element a at the end of it.
+            ///@tparam Args... the type of the elements inside the tuple t
+            /// @tparam T the type of the new element going to be added at the end of tuple
+            /// @tparam I... is the list of index from [0 to sizeof...(t))
+            /// @param t the tuple on which we want to append a.
+            /// @param a the new elements going to be added to the tuple
+            /// @return Tuple<Args..., T>
+            template<typename... Args, typename T, size_t... I>
+            Tuple<Args..., T> append_base(Tuple<Args...> t, T a, IndexList<I...>)
+            {
+                return pmacc::memory::tuple::make_tuple(get<I>(t)..., a);
+            }
 
-}  // namespace tuple
-}  // namespace memory
-}  // namespace pmacc
+            /// append
+            /// @brief the deduction function for @ref append_base that automatically
+            /// generate the @ref IndexRange
+            ///@tparam Args... the type of the elements inside the tuple t
+            /// @tparam T the type of the new element going to be added at the end of tuple
+            /// @param t the tuple on which we want to append a.
+            /// @param a the new elements going to be added to the tuple
+            /// @return Tuple<Args..., T>
+            template<typename... Args, typename T>
+            Tuple<Args..., T> append(Tuple<Args...> t, T a)
+            {
+                return pmacc::memory::tuple::append_base(t, a, IndexRange<0, sizeof...(Args)>());
+            }
+
+            /// append_base
+            /// @brief This is a specialisation of @ref append_base when we want to
+            /// concatenate
+            /// tuple t2 at the end of the tuple t1. Here we unpack both tuples, generate
+            /// the IndexRange for each of them and create an output tuple T that contains
+            /// both elements of t1 and t2.
+            ///@tparam Args1... the type of the elements inside the tuple t1
+            ///@tparam Args2... the type of the elements inside the tuple t2
+            /// @tparam I1... is the list of index from [0 to sizeof...(t1))
+            /// @tparam I2... is the list of index from [0 to sizeof...(t2))
+            /// @param t1 is the tuple on which we want to append t2.
+            /// @param t2 is the tuple that is going to be added on t1.
+            /// @return Tuple<Args1..., Args2...>
+            template<typename... Args1, typename... Args2, size_t... I1, size_t... I2>
+            Tuple<Args1..., Args2...> append_base(
+                Tuple<Args1...> t1,
+                Tuple<Args2...> t2,
+                IndexList<I1...>,
+                IndexList<I2...>)
+            {
+                return pmacc::memory::tuple::make_tuple(get<I1>(t1)..., get<I2>(t2)...);
+            }
+
+            /// append
+            /// @brief deduction function for @ref append_base when we are appending tuple
+            /// t1 by tuple t2. In this case the @ref IndexRange for both tuple are
+            /// automatically generated.
+            ///@tparam Args1... the type of the elements inside the tuple t1
+            ///@tparam Args2... the type of the elements inside the tuple t2
+            /// @param t1 is the tuple on which we want to append t2.
+            /// @param t2 is the tuple that is going to be added on t1.
+            /// @return Tuple<Args1..., Args2...>
+            template<typename... Args1, typename... Args2>
+            Tuple<Args1..., Args2...> append(Tuple<Args1...> t1, Tuple<Args2...> t2)
+            {
+                return pmacc::memory::tuple::append_base(
+                    t1,
+                    t2,
+                    IndexRange<0, sizeof...(Args1)>(),
+                    IndexRange<0, sizeof...(Args2)>());
+            }
+
+        } // namespace tuple
+    } // namespace memory
+} // namespace pmacc
 
 #if BOOST_COMP_CLANG
-#   pragma clang diagnostic pop
+#    pragma clang diagnostic pop
 #endif
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #    pragma warning(pop)
 #endif
-// clang-format on


### PR DESCRIPTION
Implementation of a trivially copyable tuple
Add tuple_size_v
Passes paramters by forwarding
Added forward as tuple and tie
uses stl index sequence instead of self written metafunctions