### PR TITLE
Harden cut command in Snakefiles

### DIFF
--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile
@@ -70,13 +70,13 @@ rule simulate:
             sbatch {input}/tbg/submit.start > simulated/job_id_{params.name}.txt
         fi
 
-        job_id=$(cut -c 21-27 simulated/job_id_{params.name}.txt)
+        job_id=$(cut -d' ' -f4 simulated/job_id_{params.name}.txt)
         status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
 
         # if job isn't running, pending or configuring -> restart job
         if ! [[ "$status" == "PD" || "$status" == "R " || "$status" == "CF" ]]; then
             sbatch {input}/tbg/submit.start >  simulated/job_id_{params.name}.txt
-            job_id=$(cut -c 21-27 simulated/job_id_{params.name}.txt)
+            job_id=$(cut -d' ' -f4 simulated/job_id_{params.name}.txt)
             status=$(squeue --jobs $job_id -o "%2t" | tail -n 1 )
         fi
         # wait till job is finished

--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile_LSF
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile_LSF
@@ -77,13 +77,13 @@ rule simulate:
             bsub {input}/tbg/submit.start > simulated/job_id_{params.name}.txt
         fi
 
-        job_id=$(cut -c 6-12 simulated/job_id_{params.name}.txt)
+        job_id=$(cut -d'<' -f2 simulated/job_id_{params.name}.txt | cut -d'>' -f1)
         status=$(bjobs -noheader -o stat:4 $job_id)
 
         # if job isn't running or pending -> restart job
         if ! [[ "$status" == "PEND" || "$status" == "RUN " ]]; then
             bsub {input}/tbg/submit.start >  simulated/job_id_{params.name}.txt
-            job_id=$(cut -c 6-12 simulated/job_id_{params.name}.txt)
+            job_id=$(cut -d'<' -f2 simulated/job_id_{params.name}.txt | cut -d'>' -f1)
             status=$(bjobs -noheader -o stat:4 $job_id)
         fi
         # wait till job is finished


### PR DESCRIPTION
Found this bug with Arthur. Hemera just hit the next digit in job ids and these `cut` commands were not up to that challenge. The one for LSF is an educated guess from what the internet says the output should look like. I think I've never run on an LSF cluster.