### PR TITLE
Add field binning to the binning plugin

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -3,15 +3,18 @@
 Binning
 #######
 
-This binning plugin is a flexible binner for particles properties.
+This binning plugin is a flexible binner for particles and field properties.
 Users can
-    - Define their own axes
-    - Define their own quantity which is binned
-    - Choose which species are used for the binning
-    - Choose how frequently they want the binning to be executed
-    - Choose if the binning should be time averaging or normalized by bin volume
-    - Write custom output to file, for example other quantites related to the simulation which the user is interested in
-    - Execute multiple binnings at the same time
+	- Define their own axes
+	- Define their own quantity which is binned
+	- Choose which species are used for particle binning
+	- Choose which fields are used for field binning
+	- Choose how frequently they want the binning to be executed
+	- Choose if the binning should be time averaging or normalized by bin volume
+	- Write custom output to file, for example other quantities related to the simulation which the user is interested in
+	- Execute multiple binnings at the same time
+	- Pass extra parameters as a tuple, if additional information is required by the kernels to do binning.
+	- Define a host-side hook to execute code before binning at each notify step, for example to fill ``FieldTmp``.
 
 User Input
 ==========
@@ -19,13 +22,13 @@ Users can set up their binning in the ``binningSetup.param`` file. After setup, 
 
 .. attention::
 
-   Unlike other plugins, the binning plugin doesn't provide any runtime configuration. To set up binning, users need to define it in the param file and then recompile.
+	Unlike other plugins, the binning plugin doesn't provide any runtime configuration. To set up binning, users need to define it in the param file and then recompile.
 
-A binner is created using the ``addBinner()`` function, which describes the configuration options available to the user to set up the binning.
-Multiple binnings can be run at the same time by simply calling ``addBinner()`` multiple times with different parameters.
+A binner is created using the `addParticleBinner()` or `addFieldBinner()` functions, which describe the configuration options available to the user to set up particle and field binning respectively.
+Multiple binnings can be run at the same time by simply calling `addParticleBinner()` or `addFieldBinner()` multiple times with different parameters.
 
 .. doxygenclass:: picongpu::plugins::binning::BinningCreator
-    :members: addBinner
+	:members: addParticleBinner, addFieldBinner
 
 The most important parts of defining a binning are the axes (the axes of the histogram which define the bins) and the deposited quantity (the quantity to be binned).
 Both of these are described using the "Functor Description".
@@ -34,7 +37,7 @@ Both of these are described using the "Functor Description".
 Functor Description
 -------------------
 The basic building block for the binning plugin is the Functor Description object, and it is used to describe both axes and the deposited quantity.
-It describes the particle properties which we find interesting and how we can calculate/get this property from the particle.
+It describes the properties which we find interesting and how we can calculate/get this property from the particle or field.
 A functor description is created using createFunctorDescription.
 
 .. doxygenfunction:: picongpu::plugins::binning::createFunctorDescription
@@ -42,27 +45,73 @@ A functor description is created using createFunctorDescription.
 
 Functor
 ^^^^^^^
-The functor needs to follow the signature shown below. This provides the user access to the particle object and with information about the :ref:`domain <usage/plugins/binningPlugin:Domain Info>`.
-
-.. code-block:: c++
-
-    auto myFunctor = [] ALPAKA_FN_ACC(auto const& domainInfo, auto const& worker, auto const& particle) -> returnType
-    {
-        // fn body
-        return myParameter;
-    };
+The functor needs to follow the signature shown below. This provides the user access to the particle or field object and with information about the :ref:`domain <usage/plugins/binningPlugin:Domain Info>`.
 
 The return type is defined by the user.
 
