### PR TITLE
Remove unused return statement that breaks compile

### DIFF
--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -213,8 +213,6 @@ namespace picongpu
 
                 return relative_cellpos;
             }
-
-            return relative_cellpos;
         }
     } // namespace plugins::binning
 } // namespace picongpu


### PR DESCRIPTION
@ikbuibui, this return statement is never executed, but since it is not guarded by an `if  constexpr` block the compiler will try to ensure that the return type is correct. This will fail if either precision or unit is different from cell. Basically, `rellative_cellpos` is a vector of `int`, but for all other configurations the return type is a vector of `float_X`.