### PR TITLE
Enable 2D simulations with the FromOpenPMDPulse profile

### DIFF
--- a/docs/source/usage/workflows/addLaser.rst
+++ b/docs/source/usage/workflows/addLaser.rst
@@ -58,10 +58,11 @@ With the ``Free`` profile, it is on a user to provide functors to calculate inci
 Please refer to :ref:`the detailed description <model-TFSF>` for setting up ``Free`` profile, also for the case when only one of the external fields is known in explicit form.
 For a laser profile with non zero field amplitudes on the transversal borders of the profile e.g. defined by the profile ``Free`` without a transversal envelope the trait ``MakePeriodicTransversalHuygensSurfaceContiguous`` must be specialized and returning true to handle field periodic boundaries correctly.
 
-Another special case is the ``FromOpenPMDPulse`` profile, which reads a laser pulse profile, defined in space-time domain, from an openPMD file into the simulation. Specifically this allows to read a pulse profile obtained from an (Insight) measurement, after certain preparaion steps.
-For now, it is less flexible in choosing the propagation and polarisation direction, since those are only allowed along the cell edges, but not diagonally.
-Furthermore, one has to increase the reserved GPU memory size in memory.param, because the corresponding field chunk will be stored on every used device at timestep 0 of the simulation. Otherwise, the simulation could run into memory issues.
-For a description how to obtain the ready-to-read-in field data from an Insight measurement and how to properly set up this profile, please refer to the corresponding example parameter set.
+Another special case is the ``FromOpenPMDPulse`` profile, which reads a laser pulse profile, defined in space-time domain (= (2+1)-dimensional), from an openPMD file into the simulation. 
+For example, it can be used to read a pulse profile obtained from an INSIGHT measurement into the simulation, after pre-proccessing the measurement with the ``preparingInsightData.py``-script, which has been developed for this purpose and is located in /picongpu/lib/python/picongpu/extra/input/.
+At the moment, the ``FromOpenPMDPulse`` profile is less flexible in choosing the propagation and polarisation direction, since those are only allowed along the cell edges, but not diagonally.
+Furthermore, one has to increase the reserved GPU memory size in ``memory.param`` by about the size of the openPMD file, because the corresponding field chunk will be stored on every used device at timestep 0 of the simulation. Otherwise, the simulation will run into memory issues.
+For a description how to set up this profile, please refer to ``FromOpenPMDPulse.def``.
 
 Incident field is compatible to all field solvers, however using field solvers other than Yee requires a larger offset of the generating surface from absorber depending on the stencil width along the boundary axis.
 As a rule of thumb, this extra requirement is (order of FDTD solver / 2 - 1) cells.

--- a/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Fabia Dietrich
+/* Copyright 2024-2025 Fabia Dietrich
  *
  * This file is part of PIConGPU.
  *
@@ -17,7 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+#if(ENABLE_OPENPMD == 1)
 
 #    pragma once
 
@@ -42,14 +42,21 @@ namespace picongpu
                          * saving the resulting E-field chunk to openPMD.
                          *
                          * This field chunk will be stored at timestep 0 of the simulation on every used device, which
-                         * is why one has to increase the reserved GPU memory size in memory.param. Otherwise, the
-                         * simulation could run into memory issues.
+                         * is why one has to increase the reserved GPU memory size in memory.param by about the size of
+                         * the openPMD file. Otherwise, the simulation will run into memory issues.
+                         *
+                         * For 2D simulations, the input still has to be 3D. Then, only the central slice parallel to
+                         * propagation and polarisation direction of the input field will be used in the simulation.
+                         * To reduce GPU memory occupancy, it is recommended to trim the extent of the omitted
+                         * transverse axis to a minimum (but still including the slice that shall feed the simulation).
+                         * In case of working with INSIGHT data, this can be achieved during the data pre-procession
+                         * with 'preparingInsightData.py' with the parameters 'crop_x' or 'crop_y'.
                          *
                          * It is recommended to use a full path to make it independent of how PIConGPU is launched.
                          * Relative paths require consistency to the current directory when PIConGPU is started
                          * with tbg and the standard .tpl files, relative to the resulting simOutput directory.
                          */
-                        static constexpr char const* filename = "/path/to/file%T.h5";
+                        static constexpr char const* filename = "/path/to/file%T.bp5";
 
                         /** Iteration inside the file (where the whole field is stored in, not related to the current
                          * simulation time iteration)

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -23,7 +23,7 @@
 #include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.def"
 #include "picongpu/fields/incidentField/profiles/Free.def"
 #include "picongpu/fields/incidentField/profiles/GaussianPulse.def"
-#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+#if(ENABLE_OPENPMD == 1)
 #    include "picongpu/fields/incidentField/profiles/FromOpenPMDPulse.def"
 #endif
 #include "picongpu/fields/incidentField/profiles/None.def"

--- a/include/picongpu/fields/incidentField/profiles/profiles.hpp
+++ b/include/picongpu/fields/incidentField/profiles/profiles.hpp
@@ -23,7 +23,7 @@
 #include "picongpu/fields/incidentField/profiles/ExpRampWithPrepulse.hpp"
 #include "picongpu/fields/incidentField/profiles/Free.hpp"
 #include "picongpu/fields/incidentField/profiles/GaussianPulse.hpp"
-#if(ENABLE_OPENPMD == 1) && (SIMDIM == DIM3)
+#if(ENABLE_OPENPMD == 1)
 #    include "picongpu/fields/incidentField/profiles/FromOpenPMDPulse.hpp"
 #endif
 #include "picongpu/fields/incidentField/profiles/None.hpp"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -26,8 +26,8 @@
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::FromOpenPMDPulse<>    : reads an experimental pulse chunk defined in space-time domain into the
- * simulation; requires openPMD API dependency and a 3D simulation
+ *  - profiles::FromOpenPMDPulse<>    : reads a field chunk defined in space-time domain (= (2+1)-dimensional) from
+ * openPMD into the simulation; requires openPMD API dependency
  *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters

--- a/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
+++ b/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
@@ -491,7 +491,8 @@
     "## Save data to openPMD\n",
     "The data is now nearly ready te be used as FromOpenPMDPulse input. The amplitude of the pulse in the time domain still has to be corrected (= scaled to the actual beam energy in Joule) before saving it to an openPMD file at the provided destination path.\n",
     "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm), `crop_t_neg` and `crop_t_pos` (in fs).\n",
-    "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input."
+    "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input.",
+    "The 3D field data can also serve as input for 2D simulations. The the `FromOpenPMDPulse` profile will then extract the central field slice parallel to propagation and polarisation direction and use this as incident field input. To reduce GPU memory occupancy, it is recommended to trim the extent of the ommited transverse axis with `crop_x` or `crop_y` to $\\geqslant 2$, centered around the central slice."
    ]
   },
   {


### PR DESCRIPTION
In 2D simulations, the central slice of the input field parallel to propagation and polarisation direction will be extracted and serve as incident field input. The whole 3D input field will still be loaded to the GPUs. Until I implement field-slice-loading, I recommend to trim the extent of the omitted transverse axis of the input field to $\geqslant 2$, centered around the central slice, to reduce GPU memory occupancy.