### PR TITLE
add capella cluster at ZIH / TU Dresden setup

### DIFF
--- a/etc/picongpu/taurus-tud/capella.tpl
+++ b/etc/picongpu/taurus-tud/capella.tpl
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Copyright 2013-2024 Axel Huebl, Richard Pausch, Alexander Debus, Klaus Steiniger
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# PIConGPU batch script for alpha centauri's SLURM batch system
+
+#SBATCH --partition=!TBG_queue
+#SBATCH --time=!TBG_wallTime
+# Sets batch job's name
+#SBATCH --job-name=!TBG_jobName
+#SBATCH --nodes=!TBG_nodes
+#SBATCH --ntasks=!TBG_tasks
+#SBATCH --ntasks-per-node=!TBG_gpusPerNode
+#SBATCH --mincpus=!TBG_mpiTasksPerNode
+#SBATCH --cpus-per-task=!TBG_coresPerGPU
+#SBATCH --mem=0
+#SBATCH --gres=gpu:!TBG_gpusPerNode
+#SBATCH --exclusive
+
+# disable hyperthreading (default on taurus)
+#SBATCH --hint=nomultithread
+
+#SBATCH --mail-type=!TBG_mailSettings
+#SBATCH --mail-user=!TBG_mailAddress
+#SBATCH --chdir=!TBG_dstPath
+
+#SBATCH -o stdout
+#SBATCH -e stderr
+
+
+## calculations will be performed by tbg ##
+.TBG_queue="capella"
+
+# settings that can be controlled by environment variables before submit
+.TBG_mailSettings=${MY_MAILNOTIFY:-"ALL"}
+.TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
+.TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
+
+# number of CPU cores to block per GPU
+# we got 14 CPU cores per GPU ((65-8)cores/4gpus = 14cores)
+.TBG_coresPerGPU=14
+.TBG_numHostedGPUPerNode=4
+.TBG_gpusPerNode=$(if [ $TBG_tasks -gt $TBG_numHostedGPUPerNode ] ; then echo $TBG_numHostedGPUPerNode; else echo $TBG_tasks; fi)
+
+# We only start 1 MPI task per GPU
+.TBG_mpiTasksPerNode="$(( TBG_gpusPerNode * 1 ))"
+
+# use ceil to calculate nodes
+.TBG_nodes="$((( TBG_tasks + TBG_gpusPerNode -1 ) / TBG_gpusPerNode))"
+
+## end calculations ##
+
+echo 'Running program...'
+
+cd !TBG_dstPath
+
+export MODULES_NO_OUTPUT=1
+source !TBG_profile
+if [ $? -ne 0 ] ; then
+  echo "Error: PIConGPU environment profile under \"!TBG_profile\" not found!"
+  exit 1
+fi
+unset MODULES_NO_OUTPUT
+
+# set user rights to u=rwx;g=r-x;o=---
+umask 0027
+
+mkdir simOutput 2> /dev/null
+cd simOutput
+ln -s ../stdout output
+
+# we are not sure if the current bullxmpi/1.2.4.3 catches pinned memory correctly
+#   support ticket [Ticket:2014052241001186] srun: mpi mca flags
+#   see bug https://github.com/ComputationalRadiationPhysics/picongpu/pull/438
+export OMPI_MCA_mpi_leave_pinned=0
+
+# test if cuda_memtest binary is available
+if [ -f !TBG_dstPath/input/bin/cuda_memtest ] ; then
+  # Run CUDA memtest to check GPU's health
+  srun -K1 !TBG_dstPath/input/bin/cuda_memtest.sh
+else
+  echo "Note: GPU memory test was skipped as no binary 'cuda_memtest' available. This does not affect PIConGPU, starting it now" >&2
+fi
+
+if [ $? -eq 0 ] ; then
+  # Run PIConGPU
+  srun -K1 !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+fi

