### PR TITLE
guard against rate cache equal to zero

### DIFF
--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseInstantNonReversibleTransition.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseInstantNonReversibleTransition.kernel
@@ -30,6 +30,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/UpdateIon.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
 #include <pmacc/lockstep/ForEach.hpp>
@@ -290,12 +291,8 @@ namespace picongpu::particles::atomicPhysics::kernel
                         if(r <= cumSum)
                         {
                             // found chosen transition
-                            ion[processClass_] = u8(s_enums::ProcessClass::fieldIonization);
-                            ion[transitionIndex_] = transitionCollectionIndex;
-                            /* field ionizations are not bin based therefore we do not set a bin, and old values are
-                             * ignored */
-                            // we set the accepted flag to allow easy resource use accounting in a later kernel call
-                            ion[accepted_] = true;
+                            // field ionizations are not collisional we therefore use the non bin variant
+                            updateIon(ion, u8(s_enums::ProcessClass::fieldIonization), transitionCollectionIndex);
                             return;
                         }
                     }

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransitionGroup.kernel
@@ -25,7 +25,7 @@
 #include "picongpu/algorithms/FieldToParticleInterpolation.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
-#include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/UpdateIon.hpp"
 #include "picongpu/particles/shapes.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
@@ -175,10 +175,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // definition of time step guarantees that cumSum is always <= 1
                     if(r >= cumSum)
                     {
-                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
-                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
-                        //  and accepted_ = true prevents it being worked on by ChooseTransitionKernels
-                        ion[accepted_] = true;
+                        setNoChangeTransition(ion);
                     }
                 });
         }

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
@@ -157,15 +157,25 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // get random number
                     float_X const r = rngGeneratorFloat();
 
-                    // compare to cumulative sum of normalized transition rates to find choosen transition
+                    auto const stateTotalLossRate = rateCache.rate(
+                        u32(s_enums::ChooseTransitionGroup::autonomousDownward),
+                        atomicStateCollectionIndex);
 
