### PR TITLE
fix copyright comment 2

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -641,7 +641,7 @@ the "copyright" line and a pointer to where the full notice is found.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License

--- a/bin/cuda_memtest.sh
+++ b/bin/cuda_memtest.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/egetopt
+++ b/bin/egetopt
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/pic-build
+++ b/bin/pic-build
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/pic-compile
+++ b/bin/pic-compile
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/pic-configure
+++ b/bin/pic-configure
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/pic-create
+++ b/bin/pic-create
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/pic-edit
+++ b/bin/pic-edit
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/bin/tbg
+++ b/bin/tbg
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/buildsystem/CompileSuite/color.sh
+++ b/buildsystem/CompileSuite/color.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/buildsystem/CompileSuite/compileSet.sh
+++ b/buildsystem/CompileSuite/compileSet.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/buildsystem/CompileSuite/exec_helper.sh
+++ b/buildsystem/CompileSuite/exec_helper.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/buildsystem/CompileSuite/help.sh
+++ b/buildsystem/CompileSuite/help.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/buildsystem/CompileSuite/options.sh
+++ b/buildsystem/CompileSuite/options.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/buildsystem/CompileSuite/path.sh
+++ b/buildsystem/CompileSuite/path.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/cmake/riscv64-clang.toolchain.cmake
+++ b/cmake/riscv64-clang.toolchain.cmake
@@ -10,7 +10,7 @@
 #
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/cmake/riscv64-gnu.toolchain.cmake
+++ b/cmake/riscv64-gnu.toolchain.cmake
@@ -10,7 +10,7 @@
 #
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/aris-grnet/gpu.tpl
+++ b/etc/picongpu/aris-grnet/gpu.tpl
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/ascent-ornl/gpu_batch.tpl
+++ b/etc/picongpu/ascent-ornl/gpu_batch.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/bash-devServer-hzdr/mpiexec.tpl
+++ b/etc/picongpu/bash-devServer-hzdr/mpiexec.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/bash/mpiexec.tpl
+++ b/etc/picongpu/bash/mpiexec.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/bash/mpirun.tpl
+++ b/etc/picongpu/bash/mpirun.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/cori-nersc/a100.tpl
+++ b/etc/picongpu/cori-nersc/a100.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/cpuNumaStarter.sh
+++ b/etc/picongpu/cpuNumaStarter.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/crusher-ornl/batch.tpl
+++ b/etc/picongpu/crusher-ornl/batch.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/davide-cineca/gpu.tpl
+++ b/etc/picongpu/davide-cineca/gpu.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/davinci-rice/picongpu.tpl
+++ b/etc/picongpu/davinci-rice/picongpu.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/draco-mpcdf/general.tpl
+++ b/etc/picongpu/draco-mpcdf/general.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/eli-np/gpu_v100.tpl
+++ b/etc/picongpu/eli-np/gpu_v100.tpl
@@ -12,7 +12,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/frontier-ornl/batch.tpl
+++ b/etc/picongpu/frontier-ornl/batch.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/frontier-ornl/batch_pipe.tpl
+++ b/etc/picongpu/frontier-ornl/batch_pipe.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/handleSlurmSignals.sh
+++ b/etc/picongpu/handleSlurmSignals.sh
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100.tpl
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/hemera-hzdr/gpu.tpl
+++ b/etc/picongpu/hemera-hzdr/gpu.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/jedi-jsc/gh200.tpl
+++ b/etc/picongpu/jedi-jsc/gh200.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/jureca-jsc/batch.tpl
+++ b/etc/picongpu/jureca-jsc/batch.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/jureca-jsc/booster.tpl
+++ b/etc/picongpu/jureca-jsc/booster.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/jureca-jsc/gpus.tpl
+++ b/etc/picongpu/jureca-jsc/gpus.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/juwels-jsc/batch.tpl
+++ b/etc/picongpu/juwels-jsc/batch.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/juwels-jsc/booster.tpl
+++ b/etc/picongpu/juwels-jsc/booster.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/juwels-jsc/booster_pipe.tpl
+++ b/etc/picongpu/juwels-jsc/booster_pipe.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/juwels-jsc/gpus.tpl
+++ b/etc/picongpu/juwels-jsc/gpus.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/karolina-it4i/gpu_a100.tpl
+++ b/etc/picongpu/karolina-it4i/gpu_a100.tpl
@@ -12,7 +12,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/lumi-eurohpc/standard-g.tpl
+++ b/etc/picongpu/lumi-eurohpc/standard-g.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/pizdaint-cscs/large.tpl
+++ b/etc/picongpu/pizdaint-cscs/large.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/pizdaint-cscs/normal.tpl
+++ b/etc/picongpu/pizdaint-cscs/normal.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/spock-ornl/caar.tpl
+++ b/etc/picongpu/spock-ornl/caar.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/submitAction.sh
+++ b/etc/picongpu/submitAction.sh
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/summit-ornl/gpu_batch.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/summit-ornl/gpu_batch_pipe.tpl
+++ b/etc/picongpu/summit-ornl/gpu_batch_pipe.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/taurus-tud/A100.tpl
+++ b/etc/picongpu/taurus-tud/A100.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/taurus-tud/A100_restart.tpl
+++ b/etc/picongpu/taurus-tud/A100_restart.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/taurus-tud/V100.tpl
+++ b/etc/picongpu/taurus-tud/V100.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/taurus-tud/V100_restart.tpl
+++ b/etc/picongpu/taurus-tud/V100_restart.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/taurus-tud/k80.tpl
+++ b/etc/picongpu/taurus-tud/k80.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/zsh/mpiexec.tpl
+++ b/etc/picongpu/zsh/mpiexec.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/etc/picongpu/zsh/mpirun.tpl
+++ b/etc/picongpu/zsh/mpirun.tpl
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/include/picongpu/param/atomicPhysics.param
+++ b/include/picongpu/param/atomicPhysics.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/param/atomicPhysics_Debug.param
+++ b/include/picongpu/param/atomicPhysics_Debug.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/param/shadowgraphy.param
+++ b/include/picongpu/param/shadowgraphy.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/param/synchrotron.param
+++ b/include/picongpu/param/synchrotron.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/manipulators/unary/MaxwellJuettner.def
+++ b/include/picongpu/particles/manipulators/unary/MaxwellJuettner.def
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/manipulators/unary/MaxwellJuettner.hpp
+++ b/include/picongpu/particles/manipulators/unary/MaxwellJuettner.hpp
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/manipulators/unary/SparserMacroParticlesPerSuperCell.def
+++ b/include/picongpu/particles/manipulators/unary/SparserMacroParticlesPerSuperCell.def
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/manipulators/unary/SparserMacroParticlesPerSuperCell.hpp
+++ b/include/picongpu/particles/manipulators/unary/SparserMacroParticlesPerSuperCell.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/synchrotron/AlgorithmSynchrotron.hpp
+++ b/include/picongpu/particles/synchrotron/AlgorithmSynchrotron.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/traits/GetAtomicDataType.hpp
+++ b/include/picongpu/particles/traits/GetAtomicDataType.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/traits/GetIonizationElectronSpecies.hpp
+++ b/include/picongpu/particles/traits/GetIonizationElectronSpecies.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/particles/traits/GetNumberAtomicStates.hpp
+++ b/include/picongpu/particles/traits/GetNumberAtomicStates.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/plugins/binning/axis/LogAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LogAxis.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
+++ b/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/plugins/shadowgraphy/ShadowgraphyHelper.hpp
+++ b/include/picongpu/plugins/shadowgraphy/ShadowgraphyHelper.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/simulation/stage/AtomicPhysics.hpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.hpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
+++ b/include/picongpu/simulation/stage/SynchrotronRadiation.hpp
@@ -12,7 +12,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/picongpu/simulation/stage/SynchrotronRadiation.x.cpp
+++ b/include/picongpu/simulation/stage/SynchrotronRadiation.x.cpp
@@ -12,7 +12,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/include/pmacc/mappings/kernel/RangeMapping.hpp
+++ b/include/pmacc/mappings/kernel/RangeMapping.hpp
@@ -10,7 +10,7 @@
  *
  * PMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License and the GNU Lesser General Public License
  * for more details.
  *

