### PR TITLE
Add period syntax to PICMI

### DIFF
--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -1,6 +1,7 @@
 """
 PICMI for PIConGPU
 """
+
 from .simulation import Simulation
 from .grid import Cartesian3DGrid
 from .solver import ElectromagneticSolver
@@ -8,14 +9,17 @@ from .gaussian_laser import GaussianLaser
 from .species import Species
 from .layout import PseudoRandomLayout
 from . import constants
-from .phase_space import PhaseSpace
-from .energy_histogram import EnergyHistogram
-from .macro_particle_count import MacroParticleCount
-from . import output
+from . import diagnostics
 
 from .distribution import FoilDistribution, UniformDistribution, GaussianDistribution
 from .interaction import Interaction
-from .interaction.ionization.fieldionization import ADK, ADKVariant, BSI, BSIExtension, Keldysh
+from .interaction.ionization.fieldionization import (
+    ADK,
+    ADKVariant,
+    BSI,
+    BSIExtension,
+    Keldysh,
+)
 from .interaction.ionization.electroniccollisionalequilibrium import ThomasFermi
 
 import picmistandard
@@ -42,10 +46,7 @@ __all__ = [
     "Keldysh",
     "ThomasFermi",
     "Interaction",
-    "PhaseSpace",
-    "EnergyHistogram",
-    "MacroParticleCount",
-    "output",
+    "diagnostics",
 ]
 
 

--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -1,13 +1,20 @@
-from .auto import Auto
+"""
+This file is part of PIConGPU.
+Copyright 2024 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .timestepspec import TimeStepSpec
 from .phase_space import PhaseSpace
 from .energy_histogram import EnergyHistogram
 from .macro_particle_count import MacroParticleCount
-from .timestepspec import TimeStepSpec
+from .auto import Auto
 
 __all__ = [
-    "Auto",
     "PhaseSpace",
     "EnergyHistogram",
     "MacroParticleCount",
+    "Auto",
     "TimeStepSpec",
 ]

--- a/lib/python/picongpu/picmi/diagnostics/auto.py
+++ b/lib/python/picongpu/picmi/diagnostics/auto.py
@@ -5,6 +5,7 @@ Authors: Pawel Ordyna
 License: GPLv3+
 """
 
+from .timestepspec import TimeStepSpec
 from ...pypicongpu.output.auto import Auto as PyPIConGPUAuto
 from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
 
@@ -13,11 +14,10 @@ from ..species import Species as PICMISpecies
 
 
 import typeguard
-import pydantic
 
 
 @typeguard.typechecked
-class Auto(pydantic.BaseModel):
+class Auto:
     """
     Specifies the parameters for the Auto output.
 
@@ -28,20 +28,23 @@ class Auto(pydantic.BaseModel):
         Unit: steps (simulation time steps).
     """
 
-    period: int
+    period: TimeStepSpec
     """Number of simulation steps between consecutive outputs. Unit: steps (simulation time steps)."""
 
+    def __init__(self, period: TimeStepSpec) -> None:
+        self.period = period
+
     def check(self):
-        if self.period <= 0:
-            raise ValueError("Period must be > 0")
+        pass
 
     def get_as_pypicongpu(
         self,
         # not used here, but needed for the interface
         dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
+        time_step_size,
+        num_steps,
     ) -> PyPIConGPUAuto:
         self.check()
-
         pypicongpu_auto = PyPIConGPUAuto()
-        pypicongpu_auto.period = self.period
+        pypicongpu_auto.period = self.period.get_as_pypicongpu(time_step_size, num_steps)
         return pypicongpu_auto

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -5,11 +5,14 @@ Authors: Masoud Afshari
 License: GPLv3+
 """
 
-from ..pypicongpu.output.energy_histogram import EnergyHistogram as PyPIConGPUEnergyHistogram
-from ..pypicongpu.species.species import Species as PyPIConGPUSpecies
+from .timestepspec import TimeStepSpec
+from ...pypicongpu.output.energy_histogram import (
+    EnergyHistogram as PyPIConGPUEnergyHistogram,
+)
+from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
 
 
-from .species import Species as PICMISpecies
+from ..species import Species as PICMISpecies
 
 import typeguard
 
@@ -51,8 +54,6 @@ class EnergyHistogram:
     """
 
     def check(self):
-        if self.period <= 0:
-            raise ValueError("Period must be > 0")
         if self.min_energy >= self.max_energy:
             raise ValueError("min_energy must be less than max_energy")
         if self.bin_count <= 0:
@@ -61,7 +62,7 @@ class EnergyHistogram:
     def __init__(
         self,
         species: PICMISpecies,
-        period: int,
+        period: TimeStepSpec,
         bin_count: int,
         min_energy: float,
         max_energy: float,
@@ -76,6 +77,8 @@ class EnergyHistogram:
         # to get the corresponding PyPIConGPUSpecies instance for the given PICMISpecies.
         self,
         dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
+        time_step_size,
+        num_steps,
     ) -> PyPIConGPUEnergyHistogram:
         self.check()
 
@@ -90,7 +93,7 @@ class EnergyHistogram:
 
         pypicongpu_energy_histogram = PyPIConGPUEnergyHistogram()
         pypicongpu_energy_histogram.species = pypicongpu_species
-        pypicongpu_energy_histogram.period = self.period
+        pypicongpu_energy_histogram.period = self.period.get_as_pypicongpu(time_step_size, num_steps)
         pypicongpu_energy_histogram.bin_count = self.bin_count
         pypicongpu_energy_histogram.min_energy = self.min_energy
         pypicongpu_energy_histogram.max_energy = self.max_energy

--- a/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
+++ b/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
@@ -5,10 +5,13 @@ Authors: Masoud Afshari
 License: GPLv3+
 """
 
-from ..pypicongpu.output.macro_particle_count import MacroParticleCount as PyPIConGPUMacroParticleCount
-from ..pypicongpu.species.species import Species as PyPIConGPUSpecies
+from .timestepspec import TimeStepSpec
+from ...pypicongpu.output.macro_particle_count import (
+    MacroParticleCount as PyPIConGPUMacroParticleCount,
+)
+from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
 
-from .species import Species as PICMISpecies
+from ..species import Species as PICMISpecies
 
 import typeguard
 
@@ -35,20 +38,17 @@ class MacroParticleCount:
     """
 
     def check(self):
-        if self.period <= 0:
-            raise ValueError("Period must be > 0")
+        pass
 
-    def __init__(
-        self,
-        species: PICMISpecies,
-        period: int,
-    ):
+    def __init__(self, species: PICMISpecies, period: TimeStepSpec):
         self.species = species
         self.period = period
 
     def get_as_pypicongpu(
         self,
         dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
+        time_step_size,
+        num_steps,
     ) -> PyPIConGPUMacroParticleCount:
         self.check()
 
@@ -62,6 +62,6 @@ class MacroParticleCount:
 
         pypicongpu_macro_count = PyPIConGPUMacroParticleCount()
         pypicongpu_macro_count.species = pypicongpu_species
-        pypicongpu_macro_count.period = self.period
+        pypicongpu_macro_count.period = self.period.get_as_pypicongpu(time_step_size, num_steps)
 
         return pypicongpu_macro_count

--- a/lib/python/picongpu/picmi/diagnostics/timestepspec.py
+++ b/lib/python/picongpu/picmi/diagnostics/timestepspec.py
@@ -5,13 +5,31 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from enum import Enum
+from enum import Enum, EnumMeta
 from math import ceil
 
 from ...pypicongpu.output import TimeStepSpec as PyPIConGPUTimeStepSpec
 
 
