### PR TITLE
guard against bound-free transitions with a negative or zero energy difference

### DIFF
--- a/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
@@ -462,6 +462,7 @@ namespace picongpu::particles::atomicPhysics::debug
                 else
                     std::cout << " x Fail" << std::endl;
             }
+            std::cout << std::endl;
             return pass_total;
         }
     };

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/AutonomousTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/AutonomousTransitionRates.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre, Axel Huebl
+/* Copyright 2023-2025 Brian Marre, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -49,14 +49,15 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          * @param transitionCollectionIndex index of transition in autonomousTransitionDataBox
          * @param autonomousTransitionDataBox access to autonomous transition data
          *
-         * @return unit: 1/sim.unit.time(), usually Delta_T_SI ... PIC time step length
+         * @return unit: 1/sim.unit.time
          */
         template<typename T_AutonomousTransitionDataBox>
         HDINLINE static float_X rateAutonomousIonization(
             uint32_t const transitionCollectionIndex,
             T_AutonomousTransitionDataBox const autonomousTransitionDataBox)
         {
-            return autonomousTransitionDataBox.rate(transitionCollectionIndex); // 1/sim.unit.time()
+            // 1/sim.unit.time
+            return autonomousTransitionDataBox.rate(transitionCollectionIndex);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::rateCalculation

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
@@ -182,7 +182,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          * @tparam T_BoundBoundTransitionDataBox instantiated type of dataBox
          * @tparam T_excitation true =^= excitation, false =^= deexcitation, direction of transition
          *
-         * @param energyElectron kinetic energy of interacting free electron(/electron bin), [eV]
+         * @param energyElectron kinetic energy of interacting free electron(/electron bin), in eV
          * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
          * @param atomicStateDataBox access to atomic state property data
          * @param boundBoundTransitionDataBox access to bound-bound transition data
@@ -194,7 +194,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          */
         template<typename T_AtomicStateDataBox, typename T_BoundBoundTransitionDataBox, bool T_excitation>
         HDINLINE static float_X collisionalBoundBoundCrossSection(
-            float_X const energyElectron, // [eV]
+            float_X const energyElectron,
             uint32_t const transitionCollectionIndex,
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundBoundTransitionDataBox const boundBoundTransitionDataBox)

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre, Axel Huebl
+/* Copyright 2023-2025 Brian Marre, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -83,6 +83,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          * @param U (kinetic energy of interacting electron)/(ionization potential of initial level), unitless
          * @param beta beta factor from
          *
+         * @attention U must be > 0
+         *
          * @return unitless
          */
         HDINLINE static float_64 wFactor(float_X const U, float_X const beta)
@@ -97,8 +99,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          * @tparam T_AtomicStateDataBox instantiated type of dataBox
          * @tparam T_BoundFreeTransitionDataBox instantiated type of dataBox
          *
-         * @param energyElectron kinetic energy of interacting free electron(/electron bin), eV
-         * @param ionizationPotentialDepression in eV
+         * @param energyElectron kinetic energy of interacting free electron(/electron bin), in eV
+         * @param ionizationPotentialDepression, in eV
          * @param transitionCollectionIndex index of transition in boundBoundTransitionDataBox
          * @param atomicStateDataBox access to atomic state property data
          * @param boundBoundTransitionDataBox access to bound-bound transition data
@@ -154,20 +156,30 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             }
 
             float_X result = 0._X;
-            if(energyDifference <= energyElectron)
+
+            /// @details ">", since energyDifference == energyElectron causes w == 0 -> cross section == 0, therefore
+            /// skip calculation
+            bool const electronEnergySufficientForTransitions = (energyDifference < energyElectron);
+
+            /// @details energyDifference > = since otherwise U is a NaN
+            /// @details also ensures energyElectron > 0, otherwise U = 0 for which the wFactor(U, beta) is not defined
+            if((energyDifference > 0) && electronEnergySufficientForTransitions)
             {
-                constexpr float_64 C = 2.3; // a fitting factor well suited for Z >= 2, unitless
-                constexpr float_64 a0 = sim.si.getBohrRadius(); // m
-                constexpr float_64 E_R = sim.si.conv().joule2eV(sim.si.getRydbergEnergy()); // eV
+                // a fitting factor well suited for Z >= 2, unitless
+                constexpr float_64 C = 2.3;
+                // m
+                constexpr float_64 a0 = sim.si.getBohrRadius();
+                // eV
+                constexpr float_64 E_R = sim.si.conv().joule2eV(sim.si.getRydbergEnergy());
+                /* m^2 / (m^2/10^6*b) * (eV)^2= m^2/m^2 * 10^6*b * eV^2
+                 * unit:  10^6*b * eV^2*/
                 constexpr float_64 scalingConstant
                     = C * picongpu::PI * pmacc::math::cPow(a0, 2u) / 1e-22 * pmacc::math::cPow(E_R, 2u);
-                // 10^6*b * eV^2
-                // m^2 / (m^2/10^6*b) * (eV)^2= m^2/m^2 * 10^6*b * eV^2
 
                 uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
 
-                /// @todo replace with screenedCharge(upperStateChargeState)?, Brian Marre, 2023
-                float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X; // [e]
+                // e
+                float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
 
                 // unitless
                 float_X const U = energyElectron / energyDifference;
@@ -175,11 +187,14 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
                 float_X const beta = betaFactor(screenedCharge);
                 // unitless
                 float_64 const w = wFactor(U, beta);
+
+                /* 1e6*b * (eV)^2 * unitless / (eV)^2 / unitless * log(unitless) * unitless
+                 * unit: 1e6*b */
                 float_X const crossSection = static_cast<float_X>(
                     scalingConstant * combinatorialFactor
                     / static_cast<float_64>(pmacc::math::cPow(energyDifference, 2u)) / static_cast<float_64>(U)
-                    * math::log(static_cast<float_64>(U)) * w); // [1e6*b]
-                // 1e6*b * (eV)^2 * unitless / (eV)^2 / unitless * log(unitless) * unitless
+                    * math::log(static_cast<float_64>(U)) * w);
+
                 if(crossSection > 0._X)
                     result = crossSection;
             }

