### PR TITLE
Add perlmutter profile

### DIFF
--- a/etc/picongpu/perlmutter-nersc/README.md
+++ b/etc/picongpu/perlmutter-nersc/README.md
@@ -1,0 +1,24 @@
+# PIConGPU on Perlmutter
+## General Remarks
+PIConGPU can be compiled on a login node, but remember to limit the number of used CPU cores. `pic-build -j 16` works fine; reduce the number if the compiler gets killed.
+
+## Installing Dependencies
+Missing dependencies can be installed from source with `dependencies_autoinstall.sh`. Change the project number in the `gpu.profile`, source it, and execute the install script on a login node.
+
+## Preemptive Jobs
+When using preemptive queues, you should uncomment the `sleep 120` command at the end of the tpl file.
+
+## Streaming
+Note: This is quite an old example; some things may have changed. `gpu_stream.tpl` is an example streaming configuration. It needs to be adjusted (CPU distribution between PIConGPU and reader) to individual needs. The reader has to be provided as `input/bin/reader`. The minimal writer (PIConGPU)/reader JSON OpenPMD configuration is:
+```json
+{
+  "adios2": {
+    "engine": {
+      "parameters": {
+        "DataTransport": "rdma"
+      }
+    }
+  }
+}
+```
+Currently, this requires at least two nodes to ensure that the network interface is available.

--- a/etc/picongpu/perlmutter-nersc/dependencies_autoinstall.sh
+++ b/etc/picongpu/perlmutter-nersc/dependencies_autoinstall.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Copyright 2023-2025 Axel Huebl, Marco Garten, Klaus Steiniger, Pawel Ordyna
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+# last updated: 2025-03-10
+
+PIC_BRANCH="dev"
+PROJECT=$proj
+echo $PROJECT
+
+# get PIConGPU profile
+if [ ! -f "$PIC_PROFILE" ]; then
+    printf "Source a profile!\n"
+    exit 1
+else
+    source "$PIC_PROFILE"
+fi
+
+set -euf -o pipefail
+# create temporary directory for software source files
+export SOURCE_DIR="$CFS/$PROJECT/$USER/lib_run_tmp"
+mkdir -p $SOURCE_DIR
+# Boost
+if [ ! -d "$BOOST_ROOT" ]; then
+    cd $SOURCE_DIR
+    curl -L -s -o boost_1_87_0.tar.gz \
+        https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
+    tar -xzf boost_1_87_0.tar.gz
+    cd boost_1_87_0/
+    ./bootstrap.sh --with-libraries=atomic,chrono,context,date_time,fiber,filesystem,math,program_options,serialization,system,thread --prefix=$BOOST_ROOT \
+        CC=$(which cc) CXX=$(which CC)
+    ./b2 cxxflags="-std=c++20" -j 10 && ./b2 install
+fi
+
+#   c-blosc
+if [ ! -d "$BLOSC_ROOT" ]; then
+    cd $SOURCE_DIR
+    git clone -b v2.17.0 https://github.com/Blosc/c-blosc2.git \
+        $SOURCE_DIR/c-blosc
+    mkdir c-blosc-build
+    cd c-blosc-build
+    cmake -DCMAKE_INSTALL_PREFIX=$BLOSC_ROOT \
+        -DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC \
+        $SOURCE_DIR/c-blosc
+    make -j 10 install
+fi
+
+#   PNGwriter
+if [ ! -d "$PNGwriter_ROOT" ]; then
+    cd $SOURCE_DIR
+    git clone -b 0.7.0 https://github.com/pngwriter/pngwriter.git \
+        $SOURCE_DIR/pngwriter
+    mkdir pngwriter-build
+    cd pngwriter-build
+    cmake -DCMAKE_INSTALL_PREFIX=$PNGwriter_ROOT \
+        $SOURCE_DIR/pngwriter
+    make -j 10 install
+fi
+
+#   HDF5
+if [ ! -d "$HDF5_ROOT" ]; then
+    cd $SOURCE_DIR
+    curl -Lo hdf5-1.14.6.tar.gz \
+        https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_6/downloads/hdf5-1.14.6.tar.gz
+    tar -xzf hdf5-1.14.6.tar.gz
+    cd hdf5-1.14.6
+    ./configure --enable-parallel --enable-shared --prefix $HDF5_ROOT CC=$(which cc) CXX=$(which CC)
+    make -j 10 && make install
+fi
+
+#   ADIOS2
+# force usage of MPI and HDF5 and point directly to MPI headers and libraries
+if [ ! -d "$ADIOS2_ROOT" ]; then
+    cd $SOURCE_DIR
+    git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git \
+        $SOURCE_DIR/adios2
+        cd $SOURCE_DIR/adios2
+        sed -i 's|if (ADIOS2_HAVE_MPI_CLIENT_SERVER)|if (TRUE)|' cmake/DetectOptions.cmake
+    mkdir $SOURCE_DIR/adios2-build
+    cd $SOURCE_DIR/adios2-build
+    cmake $SOURCE_DIR/adios2 -DADIOS2_BUILD_EXAMPLES=OFF \
+        -DCMAKE_INSTALL_PREFIX=$ADIOS2_ROOT -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_USE_BZip2=OFF \
+        -DADIOS2_USE_MPI=ON -DADIOS2_USE_HDF5=ON \
+        -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) \
+        -DMPI_CXX_HEADER_DIR=${MPICH_DIR}/include \
+        -DMPI_C_HEADER_DIR=${MPICH_DIR}/include \
+        -DMPI_mpi_gnu_123_LIBRARY=${MPICH_DIR}/lib/libmpi_gnu_123.so
+    make -j 10 && make install
+fi
+
+#   openPMD-api
+if [ ! -d "OPENPMD_ROOT" ]; then
+    cd $SOURCE_DIR
+    git clone -b 0.16.1 https://github.com/openPMD/openPMD-api.git \
+        $SOURCE_DIR/openpmd-api
+    mkdir $SOURCE_DIR/openpmd-api-build
+    cd $SOURCE_DIR/openpmd-api-build
+    cmake $SOURCE_DIR/openpmd-api \
+        -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF \
+        -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) \
+        -DMPI_CXX_HEADER_DIR=${MPICH_DIR}/include \
+        -DMPI_C_HEADER_DIR=${MPICH_DIR}/include \
+        -DMPI_mpi_gnu_123_LIBRARY=${MPICH_DIR}/lib/libmpi_gnu_123.so \
+        -DCMAKE_INSTALL_PREFIX="$OPENPMD_ROOT"
+    make -j 10 install
+fi
+
+
+# message to user
+echo ''
+echo 'edit user & email within picongpu.profile, e.g. via:'
+echo '    vim $PIC_PROFILE'
+echo 'delete temporary folder for library compilation'
+printf "    rm -rf %s\n" $SOURCE_DIR