-class TimeStepUnits(Enum):
+class CustomStrEnumMeta(EnumMeta):
+    """
+    This class provides some functionality of 3.12 StrEnum,
+    namely its __contains__() method.
+
+    You can safely remove this and inherit directly from StrEnum
+    once we switched to 3.12.
+    """
+
+    def __contains__(cls, val):
+        try:
+            cls(val)
+        except ValueError:
+            return False
+        else:
+            return True
+
+
+class TimeStepUnits(Enum, metaclass=CustomStrEnumMeta):
     """
     Units allowed in TimeStepSpec.
     """

--- a/lib/python/picongpu/picmi/diagnostics/timestepspec.py
+++ b/lib/python/picongpu/picmi/diagnostics/timestepspec.py
@@ -1,0 +1,180 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from enum import StrEnum, auto
+from math import ceil
+
+from ...pypicongpu.output import TimeStepSpec as PyPIConGPUTimeStepSpec
+
+
+class TimeStepUnits(StrEnum):
+    """
+    Units allowed in TimeStepSpec.
+    """
+
+    STEPS = auto()
+    SECONDS = auto()
+
+    @classmethod
+    def _missing_(cls, value):
+        value = str(value).lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        raise ValueError(f"Unknown time step unit. You gave {value}.")
+
+
+# The following might look slightly convoluted but is preferred over the more obvious use of `__class_getitem__`.
+# This is because the latter is supposed to return a GenericAlias which is not what we want.
+# That would be like list[int].
+# We are more like an `Enum` where indexing into the class means something different.
+# See [here](https://docs.python.org/3/reference/datamodel.html#object.__getitem__) and
+# [here](https://docs.python.org/3/reference/datamodel.html#classgetitem-versus-getitem).
+
+
+class _TimeStepSpecMeta(type):
+    """
+    Custom metaclass providing the [] operator on its children.
+    """
+
+    # Provide this to have a nice syntax picmi.diagnostics.TimeStepSpec[10:200:5, 3, 7, 11, 17]
+    def __getitem__(cls, args):
+        if not isinstance(args, tuple):
+            args = (args,)
+        return cls(*args)
+
+
+class TimeStepSpec(metaclass=_TimeStepSpecMeta):
+    """
+    A class to specify time steps for simulation output.
+
+    This class allows for flexible specification of time steps using slices
+    or individual indices. Its custom metaclass provides a [] operator on the class itself
+    for slicing and the () operator for choosing the unit such that the most convenient
+    way to use it is as follows:
+
+        ts = TimeStepSpec[:12:2, 7]("steps") + TimeStepSpec[1.e-15:5.e-15:2.e-16]("seconds")
+
+    In this example, `ts` specifies:
+    - every other time step for the first 12 time steps inclusively (`0, 2, 4, 6, 8, 10, 12`)
+    - AND the 7th time step
+    - AND one output every 2.e-16 seconds in the (inclusive) range 1.e-15 to 5.e-15 seconds
+      (which indices this maps to depends on the time step size and the number of time steps)
+
+    In general, the class implements the following semantics for the operator []:
+    - the [] operator understands slices and numbers separated by commas
+    - specifications separated by commas are interpreted as unions
+    - slices are interpreted as inclusive on both ends, so `start:stop:step` includes the values
+      `start` and `stop` (if there exists an integer n such that `n*step+start == stop`)
+    - negative values are allowed for `start` and `stop` but not `step` (due to practical limitations
+      of the simulation code); as expected in Python they count from the end but due to inclusiveness
+      `:-1` includes the last element
+    - individual numbers denote a single time step
+    - multiple specifications (particularly in different units) can be concatenated (as set unions)
+      via the + operator
+
+    Default units are `steps`. If other units are given (see which are implemented in `TimeStepUnits`),
+    rounding must happen in the translation into steps (the only unit available in the backend). This
+    rounding is implemented to round down (up) for the lower (upper) bound such that the interval will
+    never be clipped. The time step is always rounded down to the next available multiple of the time
+    step size, such that for long and sparsely sampled intervals distortions may occur.
+
+    An extensive list of tests is available in the corresponding directory, mapping the syntax to
+    concrete index sets. The reader is encouraged to look for clarification there.
+    """
+
+    unit_system = None
+
+    def __init__(self, *args, specs_in_seconds=tuple()):
+        self.specs = tuple()
+        self.specs_in_seconds = tuple()
+
+        # allow copy initialisation from another TimeStepSpec.
+        if len(args) == 1 and isinstance(args[0], TimeStepSpec):
+            self.specs = args[0].specs
+            self.specs_in_seconds = args[0].specs_in_seconds
+            return
+
+        self.specs = tuple(
+            # The else branch is supposed to handle integers.
+            # We use a slice here because PIConGPU's interpretation of the
+            # --period argument for single integers is different.
+            # In PIConGPU, a single integer would be interpreted as
+            # slice(None, None, value) but this is unnatural for the
+            # Python [] operator.
+            spec if isinstance(spec, slice) else slice(int(spec), int(spec), 1)
+            for spec in args
+        )
+        self.specs_in_seconds = tuple(specs_in_seconds)
+
+    def __call__(self, unit_system="steps"):
+        if unit_system not in TimeStepUnits:
+            raise ValueError(f"Unknown unit in TimeStepSpec. You gave {unit_system} which is not in TimeStepUnits.")
+        if self.unit_system is not None and self.unit_system != unit_system:
+            raise ValueError(
+                "Don't reset units on a TimeStepSpec. "
+                f"You've tried to set {unit_system} but it's already {self.unit_system}."
+            )
+        self.unit_system = unit_system
+        if unit_system == "seconds":
+            self.specs_in_seconds = self.specs
+            self.specs = tuple()
+        return self
+
+    def __add__(self, other):
+        if not (isinstance(other, TimeStepSpec)):
+            raise TypeError("unsupported operand type(s) for +: TimeStepSpec and {type(other)}")
+        ts = TimeStepSpec(
+            *self.specs,
+            *other.specs,
+            specs_in_seconds=(*self.specs_in_seconds, *other.specs_in_seconds),
+        )
+        # The following guards against setting units on the result of the addition.
+        # Otherwise one could specify time steps in "steps" unit, add that to
+        # another TimeStepSpec and reset the units.
+        ts.unit_system = "mixed"
+        return ts
+
+    def _transform_to_steps(self, specs_in_seconds, time_step_size):
+        return tuple(
+            slice(
+                int(spec.start / time_step_size if spec.start is not None else 0),
+                int(ceil(spec.stop / time_step_size)) if spec.stop is not None else None,
+                int(spec.step / time_step_size if spec.step is not None else 1) or 1,
+            )
+            for spec in specs_in_seconds
+        )
+
+    def _interpret_nones(self, spec):
+        # We must communicate an open end explicitly, so we leave spec.stop as None.
+        return slice(
+            spec.start if spec.start is not None else 0,
+            spec.stop if spec.stop is not None else -1,
+            spec.step if spec.step is not None else 1,
+        )
+
+    def _interpret_negatives(self, spec, num_steps):
+        if spec.step < 1:
+            raise ValueError(f"Step size must be >= 1 in TimeStepSpec. You gave {spec.step}.")
+        return slice(
+            spec.start if spec.start >= 0 else num_steps + spec.start,
+            spec.stop if (spec.stop is None or spec.stop >= -1) else num_steps + spec.stop,
+            spec.step,
+        )
+
+    def get_as_pypicongpu(self, time_step_size, num_steps):
+        """
+        Creates the corresponding pypicongpu object by translating every specification
+        into non-negative (except for -1) slices in units of steps. It takes `time_step_size`
+        and `num_steps` to compute this transformation.
+        """
+        return PyPIConGPUTimeStepSpec(
+            [
+                self._interpret_negatives(self._interpret_nones(s), num_steps)
+                for s in self.specs + self._transform_to_steps(self.specs_in_seconds, time_step_size)
+            ]
+        )