+                    if(stateTotalLossRate == 0._X)
+                    {
+                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
+                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
+                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
+                        ion[accepted_] = true;
+                        return;
+                    }
+
+                    // compare to cumulative sum of normalized transition rates to find choosen transition
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitionsDown; ++transitionID)
                     {
-                        cumSum += transitionDataBox.rate(transitionID + startIndexTransitionBlock)
-                            / rateCache.rate(
-                                u32(s_enums::ChooseTransitionGroup::autonomousDownward),
-                                atomicStateCollectionIndex);
+                        cumSum
+                            += transitionDataBox.rate(transitionID + startIndexTransitionBlock) / stateTotalLossRate;
 
                         // inclusive limit, to make sure that r==1 is assigned a transition
                         if(r <= cumSum)

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_Autonomous.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre
+/* Copyright 2023-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -26,6 +26,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
+#include "picongpu/particles/atomicPhysics/kernel/UpdateIon.hpp"
 
 #include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/static_assert.hpp>
@@ -163,10 +164,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     if(stateTotalLossRate == 0._X)
                     {
-                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
-                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
-                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
-                        ion[accepted_] = true;
+                        setNoChangeTransition(ion);
                         return;
                     }
 
@@ -194,15 +192,6 @@ namespace picongpu::particles::atomicPhysics::kernel
                         u8(s_enums::ProcessClass::autonomousIonization),
                         startIndexTransitionBlock + numberTransitionsDown - 1u);
                 });
-        }
-
-        template<typename T_Ion>
-        HDINLINE static void updateIon(T_Ion& ion, uint8_t selectedProcessClass, uint32_t selectedTransitionIndex)
-        {
-            ion[processClass_] = selectedProcessClass;
-            ion[transitionIndex_] = selectedTransitionIndex;
-            // autonomous does not require binIndex
-            ion[accepted_] = true;
         }
     };
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
@@ -219,6 +219,19 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // get random number
                     float_X const r = rngGeneratorFloat();
 
+                    // 1/unit_time
+                    auto const stateTotalLossRate
+                        = rateCache.rate(u32(chooseTransitionGroup), atomicStateCollectionIndex);
+
+                    if(stateTotalLossRate == 0._X)
+                    {
+                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
+                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
+                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
+                        ion[accepted_] = true;
+                        return;
+                    }
+
                     // compare to cumulative sum of normalized transition rates to find choosen transition
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
@@ -245,8 +258,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                         atomicStateDataDataBox,
                                         transitionDataBox);
 
-                                cumSum += rateTransition
-                                    / rateCache.rate(u32(chooseTransitionGroup), atomicStateCollectionIndex);
+                                cumSum += rateTransition / stateTotalLossRate;
 
                                 // debug only
                                 if constexpr(picongpu::atomicPhysics::debug::kernel::chooseTransition::
@@ -296,8 +308,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                     atomicStateDataDataBox,
                                     transitionDataBox);
 
-                            cumSum += rateTransition
-                                / rateCache.rate(u32(chooseTransitionGroup), atomicStateCollectionIndex);
+                            cumSum += rateTransition / stateTotalLossRate;
 
                             // debug only
                             if constexpr(picongpu::atomicPhysics::debug::kernel::chooseTransition::

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_BoundBound.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre
+/* Copyright 2023-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -225,10 +225,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     if(stateTotalLossRate == 0._X)
                     {
-                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
-                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
-                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
-                        ion[accepted_] = true;
+                        setNoChangeTransition(ion);
                         return;
                     }
 
@@ -242,7 +239,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                         if constexpr(electronicChannelActive)
                         {
                             // test for each bin separately
-                            for(int binIndex = 0; binIndex < static_cast<int>(T_Histogram::numberBins); ++binIndex)
+                            for(uint32_t binIndex = 0; binIndex < T_Histogram::numberBins; ++binIndex)
                             {
                                 float_X const density = cachedHistogram.density[binIndex];
                                 // 1/sim.unit.time()
@@ -272,7 +269,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                         printf("    stateIndex = %u\n", atomicStateCollectionIndex);
                                         printf("    transitionID = %u\n", transitionID);
                                         printf("    rateTransition = %f\n", rateTransition);
-                                        printf("        binIndex = %i\n", binIndex);
+                                        printf("        binIndex = %u\n", binIndex);
                                         printf("        density = %f\n", density);
                                         printf(
                                             "    rateCache.rate = %.8e\n",
@@ -343,27 +340,26 @@ namespace picongpu::particles::atomicPhysics::kernel
                     }
 
                     // select last resort, choose last possible transition
-                    updateIon(
-                        ion,
-                        s_enums::LastResort<chooseTransitionGroup>::template processClass<T_spontaneousDeexcitation>(),
-                        startIndexTransitionBlock + numberTransitions - 1u,
-                        (isUpward || !T_spontaneousDeexcitation) ? static_cast<int>(T_Histogram::numberBins - 1u)
-                                                                 : -1);
+                    if constexpr(isUpward || !T_spontaneousDeexcitation)
+                    {
+                        // was electronic collisional transition
+                        updateIon(
+                            ion,
+                            s_enums::LastResort<chooseTransitionGroup>::template processClass<
+                                T_spontaneousDeexcitation>(),
+                            startIndexTransitionBlock + numberTransitions - 1u,
+                            T_Histogram::numberBins - 1u);
+                    }
+                    else
+                    {
+                        // was non-collisional
+                        updateIon(
+                            ion,
+                            s_enums::LastResort<chooseTransitionGroup>::template processClass<
+                                T_spontaneousDeexcitation>(),
+                            startIndexTransitionBlock + numberTransitions - 1u);
+                    }
                 });
-        }
-
-        template<typename T_Ion>
-        HDINLINE static void updateIon(
-            T_Ion& ion,
-            uint8_t selectedProcessClass,
-            uint32_t selectedTransitionIndex,
-            int selectedBinIndex = -1)
-        {
-            ion[processClass_] = selectedProcessClass;
-            ion[transitionIndex_] = selectedTransitionIndex;
-            if(electronicChannelActive && (selectedBinIndex != -1))
-                ion[binIndex_] = u32(selectedBinIndex);
-            ion[accepted_] = true;
         }
     };
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre
+/* Copyright 2023-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -207,10 +207,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     if(stateTotalLossrate == 0._X)
                     {
-                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
-                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
-                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
-                        ion[accepted_] = true;
+                        setNoChangeTransition(ion);
                         return;
                     }
 
@@ -262,20 +259,6 @@ namespace picongpu::particles::atomicPhysics::kernel
                         startIndexTransitionBlock + numberTransitions - 1u,
                         numberBins - 1u);
                 });
-        }
-
-        //! update ion with selected transition data
-        template<typename T_Ion>
-        HDINLINE static void updateIon(
-            T_Ion& ion,
-            uint8_t selectedProcessClass,
-            uint32_t selectedTransitionIndex,
-            uint32_t selectedBinIndex)
-        {
-            ion[processClass_] = selectedProcessClass;
-            ion[transitionIndex_] = selectedTransitionIndex;
-            ion[binIndex_] = selectedBinIndex;
-            ion[accepted_] = true;
         }
     };
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
@@ -200,6 +200,20 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // compare to cumulative sum of normalized transition rates to find choosen transition
                     constexpr uint32_t numberBins = T_Histogram::numberBins;
 
+                    // 1/unit_time
+                    auto const stateTotalLossrate = rateCache.rate(
+                        u32(s_enums::ChooseTransitionGroup::collisionalBoundFreeUpward),
+                        atomicStateCollectionIndex);
+
+                    if(stateTotalLossrate == 0._X)
+                    {
+                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
+                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
+                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
+                        ion[accepted_] = true;
+                        return;
+                    }
+
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
                     {
@@ -223,10 +237,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                         atomicStateDataDataBox,
                                         transitionDataBox);
 
-                            cumSum += rateTransition
-                                / rateCache.rate(
-                                    u32(s_enums::ChooseTransitionGroup::collisionalBoundFreeUpward),
-                                    atomicStateCollectionIndex);
+                            cumSum += rateTransition / stateTotalLossrate;
 
                             // inclusive limit, to make sure that r==1 is assigned a transition
                             if(r <= cumSum)

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -167,6 +167,20 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // get random number
                     float_X const r = rngGeneratorFloat();
 
+                    // 1/unit_time
+                    auto const stateTotalLossRate = rateCache.rate(
+                        u32(s_enums::ChooseTransitionGroup::fieldBoundFreeUpward),
+                        atomicStateCollectionIndex);
+
+                    if(stateTotalLossRate == 0._X)
+                    {
+                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
+                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
+                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
+                        ion[accepted_] = true;
+                        return;
+                    }
+
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)
                     {
@@ -189,10 +203,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                                 printf("atomicPhysics ERROR: encountered infinite transition rate in non instant "
                                        "transition ion");
 
-                        cumSum += rateTransition
-                            / rateCache.rate(
-                                u32(s_enums::ChooseTransitionGroup::fieldBoundFreeUpward),
-                                atomicStateCollectionIndex);
+                        cumSum += rateTransition / stateTotalLossRate;
 
                         // inclusive limit, to make sure that r==1 is assigned a transition
                         if(r <= cumSum)

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Brian Marre
+/* Copyright 2024-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -174,10 +174,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     if(stateTotalLossRate == 0._X)
                     {
-                        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
-                        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
-                        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
-                        ion[accepted_] = true;
+                        setNoChangeTransition(ion);
                         return;
                     }
 
@@ -209,21 +206,16 @@ namespace picongpu::particles::atomicPhysics::kernel
                         if(r <= cumSum)
                         {
                             // found chosen transition
-                            ion[processClass_] = u8(s_enums::ProcessClass::fieldIonization);
-                            ion[transitionIndex_] = transitionCollectionIndex;
-                            // field ionizations are not bin based therefore we do not set a bin, and old values are
-                            // ignored
-                            ion[accepted_] = true;
+
+                            // field ionizations are not bin based therefore use non-collision version
+                            updateIon(ion, u8(s_enums::ProcessClass::fieldIonization), transitionCollectionIndex);
                             return;
                         }
                     }
 
                     /* ADK rate for particle cell E-Field below superCell maximum ADK rate
                      * -> need to do noChange Transition for correct division into other channels. */
-                    ion[processClass_] = u8(s_enums::ProcessClass::noChange);
-                    // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
-                    // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
-                    ion[accepted_] = true;
+                    setNoChangeTransition(ion);
                 });
         }
     };

