### PR TITLE
Use flatter scatter per default

### DIFF
--- a/include/picongpu/param/mallocMC.param
+++ b/include/picongpu/param/mallocMC.param
@@ -29,38 +29,21 @@
 
 #include <pmacc/alpakaHelper/acc.hpp>
 
+#include <cstdint>
+
 #include <mallocMC/mallocMC.hpp>
 
 namespace picongpu
 {
-    //! configure the CreationPolicy "Scatter"
-    struct DeviceHeapConfig
-    {
-        //! 2MiB page can hold around 256 particle frames
-        static constexpr uint32_t pagesize = 2u * 1024u * 1024u;
+    constexpr uint32_t blockSize = 128U * 1024U * 1024U;
+    constexpr uint32_t pageSize = 128U * 1024U;
+    constexpr uint32_t wastefactor = 2U;
+    using DeviceHeapConfig
+        = mallocMC::CreationPolicies::FlatterScatterAlloc::DefaultHeapConfig<blockSize, pageSize, wastefactor>;
 
-        /** accessblocksize, regionsize and wastefactor are not conclusively
-         * investigated and might be performance sensitive for multiple
-         * particle species with heavily varying attributes (frame sizes)
-         */
-        static constexpr uint32_t accessblocksize = 2u * 1024u * 1024u * 1024u;
-        static constexpr uint32_t regionsize = 16u;
-        static constexpr uint32_t wastefactor = 2u;
-
-        /** resetfreedpages is used to minimize memory fragmentation with
-         * varying frame sizes
-         */
-        static constexpr bool resetfreedpages = true;
-    };
-
-    /** Define a new allocator
-     *
-     * This is an allocator resembling the behaviour of the ScatterAlloc
-     * algorithm.
-     */
     using DeviceHeap = mallocMC::Allocator<
         alpaka::AccToTag<pmacc::Acc<DIM1>>,
-        mallocMC::CreationPolicies::Scatter<DeviceHeapConfig>,
+        mallocMC::CreationPolicies::FlatterScatter<DeviceHeapConfig>,
         mallocMC::DistributionPolicies::Noop,
         mallocMC::OOMPolicies::ReturnNull,
         mallocMC::ReservePoolPolicies::AlpakaBuf<pmacc::Acc<DIM1>>,


### PR DESCRIPTION
- [x] Wait for #5280 to be merged.

@psychocoderHPC explicitly requested to have the parameters written down there. I've made a compromise because the `DefaultHeapConfig` in FlatterScatter is already a template with the main parameters being compile-time configurable. Does that suffice or do you want me to copy over the full struct including the function for checking if a chunk size fits, etc.?