### PR TITLE
Use lazy parsing for checkpoint-restart in the openPMD plugin

### DIFF
--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -164,7 +164,7 @@ namespace picongpu
                 auto datasetName = baseName + "/" + group + "/" + dataset;
                 ::openPMD::Series& series = *params.openPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
-                    = series.iterations[currentStep].meshes[baseName + "_" + group][dataset];
+                    = series.iterations[currentStep].open().meshes[baseName + "_" + group][dataset];
                 auto ndim = mrc.getDimensionality();
                 if(ndim != simDim)
                 {

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -188,7 +188,7 @@ namespace picongpu
 
                 std::shared_ptr<T_Scalar> readValue = mrc.loadChunk<T_Scalar>(start, count);
 
-                series.flush();
+                mrc.seriesFlush();
 
                 *value = *readValue;
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -249,7 +249,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             plugins::multi::Option<std::string> jsonRestartConfig
                 = {"jsonRestart",
                    "advanced (backend) configuration for openPMD in JSON format (used when reading from a checkpoint)",
-                   "{}"};
+                   R"({"defer_iteration_parsing": true})"};
 
             plugins::multi::Option<std::string> dataPreparationStrategy
                 = {"dataPreparationStrategy",
@@ -644,11 +644,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 jsonMatcher = AbstractJsonMatcher::construct(jsonConfigString, communicator);
             }
 
-            log<picLog::INPUT_OUTPUT>("openPMD: global JSON config: %1%") % jsonMatcher->getDefault();
-            if(jsonRestartParams != "{}")
-            {
-                log<picLog::INPUT_OUTPUT>("openPMD: global JSON restart config: %1%") % jsonRestartParams;
-            }
+            log<picLog::INPUT_OUTPUT>("openPMD: global JSON output config: %1%") % jsonMatcher->getDefault();
+            log<picLog::INPUT_OUTPUT>("openPMD: global JSON restart config: %1%") % jsonRestartParams;
 
             {
                 if(dataPreparationStrategyString == "adios" || dataPreparationStrategyString == "doubleBuffer")
@@ -978,7 +975,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 auto rngProvider = dc.get<RNGProvider>(RNGProvider::getName());
                 auto const name = rngProvider->getName();
 
-                ::openPMD::Iteration iteration = params->openPMDSeries->iterations[restartStep];
+                ::openPMD::Iteration iteration = params->openPMDSeries->iterations[restartStep].open();
                 ::openPMD::Mesh mesh = iteration.meshes[name];
                 ::openPMD::MeshRecordComponent mrc = mesh[::openPMD::RecordComponent::SCALAR];
 
@@ -1307,7 +1304,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                 checkIOFileVersionRestartCompatibility(mThreadParams.openPMDSeries);
 
-                ::openPMD::Iteration iteration = mThreadParams.openPMDSeries->iterations[restartStep];
+                ::openPMD::Iteration iteration = mThreadParams.openPMDSeries->iterations[restartStep].open();
 
                 /* load number of slides to initialize MovingWindow */
                 log<picLog::INPUT_OUTPUT>("openPMD: (begin) read attr (%1% available)") % iteration.numAttributes();

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1010,7 +1010,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     rawPtr,
                     asStandardVector<VecUInt64, ::openPMD::Offset>(recordOffsetDims),
                     asStandardVector<VecUInt64, ::openPMD::Extent>(recordLocalSizeDims));
-                params->openPMDSeries->flush();
+                iteration.seriesFlush();
                 // Copy data to device
                 rngProvider->syncToDevice();
             }

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -85,7 +85,8 @@ namespace picongpu
                 GridController<simDim>& gc = Environment<simDim>::get().GridController();
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Container<::openPMD::ParticleSpecies>& particles = series.iterations[currentStep].particles;
+                ::openPMD::Container<::openPMD::ParticleSpecies>& particles
+                    = series.iterations[currentStep].open().particles;
                 ::openPMD::ParticleSpecies particleSpecies = particles[speciesName];
 
                 const SubGrid<simDim>& subGrid = Environment<simDim>::get().SubGrid();

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -102,12 +102,12 @@ namespace picongpu
 
                 auto numRanks = gc.getGlobalSize();
 
-                size_t patchIdx = getPatchIdx(params, series, particleSpecies, numRanks);
+                size_t patchIdx = getPatchIdx(params, particleSpecies, numRanks);
 
                 std::shared_ptr<uint64_t> fullParticlesInfoShared
                     = particleSpecies.particlePatches["numParticles"][::openPMD::RecordComponent::SCALAR]
                           .load<uint64_t>();
-                series.flush();
+                particles.seriesFlush();
                 uint64_t* fullParticlesInfo = fullParticlesInfoShared.get();
 
                 /* Run a prefix sum over the numParticles[0] element in
@@ -200,7 +200,6 @@ namespace picongpu
              */
             HINLINE size_t getPatchIdx(
                 ThreadParams* params,
-                ::openPMD::Series& series,
                 ::openPMD::ParticleSpecies particleSpecies,
                 size_t numRanks)
             {
@@ -216,7 +215,7 @@ namespace picongpu
                         = particleSpecies.particlePatches["offset"][name_lookup[d]].load<uint64_t>();
                     std::shared_ptr<uint64_t> patchExtentsInfoShared
                         = particleSpecies.particlePatches["extent"][name_lookup[d]].load<uint64_t>();
-                    series.flush();
+                    particleSpecies.seriesFlush();
                     for(size_t i = 0; i < numRanks; ++i)
                     {
                         offsets[i][d] = patchOffsetsInfoShared.get()[i];

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -198,10 +198,8 @@ namespace picongpu
              *
              * @return index of the particle patch within the openPMD data
              */
-            HINLINE size_t getPatchIdx(
-                ThreadParams* params,
-                ::openPMD::ParticleSpecies particleSpecies,
-                size_t numRanks)
+            HINLINE size_t
+            getPatchIdx(ThreadParams* params, ::openPMD::ParticleSpecies particleSpecies, size_t numRanks)
             {
                 const std::string name_lookup[] = {"x", "y", "z"};
 

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -124,7 +124,7 @@ namespace picongpu
                 }
 
                 ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Container<::openPMD::Mesh>& meshes = series.iterations[currentStep].meshes;
+                ::openPMD::Container<::openPMD::Mesh>& meshes = series.iterations[currentStep].open().meshes;
 
                 auto destBox = field.getHostBuffer().getDataBox();
                 for(uint32_t n = 0; n < numComponents; ++n)

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -159,7 +159,7 @@ namespace picongpu
                     std::shared_ptr<float_X> field_container = rc.loadChunk<float_X>(start, count);
 
                     /* start a blocking read of all scheduled variables */
-                    series.flush();
+                    meshes.seriesFlush();
 
 
                     int const elementCount = local_domain_size.productOfComponents();


### PR DESCRIPTION
Currently, the openPMD plugin opens the entire checkpoint series for restarting, which is not necessary since only one Iteration will be used for restarting. This enables lazy parsing by default.

Additionally, use `Attributable::seriesFlush()` instead of direct `Series::flush()`. When called from within an Iteration, openPMD-api >= 0.16.1 will guarantee that this Iteration is opened, no matter if modified or not.

~~This PR is also an attempt to workaround an IO issue that was observed in a restart workflow. Since the actual cause for the observed error is not yet known, please do not merge yet.~~ The cause for the error is now known and it has nothing to do with PIConGPU. Still, the first commit makes restarting more efficient, and the second commit makes it somewhat more resilient against errors, so we can still go ahead with this change.