### PR TITLE
Enable complex input for FromOpenPMDPulse profile

### DIFF
--- a/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def
@@ -80,8 +80,10 @@ namespace picongpu
                         /** Datatype of the field record
                          *
                          * openPMD needs this information at compile time.
+                         * @attention: supported are float, double and std::complex<double>.
+                         * In case of complex input, the simulation uses only the real part.
                          */
-                        using dataType = float_64;
+                        using dataType = double;
 
                         //! Defining the propagation ( = time) and polarisation axes of the input data
                         static constexpr char const* polarisationAxisOpenPMD = "x";

--- a/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.hpp
+++ b/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.hpp
@@ -181,7 +181,8 @@ namespace picongpu
                     {
                         //! Unitless parameters type
                         using Params = FromOpenPMDPulseUnitless<T_Params>;
-                        using dataType = typename Params::dataType; // field record data type
+                        //! field record data type
+                        using dataType = typename Params::dataType;
 
                         //! FromOpenPMD pulse E functor
                         using Functor = FromOpenPMDPulseFunctorIncidentE<T_Params>;
@@ -289,9 +290,6 @@ namespace picongpu
 
                             // field data
                             bufferFieldData = std::make_shared<pmacc::HostDeviceBuffer<float_X, 3u>>(extentOpenPMD);
-                            // das Problem ist hier wenn komplex!!
-                            // error: Type conversion during chunk loading not yet implemented! Data: CDOUBLE; Load as:
-                            // UNDEFINED', terminating
                             auto fieldData = std::shared_ptr<dataType>{nullptr};
                             fieldData = meshRecord.loadChunk<dataType>();
 

--- a/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
+++ b/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
@@ -490,7 +490,8 @@
    "source": [
     "## Save data to openPMD\n",
     "The data is now nearly ready te be used as FromOpenPMDPulse input. The amplitude of the pulse in the time domain still has to be corrected (= scaled to the actual beam energy in Joule) before saving it to an openPMD file at the provided destination path.\n",
-    "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm) and `crop_t` (in fs)."
+    "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm), `crop_t_neg` and `crop_t_pos` (in fs).\n",
+    "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input."
    ]
   },
   {
@@ -506,9 +507,10 @@
     "pol = \"y\"  # polarisation axis (can be 'x' or 'y')\n",
     "crop_x = 0.3  # mm, trim transversal x axis\n",
     "crop_y = 0.3  # mm, trim transversal y axis\n",
-    "crop_t = 100  # fs, trim time axis\n",
+    "crop_t_neg = 100  # fs, trim time axis from below\n",
+    "crop_t_pos = 100  # fs, trim time axis from above\n",
     "\n",
-    "insight.save_to_openPMD(\"\", \"insightData_prepared%T.h5\", E, pol, crop_x, crop_y, crop_t)"
+    "insight.save_to_openPMD(\"\", \"insightData_prepared%T.bp5\", E, pol, crop_x, crop_y, crop_t_neg, crop_t_pos)"
    ]
   },
   {


### PR DESCRIPTION
The FromOpenPMDPulse profile can now process complex field data as input. It will then only use its real part. 
Hence, LASY profiles can now serve as laser in simulations.

Also, the script for preparing INSIGHT measurements has been refactored. Now, the user can decide wheter to store the prepared field in the time domain as real or complex-valued.