--- a/lib/python/picongpu/picmi/diagnostics/timestepspec.py
+++ b/lib/python/picongpu/picmi/diagnostics/timestepspec.py
@@ -145,7 +145,7 @@ class TimeStepSpec(metaclass=_TimeStepSpecMeta):
 
     def __add__(self, other):
         if not (isinstance(other, TimeStepSpec)):
-            raise TypeError("unsupported operand type(s) for +: TimeStepSpec and {type(other)}")
+            raise TypeError(f"unsupported operand type(s) for +: TimeStepSpec and {type(other)}")
         ts = TimeStepSpec(
             *self.specs,
             *other.specs,
@@ -158,6 +158,8 @@ class TimeStepSpec(metaclass=_TimeStepSpecMeta):
         return ts
 
     def _transform_to_steps(self, specs_in_seconds, time_step_size):
+        if time_step_size <= 0:
+            raise ValueError(f"Time step size must be strictly positive. You gave {time_step_size}.")
         return tuple(
             slice(
                 int(spec.start / time_step_size if spec.start is not None else 0),

--- a/lib/python/picongpu/picmi/diagnostics/timestepspec.py
+++ b/lib/python/picongpu/picmi/diagnostics/timestepspec.py
@@ -5,19 +5,19 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from enum import StrEnum, auto
+from enum import Enum
 from math import ceil
 
 from ...pypicongpu.output import TimeStepSpec as PyPIConGPUTimeStepSpec
 
 
-class TimeStepUnits(StrEnum):
+class TimeStepUnits(Enum):
     """
     Units allowed in TimeStepSpec.
     """
 
-    STEPS = auto()
-    SECONDS = auto()
+    STEPS = "steps"
+    SECONDS = "seconds"
 
     @classmethod
     def _missing_(cls, value):

--- a/lib/python/picongpu/picmi/distribution/UniformDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/UniformDistribution.py
@@ -44,8 +44,8 @@ class UniformDistribution(picmistandard.PICMI_UniformDistribution):
 
     def get_as_pypicongpu(self) -> species.operation.densityprofile.DensityProfile:
         util.unsupported("fill in", self.fill_in)
-        util.unsupported("lower bound", self.lower_bound, (None, None, None))
-        util.unsupported("upper bound", self.upper_bound, (None, None, None))
+        util.unsupported("lower bound", self.lower_bound, [None, None, None])
+        util.unsupported("upper bound", self.upper_bound, [None, None, None])
 
         profile = species.operation.densityprofile.Uniform()
         profile.density_si = self.density

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -475,10 +475,10 @@ class Simulation(picmistandard.PICMI_Simulation):
 
         s.init_manager, pypicongpu_by_picmi_species = self.__get_init_manager()
 
-        plugins = []
-        for entry in self.diagnostics:
-            plugins.append(entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, self.max_steps))
-        s.plugins = plugins
+        s.plugins = [
+            entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, self.max_steps)
+            for entry in self.diagnostics
+        ]
 
         # set typical ppc if not set explicitly by user
         if self.picongpu_typical_ppc is None:

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -305,7 +305,14 @@ class Simulation(picmistandard.PICMI_Simulation):
         self,
     ) -> tuple[
         dict[Species, pypicongpu.species.Species],
-        dict[Species, None | dict[IonizationModel, pypicongpu.species.constant.ionizationmodel.IonizationModel]],
+        dict[
+            Species,
+            None
+            | dict[
+                IonizationModel,
+                pypicongpu.species.constant.ionizationmodel.IonizationModel,
+            ],
+        ],
     ]:
         """
         get mappping of PICMI species to PyPIConGPU species and mapping of of simulation
@@ -328,7 +335,12 @@ class Simulation(picmistandard.PICMI_Simulation):
         self,
         pypicongpu_by_picmi_species: dict[Species, pypicongpu.species.Species],
         ionization_model_conversion_by_species: dict[
-            Species, None | dict[IonizationModel, pypicongpu.species.constant.ionizationmodel.IonizationModel]
+            Species,
+            None
+            | dict[
+                IonizationModel,
+                pypicongpu.species.constant.ionizationmodel.IonizationModel,
+            ],
         ],
     ) -> None:
         """
@@ -342,7 +354,9 @@ class Simulation(picmistandard.PICMI_Simulation):
                 pypicongpu_by_picmi_species, ionization_model_conversion_by_species
             )
 
-    def __get_init_manager(self) -> tuple[InitManager, typing.Dict[Species, pypicongpu.species.Species]]:
+    def __get_init_manager(
+        self,
+    ) -> tuple[InitManager, typing.Dict[Species, pypicongpu.species.Species]]:
         """
         create & fill an Initmanager
 
@@ -378,7 +392,9 @@ class Simulation(picmistandard.PICMI_Simulation):
         return initmgr, pypicongpu_by_picmi_species
 
     def write_input_file(
-        self, file_name: str, pypicongpu_simulation: typing.Optional[pypicongpu.simulation.Simulation] = None
+        self,
+        file_name: str,
+        pypicongpu_simulation: typing.Optional[pypicongpu.simulation.Simulation] = None,
     ) -> None:
         """
         generate input data set for picongpu
@@ -461,7 +477,7 @@ class Simulation(picmistandard.PICMI_Simulation):
 
         plugins = []
         for entry in self.diagnostics:
-            plugins.append(entry.get_as_pypicongpu(pypicongpu_by_picmi_species))
+            plugins.append(entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, self.max_steps))
         s.plugins = plugins
 
         # set typical ppc if not set explicitly by user

--- a/lib/python/picongpu/pypicongpu/output/auto.py
+++ b/lib/python/picongpu/pypicongpu/output/auto.py
@@ -5,6 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+
 """
 
+from .timestepspec import TimeStepSpec
 from .. import util
 from .plugin import Plugin
 
@@ -25,7 +26,7 @@ class Auto(Plugin):
     create a separate class.
     """
 
-    period = util.build_typesafe_property(int)
+    period = util.build_typesafe_property(TimeStepSpec)
     """period to print data at"""
 
     def __init__(self):
@@ -34,20 +35,13 @@ class Auto(Plugin):
     def check(self) -> None:
         """
         validate attributes
-
-        if ok pass silently, otherwise raises error
-
-        :raises ValueError: period is non-negative integer
-        :raises ValueError: species_names contains empty string
-        :raises ValueError: species_names contains non-unique name
         """