--- a/include/pmacc/math/Matrix.hpp
+++ b/include/pmacc/math/Matrix.hpp
@@ -10,7 +10,7 @@
  *
  * PMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License and the GNU Lesser General Public License
  * for more details.
  *

--- a/include/pmacc/math/operation/And.hpp
+++ b/include/pmacc/math/operation/And.hpp
@@ -10,7 +10,7 @@
  *
  * PMacc is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License and the GNU Lesser General Public License
  * for more details.
  *

--- a/lib/python/picongpu/extra/plugins/data/calorimeter.py
+++ b/lib/python/picongpu/extra/plugins/data/calorimeter.py
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/lib/python/picongpu/extra/plugins/data/radiation.py
+++ b/lib/python/picongpu/extra/plugins/data/radiation.py
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/cmakeFlags
+++ b/share/picongpu/benchmarks/TWEAC-FOM/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/12288.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/12288.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/1536.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/1536.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/16.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/16.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/162.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/162.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/192.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/192.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/256_adios.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/256_adios.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/27600.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/27600.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/3072.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/3072.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/384.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/384.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/4.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/420.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/420.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/48.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/48.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/6.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/6.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/6144.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/6144.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/768.cfg
+++ b/share/picongpu/benchmarks/TWEAC-FOM/etc/picongpu/768.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/TwtsBackgroundLaser.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/TwtsBackgroundLaser.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/Thermal/cmakeFlags
+++ b/share/picongpu/benchmarks/Thermal/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/Thermal/etc/picongpu/1.cfg
+++ b/share/picongpu/benchmarks/Thermal/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/benchmarks/Thermal/etc/picongpu/1_noIO.cfg
+++ b/share/picongpu/benchmarks/Thermal/etc/picongpu/1_noIO.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/cmakeFlags
+++ b/share/picongpu/examples/AtomicPhysics/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/1.cfg
+++ b/share/picongpu/examples/AtomicPhysics/etc/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/4.cfg
+++ b/share/picongpu/examples/AtomicPhysics/etc/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/build.sh
+++ b/share/picongpu/examples/AtomicPhysics/etc/build.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/cpuNumaStarter.sh
+++ b/share/picongpu/examples/AtomicPhysics/etc/cpuNumaStarter.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/getAtomicInputData.sh
+++ b/share/picongpu/examples/AtomicPhysics/etc/getAtomicInputData.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/handleSlurmSignals.sh
+++ b/share/picongpu/examples/AtomicPhysics/etc/handleSlurmSignals.sh
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/etc/submitAction.sh
+++ b/share/picongpu/examples/AtomicPhysics/etc/submitAction.sh
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/density.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/density.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/simulation.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/simulation.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/speciesDefinition.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/speciesInitialization.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/Bunch/cmakeFlags
+++ b/share/picongpu/examples/Bunch/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/Bunch/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/Bunch/etc/picongpu/32.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/Empty/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/Empty/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/FoilLCT/cmakeFlags
+++ b/share/picongpu/examples/FoilLCT/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/4_isaac.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/4_isaac.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/8.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/FoilLCT/etc/picongpu/8_isaac.cfg
+++ b/share/picongpu/examples/FoilLCT/etc/picongpu/8_isaac.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/IncidentField/cmakeFlags
+++ b/share/picongpu/examples/IncidentField/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/IncidentField/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/cmakeFlags
+++ b/share/picongpu/examples/KelvinHelmholtz/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/16.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1_bench.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/1_bench.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_bench.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_bench.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_pipe.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_bench.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_bench.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_pipe.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/cmakeFlags
+++ b/share/picongpu/examples/LaserWakefield/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/16.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1_isaac.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/32.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/32.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4_gui.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4_gui.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4_isaac.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8_isaac.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8_isaac.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
+++ b/share/picongpu/examples/TransitionRadiation/etc/picongpu/16.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/examples/WeibelTransverse/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/WeibelTransverse/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CollisionsBeamRelaxation/cmakeFlags
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CollisionsBeamRelaxation/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CollisionsThermalisation/cmakeFlags
+++ b/share/picongpu/tests/CollisionsThermalisation/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CollisionsThermalisation/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/CollisionsThermalisation/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/cmakeFlags
+++ b/share/picongpu/tests/CurrentDeposition/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/CurrentDeposition/etc/picongpu/1.cfg
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/density.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/density.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/fileOutput.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/species.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/species.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/speciesDefinition.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/speciesInitialization.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/FieldAbsorber/cmakeFlags
+++ b/share/picongpu/tests/FieldAbsorber/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/FieldAbsorber/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/FieldAbsorber/etc/picongpu/1.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/FieldAbsorber/etc/picongpu/4.cfg
+++ b/share/picongpu/tests/FieldAbsorber/etc/picongpu/4.cfg
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/KHI_growthRate/cmakeFlags
+++ b/share/picongpu/tests/KHI_growthRate/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/cmakeFlags
+++ b/share/picongpu/tests/Pusher/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/Pusher/etc/picongpu/1.cfg
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/density.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/density.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/dimension.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/fieldBackground.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/fileOutput.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/species.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/species.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/speciesDefinition.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Pusher/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/speciesInitialization.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/cmakeFlags
+++ b/share/picongpu/tests/PusherScaling/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/PusherScaling/etc/picongpu/1.cfg
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/density.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/density.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/dimension.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/fieldBackground.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/fileOutput.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/species.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/species.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/speciesDefinition.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/PusherScaling/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/PusherScaling/include/picongpu/param/speciesInitialization.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Shadowgraphy/include/picongpu/param/incidentField.param
+++ b/share/picongpu/tests/Shadowgraphy/include/picongpu/param/incidentField.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Shadowgraphy/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/Shadowgraphy/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Shadowgraphy/include/picongpu/param/shadowgraphy.param
+++ b/share/picongpu/tests/Shadowgraphy/include/picongpu/param/shadowgraphy.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Shadowgraphy/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/Shadowgraphy/include/picongpu/param/speciesDefinition.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/SingleParticle/cmakeFlags
+++ b/share/picongpu/tests/SingleParticle/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/SingleParticle/etc/picongpu/1.cfg
+++ b/share/picongpu/tests/SingleParticle/etc/picongpu/1.cfg
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/density.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/density.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/dimension.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/dimension.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/fieldBackground.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/speciesDefinition.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/speciesInitialization.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/synchrotron.param
+++ b/share/picongpu/tests/Synchrotron_plugin/include/picongpu/param/synchrotron.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/Synchrotron_plugin/lib/change_parameters_randomly.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/change_parameters_randomly.py
@@ -10,7 +10,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 PIConGPU is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/compile/cmakeFlags
+++ b/share/picongpu/tests/compile/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/compileLaser/cmakeFlags
+++ b/share/picongpu/tests/compileLaser/cmakeFlags
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/density.param
+++ b/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/density.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/fieldBackground.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/particle.param
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/speciesDefinition.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/speciesInitialization.param
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/share/picongpu/unit/CMakeLists.txt
+++ b/share/picongpu/unit/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/share/pmacc/examples/gameOfLife2D/submit/1.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/1.cfg
@@ -10,7 +10,7 @@
 # (at your option) any later version.
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/2.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/2.cfg
@@ -10,7 +10,7 @@
 # (at your option) any later version.
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/4.cfg
+++ b/share/pmacc/examples/gameOfLife2D/submit/4.cfg
@@ -10,7 +10,7 @@
 # (at your option) any later version.
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
+++ b/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpiexec.tpl
@@ -12,7 +12,7 @@
 #
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
+++ b/share/pmacc/examples/gameOfLife2D/submit/bash/bash_mpirun.tpl
@@ -12,7 +12,7 @@
 #
 # PMacc is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License and the GNU Lesser General Public License
 # for more details.
 #