--- a/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/BoundFreeCollisionalTransitions.py
+++ b/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/BoundFreeCollisionalTransitions.py
@@ -59,9 +59,15 @@ class BoundFreeCollisionalTransitions:
             lowerStateLevelVector, upperStateLevelVector
         )
 
+        print("\t\t ionizationEnergy: {:.4}".format(ionizationEnergy))
+        print("\t\t energyDifference: {:.4}".format(energyDifference))
+        print("\t\t U: {:.4}".format(U))
+        print("\t\t wFactor: {:.4}".format(BoundFreeCollisionalTransitions._wFactor(U, screenedCharge)))
+
+        rate = 0
         # m^2 * (eV/(eV))^2 * 1/(eV/eV) * unitless * unitless / (m^2/1e6b) = 1e6b
         if U > 1:
-            return (
+            rate = (
                 np.pi
                 * const.value("Bohr radius") ** 2
                 * 2.3
@@ -72,8 +78,8 @@ class BoundFreeCollisionalTransitions:
                 * np.log(U)
                 * BoundFreeCollisionalTransitions._wFactor(U, screenedCharge)
             ) / 1e-22  # 1e6b, 1e-22 m^2
-        else:
-            return 0.0
+
+        return rate
 
     @staticmethod
     def rateCollisionalIonization(

--- a/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/BoundFreeFieldTransitions.py
+++ b/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/BoundFreeFieldTransitions.py
@@ -94,6 +94,7 @@ class BoundFreeFieldTransitions:
         rate = (
             F * np.float32(D**2.0 * gamowFactor) * np.sqrt((3.0 * nEff**3.0 * F) / (np.pi * Z**3.0)) / (8.0 * np.pi * Z)
         )
+        print("\t\t rate[AU]: {:.6}".format(rate))
         return rate
 
     @staticmethod

--- a/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/calculatorMain.py
+++ b/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/calculatorMain.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     # in eV
     Hartree = 27.211386245981
     # in Hartree
-    ionizationEnergy = 5.0 / Hartree
+    ionizationEnergy_ADK = 5.0 / Hartree
     # in atomic_unit["electric field"] ~ 5.1422e11 V/m
     fieldStrength = 0.0126
 
@@ -131,13 +131,13 @@ if __name__ == "__main__":
 
     print("- bound-free field")
     # in unit electric field atomic units
-    nEff = boundfreefield.BoundFreeFieldTransitions.n_eff_numpy(screenedCharge, ionizationEnergy)
+    nEff = boundfreefield.BoundFreeFieldTransitions.n_eff_numpy(screenedCharge, ionizationEnergy_ADK)
     fieldStrengthMaxADKRate = 4.0 * screenedCharge**3 / (3.0 * nEff**3 * (4.0 * nEff - 3.0))
     print(
-        "\t ADK fieldStrength: {0:.4e}, F_maxADK: {1:.4e}, F_crit_BSI: {2:.4e}".format(
+        "\t ADK:\n \t\t fieldStrength: {0:.4e}\n\t\t F_maxADK: {1:.4e}\n\t\t F_crit_BSI: {2:.4e}".format(
             fieldStrength,
             fieldStrengthMaxADKRate,
-            boundfreefield.BoundFreeFieldTransitions.F_crit_BSI(screenedCharge, ionizationEnergy),
+            boundfreefield.BoundFreeFieldTransitions.F_crit_BSI(screenedCharge, ionizationEnergy_ADK),
         )
     )
 
@@ -145,7 +145,7 @@ if __name__ == "__main__":
         "\t ADK rate(numpy) : {0:.9e} * 1/(3.3e-17s)".format(
             np.float32(
                 boundfreefield.BoundFreeFieldTransitions.ADKRate_numpy(
-                    np.float32(screenedCharge), np.float32(ionizationEnergy), np.float32(fieldStrength)
+                    np.float32(screenedCharge), np.float32(ionizationEnergy_ADK), np.float32(fieldStrength)
                 )
                 * 3.3e-17
                 / boundfreefield.atomic_unit["time"]
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         "\t ADK rate(mpmath): "
         + mp.nstr(
             boundfreefield.BoundFreeFieldTransitions.ADKRate_mpmath(
-                mp.mpf(screenedCharge), mp.mpf(ionizationEnergy), mp.mpf(fieldStrength)
+                mp.mpf(screenedCharge), mp.mpf(ionizationEnergy_ADK), mp.mpf(fieldStrength)
             )
             * mp.mpf(3.3e-17)
             / mp.mpf(boundfreefield.atomic_unit["time"]),


### PR DESCRIPTION
adds missing guards in the bound-free transition rate calculations for bound-free transitions for an energy difference between lower and upper state below or equal to 0.