### PR TITLE
Checkpoint-restart: Fix reading of RNG states

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -978,7 +978,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 auto rngProvider = dc.get<RNGProvider>(RNGProvider::getName());
                 auto const name = rngProvider->getName();
 
-                ::openPMD::Iteration iteration = params->openPMDSeries->writeIterations()[restartStep];
+                ::openPMD::Iteration iteration = params->openPMDSeries->iterations[restartStep];
                 ::openPMD::Mesh mesh = iteration.meshes[name];
                 ::openPMD::MeshRecordComponent mrc = mesh[::openPMD::RecordComponent::SCALAR];
 


### PR DESCRIPTION
With the current release of the openPMD-api, this apparently works anyway, but with the dev version (precisely: after merging https://github.com/openPMD/openPMD-api/pull/1592) this throws an error.
With current versions of openPMD, random-access reading works via `series.iterations`, in future, there will be one unified API call `series.snapshots()` that works for writing and reading, streaming and random-access.

I don't know if this solves Alex's simulation freezes on Frontier, but it should fix the RNG state issue he saw.