### PR TITLE
Add picmi custom templates

### DIFF
--- a/docs/source/usage/picmi/custom_template.rst
+++ b/docs/source/usage/picmi/custom_template.rst
@@ -20,6 +20,8 @@ Fundamentally there are three different approaches to custom template, differing
 - variable custom templates utilising custom user input
 
 To get started take a look at the examples below, have a look at :ref:`step-by-step guide <step_by_step>`, or at the detailed :ref:`rendering example <pypicongpu-translation-example-boundingbox>` in the developer documentation.
+Alternatively, you can jump right in and have a look at the `laser_wakefield example <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/share/picongpu/pypicongpu/examples/laser_wakefield>`
+utilising custom user input and custom templates.
 
 Step-by-Step Guide
 ------------------

--- a/lib/python/picongpu/pypicongpu/customuserinput.py
+++ b/lib/python/picongpu/pypicongpu/customuserinput.py
@@ -59,6 +59,19 @@ class InterfaceCustomUserInput(RenderedObject, pydantic.BaseModel):
         raise NotImplementedError("Abstract Interface only!")
 
 
+def recursively_replace_bools_with_str(dictionary):
+    """
+    Recursively replace bools with strings
+
+    This is necessary because Python bools render as capital "True"/"False" while C++ needs "true"/"false"
+    """
+    if isinstance(dictionary, dict):
+        return {key: recursively_replace_bools_with_str(value) for key, value in dictionary.items()}
+    if isinstance(dictionary, bool):
+        return "true" if dictionary else "false"
+    return dictionary
+
+
 class CustomUserInput(InterfaceCustomUserInput):
     """
     container for easy passing of additional input as dict from user script to rendering context of simulation input
@@ -104,7 +117,7 @@ class CustomUserInput(InterfaceCustomUserInput):
 
     def _get_serialized(self) -> dict[str, typing.Any]:
         self.check()
-        return self.rendering_context
+        return recursively_replace_bools_with_str(self.rendering_context)
 
     def get_generic_rendering_context(self) -> dict[str, typing.Any]:
         return self.get_rendering_context()

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/etc/picongpu/N.cfg.mustache
@@ -111,6 +111,7 @@ pypicongpu_output_with_newlines="
         --openPMD.period {{{customuserinput.openPMD_period}}}
         --openPMD.file {{{customuserinput.openPMD_file}}}
         --openPMD.ext {{{customuserinput.openPMD_extension}}}
+        --openPMD.dataPreparationStrategy {{{customuserinput.openPMD_dataPreparationStrategy}}}
 
         --checkpoint.backend {{{customuserinput.checkpoint_backend}}}
         --checkpoint.period {{{customuserinput.checkpoint_period}}}

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/etc/picongpu/N.cfg.mustache
@@ -1,0 +1,182 @@
+# Copyright 2013-2025 Axel Huebl, Rene Widera, Felix Schmitt, Franz Poeschel,
+#                     Hannes Tropegen, Brian Marre, Masoud Afshari, Julian Lenz
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+# enable unbound variable safeguard
+# see `set --help` for explanation on shell flags
+# here used: u (`set -u`) which make the shell crash on undefined variables
+#
+# This defines a command to be executed after this script which restores
+# the shell option "u" to its previous state
+if [[ "$-" =~ ^.*u.*$ ]]
+then
+    SHELL_OPT_U_RESTORE='set -u'
+else
+    SHELL_OPT_U_RESTORE='set +u'
+fi
+
+set -u
+# -> unbound vars will now raise error
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="1:00:00"
+
+{{#grid.gpu_cnt}}
+  TBG_devices_x={{{x}}}
+  TBG_devices_y={{{y}}}
+  TBG_devices_z={{{z}}}
+{{/grid.gpu_cnt}}
+
+{{#grid.cell_cnt}}
+  TBG_gridSize="{{{x}}} {{{y}}} {{{z}}}"
+{{/grid.cell_cnt}}
+
+TBG_steps="{{{time_steps}}}"
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+{{#grid.boundary_condition}}
+  TBG_periodic="--periodic {{{x}}} {{{y}}} {{{z}}}"
+{{/grid.boundary_condition}}
+
+{{#output.auto}}
+# only use charge conservation if solver is yee AND using cuda backend
+if [[ "Yee" = "{{{solver.name}}}" ]] && [[ "$PIC_BACKEND" =~ ^cuda(:.+)?$ ]]
+then
+    USED_CHARGE_CONSERVATION_FLAGS="--chargeConservation.period {{{period}}}"
+else
+    USED_CHARGE_CONSERVATION_FLAGS=""
+fi
+{{/output.auto}}
+
+{{#moving_window}}
+  TBG_movingWindow="-m"
+  TBG_windowMovePoint="--windowMovePoint {{{move_point}}}"
+  {{#stop_iteration}}
+    TBG_stopWindow="--stopWindow {{{stop_iteration}}}"
+  {{/stop_iteration}}
+{{/moving_window}}
+
+pypicongpu_output_with_newlines="
+  {{#customuserinput}}
+
+        --{{{customuserinput.png_plugin_species_name}}}_png.period {{{customuserinput.png_plugin_period}}}
+        --{{{customuserinput.png_plugin_species_name}}}_png.axis {{{customuserinput.png_plugin_axis}}}
+        --{{{customuserinput.png_plugin_species_name}}}_png.slicePoint {{{customuserinput.png_plugin_slicePoint}}}
+        --{{{customuserinput.png_plugin_species_name}}}_png.folder {{{customuserinput.png_plugin_folder_name}}}
+
+        --{{{customuserinput.energy_histogram_species_name}}}_energyHistogram.period {{{customuserinput.energy_histogram_period}}}
+        --{{{customuserinput.energy_histogram_species_name}}}_energyHistogram.binCount {{{customuserinput.energy_histogram_bin_count}}}
+        --{{{customuserinput.energy_histogram_species_name}}}_energyHistogram.minEnergy {{{customuserinput.energy_histogram_min_energy}}}
+        --{{{customuserinput.energy_histogram_species_name}}}_energyHistogram.maxEnergy {{{customuserinput.energy_histogram_max_energy}}}
+        --{{{customuserinput.energy_histogram_species_name}}}_energyHistogram.filter {{{customuserinput.energy_histogram_filter}}}
+
+         --{{{customuserinput.phase_space_species_name}}}_phaseSpace.period {{{customuserinput.phase_space_period}}}
+         --{{{customuserinput.phase_space_species_name}}}_phaseSpace.space {{{customuserinput.phase_space_space}}}
+         --{{{customuserinput.phase_space_species_name}}}_phaseSpace.momentum {{{customuserinput.phase_space_momentum}}}
+         --{{{customuserinput.phase_space_species_name}}}_phaseSpace.min {{{customuserinput.phase_space_min}}}
+         --{{{customuserinput.phase_space_species_name}}}_phaseSpace.max {{{customuserinput.phase_space_max}}}
+         --{{{customuserinput.phase_space_species_name}}}_phaseSpace.filter {{{customuserinput.phase_space_filter}}}
+
+        --openPMD.period {{{customuserinput.openPMD_period}}}
+        --openPMD.file {{{customuserinput.openPMD_file}}}
+        --openPMD.ext {{{customuserinput.openPMD_extension}}}
+
+        --checkpoint.backend {{{customuserinput.checkpoint_backend}}}
+        --checkpoint.period {{{customuserinput.checkpoint_period}}}
+        --checkpoint.restart.backend {{{customuserinput.checkpoint_restart_backend}}}
+
+        --{{{customuserinput.macro_particle_count_species_name}}}_macroParticlesCount.period {{{customuserinput.macro_particle_count_period}}}
+  {{/customuserinput}}
+  {{^customuserinput}}
+      {{#output.auto}}
+        --fields_energy.period {{{period}}}
+        --sumcurr.period {{{period}}}
+        $USED_CHARGE_CONSERVATION_FLAGS
+
+        {{#species_initmanager.species}}
+            --{{{name}}}_macroParticlesCount.period {{{period}}}
+
+            --{{{name}}}_energy.period {{{period}}}
+            --{{{name}}}_energy.filter all
+
+            --{{{name}}}_energyHistogram.period {{{period}}}
+            --{{{name}}}_energyHistogram.filter all
+            --{{{name}}}_energyHistogram.binCount 1024
+            --{{{name}}}_energyHistogram.minEnergy 0
+            --{{{name}}}_energyHistogram.maxEnergy 256000
+
+            {{#png_axis}}
+                --{{{name}}}_png.period {{{period}}}
+                --{{{name}}}_png.axis {{{axis}}}
+                --{{{name}}}_png.slicePoint 0.5
+                --{{{name}}}_png.folder png_{{{name}}}_{{{axis}}}
+            {{/png_axis}}
+        {{/species_initmanager.species}}
+
+      {{/output.auto}}
+    {{/customuserinput}}
+  "
+
+# remove newlines
+TBG_pypicongpu_output=$(sed -z 's/\n/ /g' <<< "$pypicongpu_output_with_newlines")
+
+TBG_plugins="!TBG_pypicongpu_output"
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist   \
+                   -g !TBG_gridSize     \
+                   -s !TBG_steps        \
+                   !TBG_periodic        \
+                   !TBG_plugins         \
+                {{#moving_window}}
+                   !TBG_movingWindow    \
+                   !TBG_windowMovePoint \
+                  {{#stop_iteration}}
+                   !TBG_stopWindow      \
+                  {{/stop_iteration}}
+                {{/moving_window}}
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+# restore shell opt u to previous state
+$SHELL_OPT_U_RESTORE
+
+"$TBG_cfgPath"/submitAction.sh

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/etc/picongpu/N.cfg.mustache
@@ -116,6 +116,7 @@ pypicongpu_output_with_newlines="
         --checkpoint.backend {{{customuserinput.checkpoint_backend}}}
         --checkpoint.period {{{customuserinput.checkpoint_period}}}
         --checkpoint.restart.backend {{{customuserinput.checkpoint_restart_backend}}}
+        --checkpoint.openPMD.dataPreparationStrategy {{{customuserinput.checkpoint_openPMD_dataPreparationStrategy}}}
 
         --{{{customuserinput.macro_particle_count_species_name}}}_macroParticlesCount.period {{{customuserinput.macro_particle_count_period}}}
   {{/customuserinput}}

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/density.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/density.param.mustache
@@ -1,0 +1,151 @@
+/* Copyright 2013-2025 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+ *                     Richard Pausch, Marco Garten, Brian Marre, Kristin Tippey
+ *                     Hannes Troepgen, Masoud Afshari, Julian Lenz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/densityProfiles/profiles.def"
+#include "picongpu/particles/traits/GetDensityRatio.hpp"
+
+namespace picongpu
+{
+    namespace densityProfiles::pypicongpu
+    {
+        {{#species_initmanager.operations.simple_density}}
+        // a species has always only exactly one profile, so only one of the following blocks below will be present
+
+          {{#profile.type.gaussian}}
+            /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
+             *
+             * @note the density may be further modified from this profile by the densityRatio of the species, set in
+             *  the init-pipeline.
+             */
+            struct init_{{{placed_species_initial.typename}}}_GaussianParam
+            {
+                static constexpr float_X gasFactor = {{{profile.data.gas_factor}}};
+                static constexpr float_X gasPower  = {{{profile.data.gas_power}}};
+
+                //! height of vacuum area on top border, unit: cells
+                static constexpr uint32_t vacuumCellsY = {{{profile.data.vacuum_cells_front}}};
+
+                //! The edges of the constant center of the profile, unit: meter
+                static constexpr float_64 gasCenterLeft_SI  = {{{profile.data.gas_center_front}}};
+                static constexpr float_64 gasCenterRight_SI = {{{profile.data.gas_center_rear}}};
+
+                /** the distance from gasCenter_SI until the gas density decreases to its 1/e-th part
+                 *  unit: meter
+                 */
+                static constexpr float_64 gasSigmaLeft_SI  = {{{profile.data.gas_sigma_front}}};
+                static constexpr float_64 gasSigmaRight_SI = {{{profile.data.gas_sigma_rear}}};
+
+                //! factor to multiply BASE_DENSITY_SI by to get density
+                static constexpr float_X densityFactor
+                    = static_cast<float_X>({{{profile.data.density}}} / SI::BASE_DENSITY_SI);
+            };
+
+            using init_{{{placed_species_initial.typename}}} = GaussianImpl<init_{{{placed_species_initial.typename}}}_GaussianParam>;
+          {{/profile.type.gaussian}}
+
+          {{#profile.type.uniform}}
+            /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
+             *
+             * @note the density may be further modified from this profile by the densityRatio of the species set in the
+             *  init-pipeline.
+             */
+            struct init_{{{placed_species_initial.typename}}}_functor
+            {
+                /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
+                 *
+                 * @note the density may be further modified from this profile by the densityRatio of the species, set in
+                 *  the init-pipeline.
+                 */
+                HDINLINE float_X operator()(const floatD_64& position_SI, const float3_64& cellSize_SI)
+                {
+                    //! @todo respect bounding box, Brian Marre, 2023
+                    return static_cast<float_X>({{{profile.data.density_si}}} / SI::BASE_DENSITY_SI);
+                }
+            };
+            using init_{{{placed_species_initial.typename}}} = FreeFormulaImpl<init_{{{placed_species_initial.typename}}}_functor>;
+          {{/profile.type.uniform}}
+
+          {{#profile.type.foil}}
+            /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
+             *
+             * @note the density may be further modified from this profile by the densityRatio of the species, set in
+             *  the init-pipeline.
+             */
+            struct init_{{{placed_species_initial.typename}}}_functor
+            {
+                HDINLINE float_X operator()(const floatD_64& position_SI, const float3_64& cellSize_SI)
+                {
+                    //! @todo respect bounding box, Brian Marre, 2023
+                    float_64 const y = position_SI.y(); // m
+                    float_X dens = 0._X; // in units of BASE_DENSITY_SI
+
+                    // begin & end plateau of foil
+                    constexpr float_64 y0 = {{{profile.data.y_value_front_foil_si}}};
+                    constexpr float_64 y1 = y0 + {{{profile.data.thickness_foil_si}}};
+
+                    // prePlasma ramp
+                    {{#profile.data.pre_foil_plasmaRamp.type.exponential}}
+                        // exponential pre-expanded density ramp before plateau of foil
+                        constexpr float_64 prePlasmaLength = {{{profile.data.pre_foil_plasmaRamp.data.PlasmaLength}}};
+                        constexpr float_64 prePlasmaCutoff = {{{profile.data.pre_foil_plasmaRamp.data.PlasmaCutoff}}};
+
+                        // prefoil upramp
+                        if((y < y0) &&  y > y0 - prePlasmaCutoff)
+                            dens = static_cast<float_X>({{{profile.data.density_si}}} / SI::BASE_DENSITY_SI)
+                                * math::exp((y - y0) / prePlasmaLength);
+                    {{/profile.data.pre_foil_plasmaRamp.type.exponential}}
+
+                    {{#profile.data.pre_foil_plasmaRamp.type.none}}
+                        // no prePlasma ramp
+                    {{/profile.data.pre_foil_plasmaRamp.type.none}}
+
+                    // postPlasma ramp
+                    {{#profile.data.post_foil_plasmaRamp.type.exponential}}
+                        // exponential pre-expanded density ramp after plateau of foil
+                        constexpr float_64 postPlasmaLength = {{{profile.data.post_foil_plasmaRamp.data.PlasmaLength}}};
+                        constexpr float_64 postPlasmaCutoff = {{{profile.data.post_foil_plasmaRamp.data.PlasmaCutoff}}};
+                    // postfoil downramp
+                        if(y > y1 && y < y1 + postPlasmaCutoff)
+                            dens = static_cast<float_X>({{{profile.data.density_si}}} / SI::BASE_DENSITY_SI)
+                                * math::exp((y1 - y) / postPlasmaLength);
+                    {{/profile.data.post_foil_plasmaRamp.type.exponential}}
+
+                    {{#profile.data.post_foil_plasmaRamp.type.none}}
+                        // no postPlasma ramp
+                    {{/profile.data.post_foil_plasmaRamp.type.none}}
+
+                    // foil plateau
+                    if(y >= y0 && y <= y1)
+                        dens = static_cast<float_X>({{{profile.data.density_si}}} / SI::BASE_DENSITY_SI);
+
+                    // safety check: all parts of the function MUST be > 0
+                    dens *= float_64(dens >= 0.0);
+                    return dens;
+                }
+            };
+            using init_{{{placed_species_initial.typename}}} = FreeFormulaImpl<init_{{{placed_species_initial.typename}}}_functor>;
+          {{/profile.type.foil}}
+
+        {{/species_initmanager.operations.simple_density}}
+    } // namespace densityProfiles::pypicongpu
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/fieldSolver.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/fieldSolver.param.mustache
@@ -1,0 +1,57 @@
+/* Copyright 2013-2025 Axel Huebl, Heiko Burau, Rene Widera, Sergei Bastrakov,
+ *                     Klaus Steiniger, Hannes Troepgen
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Configure the field solver.
+ *
+ * Select the numerical Maxwell solver (e.g. Yee's method).
+ *
+ * \attention
+ * Currently, the laser initialization in PIConGPU is implemented to work with the standard Yee solver.
+ * Using a solver of higher order will result in a slightly increased laser amplitude and energy than expected.
+ *
+ */
+
+#pragma once
+
+#include "picongpu/fields/MaxwellSolver/Solvers.def"
+
+namespace picongpu
+{
+    namespace fields
+    {
+        /** FieldSolver
+         *
+         * Field Solver Selection (note <> for some solvers):
+         *  - Yee : Standard Yee solver approximating derivatives with respect to time and
+         * space by second order finite differences.
+         *  - Lehe<>: Num. Cherenkov free field solver in a chosen direction
+         *  - ArbitraryOrderFDTD<4>: Solver using 4 neighbors to each direction to approximate
+         * *spatial* derivatives by finite differences. The number of neighbors can be changed from 4 to any positive,
+         * integer number. The order of the solver will be twice the number of neighbors in each direction. Yee's
+         * method is a special case of this using one neighbor to each direction.
+         *  - None: disable the vacuum update of E and B
+         */
+
+        using Solver = maxwellSolver::{{{solver.name}}};
+
+    } // namespace fields
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/incidentField.param.mustache
@@ -1,0 +1,199 @@
+/* Copyright 2020-2025 Sergei Bastrakov, Rene Widera, Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file incidentField.param
+ *
+ * Configure incident field profile and offset of the Huygens surface for each boundary.
+ *
+ * Available profiles:
+ *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
+ * in focus. That is, SD, AD, GDD, and TOD, respectively.
+ *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
+ *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
+ *  - profiles::None                  : no incident field
+ *  - profiles::PlaneWave<>           : plane wave profile with given parameters
+ *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
+ * parameters
+ *  - profiles::PulseFrontTilt<>      : GaussianPulse with tilted pulse front with given parameters
+ *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
+ * parameters
+ *
+ * All profiles but `Free<>` and `None` are parametrized with a profile-specific structure.
+ * Their interfaces are defined in the corresponding `.def` files inside directory
+ * picongpu/fields/incidentField/profiles/. Note that all these parameter structures inherit common base structures
+ * from `BaseParam.def`. Thus, a user-provided structure must also define all members according to the base struct.
+ *
+ * In the end, this file needs to define `XMin`, `XMax`, `YMin`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
+ * in 2d) type aliases in namespace `picongpu::fields::incidentField`. Each of them could be a single profile or a
+ * typelist of profiles created with `MakeSeq_t`. In case a typelist is used, the resulting field is a sum of
+ * effects of all profiles in the list. This file also has to define constexpr array `POSITION` that controls
+ * positioning of the generating surface relative to total domain. For example:
+ *
+ * @code{.cpp}
+ * using XMin = profiles::Free<UserFunctorIncidentE, UserFunctorIncidentB>;
+ * using XMax = profiles::None;
+ * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
+ * using YMax = profiles::None;
+ * using ZMin = profiles::Polynom<UserPolynomParams>;
+ * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
+ *
+ * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
+ * @endcode
+ */
+
+#pragma once
+
+#include "picongpu/fields/incidentField/profiles/profiles.def"
+
+namespace picongpu::fields::incidentField
+{
+    {{#laser}}
+    /** Base structure for parameters of all lasers
+     *
+     * The particular used parameter structures do not have to inherit this, but must define same members
+     * with same meaning.
+     */
+    struct PyPIConGPULaserBaseParam : profiles::BaseParam
+    {
+        static constexpr float_64 WAVE_LENGTH_SI = {{{wave_length_si}}}; // m
+        static constexpr float_64 AMPLITUDE_SI = {{{E0_si}}}; // V/m
+        static constexpr float_64 PULSE_DURATION_SI = {{{pulse_duration_si}}}; // s (1 sigma)
+        static constexpr float_X LASER_PHASE = {{{phase}}}; // unitless
+
+        static constexpr float_64 propagation_direction[3u] = {
+                {{#propagation_direction}}
+                {{{component}}}{{^_last}},{{/_last}}
+                {{/propagation_direction}}
+            };
+        static constexpr float_64 DIRECTION_X = propagation_direction[0];
+        static constexpr float_64 DIRECTION_Y = propagation_direction[1];
+        static constexpr float_64 DIRECTION_Z = propagation_direction[2];
+
+        static constexpr float_64 focus_position[3u] = {
+                {{#focus_pos_si}}
+                {{{component}}}{{^_last}},{{/_last}}
+                {{/focus_pos_si}}
+            };
+        static constexpr float_64 FOCUS_POSITION_X_SI = focus_position[0];
+        static constexpr float_64 FOCUS_POSITION_Y_SI = focus_position[1];
+        static constexpr float_64 FOCUS_POSITION_Z_SI = focus_position[2];
+
+        static constexpr PolarisationType Polarisation = PolarisationType::{{{polarization_type}}};
+
+        static constexpr float_64 polarisation_direction[3u] = {
+                {{#polarization_direction}}
+                {{{component}}}{{^_last}},{{/_last}}
+                {{/polarization_direction}}
+            };
+        static constexpr float_64 POLARISATION_DIRECTION_X = polarisation_direction[0];
+        static constexpr float_64 POLARISATION_DIRECTION_Y = polarisation_direction[1];
+        static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
+    };
+
+    struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
+    {
+        /** Beam waist: distance from the axis where the pulse intensity (E^2)
+         *              decreases to its 1/e^2-th part,
+         *              at the focus position of the laser
+         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+         *                             [   1.17741    ]
+         *
+         * unit: meter
+         */
+        static constexpr float_64 W0_SI = {{{waist_si}}};
+
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
+         *
+         *  unit: none
+         */
+        static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
+
+        /** Laguerre mode parameters
+         *
+         * @{
+         */
+        static constexpr uint32_t numModes = {{{modenumber}}};
+        static constexpr auto laguerreModes = floatN_X<numModes+1>(
+            {{#laguerre_modes}}
+            {{{single_laguerre_mode}}}{{^_last}},{{/_last}}
+            {{/laguerre_modes}}
+            );
+        static constexpr auto laguerrePhases = floatN_X<numModes+1>(
+            {{#laguerre_phases}}
+            {{{single_laguerre_phase}}}{{^_last}},{{/_last}}
+            {{/laguerre_phases}}
+            );
+        /** @} */
+    };
+
+    /** Position in cells of the Huygens surface relative to start of the total domain
+     *
+     * The position is set as an offset, in cells, counted from the start of the total domain.
+     * For the max boundaries, negative position values are allowed.
+     * These negative values are treated as position at (global_domain_size[d] + POSITION[d][1]).
+     * It is also possible to specify the position explicitly as a positive number.
+     * Then it is on a user to make sure the position is correctly calculated wrt the grid size.
+     *
+     * Except moving window simulations, the position must be inside the global domain.
+     * The distance between the Huygens surface and each global domain boundary must be at least
+     * absorber_thickness + (FDTD_spatial_order / 2 - 1). However beware of setting position = direction *
+     * (absorber_thickness + const), as then changing absorber parameters will affect laser positioning.
+     * When all used profiles are None, the check for POSITION validity is skipped.
+     *
+     * For moving window simulations, POSITION for the YMax side can be located outside the initially
+     * simulated volume. In this case, parts of the generation surface outside of the currently simulated
+     * volume is are treated as if they had zero incident field and it is user's responsibility to apply a
+     * source matching such a case.
+     */
+    constexpr int32_t POSITION[3][2] = {
+        {{#huygens_surface_positions}}
+        {{#row_x}}
+            { {{{negative}}}, {{{positive}}} },
+        {{/row_x}}
+        {{#row_y}}
+            { {{{negative}}}, {{{positive}}} },
+        {{/row_y}}
+        {{#row_z}}
+            { {{{negative}}}, {{{positive}}} }
+        {{/row_z}}
+        {{/huygens_surface_positions}}
+    };
+
+    /**@{*/
+    //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
+    using YMin = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>;
+    {{/laser}}
+    {{^laser}}
+    // no laser defined case
+    constexpr int32_t POSITION[3][2] = {
+                {16, -16}, // x direction [negative, positive]
+                {16, -16}, // y direction [negative, positive]
+                {16, -16} // z direction [negative, positive]
+    };
+
+    using YMin = profiles::None;
+    {{/laser}}
+    using XMin = profiles::None;
+    using XMax = profiles::None;
+    using YMax = profiles::None;
+    using ZMin = profiles::None;
+    using ZMax = profiles::None;
+    /**@}*/
+} // namespace picongpu::fields::incidentField

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/memory.param
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/memory.param
@@ -1,0 +1,120 @@
+/* Copyright 2013-2025 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Define low-level memory settings for compute devices.
+ *
+ * Settings for memory layout for supercells and particle frame-lists,
+ * data exchanges in multi-device domain-decomposition and reserved
+ * fields for temporarily derived quantities are defined here.
+ */
+
+#pragma once
+#include <pmacc/mappings/kernel/MappingDescription.hpp>
+#include <pmacc/math/Vector.hpp>
+
+#include <array>
+
+
+namespace picongpu
+{
+    /* We have to hold back 350MiB for gpu-internal operations:
+     *   - random number generator
+     *   - reduces
+     *   - ...
+     */
+    constexpr size_t reservedGpuMemorySize = 350 * 1024 * 1024;
+
+    /* short namespace*/
+    namespace mCT = pmacc::math::CT;
+    /** size of a superCell
+     *
+     * volume of a superCell must be <= 1024
+     */
+    using SuperCellSize = typename mCT::shrinkTo<mCT::Int<8, 8, 4>, simDim>::type;
+
+    /** number of slots for particles within a frame */
+    static constexpr uint32_t numFrameSlots = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+    /** define mapper which is used for kernel call mappings */
+    using MappingDesc = MappingDescription<simDim, SuperCellSize>;
+
+    /** define the size of the core, border and guard area
+     *
+     * PIConGPU uses spatial domain-decomposition for parallelization
+     * over multiple devices with non-shared memory architecture.
+     * The global spatial domain is organized per device in three
+     * sections: the GUARD area contains copies of neighboring
+     * devices (also known as "halo"/"ghost").
+     * The BORDER area is the outermost layer of cells of a device,
+     * equally to what neighboring devices see as GUARD area.
+     * The CORE area is the innermost area of a device. In union with
+     * the BORDER area it defines the "active" spatial domain on a device.
+     *
+     * GuardSize is defined in units of SuperCellSize per dimension.
+     */
+    using GuardSize = typename mCT::shrinkTo<mCT::Int<1, 1, 1>, simDim>::type;
+
+    /** bytes reserved for species exchange buffer
+     *
+     * This is the default configuration for species exchanges buffer sizes.
+     * The default exchange buffer sizes can be changed per species by adding
+     * the alias exchangeMemCfg with similar members like in DefaultExchangeMemCfg
+     * to its flag list.
+     */
+    struct DefaultExchangeMemCfg
+    {
+        // memory used for a direction
+        static constexpr uint32_t BYTES_EXCHANGE_X = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Y = 3 * 1024 * 1024; // 3 MiB
+        static constexpr uint32_t BYTES_EXCHANGE_Z = 1 * 1024 * 1024; // 1 MiB
+        static constexpr uint32_t BYTES_EDGES = 32 * 1024; // 32 kiB
+        static constexpr uint32_t BYTES_CORNER = 8 * 1024; // 8 kiB
+
+        /** Reference local domain size
+         *
+         * The size of the local domain for which the exchange sizes `BYTES_*` are configured for.
+         * The required size of each exchange will be calculated at runtime based on the local domain size and the
+         * reference size. The exchange size will be scaled only up and not down. Zero means that there is no reference
+         * domain size, exchanges will not be scaled.
+         */
+        using REF_LOCAL_DOM_SIZE = mCT::Int<0, 0, 0>;
+        /** Scaling rate per direction.
+         *
+         * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
+         * domain size.
+         */
+        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{0.0, 0.0, 0.0}};
+    };
+
+    /** number of scalar fields that are reserved as temporary fields */
+    constexpr uint32_t fieldTmpNumSlots = 2;
+
+    /** can `FieldTmp` gather neighbor information
+     *
+     * If `true` it is possible to call the method `asyncCommunicationGather()`
+     * to copy data from the border of neighboring GPU into the local guard.
+     * This is also known as building up a "ghost" or "halo" region in domain
+     * decomposition and only necessary for specific algorithms that extend
+     * the basic PIC cycle, e.g. with dependence on derived density or energy fields.
+     */
+    constexpr bool fieldTmpSupportGatherCommunication = true;
+
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/particle.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/particle.param.mustache
@@ -1,0 +1,125 @@
+/* Copyright 2013-2025 Axel Huebl, Rene Widera, Marco Garten, Benjamin Worpitz,
+ *                     Richard Pausch, Masoud Afshari
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <picongpu/unitless/precision.unitless>
+
+#include "picongpu/particles/manipulators/manipulators.def"
+#include "picongpu/particles/startPosition/functors.def"
+
+#include <pmacc/math/operation.hpp>
+
+#include <picongpu/pypicongpu/util.hpp>
+
+
+namespace picongpu
+{
+    namespace particles
+    {
+        /** a particle with a weighting below MIN_WEIGHTING will not
+         *      be created / will be deleted
+         *  unit: none
+         */
+        {{#customuserinput}}
+        constexpr float_X MIN_WEIGHTING = {{{minimum_weight}}};
+        {{/customuserinput}}
+        {{^customuserinput}}
+        constexpr float_X MIN_WEIGHTING = 1.0_X;
+        {{/customuserinput}}
+
+        namespace startPosition
+        {
+            namespace pypicongpu
+            {
+                {{#species_initmanager.operations.simple_density}}
+                    struct random_ppc_{{{placed_species_initial.typename}}}
+                    {
+                        /** Maximum number of macro-particles per cell during density profile evaluation.
+                         *
+                         * Determines the weighting of a macro particle as well as the number of
+                         * macro-particles which sample the evolution of the particle distribution
+                         * function in phase space.
+                         *
+                         * unit: none
+                         */
+                        static constexpr uint32_t numParticlesPerCell = {{{ppc}}};
+                    };
+                    using init_{{{placed_species_initial.typename}}} = RandomImpl<random_ppc_{{{placed_species_initial.typename}}}>;
+                {{/species_initmanager.operations.simple_density}}
+            } // namespace pypicongpu
+        } // namespace startPosition
+
+        /** Approximate number of maximum macro-particles per cell.
+         *
+         * Used internally for unit normalization.
+         */
+        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = {{{typical_ppc}}}u;
+
+        namespace manipulators
+        {
+            namespace pypicongpu {
+                {{#species_initmanager.operations.simple_momentum}}
+                    {{! note: this is a loop }}
+                    {{! -> there can be multiple "simple momentum"s }}
+
+                    {{#drift}}
+                        {{! note: this is an "if" condition }}
+                        {{! -> simple momentum does not require a drift }}
+
+                        struct AssignDrift_{{{species.typename}}}_Param
+                        {
+                            /** Initial particle drift velocity for electrons and ions
+                             *  Examples:
+                             *    - No drift is equal to 1.0
+                             *  unit: none
+                             */
+                            static constexpr float_64 gamma = {{{gamma}}};
+
+                            {{#direction_normalized}}
+                                {{! this only serves to enter the "direction_normalized" context}}
+
+                                //! Define initial particle drift direction vector.
+                                static constexpr auto driftDirection = float3_X({{{x}}}, {{{y}}}, {{{z}}});
+                            {{/direction_normalized}}
+                        };
+                        using AssignDrift_{{{species.typename}}} = unary::Drift<AssignDrift_{{{species.typename}}}_Param, pmacc::math::operation::Assign>;
+                    {{/drift}}
+
+                    {{#temperature}}
+                        {{! note: this is an "if" condition }}
+                        {{! -> simple momentum does not require a temperature }}
+                            struct AddTemperature_{{{species.typename}}}_Param
+                            {
+                                //! Initial temperature, unit: keV
+                                static constexpr float_64 temperature = {{{temperature_kev}}};
+                            };
+                            using AddTemperature_{{{species.typename}}} = unary::Temperature<AddTemperature_{{{species.typename}}}_Param>;
+                    {{/temperature}}
+                {{/species_initmanager.operations.simple_momentum}}
+
+                {{#species_initmanager.operations.set_charge_state}}
+                    //! definition of PreIonized manipulator
+                    using PreIonize_{{{species.typename}}} = unary::ChargeState<{{{charge_state}}}u>;;
+                {{/species_initmanager.operations.set_charge_state}}
+            } // namespace pypicongpu
+        } // namespace manipulators
+    } // namespace particles
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/png.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/png.param.mustache
@@ -1,0 +1,160 @@
+/* Copyright 2013-2025 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ *                     Benjamin Worpitz, Sergei Bastrakov, Hannes Troepgen, Masoud Afshari
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include <cmath>
+
+
+namespace picongpu
+{
+    {{#customuserinput}}
+    constexpr float_64 scale_image = {{{png_plugin_SCALE_IMAGE}}};
+    constexpr bool scale_to_cellsize = {{{png_plugin_SCALE_TO_CELLSIZE}}};
+    constexpr bool white_box_per_GPU = {{{png_plugin_WHITE_BOX_PER_GPU}}};
+
+    namespace visPreview
+    {
+        // normalize EM fields to typical laser or plasma quantities
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    [outdated]
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  [outdated]
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
+#define EM_FIELD_SCALE_CHANNEL1 {{{png_plugin_EM_FIELD_SCALE_CHANNEL1}}}
+#define EM_FIELD_SCALE_CHANNEL2 {{{png_plugin_EM_FIELD_SCALE_CHANNEL2}}}
+#define EM_FIELD_SCALE_CHANNEL3 {{{png_plugin_EM_FIELD_SCALE_CHANNEL3}}}
+
+        /** SI values to be used for Custom normalization
+         *
+         * The order of normalization values is: B, E, current (note - current, not current density).
+         * This variable must always be defined, but has no effect for other normalization types.
+         */
+        constexpr float_64 customNormalizationSI[3] = {{{png_plugin_CUSTOM_NORMALIZATION_SI}}};
+
+
+        // multiply highest undisturbed particle density with factor
+
+        constexpr float_X preParticleDens_opacity = {{{png_plugin_PRE_PARTICLE_DENS_OPACITY}}};
+        constexpr float_X preChannel1_opacity = {{{png_plugin_PRE_CHANNEL1_OPACITY}}};
+        constexpr float_X preChannel2_opacity = {{{png_plugin_PRE_CHANNEL2_OPACITY}}};
+        constexpr float_X preChannel3_opacity = {{{png_plugin_PRE_CHANNEL3_OPACITY}}};
+
+        // test custom user input
+
+        // specify color scales for each channel
+        namespace preParticleDensCol = {{{png_plugin_preParticleDensCol}}};
+        namespace preChannel1Col = {{{png_plugin_preChannel1_colorScale}}};
+        namespace preChannel2Col = {{{png_plugin_preChannel2_colorScale}}};
+        namespace preChannel3Col = {{{png_plugin_preChannel3_colorScale}}};
+
+        DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
+        {
+            return   {{{png_plugin_preChannel1}}};
+        }
+
+        DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
+        {
+            return {{{png_plugin_preChannel2}}};
+        }
+
+        DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_J)
+        {
+            return {{{png_plugin_preChannel3}}};
+        }
+
+    } // namespace visPreview
+    {{/customuserinput}}
+    {{^customuserinput}}
+    constexpr float_64 scale_image = 1.0;
+    constexpr bool scale_to_cellsize = true;
+    constexpr bool white_box_per_GPU = false;
+
+    namespace visPreview
+    {
+        // normalize EM fields to typical laser or plasma quantities
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    [outdated]
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  [outdated]
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
+        {{#laser}}
+#define EM_FIELD_SCALE_CHANNEL1 7
+        {{/laser}}
+        {{^laser}}
+#define EM_FIELD_SCALE_CHANNEL1 -1
+        {{/laser}}
+#define EM_FIELD_SCALE_CHANNEL2 -1
+#define EM_FIELD_SCALE_CHANNEL3 -1
+
+
+        constexpr float_64 customNormalizationSI[3] = {5.0e12 / sim.si.getSpeedOfLight(), 5.0e12, 15.0};
+
+        // multiply highest undisturbed particle density with factor
+        constexpr float_X preParticleDens_opacity = 0.25;
+        constexpr float_X preChannel1_opacity = 1.0;
+        constexpr float_X preChannel2_opacity = 1.0;
+        constexpr float_X preChannel3_opacity = 1.0;
+
+        // specify color scales for each channel
+        namespace preParticleDensCol = colorScales::grayInv;
+        namespace preChannel1Col = colorScales::green;
+        namespace preChannel2Col = colorScales::none;
+        namespace preChannel3Col = colorScales::none;
+
+        /** Calculate values for png channels for given field values
+         *
+         * @param field_B normalized magnetic field value
+         * @param field_E normalized electric field value
+         * @param field_Current normalized electric current value (note - not current density)
+         *
+         * @{
+         */
+        DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
+        {
+            return field_E.x() * field_E.x();
+        }
+
+        DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
+        {
+            return field_E.y();
+        }
+
+        DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
+        {
+            return -1.0_X * field_E.y();
+        }
+
+        /** @} */
+    } // namespace visPreview
+    {{/customuserinput}}
+
+    } // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/simulation.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/simulation.param.mustache
@@ -1,0 +1,96 @@
+/* Copyright 2013-2025 Axel Huebl, Rene Widera, Benjamin Worpitz
+ *                     Hannes Troepgen
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Definition of cell sizes and time step. Our cells are defining a regular,
+ * cartesian grid. Our explicit FDTD field solvers require an upper bound for
+ * the time step value in relation to the cell size for convergence. Make
+ * sure to resolve important wavelengths of your simulation, e.g. shortest
+ * plasma wavelength, Debye length and central laser wavelength both spatially
+ * and temporarily.
+ *
+ * **Units in reduced dimensions**
+ *
+ * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+ * is still used for normalization of densities, etc..
+ *
+ * A 2D3V simulation in a cartesian PIC simulation such as
+ * ours only changes the degrees of freedom in motion for
+ * (macro) particles and all (field) information in z
+ * travels instantaneously, making the 2D3V simulation
+ * behave like the interaction of infinite "wire particles"
+ * in fields with perfect symmetry in Z.
+ *
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** Duration of one timestep
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = {{{delta_t_si}}};
+
+        {{#grid.cell_size}}
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = {{{x}}};
+        /** equals Y - the laser & moving window propagation direction
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = {{{y}}};
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = {{{z}}};
+        {{/grid.cell_size}}
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneously, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+
+        /** Base density in particles per m^3 in the density profiles.
+         *
+         * This is often taken as reference maximum density in normalized profiles.
+         * Individual particle species can define a `densityRatio` flag relative
+         * to this value.
+         *
+         * unit: ELEMENTS/m^3
+         */
+        //! @todo find way to compute on the fly, Brian Marre, 2023
+        constexpr float_64 BASE_DENSITY_SI = 1.e25;
+    } // namespace SI
+
+    /** Approximate number of maximum macro-particles per cell.
+     *
+     * Used internally for unit normalization.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = {{{typical_ppc}}}u;
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/speciesDefinition.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/speciesDefinition.param.mustache
@@ -1,0 +1,114 @@
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau,
+ *                     Hannes Troepgen
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+
+#include "picongpu/particles/Particles.hpp"
+
+#include <pmacc/identifier/value_identifier.hpp>
+#include <pmacc/meta/String.hpp>
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+#include <pmacc/particles/Identifier.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+
+namespace picongpu
+{
+    {{#species_initmanager.species}}
+        /****************************************
+            Definition of Species {{{name}}}
+        ****************************************/
+
+        {{#constants}}
+            {{#mass}}
+                value_identifier(float_X, MassRatio_{{{typename}}}, {{{mass_si}}} / sim.si.getBaseMass());
+            {{/mass}}
+            {{#charge}}
+                value_identifier(float_X, ChargeRatio_{{{typename}}}, {{{charge_si}}} / sim.si.getBaseCharge());
+            {{/charge}}
+            {{#density_ratio}}
+                value_identifier(float_X, DensityRatio_{{{typename}}}, {{{ratio}}});
+            {{/density_ratio}}
+        {{/constants}}
+
+        using ParticleFlags_{{{typename}}} = MakeSeq_t<
+            {{! note: put defaults at end, s.t. that generated section may always safely end in comma }}
+            {{#constants}}
+                {{#mass}}
+                    massRatio<MassRatio_{{{typename}}}>,
+                {{/mass}}
+                {{#charge}}
+                    chargeRatio<ChargeRatio_{{{typename}}}>,
+                {{/charge}}
+                {{#density_ratio}}
+                    densityRatio<DensityRatio_{{{typename}}}>,
+                {{/density_ratio}}
+
+                {{#ground_state_ionization}}
+                    ionizers<MakeSeq_t<
+                      {{#ionization_model_list}}
+                        particles::ionization::{{{ionizer_picongpu_name}}}<
+                            {{{ionization_electron_species.typename}}}
+                          {{#ionization_current}}
+                            , particles::ionization::current::{{{picongpu_name}}}
+                          {{/ionization_current}}
+                        >{{^_last}},{{/_last}}
+                      {{/ionization_model_list}}
+                    >>,
+                {{/ground_state_ionization}}
+
+                {{#element_properties}}
+                    atomicNumbers<ionization::atomicNumbers::{{{element.picongpu_name}}}_t>,
+                    ionizationEnergies<ionization::energies::AU::{{{element.picongpu_name}}}_t>,
+                    effectiveNuclearCharge<ionization::effectiveNuclearCharge::{{{element.picongpu_name}}}_t>,
+                {{/element_properties}}
+            {{/constants}}
+
+            particlePusher<UsedParticlePusher>,
+            shape<UsedParticleShape>,
+            interpolation<UsedField2Particle>,
+            current<UsedParticleCurrentSolver>>;
+
+        using ParticleAttributes_{{{typename}}} = MakeSeq_t<
+            {{#attributes}}
+                {{{picongpu_name}}}
+                {{^_last}}
+                    ,
+                {{/_last}}
+            {{/attributes}}
+            >;
+
+        using {{{typename}}} = Particles<
+            PMACC_CSTRING("{{{name}}}"),
+            ParticleFlags_{{{typename}}},
+            ParticleAttributes_{{{typename}}}>;
+    {{/species_initmanager.species}}
+
+
+    using VectorAllSpecies = MakeSeq_t<
+        {{#species_initmanager.species}}
+            {{{typename}}}
+            {{^_last}}
+                ,
+            {{/_last}}
+        {{/species_initmanager.species}}
+        >;
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/speciesInitialization.param.mustache
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/param/speciesInitialization.param.mustache
@@ -1,0 +1,94 @@
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau,
+ *                     Hannes Troepgen
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/particles/InitFunctors.hpp"
+
+#include <picongpu/param/particle.param>
+#include <picongpu/pypicongpu/util.hpp>
+
+namespace picongpu
+{
+    namespace particles
+    {
+        /** InitPipeline define in which order species are initialized
+         *
+         * the functors are called in order (from first to last functor)
+         */
+        {{! note: this serves to enter the context -- it is NOT a loop }}
+        {{#species_initmanager}}
+        using InitPipeline = pmacc::mp_list<
+            /* note to the editors of this file:
+             *
+             * Sometimes it is not possible to split the initialization separate "creation" and "manipulation" phases,
+             * because some init pipeline operations mix the two phases.
+             *
+             * Hence, consider removing these explicit "phase 1/2" comments when editing the init pipeline by hand.
+             */
+
+            /**********************************/
+            /* phase 1: create macroparticles */
+            /**********************************/
+
+            {{#operations.simple_density}}
+                /// @details This functor assumes the ratio to be 1. The correct density ratio of the species is applied
+                /// here (automatically by CreateDensity).
+
+                CreateDensity<
+                    densityProfiles::pypicongpu::init_{{{placed_species_initial.typename}}},
+                    startPosition::pypicongpu::init_{{{placed_species_initial.typename}}},
+                    {{{placed_species_initial.typename}}}>,
+
+                {{#placed_species_copied}}
+                    ManipulateDerive<
+                        manipulators::binary::DensityWeighting,
+                        {{{placed_species_initial.typename}}},
+                        {{{typename}}}>,
+                {{/placed_species_copied}}
+
+            {{/operations.simple_density}}
+
+            /*********************************************/
+            /* phase 2: adjust other attributes (if any) */
+            /*********************************************/
+
+            {{#operations.simple_momentum}}
+                {{! simple momentum adds a temperature & drift without inter-species dependencies }}
+                {{#drift}}
+                    // *sets* drift, i.e. overwrites momentum
+                    Manipulate<manipulators::pypicongpu::AssignDrift_{{{species.typename}}}, {{{species.typename}}}>,
+                {{/drift}}
+                {{#temperature}}
+                    // *adds* temperature, does *NOT* overwrite
+                    Manipulate<manipulators::pypicongpu::AddTemperature_{{{species.typename}}}, {{{species.typename}}}>,
+                {{/temperature}}
+            {{/operations.simple_momentum}}
+
+            {{#operations.set_charge_state}}
+                Manipulate<manipulators::pypicongpu::PreIonize_{{{species.typename}}}, {{{species.typename}}}>,
+            {{/operations.set_charge_state}}
+
+            // does nothing -- exists to catch trailing comma left by code generation
+            pypicongpu::nop>;
+        {{/species_initmanager}}
+
+    } // namespace particles
+} // namespace picongpu

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/pypicongpu/util.hpp
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates/include/picongpu/pypicongpu/util.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <pmacc/attribute/FunctionSpecifier.hpp>
+#include <pmacc/functor/Call.hpp>
+
+namespace picongpu
+{
+    namespace particles
+    {
+        namespace pypicongpu
+        {
+            /**
+             * functor for initpipeline: does nothing
+             *
+             * Does *NOT* have an operator(), b/c should not be called anyways.
+             * (Which is ensured via template specialization of the struct for handling init operations
+             * pmacc::functor::Call below.)
+             *
+             * Background: Code generation creates trailing commas, this functor "catches" the final trailing comma
+             * (i.e. prevents a syntax error).
+             *
+             * NOP: "no operation" (from assembly)
+             */
+            struct nop
+            {
+                // intentionally left blank
+            };
+        } // namespace pypicongpu
+    } // namespace particles
+} // namespace picongpu
+
+namespace pmacc
+{
+    namespace functor
+    {
+        /**
+         * specialization for pypicongpu nop functor
+         *
+         * Ensure that pypicongpu::nop initpipeline functor is not even scheduled to GPU (as functors typically are)
+         */
+        template<>
+        struct Call<picongpu::particles::pypicongpu::nop>
+        {
+            HINLINE void operator()(const uint32_t currentStep)
+            {
+                // do nothing!
+                // (default for pmacc Call: schedule given functor to GPU)
+            }
+        };
+    } // namespace functor
+} // namespace pmacc

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -60,8 +60,16 @@ laser = picmi.GaussianLaser(
     duration=5.0e-15,
     propagation_direction=[0.0, 1.0, 0.0],
     polarization_direction=[1.0, 0.0, 0.0],
-    focal_position=[float(numberCells[0] * cellSize[0] / 2.0), 4.62e-5, float(numberCells[2] * cellSize[2] / 2.0)],
-    centroid_position=[float(numberCells[0] * cellSize[0] / 2.0), 0.0, float(numberCells[2] * cellSize[2] / 2.0)],
+    focal_position=[
+        float(numberCells[0] * cellSize[0] / 2.0),
+        4.62e-5,
+        float(numberCells[2] * cellSize[2] / 2.0),
+    ],
+    centroid_position=[
+        float(numberCells[0] * cellSize[0] / 2.0),
+        0.0,
+        float(numberCells[2] * cellSize[2] / 2.0),
+    ],
     picongpu_polarization_type=pypicongpu.laser.GaussianLaser.PolarizationType.CIRCULAR,
     a0=8.0,
     picongpu_phase=0.0,
@@ -82,7 +90,10 @@ if not ENABLE_IONIZATION:
 
     if ENABLE_IONS:
         hydrogen_fully_ionized = picmi.Species(
-            particle_type="H", name="hydrogen", picongpu_fixed_charge=True, initial_distribution=gaussianProfile
+            particle_type="H",
+            name="hydrogen",
+            picongpu_fixed_charge=True,
+            initial_distribution=gaussianProfile,
         )
         species_list.append((hydrogen_fully_ionized, random_layout))
 else:
@@ -90,7 +101,10 @@ else:
         raise ValueError("Ions species required for ionization")
 
     hydrogen_with_ionization = picmi.Species(
-        particle_type="H", name="hydrogen", charge_state=0, initial_distribution=gaussianProfile
+        particle_type="H",
+        name="hydrogen",
+        charge_state=0,
+        initial_distribution=gaussianProfile,
     )
     species_list.append((hydrogen_with_ionization, random_layout))
 
@@ -112,7 +126,10 @@ else:
     )
 
     interaction = picmi.Interaction(
-        ground_state_ionization_model_list=[adk_ionization_model, bsi_effectiveZ_ionization_model]
+        ground_state_ionization_model_list=[
+            adk_ionization_model,
+            bsi_effectiveZ_ionization_model,
+        ]
     )
 
 sim = picmi.Simulation(
@@ -195,16 +212,24 @@ if ADD_CUSTOM_INPUT:
     )
 
     output_configuration.addToCustomInput(
-        {"openPMD_period": 100, "openPMD_file": "simData", "openPMD_extension": "bp"}, "openPMD plugin configuration"
+        {"openPMD_period": 100, "openPMD_file": "simData", "openPMD_extension": "bp"},
+        "openPMD plugin configuration",
     )
 
     output_configuration.addToCustomInput(
-        {"checkpoint_period": 100, "checkpoint_backend": "openPMD", "checkpoint_restart_backend": "openPMD"},
+        {
+            "checkpoint_period": 100,
+            "checkpoint_backend": "openPMD",
+            "checkpoint_restart_backend": "openPMD",
+        },
         "checkpoint configuration",
     )
 
     output_configuration.addToCustomInput(
-        {"macro_particle_count_period": 100, "macro_particle_count_species_name": "electron"},
+        {
+            "macro_particle_count_period": 100,
+            "macro_particle_count_species_name": "electron",
+        },
         "macro particle count plugin configuration",
     )
     sim.picongpu_add_custom_user_input(output_configuration)

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -21,6 +21,10 @@ ENABLE_IONIZATION = True
 ADD_CUSTOM_INPUT = True
 OUTPUT_DIRECTORY_PATH = "LWFA"
 
+# This assumes that you have copied the full example folder.
+# Otherwise, point this to your `/path/to/picongpu/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates`
+TEMPLATE_PATH = "./customTemplates/" if ADD_CUSTOM_INPUT else None
+
 numberCells = np.array([192, 2048, 192])
 cellSize = np.array([0.1772e-6, 0.4430e-7, 0.1772e-6])  # unit: meter)
 
@@ -117,6 +121,7 @@ sim = picmi.Simulation(
     time_step_size=1.39e-16,
     picongpu_moving_window_move_point=0.9,
     picongpu_interaction=interaction,
+    picongpu_template_dir=TEMPLATE_PATH,
 )
 for species, layout in species_list:
     sim.add_species(species, layout=layout)
@@ -149,9 +154,9 @@ if ADD_CUSTOM_INPUT:
             "png_plugin_PRE_CHANNEL2_OPACITY": 1.0,
             "png_plugin_PRE_CHANNEL3_OPACITY": 1.0,
             "png_plugin_preParticleDensCol": "colorScales::grayInv",
-            "png_plugin_preChannel1Col": "colorScales::green",
-            "png_plugin_preChannel2Col": "colorScales::none",
-            "png_plugin_preChannel3Col": "colorScales::none",
+            "png_plugin_preChannel1_colorScale": "colorScales::green",
+            "png_plugin_preChannel2_colorScale": "colorScales::none",
+            "png_plugin_preChannel3_colorScale": "colorScales::none",
             "png_plugin_preChannel1": "field_E.x() * field_E.x();",
             "png_plugin_preChannel2": "field_E.y()",
             "png_plugin_preChannel3": "-1.0_X * field_E.y()",
@@ -170,7 +175,7 @@ if ADD_CUSTOM_INPUT:
             "energy_histogram_period": 100,
             "energy_histogram_bin_count": 1024,
             "energy_histogram_min_energy": 0.0,
-            "energy_histogram_maxEnergy": 1000.0,
+            "energy_histogram_max_energy": 1000.0,
             "energy_histogram_filter": "all",
         },
         "energy histogram plugin configuration",

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -5,6 +5,8 @@ Authors: Masoud Afshari, Brian Edward Marre
 License: GPLv3+
 """
 
