### PR TITLE
Supercharge getParticlePosition in binning plugin

### DIFF
--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -76,7 +76,7 @@ namespace picongpu
 
         enum class PositionPrecision
         {
-            // Returns the cell index in which the particle
+            // Returns the cell index of the particle
             Cell,
             // Returns the position of the particle as the cell index + the position of the particle inside the cell
             // [0,1) This value is a floating point number of cells

--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/defines.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
+#include <pmacc/math/vector/Vector.hpp>
 
 #include <cstdint>
 
@@ -73,12 +74,68 @@ namespace picongpu
             LOCAL
         };
 
-        template<DomainOrigin T_Origin, typename T_Particle>
-        ALPAKA_FN_ACC auto getParticlePosition(DomainInfo domainInfo, T_Particle particle) -> pmacc::DataSpace<simDim>
+        enum class PositionPrecision
+        {
+            // Returns the cell index in which the particle
+            Cell,
+            // Returns the position of the particle as the cell index + the position of the particle inside the cell
+            // [0,1) This value is a floating point number of cells
+            SubCell
+        };
+
+        /**
+         * @brief Output unit type for particle position.
+         */
+        enum class PositionUnits
+        {
+            /**
+             * @brief Returns the position in SI units.
+             * @note Converting the particle positions to SI might be dangerous, especially with respect to the total
+             * origin, as floating point numbers lose precision as the distance from the origin increases.
+             */
+            SI,
+            /**
+             * @brief Returns the position as the number of cells.
+             * Integral value if PositionPrecision is Cell and floating point if PositionPrecision is SubCell.
+             */
+            Cell
+        };
+
+        /**
+         * @brief Returns the particle position as a pmacc vector.
+         *
+         * By default, returns the cell index of the cell the particle is in.
+         * Returns a fractional cell index representing the in-cell position if PositionPrecision::SubCell is passed.
+         * Returns in SI units if PositionUnits::SI is specified.
+         *
+         * @warning Converting the particle positions to SI might be dangerous, especially with respect to the total
+         * origin, as floating point numbers lose precision as the distance from the origin increases.
+         *
+         * @tparam T_Origin The origin reference for the position.
+         * @tparam T_Precision The precision of the position (cell index or sub-cell position).
+         * @tparam T_Units The units of the position (SI or cell).
+         * @param domainInfo The domain information.
+         * @param particle The particle whose position is to be determined.
+         * @return The particle position as a pmacc vector.
+         */
+        template<
+            DomainOrigin T_Origin,
+            PositionPrecision T_Precision = PositionPrecision::Cell,
+            PositionUnits T_Units = PositionUnits::Cell>
+        ALPAKA_FN_ACC auto getParticlePosition(DomainInfo const& domainInfo, auto const& particle)
+            -> pmacc::math::Vector<
+                typename std::conditional_t<
+                    T_Units == PositionUnits::SI,
+                    typename std::decay_t<decltype(sim.pic.getCellSize())>::type,
+                    std::conditional_t<
+                        T_Precision == PositionPrecision::SubCell,
+                        typename std::decay_t<decltype(particle[position_])>::type,
+                        int>>,
+                simDim>
         {
             int const linearCellIdx = particle[localCellIdx_];
-            DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
-            auto relative_cellpos = domainInfo.blockCellOffset;
+            pmacc::DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
+            auto relative_cellpos = domainInfo.blockCellOffset + cellIdx;
 
             if constexpr(T_Origin == DomainOrigin::GLOBAL)
             {
@@ -88,9 +145,28 @@ namespace picongpu
             {
                 relative_cellpos = relative_cellpos + domainInfo.globalOffset;
             }
+            if constexpr(T_Precision == PositionPrecision::SubCell)
+            {
+                auto pos = precisionCast<typename std::decay_t<decltype(particle[position_])>::type>(relative_cellpos)
+                    + particle[position_];
+                if constexpr(T_Units == PositionUnits::SI)
+                {
+                    auto cellSize = sim.pic.getCellSize().shrink<simDim>();
+                    return precisionCast<typename std::decay_t<decltype(cellSize)>::type>(pos) * cellSize;
+                }
+                return pos;
+            }
+            else
+            {
+                if constexpr(T_Units == PositionUnits::SI)
+                {
+                    auto cellSize = sim.pic.getCellSize().shrink<simDim>();
+                    return precisionCast<typename std::decay_t<decltype(cellSize)>::type>(relative_cellpos) * cellSize;
+                }
+                return relative_cellpos;
+            }
 
-            auto posBin = cellIdx + relative_cellpos;
-            return posBin;
+            return relative_cellpos;
         }
     } // namespace plugins::binning
 } // namespace picongpu


### PR DESCRIPTION
Following input from @BrianMarre and @PrometheusPi, made ``getParticlePosition`` in the binning plugin more flexible and hopefully easier to use.

``getParticlePosition<DomainOrigin>`` now accepts two additional optional template parameters, ``PositionPrecision`` and ``PositionUnits`` as ``getParticlePosition<DomainOrigin, PositionPrecision, PositionUnits>``. 

``PositionPrecision`` by default uses cell level precision, thus returning the cell index, but if you want the exact particle position within the cell as well and not just the cell index, you can use ``PositionPrecision::SubCell``. 
``PositionUnits`` by default uses cell units, but it is also possible to get positions in SI units by specifying PositionUnits::SI

The default behaviour of this function is maintained, and this is NOT a breaking change.