### PR TITLE
fix typos in error message of axis

### DIFF
--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -218,7 +218,7 @@ namespace picongpu
             {
                 static_assert(
                     std::is_same_v<typename T_FunctorDescription::QuantityType, T_Attribute>,
-                    "Access functor return type and range type shuold be the same");
+                    "Access functor return type and range type should be the same");
                 /** this is doing an implicit conversion to T_attribute for min, max and scaling */
                 return LinearAxis<T_Attribute, typename T_FunctorDescription::FunctorType>(
                     axSplit,

--- a/include/picongpu/plugins/binning/axis/LogAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LogAxis.hpp
@@ -276,7 +276,7 @@ namespace picongpu
             {
                 static_assert(
                     std::is_same_v<typename T_FunctorDescription::QuantityType, T_Attribute>,
-                    "Access functor return type and range type shuold be the same");
+                    "Access functor return type and range type should be the same");
                 /** this is doing an implicit conversion to T_attribute for min, max and scaling */
                 return LogAxis<T_Attribute, typename T_FunctorDescription::FunctorType>(
                     axSplit,


### PR DESCRIPTION
If the return-type and range-type of an axis in the binning plugin differ, an error is thrown. This error has a typo. This pull request fixes this typo. 