--- a/etc/picongpu/perlmutter-nersc/gpu.profile.example
+++ b/etc/picongpu/perlmutter-nersc/gpu.profile.example
@@ -1,0 +1,134 @@
+# Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="ALL"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Project Information ######################################## (edit this line)
+#   - project account for computing time
+export proj="m0000"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+export EDITOR="nano"
+
+# General modules #############################################################
+#
+module load gpu/1.0
+module load cmake/3.30.2
+module load craype-accel-nvidia80
+module load cray-python/3.11.7
+
+# Additional libraries
+#
+export PARTITION_CFS=/global/cfs/cdirs/$proj/$USER
+export PARTITION_LIB=/global/cfs/cdirs/$proj/$USER/pic-libs
+mkdir -pv $PARTITION_LIB
+
+# HDF5 temporarily stored elsewhere
+HDF5_VERSION=1.14.6
+export HDF5_ROOT=$PARTITION_LIB/HDF5/$HDF5_VERSION
+export PATH=$HDF5_ROOT/bin:$PATH
+export CPATH=$HDF5_ROOT/include:$CPATH
+export LD_LIBRARY_PATH=$HDF5_ROOT/lib:$LD_LIBRARY_PATH
+#
+BOOST_VERSION=1.87.0
+export BOOST_ROOT=$PARTITION_LIB/BOOST/$BOOST_VERSION
+export CPATH=$BOOST_ROOT/include:$CPATH
+export LD_LIBRARY_PATH=$BOOST_ROOT/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=$BOST_ROOT/lib/cmake:$CMAKE_PREFIX_PATH
+
+
+PNGWRITER_VERSION=0.7.0
+export PNGwriter_ROOT=$PARTITION_LIB/PNGWRITER/$PNGWRITER_VERSION
+export CMAKE_PREFIX_PATH=$PNGwriter_ROOT:$CMAKE_PREFIX_PATH
+export CPATH=$PNGwriter_ROOT/include:$CPATH
+export LD_LIBRARY_PATH=$PNGwriter_ROOT/lib:$LD_LIBRARY_PATH
+
+
+BLOSC_VERSION=2.17.0
+BLOSC_ROOT=$PARTITION_LIB/BLOSC/$BLOSC_VERSION
+export CMAKE_PREFIX_PATH=$BLOSC_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$BLOSC_ROOT/lib:$LD_LIBRARY_PATH
+
+ADIOS2_VERSION=2.10.2
+ADIOS2_ROOT=$PARTITION_LIB/ADIOS2/$ADIOS2_VERSION
+export PATH=$ADIOS2_ROOT/bin:$PATH
+export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$ADIOS2_ROOT/lib64:$LD_LIBRARY_PATH
+export PYTHONPATH=$ADIOS2_ROOT/lib/python3.9/site-packages:$PYTHONPATH
+
+OPENPMD_VERSION=0.16.1
+OPENPMD_ROOT=$PARTITION_LIB/OPENPMD/$OPENPMD_VERSION
+export PATH=$OPENPMD_ROOT/bin:$PATH
+export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=$OPENPMD_ROOT/lib64:$LD_LIBRARY_PATH
+export PYTHONPATH=$OPENPMD_ROOT/lib64/python3.9/site-packages:$PYTHONPATH
+
+# Environment #################################################################
+#
+export CC="$(which gcc)"
+export CXX="$(which g++)"
+export CUDACXX=$(which nvcc)
+export CUDAHOSTCXX=$(which g++)
+
+export PICSRC=$HOME/src/picongpu
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:80"
+
+export PATH=$PATH:$PICSRC
+export PATH=$PATH:$PICSRC/bin
+export PATH=$PATH:$PICSRC/src/tools/bin
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "defq" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/perlmutter-nersc/gpu.tpl"
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/perlmutter-nersc"}
+# allocate an interactive node for one hour to execute a mpi parallel application
+#   getNode 2  # allocates two interactive A100 GPUs (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node 4 --gpus 4 --cpus-per-task=32 -A $proj -C gpu -q interactive
+}
+
+# allocate an interactive device for one hour to execute a mpi parallel application
+#   getDevice 2  # allocates two interactive devices (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numGPUs=1
+    else
+        if [ "$1" -gt 8 ] ; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        else
+            numGPUs=$1
+        fi
+    fi
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+    salloc --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gpus=$numGPUs -A ${proj} -C gpu
+}
+
+# allocate an interactive shell for compilation (without gpus)
+function getShell() {
+    srun --time=1:00:00 --nodes=1 --ntasks 1 --cpus-per-task=32 -A $proj -C cpu --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi

--- a/etc/picongpu/perlmutter-nersc/gpu.tpl
+++ b/etc/picongpu/perlmutter-nersc/gpu.tpl
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Copyright 2023-2025 Pawel Ordyna
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for Perlmutter's SLURM batch system
+
+#SBATCH -q regular
+#SBATCH --constraint=gpu
+#SBATCH --gpus-per-task=1
+#SBATCH --time=!TBG_wallTime
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --chdir=!TBG_dstPath
+
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --account=!TBG_nameProject
+#SBATCH --signal=SIGALRM@600
+#SBATCH --mem=!TBG_memPerNode
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+#SBATCH --open-mode=append
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+## calculations will be performed by tbg ##
+.TBG_queue="gpu"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"NONE"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_nameProject=${proj:-""}"_g"
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+
+# number of available/hosted GPUs per node in the system
+.TBG_numHostedGPUPerNode=4
+
+# required GPUs per node for the current job
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi)
+
+# number of cores to block per A100 - per node, we got 1 Epyc CPU with
+# 64 cores a 2 threads per core. We utilise only physical cores
+.TBG_coresPerGPU=32
+
+.TBG_totalHostMemory=229888
+# host memory per gpu
+.TBG_memPerGPU="$(( $TBG_totalHostMemory / $TBG_numHostedGPUPerNode))"
+# host memory per node
+.TBG_memPerNode="$((TBG_memPerGPU * TBG_gpusPerNode))"
+
+# use ceil to caculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode - 1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo "Preparing environment..."
+
+cd !TBG_dstPath
+
+# note: no need to source profile as environment is cloned from submit environment
+# source !TBG_profile
+echo "profile cloned at submit time: !TBG_profile"
+
+#set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+export OMP_NUM_THREADS=!TBG_coresPerGPU
+
+# In accordance with the example at
+# https://docs.nersc.gov/systems/perlmutter/running-jobs/#4-nodes-16-tasks-16-gpus-1-gpu-visible-to-each-task
+export SLURM_CPU_BIND="cores"
+
+  # test if cuda_memtest binary is available and we have the node exclusive
+  if [ -f !TBG_dstPath/input/bin/cuda_memtest ] && [ !TBG_numHostedGPUPerNode -eq !TBG_gpusPerNode ] ; then
+    run_cuda_memtest=1
+   # Run CUDA memtest to check GPU's health
+    export MPICH_GPU_SUPPORT_ENABLED=0
+    node_check_err=$(srun -n !TBG_tasks --nodes=$SLURM_JOB_NUM_NODES -K1 --gres=gpu:!TBG_gpusPerNode --gpu-bind=none !TBG_dstPath/input/bin/cuda_memtest.sh && echo 0 || echo 1)
+  else
+   run_cuda_memtest=0
+   echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available or compute node is not exclusively allocated. This does not affect PIConGPU, starting it now" >&2
+  fi
+
+if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
+   export MPICH_GPU_SUPPORT_ENABLED=1
+   # Run PIConGPU
+   srun --cpu-bind=cores !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+   # the sleep comand is needed for automatic resubmission of preempted job
+   # otherwise the job may exit before second signal is beeign send and it does not get the preempted slurm status
+   # uncomment if using preemptible jobs
+   # sleep 120
+fi


### PR DESCRIPTION
Adds a profile and `tpl` files for perlmutter. Comes with a short README and a dependency installer script. This config was tested today.  FoilLCT example compiles and runs on a single node with 4 GPUs. 

I also included an example `tbg` template for streaming with `openpmd-api`, this one can be quite out of date though, didn't have a chance to test it again. 

@ComputationalRadiationPhysics/picongpu-maintainers 