### PR TITLE
Add json formatter and replace ASCII enforcement in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,72 +1,72 @@
-minimum_pre_commit_version: 3.2.0  # necessitated by Lucas-C's hooks
+minimum_pre_commit_version: 3.2.0 # necessitated by Lucas-C's hooks
 default_install_hook_types: [pre-commit, pre-push]
-exclude: 'thirdParty'
+exclude: "thirdParty"
 repos:
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v12.0.1
-  hooks:
-  - id: clang-format
-    types_or: [file]
-    files: \.(cpp|def|h|cu|tpp|kernel|loader|unitless|hpp|param)$
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
-  hooks:
-  - id: no-commit-to-branch
-    args: [-b, dev]
-  - id: check-merge-conflict
-  - id: trailing-whitespace
-    exclude_types: [markdown, rst]
-  - id: end-of-file-fixer
-  - id: check-toml
-  - id: check-yaml
-  - id: mixed-line-ending
-  - id: check-executables-have-shebangs
-  - id: check-shebang-scripts-are-executable
-    exclude: \.tpl$
-- repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.5.4
-  hooks:
-    - id: forbid-tabs
-      types_or: [file]
-      exclude_types: [rst, tex, tsv]
-    - id: remove-tabs
-      types_or: [file]
-      exclude_types: [rst, tex, tsv]
-    - id: forbid-crlf
-    - id: remove-crlf
-- repo: https://github.com/brutus/enforce-ascii
-  rev: v0.2.1
-  hooks:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v12.0.1
+    hooks:
+      - id: clang-format
+        types_or: [file]
+        files: \.(cpp|def|h|cu|tpp|kernel|loader|unitless|hpp|param)$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [-b, dev]
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+        exclude_types: [markdown, rst]
+      - id: end-of-file-fixer
+      - id: check-toml
+      - id: check-yaml
+      - id: mixed-line-ending
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+        exclude: \.tpl$
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: forbid-tabs
+        types_or: [file]
+        exclude_types: [rst, tex, tsv]
+      - id: remove-tabs
+        types_or: [file]
+        exclude_types: [rst, tex, tsv]
+      - id: forbid-crlf
+      - id: remove-crlf
+  - repo: https://github.com/brutus/enforce-ascii
+    rev: v0.2.1
+    hooks:
       - id: enforce-ascii
         types_or: [file]
         exclude_types: [rst, tex, tsv, jupyter, markdown, svg]
         exclude: .zenodo.json
