### PR TITLE
Add openPMD to PICMI

### DIFF
--- a/lib/python/picongpu/pypicongpu/output/__init__.py
+++ b/lib/python/picongpu/pypicongpu/output/__init__.py
@@ -1,3 +1,4 @@
 from .auto import Auto
+from .openPMD import OpenPMD
 
-__all__ = ["Auto"]
+__all__ = ["Auto", "OpenPMD"]

--- a/lib/python/picongpu/pypicongpu/output/openPMD.py
+++ b/lib/python/picongpu/pypicongpu/output/openPMD.py
@@ -5,6 +5,7 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
+from typing import Optional
 from .. import util
 from ..rendering import RenderedObject
 
@@ -16,17 +17,44 @@ class OpenPMD(RenderedObject):
     """
     Class to configure openPMD output.
 
-    This class requires a period (in time steps) and file name.
+    This class requires a period (in time steps) and will enable OpenPMD output.
     """
 
     period = util.build_typesafe_property(int)
     """period to print data at"""
 
-    file_name = util.build_typesafe_property(str)
-    """file name for openPMD output"""
+    source = util.build_typesafe_property(str)
+    """data sources and filters to dump"""
 
-    file_extension = util.build_typesafe_property(str)
-    """file extension for openPMD output (e.g., 'bp', 'h5')"""
+    range_ = util.build_typesafe_property(str)
+    """contiguous range of cells per dimension to dump"""
+
+    file_name = util.build_typesafe_property(str)
+    """file name for OpenPMD output"""
+
+    ext = util.build_typesafe_property(str)
+    """openPMD filename extension"""
+
+    infix = util.build_typesafe_property(Optional[str])
+    """openPMD filename infix"""
+
+    json_ = util.build_typesafe_property(Optional[str])
+    """backend-specific parameters for openPMD backends in JSON format"""
+
+    jsonRestart = util.build_typesafe_property(Optional[str])
+    """backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint"""
+
+    dataPreparationStrategy = util.build_typesafe_property(Optional[str])
+    """strategy for preparation of particle data"""
+
+    toml = util.build_typesafe_property(Optional[str])
+    """configure the openPMD plugin via a TOML file"""
+
+    particleIOChunkSize = util.build_typesafe_property(Optional[int])
+    """particle data will be written in chunks of the given size"""
+
+    writeAccess = util.build_typesafe_property(Optional[str])
+    """openPMD Access mode for file writing"""
 
     def check(self) -> None:
         """
@@ -36,16 +64,28 @@ class OpenPMD(RenderedObject):
 
         :raises ValueError: period is non-negative integer
         :raises ValueError: file_name is empty string
+        :raises ValueError: ext is empty string
         """
         if 1 > self.period:
             raise ValueError("period must be non-negative integer")
         if not self.file_name:
             raise ValueError("file_name cannot be empty")
+        if not self.ext:
+            raise ValueError("ext cannot be empty")
 
     def _get_serialized(self) -> dict:
         self.check()
         return {
             "period": self.period,
+            "source": self.source,
+            "range": self.range_,
             "file_name": self.file_name,
-            "file_extension": self.file_extension,
+            "ext": self.ext,
+            "infix": self.infix,
+            "json": self.json_,
+            "jsonRestart": self.jsonRestart,
+            "dataPreparationStrategy": self.dataPreparationStrategy,
+            "toml": self.toml,
+            "particleIOChunkSize": self.particleIOChunkSize,
+            "writeAccess": self.writeAccess,
         }