--- a/etc/picongpu/taurus-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/taurus-tud/capella_picongpu.profile.example
@@ -1,0 +1,100 @@
+#Name and Path of this Script ############################### (DO NOT change!)
+export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+
+# User Information ################################# (edit the following lines)
+#   - automatically add your name and contact to output file meta data
+#   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,
+#     TIME_LIMIT, TIME_LIMIT_90, TIME_LIMIT_80 and/or TIME_LIMIT_50
+export MY_MAILNOTIFY="NONE"
+export MY_MAIL="someone@example.com"
+export MY_NAME="$(whoami) <$MY_MAIL>"
+
+# Text Editor for Tools ###################################### (edit this line)
+#   - examples: "nano", "vim", "emacs -nw", "vi" or without terminal: "gedit"
+#export EDITOR="vim"
+
+# Modules #####################################################################
+#
+module load release/24.04
+module load GCC/13.2.0
+module load CUDA/12.6.0
+module load CMake/3.27.6
+module load Boost/1.83.0
+module load OpenMPI/4.1.6
+module load HDF5/1.14.3
+module load libpng/1.6.40
+module load FFTW/3.3.10
+
+# Self-Build Software #########################################################
+#
+
+export PROJECT_NAME="p_name_of_your_project"
+
+export PIC_LIBS=/projects/$PROJECT_NAME/capella_setup/lib/
+export CMAKE_PREFIX_PATH=$PIC_LIBS/adios2/:$CMAKE_PREFIX_PATH
+export BLOSC_ROOT=$CMAKE_PREFIX_PATH/c-blosc
+export CMAKE_PREFIX_PATH=$BLOSC_ROOT:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS/openPMD-api:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$PIC_LIBS/pngwriter:$CMAKE_PREFIX_PATH
+
+
+export PICSRC=$HOME/picongpu/
+export PIC_EXAMPLES=$PICSRC/share/picongpu/examples
+export PIC_BACKEND="cuda:90"
+
+# Path to the required templates of the system,
+# relative to the PIConGPU source code of the tool bin/pic-create.
+export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/taurus-tud"}
+
+export PATH=$PICSRC/bin:$PATH
+export PATH=$PICSRC/src/tools/bin:$PATH
+
+# python not included yet
+export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
+
+# This is necessary in order to make alpaka compile.
+# The workaround is from Axel Huebl according to alpaka PR #702.
+export CXXFLAGS="-Dlinux"
+
+# "tbg" default options #######################################################
+#   - SLURM (sbatch)
+#   - "alpha" queue
+export TBG_SUBMIT="sbatch"
+export TBG_TPLFILE="etc/picongpu/taurus-tud/capella.tpl"
+
+# allocate an interactive shell for two hours
+#   getNode 2  # allocates 2 interactive nodes (default: 1)
+function getNode() {
+    if [ -z "$1" ] ; then
+        numNodes=1
+    else
+        numNodes=$1
+    fi
+    export OMP_NUM_THREADS=14
+    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((4 * $numNodes)) --ntasks-per-node=4 --cpus-per-task=14 --mem=0 --exclusive --gres=gpu:4 -p capella --pty bash
+}
+
+# allocate an interactive shell for two hours
+#   getDevice 2  # allocates 2 interactive devices on one node (default: 1)
+function getDevice() {
+    if [ -z "$1" ] ; then
+        numDevices=1
+    else
+        if [ "$1" -gt 4 ] ; then
+            echo "The maximal number of devices per node is 4." 1>&2
+            return 1
+        else
+            numDevices=$1
+        fi
+    fi
+    export OMP_NUM_THREADS=14
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=14 --mem=$((1530000 * $numDevices)) --gres=gpu:$numDevices -p capella --pty bash
+}
+
+# Load autocompletion for PIConGPU commands
+BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
+if [ -f $BASH_COMP_FILE ] ; then
+    source $BASH_COMP_FILE
+else
+    echo "bash completion file '$BASH_COMP_FILE' not found." >&2
+fi


### PR DESCRIPTION
This adds the example profile and the `*.tpl` file for the [Capella cluster](https://compendium.hpc.tu-dresden.de/jobs_and_resources/capella/) at ZIH / TU Dresden. 

There seems to be no clear documentation on how much memory one can request per node. Thus, I had to test it out. 

@BeyondEspresso Could you please test compiling with the pre-compiled libraries. 