-- repo: local
-  hooks:
-    - id: check_cpp_code_style
-      name: check_cpp_code_style
-      entry: share/ci/check_cpp_code_style.sh
-      language: system
-      files: \.(cpp|def|h|cu|tpp|kernel|loader|unitless|hpp|param)$
-      pass_filenames: false
-      # This hook runs on all files which is why it feels a bit too heavy-weight
-      # for running before every commit. The CI currently runs manually, so it's
-      # still running there and can be run manually and pre-push on demand.
-      # TODO: Adjust the script to take filenames, so that we can pass the
-      # filenames and speed things up before commits.
-      stages: [manual, pre-push]
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.2.1
-  hooks:
-    # Run the linter.
-    - id: ruff
-      types_or: [ python, pyi, jupyter ]
-      # Rule E721 is about using isinstance()
-      # but lib/python/picongpu/pypicongpu/rendering/renderer.py
-      # is strict about types. Could be solved locally but I think this is fine.
-      args: [ --fix, --ignore, E721]
-    # Run the formatter.
-    - id: ruff-format
-      types_or: [ python, pyi, jupyter ]
-      args: ["--line-length", "120"]
+  - repo: local
+    hooks:
+      - id: check_cpp_code_style
+        name: check_cpp_code_style
+        entry: share/ci/check_cpp_code_style.sh
+        language: system
+        files: \.(cpp|def|h|cu|tpp|kernel|loader|unitless|hpp|param)$
+        pass_filenames: false
+        # This hook runs on all files which is why it feels a bit too heavy-weight
+        # for running before every commit. The CI currently runs manually, so it's
+        # still running there and can be run manually and pre-push on demand.
+        # TODO: Adjust the script to take filenames, so that we can pass the
+        # filenames and speed things up before commits.
+        stages: [manual, pre-push]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.2.1
+    hooks:
+      # Run the linter.
+      - id: ruff
+        types_or: [python, pyi, jupyter]
+        # Rule E721 is about using isinstance()
+        # but lib/python/picongpu/pypicongpu/rendering/renderer.py
+        # is strict about types. Could be solved locally but I think this is fine.
+        args: [--fix, --ignore, E721]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]
+        args: ["--line-length", "120"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,13 +39,6 @@ repos:
         exclude_types: [rst, tex, tsv]
       - id: forbid-crlf
       - id: remove-crlf
-  - repo: https://github.com/brutus/enforce-ascii
-    rev: v0.2.1
-    hooks:
-      - id: enforce-ascii
-        types_or: [file]
-        exclude_types: [rst, tex, tsv, jupyter, markdown, svg]
-        exclude: .zenodo.json
   - repo: local
     hooks:
       - id: check_cpp_code_style
@@ -75,3 +68,9 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
         args: ["--line-length", "120"]
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: require-ascii
+        exclude_types: [rst]
+        exclude: CHANGELOG.md|.zenodo.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
         exclude: \.tpl$
+      - id: pretty-format-json
+        args:
+          - "--autofix"
+          - "--no-ensure-ascii"
+          - "--no-sort-keys"
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.4
     hooks:

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,288 +1,288 @@
 {
-  "creators":[
+  "creators": [
     {
-      "affiliation":"ELI-NP",
-      "name":"Berceanu, Andrei"
+      "affiliation": "ELI-NP",
+      "name": "Berceanu, Andrei"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Carstens, Finn-Ole"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Carstens, Finn-Ole"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Debus, Alexander",
-      "orcid":"0000-0002-3844-3697"
+      "affiliation": "HZDR",
+      "name": "Debus, Alexander",
+      "orcid": "0000-0002-3844-3697"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Dietrich, Fabia"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Dietrich, Fabia"
     },
     {
-      "affiliation":"CASUS, HZDR",
-      "name":"Ehrig, Simeon",
-      "orcid":"0000-0002-8218-3116"
+      "affiliation": "CASUS, HZDR",
+      "name": "Ehrig, Simeon",
+      "orcid": "0000-0002-8218-3116"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Ermakov, Sergey Konstantin"
+      "affiliation": "HZDR",
+      "name": "Ermakov, Sergey Konstantin"
     },
     {
-      "name":"Marre, Brian Edward",
-      "affiliation":"HZDR, TU Dresden",
-      "orcid":"0009-0005-6873-8292"
+      "name": "Marre, Brian Edward",
+      "affiliation": "HZDR, TU Dresden",
+      "orcid": "0009-0005-6873-8292"
     },
     {
-      "name":"Lenz, Julian",
-      "affiliation":"CASUS, HZDR",
-      "orcid":"0000-0001-5250-0005"
+      "name": "Lenz, Julian",
+      "affiliation": "CASUS, HZDR",
+      "orcid": "0000-0001-5250-0005"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Lehmann, Max"
+      "affiliation": "HZDR",
+      "name": "Lehmann, Max"
     },
     {
-      "affiliation":"CASUS, HZDR",
-      "name":"Afshari, Masoud",
-      "orcid":"0000-0003-4486-9683"
+      "affiliation": "CASUS, HZDR",
+      "name": "Afshari, Masoud",
+      "orcid": "0000-0003-4486-9683"
     },
     {
-      "affiliation":"CASUS, HZDR",
-      "name":"Narwal, Tapish",
-      "orcid":"0000-0002-5726-2330"
+      "affiliation": "CASUS, HZDR",
+      "name": "Narwal, Tapish",
+      "orcid": "0000-0002-5726-2330"
     },
     {
-      "name":"Ordyna, Paweł",
-      "affiliation":"HZDR, TU Dresden"
+      "name": "Ordyna, Paweł",
+      "affiliation": "HZDR, TU Dresden"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Pausch, Richard",
-      "orcid":"0000-0001-7990-9564"
+      "affiliation": "HZDR",
+      "name": "Pausch, Richard",
+      "orcid": "0000-0001-7990-9564"
     },
     {
-      "name":"Poeschel, Franz",
-      "affiliation":"CASUS, HZDR",
-      "orcid":"0000-0001-7042-5088"
+      "name": "Poeschel, Franz",
+      "affiliation": "CASUS, HZDR",
+      "orcid": "0000-0001-7042-5088"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Sprenger, Lennert"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Sprenger, Lennert"
     },
     {
-      "affiliation":"CASUS, HZDR",
-      "name":"Steiniger, Klaus",
-      "orcid":"0000-0001-8965-1149"
+      "affiliation": "CASUS, HZDR",
+      "name": "Steiniger, Klaus",
+      "orcid": "0000-0001-8965-1149"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Tiebel, Jessica"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Tiebel, Jessica"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Widera, René",
-      "orcid":"0000-0003-1642-0459"
+      "affiliation": "HZDR",
+      "name": "Widera, René",
+      "orcid": "0000-0003-1642-0459"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Wolf, Hannes"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Wolf, Hannes"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Wrobel, Nico"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Wrobel, Nico"
     }
   ],
-  "contributors":[
+  "contributors": [
     {
-      "affiliation":"LOA",
-      "name":"Andriyash, Igor",
-      "type":"Other"
+      "affiliation": "LOA",
+      "name": "Andriyash, Igor",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Bastrakova, Kseniia",
-      "type":"Other"
+      "affiliation": "HZDR",
+      "name": "Bastrakova, Kseniia",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Bastrakov, Sergei",
-      "orcid":"0000-0003-3396-6154",
-      "type":"Other"
+      "affiliation": "HZDR",
+      "name": "Bastrakov, Sergei",
+      "orcid": "0000-0003-3396-6154",
+      "type": "Other"
     },
     {
-      "affiliation":"University Jena",
-      "name":"Bifeng, Lei",
-      "type":"Other"
+      "affiliation": "University Jena",
+      "name": "Bifeng, Lei",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Burau, Heiko",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Burau, Heiko",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, CASUS",
-      "name":"Bussmann, Michael",
-      "orcid":"0000-0002-8258-3881",
-      "type":"Other"
+      "affiliation": "HZDR, CASUS",
+      "name": "Bussmann, Michael",
+      "orcid": "0000-0002-8258-3881",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Eckert, Carlchristian",
-      "type":"Other"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Eckert, Carlchristian",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Voß, Mika Soren",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Voß, Mika Soren",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Garten, Marco",
-      "orcid":"0000-0001-6994-2475",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Garten, Marco",
+      "orcid": "0000-0001-6994-2475",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Göthel, Ilja",
-      "type":"Other"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Göthel, Ilja",
+      "type": "Other"
     },
     {
-      "name":"Gruber, Bernhard Manfred",
-      "affiliation":"CASUS, HZDR, CERN",
-      "orcid":"0000-0001-7848-1690",
-      "type":"Other"
+      "name": "Gruber, Bernhard Manfred",
+      "affiliation": "CASUS, HZDR, CERN",
+      "orcid": "0000-0001-7848-1690",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Grund, Alexander",
-      "orcid":"0000-0002-7196-8452",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Grund, Alexander",
+      "orcid": "0000-0002-7196-8452",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Hahn, Sebastian",
-      "type":"Other"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Hahn, Sebastian",
+      "type": "Other"
     },
     {
-      "affiliation":"TU-Dresden",
-      "name":"Hoehnig, Wolfgang",
-      "type":"Other"
+      "affiliation": "TU-Dresden",
+      "name": "Hoehnig, Wolfgang",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden, LBNL",
-      "name":"Huebl, Axel",
-      "orcid":"0000-0003-1943-7141",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden, LBNL",
+      "name": "Huebl, Axel",
+      "orcid": "0000-0003-1943-7141",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Kelling, Jeffrey",
-      "orcid":"0000-0003-1761-2591",
-      "type":"Other"
+      "affiliation": "HZDR",
+      "name": "Kelling, Jeffrey",
+      "orcid": "0000-0003-1761-2591",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Knespel, Maximilian",
-      "type":"Other"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Knespel, Maximilian",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Lebedev, Anton",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Lebedev, Anton",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Matthes, Alexander",
-      "orcid":"0000-0002-6702-2015",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Matthes, Alexander",
+      "orcid": "0000-0002-6702-2015",
+      "type": "Other"
     },
     {
-      "name":"Meyer, Felix",
-      "affiliation":"HZDR, TU Dresden",
-      "type":"Other"
+      "name": "Meyer, Felix",
+      "affiliation": "HZDR, TU Dresden",
+      "type": "Other"
     },
     {
-      "affiliation":"ELI-NP",
-      "name":"Ong, Jian Fuh",
-      "type":"Other"
+      "affiliation": "ELI-NP",
+      "name": "Ong, Jian Fuh",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Prinz, Nils",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Prinz, Nils",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Rudat, Sophie",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Rudat, Sophie",
+      "type": "Other"
     },
     {
-      "affiliation":"TU-Dresden",
-      "name":"Schmitt, Felix",
-      "type":"Other"
+      "affiliation": "TU-Dresden",
+      "name": "Schmitt, Felix",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Schneider, Benjamin",
-      "type":"Other"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Schneider, Benjamin",
+      "type": "Other"
     },
     {
-      "affiliation":"TU-Dresden",
-      "name":"Schumann, Conrad",
-      "type":"Other"
+      "affiliation": "TU-Dresden",
+      "name": "Schumann, Conrad",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR",
-      "name":"Starke, Sebastian",
-      "type":"Other"
+      "affiliation": "HZDR",
+      "name": "Starke, Sebastian",
+      "type": "Other"
     },
     {
-      "name":"Stephan, Jan",
-      "affiliation":"CASUS, HZDR, TU Dresden",
-      "orcid":"0000-0001-7839-4386",
-      "type":"Other"
+      "name": "Stephan, Jan",
+      "affiliation": "CASUS, HZDR, TU Dresden",
+      "orcid": "0000-0001-7839-4386",
+      "type": "Other"
     },
     {
-      "name":"Thévenet, Maxence",
-      "affiliation":"Desy",
-      "type":"Other"
+      "name": "Thévenet, Maxence",
+      "affiliation": "Desy",
+      "type": "Other"
     },
     {
-      "affiliation":"University Jena",
-      "name":"Tietze, Stefan",
-      "type":"Other"
+      "affiliation": "University Jena",
+      "name": "Tietze, Stefan",
+      "type": "Other"
     },
     {
-      "name":"Trojok, Jakob",
-      "affiliation":"HZDR, TU Dresden",
-      "type":"Other"
+      "name": "Trojok, Jakob",
+      "affiliation": "HZDR, TU Dresden",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU Dresden",
-      "name":"Tröpgen, Hannes",
-      "type":"Other"
+      "affiliation": "HZDR, TU Dresden",
+      "name": "Tröpgen, Hannes",
+      "type": "Other"
     },
     {
-      "name":"Wang, Manhui",
-      "affiliation":"University of Liverpool",
-      "type":"Other"
+      "name": "Wang, Manhui",
+      "affiliation": "University of Liverpool",
+      "type": "Other"
     },
     {
-      "affiliation":"TU-Dresden",
-      "name":"Winkler, Frank",
-      "type":"Other"
+      "affiliation": "TU-Dresden",
+      "name": "Winkler, Frank",
+      "type": "Other"
     },
     {
-      "affiliation":"LogMeIn, Inc.",
-      "name":"Worpitz, Benjamin",
-      "type":"Other"
+      "affiliation": "LogMeIn, Inc.",
+      "name": "Worpitz, Benjamin",
+      "type": "Other"
     },
     {
-      "affiliation":"HZDR, TU-Dresden",
-      "name":"Zenker, Erik",
-      "type":"Other"
+      "affiliation": "HZDR, TU-Dresden",
+      "name": "Zenker, Erik",
+      "type": "Other"
     }
   ],
-  "keywords":[
+  "keywords": [
     "PIConGPU",
     "CUDA",
     "OpenMP",
@@ -292,12 +292,12 @@
     "HIP",
     "C++"
   ],
-  "language":"eng",
-  "access_right":"open",
-  "license":{
-    "id":"GPL-3.0"
+  "language": "eng",
+  "access_right": "open",
+  "license": {
+    "id": "GPL-3.0"
   },
-  "references":[
+  "references": [
     "L. V. Keldysh (1965). Ionization in the field of a strong electromagnetic wave.",
     "D. Bauer and P. Mulser (1999). Exact field ionization rates in the barrier-suppression regime from numerical time-dependent Schrödinger-equation calculations. DOI:10.1103/PhysRevA.59.569",
     "R. Pausch et al. (2014). How to test and verify radiation diagnostics simulations within particle-in-cell frameworks. DOI:10.1016/j.nima.2013.10.073",

--- a/lib/python/picongpu/extra/input/createBunch_example.ipynb
+++ b/lib/python/picongpu/extra/input/createBunch_example.ipynb
@@ -1,282 +1,282 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Define a PWFA driver bunch and add it to a PIConGPU simulation"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Define a PWFA driver bunch and add it to a PIConGPU simulation"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Intro\n",
+        "\n",
+        "This notebook allows you to define a simple PWFA driver bunch using numpy.\n",
+        "Each step will be explained on the way.\n",
+        "In the end, the particles (of the driver bunch) will be added to an empty **openPMD-api** checkpoint in **bp** format.\n",
+        "This serves as an example on how to use the checkpoint edit tool.\n",
+        "\n",
+        "**!!! The copying of checkpoints can take up a lot of memory, so enough should be reserved beforehand. `.bp5` should be given as file ending for the written checkpoint. This will enable openPMD to only hold the currently written field in memory instead of cumulating all data of the checkpoint until the end. Big simulations may still run into memory issues, as single fields may contain over 50 GB of data. `copyRNG=False` can be used to skip one such field by not copying RNG values from the source checkpoint !!!**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## load modules"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# standard modules\n",
+        "import numpy as np\n",
+        "from scipy import constants"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# own modules from script\n",
+        "\n",
+        "from bunchInit_openPMD_bp import vec3D\n",
+        "from bunchInit_openPMD_bp import addParticles2Checkpoint"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Generate a electron bunch at a known location\n",
+        "For our L|PWFA setups, we usually assume that the driver bunch of the 2nd stage/PWFA stage - which originate as witness bunch from the first stage/LWFA stage - is Gaussian/uncorrelated when exiting the LWFA stage and thus easy to define."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### define bunch parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# set these values\n",
+        "\n",
+        "Q = 400e-12  # define total charge of driver in [C]\n",
+        "radius_LWFA_exit_rms = 1.0e-6 * 10.0  # rms radius of bunch in [m]\n",
+        "tau_FWHM = 20.0e-15  # FWHM duration of bunch in [s]\n",
+        "E_kin_mean = 250.0e6  # mean energy in [eV]\n",
+        "E_kin_FWHM = 10.0e6  # energy spread in [eV]\n",
+        "theta_sigma = 1.6e-3  # standard deviation of divergence in [rad]\n",
+        "mean_weight = 50000  # define a constant weight for all macro-particles"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# compute relevant quantities\n",
+        "\n",
+        "# number of macro particles:\n",
+        "N = int(Q / constants.elementary_charge / mean_weight)\n",
+        "\n",
+        "# convert rms to std of radius\n",
+        "sigma_LWFA_exit = radius_LWFA_exit_rms / np.sqrt(2)\n",
+        "\n",
+        "# monte carlo: transversal position\n",
+        "x = np.random.normal(scale=sigma_LWFA_exit, size=N)\n",
+        "z = np.random.normal(scale=sigma_LWFA_exit, size=N)\n",
+        "\n",
+        "# constant conversion_factor, equals 2*sqrt(2*ln(2))\n",
+        "const_FWHM_to_sigma = 2.35482004503\n",
+        "\n",
+        "# convert FWHM to std of duration\n",
+        "sigma_y = tau_FWHM * constants.c / const_FWHM_to_sigma\n",
+        "\n",
+        "# monte-carlo longitudinal distribution\n",
+        "y = np.random.normal(scale=sigma_y, size=N)\n",
+        "\n",
+        "# monte-carlo energy distribution\n",
+        "E_kin = np.random.normal(loc=E_kin_mean, scale=E_kin_FWHM / const_FWHM_to_sigma, size=N)\n",
+        "\n",
+        "# monte-carlo azimutal angle\n",
+        "theta = np.random.normal(loc=0.0, scale=theta_sigma * np.sqrt(2), size=N)\n",
+        "# monte-carlo polar angle (uniform distribution)\n",
+        "phi = np.random.uniform(low=-np.pi, high=+np.pi, size=N)\n",
+        "\n",
+        "# convert kinetic energy to absolute momentum\n",
+        "convert_Ekin_to_momentum = (E_kin * constants.elementary_charge) / constants.c * mean_weight\n",
+        "# distribute to direction\n",
+        "px = np.sin(phi) * np.sin(theta) * convert_Ekin_to_momentum\n",
+        "py = 1.0 * np.cos(theta) * convert_Ekin_to_momentum\n",
+        "pz = np.cos(phi) * np.sin(theta) * convert_Ekin_to_momentum"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Getting particles into the PIC code\n",
+        "\n",
+        "In this section, we will prepare the particle distribution to go into the empty checkpoint of PIConGPU."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Parameters from the actual simulation\n",
+        "Get the resolution of the PIConGPU simulation. These parameters can be found in `include/picongpu/param/simulation.param` and the `*.cfg` file you are using."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# set parameters\n",
+        "delta_x = 0.1772e-6  # [m]\n",
+        "delta_y = delta_x  # [m]\n",
+        "delta_z = delta_x  # [m]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# set distribution to GPUs\n",
+        "cells = (512, 1024, 512)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "### place particles inside simulation box\n",
+        "So far, we used a simple coordinate system. Now, we have to decide were to place the center (mean position) of the bunch inside our simulation box. \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# define center position\n",
+        "center_pos_x = delta_x * cells[0] / 2.0\n",
+        "center_pos_y = delta_y * cells[1] * 2.4 / 4.0\n",
+        "center_pos_z = delta_z * cells[2] / 2.0"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# make weighting an array (all macro-particle have the same weighting)\n",
+        "weighting = np.ones(N) * mean_weight\n",
+        "\n",
+        "# shift particles to new center position\n",
+        "x_PIConGPU = x + center_pos_x\n",
+        "y_PIConGPU = y + center_pos_y\n",
+        "z_PIConGPU = z + center_pos_z"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "tags": []
+      },
+      "source": [
+        "### convert data and write to checkpoint"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# convert data to 3d vector object\n",
+        "pos = vec3D(x_PIConGPU, y_PIConGPU, z_PIConGPU)\n",
+        "mom = vec3D(px / mean_weight, py / mean_weight, pz / mean_weight)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# assign to (existing) checkpoint file\n",
+        "# replace with your own paths and species name (from speciesDefinition.param of the input simulation)\n",
+        "# copyRNG can be used to skip the copying of the RNG values\n",
+        "checkPoint_b = addParticles2Checkpoint(\n",
+        "    \"<path_to_source_checkpoint>/checkpoint_%T.bp5\",\n",
+        "    \"<path_to_destination_checkpoint>/checkpoint_%06T.bp5\",\n",
+        "    speciesName=\"b\",\n",
+        "    copyRNG=True,\n",
+        "    verbose=False,\n",
+        ")\n",
+        "\n",
+        "# this will throw an error if particles of speciesName are already in the checkpoint - make sure you use an empty checkpoint as source\n",
+        "# the output checkpoint should have the file endling bp5, else the entire checkpoint will be held in memory, which might crash the kernel"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# write data to file\n",
+        "checkPoint_b.addParticles(pos, mom, weighting)\n",
+        "checkPoint_b.writeParticles()\n",
+        "\n",
+        "# delete data we wrote\n",
+        "del checkPoint_b"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.9"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Intro\n",
-    "\n",
-    "This notebook allows you to define a simple PWFA driver bunch using numpy.\n",
-    "Each step will be explained on the way.\n",
-    "In the end, the particles (of the driver bunch) will be added to an empty **openPMD-api** checkpoint in **bp** format.\n",
-    "This serves as an example on how to use the checkpoint edit tool.\n",
-    "\n",
-    "**!!! The copying of checkpoints can take up a lot of memory, so enough should be reserved beforehand. `.bp5` should be given as file ending for the written checkpoint. This will enable openPMD to only hold the currently written field in memory instead of cumulating all data of the checkpoint until the end. Big simulations may still run into memory issues, as single fields may contain over 50 GB of data. `copyRNG=False` can be used to skip one such field by not copying RNG values from the source checkpoint !!!**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## load modules"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# standard modules\n",
-    "import numpy as np\n",
-    "from scipy import constants"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# own modules from script\n",
-    "\n",
-    "from bunchInit_openPMD_bp import vec3D\n",
-    "from bunchInit_openPMD_bp import addParticles2Checkpoint"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Generate a electron bunch at a known location\n",
-    "For our L|PWFA setups, we usually assume that the driver bunch of the 2nd stage/PWFA stage - which originate as witness bunch from the first stage/LWFA stage - is Gaussian/uncorrelated when exiting the LWFA stage and thus easy to define."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### define bunch parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set these values\n",
-    "\n",
-    "Q = 400e-12  # define total charge of driver in [C]\n",
-    "radius_LWFA_exit_rms = 1.0e-6 * 10.0  # rms radius of bunch in [m]\n",
-    "tau_FWHM = 20.0e-15  # FWHM duration of bunch in [s]\n",
-    "E_kin_mean = 250.0e6  # mean energy in [eV]\n",
-    "E_kin_FWHM = 10.0e6  # energy spread in [eV]\n",
-    "theta_sigma = 1.6e-3  # standard deviation of divergence in [rad]\n",
-    "mean_weight = 50000  # define a constant weight for all macro-particles"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# compute relevant quantities\n",
-    "\n",
-    "# number of macro particles:\n",
-    "N = int(Q / constants.elementary_charge / mean_weight)\n",
-    "\n",
-    "# convert rms to std of radius\n",
-    "sigma_LWFA_exit = radius_LWFA_exit_rms / np.sqrt(2)\n",
-    "\n",
-    "# monte carlo: transversal position\n",
-    "x = np.random.normal(scale=sigma_LWFA_exit, size=N)\n",
-    "z = np.random.normal(scale=sigma_LWFA_exit, size=N)\n",
-    "\n",
-    "# constant conversion_factor, equals 2*sqrt(2*ln(2))\n",
-    "const_FWHM_to_sigma = 2.35482004503\n",
-    "\n",
-    "# convert FWHM to std of duration\n",
-    "sigma_y = tau_FWHM * constants.c / const_FWHM_to_sigma\n",
-    "\n",
-    "# monte-carlo longitudinal distribution\n",
-    "y = np.random.normal(scale=sigma_y, size=N)\n",
-    "\n",
-    "# monte-carlo energy distribution\n",
-    "E_kin = np.random.normal(loc=E_kin_mean, scale=E_kin_FWHM / const_FWHM_to_sigma, size=N)\n",
-    "\n",
-    "# monte-carlo azimutal angle\n",
-    "theta = np.random.normal(loc=0.0, scale=theta_sigma * np.sqrt(2), size=N)\n",
-    "# monte-carlo polar angle (uniform distribution)\n",
-    "phi = np.random.uniform(low=-np.pi, high=+np.pi, size=N)\n",
-    "\n",
-    "# convert kinetic energy to absolute momentum\n",
-    "convert_Ekin_to_momentum = (E_kin * constants.elementary_charge) / constants.c * mean_weight\n",
-    "# distribute to direction\n",
-    "px = np.sin(phi) * np.sin(theta) * convert_Ekin_to_momentum\n",
-    "py = 1.0 * np.cos(theta) * convert_Ekin_to_momentum\n",
-    "pz = np.cos(phi) * np.sin(theta) * convert_Ekin_to_momentum"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Getting particles into the PIC code\n",
-    "\n",
-    "In this section, we will prepare the particle distribution to go into the empty checkpoint of PIConGPU."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Parameters from the actual simulation\n",
-    "Get the resolution of the PIConGPU simulation. These parameters can be found in `include/picongpu/param/simulation.param` and the `*.cfg` file you are using."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set parameters\n",
-    "delta_x = 0.1772e-6  # [m]\n",
-    "delta_y = delta_x  # [m]\n",
-    "delta_z = delta_x  # [m]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set distribution to GPUs\n",
-    "cells = (512, 1024, 512)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### place particles inside simulation box\n",
-    "So far, we used a simple coordinate system. Now, we have to decide were to place the center (mean position) of the bunch inside our simulation box. \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# define center position\n",
-    "center_pos_x = delta_x * cells[0] / 2.0\n",
-    "center_pos_y = delta_y * cells[1] * 2.4 / 4.0\n",
-    "center_pos_z = delta_z * cells[2] / 2.0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# make weighting an array (all macro-particle have the same weighting)\n",
-    "weighting = np.ones(N) * mean_weight\n",
-    "\n",
-    "# shift particles to new center position\n",
-    "x_PIConGPU = x + center_pos_x\n",
-    "y_PIConGPU = y + center_pos_y\n",
-    "z_PIConGPU = z + center_pos_z"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### convert data and write to checkpoint"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# convert data to 3d vector object\n",
-    "pos = vec3D(x_PIConGPU, y_PIConGPU, z_PIConGPU)\n",
-    "mom = vec3D(px / mean_weight, py / mean_weight, pz / mean_weight)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# assign to (existing) checkpoint file\n",
-    "# replace with your own paths and species name (from speciesDefinition.param of the input simulation)\n",
-    "# copyRNG can be used to skip the copying of the RNG values\n",
-    "checkPoint_b = addParticles2Checkpoint(\n",
-    "    \"<path_to_source_checkpoint>/checkpoint_%T.bp5\",\n",
-    "    \"<path_to_destination_checkpoint>/checkpoint_%06T.bp5\",\n",
-    "    speciesName=\"b\",\n",
-    "    copyRNG=True,\n",
-    "    verbose=False,\n",
-    ")\n",
-    "\n",
-    "# this will throw an error if particles of speciesName are already in the checkpoint - make sure you use an empty checkpoint as source\n",
-    "# the output checkpoint should have the file endling bp5, else the entire checkpoint will be held in memory, which might crash the kernel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# write data to file\n",
-    "checkPoint_b.addParticles(pos, mom, weighting)\n",
-    "checkPoint_b.writeParticles()\n",
-    "\n",
-    "# delete data we wrote\n",
-    "del checkPoint_b"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.9"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
+++ b/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
@@ -1,547 +1,547 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "d25194cb-4633-4cfd-ab12-faa10f9926bc",
-   "metadata": {},
-   "source": [
-    "This file is part of PIConGPU. \\\n",
-    "Copyright 2024-2024 Fabia Dietrich\n",
-    "\n",
-    "# Preparing Insight data for PIConGPU\n",
-    "\n",
-    "## Intro\n",
-    "This notebook allows you to analyse, further process and prepare Insight data to be read via the FromOpenPMDPulse profile into PIConGPU.\n",
-    "The raw Insight data cannot be used, since it (at least) has to be phase corrected and transformed into the time domain. \n",
-    "Furthermore, the field can be propagated out of the focus.\n",
-    "\n",
-    "## Load modules"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "d25194cb-4633-4cfd-ab12-faa10f9926bc",
+      "metadata": {},
+      "source": [
+        "This file is part of PIConGPU. \\\n",
+        "Copyright 2024-2024 Fabia Dietrich\n",
+        "\n",
+        "# Preparing Insight data for PIConGPU\n",
+        "\n",
+        "## Intro\n",
+        "This notebook allows you to analyse, further process and prepare Insight data to be read via the FromOpenPMDPulse profile into PIConGPU.\n",
+        "The raw Insight data cannot be used, since it (at least) has to be phase corrected and transformed into the time domain. \n",
+        "Furthermore, the field can be propagated out of the focus.\n",
+        "\n",
+        "## Load modules"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8f20b708-32b3-416e-b3d6-018884281b8c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# standard modules\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "# modules from preparingInsightData.py\n",
+        "from preparingInsightData import PrepRoutines"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6e06caf1-30ea-46f9-90c9-4d691dccf127",
+      "metadata": {},
+      "source": [
+        "## Get the data\n",
+        "The far field data (= at the focal plane) from an Insight measurement is stored in a h5 file and typically measured in dependence of two transversal coordinates (\"x\" and \"y\" in mm) and the frequency (\"w\" in rad/fs). If there are any deviations from this scheme, you will have to adjust unit of the speed of light `c` in line 32 of the _PrepRoutines_ source code. \n",
+        "\n",
+        "Then, the first steps are:\n",
+        "1. read the far field data and store it in numpy arrays\n",
+        "2. fit the far field data intensity with a 2D gaussian to extract the beam center and waist size\n",
+        "3. propagate to the near field (= just before the diffracting element)\n",
+        "4. fit the near field data with a 2D supergaussian to extract the beam center and waist size\n",
+        "\n",
+        "For that, you need to provide path, filename and focal distance (same unit as the transversal scales) to the init function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "df9bc30d-c03b-4cb4-9621-b2aa62142f6a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "foc = 2000  # mm, focal distance\n",
+        "insight = PrepRoutines(\"/put/your/path/here/\", \"filename.h5\", foc)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2c7db135-e858-4152-9ec6-1d0358180f43",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# some nice colorful pictures of your data\n",
+        "fig = plt.figure(figsize=(14, 8))\n",
+        "\n",
+        "ax1 = fig.add_subplot(231)\n",
+        "ax1.imshow(\n",
+        "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+        ")\n",
+        "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+        "ax1.set_xlabel(\"x [mm]\")\n",
+        "ax1.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "ax2 = fig.add_subplot(232)\n",
+        "ax2.imshow(\n",
+        "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
+        ")\n",
+        "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
+        "ax2.set_xlabel(\"x [mm]\")\n",
+        "ax2.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "ax3 = fig.add_subplot(233)\n",
+        "ax3.plot(\n",
+        "    insight.w,\n",
+        "    np.angle(\n",
+        "        insight.Ew_NF[np.abs(insight.y_NF - insight.yc_NF).argmin(), np.abs(insight.x_NF - insight.xc_NF).argmin(), :]\n",
+        "    ),\n",
+        ")\n",
+        "ax3.set_title(\"phase in near field beam center\")\n",
+        "ax3.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+        "ax3.set_ylabel(\"rad\")\n",
+        "\n",
+        "ax4 = fig.add_subplot(234)\n",
+        "ax4.imshow(\n",
+        "    np.sum(np.abs(insight.Ew), axis=0),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    aspect=\"auto\",\n",
+        "    extent=(insight.w[0], insight.w[-1], insight.x[0], insight.x[-1]),\n",
+        ")\n",
+        "ax4.set_title(r\"SD$_x$ in focus\")\n",
+        "ax4.set_ylabel(\"x [mm]\")\n",
+        "ax4.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+        "\n",
+        "ax5 = fig.add_subplot(235)\n",
+        "ax5.imshow(\n",
+        "    np.sum(np.abs(insight.Ew), axis=1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    aspect=\"auto\",\n",
+        "    extent=(insight.w[0], insight.w[-1], insight.x[0], insight.x[-1]),\n",
+        ")\n",
+        "ax5.set_title(r\"SD$_y$ in focus\")\n",
+        "ax5.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+        "ax5.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "ax6 = fig.add_subplot(236)\n",
+        "# sum just over the main beam spot (+- 2 * waist size around beam center) to extract the spectrum\n",
+        "ax6.plot(\n",
+        "    insight.w,\n",
+        "    np.sum(\n",
+        "        np.sum(\n",
+        "            np.abs(\n",
+        "                insight.Ew[\n",
+        "                    np.abs(insight.y - insight.yc + 2 * insight.waist).argmin() : np.abs(\n",
+        "                        insight.y - insight.yc - 2 * insight.waist\n",
+        "                    ).argmin(),\n",
+        "                    np.abs(insight.x - insight.xc + 2 * insight.waist).argmin() : np.abs(\n",
+        "                        insight.x - insight.xc - 2 * insight.waist\n",
+        "                    ).argmin(),\n",
+        "                    :,\n",
+        "                ]\n",
+        "            )\n",
+        "            ** 2,\n",
+        "            axis=0,\n",
+        "        ),\n",
+        "        axis=0,\n",
+        "    ),\n",
+        ")\n",
+        "ax6.set_title(\"spectral intensity\")\n",
+        "ax6.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
+        "ax6.set_ylabel(\"arb. units\")\n",
+        "\n",
+        "plt.subplots_adjust(hspace=0.3, wspace=0.3)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "18bee9ee-bd16-4e28-b9a7-ac5bc12e112e",
+      "metadata": {},
+      "source": [
+        "## Correct the data\n",
+        "### Adjust beam compression and add dispersion parameters\n",
+        "Before going on with any calculations, the phase has to be corrected. Insight reconstructs the amplitude of the far field beam as well as the phase, up to an unknown global phase for every frequency.\n",
+        "For an estimation of this global phase, perfect compression is assumed in the (near field) beam center. Thus, the phase is extracted in the beam center in dependence of the frequency and substracted globally (i.e. from the measured phase in dependence of the frequency at every space point).\n",
+        "Here, one also has the possibility to add dispersion parameters such as group delay dispersion (`GDD`) and third order dispersion (`TOD`) (both are set to 0 by default)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "db7ee493-ac2f-4c62-9121-70d270587ae5",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "insight.correct_phase()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "fe86408e-4e08-4f9a-8044-b0dfc989d408",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plt.plot(\n",
+        "    insight.w,\n",
+        "    np.angle(\n",
+        "        insight.Ew_NF[np.abs(insight.y_NF - insight.yc_NF).argmin(), np.abs(insight.x_NF - insight.xc_NF).argmin(), :]\n",
+        "    ),\n",
+        ")\n",
+        "plt.title(\"corrected phase in near field beam center\")\n",
+        "plt.xlabel(r\"$\\omega$ [rad/fs]\")\n",
+        "plt.ylabel(\"rad\")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "11125a32-e618-40b4-aa4b-e1e51def5c3e",
+      "metadata": {},
+      "source": [
+        "### Correct ugly spots in the near field (optional)\n",
+        "Sometimes, the amplitude in the near field looks weird, showing some (unphysical) peaks or holes. These can cause artifacts in the far field and will thus be smoothened out."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0c772bfd-2d6b-4206-8dbd-f574d50d3931",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "ugly_x = 0.0  # mm\n",
+        "ugly_y = 0.0  # mm\n",
+        "insight.correct_ugly_spot_in_nf(ugly_x, ugly_y)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2ab764a7-979d-417f-bae4-15f19ca790e8",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plt.figure(figsize=(10, 4))\n",
+        "\n",
+        "ax1 = fig.add_subplot(121)\n",
+        "ax1.imshow(\n",
+        "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+        ")\n",
+        "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+        "ax1.set_xlabel(\"x [mm]\")\n",
+        "ax1.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "ax2 = fig.add_subplot(122)\n",
+        "ax2.imshow(\n",
+        "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
+        ")\n",
+        "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
+        "ax2.set_xlabel(\"x [mm]\")\n",
+        "ax2.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d63c3650-d902-4d71-8bbf-60a8c3b8bca6",
+      "metadata": {},
+      "source": [
+        "### Center the near field beam spot (optional)\n",
+        "When the near field beam spot is not centered (please check the center coordinates above), the far field will propagate obliquely instead of straight ahead. Centering the near field prevents this."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b88a2410-f9ca-4ff9-ab1b-3954c38b90b5",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "insight.shift_nf_to_center()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cfbe99d5-97b1-44b6-879c-ed97e3eae945",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plt.figure(figsize=(14, 4))\n",
+        "\n",
+        "ax1 = fig.add_subplot(131)\n",
+        "ax1.imshow(\n",
+        "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+        ")\n",
+        "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+        "ax1.set_xlabel(\"x [mm]\")\n",
+        "ax1.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "ax2 = fig.add_subplot(132)\n",
+        "ax2.imshow(\n",
+        "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
+        ")\n",
+        "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
+        "ax2.set_xlabel(\"x [mm]\")\n",
+        "ax2.set_ylabel(\"y [mm]\")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8f6942a0-43a0-4b55-92fa-a7d6ceb9a59a",
+      "metadata": {},
+      "source": [
+        "## Measure dispersion parameters\n",
+        "You can measure angular dispersion and spatial dispersion in far- and near field.\n",
+        "For a consistency check of those values, you can check those relations: \n",
+        "\\begin{equation*}\n",
+        "\\begin{aligned}\n",
+        "AD_\\mathrm{FF} &= - \\frac{SD_\\mathrm{NF}}{f_\\mathrm{eff}} - AD_\\mathrm{NF} \\\\\n",
+        "SD_\\mathrm{FF} &= f_\\mathrm{eff} \\cdot AD_\\mathrm{NF}\n",
+        "\\end{aligned}\n",
+        "\\end{equation*}\n",
+        "$f_\\mathrm{eff}$ is the effective focal length."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ae6d2380-f5c3-4ec4-8918-23ca0fbb6ce2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "insight.measure_ad_in_nf()\n",
+        "insight.measure_ad_in_ff()\n",
+        "insight.measure_sd_in_nf()\n",
+        "insight.measure_sd_in_ff()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6d645f08-4e8d-40ba-af73-533fdd9aa8cb",
+      "metadata": {},
+      "source": [
+        "## Add an aperture in the mid field (optional)\n",
+        "Here, you can apply an aperture to the beam, located in the mid field. The algorithm which propagates the beam to the mid field uses paraxial approximation; so please make sure to put the aperture not too close to the focal plane (`d` $\\gg$ `insight.waist`). "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "fb07e460-f729-46a9-8e28-d32e968968ed",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "d = 1000  # mm, distance from focal plane to aperture\n",
+        "R = 38.5 / 2  # mm, aperture radius\n",
+        "insight.aperture_in_mf(d, R)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "87430869-9a85-47b9-8127-fbea86f7bbdf",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plt.figure()\n",
+        "ax1 = fig.add_subplot(111)\n",
+        "ax1.imshow(\n",
+        "    np.sum(np.abs(insight.Ew), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+        ")\n",
+        "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
+        "ax1.set_xlabel(\"x [mm]\")\n",
+        "ax1.set_ylabel(\"y [mm]\")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9988b6e5-f3e4-4395-a1ff-4159ede3b4cd",
+      "metadata": {},
+      "source": [
+        "## Propagate\n",
+        "Now the far field data is ready to be propagated. For that, the angular spectrum method is used. \n",
+        "Watch out not to propagate too far, since then the growing beam diameter could reach the transversal window borders and thus cause fourier transform artifacts."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "3db3f073-cf90-48f8-a3e7-8bc220c390a2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "z = -2  # mm\n",
+        "Ew_prop = insight.propagate(z)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c6ff5e59-4b93-41ec-b8a2-68d28a0f26d6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plt.imshow(\n",
+        "    np.sum(np.abs(Ew_prop), axis=-1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
+        ")\n",
+        "plt.title(\"spectrally integrated amplitude, propagated to %.2f mm\" % (z))\n",
+        "plt.xlabel(\"x [mm]\")\n",
+        "plt.ylabel(\"y [mm]\")\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9bfb7cc2-0327-43fb-8364-0dbcc62e0553",
+      "metadata": {},
+      "source": [
+        "## Transform to the time domain\n",
+        "The far field data will be transformed to the time domain via a 1D fourier transformation. This takes a while, since the spectrum has to be extended and the field data extrapolated. One can adjust the number of samples per wavelength, which is set to 10 by default. \\\n",
+        "**Attention:** it is recommeded to adjust the time sampling to the PIConGPU simulation timestep! \\\n",
+        "The real part of the resulting complex matrix `insight.Et` will be the field needed for PIConGPU and its absolute value is the envelope, which can be used for further analysis."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f44373f9-d947-41d8-8e21-2eafe7584de8",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "insight.to_time_domain(Ew_prop)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "268a89c7-4334-4906-ad16-c4536a128617",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = plt.figure(figsize=(6, 9))\n",
+        "\n",
+        "ax1 = fig.add_subplot(311)\n",
+        "ax1.imshow(\n",
+        "    np.sum(np.abs(insight.Et), axis=0),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    aspect=\"auto\",\n",
+        "    extent=(insight.t[0], insight.t[-1], insight.x[0], insight.x[-1]),\n",
+        ")\n",
+        "ax1.set_ylabel(\"x [mm]\")\n",
+        "ax1.set_title(\"transversally integrated field\")\n",
+        "\n",
+        "ax2 = fig.add_subplot(312)\n",
+        "ax2.imshow(\n",
+        "    np.sum(np.abs(insight.Et), axis=1),\n",
+        "    cmap=\"cubehelix\",\n",
+        "    origin=\"lower\",\n",
+        "    aspect=\"auto\",\n",
+        "    extent=(insight.t[0], insight.t[-1], insight.x[0], insight.x[-1]),\n",
+        ")\n",
+        "ax2.set_ylabel(\"y [mm]\")\n",
+        "\n",
+        "ax3 = fig.add_subplot(313)\n",
+        "Et_center = insight.Et[np.abs(insight.y - insight.yc).argmin(), np.abs(insight.x - insight.xc).argmin(), :]\n",
+        "ax3.plot(insight.t, np.real(Et_center), label=\"real part\")\n",
+        "ax3.plot(insight.t, np.abs(Et_center), label=\"envelope\")\n",
+        "ax3.set_xlabel(\"t [fs]\")\n",
+        "ax3.set_ylabel(\"field strength [arb. units]\")\n",
+        "ax3.set_title(\"field in beam center\")\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.subplots_adjust(hspace=0.25)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8b5e94b1-d37e-4639-ad5c-8990206df22e",
+      "metadata": {},
+      "source": [
+        "## Save data to openPMD\n",
+        "The data is now nearly ready te be used as FromOpenPMDPulse input. The amplitude of the pulse in the time domain still has to be corrected (= scaled to the actual beam energy in Joule) before saving it to an openPMD file at the provided destination path.\n",
+        "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm), `crop_t_neg` and `crop_t_pos` (in fs).\n",
+        "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input.",
+        "The 3D field data can also serve as input for 2D simulations. The the `FromOpenPMDPulse` profile will then extract the central field slice parallel to propagation and polarisation direction and use this as incident field input. To reduce GPU memory occupancy, it is recommended to trim the extent of the ommited transverse axis with `crop_x` or `crop_y` to $\\geqslant 2$, centered around the central slice."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5018ef1c-2696-4981-b25f-7565a3faaea6",
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [],
+      "source": [
+        "E = 4.5  # J, beam energy\n",
+        "pol = \"y\"  # polarisation axis (can be 'x' or 'y')\n",
+        "crop_x = 0.3  # mm, trim transversal x axis\n",
+        "crop_y = 0.3  # mm, trim transversal y axis\n",
+        "crop_t_neg = 100  # fs, trim time axis from below\n",
+        "crop_t_pos = 100  # fs, trim time axis from above\n",
+        "\n",
+        "insight.save_to_openPMD(\"\", \"insightData_prepared%T.bp5\", E, pol, crop_x, crop_y, crop_t_neg, crop_t_pos)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b45022ea-d79a-4ef2-b615-9ca74833e31e",
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.5"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8f20b708-32b3-416e-b3d6-018884281b8c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# standard modules\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# modules from preparingInsightData.py\n",
-    "from preparingInsightData import PrepRoutines"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6e06caf1-30ea-46f9-90c9-4d691dccf127",
-   "metadata": {},
-   "source": [
-    "## Get the data\n",
-    "The far field data (= at the focal plane) from an Insight measurement is stored in a h5 file and typically measured in dependence of two transversal coordinates (\"x\" and \"y\" in mm) and the frequency (\"w\" in rad/fs). If there are any deviations from this scheme, you will have to adjust unit of the speed of light `c` in line 32 of the _PrepRoutines_ source code. \n",
-    "\n",
-    "Then, the first steps are:\n",
-    "1. read the far field data and store it in numpy arrays\n",
-    "2. fit the far field data intensity with a 2D gaussian to extract the beam center and waist size\n",
-    "3. propagate to the near field (= just before the diffracting element)\n",
-    "4. fit the near field data with a 2D supergaussian to extract the beam center and waist size\n",
-    "\n",
-    "For that, you need to provide path, filename and focal distance (same unit as the transversal scales) to the init function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "df9bc30d-c03b-4cb4-9621-b2aa62142f6a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "foc = 2000  # mm, focal distance\n",
-    "insight = PrepRoutines(\"/put/your/path/here/\", \"filename.h5\", foc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c7db135-e858-4152-9ec6-1d0358180f43",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# some nice colorful pictures of your data\n",
-    "fig = plt.figure(figsize=(14, 8))\n",
-    "\n",
-    "ax1 = fig.add_subplot(231)\n",
-    "ax1.imshow(\n",
-    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
-    ")\n",
-    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
-    "ax1.set_xlabel(\"x [mm]\")\n",
-    "ax1.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "ax2 = fig.add_subplot(232)\n",
-    "ax2.imshow(\n",
-    "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
-    ")\n",
-    "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
-    "ax2.set_xlabel(\"x [mm]\")\n",
-    "ax2.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "ax3 = fig.add_subplot(233)\n",
-    "ax3.plot(\n",
-    "    insight.w,\n",
-    "    np.angle(\n",
-    "        insight.Ew_NF[np.abs(insight.y_NF - insight.yc_NF).argmin(), np.abs(insight.x_NF - insight.xc_NF).argmin(), :]\n",
-    "    ),\n",
-    ")\n",
-    "ax3.set_title(\"phase in near field beam center\")\n",
-    "ax3.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
-    "ax3.set_ylabel(\"rad\")\n",
-    "\n",
-    "ax4 = fig.add_subplot(234)\n",
-    "ax4.imshow(\n",
-    "    np.sum(np.abs(insight.Ew), axis=0),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    aspect=\"auto\",\n",
-    "    extent=(insight.w[0], insight.w[-1], insight.x[0], insight.x[-1]),\n",
-    ")\n",
-    "ax4.set_title(r\"SD$_x$ in focus\")\n",
-    "ax4.set_ylabel(\"x [mm]\")\n",
-    "ax4.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
-    "\n",
-    "ax5 = fig.add_subplot(235)\n",
-    "ax5.imshow(\n",
-    "    np.sum(np.abs(insight.Ew), axis=1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    aspect=\"auto\",\n",
-    "    extent=(insight.w[0], insight.w[-1], insight.x[0], insight.x[-1]),\n",
-    ")\n",
-    "ax5.set_title(r\"SD$_y$ in focus\")\n",
-    "ax5.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
-    "ax5.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "ax6 = fig.add_subplot(236)\n",
-    "# sum just over the main beam spot (+- 2 * waist size around beam center) to extract the spectrum\n",
-    "ax6.plot(\n",
-    "    insight.w,\n",
-    "    np.sum(\n",
-    "        np.sum(\n",
-    "            np.abs(\n",
-    "                insight.Ew[\n",
-    "                    np.abs(insight.y - insight.yc + 2 * insight.waist).argmin() : np.abs(\n",
-    "                        insight.y - insight.yc - 2 * insight.waist\n",
-    "                    ).argmin(),\n",
-    "                    np.abs(insight.x - insight.xc + 2 * insight.waist).argmin() : np.abs(\n",
-    "                        insight.x - insight.xc - 2 * insight.waist\n",
-    "                    ).argmin(),\n",
-    "                    :,\n",
-    "                ]\n",
-    "            )\n",
-    "            ** 2,\n",
-    "            axis=0,\n",
-    "        ),\n",
-    "        axis=0,\n",
-    "    ),\n",
-    ")\n",
-    "ax6.set_title(\"spectral intensity\")\n",
-    "ax6.set_xlabel(r\"$\\omega$ [rad/fs]\")\n",
-    "ax6.set_ylabel(\"arb. units\")\n",
-    "\n",
-    "plt.subplots_adjust(hspace=0.3, wspace=0.3)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "18bee9ee-bd16-4e28-b9a7-ac5bc12e112e",
-   "metadata": {},
-   "source": [
-    "## Correct the data\n",
-    "### Adjust beam compression and add dispersion parameters\n",
-    "Before going on with any calculations, the phase has to be corrected. Insight reconstructs the amplitude of the far field beam as well as the phase, up to an unknown global phase for every frequency.\n",
-    "For an estimation of this global phase, perfect compression is assumed in the (near field) beam center. Thus, the phase is extracted in the beam center in dependence of the frequency and substracted globally (i.e. from the measured phase in dependence of the frequency at every space point).\n",
-    "Here, one also has the possibility to add dispersion parameters such as group delay dispersion (`GDD`) and third order dispersion (`TOD`) (both are set to 0 by default)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db7ee493-ac2f-4c62-9121-70d270587ae5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "insight.correct_phase()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fe86408e-4e08-4f9a-8044-b0dfc989d408",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.plot(\n",
-    "    insight.w,\n",
-    "    np.angle(\n",
-    "        insight.Ew_NF[np.abs(insight.y_NF - insight.yc_NF).argmin(), np.abs(insight.x_NF - insight.xc_NF).argmin(), :]\n",
-    "    ),\n",
-    ")\n",
-    "plt.title(\"corrected phase in near field beam center\")\n",
-    "plt.xlabel(r\"$\\omega$ [rad/fs]\")\n",
-    "plt.ylabel(\"rad\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11125a32-e618-40b4-aa4b-e1e51def5c3e",
-   "metadata": {},
-   "source": [
-    "### Correct ugly spots in the near field (optional)\n",
-    "Sometimes, the amplitude in the near field looks weird, showing some (unphysical) peaks or holes. These can cause artifacts in the far field and will thus be smoothened out."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0c772bfd-2d6b-4206-8dbd-f574d50d3931",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ugly_x = 0.0  # mm\n",
-    "ugly_y = 0.0  # mm\n",
-    "insight.correct_ugly_spot_in_nf(ugly_x, ugly_y)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2ab764a7-979d-417f-bae4-15f19ca790e8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure(figsize=(10, 4))\n",
-    "\n",
-    "ax1 = fig.add_subplot(121)\n",
-    "ax1.imshow(\n",
-    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
-    ")\n",
-    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
-    "ax1.set_xlabel(\"x [mm]\")\n",
-    "ax1.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "ax2 = fig.add_subplot(122)\n",
-    "ax2.imshow(\n",
-    "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
-    ")\n",
-    "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
-    "ax2.set_xlabel(\"x [mm]\")\n",
-    "ax2.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d63c3650-d902-4d71-8bbf-60a8c3b8bca6",
-   "metadata": {},
-   "source": [
-    "### Center the near field beam spot (optional)\n",
-    "When the near field beam spot is not centered (please check the center coordinates above), the far field will propagate obliquely instead of straight ahead. Centering the near field prevents this."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b88a2410-f9ca-4ff9-ab1b-3954c38b90b5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "insight.shift_nf_to_center()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cfbe99d5-97b1-44b6-879c-ed97e3eae945",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure(figsize=(14, 4))\n",
-    "\n",
-    "ax1 = fig.add_subplot(131)\n",
-    "ax1.imshow(\n",
-    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
-    ")\n",
-    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
-    "ax1.set_xlabel(\"x [mm]\")\n",
-    "ax1.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "ax2 = fig.add_subplot(132)\n",
-    "ax2.imshow(\n",
-    "    np.sum(np.abs(insight.Ew_NF), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x_NF[0], insight.x_NF[-1], insight.y_NF[0], insight.y_NF[-1]),\n",
-    ")\n",
-    "ax2.set_title(\"spectrally integrated amplitude, near field\")\n",
-    "ax2.set_xlabel(\"x [mm]\")\n",
-    "ax2.set_ylabel(\"y [mm]\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8f6942a0-43a0-4b55-92fa-a7d6ceb9a59a",
-   "metadata": {},
-   "source": [
-    "## Measure dispersion parameters\n",
-    "You can measure angular dispersion and spatial dispersion in far- and near field.\n",
-    "For a consistency check of those values, you can check those relations: \n",
-    "\\begin{equation*}\n",
-    "\\begin{aligned}\n",
-    "AD_\\mathrm{FF} &= - \\frac{SD_\\mathrm{NF}}{f_\\mathrm{eff}} - AD_\\mathrm{NF} \\\\\n",
-    "SD_\\mathrm{FF} &= f_\\mathrm{eff} \\cdot AD_\\mathrm{NF}\n",
-    "\\end{aligned}\n",
-    "\\end{equation*}\n",
-    "$f_\\mathrm{eff}$ is the effective focal length."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ae6d2380-f5c3-4ec4-8918-23ca0fbb6ce2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "insight.measure_ad_in_nf()\n",
-    "insight.measure_ad_in_ff()\n",
-    "insight.measure_sd_in_nf()\n",
-    "insight.measure_sd_in_ff()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d645f08-4e8d-40ba-af73-533fdd9aa8cb",
-   "metadata": {},
-   "source": [
-    "## Add an aperture in the mid field (optional)\n",
-    "Here, you can apply an aperture to the beam, located in the mid field. The algorithm which propagates the beam to the mid field uses paraxial approximation; so please make sure to put the aperture not too close to the focal plane (`d` $\\gg$ `insight.waist`). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb07e460-f729-46a9-8e28-d32e968968ed",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "d = 1000  # mm, distance from focal plane to aperture\n",
-    "R = 38.5 / 2  # mm, aperture radius\n",
-    "insight.aperture_in_mf(d, R)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "87430869-9a85-47b9-8127-fbea86f7bbdf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure()\n",
-    "ax1 = fig.add_subplot(111)\n",
-    "ax1.imshow(\n",
-    "    np.sum(np.abs(insight.Ew), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
-    ")\n",
-    "ax1.set_title(\"spectrally integrated amplitude, far field\")\n",
-    "ax1.set_xlabel(\"x [mm]\")\n",
-    "ax1.set_ylabel(\"y [mm]\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9988b6e5-f3e4-4395-a1ff-4159ede3b4cd",
-   "metadata": {},
-   "source": [
-    "## Propagate\n",
-    "Now the far field data is ready to be propagated. For that, the angular spectrum method is used. \n",
-    "Watch out not to propagate too far, since then the growing beam diameter could reach the transversal window borders and thus cause fourier transform artifacts."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3db3f073-cf90-48f8-a3e7-8bc220c390a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "z = -2  # mm\n",
-    "Ew_prop = insight.propagate(z)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c6ff5e59-4b93-41ec-b8a2-68d28a0f26d6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(\n",
-    "    np.sum(np.abs(Ew_prop), axis=-1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    extent=(insight.x[0], insight.x[-1], insight.y[0], insight.y[-1]),\n",
-    ")\n",
-    "plt.title(\"spectrally integrated amplitude, propagated to %.2f mm\" % (z))\n",
-    "plt.xlabel(\"x [mm]\")\n",
-    "plt.ylabel(\"y [mm]\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9bfb7cc2-0327-43fb-8364-0dbcc62e0553",
-   "metadata": {},
-   "source": [
-    "## Transform to the time domain\n",
-    "The far field data will be transformed to the time domain via a 1D fourier transformation. This takes a while, since the spectrum has to be extended and the field data extrapolated. One can adjust the number of samples per wavelength, which is set to 10 by default. \\\n",
-    "**Attention:** it is recommeded to adjust the time sampling to the PIConGPU simulation timestep! \\\n",
-    "The real part of the resulting complex matrix `insight.Et` will be the field needed for PIConGPU and its absolute value is the envelope, which can be used for further analysis."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f44373f9-d947-41d8-8e21-2eafe7584de8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "insight.to_time_domain(Ew_prop)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "268a89c7-4334-4906-ad16-c4536a128617",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure(figsize=(6, 9))\n",
-    "\n",
-    "ax1 = fig.add_subplot(311)\n",
-    "ax1.imshow(\n",
-    "    np.sum(np.abs(insight.Et), axis=0),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    aspect=\"auto\",\n",
-    "    extent=(insight.t[0], insight.t[-1], insight.x[0], insight.x[-1]),\n",
-    ")\n",
-    "ax1.set_ylabel(\"x [mm]\")\n",
-    "ax1.set_title(\"transversally integrated field\")\n",
-    "\n",
-    "ax2 = fig.add_subplot(312)\n",
-    "ax2.imshow(\n",
-    "    np.sum(np.abs(insight.Et), axis=1),\n",
-    "    cmap=\"cubehelix\",\n",
-    "    origin=\"lower\",\n",
-    "    aspect=\"auto\",\n",
-    "    extent=(insight.t[0], insight.t[-1], insight.x[0], insight.x[-1]),\n",
-    ")\n",
-    "ax2.set_ylabel(\"y [mm]\")\n",
-    "\n",
-    "ax3 = fig.add_subplot(313)\n",
-    "Et_center = insight.Et[np.abs(insight.y - insight.yc).argmin(), np.abs(insight.x - insight.xc).argmin(), :]\n",
-    "ax3.plot(insight.t, np.real(Et_center), label=\"real part\")\n",
-    "ax3.plot(insight.t, np.abs(Et_center), label=\"envelope\")\n",
-    "ax3.set_xlabel(\"t [fs]\")\n",
-    "ax3.set_ylabel(\"field strength [arb. units]\")\n",
-    "ax3.set_title(\"field in beam center\")\n",
-    "plt.legend()\n",
-    "\n",
-    "plt.subplots_adjust(hspace=0.25)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b5e94b1-d37e-4639-ad5c-8990206df22e",
-   "metadata": {},
-   "source": [
-    "## Save data to openPMD\n",
-    "The data is now nearly ready te be used as FromOpenPMDPulse input. The amplitude of the pulse in the time domain still has to be corrected (= scaled to the actual beam energy in Joule) before saving it to an openPMD file at the provided destination path.\n",
-    "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm), `crop_t_neg` and `crop_t_pos` (in fs).\n",
-    "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input.",
-    "The 3D field data can also serve as input for 2D simulations. The the `FromOpenPMDPulse` profile will then extract the central field slice parallel to propagation and polarisation direction and use this as incident field input. To reduce GPU memory occupancy, it is recommended to trim the extent of the ommited transverse axis with `crop_x` or `crop_y` to $\\geqslant 2$, centered around the central slice."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5018ef1c-2696-4981-b25f-7565a3faaea6",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "E = 4.5  # J, beam energy\n",
-    "pol = \"y\"  # polarisation axis (can be 'x' or 'y')\n",
-    "crop_x = 0.3  # mm, trim transversal x axis\n",
-    "crop_y = 0.3  # mm, trim transversal y axis\n",
-    "crop_t_neg = 100  # fs, trim time axis from below\n",
-    "crop_t_pos = 100  # fs, trim time axis from above\n",
-    "\n",
-    "insight.save_to_openPMD(\"\", \"insightData_prepared%T.bp5\", E, pol, crop_x, crop_y, crop_t_neg, crop_t_pos)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b45022ea-d79a-4ef2-b615-9ca74833e31e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.5"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/share/picongpu/pypicongpu/schema/customrenderingcontext.CustomRenderingContext.json
+++ b/share/picongpu/pypicongpu/schema/customrenderingcontext.CustomRenderingContext.json
@@ -1,19 +1,19 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customrenderingcontext.CustomRenderingContext",
-    "description": "additional input provided by user directly to the PyPIConGPU simulation object for use in custom templates",
-    "type": "object",
-    "properties": {
-        "tags":{
-            "description": "list of unique strings identifying the version/content of the custom input",
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
-        }
-    },
-    "required": [
-        "tags"
-        ],
-    "unevaluatedProperties": true
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customrenderingcontext.CustomRenderingContext",
+  "description": "additional input provided by user directly to the PyPIConGPU simulation object for use in custom templates",
+  "type": "object",
+  "properties": {
+    "tags": {
+      "description": "list of unique strings identifying the version/content of the custom input",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "tags"
+  ],
+  "unevaluatedProperties": true
 }

--- a/share/picongpu/pypicongpu/schema/customuserinput.CustomUserInput.json
+++ b/share/picongpu/pypicongpu/schema/customuserinput.CustomUserInput.json
@@ -1,6 +1,6 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customuserinput.CustomUserInput",
-    "description": "container class for passing dictionaries from the user script to the PyPIConGPU renderer",
-    "type": "object",
-    "unevaluatedProperties": true
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customuserinput.CustomUserInput",
+  "description": "container class for passing dictionaries from the user script to the PyPIConGPU renderer",
+  "type": "object",
+  "unevaluatedProperties": true
 }

--- a/share/picongpu/pypicongpu/schema/grid.Grid3D.json
+++ b/share/picongpu/pypicongpu/schema/grid.Grid3D.json
@@ -1,89 +1,105 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.grid.Grid3D",
-    "description": "Specification of a (cartesian) grid of cells with 3 spacial dimensions.",
-    "type": "object",
-    "properties": {
-        "cell_size": {
-            "description": "width of a single cell in m",
-            "type": "object",
-            "unevaluatedProperties": false,
-            "required": ["x", "y", "z"],
-            "properties": {
-                "x": {
-                    "$anchor": "cell_size_component",
-                    "type": "number",
-                    "exclusiveMinimum": 0
-                },
-                "y": {
-                    "$ref": "#cell_size_component"
-                },
-                "z": {
-                    "$ref": "#cell_size_component"
-                }
-            }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.grid.Grid3D",
+  "description": "Specification of a (cartesian) grid of cells with 3 spacial dimensions.",
+  "type": "object",
+  "properties": {
+    "cell_size": {
+      "description": "width of a single cell in m",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "properties": {
+        "x": {
+          "$anchor": "cell_size_component",
+          "type": "number",
+          "exclusiveMinimum": 0
         },
-        "cell_cnt": {
-            "description": "number of cells",
-            "type": "object",
-            "unevaluatedProperties": false,
-            "required": ["x", "y", "z"],
-            "properties": {
-                "x": {
-                    "$anchor": "cell_cnt_component",
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "y": {
-                    "$ref": "#cell_cnt_component"
-                },
-                "z": {
-                    "$ref": "#cell_cnt_component"
-                }
-            }
+        "y": {
+          "$ref": "#cell_size_component"
         },
-        "gpu_cnt": {
-            "description": "number of gpus",
-            "type": "object",
-            "unevaluatedProperties": false,
-            "required": ["x", "y", "z"],
-            "properties": {
-                "x": {
-                    "$anchor": "gpu_cnt_component",
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "y": {
-                    "$ref": "#gpu_cnt_component"
-                },
-                "z": {
-                    "$ref": "#gpu_cnt_component"
-                }
-            }
-        },
-        "boundary_condition": {
-            "description": "boundary condition to be passed to --periodic (encoded as number)",
-            "type": "object",
-            "unevaluatedProperties": false,
-            "required": ["x", "y", "z"],
-            "properties": {
-                "x": {
-                    "$anchor": "boundary_condition_component",
-                    "type": "string",
-                    "pattern": "^(0|1)$"
-                },
-                "y": {
-                    "$ref": "#boundary_condition_component"
-                },
-                "z": {
-                    "$ref": "#boundary_condition_component"
-                }
-            }
+        "z": {
+          "$ref": "#cell_size_component"
         }
+      }
     },
-    "required": [
-        "cell_size",
-        "cell_cnt",
-        "boundary_condition"
-    ],
-    "unevaluatedProperties": false
+    "cell_cnt": {
+      "description": "number of cells",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "properties": {
+        "x": {
+          "$anchor": "cell_cnt_component",
+          "type": "integer",
+          "minimum": 1
+        },
+        "y": {
+          "$ref": "#cell_cnt_component"
+        },
+        "z": {
+          "$ref": "#cell_cnt_component"
+        }
+      }
+    },
+    "gpu_cnt": {
+      "description": "number of gpus",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "properties": {
+        "x": {
+          "$anchor": "gpu_cnt_component",
+          "type": "integer",
+          "minimum": 1
+        },
+        "y": {
+          "$ref": "#gpu_cnt_component"
+        },
+        "z": {
+          "$ref": "#gpu_cnt_component"
+        }
+      }
+    },
+    "boundary_condition": {
+      "description": "boundary condition to be passed to --periodic (encoded as number)",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "properties": {
+        "x": {
+          "$anchor": "boundary_condition_component",
+          "type": "string",
+          "pattern": "^(0|1)$"
+        },
+        "y": {
+          "$ref": "#boundary_condition_component"
+        },
+        "z": {
+          "$ref": "#boundary_condition_component"
+        }
+      }
+    }
+  },
+  "required": [
+    "cell_size",
+    "cell_cnt",
+    "boundary_condition"
+  ],
+  "unevaluatedProperties": false
 }

--- a/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
@@ -1,163 +1,182 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser",
-    "description": "Specification of a (super-)gaussian laser pulse, optionally with higher laguerre modes",
-    "type": "object",
-    "properties": {
-        "wave_length_si": {
-            "type": "number",
-            "description": "wavelength of laser [m]",
-            "exclusiveMinimum": 0
-        },
-        "waist_si": {
-            "type": "number",
-            "description": "Waist of the Gaussian pulse at focus [m]",
-            "exclusiveMinimum": 0
-        },
-        "pulse_duration_si": {
-            "type": "number",
-            "description": "sigma of std. gauss for intensity (E^2) [s]",
-            "exclusiveMinimum": 0
-        },
-        "focus_pos_si": {
-            "description": "position of focus in total coordinate system, [m]",
-            "type": "array",
-            "minItems": 3,
-            "maxItems": 3,
-            "items": {
-                "type": "object",
-                "required": ["component"],
-                "unevaluatedProperties": false,
-                "properties": {
-                    "component": {
-                        "type": "number"
-                    }
-                }
-            }
-        },
-        "phase": {
-            "type": "number",
-            "minimum": -3.1416,
-            "exclusiveMaximum": 6.2832
-        },
-        "E0_si": {
-            "type": "number",
-            "exclusiveMinimum": 0
-        },
-        "pulse_init": {
-            "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
-            "type": "number",
-            "exclusiveMinimum": 0
-        },
-        "propagation_direction": {
-            "type": "array",
-            "minItems": 3,
-            "maxItems": 3,
-            "items": {
-                "type": "object",
-                "required": ["component"],
-                "unevaluatedProperties": false,
-                "properties": {
-                    "component": {
-                        "type": "number"
-                    }
-                }
-            }
-        },
-        "polarization_type": {
-            "description": "type of polarization, not direction!",
-            "type": "string",
-            "pattern": "^(Linear|Circular)$"
-        },
-        "polarization_direction":{
-            "description": "Unit E polarization direction",
-            "type": "array",
-            "minItems": 3,
-            "maxItems": 3,
-            "items": {
-                "type": "object",
-                "required": ["component"],
-                "unevaluatedProperties": false,
-                "properties": {
-                    "component": {
-                        "type": "number"
-                    }
-                }
-            }
-        },
-        "laguerre_modes": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "required": ["single_laguerre_mode"],
-                "unevaluatedProperties": false,
-                "properties": {
-                    "single_laguerre_mode": {
-                        "type": "number"
-                    }
-                }
-            }
-        },
-        "laguerre_phases": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "required": ["single_laguerre_phase"],
-                "unevaluatedProperties": false,
-                "properties": {
-                    "single_laguerre_phase": {
-                        "type": "number"
-                    }
-                }
-            }
-        },
-        "modenumber": {
-            "type": "integer",
-            "minimum": 0
-        },
-        "huygens_surface_positions":{
-            "description": "position of the huygens surface relative from domain boundaries",
-            "type": "object",
-            "required": ["row_x", "row_y", "row_z"],
-            "unevaluatedProperties": false,
-            "properties": {
-                "row_x": {
-                    "$anchor": "row_hygens_surface",
-                    "type": "object",
-                    "required": ["negative", "positive"],
-                    "unevaluatedProperties": false,
-                    "properties": {
-                        "negative": {
-                            "type": "integer"
-                        },
-                        "positive": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "row_y":{ "$ref":"#row_hygens_surface"
-                },
-                "row_z":{ "$ref":"#row_hygens_surface"
-                }
-            }
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser",
+  "description": "Specification of a (super-)gaussian laser pulse, optionally with higher laguerre modes",
+  "type": "object",
+  "properties": {
+    "wave_length_si": {
+      "type": "number",
+      "description": "wavelength of laser [m]",
+      "exclusiveMinimum": 0
     },
-    "required": [
-        "wave_length_si",
-        "waist_si",
-        "pulse_duration_si",
-        "focus_pos_si",
-        "phase",
-        "E0_si",
-        "pulse_init",
-        "propagation_direction",
-        "polarization_type",
-        "polarization_direction",
-        "laguerre_modes",
-        "laguerre_phases",
-        "modenumber",
-        "huygens_surface_positions"
-    ],
-    "unevaluatedProperties": false
+    "waist_si": {
+      "type": "number",
+      "description": "Waist of the Gaussian pulse at focus [m]",
+      "exclusiveMinimum": 0
+    },
+    "pulse_duration_si": {
+      "type": "number",
+      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "exclusiveMinimum": 0
+    },
+    "focus_pos_si": {
+      "description": "position of focus in total coordinate system, [m]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "phase": {
+      "type": "number",
+      "minimum": -3.1416,
+      "exclusiveMaximum": 6.2832
+    },
+    "E0_si": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "pulse_init": {
+      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "propagation_direction": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "polarization_type": {
+      "description": "type of polarization, not direction!",
+      "type": "string",
+      "pattern": "^(Linear|Circular)$"
+    },
+    "polarization_direction": {
+      "description": "Unit E polarization direction",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "laguerre_modes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "single_laguerre_mode"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "single_laguerre_mode": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "laguerre_phases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "single_laguerre_phase"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "single_laguerre_phase": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "modenumber": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "huygens_surface_positions": {
+      "description": "position of the huygens surface relative from domain boundaries",
+      "type": "object",
+      "required": [
+        "row_x",
+        "row_y",
+        "row_z"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "row_x": {
+          "$anchor": "row_hygens_surface",
+          "type": "object",
+          "required": [
+            "negative",
+            "positive"
+          ],
+          "unevaluatedProperties": false,
+          "properties": {
+            "negative": {
+              "type": "integer"
+            },
+            "positive": {
+              "type": "integer"
+            }
+          }
+        },
+        "row_y": {
+          "$ref": "#row_hygens_surface"
+        },
+        "row_z": {
+          "$ref": "#row_hygens_surface"
+        }
+      }
+    }
+  },
+  "required": [
+    "wave_length_si",
+    "waist_si",
+    "pulse_duration_si",
+    "focus_pos_si",
+    "phase",
+    "E0_si",
+    "pulse_init",
+    "propagation_direction",
+    "polarization_type",
+    "polarization_direction",
+    "laguerre_modes",
+    "laguerre_phases",
+    "modenumber",
+    "huygens_surface_positions"
+  ],
+  "unevaluatedProperties": false
 }

--- a/share/picongpu/pypicongpu/schema/movingwindow.MovingWindow.json
+++ b/share/picongpu/pypicongpu/schema/movingwindow.MovingWindow.json
@@ -1,24 +1,27 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.movingwindow.MovingWindow",
-    "type": "object",
-    "description": "moving window setting of picongpu",
-    "unevaluatedProperties": false,
-    "required": ["move_point", "stop_iteration"],
-    "properties": {
-        "move_point": {
-            "type": "number",
-            "minimum" : 0
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.movingwindow.MovingWindow",
+  "type": "object",
+  "description": "moving window setting of picongpu",
+  "unevaluatedProperties": false,
+  "required": [
+    "move_point",
+    "stop_iteration"
+  ],
+  "properties": {
+    "move_point": {
+      "type": "number",
+      "minimum": 0
+    },
+    "stop_iteration": {
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "stop_iteration": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "integer",
-                    "exclusiveMinimum" : 0
-                }
-            ]
+        {
+          "type": "integer",
+          "exclusiveMinimum": 0
         }
+      ]
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/output/phase_space.PhaseSpace.json
+++ b/share/picongpu/pypicongpu/schema/output/phase_space.PhaseSpace.json
@@ -1,34 +1,48 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.phase_space.PhaseSpace",
-
-    "type": "object",
-    "description": "Phase space output configuration for PIConGPU",
-    "unevaluatedProperties": false,
-    "required": ["species", "period", "spatial_coordinate", "momentum_coordinate","min_momentum","max_momentum"],
-    "properties": {
-        "species":{
-                    "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-        },
-        "period": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec"
-        },
-        "spatial_coordinate": {
-            "type": "string",
-            "enum": ["x", "y", "z"],
-            "description": "Spatial coordinate for phase space analysis."
-        },
-        "momentum_coordinate": {
-            "type": "string",
-            "enum": ["px", "py", "pz"],
-            "description": "Momentum component for phase space analysis."
-        },
-        "min_momentum": {
-            "type": "number",
-            "description": "Minimum momentum value for phase space filtering."
-        },
-        "max_momentum": {
-            "type": "number",
-            "description": "Maximum momentum value for phase space filtering."
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.phase_space.PhaseSpace",
+  "type": "object",
+  "description": "Phase space output configuration for PIConGPU",
+  "unevaluatedProperties": false,
+  "required": [
+    "species",
+    "period",
+    "spatial_coordinate",
+    "momentum_coordinate",
+    "min_momentum",
+    "max_momentum"
+  ],
+  "properties": {
+    "species": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "period": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec"
+    },
+    "spatial_coordinate": {
+      "type": "string",
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Spatial coordinate for phase space analysis."
+    },
+    "momentum_coordinate": {
+      "type": "string",
+      "enum": [
+        "px",
+        "py",
+        "pz"
+      ],
+      "description": "Momentum component for phase space analysis."
+    },
+    "min_momentum": {
+      "type": "number",
+      "description": "Minimum momentum value for phase space filtering."
+    },
+    "max_momentum": {
+      "type": "number",
+      "description": "Maximum momentum value for phase space filtering."
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/output/plugin.Plugin.json
+++ b/share/picongpu/pypicongpu/schema/output/plugin.Plugin.json
@@ -1,30 +1,54 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.plugin.Plugin",
-    "type": "object",
-    "description": "any output. consists of (1) the type of the plugin instance and (2) the data of the plugin instance",
-    "required": ["typeID", "data"],
-    "unevaluatedProperties": false,
-    "properties": {
-        "typeID": {
-            "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
-            "type": "object",
-            "required": ["auto", "phasespace", "energyhistogram", "macroparticlecount"],
-            "unevaluatedProperties": false,
-            "properties": {
-                "auto": { "type": "boolean" },
-                "phasespace": { "type": "boolean" },
-                "energyhistogram": { "type": "boolean" },
-                "macroparticlecount": { "type": "boolean" }
-            }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.plugin.Plugin",
+  "type": "object",
+  "description": "any output. consists of (1) the type of the plugin instance and (2) the data of the plugin instance",
+  "required": [
+    "typeID",
+    "data"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "typeID": {
+      "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
+      "type": "object",
+      "required": [
+        "auto",
+        "phasespace",
+        "energyhistogram",
+        "macroparticlecount"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "auto": {
+          "type": "boolean"
         },
-        "data": {
-            "description": "configuration data of plugin",
-            "anyOf": [
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.phase_space.PhaseSpace"},
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.auto.Auto"},
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.energy_histogram.EnergyHistogram"},
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.macro_particle_count.MacroParticleCount"}
-            ]
+        "phasespace": {
+          "type": "boolean"
+        },
+        "energyhistogram": {
+          "type": "boolean"
+        },
+        "macroparticlecount": {
+          "type": "boolean"
         }
+      }
+    },
+    "data": {
+      "description": "configuration data of plugin",
+      "anyOf": [
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.phase_space.PhaseSpace"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.auto.Auto"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.energy_histogram.EnergyHistogram"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.macro_particle_count.MacroParticleCount"
+        }
+      ]
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -1,85 +1,86 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.simulation.Simulation",
-    "type": "object",
-    "description": "Holds all data associated with a single simulation run. Gets passed into the rendering engine.",
-    "properties": {
-        "delta_t_si": {
-            "type": "number",
-            "description": "width of a single timestamp in s"
-        },
-        "time_steps": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "total number of time steps to run for"
-        },
-        "typical_ppc":{
-            "type": "integer",
-            "minimum": 1,
-            "description": "typical number of macroparticles per cell, used for normalization"
-        },
-        "solver": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver"
-        },
-        "grid": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.grid.Grid3D"
-        },
-        "laser": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
-                }
-            ]
-        },
-        "moving_window": {
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.movingwindow.MovingWindow"
-                }
-            ]
-        },
-        "species_initmanager": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.initmanager.InitManager"
-        },
-        "output": {
-            "description": "configuration of simulation output",
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "description": "list of plugins",
-                    "type": "array",
-                    "items": {
-                        "$ref":"https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.plugin.Plugin"
-                    }
-                }
-            ]
-        },
-        "customuserinput":{
-            "anyOf": [
-            {
-                "type": "null"
-            },
-            {
-                "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customrenderingcontext.CustomRenderingContext"
-            }]
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.simulation.Simulation",
+  "type": "object",
+  "description": "Holds all data associated with a single simulation run. Gets passed into the rendering engine.",
+  "properties": {
+    "delta_t_si": {
+      "type": "number",
+      "description": "width of a single timestamp in s"
     },
-    "required": [
-        "delta_t_si",
-        "time_steps",
-        "typical_ppc",
-        "solver",
-        "grid",
-        "laser",
-        "moving_window",
-        "customuserinput"
-    ],
-    "unevaluatedProperties": false
+    "time_steps": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "total number of time steps to run for"
+    },
+    "typical_ppc": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "typical number of macroparticles per cell, used for normalization"
+    },
+    "solver": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver"
+    },
+    "grid": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.grid.Grid3D"
+    },
+    "laser": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
+        }
+      ]
+    },
+    "moving_window": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.movingwindow.MovingWindow"
+        }
+      ]
+    },
+    "species_initmanager": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.initmanager.InitManager"
+    },
+    "output": {
+      "description": "configuration of simulation output",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "description": "list of plugins",
+          "type": "array",
+          "items": {
+            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.plugin.Plugin"
+          }
+        }
+      ]
+    },
+    "customuserinput": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.customrenderingcontext.CustomRenderingContext"
+        }
+      ]
+    }
+  },
+  "required": [
+    "delta_t_si",
+    "time_steps",
+    "typical_ppc",
+    "solver",
+    "grid",
+    "laser",
+    "moving_window",
+    "customuserinput"
+  ],
+  "unevaluatedProperties": false
 }

--- a/share/picongpu/pypicongpu/schema/solver.YeeSolver.json
+++ b/share/picongpu/pypicongpu/schema/solver.YeeSolver.json
@@ -1,11 +1,13 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver",
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string"
-        }
-    },
-    "required": ["name"],
-    "unevaluatedProperties": false
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "unevaluatedProperties": false
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/charge.Charge.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/charge.Charge.json
@@ -1,15 +1,15 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.charge.Charge",
-    "description": "charge of a macroparticle",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [
-        "charge_si"
-    ],
-    "properties": {
-        "charge_si": {
-            "type": "number",
-            "description": "charge in C"
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.charge.Charge",
+  "description": "charge of a macroparticle",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "charge_si"
+  ],
+  "properties": {
+    "charge_si": {
+      "type": "number",
+      "description": "charge in C"
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/densityratio.DensityRatio.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/densityratio.DensityRatio.json
@@ -1,14 +1,16 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.densityratio.DensityRatio",
-    "description": "ratio for weighting calculations",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": ["ratio"],
-    "properties": {
-        "ratio": {
-            "description": "numerical density ratio",
-            "type": "number",
-            "exclusiveMinimum": 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.densityratio.DensityRatio",
+  "description": "ratio for weighting calculations",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "ratio"
+  ],
+  "properties": {
+    "ratio": {
+      "description": "numerical density ratio",
+      "type": "number",
+      "exclusiveMinimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/elementproperties.ElementProperties.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/elementproperties.ElementProperties.json
@@ -1,13 +1,15 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.elementproperties.ElementProperties",
-    "description": "species constants (flags) associated to a chemical element (matter constants), e.g. ionization levels",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": ["element"],
-    "properties": {
-        "element": {
-            "description": "element to use matter constants for",
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.util.element.Element"
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.elementproperties.ElementProperties",
+  "description": "species constants (flags) associated to a chemical element (matter constants), e.g. ionization levels",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "element"
+  ],
+  "properties": {
+    "element": {
+      "description": "element to use matter constants for",
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.util.element.Element"
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/groundstateionization.GroundStateIonization.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/groundstateionization.GroundStateIonization.json
@@ -1,14 +1,16 @@
 {
-    "$id":"https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.groundstateionization.GroundStateIonization",
-    "required":["ionization_model_list"],
-    "unevaluatedProperties":false,
-    "properties": {
-        "ionization_model_list": {
-            "type": "array",
-            "description": "list of ionization models for species",
-            "items": {
-                "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationmodel.ionizationmodel.IonizationModel"
-            }
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.groundstateionization.GroundStateIonization",
+  "required": [
+    "ionization_model_list"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "ionization_model_list": {
+      "type": "array",
+      "description": "list of ionization models for species",
+      "items": {
+        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationmodel.ionizationmodel.IonizationModel"
+      }
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/ionizationcurrent.ionizationcurrent.IonizationCurrent.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/ionizationcurrent.ionizationcurrent.IonizationCurrent.json
@@ -1,15 +1,17 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationcurrent.ionizationcurrent.IonizationCurrent",
-    "type": "object",
-    "description": "ionization current configuration",
-    "required": ["picongpu_name"],
-    "unevaluatedProperties": false,
-    "properties": {
-        "picongpu_name": {
-            "type": "string",
-            "description": "c++ code name of ionization current corresponding to ionization current model",
-            "minLength": 1,
-            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationcurrent.ionizationcurrent.IonizationCurrent",
+  "type": "object",
+  "description": "ionization current configuration",
+  "required": [
+    "picongpu_name"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "picongpu_name": {
+      "type": "string",
+      "description": "c++ code name of ionization current corresponding to ionization current model",
+      "minLength": 1,
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/ionizationmodel.Implementation.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/ionizationmodel.Implementation.json
@@ -1,3 +1,3 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/quick.pypicongpu.species.constant.ionizationmodel.ionizationmodel.Implementation"
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/quick.pypicongpu.species.constant.ionizationmodel.ionizationmodel.Implementation"
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/ionizationmodel.ionizationmodel.IonizationModel.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/ionizationmodel.ionizationmodel.IonizationModel.json
@@ -1,28 +1,32 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationmodel.ionizationmodel.IonizationModel",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [
-        "ionizer_picongpu_name",
-        "ionization_electron_species",
-        "ionization_current"
-        ],
-    "properties": {
-        "ionizer_picongpu_name": {
-            "type": "string",
-            "description": "c++ code name of ionizer corresponding to ionization model",
-            "minLength": 1,
-            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
-            },
-        "ionization_electron_species": {
-            "description": "Electron species spawned by ionization.",
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-            },
-        "ionization_current": {
-            "anyOf": [
-                {"type": "null"},
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationcurrent.ionizationcurrent.IonizationCurrent"}
-            ]
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationmodel.ionizationmodel.IonizationModel",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "ionizer_picongpu_name",
+    "ionization_electron_species",
+    "ionization_current"
+  ],
+  "properties": {
+    "ionizer_picongpu_name": {
+      "type": "string",
+      "description": "c++ code name of ionizer corresponding to ionization model",
+      "minLength": 1,
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "ionization_electron_species": {
+      "description": "Electron species spawned by ionization.",
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "ionization_current": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.ionizationcurrent.ionizationcurrent.IonizationCurrent"
         }
+      ]
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/constant/mass.Mass.json
+++ b/share/picongpu/pypicongpu/schema/species/constant/mass.Mass.json
@@ -1,16 +1,16 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.mass.Mass",
-    "description": "mass of a single particle",
-    "unevaluatedProperties": false,
-    "type": "object",
-    "required": [
-        "mass_si"
-    ],
-    "properties": {
-        "mass_si": {
-            "type": "number",
-            "description": "mass in kg",
-            "minimum": 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.mass.Mass",
+  "description": "mass of a single particle",
+  "unevaluatedProperties": false,
+  "type": "object",
+  "required": [
+    "mass_si"
+  ],
+  "properties": {
+    "mass_si": {
+      "type": "number",
+      "description": "mass in kg",
+      "minimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/initmanager.InitManager.json
+++ b/share/picongpu/pypicongpu/schema/species/initmanager.InitManager.json
@@ -1,47 +1,47 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.initmanager.InitManager",
-    "description": "collects all information (singleton) for species declaration and initialization",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [
-        "species"
-    ],
-    "properties": {
-        "species": {
-            "description": "all species to be defined",
-            "type": "array",
-            "items": {
-                "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-            }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.initmanager.InitManager",
+  "description": "collects all information (singleton) for species declaration and initialization",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "species"
+  ],
+  "properties": {
+    "species": {
+      "description": "all species to be defined",
+      "type": "array",
+      "items": {
+        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+      }
+    },
+    "operations": {
+      "description": "All operations, ordered by type of operation. Note that all keys are always defined, they may contain empty lists though.",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": [
+        "simple_density",
+        "simple_momentum"
+      ],
+      "properties": {
+        "simple_density": {
+          "type": "array",
+          "items": {
+            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simpledensity.SimpleDensity"
+          }
         },
-        "operations": {
-            "description": "All operations, ordered by type of operation. Note that all keys are always defined, they may contain empty lists though.",
-            "type": "object",
-            "unevaluatedProperties": false,
-            "required": [
-                "simple_density",
-                "simple_momentum"
-            ],
-            "properties": {
-                "simple_density": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simpledensity.SimpleDensity"
-                    }
-                },
-                "simple_momentum": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simplemomentum.SimpleMomentum"
-                    }
-                },
-                "set_charge_state": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.setchargestate.SetChargeState"
-                    }
-                }
-            }
+        "simple_momentum": {
+          "type": "array",
+          "items": {
+            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simplemomentum.SimpleMomentum"
+          }
+        },
+        "set_charge_state": {
+          "type": "array",
+          "items": {
+            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.setchargestate.SetChargeState"
+          }
         }
+      }
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/densityprofile.DensityProfile.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/densityprofile.DensityProfile.json
@@ -1,32 +1,47 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.densityprofile.DensityProfile",
-    "description": "Any density profile. Consists of (1) the type of density profile used and (2) the actual data for that profile.",
-    "type": "object",
-    "required": ["type", "data"],
-    "unevaluatedProperties": false,
-    "properties": {
-        "type": {
-            "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
-            "type": "object",
-            "required": [
-                "uniform",
-                "foil",
-                "gaussian"
-            ],
-            "unevaluatedProperties": false,
-            "properties": {
-                "uniform": {"type": "boolean"},
-                "foil": {"type": "boolean"},
-                "gaussian": {"type": "boolean"}
-            }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.densityprofile.DensityProfile",
+  "description": "Any density profile. Consists of (1) the type of density profile used and (2) the actual data for that profile.",
+  "type": "object",
+  "required": [
+    "type",
+    "data"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "type": {
+      "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
+      "type": "object",
+      "required": [
+        "uniform",
+        "foil",
+        "gaussian"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "uniform": {
+          "type": "boolean"
         },
-        "data": {
-            "description": "data as provided by any density profile (schema)",
-            "anyOf": [
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.uniform.Uniform"},
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.foil.Foil"},
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.gaussian.Gaussian"}
-            ]
+        "foil": {
+          "type": "boolean"
+        },
+        "gaussian": {
+          "type": "boolean"
         }
+      }
+    },
+    "data": {
+      "description": "data as provided by any density profile (schema)",
+      "anyOf": [
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.uniform.Uniform"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.foil.Foil"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.gaussian.Gaussian"
+        }
+      ]
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/foil.Foil.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/foil.Foil.json
@@ -1,36 +1,36 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.foil.Foil",
-    "type": "object",
-    "description": "Describes a foil target.",
-    "unevaluatedProperties": false,
-    "required": [
-        "density_si",
-        "y_value_front_foil_si",
-        "thickness_foil_si",
-        "pre_foil_plasmaRamp",
-        "post_foil_plasmaRamp"
-    ],
-    "properties": {
-        "density_si": {
-            "type": "number",
-            "description": "particle number density in m^-3",
-            "exclusiveMinimum": 0
-        },
-        "y_value_front_foil_si" : {
-            "type" : "number",
-            "description": "y-postion of front surface of foil in m",
-            "minimum": 0
-        },
-        "thickness_foil_si": {
-            "type": "number",
-            "description": "thickness of the foil in m",
-            "exclusiveMinimum": 0
-        },
-        "pre_foil_plasmaRamp": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.plasmaramp.PlasmaRamp"
-        },
-        "post_foil_plasmaRamp": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.plasmaramp.PlasmaRamp"
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.foil.Foil",
+  "type": "object",
+  "description": "Describes a foil target.",
+  "unevaluatedProperties": false,
+  "required": [
+    "density_si",
+    "y_value_front_foil_si",
+    "thickness_foil_si",
+    "pre_foil_plasmaRamp",
+    "post_foil_plasmaRamp"
+  ],
+  "properties": {
+    "density_si": {
+      "type": "number",
+      "description": "particle number density in m^-3",
+      "exclusiveMinimum": 0
+    },
+    "y_value_front_foil_si": {
+      "type": "number",
+      "description": "y-postion of front surface of foil in m",
+      "minimum": 0
+    },
+    "thickness_foil_si": {
+      "type": "number",
+      "description": "thickness of the foil in m",
+      "exclusiveMinimum": 0
+    },
+    "pre_foil_plasmaRamp": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.plasmaramp.PlasmaRamp"
+    },
+    "post_foil_plasmaRamp": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.plasmaramp.PlasmaRamp"
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/gaussian.Gaussian.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/gaussian.Gaussian.json
@@ -1,56 +1,56 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.gaussian.Gaussian",
-    "type": "object",
-    "description": "Describes  a Gaussian density profile, meaning density_si * exp(gasFactor * pow(abs((y - gasCenter_SI) / gasSigma_SI), gasPower)) for front and rear of the profile and constant in between",
-    "unevaluatedProperties": false,
-    "required": [
-        "gas_center_front",
-        "gas_center_rear",
-        "gas_sigma_front",
-        "gas_sigma_rear",
-        "gas_factor",
-        "gas_power",
-        "vacuum_cells_front",
-        "density"
-    ],
-    "properties": {
-        "gas_center_front": {
-            "description": "The central position of the left part of the gas distribution in meters",
-            "type": "number",
-            "minimum": 0
-        },
-        "gas_center_rear": {
-            "description": "The central position of the right part of the gas distribution in meters",
-            "type": "number",
-            "minimum": 0
-        },
-        "gas_sigma_front": {
-            "description": "The distance from gasCenterFront until the gas density decreases to its 1/e-th part in meters",
-            "type": "number"
-        },
-        "gas_sigma_rear": {
-            "description": "The distance from gasCenterRear until the gas density decreases to its 1/e-th part in meters",
-            "type": "number"
-        },
-        "gas_factor": {
-            "description": "Factor for the Gaussian exponent",
-            "type": "number",
-            "exclusiveMaximum": 0
-        },
-        "gas_power": {
-            "description": "Power for the Gaussian exponent",
-            "type": "number",
-            "exclusiveMinimum": 0
-        },
-        "vacuum_cells_front": {
-            "description": "Because of the laser initialization which is done in the first cells of the simulation and assumes a charge-free volume",
-            "type": "number",
-            "minimum" : 0
-        },
-        "density": {
-            "description": "particle number density in m^-3",
-            "type": "number",
-            "exclusiveMinimum" : 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.gaussian.Gaussian",
+  "type": "object",
+  "description": "Describes  a Gaussian density profile, meaning density_si * exp(gasFactor * pow(abs((y - gasCenter_SI) / gasSigma_SI), gasPower)) for front and rear of the profile and constant in between",
+  "unevaluatedProperties": false,
+  "required": [
+    "gas_center_front",
+    "gas_center_rear",
+    "gas_sigma_front",
+    "gas_sigma_rear",
+    "gas_factor",
+    "gas_power",
+    "vacuum_cells_front",
+    "density"
+  ],
+  "properties": {
+    "gas_center_front": {
+      "description": "The central position of the left part of the gas distribution in meters",
+      "type": "number",
+      "minimum": 0
+    },
+    "gas_center_rear": {
+      "description": "The central position of the right part of the gas distribution in meters",
+      "type": "number",
+      "minimum": 0
+    },
+    "gas_sigma_front": {
+      "description": "The distance from gasCenterFront until the gas density decreases to its 1/e-th part in meters",
+      "type": "number"
+    },
+    "gas_sigma_rear": {
+      "description": "The distance from gasCenterRear until the gas density decreases to its 1/e-th part in meters",
+      "type": "number"
+    },
+    "gas_factor": {
+      "description": "Factor for the Gaussian exponent",
+      "type": "number",
+      "exclusiveMaximum": 0
+    },
+    "gas_power": {
+      "description": "Power for the Gaussian exponent",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "vacuum_cells_front": {
+      "description": "Because of the laser initialization which is done in the first cells of the simulation and assumes a charge-free volume",
+      "type": "number",
+      "minimum": 0
+    },
+    "density": {
+      "description": "particle number density in m^-3",
+      "type": "number",
+      "exclusiveMinimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/exponential.Exponential.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/exponential.Exponential.json
@@ -1,22 +1,22 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.exponential.Exponential",
-    "type": "object",
-    "description": "Describes an exponential plasma ramp.",
-    "unevaluatedProperties": false,
-    "required": [
-        "PlasmaLength",
-        "PlasmaCutoff"
-    ],
-    "properties": {
-        "PlasmaLength" : {
-            "type" : "number",
-            "description": "length scale of expoential decay of pre-foil plasma density",
-            "exclusiveMinimum": 0
-        },
-        "PlasmaCutoff" : {
-            "type" : "number",
-            "description": "cutoff length for exponential decay of pre-foil density",
-            "exclusiveMinimum": 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.exponential.Exponential",
+  "type": "object",
+  "description": "Describes an exponential plasma ramp.",
+  "unevaluatedProperties": false,
+  "required": [
+    "PlasmaLength",
+    "PlasmaCutoff"
+  ],
+  "properties": {
+    "PlasmaLength": {
+      "type": "number",
+      "description": "length scale of expoential decay of pre-foil plasma density",
+      "exclusiveMinimum": 0
+    },
+    "PlasmaCutoff": {
+      "type": "number",
+      "description": "cutoff length for exponential decay of pre-foil density",
+      "exclusiveMinimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/none.None_.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/none.None_.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.none.None_",
-    "type": "null",
-    "description": "Describes no plasma ramp."
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.none.None_",
+  "type": "null",
+  "description": "Describes no plasma ramp."
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/plasmaramp.PlasmaRamp.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/plasmaramp.PlasmaRamp.json
@@ -1,29 +1,40 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.plasmaramp.PlasmaRamp",
-    "description": "Any plasma ramp. Consists of (1) the type of plasma ramp used and (2) the actual data for that plasma ramp.",
-    "type": "object",
-    "required": ["type", "data"],
-    "unevaluatedProperties": false,
-    "properties": {
-        "type": {
-            "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
-            "type": "object",
-            "required": [
-                "exponential",
-                "none"
-            ],
-            "unevaluatedProperties": false,
-            "properties": {
-                "exponential": {"type": "boolean"},
-                "none": {"type": "boolean"}
-            }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.plasmaramp.PlasmaRamp",
+  "description": "Any plasma ramp. Consists of (1) the type of plasma ramp used and (2) the actual data for that plasma ramp.",
+  "type": "object",
+  "required": [
+    "type",
+    "data"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "type": {
+      "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
+      "type": "object",
+      "required": [
+        "exponential",
+        "none"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "exponential": {
+          "type": "boolean"
         },
-        "data": {
-            "description": "data as provided by plasma ramp (schema)",
-            "anyOf": [
-                {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.exponential.Exponential"},
-                {"type" : "null"}
-            ]
+        "none": {
+          "type": "boolean"
         }
+      }
+    },
+    "data": {
+      "description": "data as provided by plasma ramp (schema)",
+      "anyOf": [
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.plasmaramp.exponential.Exponential"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/uniform.Uniform.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/uniform.Uniform.json
@@ -1,16 +1,16 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.uniform.Uniform",
-    "type": "object",
-    "description": "Describes a globally constant density.",
-    "unevaluatedProperties": false,
-    "required": [
-        "density_si"
-    ],
-    "properties": {
-        "density_si": {
-            "type": "number",
-            "description": "particle number density in m^-3",
-            "exclusiveMinimum": 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.uniform.Uniform",
+  "type": "object",
+  "description": "Describes a globally constant density.",
+  "unevaluatedProperties": false,
+  "required": [
+    "density_si"
+  ],
+  "properties": {
+    "density_si": {
+      "type": "number",
+      "description": "particle number density in m^-3",
+      "exclusiveMinimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/momentum/drift.Drift.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/momentum/drift.Drift.json
@@ -1,31 +1,38 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.drift.Drift",
-    "description": "initial velocity of particles",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": ["gamma", "direction_normalized"],
-    "properties": {
-        "gamma": {
-            "description": "scales direction_normalized",
-            "type": "number",
-            "minimum": 0
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.drift.Drift",
+  "description": "initial velocity of particles",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "gamma",
+    "direction_normalized"
+  ],
+  "properties": {
+    "gamma": {
+      "description": "scales direction_normalized",
+      "type": "number",
+      "minimum": 0
+    },
+    "direction_normalized": {
+      "description": "drift direction, length of 1",
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "properties": {
+        "x": {
+          "type": "number"
         },
-        "direction_normalized": {
-            "description": "drift direction, length of 1",
-            "type": "object",
-            "unevaluatedProperties": false,
-            "required": ["x", "y", "z"],
-            "properties": {
-                "x": {
-                    "type": "number"
-                },
-                "y": {
-                    "type": "number"
-                },
-                "z": {
-                    "type": "number"
-                }
-            }
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
         }
+      }
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/momentum/temperature.Temperature.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/momentum/temperature.Temperature.json
@@ -1,14 +1,16 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.temperature.Temperature",
-    "description": "(positive) temperature of a species",
-    "type": "object",
-    "required": ["temperature_kev"],
-    "unevaluatedProperties": false,
-    "properties": {
-        "temperature_kev": {
-            "description": "temperature in keV, zero forbidden: if at rest, do not use this object",
-            "type": "number",
-            "exclusiveMinimum": 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.temperature.Temperature",
+  "description": "(positive) temperature of a species",
+  "type": "object",
+  "required": [
+    "temperature_kev"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "temperature_kev": {
+      "description": "temperature in keV, zero forbidden: if at rest, do not use this object",
+      "type": "number",
+      "exclusiveMinimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/setchargestate.SetChargeState.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/setchargestate.SetChargeState.json
@@ -1,18 +1,21 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.setchargestate.SetChargeState",
-    "description": "set bound electrons attribute to given value",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": ["species", "charge_state"],
-    "properties": {
-        "species": {
-            "description": "species to set bound electrons for",
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-        },
-        "charge_state": {
-            "description": "charge state to set boundElectrons attribute for",
-            "type": "integer",
-            "minimum": 0
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.setchargestate.SetChargeState",
+  "description": "set bound electrons attribute to given value",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "species",
+    "charge_state"
+  ],
+  "properties": {
+    "species": {
+      "description": "species to set bound electrons for",
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "charge_state": {
+      "description": "charge state to set boundElectrons attribute for",
+      "type": "integer",
+      "minimum": 0
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/simpledensity.SimpleDensity.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/simpledensity.SimpleDensity.json
@@ -1,32 +1,32 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simpledensity.SimpleDensity",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [
-        "ppc",
-        "profile",
-        "placed_species_initial",
-        "placed_species_copied"
-    ],
-    "properties": {
-        "ppc": {
-            "description": "Number of macro particles per cell (random position).",
-            "type": "integer",
-            "exclusiveMinimum": 0
-        },
-        "profile": {
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.densityprofile.DensityProfile"
-        },
-        "placed_species_initial": {
-            "description": "species to be placed first, lowest ratio of species placed in this operation",
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-        },
-        "placed_species_copied": {
-            "type": "array",
-            "description": "species to be placed which have their position copied from placed_species_initial",
-            "items": {
-                "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
-            }
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simpledensity.SimpleDensity",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "ppc",
+    "profile",
+    "placed_species_initial",
+    "placed_species_copied"
+  ],
+  "properties": {
+    "ppc": {
+      "description": "Number of macro particles per cell (random position).",
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "profile": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.densityprofile.DensityProfile"
+    },
+    "placed_species_initial": {
+      "description": "species to be placed first, lowest ratio of species placed in this operation",
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "placed_species_copied": {
+      "type": "array",
+      "description": "species to be placed which have their position copied from placed_species_initial",
+      "items": {
+        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+      }
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/operation/simplemomentum.SimpleMomentum.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/simplemomentum.SimpleMomentum.json
@@ -1,35 +1,35 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simplemomentum.SimpleMomentum",
-    "description": "set momentum of one species using temperature, drift, both, or none",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [],
-    "properties": {
-        "species": {
-            "description": "species for the momentum is given",
-            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.simplemomentum.SimpleMomentum",
+  "description": "set momentum of one species using temperature, drift, both, or none",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [],
+  "properties": {
+    "species": {
+      "description": "species for the momentum is given",
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+    },
+    "drift": {
+      "description": "initial velocity (optional)",
+      "anyOf": [
+        {
+          "type": "null"
         },
-        "drift": {
-            "description": "initial velocity (optional)",
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.drift.Drift"
-                }
-            ]
-        },
-        "temperature": {
-            "description": "initial temperature (optional)",
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.temperature.Temperature"
-                }
-            ]
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.drift.Drift"
         }
+      ]
+    },
+    "temperature": {
+      "description": "initial temperature (optional)",
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.momentum.temperature.Temperature"
+        }
+      ]
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/species.Species.json
+++ b/share/picongpu/pypicongpu/schema/species/species.Species.json
@@ -1,86 +1,108 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species",
-    "description": "defines a species C++ type",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [
-        "name",
-        "typename",
-        "attributes",
-        "constants"
-    ],
-    "properties": {
-        "name": {
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species",
+  "description": "defines a species C++ type",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "name",
+    "typename",
+    "attributes",
+    "constants"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "name of the species (e.g. for output)",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_]+$"
+    },
+    "typename": {
+      "type": "string",
+      "description": "name of c++ species type",
+      "minLength": 1,
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "attributes": {
+      "type": "array",
+      "description": "names of attributes of each macro particle of this species",
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "required": [
+          "picongpu_name"
+        ],
+        "properties": {
+          "picongpu_name": {
             "type": "string",
-            "description": "name of the species (e.g. for output)",
-            "minLength": 1,
-            "pattern": "^[A-Za-z0-9_]+$"
-        },
-        "typename": {
-            "type": "string",
-            "description": "name of c++ species type",
-            "minLength": 1,
-            "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
-        },
-        "attributes": {
-            "type": "array",
-            "description": "names of attributes of each macro particle of this species",
-            "items": {
-                "type": "object",
-                "unevaluatedProperties": false,
-                "required": ["picongpu_name"],
-                "properties": {
-                    "picongpu_name": {
-                        "type": "string",
-                        "description": "c++ code to define this property",
-                        "minLength": 1
-                    }
-                }
-            }
-        },
-        "constants": {
-            "type": "object",
-            "description": "species constants (flags), accessible by a well defined name -- keys must always be defined, may be null if not present",
-            "unevaluatedProperties": false,
-            "required": [
-                "mass",
-                "charge",
-                "density_ratio",
-                "ground_state_ionization",
-                "element_properties"
-            ],
-            "properties": {
-                "mass": {
-                    "anyOf": [
-                        {"type": "null"},
-                        {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.mass.Mass"}
-                    ]
-                },
-                "charge": {
-                    "anyOf": [
-                        {"type": "null"},
-                        {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.charge.Charge"}
-                    ]
-                },
-                "density_ratio": {
-                    "anyOf": [
-                        {"type": "null"},
-                        {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.densityratio.DensityRatio"}
-                    ]
-                },
-                "ground_state_ionization": {
-                    "anyOf":  [
-                        {"type": "null"},
-                        {"$ref":"https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.groundstateionization.GroundStateIonization"}
-                    ]
-                },
-                "element_properties": {
-                    "anyOf": [
-                        {"type": "null"},
-                        {"$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.elementproperties.ElementProperties"}
-                    ]
-                }
-            }
+            "description": "c++ code to define this property",
+            "minLength": 1
+          }
         }
+      }
+    },
+    "constants": {
+      "type": "object",
+      "description": "species constants (flags), accessible by a well defined name -- keys must always be defined, may be null if not present",
+      "unevaluatedProperties": false,
+      "required": [
+        "mass",
+        "charge",
+        "density_ratio",
+        "ground_state_ionization",
+        "element_properties"
+      ],
+      "properties": {
+        "mass": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.mass.Mass"
+            }
+          ]
+        },
+        "charge": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.charge.Charge"
+            }
+          ]
+        },
+        "density_ratio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.densityratio.DensityRatio"
+            }
+          ]
+        },
+        "ground_state_ionization": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.groundstateionization.GroundStateIonization"
+            }
+          ]
+        },
+        "element_properties": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.constant.elementproperties.ElementProperties"
+            }
+          ]
+        }
+      }
     }
+  }
 }

--- a/share/picongpu/pypicongpu/schema/species/util/element.Element.json
+++ b/share/picongpu/pypicongpu/schema/species/util/element.Element.json
@@ -1,22 +1,22 @@
 {
-    "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.util.element.Element",
-    "description": "a chemical element from the periodic table of elements",
-    "type": "object",
-    "unevaluatedProperties": false,
-    "required": [
-        "symbol",
-        "picongpu_name"
-    ],
-    "properties": {
-        "symbol": {
-            "description": "symbol from the periodic table of elements, case sensitive",
-            "type": "string",
-            "pattern": "^[A-Z][a-z]?$"
-        },
-        "picongpu_name": {
-            "description": "name as used in PIConGPU lookup tables",
-            "type": "string",
-            "pattern": "^[A-Za-z0-9_]*$"
-        }
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.util.element.Element",
+  "description": "a chemical element from the periodic table of elements",
+  "type": "object",
+  "unevaluatedProperties": false,
+  "required": [
+    "symbol",
+    "picongpu_name"
+  ],
+  "properties": {
+    "symbol": {
+      "description": "symbol from the periodic table of elements, case sensitive",
+      "type": "string",
+      "pattern": "^[A-Z][a-z]?$"
+    },
+    "picongpu_name": {
+      "description": "name as used in PIConGPU lookup tables",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_]*$"
     }
+  }
 }


### PR DESCRIPTION
Adds a json formatter because handling all those pypicongpu schemas became really annoying. Also tackles the outdated `enforce-ascii` thing.

For review: The first and last commit are third-party autoformatting commits that can be ignored during review.

Closes #5331 