### PR TITLE
Remove normalization from the Binning plugin

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -10,7 +10,7 @@ Users can
 	- Choose which species are used for particle binning
 	- Choose which fields are used for field binning
 	- Choose how frequently they want the binning to be executed
-	- Choose if the binning should be time averaging or normalized by bin volume
+	- Choose if the binning should be time averaging
 	- Write custom output to file, for example other quantities related to the simulation which the user is interested in
 	- Execute multiple binnings at the same time
 	- Pass extra parameters as a tuple, if additional information is required by the kernels to do binning.
@@ -270,10 +270,6 @@ When dumping the accumulated output, whether or not to divide by the dump period
 
 	The user needs to set a dump period to enable time averaging.
 
-Normalize by Bin Volume
------------------------
-Since it is possible to have non-uniformly sized axes, it makes sense to normalize the binned quantity by the bin volume to enable a fair comparison between bins. Enabled by default.
-
 
 Binning Particles Leaving the Simulation Volume
 -----------------------------------------------
@@ -318,8 +314,6 @@ The OpenPMD mesh is call "Binning".
 
 The outputs in written in SI units.
 
-If normalization is enabled, the output is normalized by the bin volume.
-
 The output histogram has 2 bins more in each dimension than the user-defined ``nBins`` in that dimension, to deal with under and overflow.
 
 The number of bin edges written out for an axis is one more than the user-defined ``nBins``. These represent the bins in [min,max]. Since there are actually ``nBins + 2`` bins, two edges are not written out.
@@ -341,7 +335,6 @@ Example binning plugin usage: Laser Wakefield electron spectrometer
 The :ref:`LWFA example <LWFA-example>`  contains a sample binning plugin setup to calculate an in-situ electron spectrometer.
 The kinetic energy of the electrons :math:`E = (\gamma - 1) m_o c^2` is plotted on axis 1 and the direction of the electrons :math:`\theta = \mathrm{atan}(p_x/p_y)` is plotted on axis 2.
 The charge :math:`Q` moving in the bin direction :math:`\theta` at the bin energy :math:`E` is calculated for each bin.
-The charge is normalized to the bin volume :math:`\Delta E \cdot \Delta \theta`.
 Such spectrometers are a common tool in plasma based electron acceleration experiments [Kurz2018]_.
 
 .. note::

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -116,13 +116,6 @@ namespace picongpu
                 return interpretAsChild();
             }
 
-            /** @brief Defaults to true */
-            Child& setNormalizeByBinVolume(bool normalize)
-            {
-                this->normalizeByBinVolume = normalize;
-                return interpretAsChild();
-            }
-
             /** @brief The periodicity of the output. Defaults to 1 */
             Child& setNotifyPeriod(std::string notify)
             {

--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -57,7 +57,6 @@ namespace picongpu
                 OpenPMDWriteParams params,
                 std::unique_ptr<HostBuffer<T_Type, 1u>> hReducedBuffer,
                 T_BinningData const& binningData,
-                std::array<double, numUnits> const& outputUnits,
                 uint32_t const currentStep,
                 bool const isCheckpoint = false,
                 uint32_t const accumulateCounter = 0)
@@ -165,9 +164,7 @@ namespace picongpu
                 mesh.setGridSpacing(gridSpacingVector);
                 mesh.setGridGlobalOffset(gridOffsetVector);
 