+from pathlib import Path
+
 from picongpu import picmi
 from picongpu import pypicongpu
 import numpy as np
@@ -23,7 +25,7 @@ OUTPUT_DIRECTORY_PATH = "LWFA"
 
 # This assumes that you have copied the full example folder.
 # Otherwise, point this to your `/path/to/picongpu/share/picongpu/pypicongpu/examples/laser_wakefield/customTemplates`
-TEMPLATE_PATH = "./customTemplates/" if ADD_CUSTOM_INPUT else None
+TEMPLATE_PATH = Path(__file__).parent / "customTemplates" if ADD_CUSTOM_INPUT else None
 
 numberCells = np.array([192, 2048, 192])
 cellSize = np.array([0.1772e-6, 0.4430e-7, 0.1772e-6])  # unit: meter)

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -214,7 +214,12 @@ if ADD_CUSTOM_INPUT:
     )
 
     output_configuration.addToCustomInput(
-        {"openPMD_period": 100, "openPMD_file": "simData", "openPMD_extension": "bp"},
+        {
+            "openPMD_period": 100,
+            "openPMD_file": "simData",
+            "openPMD_extension": "bp",
+            "openPMD_dataPreparationStrategy": "hdf5",
+        },
         "openPMD plugin configuration",
     )
 

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -228,6 +228,7 @@ if ADD_CUSTOM_INPUT:
             "checkpoint_period": 100,
             "checkpoint_backend": "openPMD",
             "checkpoint_restart_backend": "openPMD",
