### PR TITLE
Fix bugs in and refactor toSlice.hpp

### DIFF
--- a/share/picongpu/unit/toSlice.cpp
+++ b/share/picongpu/unit/toSlice.cpp
@@ -1,0 +1,163 @@
+/* Copyright 2025 Julian Lenz
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pmacc/pluginSystem/toSlice.hpp"
+
+#include "catch2/matchers/catch_matchers.hpp"
+#include "catch2/matchers/catch_matchers_range_equals.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+using Catch::Matchers::IsEmpty;
+using Catch::Matchers::SizeIs;
+using pmacc::pluginSystem::Slice;
+
+using pmacc::pluginSystem::toRangeSlice;
+using pmacc::pluginSystem::toTimeSlice;
+
+
+struct SliceEqual
+{
+    auto operator()(const Slice& lhs, const Slice& rhs) const
+    {
+        return std::equal(lhs.values.cbegin(), lhs.values.cend(), rhs.values.cbegin());
+    }
+};
+
+namespace pmacc::pluginSystem
+{
+    // This allows catch2 to print usable output in case of a failure.
+    template<typename T_Stream>
+    auto operator<<(T_Stream& out, Slice const& s)
+    {
+        out << "{" << s.values[0] << ", " << s.values[1] << ", " << s.values[2] << "}";
+    }
+} // namespace pmacc::pluginSystem
+
+TEST_CASE("Both slices", "")
+{
+    std::function<std::vector<Slice>(std::string const&)> toSlice = GENERATE(toTimeSlice, toRangeSlice);
+
+    SECTION("accept empty strings.")
+    {
+        std::string input = "";
+        auto result = toSlice(input);
+        CHECK_THAT(result, IsEmpty());
+    }
+
+    SECTION("accept : and , syntax.")
+    {
+        std::vector<std::pair<std::string, std::vector<Slice>>> testCases = {
+            {"", {}},
+            {"1:5", {Slice{1, 5, 1}}},
+            {"1:5:2", {Slice{1, 5, 2}}},
+            {"1:-1", {Slice{1, static_cast<uint32_t>(-1), 1}}},
+            {":", {Slice{0, static_cast<uint32_t>(-1), 1}}},
+            {"::", {Slice{0, static_cast<uint32_t>(-1), 1}}},
+            {"1:5,10:15", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
+            {"1:5:2,10:15:3", {Slice{1, 5, 2}, Slice{10, 15, 3}}},
+            {"1:-1,10:15", {Slice{1, static_cast<uint32_t>(-1), 1}, Slice{10, 15, 1}}},
+            {",1:5,,10:15,", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
+        };
+
+        for(const auto& testCase : testCases)
+        {
+            const auto result = toSlice(testCase.first);
+            CHECK_THAT(result, SizeIs(testCase.second.size()));
+            CHECK_THAT(result, Catch::Matchers::RangeEquals(testCase.second, SliceEqual{}));
+        }
+    }
+
+
+    SECTION("throw on")
+    {
+        std::vector<std::string> testCases;
+        SECTION("non-digit input.")
+        {
+            testCases = {
+                "a:b:c",
+                "1:5,7:1:c,10:15",
+                "1:5,a:1:99,10:15",
+            };
+        }
+        SECTION("end values < -1.")
+        {
+            testCases = {
+                "1:-5:1,10:15",
+            };
+        }
+
+        SECTION("-1 values for anything but end value.")
+        {
+            testCases = {
+                "-1:4:1,10:15",
+                "1:4:1,10:15:-3",
+            };
+        }
+
+        SECTION("whitespaces.")
+        {
+            testCases = {" 1:5", "1: 5", "1:5 "};
+        }
+
+
+        for(const auto& testCase : testCases)
+        {
+            CHECK_THROWS_AS(toSlice(testCase), std::runtime_error);
+        }
+    }
+}
+
+TEST_CASE("toRangeSlice interprets single int as single slice.")
+{
+    std::vector<std::pair<std::string, std::vector<Slice>>> testCases = {
+        {"5", {Slice{5, 6, 1}}},
+        {"5,10", {Slice{5, 6, 1}, Slice{10, 11, 1}}},
+    };
+
+    for(const auto& testCase : testCases)
+    {
+        const auto result = toRangeSlice(testCase.first);
+        CHECK_THAT(result, SizeIs(testCase.second.size()));
+        CHECK_THAT(result, Catch::Matchers::RangeEquals(testCase.second, SliceEqual{}));
+    }
+}
+
+TEST_CASE("toTimeSlice interprets single int as step size.")
+{
+    std::vector<std::pair<std::string, std::vector<Slice>>> testCases = {
+        {"5", {Slice{0, static_cast<uint32_t>(-1), 5}}},
+        {"5,10", {Slice{0, static_cast<uint32_t>(-1), 5}, Slice{0, static_cast<uint32_t>(-1), 10}}},
+    };
+
+    for(const auto& testCase : testCases)
+    {
+        const auto result = toTimeSlice(testCase.first);
+        CHECK_THAT(result, SizeIs(testCase.second.size()));
+        CHECK_THAT(result, Catch::Matchers::RangeEquals(testCase.second, SliceEqual{}));
+    }
+}

--- a/share/picongpu/unit/toSlice.cpp
+++ b/share/picongpu/unit/toSlice.cpp
@@ -72,12 +72,27 @@ TEST_CASE("Both slices", "")
     SECTION("accept : and , syntax.")
     {
         std::vector<std::pair<std::string, std::vector<Slice>>> testCases = {
+            // empty
             {"", {}},
-            {"1:5", {Slice{1, 5, 1}}},
-            {"1:5:2", {Slice{1, 5, 2}}},
-            {"1:-1", {Slice{1, static_cast<uint32_t>(-1), 1}}},
+            // only colons
             {":", {Slice{0, static_cast<uint32_t>(-1), 1}}},
             {"::", {Slice{0, static_cast<uint32_t>(-1), 1}}},
+            // single value
+            {":2", {Slice{0, 2, 1}}},
+            {":2:", {Slice{0, 2, 1}}},
+            {"2:", {Slice{2, static_cast<uint32_t>(-1), 1}}},
+            {"2::", {Slice{2, static_cast<uint32_t>(-1), 1}}},
+            {"::2", {Slice{0, static_cast<uint32_t>(-1), 2}}},
+            // two values
+            {"1:5", {Slice{1, 5, 1}}},
+            {"1:5:", {Slice{1, 5, 1}}},
+            {":1:5", {Slice{0, 1, 5}}},
+            {"1::5", {Slice{1, static_cast<uint32_t>(-1), 5}}},
+            // three values
+            {"1:5:2", {Slice{1, 5, 2}}},
+            // explicit -1 as end
+            {"1:-1", {Slice{1, static_cast<uint32_t>(-1), 1}}},
+            // multiple slices
             {"1:5,10:15", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
             {"1:5:2,10:15:3", {Slice{1, 5, 2}, Slice{10, 15, 3}}},
             {"1:-1,10:15", {Slice{1, static_cast<uint32_t>(-1), 1}, Slice{10, 15, 1}}},


### PR DESCRIPTION
This PR fixes a bug in `to{Range,Time}Slice`. Despite claims to the contrary in the documentation and their respective docstrings they didn't handle `-1` input but threw an exception. In the process of fixing this, I added unit tests and refactored them by extracting a common function.