--- a/src/tools/bin/BinEnergyPlot.sh
+++ b/src/tools/bin/BinEnergyPlot.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/create.sh
+++ b/src/tools/bin/create.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/findAndDo
+++ b/src/tools/bin/findAndDo
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/newVersion.sh
+++ b/src/tools/bin/newVersion.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/nextstep_from_period.sh
+++ b/src/tools/bin/nextstep_from_period.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/plotIntensity
+++ b/src/tools/bin/plotIntensity
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/plotRadiation.py
+++ b/src/tools/bin/plotRadiation.py
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/plotSumEnergyRange
+++ b/src/tools/bin/plotSumEnergyRange
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/png2video.sh
+++ b/src/tools/bin/png2video.sh
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/printField.py
+++ b/src/tools/bin/printField.py
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/radiationSyntheticDetector.py
+++ b/src/tools/bin/radiationSyntheticDetector.py
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/smooth.py
+++ b/src/tools/bin/smooth.py
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/bin/transpose
+++ b/src/tools/bin/transpose
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/share/awk/BinEnergyPlot.awk
+++ b/src/tools/share/awk/BinEnergyPlot.awk
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/share/awk/SumEnergyRange.awk
+++ b/src/tools/share/awk/SumEnergyRange.awk
@@ -10,7 +10,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/src/tools/share/gnuplot/BinEnergyPlot.gnuplot
+++ b/src/tools/share/gnuplot/BinEnergyPlot.gnuplot
@@ -9,7 +9,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/test/hasCudaGlobalKeyword
+++ b/test/hasCudaGlobalKeyword
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/test/hasExtLibIncludeBrackets
+++ b/test/hasExtLibIncludeBrackets
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License

--- a/test/hasWrongDoxygenStyle
+++ b/test/hasWrongDoxygenStyle
@@ -11,7 +11,7 @@
 #
 # PIConGPU is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License


### PR DESCRIPTION
removes a doubled space in the copyright file header comment of files missed in the original PR #4847

ci: no-compile