### PR TITLE
rename transition radiation plugin variables

### DIFF
--- a/include/picongpu/param/transitionRadiation.param
+++ b/include/picongpu/param/transitionRadiation.param
@@ -246,7 +246,7 @@ namespace picongpu
                 /** get index for computing angle theta: */
                 const int index_theta = observation_id_extern / parameters::N_phi;
 
-                /** step width angle theta */
+                /** step width angle theta, set it to 0 if nTheta = 1 */
                 const picongpu::float_64 delta__theta = (parameters::N_theta > 1)
                     ? (parameters::theta_max - parameters::theta_min) / (parameters::N_theta - 1.0)
                     : 0.0;
@@ -257,7 +257,7 @@ namespace picongpu
                 /** get index for computing angle phi: */
                 const int index_phi = observation_id_extern % parameters::N_phi;
 
-                /** step width angle phi */
+                /** step width angle phi, set it to 0 if nPhi = 1 */
                 const picongpu::float_64 delta__phi = (parameters::N_phi > 1)
                     ? (parameters::phi_max - parameters::phi_min) / (parameters::N_phi - 1.0)
                     : 0.0;

--- a/include/picongpu/param/transitionRadiation.param
+++ b/include/picongpu/param/transitionRadiation.param
@@ -76,55 +76,55 @@ namespace picongpu
 
         namespace transitionRadiation
         {
-            namespace linearFrequencies
+            namespace linear_frequencies
             {
                 namespace SI
                 {
                     //! mimimum frequency of the linear frequency scale in units of [1/s]
-                    constexpr float_64 omegaMin = 0.0;
+                    constexpr float_64 omega_min = 0.0;
                     //! maximum frequency of the linear frequency scale in units of [1/s]
-                    constexpr float_64 omegaMax = 1.06e16;
+                    constexpr float_64 omega_max = 1.06e16;
                 } // namespace SI
 
                 //! number of frequency values to compute in the linear frequency [unitless]
-                constexpr unsigned int nOmega = 512;
+                constexpr unsigned int N_omega = 512;
 
-            } // namespace linearFrequencies
+            } // namespace linear_frequencies
 
-            namespace logFrequencies
+            namespace log_frequencies
             {
                 namespace SI
                 {
                     //! mimimum frequency of the logarithmic frequency scale in units of [1/s]
-                    constexpr float_64 omegaMin = 1.0e13;
+                    constexpr float_64 omega_min = 1.0e13;
                     //! maximum frequency of the logarithmic frequency scale in units of [1/s]
-                    constexpr float_64 omegaMax = 1.0e17;
+                    constexpr float_64 omega_max = 1.0e17;
                 } // namespace SI
 
                 //! number of frequency values to compute in the logarithmic frequency [unitless]
-                constexpr unsigned int nOmega = 256;
+                constexpr unsigned int N_omega = 256;
 
-            } // namespace logFrequencies
+            } // namespace log_frequencies
 
 
-            namespace listFrequencies
+            namespace frequencies_from_list
             {
                 //! path to text file with frequencies
                 constexpr char listLocation[] = "/path/to/frequency_list";
                 //! number of frequency values to compute if frequencies are given in a file [unitless]
-                constexpr unsigned int nOmega = 512;
+                constexpr unsigned int N_omega = 512;
 
-            } // namespace listFrequencies
+            } // namespace frequencies_from_list
 
 
             /** selected mode of frequency scaling:
              *
              * options:
-             * - linearFrequencies
-             * - logFrequencies
-             * - listFrequencies
+             * - linear_frequencies
+             * - log_frequencies
+             * - frequencies_from_list
              */
-            namespace frequencies = logFrequencies;
+            namespace frequencies = log_frequencies;
 
             ///////////////////////////////////////////////////
 
@@ -143,7 +143,7 @@ namespace picongpu
              *  - ::picongpu::plugins::radiation::radFormFactor_incoherent ... only incoherent radiation
              *  - ::picongpu::plugins::radiation::radFormFactor_coherent ... only coherent radiation
              */
-            namespace macroParticleFormFactor = ::picongpu::plugins::radiation::radFormFactor_Gauss_spherical;
+            namespace radFormFactor = ::picongpu::plugins::radiation::radFormFactor_Gauss_spherical;
 
             ///////////////////////////////////////////////////////////
 
