### PR TITLE
Fix CFL condition assert messages

### DIFF
--- a/include/picongpu/fields/MaxwellSolver/CKC/CKC.hpp
+++ b/include/picongpu/fields/MaxwellSolver/CKC/CKC.hpp
@@ -58,7 +58,7 @@ namespace picongpu
 
                     // Dependence on T_Defer is required, otherwise this check would have been enforced for each setup
                     PMACC_CASSERT_MSG(
-                        Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
+                        Courant_Friedrichs_Lewy_condition_failure____check_your_simulation_param_file,
                         (cdt <= delta) && sizeof(T_Defer*) != 0);
 
                     return delta;

--- a/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Lehe/Lehe.hpp
@@ -60,7 +60,7 @@ namespace picongpu
                     // Dependance on T_Defer is required, otherwise this check would have been enforced for each setup
                     constexpr auto dt = getTimeStep();
                     PMACC_CASSERT_MSG(
-                        Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
+                        Courant_Friedrichs_Lewy_condition_failure____check_your_simulation_param_file,
                         (sim.pic.getSpeedOfLight() * dt) <= stepFreeDirection && sizeof(T_Defer*) != 0);
 
                     return stepFreeDirection;

--- a/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
+++ b/include/picongpu/fields/MaxwellSolver/Yee/Yee.hpp
@@ -54,7 +54,7 @@ namespace picongpu
                     constexpr float_X invCellSizeSquaredSum
                         = (1.0 / (cellSizeSimDim * cellSizeSimDim)).sumOfComponents();
                     PMACC_CASSERT_MSG(
-                        Courant_Friedrichs_Lewy_condition_failure____check_your_grid_param_file,
+                        Courant_Friedrichs_Lewy_condition_failure____check_your_simulation_param_file,
                         (sim.pic.getSpeedOfLight() * sim.pic.getSpeedOfLight() * dt * dt * invCellSizeSquaredSum)
                                 <= 1.0
                             && sizeof(T_Defer*) != 0);

--- a/include/picongpu/particles/Particles.tpp
+++ b/include/picongpu/particles/Particles.tpp
@@ -327,7 +327,7 @@ namespace picongpu
         constexpr auto dz = (simDim == 3) ? sim.pic.getCellSize().z() : std::numeric_limits<float_X>::infinity();
         constexpr auto minCellSize = std::min({sim.pic.getCellSize().x(), sim.pic.getCellSize().y(), dz});
         PMACC_CASSERT_MSG(
-            Particle_in_pusher_cannot_pass_more_than_1_cell_per_time_step____check_your_grid_param_file,
+            Particle_in_pusher_must_not_pass_more_than_1_cell_per_time_step____check_your_simulation_param_file,
             (sim.pic.getSpeedOfLight() * sim.pic.getDt() / minCellSize <= 1.0) && sizeof(T_Pusher*) != 0);
 
         PMACC_CASSERT_MSG(

--- a/include/picongpu/simulation/stage/CurrentDeposition.x.cpp
+++ b/include/picongpu/simulation/stage/CurrentDeposition.x.cpp
@@ -66,7 +66,7 @@ namespace picongpu
                         constexpr auto minCellSize
                             = std::min({sim.pic.getCellSize().x(), sim.pic.getCellSize().y(), dz});
                         PMACC_CASSERT_MSG(
-                            Particle_in_current_deposition_cannot_pass_more_than_1_cell_per_time_step____check_your_grid_param_file,
+                            Particle_in_current_deposition_cannot_pass_more_than_1_cell_per_time_step____check_your_simulation_param_file,
                             (sim.pic.getSpeedOfLight() * sim.pic.getDt() / minCellSize <= 1.0)
                                 && sizeof(SpeciesType*) != 0);
 


### PR DESCRIPTION
Needed to point to `simulation.param` instead of `grid.param` since #5061.