### PR TITLE
Richard's slice test cases

### DIFF
--- a/share/picongpu/unit/non_dimensional_tests/toSlice.cpp
+++ b/share/picongpu/unit/non_dimensional_tests/toSlice.cpp
@@ -71,33 +71,40 @@ TEST_CASE("Both slices", "")
 
     SECTION("accept : and , syntax.")
     {
-        std::vector<std::pair<std::string, std::vector<Slice>>> testCases = {
-            // empty
-            {"", {}},
-            // only colons
-            {":", {Slice{0, static_cast<uint32_t>(-1), 1}}},
-            {"::", {Slice{0, static_cast<uint32_t>(-1), 1}}},
-            // single value
-            {":2", {Slice{0, 2, 1}}},
-            {":2:", {Slice{0, 2, 1}}},
-            {"2:", {Slice{2, static_cast<uint32_t>(-1), 1}}},
-            {"2::", {Slice{2, static_cast<uint32_t>(-1), 1}}},
-            {"::2", {Slice{0, static_cast<uint32_t>(-1), 2}}},
-            // two values
-            {"1:5", {Slice{1, 5, 1}}},
-            {"1:5:", {Slice{1, 5, 1}}},
-            {":1:5", {Slice{0, 1, 5}}},
-            {"1::5", {Slice{1, static_cast<uint32_t>(-1), 5}}},
-            // three values
-            {"1:5:2", {Slice{1, 5, 2}}},
-            // explicit -1 as end
-            {"1:-1", {Slice{1, static_cast<uint32_t>(-1), 1}}},
-            // multiple slices
-            {"1:5,10:15", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
-            {"1:5:2,10:15:3", {Slice{1, 5, 2}, Slice{10, 15, 3}}},
-            {"1:-1,10:15", {Slice{1, static_cast<uint32_t>(-1), 1}, Slice{10, 15, 1}}},
-            {",1:5,,10:15,", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
-        };
+        std::vector<std::pair<std::string, std::vector<Slice>>> testCases
+            = {// empty
+               {"", {}},
+               // only colons
+               {":", {Slice{0, static_cast<uint32_t>(-1), 1}}},
+               {"::", {Slice{0, static_cast<uint32_t>(-1), 1}}},
+               // single value
+               {":2", {Slice{0, 2, 1}}},
+               {":2:", {Slice{0, 2, 1}}},
+               {"2:", {Slice{2, static_cast<uint32_t>(-1), 1}}},
+               {"2::", {Slice{2, static_cast<uint32_t>(-1), 1}}},
+               {"::2", {Slice{0, static_cast<uint32_t>(-1), 2}}},
+               // two values
+               {"1:5", {Slice{1, 5, 1}}},
+               {"1:5:", {Slice{1, 5, 1}}},
+               {":1:5", {Slice{0, 1, 5}}},
+               {"1::5", {Slice{1, static_cast<uint32_t>(-1), 5}}},
+               // three values
+               {"1:5:2", {Slice{1, 5, 2}}},
+               // explicit -1 as end
+               {"1:-1", {Slice{1, static_cast<uint32_t>(-1), 1}}},
+               // multiple slices
+               {"1:5,10:15", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
+               {"1:5:2,10:15:3", {Slice{1, 5, 2}, Slice{10, 15, 3}}},
+               {"1:-1,10:15", {Slice{1, static_cast<uint32_t>(-1), 1}, Slice{10, 15, 1}}},
+               {",1:5,,10:15,", {Slice{1, 5, 1}, Slice{10, 15, 1}}},
+               {":,:,:",
+                {Slice{0, static_cast<uint32_t>(-1), 1},
+                 Slice{0, static_cast<uint32_t>(-1), 1},
+                 Slice{0, static_cast<uint32_t>(-1), 1}}},
+               {"0:,:,:",
+                {Slice{0, static_cast<uint32_t>(-1), 1},
+                 Slice{0, static_cast<uint32_t>(-1), 1},
+                 Slice{0, static_cast<uint32_t>(-1), 1}}}};
 
         for(const auto& testCase : testCases)
         {


### PR DESCRIPTION
@PrometheusPi reported that the first added test case failed to run while the second one did run and suggested that it might be a consequence of the recent refactoring failing to parse this. Alternatively, @franzpoeschel suggested that it's an issue with slurm passing on the arguments. Given the passing test cases that I added, the second seems to be more likely.