@@ -151,20 +151,20 @@ namespace picongpu
             {
                 /** Number of observation directions
                  *
-                 * If nPhi or nTheta is equal to 1, the transition radiation will be calculated
-                 * for phiMin or thetaMin respectively.
+                 * If N_phi or N_theta is equal to 1, the transition radiation will be calculated
+                 * for phi_min or theta_min respectively.
                  */
-                constexpr unsigned int nPhi = 128;
-                constexpr unsigned int nTheta = 128;
-                constexpr unsigned int nObserver = nPhi * nTheta;
+                constexpr unsigned int N_phi = 128;
+                constexpr unsigned int N_theta = 128;
+                constexpr unsigned int N_observer = N_phi * N_theta;
 
                 // theta goes from 0 to pi
-                constexpr float_64 thetaMin = 0.0;
-                constexpr float_64 thetaMax = picongpu::PI;
+                constexpr float_64 theta_min = 0.0;
+                constexpr float_64 theta_max = picongpu::PI;
 
                 // phi goes from 0 to 2*pi
-                constexpr float_64 phiMin = 0.0;
-                constexpr float_64 phiMax = 2 * picongpu::PI;
+                constexpr float_64 phi_min = 0.0;
+                constexpr float_64 phi_max = 2 * picongpu::PI;
             } /* end namespace parameters */
 
 
@@ -206,11 +206,11 @@ namespace picongpu
              * observation directions for 2D virtual detector field
              * with its center pointing toward the +y direction (for theta=0, phi=0)
              * with observation angles ranging from
-             * theta = [angle_theta_start : angle_theta_end]
-             * phi   = [angle_phi_start   : angle_phi_end  ]
+             * theta = [theta_min : theta_max]
+             * phi   = [phi_min   : phi_max  ]
              * Every observation_id_extern index moves the phi angle from its
              * start value toward its end value until the observation_id_extern
-             * reaches N_split. After that the theta angle moves further from its
+             * reaches N_phi. After that the theta angle moves further from its
              * start value towards its end value while phi is reset to its start
              * value.
              *
@@ -244,26 +244,26 @@ namespace picongpu
                  * index_b = index % split_distance
                  */
                 /** get index for computing angle theta: */
-                const int indexTheta = observation_id_extern / parameters::nPhi;
+                const int index_theta = observation_id_extern / parameters::N_phi;
 
                 /** step width angle theta */
-                const picongpu::float_64 deltaTheta = (parameters::nTheta > 1)
-                    ? (parameters::thetaMax - parameters::thetaMin) / (parameters::nTheta - 1.0)
+                const picongpu::float_64 delta__theta = (parameters::N_theta > 1)
+                    ? (parameters::theta_max - parameters::theta_min) / (parameters::N_theta - 1.0)
                     : 0.0;
 
                 /** compute observation angles theta */
-                const picongpu::float_64 theta = indexTheta * deltaTheta + parameters::thetaMin;
+                const picongpu::float_64 theta = index_theta * delta__theta + parameters::theta_min;
 
                 /** get index for computing angle phi: */
-                const int indexPhi = observation_id_extern % parameters::nPhi;
+                const int index_phi = observation_id_extern % parameters::N_phi;
 
                 /** step width angle phi */
-                const picongpu::float_64 deltaPhi = (parameters::nPhi > 1)
-                    ? (parameters::phiMax - parameters::phiMin) / (parameters::nPhi - 1.0)
+                const picongpu::float_64 delta__phi = (parameters::N_phi > 1)
+                    ? (parameters::phi_max - parameters::phi_min) / (parameters::N_phi - 1.0)
                     : 0.0;
 
                 /** compute observation angles phi */
-                const picongpu::float_64 phi = indexPhi * deltaPhi - parameters::phiMin;
+                const picongpu::float_64 phi = index_phi * delta__phi - parameters::phi_min;
 
                 /* helper functions for efficient trigonometric calculations */
                 picongpu::float_32 sinPhi;

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.kernel
@@ -289,7 +289,7 @@ namespace picongpu
                             worker.sync();
 
                             // run over all  valid omegas for this thread