+            "checkpoint_openPMD_dataPreparationStrategy": "hdf5",
         },
         "checkpoint configuration",
     )

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -165,7 +165,7 @@ if ADD_CUSTOM_INPUT:
             "png_plugin_EM_FIELD_SCALE_CHANNEL1": 7,
             "png_plugin_EM_FIELD_SCALE_CHANNEL2": -1,
             "png_plugin_EM_FIELD_SCALE_CHANNEL3": -1,
-            "png_plugin_CUSTOM_NORMALIZATION_SI": "5.0e12 / constants.c, 5.0e12, 15.0",
+            "png_plugin_CUSTOM_NORMALIZATION_SI": "{5.0e12 / sim.si.getSpeedOfLight(), 5.0e12, 15.0}",
             "png_plugin_PRE_PARTICLE_DENS_OPACITY": 0.25,
             "png_plugin_PRE_CHANNEL1_OPACITY": 1.0,
             "png_plugin_PRE_CHANNEL2_OPACITY": 1.0,


### PR DESCRIPTION
Based on work of @BrianMarre and @mafshari64: This PR adds the custom templates that are necessary for the custom user input (already present in the PICMI laser wakefield example) to actually render to something.

More detail: The [laser_wakefield example](https://github.com/ComputationalRadiationPhysics/picongpu/blob/28825ebdf93fb187ecabe173323848291a6cb54e/share/picongpu/pypicongpu/examples/laser_wakefield/main.py#L131) already contains custom user input on the front-end level. But current mainline does not include the custom templates such that this additionally provided information is actually used for anything. This PR adds custom template files that allow this information to be used and as such actually adding value to the corresponding code block in the `main.py` file. These files existed in an outdated form [here](https://github.com/mafshari64/Custom_template_PICMI_LWFA/tree/main) already and I've updated them to compile with the latest dev.

Also: There's one autoformatting commit and one sentence added to the docs. If you only want to see the changes, restrict your diff to the first two commits.

@ikbuibui: Please check if the C++ side of things looks up-to-date. In particular, I've replaced a few instances of `SI::...` with the new `sim.si...`. Maybe you find more (or mistakes in the those).

@BrianMarre: Please check for adequate use of PICMI-related things. I've also added a tiny piece of functionality to CustomUserInput, viz. that it converts bools to their lower-case string representation. This is better aligned with C++.

@mafshari64: Please check that I didn't do any content-wise alterations during my refactoring.