### PR TITLE
Fix static_cast-bug in TWTSTight laser

### DIFF
--- a/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
+++ b/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
@@ -68,6 +68,7 @@
 namespace picongpu::templates::twtstight
 {
     using float_T = float_X;
+    using float3_T = ::pmacc::math::Vector<float_T, 3u>;
     using complex_T = alpaka::Complex<float_T>;
     using complex_64 = alpaka::Complex<float_64>;
     /** To avoid underflows in computation, numsigmas controls where a zero cutoff is made.

--- a/include/picongpu/fields/background/templates/twtstight/TWTSTight.tpp
+++ b/include/picongpu/fields/background/templates/twtstight/TWTSTight.tpp
@@ -85,10 +85,10 @@ namespace picongpu::templates::twtstight
         if constexpr(simDim == DIM3)
         {
             /* E- or B-field normalized to the peak amplitude. */
-            return static_cast<float3_X>(
+            return precisionCast<float_X>(float3_T(
                 calcTWTSFieldX(fieldPositions_SI[0], time),
                 calcTWTSFieldY(fieldPositions_SI[1], time),
-                calcTWTSFieldZ(fieldPositions_SI[2], time));
+                calcTWTSFieldZ(fieldPositions_SI[2], time)));
         }
         if constexpr(simDim == DIM2)
         {
@@ -103,14 +103,12 @@ namespace picongpu::templates::twtstight
                 }
             }
             /* E- or B-field normalized to the peak amplitude. */
-            return static_cast<float3_X>(
-                calcTWTSFieldX(pos[0], time),
-                calcTWTSFieldY(pos[1], time),
-                calcTWTSFieldZ(pos[2], time));
+            return precisionCast<float_X>(
+                float3_T(calcTWTSFieldX(pos[0], time), calcTWTSFieldY(pos[1], time), calcTWTSFieldZ(pos[2], time)));
         }
         // We should never be here.
         else
-            return static_cast<float3_X>(NAN);
+            return float3_X(NAN);
     }
 
     template<typename T_Field>


### PR DESCRIPTION
Bad static_casts on float3_X led to wrong results. Now, precisionCasts are being used.