-                            for(uint32_t o = worker.workerIdx(); o < transitionRadiation::frequencies::nOmega;
+                            for(uint32_t o = worker.workerIdx(); o < transitionRadiation::frequencies::N_omega;
                                 o += T_Worker::numWorkers())
                             {
                                 float_X itrSum = 0.0;
@@ -300,7 +300,7 @@ namespace picongpu
                                 // create a form factor object for physical correct coherence effects within
                                 // macro-particles
                                 float_X const omega = freqFkt(o);
-                                macroParticleFormFactor::RadFormFactor const macroParticleFormFactor{
+                                radFormFactor::RadFormFactor const macroParticleFormFactor{
                                     omega,
                                     precisionCast<float_64>(look)};
 
@@ -319,7 +319,7 @@ namespace picongpu
                                 }
 
                                 uint32_t const index
-                                    = static_cast<uint32_t>(theta_idx) * transitionRadiation::frequencies::nOmega + o;
+                                    = static_cast<uint32_t>(theta_idx) * transitionRadiation::frequencies::N_omega + o;
                                 incTransRad[index] += itrSum;
                                 numParticles[index] += totalParticles;
                                 cohTransRadPara[index] += ctrSumPara;

--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
@@ -328,7 +328,7 @@ namespace picongpu
                     numParticles
                         = std::make_unique<GridBuffer<float_X, DIM1>>(DataSpace<DIM1>(elementsTransitionRadiation()));
 
-                    freqInit.Init(listFrequencies::listLocation);
+                    freqInit.Init(frequencies_from_list::listLocation);
                     freqFkt = freqInit.getFunctor();
 
                     if(isMaster)
@@ -363,8 +363,8 @@ namespace picongpu
                  */
                 static unsigned int elementsTransitionRadiation()
                 {
-                    return transitionRadiation::frequencies::nOmega
-                        * transitionRadiation::parameters::nObserver; // storage for amplitude results on GPU
+                    return transitionRadiation::frequencies::N_omega
+                        * transitionRadiation::parameters::N_observer; // storage for amplitude results on GPU
                 }
 
                 /** Combine transition radiation data from each CPU and store result on master.
@@ -492,19 +492,19 @@ namespace picongpu
                     {
                         outFile << "# \t";
                         outFile << transitionRadiation::frequencies::getParameters();
-                        outFile << transitionRadiation::parameters::nPhi << "\t";
-                        outFile << transitionRadiation::parameters::phiMin << "\t";
-                        outFile << transitionRadiation::parameters::phiMax << "\t";
-                        outFile << transitionRadiation::parameters::nTheta << "\t";
-                        outFile << transitionRadiation::parameters::thetaMin << "\t";
-                        outFile << transitionRadiation::parameters::thetaMax << "\t";
+                        outFile << transitionRadiation::parameters::N_phi << "\t";
+                        outFile << transitionRadiation::parameters::phi_min << "\t";
+                        outFile << transitionRadiation::parameters::phi_max << "\t";
+                        outFile << transitionRadiation::parameters::N_theta << "\t";
+                        outFile << transitionRadiation::parameters::theta_min << "\t";
+                        outFile << transitionRadiation::parameters::theta_max << "\t";
                         outFile << std::endl;
 
                         for(unsigned int index_direction = 0;
-                            index_direction < transitionRadiation::parameters::nObserver;
+                            index_direction < transitionRadiation::parameters::N_observer;
                             ++index_direction) // over all directions
                         {
-                            for(unsigned index_omega = 0; index_omega < transitionRadiation::frequencies::nOmega;
+                            for(unsigned index_omega = 0; index_omega < transitionRadiation::frequencies::N_omega;
                                 ++index_omega) // over all frequencies
                             {
                                 // Take Amplitude for one direction and frequency,
@@ -514,7 +514,8 @@ namespace picongpu
                                     * sim.si.getElectronCharge()
                                     * (1.0 / (4 * PI * sim.si.getEps0() * PI * PI * sim.si.getSpeedOfLight()));
                                 outFile
-                                    << values[index_direction * transitionRadiation::frequencies::nOmega + index_omega]
+                                    << values
+                                            [index_direction * transitionRadiation::frequencies::N_omega + index_omega]
                                         * transRadUnit
                                     << "\t";
 
@@ -541,9 +542,9 @@ namespace picongpu
                     ::openPMD::Series series(filename.str(), ::openPMD::Access::CREATE);
 
                     ::openPMD::Extent extent
-                        = {static_cast<unsigned long int>(transitionRadiation::frequencies::nOmega),
-                           static_cast<unsigned long int>(parameters::nPhi),
-                           static_cast<unsigned long int>(parameters::nTheta)};
+                        = {static_cast<unsigned long int>(transitionRadiation::frequencies::N_omega),
+                           static_cast<unsigned long int>(parameters::N_phi),
+                           static_cast<unsigned long int>(parameters::N_theta)};
                     ::openPMD::Offset offset = {0, 0, 0};
                     ::openPMD::Datatype datatype = ::openPMD::determineDatatype<float_X>();
                     ::openPMD::Dataset dataset{datatype, extent};
@@ -573,25 +574,26 @@ namespace picongpu
                     auto span = transitionRadiation.storeChunk<float_X>(offset, extent);
                     auto spanBuffer = span.currentBuffer();
 
-                    for(unsigned int index_direction = 0; index_direction < transitionRadiation::parameters::nObserver;
+                    for(unsigned int index_direction = 0;
+                        index_direction < transitionRadiation::parameters::N_observer;
                         ++index_direction)
                     {
                         // theta
-                        const int i = index_direction / parameters::nPhi;
+                        const int i = index_direction / parameters::N_phi;
                         // phi
-                        const int j = index_direction % parameters::nPhi;
+                        const int j = index_direction % parameters::N_phi;
 
-                        for(unsigned int k = 0; k < transitionRadiation::frequencies::nOmega; ++k)
+                        for(unsigned int k = 0; k < transitionRadiation::frequencies::N_omega; ++k)
                         {
-                            const int index = (k * parameters::nPhi + j) * parameters::nTheta + i;
+                            const int index = (k * parameters::N_phi + j) * parameters::N_theta + i;
                             spanBuffer[index] = static_cast<float_X>(
-                                theTransRad[index_direction * transitionRadiation::frequencies::nOmega + k]);
+                                theTransRad[index_direction * transitionRadiation::frequencies::N_omega + k]);
                         }
                     }
 
                     // Omega axis
                     ::openPMD::Extent extentOmega
-                        = {static_cast<unsigned long int>(transitionRadiation::frequencies::nOmega), 1, 1};
+                        = {static_cast<unsigned long int>(transitionRadiation::frequencies::N_omega), 1, 1};
                     ::openPMD::Offset offsetOmega = {0, 0, 0};
                     ::openPMD::Datatype datatypeOmega = ::openPMD::determineDatatype<float_X>();
                     ::openPMD::Dataset datasetOmega{datatypeOmega, extentOmega};
@@ -615,14 +617,14 @@ namespace picongpu
                     auto spanOmega = omega.storeChunk<float_X>(offsetOmega, extentOmega);
                     auto spanBufferOmega = spanOmega.currentBuffer();
 
-                    for(unsigned int i = 0; i < transitionRadiation::frequencies::nOmega; ++i)
+                    for(unsigned int i = 0; i < transitionRadiation::frequencies::N_omega; ++i)
                     {
                         spanBufferOmega[i] = static_cast<float_X>(freqFkt(i));
                     }
 
                     // Phi axis
                     ::openPMD::Extent extentPhi
-                        = {1, static_cast<unsigned long int>(transitionRadiation::parameters::nPhi), 1};
+                        = {1, static_cast<unsigned long int>(transitionRadiation::parameters::N_phi), 1};
                     ::openPMD::Offset offsetPhi = {0, 0, 0};
                     ::openPMD::Datatype datatypePhi = ::openPMD::determineDatatype<float_X>();
                     ::openPMD::Dataset datasetPhi{datatypePhi, extentPhi};
@@ -645,21 +647,21 @@ namespace picongpu
                     auto spanPhi = phi.storeChunk<float_X>(offsetPhi, extentPhi);
                     auto spanBufferPhi = spanPhi.currentBuffer();
 
-                    if(transitionRadiation::parameters::nPhi > 1)
+                    if(transitionRadiation::parameters::N_phi > 1)
                     {
-                        for(unsigned int i = 0; i < transitionRadiation::parameters::nPhi; ++i)
+                        for(unsigned int i = 0; i < transitionRadiation::parameters::N_phi; ++i)
                         {
-                            spanBufferPhi[i] = parameters::phiMin
-                                + i * (parameters::phiMax - parameters::phiMin) / (parameters::nPhi - 1.0);
+                            spanBufferPhi[i] = parameters::phi_min
+                                + i * (parameters::phi_max - parameters::phi_min) / (parameters::N_phi - 1.0);
                         }
                     }
                     else
                     {
-                        spanBufferPhi[0] = parameters::phiMin;
+                        spanBufferPhi[0] = parameters::phi_min;
                     }
 
                     // Theta axis
-                    ::openPMD::Extent extentTheta = {1, 1, transitionRadiation::parameters::nTheta};
+                    ::openPMD::Extent extentTheta = {1, 1, transitionRadiation::parameters::N_theta};
                     ::openPMD::Offset offsetTheta = {0, 0, 0};
                     ::openPMD::Datatype datatypeTheta = ::openPMD::determineDatatype<float_X>();
                     ::openPMD::Dataset datasetTheta{datatypeTheta, extentTheta};
@@ -682,17 +684,17 @@ namespace picongpu
                     auto spanTheta = theta.storeChunk<float_X>(offsetTheta, extentTheta);
                     auto spanBufferTheta = spanTheta.currentBuffer();
 
-                    if(transitionRadiation::parameters::nTheta > 1)
+                    if(transitionRadiation::parameters::N_theta > 1)
                     {
-                        for(unsigned int i = 0; i < transitionRadiation::parameters::nTheta; ++i)
+                        for(unsigned int i = 0; i < transitionRadiation::parameters::N_theta; ++i)
                         {
-                            spanBufferTheta[i] = parameters::thetaMin
-                                + i * (parameters::thetaMax - parameters::thetaMin) / (parameters::nTheta - 1.0);
+                            spanBufferTheta[i] = parameters::theta_min
+                                + i * (parameters::theta_max - parameters::theta_min) / (parameters::N_theta - 1.0);
                         }
                     }
                     else
                     {
-                        spanBufferTheta[0] = parameters::thetaMin;
+                        spanBufferTheta[0] = parameters::theta_min;
                     }
 
                     series.iterations[currentStep].close();
@@ -723,7 +725,7 @@ namespace picongpu
                     /* execute the particle filter */
                     transitionRadiation::executeParticleFilter(particles, currentStep);
 
-                    const auto gridDim_rad = transitionRadiation::parameters::nObserver;
+                    const auto gridDim_rad = transitionRadiation::parameters::N_observer;
 
                     /* number of threads per block = number of cells in a super cell
                      *          = number of particles in a Frame

--- a/include/picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/LinearFrequencies.hpp
@@ -28,7 +28,7 @@ namespace picongpu
     {
         namespace transitionRadiation
         {
-            namespace linearFrequencies
+            namespace linear_frequencies
             {
                 class FreqFunctor
                 {
@@ -37,7 +37,7 @@ namespace picongpu
 
                     HDINLINE float_X operator()(const int ID)
                     {
-                        return omegaMin + float_X(ID) * deltaOmega;
+                        return omega_min + float_X(ID) * deltaOmega;
                     }
 
                     HINLINE float_X get(const int ID)
@@ -67,13 +67,13 @@ namespace picongpu
                 std::string getParameters(void)
                 {
                     std::string params = std::string("lin\t");
-                    params += std::to_string(nOmega) + "\t";
-                    params += std::to_string(SI::omegaMin) + "\t";
-                    params += std::to_string(SI::omegaMax) + "\t";
+                    params += std::to_string(N_omega) + "\t";
+                    params += std::to_string(SI::omega_min) + "\t";
+                    params += std::to_string(SI::omega_max) + "\t";
                     return params;
                 }
 
-            } // namespace linearFrequencies
+            } // namespace linear_frequencies
         } // namespace transitionRadiation
     } // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/ListFrequencies.hpp
@@ -35,7 +35,7 @@ namespace picongpu
     {
         namespace transitionRadiation
         {
-            namespace listFrequencies
+            namespace frequencies_from_list
             {
                 class FreqFunctor
                 {
@@ -53,12 +53,12 @@ namespace picongpu
 
                     HDINLINE float_X operator()(const unsigned int ID)
                     {
-                        return (ID < frequencies::nOmega) ? frequencies_dev[ID] : 0.0;
+                        return (ID < frequencies::N_omega) ? frequencies_dev[ID] : 0.0;
                     }
 
                     HINLINE float_X get(const unsigned int ID)
                     {
-                        return (ID < frequencies::nOmega) ? frequencies_host[ID] : 0.0;
+                        return (ID < frequencies::N_omega) ? frequencies_host[ID] : 0.0;
                     }
 
                 private:
@@ -76,7 +76,7 @@ namespace picongpu
 
                     HINLINE void Init(const std::string path)
                     {
-                        frequencyBuffer = std::make_unique<GridBuffer<float_X, DIM1>>(DataSpace<DIM1>(nOmega));
+                        frequencyBuffer = std::make_unique<GridBuffer<float_X, DIM1>>(DataSpace<DIM1>(N_omega));
 
 
                         DBoxType frequencyDB = frequencyBuffer->getHostBuffer().getDataBox();
@@ -94,7 +94,7 @@ namespace picongpu
                         }
 
 
-                        for(i = 0; i < nOmega && !freqListFile.eof(); ++i)
+                        for(i = 0; i < N_omega && !freqListFile.eof(); ++i)
                         {
                             freqListFile >> frequencyDB[i];
                             // verbose output of loaded frequencies if verbose level PHYSICS is set:
@@ -103,7 +103,7 @@ namespace picongpu
                             frequencyDB[i] *= sim.unit.time();
                         }
 
-                        if(i != nOmega)
+                        if(i != N_omega)
                         {
                             throw std::runtime_error(std::string("The number of frequencies in the list and the "
                                                                  "number of frequencies in the parameters differ.\n"));
@@ -130,7 +130,7 @@ namespace picongpu
                     return params;
                 }
 
-            } // namespace listFrequencies
+            } // namespace frequencies_from_list
         } // namespace transitionRadiation
     } // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp
+++ b/include/picongpu/plugins/transitionRadiation/frequencies/LogFrequencies.hpp
@@ -29,15 +29,15 @@ namespace picongpu
     {
         namespace transitionRadiation
         {
-            namespace logFrequencies
+            namespace log_frequencies
             {
                 class FreqFunctor
                 {
                 public:
                     FreqFunctor(void)
                     {
-                        omega_log_min = math::log(omegaMin);
-                        delta_omega_log = (math::log(omegaMax) - omega_log_min) / float_X(nOmega - 1);
+                        omega_log_min = math::log(omega_min);
+                        delta_omega_log = (math::log(omega_max) - omega_log_min) / float_X(N_omega - 1);
                     }
 
                     HDINLINE float_X operator()(const int ID)
@@ -78,13 +78,13 @@ namespace picongpu
                 std::string getParameters(void)
                 {
                     std::string params = std::string("log\t");
-                    params += std::to_string(nOmega) + "\t";
-                    params += std::to_string(SI::omegaMin) + "\t";
-                    params += std::to_string(SI::omegaMax) + "\t";
+                    params += std::to_string(N_omega) + "\t";
+                    params += std::to_string(SI::omega_min) + "\t";
+                    params += std::to_string(SI::omega_max) + "\t";
                     return params;
                 }
 
-            } // namespace logFrequencies
+            } // namespace log_frequencies
         } // namespace transitionRadiation
     } // namespace plugins
 } // namespace picongpu

--- a/include/picongpu/unitless/transitionRadiation.unitless
+++ b/include/picongpu/unitless/transitionRadiation.unitless
@@ -28,33 +28,33 @@ namespace picongpu
         namespace transitionRadiation
         {
             //! units for linear frequencies distribution for transition radiation plugin
-            namespace linearFrequencies
+            namespace linear_frequencies
             {
-                constexpr float_X omegaMin = SI::omegaMin * sim.unit.time();
-                constexpr float_X omegaMax = SI::omegaMax * sim.unit.time();
+                constexpr float_X omega_min = SI::omega_min * sim.unit.time();
+                constexpr float_X omega_max = SI::omega_max * sim.unit.time();
                 constexpr float_X deltaOmega
-                    = (float_X) ((omegaMax - omegaMin) / (float_X) (nOmega - 1)); // difference beween two omega
+                    = (float_X) ((omega_max - omega_min) / (float_X) (N_omega - 1)); // difference beween two omega
 
                 constexpr unsigned int blocksizeOmega = numFrameSlots;
-                constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
-            } // namespace linearFrequencies
+                constexpr unsigned int gridsizeOmega = N_omega / blocksizeOmega; // size of grid (dim: x); radiation
+            } // namespace linear_frequencies
 
             //! units for logarithmic frequencies distribution for transition radiation plugin
-            namespace logFrequencies
+            namespace log_frequencies
             {
-                constexpr float_X omegaMin = (SI::omegaMin * sim.unit.time());
-                constexpr float_X omegaMax = (SI::omegaMax * sim.unit.time());
+                constexpr float_X omega_min = (SI::omega_min * sim.unit.time());
+                constexpr float_X omega_max = (SI::omega_max * sim.unit.time());
 
                 constexpr unsigned int blocksizeOmega = numFrameSlots;
-                constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
-            } // namespace logFrequencies
+                constexpr unsigned int gridsizeOmega = N_omega / blocksizeOmega; // size of grid (dim: x); radiation
+            } // namespace log_frequencies
 
             //! units for frequencies from list for transition radiation calculation
-            namespace listFrequencies
+            namespace frequencies_from_list
             {
                 constexpr unsigned int blocksizeOmega = numFrameSlots;
-                constexpr unsigned int gridsizeOmega = nOmega / blocksizeOmega; // size of grid (dim: x); radiation
-            } // namespace listFrequencies
+                constexpr unsigned int gridsizeOmega = N_omega / blocksizeOmega; // size of grid (dim: x); radiation
+            } // namespace frequencies_from_list
         } // namespace transitionRadiation
     } // namespace plugins
 } // namespace picongpu

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
@@ -76,55 +76,55 @@ namespace picongpu
 
         namespace transitionRadiation
         {
-            namespace linearFrequencies
+            namespace linear_frequencies
             {
                 namespace SI
                 {
                     //! mimimum frequency of the linear frequency scale in units of [1/s]
-                    constexpr float_64 omegaMin = 0.0;
+                    constexpr float_64 omega_min = 0.0;
                     //! maximum frequency of the linear frequency scale in units of [1/s]
-                    constexpr float_64 omegaMax = 1.06e16;
+                    constexpr float_64 omega_max = 1.06e16;
                 } // namespace SI
 
                 //! number of frequency values to compute in the linear frequency [unitless]
-                constexpr unsigned int nOmega = 512;
+                constexpr unsigned int N_omega = 512;
 
-            } // namespace linearFrequencies
+            } // namespace linear_frequencies
 
-            namespace logFrequencies
+            namespace log_frequencies
             {
                 namespace SI
                 {
                     //! mimimum frequency of the logarithmic frequency scale in units of [1/s]
-                    constexpr float_64 omegaMin = 1.0e13;
+                    constexpr float_64 omega_min = 1.0e13;
                     //! maximum frequency of the logarithmic frequency scale in units of [1/s]
-                    constexpr float_64 omegaMax = 1.0e17;
+                    constexpr float_64 omega_max = 1.0e17;
                 } // namespace SI
 
                 //! number of frequency values to compute in the logarithmic frequency [unitless]
-                constexpr unsigned int nOmega = 256;
+                constexpr unsigned int N_omega = 256;
 
-            } // namespace logFrequencies
+            } // namespace log_frequencies
 
 
-            namespace listFrequencies
+            namespace frequencies_from_list
             {
                 //! path to text file with frequencies
                 constexpr char listLocation[] = "/path/to/frequency_list";
                 //! number of frequency values to compute if frequencies are given in a file [unitless]
-                constexpr unsigned int nOmega = 512;
+                constexpr unsigned int N_omega = 512;
 
-            } // namespace listFrequencies
+            } // namespace frequencies_from_list
 
 
             /** selected mode of frequency scaling:
              *
              * options:
-             * - linearFrequencies
-             * - logFrequencies
-             * - listFrequencies
+             * - linear_frequencies
+             * - log_frequencies
+             * - frequencies_from_list
              */
-            namespace frequencies = logFrequencies;
+            namespace frequencies = log_frequencies;
 
             ///////////////////////////////////////////////////
 
@@ -143,24 +143,24 @@ namespace picongpu
              *  - ::picongpu::plugins::radiation::radFormFactor_incoherent ... only incoherent radiation
              *  - ::picongpu::plugins::radiation::radFormFactor_coherent ... only coherent radiation
              */
-            namespace macroParticleFormFactor = ::picongpu::plugins::radiation::radFormFactor_Gauss_spherical;
+            namespace radFormFactor = ::picongpu::plugins::radiation::radFormFactor_Gauss_spherical;
 
             ///////////////////////////////////////////////////////////
 
             namespace parameters
             {
                 // number of observation directions
-                constexpr unsigned int nPhi = 128;
-                constexpr unsigned int nTheta = 128;
-                constexpr unsigned int nObserver = nPhi * nTheta;
+                constexpr unsigned int N_phi = 128;
+                constexpr unsigned int N_theta = 128;
+                constexpr unsigned int N_observer = N_phi * N_theta;
 
                 // theta goes from 0 to pi
-                constexpr float_64 thetaMin = 0.0;
-                constexpr float_64 thetaMax = picongpu::PI;
+                constexpr float_64 theta_min = 0.0;
+                constexpr float_64 theta_max = picongpu::PI;
 
                 // phi goes from 0 to 2*pi
-                constexpr float_64 phiMin = 0.0;
-                constexpr float_64 phiMax = 2 * picongpu::PI;
+                constexpr float_64 phi_min = 0.0;
+                constexpr float_64 phi_max = 2 * picongpu::PI;
             } // end namespace parameters
 
 
@@ -202,11 +202,11 @@ namespace picongpu
              * observation directions for 2D virtual detector field
              * with its center pointing toward the +y direction (for theta=0, phi=0)
              * with observation angles ranging from
-             * theta = [angle_theta_start : angle_theta_end]
-             * phi   = [angle_phi_start   : angle_phi_end  ]
+             * theta = [theta_min : theta_max]
+             * phi   = [phi_min   : phi_max  ]
              * Every observation_id_extern index moves the phi angle from its
              * start value toward its end value until the observation_id_extern
-             * reaches N_split. After that the theta angle moves further from its
+             * reaches N_phi. After that the theta angle moves further from its
              * start value towards its end value while phi is reset to its start
              * value.
              *
@@ -220,6 +220,9 @@ namespace picongpu
              * The example setup describes an detector array of
              * 128X128 detectors ranging from 0 to pi for the azimuth angle
              * theta and from 0 to 2 pi for the polar angle phi.
+             *
+             * If the calculation is only supposed to be done for a single azimuth
+             * or polar angle, it will use the respective minimal angle.
              *
              * @param    observation_id_extern
              *           int index that identifies each block on the GPU
@@ -237,26 +240,26 @@ namespace picongpu
                  * index_b = index % split_distance
                  */
                 /** get index for computing angle theta: */
-                const int indexTheta = observation_id_extern / parameters::nPhi;
+                const int index_theta = observation_id_extern / parameters::N_phi;
 
-                /** step width angle theta, set it to 0 if nTheta = 1 */
-                const picongpu::float_64 deltaTheta = (parameters::nTheta > 1)
-                    ? (parameters::thetaMax - parameters::thetaMin) / (parameters::nTheta - 1.0)
+                /** step width angle theta */
+                const picongpu::float_64 delta__theta = (parameters::N_theta > 1)
+                    ? (parameters::theta_max - parameters::theta_min) / (parameters::N_theta - 1.0)
                     : 0.0;
 
                 /** compute observation angles theta */
-                const picongpu::float_64 theta = indexTheta * deltaTheta + parameters::thetaMin;
+                const picongpu::float_64 theta = index_theta * delta__theta + parameters::theta_min;
 
                 /** get index for computing angle phi: */
-                const int indexPhi = observation_id_extern % parameters::nPhi;
+                const int index_phi = observation_id_extern % parameters::N_phi;
 
-                /** step width angle phi, set it to 0 if nPhi = 1 */
-                const picongpu::float_64 deltaPhi = (parameters::nPhi > 1)
-                    ? (parameters::phiMax - parameters::phiMin) / (parameters::nPhi - 1.0)
+                /** step width angle phi */
+                const picongpu::float_64 delta__phi = (parameters::N_phi > 1)
+                    ? (parameters::phi_max - parameters::phi_min) / (parameters::N_phi - 1.0)
                     : 0.0;
 
                 /** compute observation angles phi */
-                const picongpu::float_64 phi = indexPhi * deltaPhi - parameters::phiMin;
+                const picongpu::float_64 phi = index_phi * delta__phi - parameters::phi_min;
 
                 /* helper functions for efficient trigonometric calculations */
                 picongpu::float_32 sinPhi;

--- a/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
+++ b/share/picongpu/examples/TransitionRadiation/include/picongpu/param/transitionRadiation.param
@@ -242,7 +242,7 @@ namespace picongpu
                 /** get index for computing angle theta: */
                 const int index_theta = observation_id_extern / parameters::N_phi;
 
-                /** step width angle theta */
+                /** step width angle theta, set it to 0 if nTheta = 1 */
                 const picongpu::float_64 delta__theta = (parameters::N_theta > 1)
                     ? (parameters::theta_max - parameters::theta_min) / (parameters::N_theta - 1.0)
                     : 0.0;
@@ -253,7 +253,7 @@ namespace picongpu
                 /** get index for computing angle phi: */
                 const int index_phi = observation_id_extern % parameters::N_phi;
 
-                /** step width angle phi */
+                /** step width angle phi, set it to 0 if nPhi = 1 */
                 const picongpu::float_64 delta__phi = (parameters::N_phi > 1)
                     ? (parameters::phi_max - parameters::phi_min) / (parameters::N_phi - 1.0)
                     : 0.0;


### PR DESCRIPTION
This PR addresses an [issue](https://github.com/ComputationalRadiationPhysics/picongpu/issues/5271), where the variable names in the [documentation](https://picongpu.readthedocs.io/en/latest/usage/plugins/transitionRadiation.html#transition-radiation) of the transition radiation plugin do not match the names in the corresponding param file. 
Instead of changing  the documentation, the variable names themself were changed to also match the naming of the [radiation plugin](https://picongpu.readthedocs.io/en/latest/usage/plugins/radiation.html) variables, which was the base of the CTR plugin.

This does **not** address some of the other minor issues in the documentation. I would change these in a separate PR, if not requested otherwise by a reviewer.