### PR TITLE
Fix typos in cfg files in LWFA example

### DIFF
--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/1.cfg
@@ -68,7 +68,7 @@ TBG_openPMD="--openPMD.period 100   \
              --openPMD.file simData \
              --openPMD.ext bp \
              --checkpoint.backend openPMD \
-             --checkpoint.period 100
+             --checkpoint.period 100 \
              --checkpoint.restart.backend openPMD"
 
 # macro particle counter (electrons, debug information for memory)

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/4.cfg
@@ -69,7 +69,7 @@ TBG_openPMD="--openPMD.period 100   \
             --openPMD.file simData \
             --openPMD.ext bp \
             --checkpoint.backend openPMD \
-            --checkpoint.period 100
+            --checkpoint.period 100 \
             --checkpoint.restart.backend openPMD"
 
 # macro particle counter (electrons, debug information for memory)

--- a/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
+++ b/share/picongpu/examples/LaserWakefield/etc/picongpu/8.cfg
@@ -69,7 +69,7 @@ TBG_openPMD="--openPMD.period 100   \
             --openPMD.file simData \
             --openPMD.ext bp \
             --checkpoint.backend openPMD \
-            --checkpoint.period 100
+            --checkpoint.period 100 \
             --checkpoint.restart.backend openPMD"
 
 # macro particle counter (electrons, debug information for memory)


### PR DESCRIPTION
Interestingly, the missing trailing backslashes have not been noticed before in the cfg files here