### PR TITLE
Remove circular imports in generic contexts

### DIFF
--- a/lib/python/picongpu/pypicongpu/output/auto.py
+++ b/lib/python/picongpu/pypicongpu/output/auto.py
@@ -29,6 +29,8 @@ class Auto(Plugin):
     period = util.build_typesafe_property(TimeStepSpec)
     """period to print data at"""
 
+    _name = "auto"
+
     def __init__(self):
         pass
 

--- a/lib/python/picongpu/pypicongpu/output/energy_histogram.py
+++ b/lib/python/picongpu/pypicongpu/output/energy_histogram.py
@@ -23,6 +23,8 @@ class EnergyHistogram(Plugin):
     min_energy = util.build_typesafe_property(float)
     max_energy = util.build_typesafe_property(float)
 
+    _name = "energyhistogram"
+
     def __init__(self):
         "do nothing"
 

--- a/lib/python/picongpu/pypicongpu/output/macro_particle_count.py
+++ b/lib/python/picongpu/pypicongpu/output/macro_particle_count.py
@@ -20,6 +20,8 @@ class MacroParticleCount(Plugin):
     species = util.build_typesafe_property(Species)
     period = util.build_typesafe_property(TimeStepSpec)
 
+    _name = "macroparticlecount"
+
     def __init__(self):
         "do nothing"
 

--- a/lib/python/picongpu/pypicongpu/output/phase_space.py
+++ b/lib/python/picongpu/pypicongpu/output/phase_space.py
@@ -25,6 +25,8 @@ class PhaseSpace(Plugin):
     min_momentum = util.build_typesafe_property(float)
     max_momentum = util.build_typesafe_property(float)
 
+    _name = "phasespace"
+
     def __init__(self):
         "do nothing"
 