+For particles:
+
+.. code-block:: c++
+
+	auto myParticleFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> returnType
+	{
+		// fn body
+		return myParameter;
+	};
+
+For particles with two extra data paramters:
+
+.. code-block:: c++
+
+	auto myParticleWithExtraDataFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle, auto const& extraData1, auto const& extraData2) -> returnType
+	{
+		// fn body
+		return myParameter;
+	};
+
+For fields:
+
+.. code-block:: c++
+
+	auto myFieldFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field) -> returnType
+	{
+		// fn body
+		return myParameter;
+	};
+
+For fields with extra data:
+
+.. code-block:: c++
+
+	auto myFieldWithExtraDataFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2, auto const& extraData) -> returnType
+	{
+		// fn body
+		return myParameter;
+	};
+
+.. note::
+
+	Fields and extra data may be tuples with multiple elements which are unpacked and passed to the user-defined functors. Therefore, it is the responsibility of the user to ensure that their functors have an appropriate number of arguments to match the provided tuples.
+
 Domain Info
 """""""""""
-Enables the user to find the location of the particle (in cells) in the simulation domain. Contains
+Enables the user to find the location of the particle or field (in cells) in the simulation domain. Contains
 
-.. doxygenclass:: picongpu::plugins::binning::DomainInfo
-    :members:
+For particle binning, the ``DomainInfo`` class contains:
+
+.. doxygenclass:: picongpu::plugins::binning::DomainInfoBase
+	:members:
+
+For field binning, the ``DomainInfo`` class additionally contains:
+
+.. doxygenclass:: picongpu::plugins::binning::DomainInfo< BinningType::Field >
+	:members:
 
 The global and local offsets can be understood by looking at the `PIConGPU domain definitions <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions>`_.
 
+For particle binning, the particle position is obtained at cell center precision by default. To get sub-cell precision or SI units, use optional template parameters with ``getParticlePosition<DomainOrigin, PositionPrecision, PositionUnits>``.
+
+For field binning, the field ``DomainInfo`` additionally holds the localCellIndex in the supercell and has a method to ``getCellIndex<DomainOrigin, PositionUnits>`` to get the current cell index being binned relative to an origin (global, total, local).
 
 
 Dimensionality and units
@@ -73,10 +122,10 @@ If no units are given, the quantity is assumed to be dimensionless.
 
 .. code-block:: c++
 
-    std::array<double, numUnits> momentumDimension{};
-    momentumDimension[SIBaseUnits::length] = 1.0;
-    momentumDimension[SIBaseUnits::mass] = 1.0;
-    momentumDimension[SIBaseUnits::time] = -1.0;
+	std::array<double, numUnits> momentumDimension{};
+	momentumDimension[SIBaseUnits::length] = 1.0;
+	momentumDimension[SIBaseUnits::mass] = 1.0;
+	momentumDimension[SIBaseUnits::time] = -1.0;
 
 .. doxygenenum:: picongpu::SIBaseUnits::SIBaseUnits_t
 
@@ -89,11 +138,11 @@ The name used in the functor description is used as the name of the axis for ope
 
 .. attention::
 
-   The return type of the functor as specified in the functor description is required to be the same as the type of the range (min, max).
+	The return type of the functor as specified in the functor description is required to be the same as the type of the range (min, max).
 
 Currently implemented axis types
-    - Linear Axis
-    - Log Axis
+	- Linear Axis
+	- Log Axis
 
 .. doxygenclass:: picongpu::plugins::binning::axis::LinearAxis
 
@@ -114,57 +163,117 @@ Defines the axis range and how it is split into bins. Bins are defined as closed
 In the future, this plugin will support other ways to split the domain, eg. using the binWidth or by auto-selecting the parameters.
 
 .. doxygenclass:: picongpu::plugins::binning::axis::AxisSplitting
-    :members:
+	:members:
 
 
 Range
 """""
 
 .. doxygenclass:: picongpu::plugins::binning::axis::Range
-    :members:
+	:members:
 
 .. note::
 
-   Axes are passed to addBinner grouped in a tuple. This is just a collection of axis objects and is of arbitrary size. 
-   Users can make a tuple for axes by using the ``createTuple()`` function and passing in the axis objects as arguments.
+    Axes are passed to addParticleBinner or addFieldBinner grouped in a tuple. This is just a collection of axis objects and is of arbitrary size.
+    Users can make a tuple for axes by using the ``createTuple()`` function and passing in the axis objects as arguments.
 
 Species
 -------
