### PR TITLE
add auto output to picmi

### DIFF
--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -11,6 +11,7 @@ from . import constants
 from .phase_space import PhaseSpace
 from .energy_histogram import EnergyHistogram
 from .macro_particle_count import MacroParticleCount
+from . import output
 
 from .distribution import FoilDistribution, UniformDistribution, GaussianDistribution
 from .interaction import Interaction
@@ -44,6 +45,7 @@ __all__ = [
     "PhaseSpace",
     "EnergyHistogram",
     "MacroParticleCount",
+    "output",
 ]
 
 

--- a/lib/python/picongpu/picmi/output/__init__.py
+++ b/lib/python/picongpu/picmi/output/__init__.py
@@ -1,0 +1,3 @@
+from .auto import Auto
+
+__all__ = ["Auto"]

--- a/lib/python/picongpu/picmi/output/auto.py
+++ b/lib/python/picongpu/picmi/output/auto.py
@@ -1,0 +1,47 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Pawel Ordyna
+License: GPLv3+
+"""
+
+from ...pypicongpu.output.auto import Auto as PyPIConGPUAuto
+from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
+
+
+from ..species import Species as PICMISpecies
+
+
+import typeguard
+import pydantic
+
+
+@typeguard.typechecked
+class Auto(pydantic.BaseModel):
+    """
+    Specifies the parameters for the Auto output.
+
+    Parameters
+    ----------
+    period: int
+        Number of simulation steps between consecutive outputs.
+        Unit: steps (simulation time steps).
+    """
+
+    period: int
+    """Number of simulation steps between consecutive outputs. Unit: steps (simulation time steps)."""
+
+    def check(self):
+        if self.period <= 0:
+            raise ValueError("Period must be > 0")
+
+    def get_as_pypicongpu(
+        self,
+        # not used here, but needed for the interface
+        dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
+    ) -> PyPIConGPUAuto:
+        self.check()
+
+        pypicongpu_auto = PyPIConGPUAuto()
+        pypicongpu_auto.period = self.period
+        return pypicongpu_auto

--- a/share/picongpu/pypicongpu/examples/warm_plasma/main.py
+++ b/share/picongpu/pypicongpu/examples/warm_plasma/main.py
@@ -42,6 +42,8 @@ sim = picmi.Simulation(
     solver=solver,
 )
 
+sim.add_diagnostic(picmi.output.Auto(period=100))
+
 layout = picmi.PseudoRandomLayout(n_macroparticles_per_cell=25)
 sim.add_species(electron, layout)
 


### PR DESCRIPTION
## Auto output
`PyPIConGPU` comes with the 'auto' output configuration, but there was no counterpart in PICMI. This adds the missing part on picmi side.

Now it is possible to enable the auto configuration with sth like  `sim.add_diagnostic(picmi.output.Auto(period=100))`

### Open questions
I noticed we have a weird way of importing submodules in picmi, and putting everything on the top module level. Is this somehow given by the picmi standard? Here I did it differently, but I'm willing to change it to stay consistent. If we want to stay within what PICMI  standard implementation is doing, we should probably follow their naming scheme and call this class `AutoDiagnostic` and append the `Diagnostic` to all new incoming output definitions. `picmi.Auto` is not descriptive enough. @chillenzer @BrianMarre @psychocoderHPC  what is your opinion on that?  