--- a/include/picongpu/particles/atomicPhysics/kernel/UpdateIon.hpp
+++ b/include/picongpu/particles/atomicPhysics/kernel/UpdateIon.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2023-2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
+
+#include <pmacc/attribute/FunctionSpecifier.hpp>
+
+#include <cstdint>
+
+namespace picongpu::particles::atomicPhysics::kernel
+{
+    namespace s_enums = picongpu::particles::atomicPhysics::enums;
+
+    //! set ion to no-change transition
+    template<typename T_Ion>
+    HDINLINE void setNoChangeTransition(T_Ion& ion)
+    {
+        ion[processClass_] = u8(s_enums::ProcessClass::noChange);
+        // no need to set ion[transitionIndex_] since already uniquely known by processClass = noChange
+        // no-change transitions are not bin based therefore we don't set a bin, old values are ignored
+        ion[accepted_] = true;
+    }
+
+    //! update ion with selected transition data, non-collisional version
+    template<typename T_Ion>
+    HDINLINE void updateIon(T_Ion& ion, uint8_t const selectedProcessClass, uint32_t const selectedTransitionIndex)
+    {
+        ion[processClass_] = selectedProcessClass;
+        ion[transitionIndex_] = selectedTransitionIndex;
+        // no need to set bin index for non-collisional transitions
+        ion[accepted_] = true;
+    }
+
+    //! update ion with selected transition data, collisional version
+    template<typename T_Ion>
+    HDINLINE static void updateIon(
+        T_Ion& ion,
+        uint8_t const selectedProcessClass,
+        uint32_t const selectedTransitionIndex,
+        uint32_t const selectedBinIndex)
+    {
+        updateIon(ion, selectedProcessClass, selectedTransitionIndex);
+        ion[binIndex_] = selectedBinIndex;
+    }
+} // namespace picongpu::particles::atomicPhysics::kernel


### PR DESCRIPTION
fixes a division by zero in the choose transition kernels if the rate cache entry for the state happens to be zero.

- [x] requires PR #5284 to be merged first
- [x] requires PR #5285 to be merged first
- [x] needs to be rebased to dev
