### PR TITLE
fix position offsets not being calculated correctly in Binning Plugin

### DIFF
--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -147,7 +147,7 @@ namespace picongpu
                 }
                 if constexpr(T_Origin == DomainOrigin::TOTAL)
                 {
-                    relative_cellpos = relative_cellpos + globalOffset;
+                    relative_cellpos = relative_cellpos + localOffset + globalOffset;
                 }
 
                 auto pos = localCellIdx + relative_cellpos;
@@ -228,7 +228,7 @@ namespace picongpu
             }
             if constexpr(T_Origin == DomainOrigin::TOTAL)
             {
-                relative_cellpos = relative_cellpos + domainInfo.globalOffset;
+                relative_cellpos = relative_cellpos + domainInfo.localOffset + domainInfo.globalOffset;
             }
             if constexpr(T_Precision == PositionPrecision::SubCell)
             {


### PR DESCRIPTION
Bug found by Konrad Schlicke, particle and cell positions aren't calculated correctly when requested relative to `TOTAL` origin. 