### PR TITLE
make kernel struct public in binning plugin LinearAxis

### DIFF
--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -58,6 +58,7 @@ namespace picongpu
                     }
                 }
 
+            public:
                 struct LinearAxisKernel
                 {
                     /** Function to place particle on axis, returns same type as min and max */
@@ -140,8 +141,6 @@ namespace picongpu
                     }
                 };
 
-
-            public:
                 using Type = T_Attribute;
 
                 AxisSplitting<T_Attribute> axisSplit;


### PR DESCRIPTION
Full compile of #5347 showed that with CUDA some combinations doesn't like the private definition of the `LinearAxisKernel`, so made this public