### PR TITLE
Update TWTSTight-interface

### DIFF
--- a/include/picongpu/fields/background/templates/twtstight/GetInitialTimeDelay_SI.tpp
+++ b/include/picongpu/fields/background/templates/twtstight/GetInitialTimeDelay_SI.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2024 Alexander Debus
+/* Copyright 2014-2025 Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -58,8 +58,8 @@ namespace picongpu
                         DataSpace<simDim> const& halfSimSize,
                         float_64 const pulselength_SI,
                         float_64 const focus_y_SI,
-                        float_X const phi,
-                        float_X const beta_0) const;
+                        float_64 const phi,
+                        float_64 const beta_0) const;
                 };
 
                 template<>
@@ -69,8 +69,8 @@ namespace picongpu
                     DataSpace<simDim> const& halfSimSize,
                     float_64 const pulselength_SI,
                     float_64 const focus_y_SI,
-                    float_X const phi,
-                    float_X const beta_0) const
+                    float_64 const phi,
+                    float_64 const beta_0) const
                 {
                     if(auto_tdelay)
                     {
@@ -106,8 +106,8 @@ namespace picongpu
                     DataSpace<simDim> const& halfSimSize,
                     float_64 const pulselength_SI,
                     float_64 const focus_y_SI,
-                    float_X const phi,
-                    float_X const beta_0) const
+                    float_64 const phi,
+                    float_64 const beta_0) const
                 {
                     if(auto_tdelay)
                     {
@@ -143,8 +143,8 @@ namespace picongpu
                     DataSpace<T_Dim> const& halfSimSize,
                     float_64 const pulselength_SI,
                     float_64 const focus_y_SI,
-                    float_X const phi,
-                    float_X const beta_0)
+                    float_64 const phi,
+                    float_64 const beta_0)
                 {
                     return GetInitialTimeDelay<T_Dim>()(
                         auto_tdelay,

--- a/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
+++ b/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2024 Alexander Debus, Axel Huebl, Sergei Bastrakov
+/* Copyright 2014-2025 Alexander Debus, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -90,8 +90,8 @@ namespace picongpu::templates::twtstight
     public:
         //! Helper method to define basic TWTS variables
         HDINLINE static std::array<float_T, 11u> defineBasicHelperVariables(
-            float_X const& phi,
-            float_X const& beta_0,
+            float_64 const& phi,
+            float_64 const& beta_0,
             float_64 const& wavelength_SI,
             float_64 const& pulselength_SI,
             float_64 const& w_x_SI);
@@ -120,12 +120,12 @@ namespace picongpu::templates::twtstight
          *  That is, for phi = 90 degree the laser propagates in the -z direction.
          * [rad]
          */
-        PMACC_ALIGN(phi, float_X const);
+        PMACC_ALIGN(phi, float_64 const);
         /** Takes value 1.0 for phi > 0 and -1.0 for phi < 0. */
         PMACC_ALIGN(phiPositive, float_X const);
         /** propagation speed of TWTS laser overlap
         normalized to the speed of light. [Default: beta0=1.0] */
-        PMACC_ALIGN(beta_0, float_X const);
+        PMACC_ALIGN(beta_0, float_64 const);
         /** If auto_tdelay=FALSE, then a user defined delay is used. [second] */
         PMACC_ALIGN(tdelay_user_SI, float_64 const);
         /** Make time step constant accessible to device. */
@@ -140,7 +140,7 @@ namespace picongpu::templates::twtstight
         PMACC_ALIGN(tdelay, float_64 const);
         /** Polarization of TWTS laser with respect to x-axis around propagation direction [rad, default = 0. *
          * (PI/180.)] */
-        PMACC_ALIGN(polAngle, float_X const);
+        PMACC_ALIGN(polAngle, float_64 const);
         /* imaginary unit I */
         PMACC_ALIGN(I, complex_T const);
         PMACC_ALIGN(basicTWTSHelperVariables, std::array<float_T, 11u> const);
@@ -172,11 +172,11 @@ namespace picongpu::templates::twtstight
             float_64 const wavelength_SI,
             float_64 const pulselength_SI,
             float_64 const w_x_SI,
-            float_X const phi = 90. * (PI / 180.),
-            float_X const beta_0 = 1.0,
+            float_64 const phi = 90. * (PI / 180.),
+            float_64 const beta_0 = 1.0,
             float_64 const tdelay_user_SI = 0.0,
             bool const auto_tdelay = true,
-            float_X const polAngle = 0. * (PI / 180.));
+            float_64 const polAngle = 0. * (PI / 180.));
 
         /** Specify your background field E(r, t) or B(r, t) here
          *

--- a/include/picongpu/fields/background/templates/twtstight/TWTSTight.tpp
+++ b/include/picongpu/fields/background/templates/twtstight/TWTSTight.tpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2024 Alexander Debus, Axel Huebl, Sergei Bastrakov
+/* Copyright 2014-2025 Alexander Debus, Axel Huebl, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -45,11 +45,11 @@ namespace picongpu::templates::twtstight
         float_64 const wavelength_SI,
         float_64 const pulselength_SI,
         float_64 const w_x_SI,
-        float_X const phi,
-        float_X const beta_0,
+        float_64 const phi,
+        float_64 const beta_0,
         float_64 const tdelay_user_SI,
         bool const auto_tdelay,
-        float_X const polAngle)
+        float_64 const polAngle)
         : halfSimSize(Environment<simDim>::get().SubGrid().getGlobalDomain().size / 2)
         , focus_y_SI(focus_y_SI)
         , wavelength_SI(wavelength_SI)
@@ -184,8 +184,8 @@ namespace picongpu::templates::twtstight
 
     template<typename T_Field>
     HDINLINE std::array<float_T, 11u> TWTSTight<T_Field>::defineBasicHelperVariables(
-        float_X const& phi,
-        float_X const& beta_0,
+        float_64 const& phi,
+        float_64 const& beta_0,
         float_64 const& wavelength_SI,
         float_64 const& pulselength_SI,
         float_64 const& w_x_SI)
@@ -274,8 +274,8 @@ namespace picongpu::templates::twtstight
         float_T const cotPhi = float_T(1.0) / tanPhi;
         float_T const sinPhi_2 = sinPhi * sinPhi;
         float_T const cosPhi_2 = cosPhi * cosPhi;
-        float_T const sinPolAngle = math::sin(polAngle);
-        float_T const cosPolAngle = math::cos(polAngle);
+        float_T const sinPolAngle = float_T(math::sin(polAngle));
+        float_T const cosPolAngle = float_T(math::cos(polAngle));
         float_T const sin2Phi = math::sin(float_T(2.0) * absPhi);
 
         return std::array<float_T, 7u>{tanPhi, cotPhi, sinPhi_2, cosPhi_2, sinPolAngle, cosPolAngle, sin2Phi};


### PR DESCRIPTION
For historical reasons, i.e. originally to reduce register usage on device, the parameters (`phi`, `beta_0` and `polAngle`) of TWTS were defined as `float_X`. While this is fine for calculating TWTSTight at single precision, this choice limits precision when TWTSTight is used at double precision (currently non-standard usage for development and tests only). With this PR that replaces the `float_X` with the corresponding `float_64` types, the number of significant digits at double precision that agree with the Mathematica reference implementation increases from >=5 digits to >=13 digits.