--- a/lib/python/picongpu/pypicongpu/output/plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/plugin.py
@@ -1,100 +1,18 @@
 """
 This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
-Authors: Brian Edward Marre, Masoud Afshari
+Authors: Brian Edward Marre, Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from ..rendering import RenderedObject
+from ..rendering import SelfRegisteringRenderedObject
 
 
 import typeguard
 
 
 @typeguard.typechecked
-class Plugin(RenderedObject):
+class Plugin(SelfRegisteringRenderedObject):
     """general interface for all plugins"""
 
-    def __init__(self):
-        raise NotImplementedError("abstract base class only")
-
-    def get_generic_plugin_rendering_context(self) -> dict:
-        """
-        retrieve a context valid for "any plugin"
-
-        Problem: Every plugin has its respective schema, and it is difficult
-        in JSON (particularly in a mustache-compatible way) to get the type
-        of the schema.
-
-        Solution: The normal rendering of plugins get_rendering_context()
-        provides **only their parameters**, i.e. there is **no meta
-        information** on types etc.
-
-        If a generic plugin is requested one can use the schema for
-        "Plugin" (this class), for which this method returns the
-        correct content, which includes metainformation and the data on the
-        schema itself.
-
-        E.g.:
-
-        .. code::
-
-            {
-                "type": {
-                    "phasespace": true,
-                    "auto": false,
-                    ...
-                },
-                "data": DATA
-            }
-
-        where DATA is the serialization as returned by get_rendering_context().
-
-        There are *two* context serialization methods for plugins:
-
-        - get_rendering_context()
-
-            - provided by RenderedObject parent class, serialization ("context
-              building") performed by _get_serialized()
-            - _get_serialized() implemented in *every plugin*
-            - checks against schema of respective plugin
-            - returned context is a representation of *exactly this plugin*
-            - (left empty == not implemented in parent Plugin)
-
-        - get_generic_plugin_rendering_context()
-
-            - implemented in parent class Plugin
-            - returned representation is generic for *any plugin*
-              (i.e. contains meta information which type is actually used)
-            - passes information from get_rendering_context() through
-            - returned representation is designed for easy use with templating
-              engine mustache
-        """
-        # import here to avoid circular inclusion
-        from .auto import Auto
-        from .phase_space import PhaseSpace
-        from .energy_histogram import EnergyHistogram
-        from .macro_particle_count import MacroParticleCount
-
-        template_name_by_type = {
-            Auto: "auto",
-            PhaseSpace: "phasespace",
-            EnergyHistogram: "energyhistogram",
-            MacroParticleCount: "macroparticlecount",
-        }
-        if self.__class__ not in template_name_by_type:
-            raise RuntimeError("unkown type: {}".format(self.__class__))
-
-        serialized_data = self.get_rendering_context()
-
-        # create dict with all types set to false, except for the current one
-        typeID = dict(map(lambda type_name: (type_name, False), template_name_by_type.values()))
-        self_class_template_name = template_name_by_type[self.__class__]
-        typeID[self_class_template_name] = True
-
-        # final context to be returned: data + type info
-        returned_context = {"typeID": typeID, "data": serialized_data}
-
-        # make sure it passes schema checks
-        RenderedObject.check_context_for_type(Plugin, returned_context)
-        return returned_context
+    pass

--- a/lib/python/picongpu/pypicongpu/rendering/__init__.py
+++ b/lib/python/picongpu/pypicongpu/rendering/__init__.py
@@ -1,7 +1,20 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
 from .renderer import Renderer
-from .renderedobject import RenderedObject
+from .renderedobject import (
+    RenderedObject,
+    SelfRegistering,
+    SelfRegisteringRenderedObject,
+)
 
 __all__ = [
     "Renderer",
     "RenderedObject",
+    "SelfRegistering",
+    "SelfRegisteringRenderedObject",
 ]

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -77,11 +77,11 @@ class Simulation(RenderedObject):
             auto = output.Auto()
             auto.period = TimeStepSpec([slice(0, None, max(1, int(self.time_steps / 100)))])
 
-            return [auto.get_generic_plugin_rendering_context()]
+            return [auto.get_rendering_context()]
         else:
             output_rendering_context = []
             for entry in self.plugins:
-                output_rendering_context.append(entry.get_generic_plugin_rendering_context())
+                output_rendering_context.append(entry.get_rendering_context())
 
             return output_rendering_context
 

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/densityprofile.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/densityprofile.py
@@ -1,107 +1,21 @@
 """
 This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre
+Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
-from ....rendering import RenderedObject
+from ....rendering import SelfRegisteringRenderedObject
 
 import typeguard
 
 
 @typeguard.typechecked
-class DensityProfile(RenderedObject):
+class DensityProfile(SelfRegisteringRenderedObject):
     """
     (abstract) parent class of all density profiles
 
     A density profile describes the density in space.
     """
 
-    def __init__(self):
-        raise NotImplementedError()
-
-    def check(self) -> None:
-        """
-        check self, overwritten by child class
-
-        Perform checks if own parameters are valid.
-        On error raise, if everything is okay pass silently.
-        """
-        raise NotImplementedError()
-
-    def get_generic_profile_rendering_context(self) -> dict:
-        """
-        retrieve a context valid for "any profile"
-
-        Problem: Every profile has its respective schema, and it is difficult
-        in JSON (particularly in a mustache-compatible way) to get the type
-        of the schema.
-
-        Solution: The normal rendering of profiles get_rendering_context()
-        provides **only their parameters**, i.e. there is **no meta
-        information** on types etc.
-
-        If a generic profile is requested one can use the schema for
-        "DensityProfile" (this class), for which this method returns the
-        correct content, which includes metainformation and the data on the
-        schema itself.
-
-        E.g.:
-
-        .. code::
-
-            {
-                "type": {
-                    "uniform": true,
-                    "gaussian": false,
-                    ...
-                },
-                "data": DATA
-            }
-
-        where DATA is the serialization as returned by get_rendering_context().
-
-        There are *two* context serialization methods for density profiles:
-
-        - get_rendering_context()
-
-            - provided by RenderedObject parent class, serialization ("context
-              building") performed by _get_serialized()
-            - _get_serialized() implemented in *every profile*
-            - checks against schema of respective profile
-            - returned context is a representation of *exactly this profile*
-            - (left empty == not implemented in parent ProfileDensity)
-
-        - get_generic_profile_rendering_context()
-
-            - implemented in parent densityprofile
-            - returned representation is generic for *any profile*
-              (i.e. contains meta information which type is actually used)
-            - passes information from get_rendering_context() through
-            - returned representation is designed for easy use with templating
-              engine mustache
-        """
-        # import here to avoid circular inclusion
-        from .uniform import Uniform
-        from .foil import Foil
-        from .gaussian import Gaussian
-
-        template_name_by_type = {Uniform: "uniform", Foil: "foil", Gaussian: "gaussian"}
-        if self.__class__ not in template_name_by_type:
-            raise RuntimeError("unkown type: {}".format(self.__class__))
-
-        serialized_data = self.get_rendering_context()
-
-        # create dict with all types set to false, except for the current one
-        type_dict = dict(map(lambda type_name: (type_name, False), template_name_by_type.values()))
-        self_class_template_name = template_name_by_type[self.__class__]
-        type_dict[self_class_template_name] = True
-
-        # final context to be returned: data + type info
-        returned_context = {"type": type_dict, "data": serialized_data}
-
-        # make sure it passes schema checks
-        RenderedObject.check_context_for_type(DensityProfile, returned_context)
-
-        return returned_context
+    pass

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/foil.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/foil.py
@@ -19,6 +19,8 @@ class Foil(DensityProfile):
     post-plasma lengths and cutoffs
     """
 
+    _name = "foil"
+
     density_si = util.build_typesafe_property(float)
     """particle number density at at the foil plateau (m^-3)"""
 
@@ -33,10 +35,6 @@ class Foil(DensityProfile):
 
     post_foil_plasmaRamp = util.build_typesafe_property(PlasmaRamp)
     """post(higher y) foil-plateau ramp of density"""
-
-    def __init__(self):
-        # (nothing to do, overwrite from abstract parent)
-        pass
 
     def check(self) -> None:
         if self.density_si <= 0:
@@ -55,6 +53,6 @@ class Foil(DensityProfile):
             "density_si": self.density_si,
             "y_value_front_foil_si": self.y_value_front_foil_si,
             "thickness_foil_si": self.thickness_foil_si,
-            "pre_foil_plasmaRamp": self.pre_foil_plasmaRamp.get_generic_profile_rendering_context(),
-            "post_foil_plasmaRamp": self.post_foil_plasmaRamp.get_generic_profile_rendering_context(),
+            "pre_foil_plasmaRamp": self.pre_foil_plasmaRamp.get_rendering_context(),
+            "post_foil_plasmaRamp": self.post_foil_plasmaRamp.get_rendering_context(),
         }

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -21,6 +21,8 @@ class Gaussian(DensityProfile):
     - for gasCenterRear < y;    density * exp(gasFactor * (abs( (y - gasCenterRear) / gasSigmaRear))^gasPower)
     """
 
+    _name = "gaussian"
+
     gas_center_front = util.build_typesafe_property(float)
     """position of the front edge of the constant middle of the density profile, [m]"""
 
@@ -44,10 +46,6 @@ class Gaussian(DensityProfile):
 
     density = util.build_typesafe_property(float)
     """particle number density in m^-3"""
-
-    def __init__(self):
-        # (nothing to do, overwrite from abstract parent)
-        pass
 
     def check(self) -> None:
         if self.density <= 0:

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/exponential.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/exponential.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 Copyright 2023-2024 PIConGPU contributors
-Authors: Kristin Tippey, Brian Edward Marre
+Authors: Kristin Tippey, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
@@ -13,6 +13,8 @@ from .plasmaramp import PlasmaRamp
 @typeguard.typechecked
 class Exponential(PlasmaRamp):
     """exponential plasma ramp, either up or down"""
+
+    _name = "exponential"
 
     def __init__(self, PlasmaLength: float, PlasmaCutoff: float):
         self.PlasmaLength = PlasmaLength
@@ -26,5 +28,4 @@ class Exponential(PlasmaRamp):
 
     def _get_serialized(self) -> dict:
         self.check()
-
         return {"PlasmaLength": self.PlasmaLength, "PlasmaCutoff": self.PlasmaCutoff}

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/none.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/none.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 Copyright 2023-2024 PIConGPU contributors
-Authors: Kristin Tippey, Brian Edward Marre
+Authors: Kristin Tippey, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
@@ -14,12 +14,10 @@ from .plasmaramp import PlasmaRamp
 class None_(PlasmaRamp):
     """no plasma ramp, either up or down"""
 
-    def __init__(self):
-        # just overwriting the base class method
-        pass
+    _name = "none"
 
-    def check(self) -> None:
-        return
+    def check(self):
+        pass
 
     def _get_serialized(self) -> dict | None:
         return None

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/plasmaramp.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/plasmaramp/plasmaramp.py
@@ -5,12 +5,12 @@ Authors: Brian Edward Marre
 License: GPLv3+
 """
 
-from .....rendering import RenderedObject
+from .....rendering import SelfRegisteringRenderedObject
 import typeguard
 
 
 @typeguard.typechecked
-class PlasmaRamp(RenderedObject):
+class PlasmaRamp(SelfRegisteringRenderedObject):
     """
     abstract parent class for all plasma ramps
 
@@ -18,117 +18,4 @@ class PlasmaRamp(RenderedObject):
     distribution
     """
 
-    def __init__(self):
-        raise NotImplementedError()
-
-    def check(self) -> None:
-        """
-        check self, overwritten by child class
-
-        Perform checks if own parameters are valid.
-        passes silently if everything is okay
-        """
-        foundPreviousActive = False
-        foundPreviousActiveType = ""
-        for typeEntry, marker in self.returned_context["type"].items():
-            if marker:
-                if foundPreviousActive:
-                    raise ValueError(
-                        "only one type may be marked as present!,"
-                        + " both "
-                        + foundPreviousActiveType
-                        + " and "
-                        + typeEntry
-                        + " are marked as"
-                        + "present"
-                    )
-                else:
-                    foundPreviousActive = True
-                    foundPreviousActiveType = typeEntry
-
-    def get_generic_profile_rendering_context(self) -> dict:
-        """
-        retrieve a context valid for "any profile"
-
-        **Problem:** Plasma Ramps are polymorph, there are several distinct
-        implementations, each of them has its respective schema.
-
-        In the template we need know which exact sub type of the general
-        abstract type was used to generate the correct code.
-
-        This is difficult in JSON (particularly in a mustache-compatible way)
-        since no type information is available in the schema.
-
-        **Solution:** We store which type was actually used in a wrapper
-        in addition to actual data,
-            provided as usual by get_rendering_context() by the plasma ramp
-            instance
-
-        If a generic plasma ramp is requested we us the wrapper schema for this
-        class which contains the **type** meta information and the **data**
-        content
-
-        E.g.:
-
-        .. code::
-
-            {
-                "type": {
-                    "uniform": true,
-                    "gaussian": false,
-                    ...
-                },
-                "data": DATA
-            }
-
-        where DATA is the serialization as returned by get_rendering_context().
-
-        There are *two* context serialization methods for density profiles:
-
-        - get_rendering_context()
-            - provided by RenderedObject parent class, serialization ("context
-              building") performed by _get_serialized()
-            - _get_serialized() implemented in *every plasma ramp*
-            - checks against schema of respective plasma ramp
-            - returned context is a representation of
-                    *exactly this plasma ramp*
-            - (left empty == not implemented in parent PlasmaRamp)
-
-        - get_generic_profile_rendering_context()
-            - implemented in parent PlasmaRamp
-            - returned representation is generic for *any plasma ramp*
-              (i.e. contains which type is actually used)
-            - passes information from get_rendering_context() through
-            - returned representation is designed for easy use with templating
-              engine mustache
-        """
-        # import ramps here to avoid circular inclusion
-        from .exponential import Exponential
-        from .none import None_
-
-        template_name_by_type = {Exponential: "exponential", None_: "none"}
-
-        if self.__class__ not in template_name_by_type:
-            raise RuntimeError("unkown type: {}".format(self.__class__))
-
-        # create type meta data dict
-        # init with all false
-        type_dict = dict(map(lambda type_name: (type_name, False), template_name_by_type.values()))
-        # set this class entry to true
-        self_class_template_name = template_name_by_type[self.__class__]
-        type_dict[self_class_template_name] = True
-
-        # get data from actual inheriting implementation
-        serialized_data = self.get_rendering_context()
-
-        # final context to be returned: data + type info
-        self.returned_context = {
-            "type": type_dict,
-            "data": serialized_data,
-        }
-        self.check()
-
-        # make sure it passes schema checks
-        RenderedObject.check_context_for_type(PlasmaRamp, self.returned_context)
-
-        return self.returned_context
+    pass

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/uniform.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/uniform.py
@@ -20,12 +20,10 @@ class Uniform(DensityProfile):
     ambiguities the PICMI name uniform is followed here.
     """
 
+    _name = "uniform"
+
     density_si = util.build_typesafe_property(float)
     """density at every point in space (kg * m^-3)"""
-
-    def __init__(self):
-        # (nothing to do, overwrite from abstract parent)
-        pass
 
     def check(self) -> None:
         if self.density_si <= 0:

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -120,7 +120,7 @@ class SimpleDensity(DensityOperation):
 
         return {
             "ppc": self.ppc,
-            "profile": self.profile.get_generic_profile_rendering_context(),
+            "profile": self.profile.get_rendering_context(),
             "placed_species_initial": placed_species[0],
             "placed_species_copied": placed_species[1:],
         }

--- a/lib/python/picongpu/pypicongpu/util.py
+++ b/lib/python/picongpu/pypicongpu/util.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre
+Copyright 2021-2025 PIConGPU contributors
+Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/densityprofile.DensityProfile.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/densityprofile.DensityProfile.json
@@ -3,12 +3,12 @@
   "description": "Any density profile. Consists of (1) the type of density profile used and (2) the actual data for that profile.",
   "type": "object",
   "required": [
-    "type",
+    "typeID",
     "data"
   ],
   "unevaluatedProperties": false,
   "properties": {
-    "type": {
+    "typeID": {
       "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
       "type": "object",
       "required": [

--- a/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/plasmaramp.PlasmaRamp.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/densityprofile/plasmaramp/plasmaramp.PlasmaRamp.json
@@ -3,12 +3,12 @@
   "description": "Any plasma ramp. Consists of (1) the type of plasma ramp used and (2) the actual data for that plasma ramp.",
   "type": "object",
   "required": [
-    "type",
+    "typeID",
     "data"
   ],
   "unevaluatedProperties": false,
   "properties": {
-    "type": {
+    "typeID": {
       "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
       "type": "object",
       "required": [

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/density.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/density.param.mustache
@@ -31,7 +31,7 @@ namespace picongpu
         {{#species_initmanager.operations.simple_density}}
         // a species has always only exactly one profile, so only one of the following blocks below will be present
 
-          {{#profile.type.gaussian}}
+          {{#profile.typeID.gaussian}}
             /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
              *
              * @note the density may be further modified from this profile by the densityRatio of the species, set in
@@ -61,9 +61,9 @@ namespace picongpu
             };
 
             using init_{{{placed_species_initial.typename}}} = GaussianImpl<init_{{{placed_species_initial.typename}}}_GaussianParam>;
-          {{/profile.type.gaussian}}
+          {{/profile.typeID.gaussian}}
 
-          {{#profile.type.uniform}}
+          {{#profile.typeID.uniform}}
             /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
              *
              * @note the density may be further modified from this profile by the densityRatio of the species set in the
@@ -83,9 +83,9 @@ namespace picongpu
                 }
             };
             using init_{{{placed_species_initial.typename}}} = FreeFormulaImpl<init_{{{placed_species_initial.typename}}}_functor>;
-          {{/profile.type.uniform}}
+          {{/profile.typeID.uniform}}
 
-          {{#profile.type.foil}}
+          {{#profile.typeID.foil}}
             /** generate the initial macroparticle position for species "{{{placed_species_initial.name}}}" ({{{placed_species_initial.typename}}})
              *
              * @note the density may be further modified from this profile by the densityRatio of the species, set in
@@ -104,7 +104,7 @@ namespace picongpu
                     constexpr float_64 y1 = y0 + {{{profile.data.thickness_foil_si}}};
 
                     // prePlasma ramp
-                    {{#profile.data.pre_foil_plasmaRamp.type.exponential}}
+                    {{#profile.data.pre_foil_plasmaRamp.typeID.exponential}}
                         // exponential pre-expanded density ramp before plateau of foil
                         constexpr float_64 prePlasmaLength = {{{profile.data.pre_foil_plasmaRamp.data.PlasmaLength}}};
                         constexpr float_64 prePlasmaCutoff = {{{profile.data.pre_foil_plasmaRamp.data.PlasmaCutoff}}};
@@ -113,14 +113,14 @@ namespace picongpu
                         if((y < y0) &&  y > y0 - prePlasmaCutoff)
                             dens = static_cast<float_X>({{{profile.data.density_si}}} / SI::BASE_DENSITY_SI)
                                 * math::exp((y - y0) / prePlasmaLength);
-                    {{/profile.data.pre_foil_plasmaRamp.type.exponential}}
+                    {{/profile.data.pre_foil_plasmaRamp.typeID.exponential}}
 
-                    {{#profile.data.pre_foil_plasmaRamp.type.none}}
+                    {{#profile.data.pre_foil_plasmaRamp.typeID.none}}
                         // no prePlasma ramp
-                    {{/profile.data.pre_foil_plasmaRamp.type.none}}
+                    {{/profile.data.pre_foil_plasmaRamp.typeID.none}}
 
                     // postPlasma ramp
-                    {{#profile.data.post_foil_plasmaRamp.type.exponential}}
+                    {{#profile.data.post_foil_plasmaRamp.typeID.exponential}}
                         // exponential pre-expanded density ramp after plateau of foil
                         constexpr float_64 postPlasmaLength = {{{profile.data.post_foil_plasmaRamp.data.PlasmaLength}}};
                         constexpr float_64 postPlasmaCutoff = {{{profile.data.post_foil_plasmaRamp.data.PlasmaCutoff}}};
@@ -128,11 +128,11 @@ namespace picongpu
                         if(y > y1 && y < y1 + postPlasmaCutoff)
                             dens = static_cast<float_X>({{{profile.data.density_si}}} / SI::BASE_DENSITY_SI)
                                 * math::exp((y1 - y) / postPlasmaLength);
-                    {{/profile.data.post_foil_plasmaRamp.type.exponential}}
+                    {{/profile.data.post_foil_plasmaRamp.typeID.exponential}}
 
-                    {{#profile.data.post_foil_plasmaRamp.type.none}}
+                    {{#profile.data.post_foil_plasmaRamp.typeID.none}}
                         // no postPlasma ramp
-                    {{/profile.data.post_foil_plasmaRamp.type.none}}
+                    {{/profile.data.post_foil_plasmaRamp.typeID.none}}
 
                     // foil plateau
                     if(y >= y0 && y <= y1)
@@ -144,7 +144,7 @@ namespace picongpu
                 }
             };
             using init_{{{placed_species_initial.typename}}} = FreeFormulaImpl<init_{{{placed_species_initial.typename}}}_functor>;
-          {{/profile.type.foil}}
+          {{/profile.typeID.foil}}
 
         {{/species_initmanager.operations.simple_density}}
     } // namespace densityProfiles::pypicongpu

--- a/test/python/picongpu/quick/picmi/distribution.py
+++ b/test/python/picongpu/quick/picmi/distribution.py
@@ -305,7 +305,7 @@ class TestPicmiFoilDistribution(unittest.TestCase, HelperTestPicmiBoundaries):
         """density set to zero is not accepted"""
         foil = picmi.FoilDistribution(density=0, thickness=1.0, front=2.0)
         with self.assertRaisesRegex(ValueError, ".*density must be > 0.*"):
-            foil.get_as_pypicongpu().get_generic_profile_rendering_context()
+            foil.get_as_pypicongpu().get_rendering_context()
 
     def test_front_zero(self):
         """front set to zero is accepted"""
@@ -377,7 +377,7 @@ class TestPicmiFoilDistribution(unittest.TestCase, HelperTestPicmiBoundaries):
 
         for i, entry in enumerate(testCases):
             with self.assertRaisesRegex(ValueError, ".*PlasmaCutoff must be >=0.*"):
-                entry.get_as_pypicongpu().get_generic_profile_rendering_context()
+                entry.get_as_pypicongpu().get_rendering_context()
 
     def test_length_zero(self):
         """length set to zero is not accepted"""
@@ -385,7 +385,7 @@ class TestPicmiFoilDistribution(unittest.TestCase, HelperTestPicmiBoundaries):
 
         for entry in testCases:
             with self.assertRaisesRegex(ValueError, ".*PlasmaLength must be >0.*"):
-                entry.get_as_pypicongpu().get_generic_profile_rendering_context()
+                entry.get_as_pypicongpu().get_rendering_context()
 
     def test_length_below_zero(self):
         """length below zero is not accepted"""
@@ -394,7 +394,7 @@ class TestPicmiFoilDistribution(unittest.TestCase, HelperTestPicmiBoundaries):
 
         for entry in testCases:
             with self.assertRaisesRegex(ValueError, ".*PlasmaLength must be >0.*"):
-                entry.get_as_pypicongpu().get_generic_profile_rendering_context()
+                entry.get_as_pypicongpu().get_rendering_context()
 
     def test_setting_noPlasmaRamps(self):
         testCases = self._get_test_foils(None, 1.0)
@@ -406,7 +406,7 @@ class TestPicmiFoilDistribution(unittest.TestCase, HelperTestPicmiBoundaries):
                 "length and exponential_(pre|post)_plasma_cutoff must be"
                 " set to none or neither!",
             ):
-                entry.get_as_pypicongpu().get_generic_profile_rendering_context()
+                entry.get_as_pypicongpu().get_rendering_context()
 
         testCases = self._get_test_foils(1.0, None)
         for entry in testCases:
@@ -416,7 +416,7 @@ class TestPicmiFoilDistribution(unittest.TestCase, HelperTestPicmiBoundaries):
                 "length and exponential_(pre|post)_plasma_cutoff must be"
                 " set to none or neither!",
             ):
-                entry.get_as_pypicongpu().get_generic_profile_rendering_context()
+                entry.get_as_pypicongpu().get_rendering_context()
 
     def test_mandatory(self):
         """check that mandatory must be given"""
@@ -499,7 +499,7 @@ class TestPicmiGaussianDistribution(unittest.TestCase, HelperTestPicmiBoundaries
         gaussian = self._get_distribution()
         gaussian.density = 0.0
         with self.assertRaisesRegex(ValueError, ".*density must be > 0.*"):
-            gaussian.get_as_pypicongpu().get_generic_profile_rendering_context()
+            gaussian.get_as_pypicongpu().get_rendering_context()
 
     def test_front_rear_swapped(self):
         """front and rear swapped is not accepted"""
@@ -507,19 +507,19 @@ class TestPicmiGaussianDistribution(unittest.TestCase, HelperTestPicmiBoundaries
         gaussian.center_front = self.values["center_rear"]
         gaussian.center_rear = self.values["center_front"]
         with self.assertRaisesRegex(ValueError, ".*center_front must be <= center_rear.*"):
-            gaussian.get_as_pypicongpu().get_generic_profile_rendering_context()
+            gaussian.get_as_pypicongpu().get_rendering_context()
 
     def test_sigma_zero(self):
         """sigma == 0 is not accepted"""
         gaussian = self._get_distribution()
         gaussian.sigma_front = 0.0
         with self.assertRaisesRegex(ValueError, ".*sigma_front must be != 0.*"):
-            gaussian.get_as_pypicongpu().get_generic_profile_rendering_context()
+            gaussian.get_as_pypicongpu().get_rendering_context()
 
         gaussian = self._get_distribution()
         gaussian.sigma_rear = 0.0
         with self.assertRaisesRegex(ValueError, ".*sigma_rear must be != 0.*"):
-            gaussian.get_as_pypicongpu().get_generic_profile_rendering_context()
+            gaussian.get_as_pypicongpu().get_rendering_context()
 
     def test_drift(self):
         """drift is correctly translated"""

--- a/test/python/picongpu/quick/pypicongpu/output/auto.py
+++ b/test/python/picongpu/quick/pypicongpu/output/auto.py
@@ -31,4 +31,6 @@ class TestAuto(unittest.TestCase):
 
         # normal rendering
         context = a.get_rendering_context()
+        self.assertTrue(context["typeID"]["auto"])
+        context = context["data"]
         self.assertEqual(17, context["period"]["specs"][0]["step"])

--- a/test/python/picongpu/quick/pypicongpu/output/phase_space.py
+++ b/test/python/picongpu/quick/pypicongpu/output/phase_space.py
@@ -94,6 +94,8 @@ class TestPhaseSpace(unittest.TestCase):
 
         # normal rendering
         context = ps.get_rendering_context()
+        self.assertTrue(context["typeID"]["phasespace"])
+        context = context["data"]
         self.assertEqual(42, context["period"]["specs"][0]["step"])
         self.assertEqual("x", context["spatial_coordinate"])
         self.assertEqual("px", context["momentum_coordinate"])

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/densityprofile.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/densityprofile.py
@@ -26,16 +26,6 @@ class TestDensityProfile(unittest.TestCase):
         def __init__(self):
             pass
 
-    def test_abstract(self):
-        """density profile is abstract"""
-        with self.assertRaises(NotImplementedError):
-            DensityProfile()
-
-        # also, check() is not implemented
-        dummy = self.DummyCheckNotImplemented()
-        with self.assertRaises(NotImplementedError):
-            dummy.check()
-
     def test_rendering_not_implemented(self):
         """rendering method is defined, but not implemented"""
         dummy = self.DummyCheckNotImplemented()
@@ -53,29 +43,29 @@ class TestDensityProfile(unittest.TestCase):
         RenderedObject._schemas_loaded = False
         RenderedObject._registry = referencing.Registry()
 
-        context = uniform.get_generic_profile_rendering_context()
+        context = uniform.get_rendering_context()
 
         # schemas now loaded
         self.assertTrue(RenderedObject._schemas_loaded)
 
-        self.assertEqual(context["data"], uniform.get_rendering_context())
+        self.assertEqual(context["data"], uniform._get_serialized())
 
         # contains information on all types
-        self.assertEqual(context["type"], {"uniform": True, "foil": False, "gaussian": False})
+        self.assertEqual(context["typeID"], {"uniform": True, "foil": False, "gaussian": False})
 
         # is actually validated against "DensityProfile" schema
         RenderedObject._schemas_loaded = False
         schema = RenderedObject._get_schema_from_class(DensityProfile)
 
         # check 1: schema actually enforce existance of all keys
-        self.assertTrue("uniform" in schema["properties"]["type"]["required"])
+        self.assertTrue("uniform" in schema["properties"]["typeID"]["required"])
         # TODO: copy line above for more types
 
         # check 1b: all keys that are available for the "type" dict are
         # required
         self.assertEqual(
-            set(schema["properties"]["type"]["required"]),
-            set(schema["properties"]["type"]["properties"].keys()),
+            set(schema["properties"]["typeID"]["required"]),
+            set(schema["properties"]["typeID"]["properties"].keys()),
         )
 
         # check 2: break the schema, schema rejects everything now
@@ -83,4 +73,4 @@ class TestDensityProfile(unittest.TestCase):
         with self.assertRaises(referencing.exceptions.NoSuchResource):
             # schema now rejects everything
             # -> must also reject previously correct context
-            uniform.get_generic_profile_rendering_context()
+            uniform.get_rendering_context()

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/foil.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/foil.py
@@ -134,9 +134,14 @@ class TestFoil(unittest.TestCase):
         f.y_value_front_foil_si = 0
         f.thickness_foil_si = 1.0e-5
 
-        expectedContextNoRamp = {"type": {"exponential": False, "none": True}, "data": None}
+        expectedContextNoRamp = {
+            "typeID": {"exponential": False, "none": True},
+            "data": None,
+        }
 
         context = f.get_rendering_context()
+        self.assertTrue(context["typeID"]["foil"])
+        context = context["data"]
         self.assertAlmostEqual(f.density_si, context["density_si"])
         self.assertAlmostEqual(f.y_value_front_foil_si, context["y_value_front_foil_si"])
         self.assertAlmostEqual(f.thickness_foil_si, context["thickness_foil_si"])

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -5,7 +5,10 @@ Authors: Brian Edward Marre
 License: GPLv3+
 """
 
-from picongpu.pypicongpu.species.operation.densityprofile import Gaussian, DensityProfile
+from picongpu.pypicongpu.species.operation.densityprofile import (
+    Gaussian,
+    DensityProfile,
+)
 
 import unittest
 import typeguard
@@ -210,6 +213,8 @@ class TestGaussian(unittest.TestCase):
         g = self._getGaussian()
 
         context = g.get_rendering_context()
+        self.assertTrue(context["typeID"]["gaussian"])
+        context = context["data"]
         self.assertAlmostEqual(g.gas_center_front, context["gas_center_front"])
         self.assertAlmostEqual(g.gas_center_rear, context["gas_center_rear"])
         self.assertAlmostEqual(g.gas_sigma_front, context["gas_sigma_front"])

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/uniform.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/uniform.py
@@ -51,6 +51,8 @@ class TestUniform(unittest.TestCase):
         u.density_si = 42.17
 
         context = u.get_rendering_context()
+        self.assertTrue(context["typeID"]["uniform"])
+        context = context["data"]
         self.assertAlmostEqual(u.density_si, context["density_si"])
 
         # ensure check() is performed

--- a/test/python/picongpu/quick/pypicongpu/species/operation/simpledensity.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/simpledensity.py
@@ -192,7 +192,7 @@ class TestSimpleDensity(unittest.TestCase):
         context = self.sd.get_rendering_context()
 
         self.assertEqual(2, context["ppc"])
-        self.assertEqual(context["profile"], self.sd.profile.get_generic_profile_rendering_context())
+        self.assertEqual(context["profile"], self.sd.profile.get_rendering_context())
 
         # species with lowest ratio must be placed as first, which is species1
         self.assertEqual(context["placed_species_initial"], self.species1.get_rendering_context())
@@ -221,7 +221,7 @@ class TestSimpleDensity(unittest.TestCase):
         context = sd.get_rendering_context()
 
         self.assertEqual(1, context["ppc"])
-        self.assertEqual(context["profile"], sd.profile.get_generic_profile_rendering_context())
+        self.assertEqual(context["profile"], sd.profile.get_rendering_context())
 
         self.assertEqual(context["placed_species_initial"], species.get_rendering_context())
         self.assertEqual(context["placed_species_copied"], [])


### PR DESCRIPTION
This refactoring introduces a protocol for PyPIConGPU classes to self-register as part of a group like `Plugin`, `DensityProfile`, ...

The previous mechanism was built on circularly including their own subclasses inside of the body of their function and maintaining a manual dictionary of those mapping them to some given names. This mechanism was implemented in multiple places with slightly different naming. This PR
- unifies the naming
- replaces the manual generation of the dictionary by a self-registration mechanism
- removes the distinction between `get_rendering_context()` and various slightly different versions of `get_generic_*_context()`

The new protocol consists of two parts:
1. New "groups" (like `Plugin` or `DensityProfile`) are created by inheriting from `SelfRegisteringRenderedObject`.
2. Subclasses of those (like `PhaseSpace` or `EnergyHistogram`) define the variable `_name` to something reasonable. At instantiation of their class (not an instance/object of that class but the class itself) `__init_subclass__()` adds those names to a list.

The manual maintenance of a list of plugins, density profiles, etc. is not completely removed. The schemas of each of their subclasses are still maintained separately and the overarching schemas for `Plugin`, `DensityProfile`, ... still have to list all allowed specialisations but if we ever want to change this, we can do so in a later PR.

The PR is not yet squashed and rebased, but please start reviewing it. I'll do so once in the end if you wish.