### PR TITLE
Fix variable-length-array warning clang18

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -426,13 +426,13 @@ namespace picongpu
                     }
 
                     // @todo combine this and the MPI_Gather above to a single gather for better scaling
-                    uint64_t numRounds[mpiSize];
+                    std::vector<uint64_t> numRounds(mpiSize);
 
                     MPI_CHECK(MPI_Allgather(
                         &requiredDumpRounds,
                         1,
                         MPI_UNSIGNED_LONG_LONG,
-                        numRounds,
+                        numRounds.data(),
                         1,
                         MPI_UNSIGNED_LONG_LONG,
                         gc.getCommunicator().getMPIComm()));


### PR DESCRIPTION
The PR fixes a warning triggered by variable length arrays in Clang 18:
```make
In file included from /ccs/home/adebus/src/picongpu/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp:50:
/ccs/home/adebus/src/picongpu/include/picongpu/../picongpu/plugins/openPMD/WriteSpecies.hpp:429:40: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
  429 |                     uint64_t numRounds[mpiSize];
      |                                        ^~~~~~~
/ccs/home/adebus/src/picongpu/include/picongpu/../picongpu/plugins/openPMD/WriteSpecies.hpp:429:40: note: read of non-const variable 'mpiSize' is not allowed in a constant expression
/ccs/home/adebus/src/picongpu/include/picongpu/../picongpu/plugins/openPMD/WriteSpecies.hpp:342:26: note: declared here
  342 |                 uint64_t mpiSize = gc.getGlobalSize();
      |                          ^
```