-PIConGPU species which should be used in binning.
+PIConGPU species which should be used in particle binning.
 Species can be instances of a species type or a particle species name as a PMACC_CSTRING. For example,
 
 .. code-block:: c++
 
-    auto electronsObj = PMACC_CSTRING("e"){};
+	auto electronsObj = PMACC_CSTRING("e"){};
 
 Optionally, users can specify a filter to be used with the species. This is a predicate functor, i.e. it is a functor with a signature as described above and which returns a boolean. If the filter returns true it means the particle is included in the binning.
-They can then create a FilteredSpecies object which contains the species and the filter. 
+They can then create a FilteredSpecies object which contains the species and the filter.
 
 .. code-block:: c++
-    
-    auto myFilter = [] ALPAKA_FN_ACC(auto const& domainInfo, auto const& worker, auto const& particle) -> bool
-    {
-        bool binningEnabled = true;
-        // fn body
-        return binningEnabled;
-    };
 
-    auto fitleredElectrons = FilteredSpecies{electronsObj, myFilter};
+	auto myFilter = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> bool
+	{
+		bool binningEnabled = true;
+		// fn body
+		return binningEnabled;
+	};
+
+	auto fitleredElectrons = FilteredSpecies{electronsObj, myFilter};
 
 .. note::
 
-   Species are passed to addBinner in the form of a tuple. This is just a collection of Species and FilteredSpecies objects (the tuple can be a mixure of both) and is of arbitrary size.
-   Users can make a species tuple by using the ``createSpeciesTuple()`` function and passing in the objects as arguments.
+			Species are passed to addParticleBinner in the form of a tuple. This is just a collection of Species and FilteredSpecies objects (the tuple can be a mixture of both) and is of arbitrary size.
+			Users can make a species tuple by using the ``createSpeciesTuple()`` function and passing in the objects as arguments.
 
+Fields
+------
+PIConGPU fields which should be used in field binning.
+Fields can be instances of a field type. For example,
+
+.. code-block:: c++
+
+	DataConnector& dc = Environment<>::get().DataConnector();
+	auto fieldsTuple = createTuple(
+	dc.get<FieldB>(FieldB::getName())->getDeviceDataBox(),
+	dc.get<FieldTmp>(FieldTmp::getUniqueId(0))->getDeviceDataBox());
+
+Fields are passed to addFieldBinner in the form of a tuple. This is just a collection of field objects and is of arbitrary size.
+Users can make a fields tuple by using the ``createTuple()`` function and passing in the objects as arguments.
+
+.. note::
+
+	It is possible to have an empty tuple for fields when doing field binning, in which case the functor will be called with no fields. This may be useful if you are passing in extra data and want field traversal over it.
 
 Deposited Quantity
 ------------------
 Quantity to be deposited is simply a :ref:`functor description <usage/plugins/binningPlugin:Functor Description>`.
+The signature of quantity functors is
 
+.. code-block:: c++
+
+	auto myQuantityFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, ...) -> returnType
+
+Extra Data
+----------
+Users can pass extra data to the functors if additional information is required by the kernels to do binning.
+	This extra data is created using the `createTuple()` function and then passed into the binning creator.
+Extra data is passed to ``addParticleBinner`` or ``addFieldBinner`` functions in the form of a tuple. This tuple is just a collection of objects and is of arbitrary size.
+Users can make a tuple of the extra data by using the ``createTuple()`` function and passing in the objects as arguments.
+
+For example, to pass extra data to a particle binner:
+
+.. code-block:: c++
+
+	auto extraData = createTuple(extraData1, extraData2);
+	addParticleBinner(axisTuple, speciesTuple, depositionFunctor, extraData);
+
+Similarly, for a field binner:
+
+.. code-block:: c++
+
+	auto extraData = createTuple(extraData1, extraData2);
+	addFieldBinner(axisTuple, fieldsTuple, depositionFunctor, extraData);
+
+.. note::
+
+	Ensure that the functors have an appropriate number of arguments to match the provided tuples. The extra data may be tuples with multiple elements which are unpacked and passed to the user-defined functors.
+
+Host-side hook
+---------------
+Users can define a host-side hook to execute code before binning starts for a notify step.
+This hook is set using the ``setHostSideHook`` method of the ``BinningCreator`` class and takes a callable (lambda/functor/std::function) which returns void.
+
+.. code-block:: c++
+
+	[]() -> void{
+		// host-side code to be executed before binning
+	}
+
+For example, this can be used to pre-process data on the host side, such as filling temporary fields before they are used in field binning.
 
 Notify period
 -------------