--- a/lib/python/picongpu/pypicongpu/output/openPMD.py
+++ b/lib/python/picongpu/pypicongpu/output/openPMD.py
@@ -1,0 +1,51 @@
+"""
+This file is part of PIConGPU.
+Copyright 2021-2024 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .. import util
+from ..rendering import RenderedObject
+
+import typeguard
+
+
+@typeguard.typechecked
+class OpenPMD(RenderedObject):
+    """
+    Class to configure openPMD output.
+
+    This class requires a period (in time steps) and file name.
+    """
+
+    period = util.build_typesafe_property(int)
+    """period to print data at"""
+
+    file_name = util.build_typesafe_property(str)
+    """file name for openPMD output"""
+
+    file_extension = util.build_typesafe_property(str)
+    """file extension for openPMD output (e.g., 'bp', 'h5')"""
+
+    def check(self) -> None:
+        """
+        validate attributes
+
+        if ok pass silently, otherwise raises error
+
+        :raises ValueError: period is non-negative integer
+        :raises ValueError: file_name is empty string
+        """
+        if 1 > self.period:
+            raise ValueError("period must be non-negative integer")
+        if not self.file_name:
+            raise ValueError("file_name cannot be empty")
+
+    def _get_serialized(self) -> dict:
+        self.check()
+        return {
+            "period": self.period,
+            "file_name": self.file_name,
+            "file_extension": self.file_extension,
+        }

--- a/lib/python/picongpu/pypicongpu/output/openPMD.py
+++ b/lib/python/picongpu/pypicongpu/output/openPMD.py
@@ -72,6 +72,11 @@ class OpenPMD(RenderedObject):
             raise ValueError("file_name cannot be empty")
         if not self.ext:
             raise ValueError("ext cannot be empty")
+        if self.ext.startswith("."):
+            raise ValueError(
+                "Don't start openPMD's `ext` with a dot. It is added automatically. "
+                f"You gave '{self.ext}' but you probably meant '{self.ext.strip('.')}'."
+            )
 
     def _get_serialized(self) -> dict:
         self.check()

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -69,11 +69,21 @@ class Simulation(RenderedObject):
     def __get_output_context(self) -> dict:
         """retrieve all output objects"""
         auto = output.Auto()
-        openPMD = output.OpenPMD()
         auto.period = max(1, int(self.time_steps / 100))
+
+        openPMD = output.OpenPMD()
         openPMD.period = max(1, int(self.time_steps / 100))
+        openPMD.source = "species_all,fields_all"
+        openPMD.range_ = ":,:,:"
         openPMD.file_name = "test"
-        openPMD.file_extension = ".h5"
+        openPMD.ext = ".h5"
+        openPMD.infix = None
+        openPMD.json_ = None
+        openPMD.jsonRestart = None
+        openPMD.dataPreparationStrategy = None
+        openPMD.toml = None
+        openPMD.particleIOChunkSize = None
+        openPMD.writeAccess = None
 
         return {
             "auto": auto.get_rendering_context(),

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -69,10 +69,15 @@ class Simulation(RenderedObject):
     def __get_output_context(self) -> dict:
         """retrieve all output objects"""
         auto = output.Auto()
+        openPMD = output.OpenPMD()
         auto.period = max(1, int(self.time_steps / 100))
+        openPMD.period = max(1, int(self.time_steps / 100))
+        openPMD.file_name = "test"
+        openPMD.file_extension = ".h5"
 
         return {
             "auto": auto.get_rendering_context(),
+            "openPMD": openPMD.get_rendering_context(),
         }
 
     def __render_custom_user_input_list(self) -> dict:

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -76,7 +76,7 @@ class Simulation(RenderedObject):
         openPMD.source = "species_all,fields_all"
         openPMD.range_ = ":,:,:"
         openPMD.file_name = "test"
-        openPMD.ext = ".h5"
+        openPMD.ext = "h5"
         openPMD.infix = None
         openPMD.json_ = None
         openPMD.jsonRestart = None

--- a/share/picongpu/pypicongpu/schema/output/openPMD.OpenPMD.json
+++ b/share/picongpu/pypicongpu/schema/output/openPMD.OpenPMD.json
@@ -1,12 +1,14 @@
 {
   "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.openPMD.OpenPMD",
-  "description": "configure openPMD output",
+  "description": "OpenPMD output configuration",
   "type": "object",
   "unevaluatedProperties": false,
   "required": [
     "period",
+    "source",
+    "range",
     "file_name",
-    "file_extension"
+    "ext"
   ],
   "properties": {
     "period": {
@@ -14,13 +16,98 @@
       "type": "integer",
       "minimum": 1
     },
-    "file_name": {
-      "description": "file name for openPMD output",
+    "source": {
+      "description": "data sources and filters to dump",
       "type": "string"
     },
-    "file_extension": {
-      "description": "file extension for openPMD output (e.g., 'bp', 'h5')",
+    "range": {
+      "description": "contiguous range of cells per dimension to dump",
       "type": "string"
+    },
+    "file_name": {
+      "description": "file name for OpenPMD output",
+      "type": "string"
+    },
+    "ext": {
+      "description": "openPMD filename extension",
+      "type": "string"
+    },
+    "infix": {
+      "description": "openPMD filename infix",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "json": {
+      "description": "backend-specific parameters for openPMD backends in JSON format",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "jsonRestart": {
+      "description": "backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "dataPreparationStrategy": {
+      "description": "strategy for preparation of particle data",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "toml": {
+      "description": "configure the openPMD plugin via a TOML file",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "particleIOChunkSize": {
+      "description": "particle data will be written in chunks of the given size",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "writeAccess": {
+      "description": "openPMD Access mode for file writing",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
     }
   }
 }

--- a/share/picongpu/pypicongpu/schema/output/openPMD.OpenPMD.json
+++ b/share/picongpu/pypicongpu/schema/output/openPMD.OpenPMD.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.openPMD.OpenPMD",
+  "description": "configure openPMD output",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "period",
+    "file_name",
+    "file_extension"
+  ],
+  "properties": {
+    "period": {
+      "description": "number of time steps: at each multiple output is generated",
+      "type": "integer",
+      "minimum": 1
+    },
+    "file_name": {
+      "description": "file name for openPMD output",
+      "type": "string"
+    },
+    "file_extension": {
+      "description": "file extension for openPMD output (e.g., 'bp', 'h5')",
+      "type": "string"
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -50,7 +50,7 @@
             "description": "configuration for all output profiles",
             "type": "object",
             "unevaluatedProperties": false,
-            "required": ["auto"],
+            "required": ["auto", "openPMD"],
             "properties": {
                 "auto": {
                     "anyOf": [
@@ -61,7 +61,17 @@
                             "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.auto.Auto"
                         }
                     ]
+                },                "openPMD": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.openPMD.OpenPMD"
+                        }
+                    ]
                 }
+
             }
         },
         "customuserinput":{

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -61,7 +61,8 @@
                             "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.auto.Auto"
                         }
                     ]
-                },                "openPMD": {
+                },
+                "openPMD": {
                     "anyOf": [
                         {
                             "type": "null"

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -114,6 +114,11 @@ pypicongpu_output_with_newlines="
         {{/species_initmanager.species}}
 
     {{/output.auto}}
+    {{#output.openPMD}}
+        --openPMD.period {{{period}}}
+        --openPMD.file {{{file_name}}}
+        --openPMD.ext {{{file_extension}}}
+    {{/output.openPMD}}
 "
 
 # remove newlines

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -116,8 +116,31 @@ pypicongpu_output_with_newlines="
     {{/output.auto}}
     {{#output.openPMD}}
         --openPMD.period {{{period}}}
+        --openPMD.source {{{source}}}
+        --openPMD.range {{{range}}}
         --openPMD.file {{{file_name}}}
-        --openPMD.ext {{{file_extension}}}
+        --openPMD.ext {{{ext}}}
+        {{#output.openPMD.infix}}
+            --openPMD.infix {{{infix}}}
+        {{/output.openPMD.infix}}
+        {{#output.openPMD.json}}
+           --openPMD.json {{{json}}}
+        {{/output.openPMD.json}}
+        {{#output.openPMD.jsonRestart}}
+           --checkpoint.openPMD.jsonRestart {{{jsonRestart}}}
+        {{/output.openPMD.jsonRestart}}
+        {{#output.openPMD.dataPreparationStrategy}}
+           --openPMD.dataPreparationStrategy {{{dataPreparationStrategy}}}
+        {{/output.openPMD.dataPreparationStrategy}}
+        {{#output.openPMD.toml}}
+           --openPMD.toml {{{toml}}}
+        {{/output.openPMD.toml}}
+        {{#output.openPMD.particleIOChunkSize}}
+           --openPMD.particleIOChunkSize {{{particleIOChunkSize}}}
+        {{/output.openPMD.particleIOChunkSize}}
+        {{#output.openPMD.writeAccess}}
+           --openPMD.writeAccess {{{writeAccess}}}
+        {{/output.openPMD.writeAccess}}
     {{/output.openPMD}}
 "
 


### PR DESCRIPTION
@BrianMarre This is a first sketch of how openPMD output could look like. Submitting this draft early, so you can have a say before I sink too much time into this. It's not actually in PICMI yet but mostly just the boilerplate of pypicongpu. Planned next:

- [ ] Go through the parameter list and check if any of the types would be worth an own class. In particular, I was thinking about using `pathlib.Path` instead of strings but that doesn't seem to be standard in the codebase yet. Also some enums could help for `ext` and others that come from a closed set.
- [ ] Of course, remove the hardcoded `openPMD` in `Simulation`.
- [ ] Propagate this interface into PICMI somehow.

The last bullet is definitely the interesting one. There's [diagnostics](https://picmi.readthedocs.io/en/latest/standard/diagnostics.html) defined already but I have not looked at them in enough detail to figure out if they align with our perspective on this.