### PR TITLE
Set the mesh unit dimension correctly if normalization by volume is enabled in the Binning plugin

### DIFF
--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -165,9 +165,7 @@ namespace picongpu
                 mesh.setGridSpacing(gridSpacingVector);
                 mesh.setGridGlobalOffset(gridOffsetVector);
 
-                {
-                    mesh.setUnitDimension(makeOpenPMDUnitMap(binningData.depositionData.units)); // charge density
-                }
+                mesh.setUnitDimension(makeOpenPMDUnitMap(outputUnits));
 
                 /*
                  * The value represents an aggregation over one cell, so any value is correct for the mesh position.


### PR DESCRIPTION
Set the correct `unitDimension` in case normalization by bin volume is enabled. 
Note : `UnitSI` was set correctly even before this fix and has had no change
If normalization by bin volume is enabled in the binning plugin, this changes the units of the deposited quantity from `UNITS` to `UNITS/NORMALIZATION_UNITS`.  For example if we are binning energy over 2d space, the units change from `J` to `J/m^2` 