-Set the periodicity of the output. Follows the period syntax defined :ref:`here <usage/plugins:period syntax>`.
+Set the periodicity of the output. Follows the period syntax defined :ref:`here <usage/plugins:period syntax>`. Notifies every time step by default.
 
 Dump Period
 -----------
@@ -172,19 +281,19 @@ Defines the number of notify steps to accumulate over. Note that this is not acc
 If time averaging is enabled, this is also the period to do time averaging over.
 For example a value of 10 means that after every 10 notifies, an accumulated file will be written out.
 If PIConGPU exits before executing 10 notifies, then there will be no output.
-The plugin dumps on every notify if this is set to either 0 or 1.
+The plugin dumps on every notify if this is set to either 0 or 1. This is the default behaviour.
 
 Time Averaging
 --------------
-When dumping the accumulated output, whether or not to divide by the dump period, i.e. do a time averaging.
+When dumping the accumulated output, whether or not to divide by the dump period, i.e. do a time averaging. Enabled by default.
 
 .. attention::
 
-    The user needs to set a dump period to enable time averaging.
+	The user needs to set a dump period to enable time averaging.
 
 Normalize by Bin Volume
 -----------------------
-Since it is possible to have non-uniformly sized axes, it makes sense to normalize the binned quantity by the bin volume to enable a fair comparison between bins.
+Since it is possible to have non-uniformly sized axes, it makes sense to normalize the binned quantity by the bin volume to enable a fair comparison between bins. Enabled by default.
 
 
 Binning Particles Leaving the Simulation Volume
@@ -192,7 +301,7 @@ Binning Particles Leaving the Simulation Volume
 
 .. doxygenenum:: picongpu::plugins::binning::ParticleRegion
 
-By default, only particles within the simulation volume are binned. However, users can modify this behavior to include or exclusively bin particles that are leaving the global simulation volume.
+By default, only particles within the simulation volume are binned by the particle binner. However, users can modify this behavior to include or exclusively bin particles that are leaving the global simulation volume.
 This can be configured using the ``enableRegion`` and ``disableRegion`` options with the regions defined by the ``ParticleRegion`` enum.
 
 .. attention::
@@ -204,18 +313,21 @@ Therefore, users should consider setting the notify period’s start at timestep
 
 writeOpenPMDFunctor
 -------------------
-Users can also write out custom output to file, for example other quantites related to the simulation which the user is interested in.
-This is a lambda with the following signature.
+Users can also write out custom output to file, for example other quantities related to the simulation which the user is interested in.
+This is a lambda with the following signature, and is set using the ``setWriteOpenPMDFunctor`` method.
 
 .. code-block:: c++
 
-    [=](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) -> void
+	[=](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) -> void
 
 .. note::
 
-   Make sure to capture by copy only, as the objects defined in the param file are not kept alive
+	Make sure to capture by copy only, as the objects defined in the param file are not kept alive
 
 
+OpenPMD JSON Configuration
+--------------------------
+Users can set a json configuration string for the OpenPMD output format using the ``setOpenPMDJsonCfg`` setter method.
 
 OpenPMD Output
 ==============
