### PR TITLE
fix CUDA lambda error

### DIFF
--- a/include/pmacc/particles/IdProvider.hpp
+++ b/include/pmacc/particles/IdProvider.hpp
@@ -47,6 +47,18 @@ namespace pmacc
     };
 
 
+    struct StoreId
+    {
+        /** get unique id
+         *
+         * @nextId storage for a single valid id
+         */
+        DINLINE void operator()(auto const& worker, auto idGenerator, uint64_t* nextId) const
+        {
+            *nextId = idGenerator.fetchInc(worker);
+        }
+    };
+
     class IdProvider : public ISimulationData
     {
     public:
@@ -88,9 +100,8 @@ namespace pmacc
         {
             HostDeviceBuffer<uint64_t, 1> newIdBuf(DataSpace<1>(1));
 
-            auto kernel = [] ALPAKA_FN_ACC(auto const& worker, auto idGenerator, uint64_t* nextId) -> void
-            { *nextId = idGenerator.fetchInc(worker); };
-            PMACC_LOCKSTEP_KERNEL(kernel).config<1>(1)(getDeviceGenerator(), newIdBuf.getDeviceBuffer().data());
+            PMACC_LOCKSTEP_KERNEL(StoreId{}).template config<1>(
+                1)(getDeviceGenerator(), newIdBuf.getDeviceBuffer().data());
             newIdBuf.deviceToHost();
             return *newIdBuf.getHostBuffer().data();
         }


### PR DESCRIPTION
fix compiler error seen with CUDA 12.1.
Remove usage of gerenic lambda by functor like kernel.

```
pmacc/particles/IdProvider.hpp(91): error: __host__ __device__ extended lambdas cannot be generic lambdas
              auto kernel = []
```

@BeyondEspresso  This should be the fix for your compile issue