### PR TITLE
Fix in cell position of binning

### DIFF
--- a/include/picongpu/plugins/binning/WriteHist.hpp
+++ b/include/picongpu/plugins/binning/WriteHist.hpp
@@ -170,7 +170,8 @@ namespace picongpu
                  * The value represents an aggregation over one cell, so any value is correct for the mesh position.
                  * Just use the center.
                  */
-                record.setPosition(std::vector<float>{0.5, 0.5});
+                std::vector<float> positionVector(binningData.getNAxes(), 0.5f);
+                record.setPosition(positionVector);
 
                 ::openPMD::Offset histOffset;
                 ::openPMD::Extent histExtent;


### PR DESCRIPTION
Fix position in openPMD output of the binning plugin to use correct number of dimensions (number of axes) 