@@ -255,10 +367,9 @@ Such spectrometers are a common tool in plasma based electron acceleration exper
 
 .. note::
 
-   Please note that if you specify the SI units of an axis, e.g. via ``energyDimension`` in the LWFA example,
-   PIConGPU automatically converts to the internal unit system, but then also expects SI-compliant values for the axis range
-   (in the case of energy Joules).
-
+	Please note that if you specify the SI units of an axis, e.g. via ``energyDimension`` in the LWFA example,
+	PIConGPU automatically converts to the internal unit system, but then also expects SI-compliant values for the axis range
+	(in the case of energy Joules).
 
 
 To read the electron spectrometer data in python, one could load and plot it like this:
@@ -321,3 +432,8 @@ References
         *Calibration and cross-laboratory implementation of scintillating screens for electron bunch charge determination*,
         Review of Scientific Instruments (2018),
         https://doi.org/10.1063/1.5041755
+
+More examples of binning plugin usage
+=====================================
+
+Further examples of the binning plugin can be found in the ``binningSetup.param`` associated with the atomic physics example and the ``compile2`` test.

--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -95,7 +95,7 @@ For fields with extra data:
 
 Domain Info
 """""""""""
-Enables the user to find the location of the particle or field (in cells) in the simulation domain. Contains
+Enables the user to find the location of the particle or field in the simulation domain. Contains
 
 For particle binning, the ``DomainInfo`` class contains:
 
@@ -109,9 +109,9 @@ For field binning, the ``DomainInfo`` class additionally contains:
 
 The global and local offsets can be understood by looking at the `PIConGPU domain definitions <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions>`_.
 
-For particle binning, the particle position is obtained at cell center precision by default. To get sub-cell precision or SI units, use optional template parameters with ``getParticlePosition<DomainOrigin, PositionPrecision, PositionUnits>``.
+For particle binning, the particle position is obtained at cell precision by default. To get sub-cell precision or SI units, use optional template parameters with ``getParticlePosition<DomainOrigin, PositionPrecision, PositionUnits>``.
 
-For field binning, the field ``DomainInfo`` additionally holds the localCellIndex in the supercell and has a method to ``getCellIndex<DomainOrigin, PositionUnits>`` to get the current cell index being binned relative to an origin (global, total, local).
+For field binning, the field ``DomainInfo`` additionally holds the localCellIndex in the supercell and has a method to ``getCellIndex<DomainOrigin, PositionUnits>`` to get the current cell index being binned relative to an origin (global, total, local). To get the exact position of the fields inside the cell, relative to the cell index, use the FieldPosition trait.
 
 
 Dimensionality and units

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -219,6 +219,33 @@ namespace picongpu
                 return (particleRegion & region) != 0;
             }
         };
+
+        template<typename T_AxisTuple, typename T_FieldsTuple, typename T_DepositionData, typename T_Extras>
+        struct FieldBinningData
+            : public BinningDataBase<
+                  FieldBinningData<T_AxisTuple, T_FieldsTuple, T_DepositionData, T_Extras>,
+                  T_AxisTuple,
+                  T_DepositionData,
+                  T_Extras>
+        {
+            T_FieldsTuple fieldsTuple;
+
+            FieldBinningData(
+                std::string const& binnerName,
+                T_AxisTuple const& axes,
+                T_FieldsTuple const& fields,
+                T_DepositionData const& depositData,
+                T_Extras const& extraData)
+                : BinningDataBase<FieldBinningData, T_AxisTuple, T_DepositionData, T_Extras>(
+                    binnerName,
+                    axes,
+                    depositData,
+                    extraData)
+                , fieldsTuple{fields}
+            {
+            }
+        };
+
     } // namespace plugins::binning
 } // namespace picongpu
 

--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -134,10 +134,10 @@ namespace picongpu
             {
             }
 
-            // returns the cell position
+            // returns the cell index. To get the exact position of the fields, use the fieldPosition trait
             // passed Can also return in SI units if CellUnits::SI is specified
             template<DomainOrigin T_Origin, PositionUnits T_Units = PositionUnits::Cell>
-            ALPAKA_FN_ACC auto getCellPosition() const
+            ALPAKA_FN_ACC auto getCellIndex() const
             {
                 auto relative_cellpos = blockCellOffset;
 

--- a/include/picongpu/plugins/binning/binners/FieldBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/FieldBinner.hpp
@@ -70,53 +70,31 @@ namespace picongpu
 
                 auto const functorBlock = FieldBinningKernel{};
 
-                if constexpr(std::tuple_size_v < decltype(this->binningData.extraData) >> 0)
-                {
-                    auto const userFunctorData = std::apply(
-                        [&](auto&&... fields)
-                        {
-                            return std::apply(
-                                [&](auto&&... extras)
-                                {
-                                    return pmacc::memory::tuple::make_tuple(
-                                        std::forward<decltype(fields)>(fields)...,
-                                        std::forward<decltype(extras)>(extras)...);
-                                },
-                                this->binningData.extraData);
-                        },
-                        this->binningData.fieldsTuple);
+                auto const userFunctorData = std::apply(
+                    [&](auto&&... fields)
+                    {
+                        return std::apply(
+                            [&](auto&&... extras)
+                            {
+                                return pmacc::memory::tuple::make_tuple(
+                                    std::forward<decltype(fields)>(fields)...,
+                                    std::forward<decltype(extras)>(extras)...);
+                            },
+                            this->binningData.extraData);
+                    },
+                    this->binningData.fieldsTuple);
 
-                    PMACC_LOCKSTEP_KERNEL(functorBlock)
-                        .config(mapper.getGridDim(), SuperCellSize{})(
-                            binningBox,
-                            localOffset,
-                            globalOffset,
-                            axisKernels,
-                            userFunctorData,
-                            this->binningData.depositionData.functor,
-                            this->binningData.axisExtentsND,
-                            currentStep,
-                            mapper);
-                }
-                else
-                {
-                    auto const fields = std::apply(
-                        [&](auto&&... args)
-                        { return pmacc::memory::tuple::make_tuple(std::forward<decltype(args)>(args)...); },
-                        this->binningData.fieldsTuple);
-
-                    PMACC_LOCKSTEP_KERNEL(functorBlock)
-                        .config(mapper.getGridDim(), SuperCellSize{})(
-                            binningBox,
-                            localOffset,
-                            globalOffset,
-                            axisKernels,
-                            fields,
-                            this->binningData.depositionData.functor,
-                            this->binningData.axisExtentsND,
-                            currentStep,
-                            mapper);
-                }
+                PMACC_LOCKSTEP_KERNEL(functorBlock)
+                    .config(mapper.getGridDim(), SuperCellSize{})(
+                        binningBox,
+                        localOffset,
+                        globalOffset,
+                        axisKernels,
+                        userFunctorData,
+                        this->binningData.depositionData.functor,
+                        this->binningData.axisExtentsND,
+                        currentStep,
+                        mapper);
             }
         };
 

--- a/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
@@ -119,7 +119,7 @@ namespace picongpu
                     [&](auto&&... extras)
                     { return pmacc::memory::tuple::make_tuple(std::forward<decltype(extras)>(extras)...); },
                     this->binningData.extraData);
-                auto const functorBlock = BinningFunctor{};
+                auto const functorBlock = ParticleBinningKernel{};
 
                 PMACC_LOCKSTEP_KERNEL(functorBlock)
                     .config(mapper.getGridDim(), particlesBox)(
@@ -183,7 +183,7 @@ namespace picongpu
                             { return pmacc::memory::tuple::make_tuple(std::forward<decltype(extras)>(extras)...); },
                             binner->binningData.extraData);
 
-                        auto const functorLeaving = BinningFunctorLeaving{};
+                        auto const functorLeaving = LeavingParticleBinningKernel{};
 
                         PMACC_LOCKSTEP_KERNEL(functorLeaving)
                             .config(mapper.getGridDim(), particlesBox)(

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -187,7 +187,7 @@ namespace picongpu
                 = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
                 -> float_X
             {
-                auto fieldValue = field1(domainInfo.template getCellPosition<DomainOrigin::TOTAL>());
+                auto fieldValue = field1(domainInfo.template getCellIndex<DomainOrigin::TOTAL>());
                 auto squaredSum = fieldValue.x() * fieldValue.x() + fieldValue.y() * fieldValue.y()
                     + fieldValue.z() * fieldValue.z();
                 return squaredSum;

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -36,6 +36,7 @@ namespace picongpu
         {
             /// USER CODE GOES BELOW
             particleBinningExample(binningCreator);
+            fieldBinningExample(binningCreator);
             /// USER CODE ENDS HERE
         }
 
@@ -71,11 +72,13 @@ namespace picongpu
                 = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> float_X
             { return particle[momentum_][1] / particle[weighting_]; };
 
+            // #doc-include-start : units
             // Define units
             std::array<double, numUnits> momentumDimension{};
             momentumDimension[SIBaseUnits::length] = 1.0;
             momentumDimension[SIBaseUnits::mass] = 1.0;
             momentumDimension[SIBaseUnits::time] = -1.0;
+            // #doc-include-end : units
 
             // Create Functor Description
             auto momentumYDescription
@@ -112,6 +115,7 @@ namespace picongpu
              */
             auto electronsObj = PMACC_CSTRING("e"){};
 
+            // #doc-include-start : filter
             /**
              * Optionally pass a particle filter to be used for this
              * Simply a particle predicate functor
@@ -120,8 +124,11 @@ namespace picongpu
                 = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> bool
             { return true; };
 
+            auto filteredElectrons = FilteredSpecies{electronsObj, allParticles};
+            // #doc-include-end : filter
+
             // Bring the species together in a tuple
-            auto speciesTuple = createSpeciesTuple(FilteredSpecies{electronsObj, allParticles});
+            auto speciesTuple = createSpeciesTuple(filteredElectrons);
 
             /**
              * Define deposited quantity here
@@ -183,7 +190,7 @@ namespace picongpu
 
             /// Axis 1
             // Define Functor
-            auto getField
+            auto getSquaredFieldAmplitude
                 = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
                 -> float_X
             {
@@ -194,14 +201,15 @@ namespace picongpu
             };
 
             // Create Functor Description
-            auto fieldDescription = createFunctorDescription<float_X>(getField, "sadasfasfasf");
+            auto fieldDescription
+                = createFunctorDescription<float_X>(getSquaredFieldAmplitude, "Field Amplitude Squared");
 
             // Create Axis Splitting
             auto fieldRange = axis::Range{0._X, 100._X};
             auto fieldSplitting = axis::AxisSplitting(fieldRange, 100);
 
             // Create Axis
-            auto ax_y = axis::createLinear(fieldSplitting, fieldDescription);
+            auto ax_sqAmp = axis::createLinear(fieldSplitting, fieldDescription);
 
             /// Axis 2
             // Define Functor
@@ -213,17 +221,18 @@ namespace picongpu
             auto timeStepDescription = createFunctorDescription<uint32_t>(getTimeStep, "time_axis");
 
             // Create Axis
-            auto ax_timeStep
-                = axis::createLinear(axis::AxisSplitting(axis::Range<uint32_t>{0, 2000}, 2000), timeStepDescription);
+            auto ax_timeStep = axis::createLinear(axis::AxisSplitting<uint32_t>{{0, 2000}, 2000}, timeStepDescription);
 
             // Bring the axes together in a tuple
-            auto axisTuple = createTuple(ax_y, ax_timeStep);
+            auto axisTuple = createTuple(ax_sqAmp, ax_timeStep);
 
+            // #doc-include-start : fieldTuple
             // Bring the fields together in a tuple
             DataConnector& dc = Environment<>::get().DataConnector();
             auto fieldsTuple = createTuple(
                 dc.get<FieldB>(FieldB::getName())->getDeviceDataBox(),
                 dc.get<FieldTmp>(FieldTmp::getUniqueId(0))->getDeviceDataBox());
+            // #doc-include-end : fieldTuple
 
             /**
              * Define deposited quantity here

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -28,6 +28,8 @@ namespace picongpu
 {
     namespace plugins::binning
     {
+        void fieldBinningExample(BinningCreator& binningCreator);
+
         void particleBinningExample(BinningCreator& binningCreator);
 
         inline void getBinning(BinningCreator& binningCreator)
@@ -172,5 +174,83 @@ namespace picongpu
                 .setDumpPeriod(2000)
                 .setNormalizeByBinVolume(false);
         }
+
+        inline void fieldBinningExample(BinningCreator& binningCreator)
+        {
+            /**
+             * define axes here
+             */
+
+            /// Axis 1
+            // Define Functor
+            auto getField
+                = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
+                -> float_X
+            {
+                auto fieldValue = field1(domainInfo.template getCellPosition<DomainOrigin::TOTAL>());
+                auto squaredSum = fieldValue.x() * fieldValue.x() + fieldValue.y() * fieldValue.y()
+                    + fieldValue.z() * fieldValue.z();
+                return squaredSum;
+            };
+
+            // Create Functor Description
+            auto fieldDescription = createFunctorDescription<float_X>(getField, "sadasfasfasf");
+
+            // Create Axis Splitting
+            auto fieldRange = axis::Range{0._X, 100._X};
+            auto fieldSplitting = axis::AxisSplitting(fieldRange, 100);
+
+            // Create Axis
+            auto ax_y = axis::createLinear(fieldSplitting, fieldDescription);
+
+            /// Axis 2
+            // Define Functor
+            auto getTimeStep
+                = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
+                -> uint32_t { return domainInfo.currentStep; };
+
+            // Create Functor Description
+            auto timeStepDescription = createFunctorDescription<uint32_t>(getTimeStep, "time_axis");
+
+            // Create Axis
+            auto ax_timeStep
+                = axis::createLinear(axis::AxisSplitting(axis::Range<uint32_t>{0, 2000}, 2000), timeStepDescription);
+
+            // Bring the axes together in a tuple
+            auto axisTuple = createTuple(ax_y, ax_timeStep);
+
+            // Bring the fields together in a tuple
+            DataConnector& dc = Environment<>::get().DataConnector();
+            auto fieldsTuple = createTuple(
+                dc.get<FieldB>(FieldB::getName())->getDeviceDataBox(),
+                dc.get<FieldTmp>(FieldTmp::getUniqueId(0))->getDeviceDataBox());
+
+            /**
+             * Define deposited quantity here
+             */
+            auto getFieldX
+                = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
+                -> float_X { return field1(domainInfo.localCellIdx).x(); };
+
+            std::array<double, numUnits> depositedUnits{}; // Tell user the 7 dimensional format
+            depositedUnits[SIBaseUnits::length] = -3.0;
+            depositedUnits[SIBaseUnits::electricCurrent] = 1.0;
+            depositedUnits[SIBaseUnits::time] = 1.0;
+
+            // @todo enforce functor return type is same as createFunctorDescription template type
+            auto fieldX = createFunctorDescription<float_X>(getFieldX, "FieldX", depositedUnits);
+
+            /** A hook that is called on every notify.
+             *  Can be used to fill fields
+             */
+            auto fillFieldsHook = []() -> void {
+
+            };
+
+            binningCreator.addFieldBinner("chargeDensityBinning", axisTuple, fieldsTuple, fieldX)
+                .setNotifyPeriod("1:500")
+                .setHostSideHook(fillFieldsHook);
+        }
+
     } // namespace plugins::binning
 } // namespace picongpu


### PR DESCRIPTION
Add the ability to bin fields in the binning plugin
Note : The ``domainInfo`` object for field binning is different from particle binning, as fields have no parallel for sub cell particle position,