-        if 1 > self.period:
-            raise ValueError("period must be non-negative integer")
+        pass
 
     def _get_serialized(self) -> dict:
         self.check()
         return {
-            "period": self.period,
+            "period": self.period.get_rendering_context(),
             # helper to avoid repeating code
             "png_axis": [
                 {"axis": "yx"},

--- a/lib/python/picongpu/pypicongpu/output/energy_histogram.py
+++ b/lib/python/picongpu/pypicongpu/output/energy_histogram.py
@@ -7,6 +7,7 @@ License: GPLv3+
 
 from .. import util
 from ..species import Species
+from .timestepspec import TimeStepSpec
 
 from .plugin import Plugin
 
@@ -17,7 +18,7 @@ import typing
 @typeguard.typechecked
 class EnergyHistogram(Plugin):
     species = util.build_typesafe_property(Species)
-    period = util.build_typesafe_property(int)
+    period = util.build_typesafe_property(TimeStepSpec)
     bin_count = util.build_typesafe_property(int)
     min_energy = util.build_typesafe_property(float)
     max_energy = util.build_typesafe_property(float)
@@ -29,7 +30,7 @@ class EnergyHistogram(Plugin):
         """Return the serialized representation of the object."""
         return {
             "species": self.species.get_rendering_context(),
-            "period": self.period,
+            "period": self.period.get_rendering_context(),
             "bin_count": self.bin_count,
             "min_energy": self.min_energy,
             "max_energy": self.max_energy,

--- a/lib/python/picongpu/pypicongpu/output/macro_particle_count.py
+++ b/lib/python/picongpu/pypicongpu/output/macro_particle_count.py
@@ -5,6 +5,7 @@ Authors: Masoud Afshari
 License: GPLv3+
 """
 
+from .timestepspec import TimeStepSpec
 from .. import util
 from ..species import Species
 
@@ -17,7 +18,7 @@ import typing
 @typeguard.typechecked
 class MacroParticleCount(Plugin):
     species = util.build_typesafe_property(Species)
-    period = util.build_typesafe_property(int)
+    period = util.build_typesafe_property(TimeStepSpec)
 
     def __init__(self):
         "do nothing"
@@ -26,5 +27,5 @@ class MacroParticleCount(Plugin):
         """Return the serialized representation of the object."""
         return {
             "species": self.species.get_rendering_context(),
-            "period": self.period,
+            "period": self.period.get_rendering_context(),
         }

--- a/lib/python/picongpu/pypicongpu/output/phase_space.py
+++ b/lib/python/picongpu/pypicongpu/output/phase_space.py
@@ -9,6 +9,7 @@ from .. import util
 from ..species import Species
 
 from .plugin import Plugin
+from .timestepspec import TimeStepSpec
 
 import typeguard
 import typing
@@ -18,7 +19,7 @@ from typing import Literal
 @typeguard.typechecked
 class PhaseSpace(Plugin):
     species = util.build_typesafe_property(Species)
-    period = util.build_typesafe_property(int)
+    period = util.build_typesafe_property(TimeStepSpec)
     spatial_coordinate = util.build_typesafe_property(Literal["x", "y", "z"])
     momentum_coordinate = util.build_typesafe_property(Literal["px", "py", "pz"])
     min_momentum = util.build_typesafe_property(float)
@@ -39,7 +40,7 @@ class PhaseSpace(Plugin):
         self.check()
         return {
             "species": self.species.get_rendering_context(),
-            "period": self.period,
+            "period": self.period.get_rendering_context(),
             "spatial_coordinate": self.spatial_coordinate,
             "momentum_coordinate": self.momentum_coordinate,
             "min_momentum": self.min_momentum,

--- a/lib/python/picongpu/pypicongpu/output/timestepspec.py
+++ b/lib/python/picongpu/pypicongpu/output/timestepspec.py
@@ -1,0 +1,32 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from ..rendering.renderedobject import RenderedObject
+from ..util import build_typesafe_property
+
+import typeguard
+
+
+def _serialize(spec):
+    if isinstance(spec, slice):
+        return {
+            "start": spec.start if spec.start is not None else 0,
+            "stop": spec.stop if spec.stop is not None else -1,
+            "step": spec.step if spec.step is not None else 1,
+        }
+    raise ValueError(f"Unknown serialization for {spec=} as a time step specifier (--period argument).")
+
+
+@typeguard.typechecked
+class TimeStepSpec(RenderedObject):
+    specs = build_typesafe_property(list[slice])
+
+    def __init__(self, specs: list[slice]):
+        self.specs = specs
+
+    def _get_serialized(self):
+        return {"specs": list(map(_serialize, self.specs))}

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -15,6 +15,7 @@ from . import output
 from .rendering import RenderedObject
 from .customuserinput import InterfaceCustomUserInput
 from .output.plugin import Plugin
+from .output.timestepspec import TimeStepSpec
 
 import typing
 import typeguard
@@ -74,7 +75,7 @@ class Simulation(RenderedObject):
 
         if self.plugins == "auto":
             auto = output.Auto()
-            auto.period = max(1, int(self.time_steps / 100))
+            auto.period = TimeStepSpec([slice(0, None, max(1, int(self.time_steps / 100)))])
 
             return [auto.get_generic_plugin_rendering_context()]
         else:

--- a/share/picongpu/pypicongpu/examples/warm_plasma/main.py
+++ b/share/picongpu/pypicongpu/examples/warm_plasma/main.py
@@ -6,6 +6,7 @@ License: GPLv3+
 """
 
 from picongpu import picmi
+from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
 
 OUTPUT_DIRECTORY_PATH = "warm_plasma"
 
@@ -42,7 +43,7 @@ sim = picmi.Simulation(
     solver=solver,
 )
 
-sim.add_diagnostic(picmi.output.Auto(period=100))
+sim.add_diagnostic(picmi.diagnostics.Auto(period=TimeStepSpec[::100]))
 
 layout = picmi.PseudoRandomLayout(n_macroparticles_per_cell=25)
 sim.add_species(electron, layout)

--- a/share/picongpu/pypicongpu/schema/output/auto.Auto.json
+++ b/share/picongpu/pypicongpu/schema/output/auto.Auto.json
@@ -1,30 +1,33 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.auto.Auto",
-    "description": "enable as many output plugins as feasible with only the period specified",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": ["period", "png_axis"],
-    "properties": {
-        "period": {
-            "description": "number of time steps: at each multiple output is generated",
-            "type": "integer",
-            "minimum": 1
-        },
-        "png_axis": {
-            "description": "axis pairs (i.e. planes) for which to generate png output",
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": ["axis"],
-                "unevaluatedProperties": false,
-                "properties": {
-                    "axis": {
-                        "description": "actually a plane of two axis, but name follows PIConGPU",
-                        "type": "string",
-                        "pattern": "^(x|y|z)(x|y|z)$"
-                    }
-                }
-            }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.auto.Auto",
+  "description": "enable as many output plugins as feasible with only the period specified",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "period",
+    "png_axis"
+  ],
+  "properties": {
+    "period": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec"
+    },
+    "png_axis": {
+      "description": "axis pairs (i.e. planes) for which to generate png output",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "axis"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "axis": {
+            "description": "actually a plane of two axis, but name follows PIConGPU",
+            "type": "string",
+            "pattern": "^(x|y|z)(x|y|z)$"
+          }
         }
+      }
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/output/energy_histogram.EnergyHistogram.json
+++ b/share/picongpu/pypicongpu/schema/output/energy_histogram.EnergyHistogram.json
@@ -1,36 +1,34 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.energy_histogram.EnergyHistogram",
-    "type": "object",
-    "description": "Energy histogram output configuration for PIConGPU",
-    "unevaluatedProperties": false,
-    "required": [
-      "species",
-      "period",
-      "bin_count",
-      "min_energy",
-      "max_energy"
-    ],
-    "properties": {
-      "species": {
-        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-      },
-      "period": {
-        "type": "integer",
-        "minimum": 1,
-        "description": "Time period for energy histogram output."
-      },
-      "bin_count": {
-        "type": "integer",
-        "minimum": 1,
-        "description": "Number of bins in the energy histogram."
-      },
-      "min_energy": {
-        "type": "number",
-        "description": "Minimum energy value for the histogram range."
-      },
-      "max_energy": {
-        "type": "number",
-        "description": "Maximum energy value for the histogram range."
-      }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.energy_histogram.EnergyHistogram",
+  "type": "object",
+  "description": "Energy histogram output configuration for PIConGPU",
+  "unevaluatedProperties": false,
+  "required": [
+    "species",
+    "period",
+    "bin_count",
+    "min_energy",
+    "max_energy"
+  ],
+  "properties": {
+    "species": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "period": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec"
+    },
+    "bin_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of bins in the energy histogram."
+    },
+    "min_energy": {
+      "type": "number",
+      "description": "Minimum energy value for the histogram range."
+    },
+    "max_energy": {
+      "type": "number",
+      "description": "Maximum energy value for the histogram range."
     }
   }
+}