-                {
-                    mesh.setUnitDimension(makeOpenPMDUnitMap(binningData.depositionData.units)); // charge density
-                }
+                mesh.setUnitDimension(makeOpenPMDUnitMap(binningData.depositionData.units));
 
                 /*
                  * The value represents an aggregation over one cell, so any value is correct for the mesh position.
@@ -186,7 +183,7 @@ namespace picongpu
                     histOffset.emplace_back(static_cast<size_t>(0));
                 }
 
-                record.setUnitSI(getConversionFactor(outputUnits));
+                record.setUnitSI(getConversionFactor(binningData.depositionData.units));
 
                 record.resetDataset({::openPMD::determineDatatype<Type>(), histExtent});
                 auto base_ptr = hReducedBuffer->data();

--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -129,26 +129,6 @@ namespace picongpu
 
                 LinearAxisKernel lAK;
 
-                struct BinWidthKernel
-                {
-                    ScalingType scaling;
-                    uint32_t nBins;
-
-                    BinWidthKernel(LinearAxisKernel const& axisKernel)
-                        : scaling{axisKernel.scaling}
-                        , nBins{axisKernel.nBins}
-                    {
-                    }
-
-                    ALPAKA_FN_ACC T_Attribute getBinWidth(uint32_t idx = 0) const
-                    {
-                        PMACC_ASSERT(idx < nBins);
-                        return 1 / scaling;
-                    }
-                };
-
-                BinWidthKernel bWK;
-
                 LinearAxis(
                     AxisSplitting<T_Attribute> const& axSplit,
                     T_AttrFunctor const& attrFunctor,
@@ -158,7 +138,6 @@ namespace picongpu
                     , label{label}
                     , units{units}
                     , lAK{attrFunctor, axSplit, units}
-                    , bWK{lAK}
                 {
                 }
 
@@ -175,11 +154,6 @@ namespace picongpu
                 LinearAxisKernel getAxisKernel() const
                 {
                     return lAK;
-                }
-
-                BinWidthKernel getBinWidthKernel() const
-                {
-                    return bWK;
                 }
 
                 /**

--- a/include/picongpu/plugins/binning/axis/LogAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LogAxis.hpp
@@ -155,21 +155,6 @@ namespace picongpu
 
                 LogAxisKernel lAK;
 
-                struct BinWidthKernel
-                {
-                    typename pmacc::HostDeviceBuffer<T_Attribute, 1>::DBuffer::DataBoxType widthsDeviceBox;
-
-                    BinWidthKernel(pmacc::HostDeviceBuffer<T_Attribute, 1>& widths)
-                        : widthsDeviceBox{widths.getDeviceBuffer().getDataBox()}
-                    {
-                    }
-
-                    ALPAKA_FN_ACC T_Attribute getBinWidth(uint32_t idx) const
-                    {
-                        return widthsDeviceBox(idx);
-                    }
-                };
-
                 LogAxis(
                     AxisSplitting<T_Attribute> axSplit,
                     T_AttrFunctor attrFunctor,
@@ -220,24 +205,6 @@ namespace picongpu
                 LogAxisKernel getAxisKernel() const
                 {
                     return lAK;
-                }
-
-                BinWidthKernel getBinWidthKernel() const
-                {
-                    // reset whenever binWidths changes
-                    static bool set = false;
-                    static pmacc::HostDeviceBuffer<T_Attribute, 1> binWidthBuffer{axisSplit.nBins};
-                    if(!set)
-                    {
-                        auto db = binWidthBuffer.getHostBuffer().getDataBox();
-                        for(size_t i = 0; i < binWidths.size(); i++)
-                        {
-                            db[i] = binWidths[i];
-                        }
-                        binWidthBuffer.hostToDevice();
-                        set = true;
-                    }
-                    return BinWidthKernel(binWidthBuffer);
                 }
 
                 /**

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/binningSetup.param
@@ -91,7 +91,6 @@ namespace picongpu::plugins::binning
         binningCreator.addParticleBinner("atomicStateBinning", axisTuple, speciesTuple, weightingData)
             .setDumpPeriod(numberTimeSteps)
             .setOpenPMDExtension("bp")
-            .setNormalizeByBinVolume(false)
             .setTimeAveraging(false)
             .setOpenPMDWriteFunctor(appendWeightScalingFactor);
     }

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/binningSetup.param
@@ -130,7 +130,6 @@ namespace picongpu
             auto chargeDepositionData = createFunctorDescription<float_X>(getParticleCharge, "Charge", depositedUnits);
 
             binningCreator.addParticleBinner("eSpec", axisTuple, speciesTuple, chargeDepositionData)
-                .setNormalizeByBinVolume(true)
                 .setNotifyPeriod("100")
                 .setOpenPMDJsonCfg(R"({"hdf5":{"dataset":{"chunks":"auto"}}})")
                 .setOpenPMDExtension("h5");

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -178,8 +178,7 @@ namespace picongpu
 
             binningCreator
                 .addParticleBinner("particleBinning", createTuple(ax_timeStep, ax_py), speciesTuple, getCounts)
-                .setDumpPeriod(2000)
-                .setNormalizeByBinVolume(false);
+                .setDumpPeriod(2000);
         }
 
         inline void fieldBinningExample(BinningCreator& binningCreator)


### PR DESCRIPTION
The option to normalize the binning by the bin volume is now removed due to there being no good way to handle normalization for overflow bins. 
The `setNormalizeByBinVolume` option is now removed from binning data

Closes #5338 since the feature is now removed.