--- a/share/picongpu/pypicongpu/schema/output/macro_particle_count.MacroParticleCount.json
+++ b/share/picongpu/pypicongpu/schema/output/macro_particle_count.MacroParticleCount.json
@@ -1,18 +1,18 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.macro_particle_count.MacroParticleCount",
-
-    "type": "object",
-    "description": "Macro particle count output configuration for PIConGPU",
-    "unevaluatedProperties": false,
-    "required": ["species", "period"],
-    "properties": {
-        "species": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-        },
-        "period": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Time period for macro particle count output."
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.macro_particle_count.MacroParticleCount",
+  "type": "object",
+  "description": "Macro particle count output configuration for PIConGPU",
+  "unevaluatedProperties": false,
+  "required": [
+    "species",
+    "period"
+  ],
+  "properties": {
+    "species": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "period": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec"
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/output/phase_space.PhaseSpace.json
+++ b/share/picongpu/pypicongpu/schema/output/phase_space.PhaseSpace.json
@@ -10,9 +10,7 @@
                     "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
         },
         "period": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Time period for phase space output."
+            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec"
         },
         "spatial_coordinate": {
             "type": "string",

--- a/share/picongpu/pypicongpu/schema/output/timestepspec.json
+++ b/share/picongpu/pypicongpu/schema/output/timestepspec.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec",
+  "type": "object",
+  "description": "Select time steps (e.g. for notifying a plugin)",
+  "unevaluatedProperties": false,
+  "properties": {
+    "specs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "slice",
+        "properties": {
+          "start": {
+            "type": "integer"
+          },
+          "stop": {
+            "type": "integer"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -74,7 +74,7 @@ TBG_steps="{{{time_steps}}}"
 # only use charge conservation if solver is yee AND using cuda backend
 if [[ "Yee" = "{{{solver.name}}}" ]] && [[ "$PIC_BACKEND" =~ ^cuda(:.+)?$ ]]
 then
-    USED_CHARGE_CONSERVATION_FLAGS="--chargeConservation.period {{{data.period}}}"
+    USED_CHARGE_CONSERVATION_FLAGS="--chargeConservation.period {{#data.period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/data.period.specs}}"
 else
     USED_CHARGE_CONSERVATION_FLAGS=""
 fi
@@ -94,24 +94,24 @@ pypicongpu_output_with_newlines="
       {{#data}}
     {{#typeID.auto}}
 
-        --fields_energy.period {{{period}}}
-        --sumcurr.period {{{period}}}
+        --fields_energy.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
+        --sumcurr.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
         $USED_CHARGE_CONSERVATION_FLAGS
 
         {{#species_initmanager.species}}
-            --{{{name}}}_macroParticlesCount.period {{{period}}}
+            --{{{name}}}_macroParticlesCount.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
 
-            --{{{name}}}_energy.period {{{period}}}
+            --{{{name}}}_energy.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
             --{{{name}}}_energy.filter all
 
-            --{{{name}}}_energyHistogram.period {{{period}}}
+            --{{{name}}}_energyHistogram.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
             --{{{name}}}_energyHistogram.filter all
             --{{{name}}}_energyHistogram.binCount 1024
             --{{{name}}}_energyHistogram.minEnergy 0
             --{{{name}}}_energyHistogram.maxEnergy 256000
 
             {{#png_axis}}
-                --{{{name}}}_png.period {{{period}}}
+                --{{{name}}}_png.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
                 --{{{name}}}_png.axis {{{axis}}}
                 --{{{name}}}_png.slicePoint 0.5
                 --{{{name}}}_png.folder png_{{{name}}}_{{{axis}}}
@@ -120,7 +120,7 @@ pypicongpu_output_with_newlines="
     {{/typeID.auto}}
 
     {{#typeID.phasespace}}
-          --{{{species.name}}}_phaseSpace.period {{{period}}}
+          --{{{species.name}}}_phaseSpace.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
           --{{{species.name}}}_phaseSpace.filter all
           --{{{species.name}}}_phaseSpace.space {{{spatial_coordinate}}}
           --{{{species.name}}}_phaseSpace.momentum {{{momentum_coordinate}}}
@@ -129,7 +129,7 @@ pypicongpu_output_with_newlines="
     {{/typeID.phasespace}}
 
     {{#typeID.energyhistogram}}
-          --{{{species.name}}}_energyHistogram.period {{{period}}}
+          --{{{species.name}}}_energyHistogram.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
           --{{{species.name}}}_energyHistogram.filter all
           --{{{species.name}}}_energyHistogram.binCount {{{bin_count}}}
           --{{{species.name}}}_energyHistogram.minEnergy {{{min_energy}}}
@@ -137,7 +137,7 @@ pypicongpu_output_with_newlines="
     {{/typeID.energyhistogram}}
 
     {{#typeID.macroparticlecount}}
-      --{{{species.name}}}_macroParticleCount.period {{{period}}}
+      --{{{species.name}}}_macroParticlesCount.period {{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}
     {{/typeID.macroparticlecount}}
 
     {{/data}}

--- a/test/python/picongpu/quick/picmi/__init__.py
+++ b/test/python/picongpu/quick/picmi/__init__.py
@@ -5,3 +5,4 @@ from .layout import *  # pyflakes.ignore
 from .distribution import *  # pyflakes.ignore
 from .gaussian_laser import *  # pyflakes.ignore
 from .grid import *  # pyflakes.ignore
+from .diagnostics import *  # pyflakes.ignore

--- a/test/python/picongpu/quick/picmi/diagnostics/__init__.py
+++ b/test/python/picongpu/quick/picmi/diagnostics/__init__.py
@@ -1,0 +1,9 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+# flake8: noqa
+from .timestepspec import *  # pyflakes.ignore

--- a/test/python/picongpu/quick/picmi/diagnostics/timestepspec.py
+++ b/test/python/picongpu/quick/picmi/diagnostics/timestepspec.py
@@ -208,6 +208,10 @@ class TestTimeStepSpec(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unknown unit in TimeStepSpec."):
             TimeStepSpec[:]("meters")
 
+    def test_raises_on_negative_time_step_size(self):
+        with self.assertRaisesRegex(ValueError, "Time step size must be strictly positive."):
+            TimeStepSpec[:]("seconds").get_as_pypicongpu(-1.0, 10)
+
     def test_rounding_in_unit_conversion(self):
         # Values are chosen to be sufficiently misaligned such that all special cases are triggered.
         time_step_size = 0.3333

--- a/test/python/picongpu/quick/picmi/diagnostics/timestepspec.py
+++ b/test/python/picongpu/quick/picmi/diagnostics/timestepspec.py
@@ -1,0 +1,274 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import unittest
+from functools import reduce
+from math import floor, ceil
+
+from picongpu.picmi.diagnostics import TimeStepSpec
+
+# choose larger than any of the numbers used in the TEST_CASES
+INDEX_MAX = 200
+
+
+def inclusive_range(*args):
+    """
+    Implements range with inclusive endpoint, i.e., in the interval [,] instead of [,).
+    """
+    args = list(args)
+    args[0 if len(args) == 1 else 1] += 1
+    return range(*args)
+
+
+def make_inclusive(spec: slice):
+    return slice(spec.start, spec.stop + 1 if spec.stop != -1 else None, spec.step)
+
+
+def _indices(ts):
+    # This function might need to change if the implementation details of
+    # TimeStepSpec ever change.
+    # It also relies on the picmi object and the pypicongpu object using
+    # the same internal variable and storage layout.
+    return reduce(
+        set.union,
+        (list(inclusive_range(INDEX_MAX))[make_inclusive(spec)] for spec in ts.specs),
+        set(),
+    )
+
+
+TESTCASES_IN_STEPS = [
+    (TimeStepSpec(), set()),
+    (TimeStepSpec[:], set(inclusive_range(INDEX_MAX))),
+    (TimeStepSpec[::], set(inclusive_range(INDEX_MAX))),
+    (TimeStepSpec[10:], set(inclusive_range(10, INDEX_MAX))),
+    (TimeStepSpec[10::], set(inclusive_range(10, INDEX_MAX))),
+    (TimeStepSpec[:10:], set(inclusive_range(0, 10))),
+    (TimeStepSpec[::10], set(inclusive_range(0, INDEX_MAX, 10))),
+    (TimeStepSpec[10:20], set(inclusive_range(10, 20))),
+    (TimeStepSpec[10:20:], set(inclusive_range(10, 20))),
+    (TimeStepSpec[:20:10], set(inclusive_range(0, 20, 10))),
+    (TimeStepSpec[20::10], set(inclusive_range(20, INDEX_MAX, 10))),
+    (TimeStepSpec[20:50:10], set(inclusive_range(20, 50, 10))),
+    (
+        TimeStepSpec[20:50:10, ::7],
+        set(inclusive_range(20, 50, 10)) | set(inclusive_range(0, INDEX_MAX, 7)),
+    ),
+    (TimeStepSpec[11], set([11])),
+    (TimeStepSpec[11:12, 11], set([11, 12])),
+    (TimeStepSpec[10:12, 11], set([10, 11, 12])),
+    (
+        TimeStepSpec[20:50:10, ::7, 11],
+        set(inclusive_range(20, 50, 10)) | set(inclusive_range(0, INDEX_MAX, 7)) | set([11]),
+    ),
+    (TimeStepSpec[-10:], set(inclusive_range(INDEX_MAX - 10, INDEX_MAX))),
+    (TimeStepSpec[:-10:], set(inclusive_range(0, INDEX_MAX - 10))),
+    (TimeStepSpec[-10:20], set(inclusive_range(INDEX_MAX - 10, 20))),
+    (TimeStepSpec[-10:195], set(inclusive_range(INDEX_MAX - 10, 195))),
+    (TimeStepSpec[10:-20], set(inclusive_range(10, INDEX_MAX - 20))),
+    (TimeStepSpec[:-20:10], set(inclusive_range(0, INDEX_MAX - 20, 10))),
+    (TimeStepSpec[-20::10], set(inclusive_range(INDEX_MAX - 20, INDEX_MAX, 10))),
+    (TimeStepSpec[-20:50:10], set(inclusive_range(INDEX_MAX - 20, 50, 10))),
+    (TimeStepSpec[-20:190:10], set(inclusive_range(INDEX_MAX - 20, 190, 10))),
+    (TimeStepSpec[20:-50:10], set(inclusive_range(20, INDEX_MAX - 50, 10))),
+    (
+        TimeStepSpec[-20:-50:10],
+        set(inclusive_range(INDEX_MAX - 20, INDEX_MAX - 50, 10)),
+    ),
+    (TimeStepSpec[-11], set([INDEX_MAX - 11])),
+]
+
+TESTCASES_IN_STEPS_RAISING = [
+    (TimeStepSpec[::-10], set(inclusive_range(0, INDEX_MAX, 10))),
+    (TimeStepSpec[:20:-10], set(inclusive_range(0, 20, 10))),
+    (TimeStepSpec[20::-10], set(inclusive_range(20, INDEX_MAX, 10))),
+    (TimeStepSpec[20:50:-10], set(inclusive_range(20, 50, 10))),
+    (TimeStepSpec[-20:50:-10], set(inclusive_range(20, 50, 10))),
+    (TimeStepSpec[20:-50:-10], set(inclusive_range(20, 50, 10))),
+    (TimeStepSpec[-20:-50:-10], set(inclusive_range(20, 50, 10))),
+]
+
+# in seconds (i.e. SI units):
+TIME_STEP_SIZE = 0.5
+# The following hinge on TIME_STEP_SIZE = 0.5
+TESTCASES_IN_SECONDS = [
+    (TimeStepSpec()("seconds"), set()),
+    (TimeStepSpec[:]("seconds"), set(inclusive_range(INDEX_MAX))),
+    (TimeStepSpec[::]("seconds"), set(inclusive_range(INDEX_MAX))),
+    (TimeStepSpec[10:]("seconds"), set(inclusive_range(20, INDEX_MAX))),
+    (TimeStepSpec[10::]("seconds"), set(inclusive_range(20, INDEX_MAX))),
+    (TimeStepSpec[:10:]("seconds"), set(inclusive_range(0, 20))),
+    (TimeStepSpec[::10]("seconds"), set(inclusive_range(0, INDEX_MAX, 20))),
+    (TimeStepSpec[10:20]("seconds"), set(inclusive_range(20, 40))),
+    (TimeStepSpec[10:20:]("seconds"), set(inclusive_range(20, 40))),
+    (TimeStepSpec[:20:10]("seconds"), set(inclusive_range(0, 40, 20))),
+    (TimeStepSpec[20::10]("seconds"), set(inclusive_range(40, INDEX_MAX, 20))),
+    (TimeStepSpec[20:50:10]("seconds"), set(inclusive_range(40, 100, 20))),
+    (
+        TimeStepSpec[20:50:10, ::7]("seconds"),
+        set(inclusive_range(40, 100, 20)) | set(inclusive_range(0, INDEX_MAX, 14)),
+    ),
+    (TimeStepSpec[11]("seconds"), set([22])),
+    (TimeStepSpec[11:12, 11]("seconds"), set([22, 23, 24])),
+    (TimeStepSpec[10:12, 11]("seconds"), set(inclusive_range(20, 24))),
+    (
+        TimeStepSpec[20:50:10, ::7, 11]("seconds"),
+        set(inclusive_range(40, 100, 20)) | set(inclusive_range(0, INDEX_MAX, 14)) | set([22]),
+    ),
+    (TimeStepSpec[-10:]("seconds"), set(inclusive_range(INDEX_MAX - 20, INDEX_MAX))),
+    (TimeStepSpec[:-10:]("seconds"), set(inclusive_range(0, INDEX_MAX - 20))),
+    (TimeStepSpec[-10:20]("seconds"), set(inclusive_range(INDEX_MAX - 20, 40))),
+    (TimeStepSpec[-10:90]("seconds"), set(inclusive_range(INDEX_MAX - 20, 180))),
+    (TimeStepSpec[10:-20]("seconds"), set(inclusive_range(20, INDEX_MAX - 40))),
+    (TimeStepSpec[:-20:10]("seconds"), set(inclusive_range(0, INDEX_MAX - 40, 20))),
+    (
+        TimeStepSpec[-20::10]("seconds"),
+        set(inclusive_range(INDEX_MAX - 40, INDEX_MAX, 20)),
+    ),
+    (TimeStepSpec[-20:50:10]("seconds"), set(inclusive_range(INDEX_MAX - 40, 100, 20))),
+    (
+        TimeStepSpec[-20:90:10]("seconds"),
+        set(inclusive_range(INDEX_MAX - 40, 180, 20)),
+    ),
+    (TimeStepSpec[20:-50:10]("seconds"), set(inclusive_range(40, INDEX_MAX - 100, 20))),
+    (
+        TimeStepSpec[-20:-50:10]("seconds"),
+        set(inclusive_range(INDEX_MAX - 40, INDEX_MAX - 100, 20)),
+    ),
+    (TimeStepSpec[-11]("seconds"), set([INDEX_MAX - 22])),
+]
+
+
+class TestTimeStepSpec(unittest.TestCase):
+    def test_get_as_pypicongpu(self):
+        """
+        The unit conversion is done in get_as_pypicongpu, so we can only test in seconds here.
+        """
+        for ts, indices in TESTCASES_IN_STEPS + TESTCASES_IN_SECONDS:
+            with self.subTest(ts=ts, indices=indices):
+                self.assertEqual(
+                    _indices(ts.get_as_pypicongpu(TIME_STEP_SIZE, INDEX_MAX)),
+                    indices,
+                )
+
+    def test_construct_from_instance(self):
+        """
+        This tests another branch of the constructor, i.e., a copy constructor.
+        """
+        for ts, indices in TESTCASES_IN_STEPS:
+            with self.subTest(ts=ts, indices=indices):
+                self.assertEqual(
+                    _indices(TimeStepSpec(ts).get_as_pypicongpu(TIME_STEP_SIZE, INDEX_MAX)),
+                    indices,
+                )
+
+    def test_addition_operator(self):
+        """
+        The unit conversion is done in get_as_pypicongpu, so we can only test in seconds here.
+        """
+        for ts_steps, indices_steps in TESTCASES_IN_STEPS + TESTCASES_IN_SECONDS:
+            for ts_seconds, indices_seconds in TESTCASES_IN_STEPS + TESTCASES_IN_SECONDS:
+                ts = ts_steps + ts_seconds
+                indices = indices_steps | indices_seconds
+                with self.subTest(ts=ts, indices=indices):
+                    self.assertEqual(
+                        _indices(ts.get_as_pypicongpu(TIME_STEP_SIZE, INDEX_MAX)),
+                        indices,
+                    )
+
+    def test_dont_reset_unit_from_steps_to_seconds(self):
+        ts = TimeStepSpec[:]("steps")
+        with self.assertRaisesRegex(ValueError, "Don't reset units on a TimeStepSpec. "):
+            ts("seconds")
+
+    def test_dont_reset_unit_from_seconds_to_steps(self):
+        ts = TimeStepSpec[:]("seconds")
+        with self.assertRaisesRegex(ValueError, "Don't reset units on a TimeStepSpec. "):
+            ts("steps")
+
+    def test_dont_reset_unit_on_addition_result(self):
+        with self.assertRaisesRegex(ValueError, "Don't reset units on a TimeStepSpec. "):
+            (TimeStepSpec[:] + TimeStepSpec[:])("seconds")
+
+    def test_resetting_to_same_unit_is_fine(self):
+        with self.subTest(msg="seconds"):
+            ts = TimeStepSpec[:]("seconds")
+            # not raising an exception
+            ts("seconds")
+
+        with self.subTest(msg="steps"):
+            ts = TimeStepSpec[:]("steps")
+            # not raising an exception
+            ts("steps")
+
+    def test_wrong_unit(self):
+        with self.assertRaisesRegex(ValueError, "Unknown unit in TimeStepSpec."):
+            TimeStepSpec[:]("meters")
+
+    def test_rounding_in_unit_conversion(self):
+        # Values are chosen to be sufficiently misaligned such that all special cases are triggered.
+        time_step_size = 0.3333
+        start = 6.8
+        stop = 20.1
+        step = 0.7
+        ts = TimeStepSpec[start:stop:step]("seconds")
+        expected = set(
+            filter(
+                lambda i: (
+                    i >= floor(start / time_step_size)
+                    and i < ceil(stop / time_step_size)
+                    and (i - floor(start / time_step_size)) % floor(step / time_step_size) == 0
+                ),
+                inclusive_range(INDEX_MAX),
+            )
+        )
+        self.assertEqual(_indices(ts.get_as_pypicongpu(time_step_size, INDEX_MAX)), expected)
+
+    def test_step_size_smaller_one_in_unit_conversion(self):
+        ts = TimeStepSpec[::0.5]("seconds")
+        self.assertEqual(
+            _indices(ts.get_as_pypicongpu(0.7, INDEX_MAX)),
+            set(inclusive_range(INDEX_MAX)),
+        )
+
+    def test_modify_after_copy_construction(self):
+        ts = TimeStepSpec[::0.5]
+        ts2 = TimeStepSpec(ts)
+        try:
+            ts.specs[0] = slice(1, 2, 3)
+        except TypeError:
+            # It's fine. This is because tuples are immutable to start with.
+            pass
+        finally:
+            self.assertEqual(ts2.specs, (slice(None, None, 0.5),))
+
+    def test_seconds_are_copied(self):
+        ts = TimeStepSpec[::0.5]("seconds")
+        ts2 = TimeStepSpec(ts)
+        self.assertEqual(ts2.specs, ts.specs)
+        self.assertEqual(ts2.specs_in_seconds, ts.specs_in_seconds)
+
+    def test_translation_does_not_contain_negative_numbers(self):
+        for ts, indices in TESTCASES_IN_STEPS:
+            with self.subTest(ts=ts, indices=indices):
+                self.assertEqual(
+                    list(
+                        filter(
+                            lambda s: s.start < 0
+                            # -1 is allowed as a value for stop only
+                            or (s is not None and s.stop < -1)
+                            and s.step < 1,
+                            ts.get_as_pypicongpu(TIME_STEP_SIZE, INDEX_MAX).specs,
+                        )
+                    ),
+                    [],
+                )
+
+    def test_raises_for_negative_step_size(self):
+        for ts, indices in TESTCASES_IN_STEPS_RAISING:
+            with self.subTest(ts=ts, indices=indices):
+                with self.assertRaisesRegex(ValueError, "Step size must be >= 1"):
+                    ts.get_as_pypicongpu(TIME_STEP_SIZE, INDEX_MAX)

--- a/test/python/picongpu/quick/pypicongpu/output/__init__.py
+++ b/test/python/picongpu/quick/pypicongpu/output/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 from .auto import *  # pyflakes.ignore
 from .phase_space import *  # pyflakes.ignore
+from .timestepspec import *  # pyflakes.ignore

--- a/test/python/picongpu/quick/pypicongpu/output/auto.py
+++ b/test/python/picongpu/quick/pypicongpu/output/auto.py
@@ -5,6 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
+from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
 from picongpu.pypicongpu.output import Auto
 
 import unittest
@@ -12,18 +13,6 @@ import typeguard
 
 
 class TestAuto(unittest.TestCase):
-    def test_empty(self):
-        """empty args handled correctly"""
-        a = Auto()
-        # unset args
-        with self.assertRaises(Exception):
-            a.check()
-
-        a.period = 1
-
-        # ok:
-        a.check()
-
     def test_types(self):
         """type safety is ensured"""
         a = Auto()
@@ -33,32 +22,13 @@ class TestAuto(unittest.TestCase):
             with self.assertRaises(typeguard.TypeCheckError):
                 a.period = invalid_periods
         # ok
-        a.period = 17
-
-    def test_period_invalid(self):
-        """period must be positive, non-zero integer"""
-        a = Auto()
-
-        invalid_periods = [-1, 0, -1273]
-        for invalid_period in invalid_periods:
-            with self.assertRaises(ValueError):
-                a.period = invalid_period
-                a.check()
-
-        # ok
-        a.period = 1
-        a.period = 2
+        a.period = TimeStepSpec([slice(0, None, 17)])
 
     def test_rendering(self):
         """data transformed to template-consumable version"""
         a = Auto()
-        a.period = 42
+        a.period = TimeStepSpec([slice(0, None, 17)])
 
         # normal rendering
         context = a.get_rendering_context()
-        self.assertEqual(42, context["period"])
-
-        # refuses to render if check does not pass
-        a.period = -1
-        with self.assertRaises(ValueError):
-            a.get_rendering_context()
+        self.assertEqual(17, context["period"]["specs"][0]["step"])

--- a/test/python/picongpu/quick/pypicongpu/output/phase_space.py
+++ b/test/python/picongpu/quick/pypicongpu/output/phase_space.py
@@ -5,6 +5,7 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
+from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
 from picongpu.pypicongpu.output import PhaseSpace
 from picongpu.pypicongpu.species import Species
 from picongpu.pypicongpu.species.attribute import Position, Momentum
@@ -30,7 +31,7 @@ class TestPhaseSpace(unittest.TestCase):
             ps._get_serialized()
 
         ps.species = create_species()
-        ps.period = 1
+        ps.period = TimeStepSpec([slice(0, None, 17)])
         ps.spatial_coordinate = "x"
         ps.momentum_coordinate = "px"
         ps.min_momentum = 0.0
@@ -75,31 +76,17 @@ class TestPhaseSpace(unittest.TestCase):
 
         # ok
         ps.species = create_species()
-        ps.period = 17
+        ps.period = TimeStepSpec([slice(0, None, 17)])
         ps.spatial_coordinate = "x"
         ps.momentum_coordinate = "px"
         ps.min_momentum = 0.0
         ps.max_momentum = 1.0
 
-    def test_period_invalid(self):
-        """period must be positive, non-zero integer"""
-        ps = PhaseSpace()
-
-        invalid_periods = [-1, 0, -1273]
-        for invalid_period in invalid_periods:
-            with self.assertRaises(Exception):
-                ps.period = invalid_period
-                ps._get_serialized()
-
-        # ok
-        ps.period = 1
-        ps.period = 2
-
     def test_rendering(self):
         """data transformed to template-consumable version"""
         ps = PhaseSpace()
         ps.species = create_species()
-        ps.period = 42
+        ps.period = TimeStepSpec([slice(0, None, 42)])
         ps.spatial_coordinate = "x"
         ps.momentum_coordinate = "px"
         ps.min_momentum = 0.0
@@ -107,7 +94,7 @@ class TestPhaseSpace(unittest.TestCase):
 
         # normal rendering
         context = ps.get_rendering_context()
-        self.assertEqual(42, context["period"])
+        self.assertEqual(42, context["period"]["specs"][0]["step"])
         self.assertEqual("x", context["spatial_coordinate"])
         self.assertEqual("px", context["momentum_coordinate"])
         self.assertEqual(0.0, context["min_momentum"])
@@ -122,7 +109,7 @@ class TestPhaseSpace(unittest.TestCase):
         """min_momentum and max_momentum values are valid"""
         ps = PhaseSpace()
         ps.species = create_species()
-        ps.period = 1
+        ps.period = TimeStepSpec([slice(0, None, 1)])
         ps.spatial_coordinate = "x"
         ps.momentum_coordinate = "px"
 

--- a/test/python/picongpu/quick/pypicongpu/output/timestepspec.py
+++ b/test/python/picongpu/quick/pypicongpu/output/timestepspec.py
@@ -1,0 +1,46 @@
+"""
+This file is part of PIConGPU.
+Copyright 2021-2024 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from picongpu.pypicongpu.output import TimeStepSpec
+import unittest
+
+
+class TestTimeStepSpec(unittest.TestCase):
+    def test_init_with_valid_slices(self):
+        specs = [slice(0, 10, 1), slice(10, 20, 2)]
+        time_step_spec = TimeStepSpec(specs)
+        self.assertEqual(time_step_spec.specs, specs)
+
+    def test_init_with_invalid_slices(self):
+        time_step_spec = TimeStepSpec([slice(0, 10, 1), "invalid"])
+        with self.assertRaises(ValueError):
+            time_step_spec.get_rendering_context()
+
+    def test_serialize_with_valid_slices(self):
+        specs = [slice(0, 10, 1), slice(10, 20, 2)]
+        time_step_spec = TimeStepSpec(specs)
+        serialized = time_step_spec.get_rendering_context()
+        expected = {
+            "specs": [
+                {"start": 0, "stop": 10, "step": 1},
+                {"start": 10, "stop": 20, "step": 2},
+            ]
+        }
+        self.assertEqual(serialized, expected)
+
+    def test_serialize_with_none_values(self):
+        specs = [slice(None, 10, 1), slice(10, None, 2), slice(10, 20, None)]
+        time_step_spec = TimeStepSpec(specs)
+        serialized = time_step_spec.get_rendering_context()
+        expected = {
+            "specs": [
+                {"start": 0, "stop": 10, "step": 1},
+                {"start": 10, "stop": -1, "step": 2},
+                {"start": 10, "stop": 20, "step": 1},
+            ]
+        }
+        self.assertEqual(serialized, expected)

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -184,7 +184,7 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(2, context["grid"]["cell_size"]["y"])
         self.assertEqual(None, context["laser"])
         self.assertEqual(self.s.init_manager.get_rendering_context(), context["species_initmanager"])
-        self.assertEqual(1, context["output"][0]["data"]["period"])
+        self.assertEqual(1, context["output"][0]["data"]["period"]["specs"][0]["step"])
 
         self.assertNotEqual([], context["species_initmanager"]["species"])
         self.assertNotEqual([], context["species_initmanager"]["operations"])
@@ -207,7 +207,10 @@ class TestSimulation(unittest.TestCase):
         """period is always at least one"""
         for time_steps in [1, 17, 99]:
             self.s.time_steps = time_steps
-            self.assertEqual(1, self.s.get_rendering_context()["output"][0]["data"]["period"])
+            self.assertEqual(
+                1,
+                self.s.get_rendering_context()["output"][0]["data"]["period"]["specs"][0]["step"],
+            )
 
     def test_custom_input_pass_thru(self):
         i = customuserinput.CustomUserInput()
@@ -217,8 +220,15 @@ class TestSimulation(unittest.TestCase):
 
         self.s.custom_user_input = [i]
 
-        renderingContextGoodResult = {"test_data_1": 1, "test_data_2": 2, "tags": ["tag_1", "tag_2"]}
-        self.assertEqual(renderingContextGoodResult, self.s.get_rendering_context()["customuserinput"])
+        renderingContextGoodResult = {
+            "test_data_1": 1,
+            "test_data_2": 2,
+            "tags": ["tag_1", "tag_2"],
+        }
+        self.assertEqual(
+            renderingContextGoodResult,
+            self.s.get_rendering_context()["customuserinput"],
+        )
 
     def test_combination_of_several_custom_inputs(self):
         i_1 = customuserinput.CustomUserInput()
@@ -229,8 +239,15 @@ class TestSimulation(unittest.TestCase):
 
         self.s.custom_user_input = [i_1, i_2]
 
-        renderingContextGoodResult = {"test_data_1": 1, "test_data_2": 2, "tags": ["tag_1", "tag_2"]}
-        self.assertEqual(renderingContextGoodResult, self.s.get_rendering_context()["customuserinput"])
+        renderingContextGoodResult = {
+            "test_data_1": 1,
+            "test_data_2": 2,
+            "tags": ["tag_1", "tag_2"],
+        }
+        self.assertEqual(
+            renderingContextGoodResult,
+            self.s.get_rendering_context()["customuserinput"],
+        )
 
     def test_duplicated_tag_over_different_custom_inputs(self):
         i_1 = customuserinput.CustomUserInput()


### PR DESCRIPTION
This PR adds an interface to the period syntax for plugins to PICMI. In the process of doing so, I've found a bug that is fixed separately in #5309. This PR also restructures our PICMI implementation by adding a separate folder for `diagnostics` as discussed in #5316.

After a number of discussions, I decided to let the semantics of slicing/indexing slightly deviate from Python's interpretation by making it INCLUSIVE on the upper end as well. That is in line with what warpx is doing and feels natural for time intervals where you would expect to cover the whole range from start to end.

Hints for review:
- The main feature is implemented and documented in `lib/python/picongpu/picmi/diagnostics/timestepspec.py`. It forwards to the rather minimalistic PyPIConGPU pendant.
- The interface has an extensive test suite that should clarify the semantics of slicing, etc. Feel free to (a) consult it in case of uncertainties and (b) suggest further edge cases if you find some.
- Another big source of changes is the re-organisation of the directory structure. That's not very important.
- Finally the feature unit conversions are lazily evaluated at `.get_as_pypicongpu`, so that function needs the time step size and number of steps, so there are some interface changes in that regard propagating through plugins into `simulation.py`.
- I've seen that sometimes the auto-formatter kicked in. If that's too annoying I can try to remove those changes.