### PR TITLE
add poisson solver to generate electrical field from non neutral charged gas densities

### DIFF
--- a/include/picongpu/fields/Fields.def
+++ b/include/picongpu/fields/Fields.def
@@ -68,4 +68,8 @@ namespace picongpu
     /** Current Density j, @see FieldJ.hpp */
     class FieldJ;
 
+    namespace fields::poissonSolver
+    {
+        struct FieldV;
+    } // namespace fields::poissonSolver
 } // namespace picongpu

--- a/include/picongpu/fields/Fields.hpp
+++ b/include/picongpu/fields/Fields.hpp
@@ -25,3 +25,4 @@
 #include "picongpu/fields/FieldJ.hpp"
 #include "picongpu/fields/FieldTmp.hpp"
 #include "picongpu/fields/Fields.def"
+#include "picongpu/fields/poissonSolver/FieldV.hpp"

--- a/include/picongpu/fields/poissonSolver/BICGStab.hpp
+++ b/include/picongpu/fields/poissonSolver/BICGStab.hpp
@@ -1,0 +1,18 @@
+
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldTmpOperations.hpp"
+
+struct BICGStab
+    {
+        // return residual
+        // return number of iterations 
+        void operator()(FieldTmp& fieldV, FieldTmp& fiedlRho, MappingDesk *cellDescription)
+        {
+            // set boundary conditions on fieldV (Dirichlet or Neuman)
+
+            // normalize the problem based on norm(fieldRho)
+
+
+
+        }
+    };

--- a/include/picongpu/fields/poissonSolver/BICGStab.hpp
+++ b/include/picongpu/fields/poissonSolver/BICGStab.hpp
@@ -1,18 +1,35 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragme once
 
 #include "picongpu/defines.hpp"
 #include "picongpu/fields/FieldTmpOperations.hpp"
 
 struct BICGStab
+{
+    // return residual
+    // return number of iterations
+    void operator()(FieldTmp& fieldV, FieldTmp& fiedlRho, MappingDesk* cellDescription)
     {
-        // return residual
-        // return number of iterations 
-        void operator()(FieldTmp& fieldV, FieldTmp& fiedlRho, MappingDesk *cellDescription)
-        {
-            // set boundary conditions on fieldV (Dirichlet or Neuman)
+        // set boundary conditions on fieldV (Dirichlet or Neuman)
 
-            // normalize the problem based on norm(fieldRho)
-
-
-
-        }
-    };
+        // normalize the problem based on norm(fieldRho)
+    }
+};

--- a/include/picongpu/fields/poissonSolver/BoundaryConditions.hpp
+++ b/include/picongpu/fields/poissonSolver/BoundaryConditions.hpp
@@ -1,94 +1,112 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
 
 #include "picongpu/defines.hpp"
 #include "picongpu/fields/FieldTmpOperations.hpp"
+#include "picongpu/fields/poissonSolver/FieldV.hpp"
 
-struct BoundaryConditionsDirichlet
+#include <pmacc/lockstep/lockstep.hpp>
+#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
+#include <pmacc/memory/dataTypes/Mask.hpp>
+
+namespace picongpu::fields::poissonSolver
+{
+    struct SolutionFunction
     {
-        // return residual
-        // return number of iterations 
-        void operator()(FieldTmp& fieldV, FieldTmp& fiedlRho, MappingDesk *cellDescription)
+        HDINLINE auto operator()(math::Vector<double, simDim> const& totalCellCoordinate) const
         {
-            // set boundary conditions on fieldV (Dirichlet or Neuman)
-
-            // normalize the problem based on norm(fieldRho)
-
-            pmacc::GridController<simDim>& gc = pmacc::Environment<simDim>::get().GridController();
-
-            DataSpace<simDim> myGPUpos(gc.getPosition());
-            DataSpace<simDim> gpus(gc.getGpuNodes());
-            SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
-            auto globalDomain = subGrid.getGlobalDomain();
-            auto localDomain = subGrid.getLocalDomain()
-            auto const mapper = makeAreaMapper<BORDER>(*cellDescription());
-
-            
-            
-            for(int dir=0; dir<simDim; dir++)
+            if constexpr(simDim == 3u)
             {
-                
-                // todo check for moving window
-                if(myGPUpos[dir] == 0){
-                    DataSpace<2*Dim> indexLimitsEdge = ;
-                    indexLimitsEdge[2*dir+1] = indexLimitsEdge[2*dir] + guardsSize[dir];
-                    PMACC_LOCKSTEP_KERNEL().config(mapper.getGridDim(), SuperCellSize{})();}
-
-                if(myGPUpos[dir] == gpus[dir] -1){
-                    PMACC_LOCKSTEP_KERNEL(KernelComputeSupercells<BlockArea>{})
-                .config(mapper.getGridDim(), pBox)(fieldTmpBox, pBox, solver, iFilter, mapper);
-                }
-
-
-
-                dirAlpaka = 2 - dir;
-                if(hasBoundary_[2*dir] && bcsType_[2*dir]==0)
-                {
-                    indexLimitsEdge = this->alpakaHelper_.indexLimitsDataAlpaka_;
-                    indexLimitsEdge[2*dirAlpaka+1]=indexLimitsEdge[2*dirAlpaka] + guards_[dir];
-                    alpaka::exec<Acc>(this->queueSolverNonBlocking1_, workDivExtentApplyDirichletBCsFromFunctionKernel_, applyDirichletBCsFromFunctionKernel, bufMdSpan, this->exactSolutionAndBCs_, 
-                                            indexLimitsEdge, this->alpakaHelper_.indexLimitsDataAlpaka_, this->alpakaHelper_.ds_, this->alpakaHelper_.origin_, 
-                                            this->alpakaHelper_.globalLocation_, this->alpakaHelper_.nlocal_noguards_, this->alpakaHelper_.haloSize_ );
-
-                }
-                if(hasBoundary_[2*dir+1] && bcsType_[2*dir+1]==0)
-                {
-                    indexLimitsEdge = this->alpakaHelper_.indexLimitsDataAlpaka_;
-                    indexLimitsEdge[2*dirAlpaka]=indexLimitsEdge[2*dirAlpaka+1] - guards_[dir];
-                    alpaka::exec<Acc>(this->queueSolverNonBlocking1_, workDivExtentApplyDirichletBCsFromFunctionKernel_, applyDirichletBCsFromFunctionKernel, bufMdSpan, this->exactSolutionAndBCs_, 
-                                            indexLimitsEdge, this->alpakaHelper_.indexLimitsDataAlpaka_, this->alpakaHelper_.ds_, this->alpakaHelper_.origin_, 
-                                            this->alpakaHelper_.globalLocation_, this->alpakaHelper_.nlocal_noguards_, this->alpakaHelper_.haloSize_ );
-                }
+                return math::sin(totalCellCoordinate.x()) + math::cos(totalCellCoordinate.y())
+                       + 3.0 * math::sin(totalCellCoordinate.z())
+                       + totalCellCoordinate.x() * totalCellCoordinate.productOfComponents() + 10.0;
             }
-
+            else if constexpr(simDim == 2u)
+            {
+                return math::sin(totalCellCoordinate.x()) + math::cos(totalCellCoordinate.y())
+                       + totalCellCoordinate.x() * totalCellCoordinate.productOfComponents() + 10.0;
+            }
         }
     };
 
-
-template<int DIM, typename T_data> 
-struct ApplyDirichletBCsFromFunctionKernel
-{
-    template<typename TAcc, typename TMdSpan>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, TMdSpan bufData, const auto boundaryFunction, DataSpace<Dim> guardsSize, DataSpace<Dim> extents, DataSpace<Dim> offsets ) const -> void
+    struct ApplyDirichletBCsFromFunctionKernel
     {
-        // Get indexes
-        auto const gridThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-    
-        auto const gridThreadIdxShifted = gridThreadIdx + guardsSize;
-        //auto const indxData = gridThreadIdxShifted + adjustIdx;
-        //auto const indxGuard = gridThreadIdxShifted - adjustIdx;
-        
-        auto const iGrid = gridThreadIdxShifted[2];
-        auto const jGrid = gridThreadIdxShifted[1];
-        auto const kGrid = gridThreadIdxShifted[0];
-
-        const T_data x = (iGrid-indexLimitsData[4])*ds[2] + offsets[2]*ds[2];
-        const T_data y = (jGrid-indexLimitsData[2])*ds[1] + offsets[1]*ds[1];
-        const T_data z = (kGrid-indexLimitsData[0])*ds[0] + offsets[0]*ds[0];
-
-
-        if( iGrid>=indexLimitsEdge[4] && iGrid<indexLimitsEdge[5] && jGrid>=indexLimitsEdge[2] && jGrid<indexLimitsEdge[3] && kGrid>=indexLimitsEdge[0] && kGrid<indexLimitsEdge[1])
+        DINLINE auto operator()(
+            auto const& worker,
+            auto fieldVBox,
+            auto const boundaryFunction,
+            DataSpace<simDim> cellOffsetToTotalOrigin,
+            auto const mapper) const -> void
         {
-            bufData(gridThreadIdxShifted[0],gridThreadIdxShifted[1],gridThreadIdxShifted[2]) = boundaryFunction(x,y,z);
+            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+            DataSpace<simDim> superCellTotalCellOffset
+                = cellOffsetToTotalOrigin + superCellIdx * SuperCellSize::toRT();
+
+            constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+            auto forEachCellInSupercell = lockstep::makeForEach<cellsPerSuperCell>(worker);
+
+            forEachCellInSupercell(
+                [&](int32_t const linearCellIdx)
+                {
+                    /* cell index within the superCell */
+                    DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
+                    DataSpace<simDim> const totalCellIdx = superCellTotalCellOffset + cellIdx;
+
+                    auto totalDistance = precisionCast<float_64>(totalCellIdx)
+                                         * precisionCast<float_64>(sim.pic.getCellSize().shrink<simDim>());
+
+                    fieldVBox(superCellIdx * SuperCellSize::toRT() + cellIdx) = boundaryFunction(totalDistance);
+                });
         }
-    }
-};
-    
+    };
+
+    struct BoundaryConditionsDirichlet
+    {
+        // return residual
+        // return number of iterations
+        void operator()(FieldV& fieldV, MappingDesc cellDescription) const
+        {
+            SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
+            auto globalDomain = subGrid.getGlobalDomain();
+            auto localDomain = subGrid.getLocalDomain();
+
+            auto cellOffsetToTotalOrigin = globalDomain.offset + localDomain.offset;
+
+
+            for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
+            {
+                /* only call for planes: left right top bottom back front*/
+                if(FRONT % i == 0 && !(Environment<simDim>::get().GridController().getCommunicationMask().isSet(i)))
+                {
+                    ExchangeMapping<GUARD, MappingDesc> mapper(cellDescription, i);
+
+                    PMACC_LOCKSTEP_KERNEL(ApplyDirichletBCsFromFunctionKernel{})
+                        .config(mapper.getGridDim(), SuperCellSize{})(
+                            fieldV.fieldVBuffer->getDeviceBuffer().getDataBox(),
+                            SolutionFunction{},
+                            cellOffsetToTotalOrigin,
+                            mapper);
+                }
+            }
+        }
+    };
+} // namespace picongpu::fields::poissonSolver

--- a/include/picongpu/fields/poissonSolver/BoundaryConditions.hpp
+++ b/include/picongpu/fields/poissonSolver/BoundaryConditions.hpp
@@ -1,0 +1,94 @@
+
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldTmpOperations.hpp"
+
+struct BoundaryConditionsDirichlet
+    {
+        // return residual
+        // return number of iterations 
+        void operator()(FieldTmp& fieldV, FieldTmp& fiedlRho, MappingDesk *cellDescription)
+        {
+            // set boundary conditions on fieldV (Dirichlet or Neuman)
+
+            // normalize the problem based on norm(fieldRho)
+
+            pmacc::GridController<simDim>& gc = pmacc::Environment<simDim>::get().GridController();
+
+            DataSpace<simDim> myGPUpos(gc.getPosition());
+            DataSpace<simDim> gpus(gc.getGpuNodes());
+            SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
+            auto globalDomain = subGrid.getGlobalDomain();
+            auto localDomain = subGrid.getLocalDomain()
+            auto const mapper = makeAreaMapper<BORDER>(*cellDescription());
+
+            
+            
+            for(int dir=0; dir<simDim; dir++)
+            {
+                
+                // todo check for moving window
+                if(myGPUpos[dir] == 0){
+                    DataSpace<2*Dim> indexLimitsEdge = ;
+                    indexLimitsEdge[2*dir+1] = indexLimitsEdge[2*dir] + guardsSize[dir];
+                    PMACC_LOCKSTEP_KERNEL().config(mapper.getGridDim(), SuperCellSize{})();}
+
+                if(myGPUpos[dir] == gpus[dir] -1){
+                    PMACC_LOCKSTEP_KERNEL(KernelComputeSupercells<BlockArea>{})
+                .config(mapper.getGridDim(), pBox)(fieldTmpBox, pBox, solver, iFilter, mapper);
+                }
+
+
+
+                dirAlpaka = 2 - dir;
+                if(hasBoundary_[2*dir] && bcsType_[2*dir]==0)
+                {
+                    indexLimitsEdge = this->alpakaHelper_.indexLimitsDataAlpaka_;
+                    indexLimitsEdge[2*dirAlpaka+1]=indexLimitsEdge[2*dirAlpaka] + guards_[dir];
+                    alpaka::exec<Acc>(this->queueSolverNonBlocking1_, workDivExtentApplyDirichletBCsFromFunctionKernel_, applyDirichletBCsFromFunctionKernel, bufMdSpan, this->exactSolutionAndBCs_, 
+                                            indexLimitsEdge, this->alpakaHelper_.indexLimitsDataAlpaka_, this->alpakaHelper_.ds_, this->alpakaHelper_.origin_, 
+                                            this->alpakaHelper_.globalLocation_, this->alpakaHelper_.nlocal_noguards_, this->alpakaHelper_.haloSize_ );
+
+                }
+                if(hasBoundary_[2*dir+1] && bcsType_[2*dir+1]==0)
+                {
+                    indexLimitsEdge = this->alpakaHelper_.indexLimitsDataAlpaka_;
+                    indexLimitsEdge[2*dirAlpaka]=indexLimitsEdge[2*dirAlpaka+1] - guards_[dir];
+                    alpaka::exec<Acc>(this->queueSolverNonBlocking1_, workDivExtentApplyDirichletBCsFromFunctionKernel_, applyDirichletBCsFromFunctionKernel, bufMdSpan, this->exactSolutionAndBCs_, 
+                                            indexLimitsEdge, this->alpakaHelper_.indexLimitsDataAlpaka_, this->alpakaHelper_.ds_, this->alpakaHelper_.origin_, 
+                                            this->alpakaHelper_.globalLocation_, this->alpakaHelper_.nlocal_noguards_, this->alpakaHelper_.haloSize_ );
+                }
+            }
+
+        }
+    };
+
+
+template<int DIM, typename T_data> 
+struct ApplyDirichletBCsFromFunctionKernel
+{
+    template<typename TAcc, typename TMdSpan>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, TMdSpan bufData, const auto boundaryFunction, DataSpace<Dim> guardsSize, DataSpace<Dim> extents, DataSpace<Dim> offsets ) const -> void
+    {
+        // Get indexes
+        auto const gridThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+    
+        auto const gridThreadIdxShifted = gridThreadIdx + guardsSize;
+        //auto const indxData = gridThreadIdxShifted + adjustIdx;
+        //auto const indxGuard = gridThreadIdxShifted - adjustIdx;
+        
+        auto const iGrid = gridThreadIdxShifted[2];
+        auto const jGrid = gridThreadIdxShifted[1];
+        auto const kGrid = gridThreadIdxShifted[0];
+
+        const T_data x = (iGrid-indexLimitsData[4])*ds[2] + offsets[2]*ds[2];
+        const T_data y = (jGrid-indexLimitsData[2])*ds[1] + offsets[1]*ds[1];
+        const T_data z = (kGrid-indexLimitsData[0])*ds[0] + offsets[0]*ds[0];
+
+
+        if( iGrid>=indexLimitsEdge[4] && iGrid<indexLimitsEdge[5] && jGrid>=indexLimitsEdge[2] && jGrid<indexLimitsEdge[3] && kGrid>=indexLimitsEdge[0] && kGrid<indexLimitsEdge[1])
+        {
+            bufData(gridThreadIdxShifted[0],gridThreadIdxShifted[1],gridThreadIdxShifted[2]) = boundaryFunction(x,y,z);
+        }
+    }
+};
+    

--- a/include/picongpu/fields/poissonSolver/BoundaryConditions.hpp
+++ b/include/picongpu/fields/poissonSolver/BoundaryConditions.hpp
@@ -56,9 +56,14 @@ namespace picongpu::fields::poissonSolver
             DataSpace<simDim> cellOffsetToTotalOrigin,
             auto const mapper) const -> void
         {
+            // including guards
             DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+
+            DataSpace<simDim> numGuardCells = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+
+            // no guards included
             DataSpace<simDim> superCellTotalCellOffset
-                = cellOffsetToTotalOrigin + superCellIdx * SuperCellSize::toRT();
+                = cellOffsetToTotalOrigin + superCellIdx * SuperCellSize::toRT() - numGuardCells;
 
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
@@ -69,6 +74,7 @@ namespace picongpu::fields::poissonSolver
                 {
                     /* cell index within the superCell */
                     DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
+                    // without guards
                     DataSpace<simDim> const totalCellIdx = superCellTotalCellOffset + cellIdx;
 
                     auto totalDistance = precisionCast<float_64>(totalCellIdx)

--- a/include/picongpu/fields/poissonSolver/ChargeDeposition.hpp
+++ b/include/picongpu/fields/poissonSolver/ChargeDeposition.hpp
@@ -1,0 +1,20 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once

--- a/include/picongpu/fields/poissonSolver/FieldV.hpp
+++ b/include/picongpu/fields/poissonSolver/FieldV.hpp
@@ -1,0 +1,52 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+
+namespace picongpu::fields::poissonSolver
+{
+    struct FieldV : pmacc::ISimulationData
+    {
+        std::shared_ptr<GridBuffer<float_64, simDim>> fieldVBuffer;
+
+        FieldV(picongpu::MappingDesc const mappingDesc)
+            : fieldVBuffer{std::make_shared<GridBuffer<float_64, simDim>>(mappingDesc.getGridLayout())}
+        {
+        }
+
+        void synchronize() override
+        {
+            fieldVBuffer->getDeviceBuffer().copyFrom(fieldVBuffer->getHostBuffer());
+        };
+
+        /**
+         * Return the globally unique identifier for this simulation data.
+         *
+         * @return globally unique identifier
+         */
+        SimulationDataId getUniqueId() override
+        {
+            return "FieldV";
+        };
+    };
+} // namespace picongpu::fields::poissonSolver

--- a/include/picongpu/fields/poissonSolver/FieldV.hpp
+++ b/include/picongpu/fields/poissonSolver/FieldV.hpp
@@ -36,7 +36,7 @@ namespace picongpu::fields::poissonSolver
 
         void synchronize() override
         {
-            fieldVBuffer->getDeviceBuffer().copyFrom(fieldVBuffer->getHostBuffer());
+            fieldVBuffer->getHostBuffer().copyFrom(fieldVBuffer->getDeviceBuffer());
         };
 
         /**

--- a/include/picongpu/fields/poissonSolver/FieldV.hpp
+++ b/include/picongpu/fields/poissonSolver/FieldV.hpp
@@ -20,6 +20,9 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
+#include "picongpu/fields/YeeCell.hpp"
+#include "picongpu/traits/FieldPosition.hpp"
+#include "picongpu/traits/SIBaseUnits.hpp"
 
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 
@@ -27,7 +30,17 @@ namespace picongpu::fields::poissonSolver
 {
     struct FieldV : pmacc::ISimulationData
     {
-        std::shared_ptr<GridBuffer<float_64, simDim>> fieldVBuffer;
+        using ValueType = float_64;
+
+        std::shared_ptr<GridBuffer<ValueType, simDim>> fieldVBuffer;
+
+        //! Unit type of field components
+        using UnitValueType = float1_64;
+
+        using DataBoxType = pmacc::DataBox<PitchedBox<ValueType, simDim>>;
+
+        //! Number of components of ValueType, for serialization
+        static constexpr int numComponents = 1u;
 
         FieldV(picongpu::MappingDesc const mappingDesc)
             : fieldVBuffer{std::make_shared<GridBuffer<float_64, simDim>>(mappingDesc.getGridLayout())}
@@ -39,6 +52,23 @@ namespace picongpu::fields::poissonSolver
             fieldVBuffer->getHostBuffer().copyFrom(fieldVBuffer->getDeviceBuffer());
         };
 
+        //! Get the host data box for the field values
+        DataBoxType getHostDataBox()
+        {
+            return fieldVBuffer->getHostBuffer().getDataBox();
+        }
+
+        //! Get the device data box for the field values
+        DataBoxType getDeviceDataBox()
+        {
+            return fieldVBuffer->getDeviceBuffer().getDataBox();
+        }
+
+        GridLayout<simDim> getGridLayout()
+        {
+            return fieldVBuffer->getGridLayout();
+        }
+
         /**
          * Return the globally unique identifier for this simulation data.
          *
@@ -48,5 +78,44 @@ namespace picongpu::fields::poissonSolver
         {
             return "FieldV";
         };
+
+        static std::string getName()
+        {
+            return "FieldV";
+        }
+
+        static UnitValueType getUnit()
+        {
+            return UnitValueType{sim.unit.eField() * sim.unit.length()};
+        }
+
+        static std::vector<float_64> getUnitDimension()
+        {
+            /* V is in volts: V  = kg * m^2 / (A * s^3)
+             *   -> L^2 * M * T^-3 * I^-1
+             */
+            std::vector<float_64> unitDimension(7, 0.0);
+            unitDimension.at(SIBaseUnits::length) = 2.0;
+            unitDimension.at(SIBaseUnits::mass) = 1.0;
+            unitDimension.at(SIBaseUnits::time) = -3.0;
+            unitDimension.at(SIBaseUnits::electricCurrent) = -1.0;
+            return unitDimension;
+        }
     };
 } // namespace picongpu::fields::poissonSolver
+
+namespace picongpu::traits
+{
+    template<>
+    struct FieldPosition<fields::YeeCell, fields::poissonSolver::FieldV, simDim>
+    {
+        using VectorVectorDD = ::pmacc::math::Vector<floatD_X, simDim> const;
+
+        HDINLINE FieldPosition() = default;
+
+        HDINLINE VectorVectorDD operator()() const
+        {
+            return VectorVectorDD::create(floatD_X::create(0.0));
+        }
+    };
+} // namespace picongpu::traits

--- a/include/picongpu/fields/poissonSolver/RightHandSideNormalization.hpp
+++ b/include/picongpu/fields/poissonSolver/RightHandSideNormalization.hpp
@@ -1,0 +1,181 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldTmpOperations.hpp"
+#include "picongpu/fields/poissonSolver/FieldV.hpp"
+
+#include <pmacc/device/Reduce.hpp>
+#include <pmacc/lockstep/lockstep.hpp>
+#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
+#include <pmacc/math/operation.hpp>
+#include <pmacc/memory/boxes/DataBoxDim1Access.hpp>
+#include <pmacc/memory/boxes/DataBoxUnaryTransform.hpp>
+#include <pmacc/memory/dataTypes/Mask.hpp>
+#include <pmacc/mpi/MPIReduce.hpp>
+#include <pmacc/mpi/reduceMethods/Reduce.hpp>
+
+namespace picongpu::fields::poissonSolver
+{
+    struct SolutionFunction
+    {
+        HDINLINE auto operator()(math::Vector<double, simDim> const& totalCellCoordinate) const
+        {
+            if constexpr(simDim == 3u)
+            {
+                return math::sin(totalCellCoordinate.x()) + math::cos(totalCellCoordinate.y())
+                       + 3.0 * math::sin(totalCellCoordinate.z())
+                       + totalCellCoordinate.x() * totalCellCoordinate.productOfComponents() + 10.0;
+            }
+            else if constexpr(simDim == 2u)
+            {
+                return math::sin(totalCellCoordinate.x()) + math::cos(totalCellCoordinate.y())
+                       + totalCellCoordinate.x() * totalCellCoordinate.productOfComponents() + 10.0;
+            }
+        }
+    };
+
+    struct RightHandSideNormalizationKernel
+    {
+        DINLINE auto operator()(auto const& worker, auto const fieldVBox, auto fieldRhoBox, auto const mapper) const
+            -> void
+        {
+            DataSpace<simDim> const relExchangeDir = Mask::getRelativeDirections<simDim>(mapper.getExchangeType());
+            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+            DataSpace<simDim> superCellCellOffset = superCellIdx * SuperCellSize::toRT();
+            DataSpace<simDim> cellOffsetInDomain
+                = superCellCellOffset - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+
+            DataSpace<simDim> numGuardCells = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+            DataSpace<simDim> adjustedSuperCellCellOffset = superCellCellOffset - (relExchangeDir * numGuardCells);
+
+            DataSpace<simDim> numCellsLocalDomain = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+
+            constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+            auto forEachCellInSupercell = lockstep::makeForEach<cellsPerSuperCell>(worker);
+
+            forEachCellInSupercell(
+                [&](int32_t const linearCellIdx)
+                {
+                    /* cell index within the superCell */
+                    DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
+                    DataSpace<simDim> const localCellIdx = adjustedSuperCellCellOffset + cellIdx;
+
+                    for(uint32_t d = 0; d < simDim; ++d)
+                    {
+                        if(relExchangeDir[d] != 0
+                           && (localCellIdx[d] == 0u || localCellIdx[d] == numCellsLocalDomain[d] - 1))
+                        {
+                            fieldRhoBox(localCellIdx + numGuardCells)
+                                += fieldVBox(localCellIdx + numGuardCells + relExchangeDir)
+                                   / (sim.pic.getCellSize()[d] * sim.pic.getCellSize()[d]);
+                        }
+                    }
+                });
+        }
+    };
+
+    struct RightHandSideNormalization
+    {
+        mpi::MPIReduce mpiReduce;
+        std::unique_ptr<pmacc::device::Reduce> localReduce;
+
+        RightHandSideNormalization() : localReduce{std::make_unique<pmacc::device::Reduce>(1024)}
+        {
+            mpiReduce.participate(true);
+        }
+
+        // return residual
+        // return number of iterations
+        void operator()(FieldV& fieldV, FieldTmp& fieldRho, MappingDesc cellDescription)
+        {
+            /* only call for planes: left right top bottom back front*/
+            for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
+            {
+                if(FRONT % i == 0 && !(Environment<simDim>::get().GridController().getCommunicationMask().isSet(i)))
+                {
+                    ExchangeMapping<GUARD, MappingDesc> mapper(cellDescription, i);
+
+                    PMACC_LOCKSTEP_KERNEL(RightHandSideNormalizationKernel{})
+                        .config(mapper.getGridDim(), SuperCellSize{})(
+                            fieldV.fieldVBuffer->getDeviceBuffer().getDataBox(),
+                            fieldRho.getDeviceDataBox(),
+                            mapper);
+                }
+            }
+        }
+
+        auto calcNorm(FieldTmp& fieldRho)
+        {
+            /*define stacked DataBox's for reduce algorithm*/
+            using TransformedBox = DataBoxUnaryTransform<typename FieldTmp::DataBoxType, squareComponentWise>;
+            using Box64bit = DataBoxUnaryTransform<TransformedBox, cast64Bit>;
+            using D1Box = DataBoxDim1Access<Box64bit>;
+
+            /* reduce field E*/
+            DataSpace<simDim> fieldSize = fieldRho.getGridLayout().sizeWithoutGuardND();
+            DataSpace<simDim> fieldGuard = fieldRho.getGridLayout().guardSizeND();
+
+            TransformedBox fieldTransform(fieldRho.getDeviceDataBox().shift(fieldGuard));
+            Box64bit field64bit(fieldTransform);
+            D1Box d1Access(field64bit, fieldSize);
+
+            float_64 fieldRhoNormSquaredLocal
+                = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents()).x();
+
+            // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+            eventSystem::getTransactionEvent().waitForFinished();
+            float_64 fieldRhoNormSquaredGlobal;
+            mpiReduce(
+                pmacc::math::operation::Add(),
+                &fieldRhoNormSquaredGlobal,
+                &fieldRhoNormSquaredLocal,
+                1,
+                mpi::reduceMethods::AllReduce());
+
+            return math::sqrt(fieldRhoNormSquaredGlobal);
+        }
+
+    private:
+        template<typename T_Type>
+        struct cast64Bit
+        {
+            using result = typename TypeCast<float_64, T_Type>::result;
+
+            HDINLINE result operator()(T_Type const& value) const
+            {
+                return precisionCast<float_64>(value);
+            }
+        };
+
+        template<typename T_Type>
+        struct squareComponentWise
+        {
+            using result = T_Type;
+
+            HDINLINE result operator()(T_Type const& value) const
+            {
+                return value * value;
+            }
+        };
+    };
+} // namespace picongpu::fields::poissonSolver

--- a/include/picongpu/fields/poissonSolver/RightHandSideNormalization.hpp
+++ b/include/picongpu/fields/poissonSolver/RightHandSideNormalization.hpp
@@ -38,13 +38,11 @@ namespace picongpu::fields::poissonSolver
             DataSpace<simDim> const relExchangeDir = Mask::getRelativeDirections<simDim>(mapper.getExchangeType());
             DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
             DataSpace<simDim> superCellCellOffset = superCellIdx * SuperCellSize::toRT();
-            DataSpace<simDim> cellOffsetInDomain
-                = superCellCellOffset - mapper.getGuardingSuperCells() * SuperCellSize::toRT();
 
             DataSpace<simDim> numGuardCells = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
             DataSpace<simDim> adjustedSuperCellCellOffset = superCellCellOffset - (relExchangeDir * numGuardCells);
 
-            DataSpace<simDim> numCellsLocalDomain = mapper.getGuardingSuperCells() * SuperCellSize::toRT();
+            DataSpace<simDim> numCellsLocalDomain = mapper.getGridSuperCells() * SuperCellSize::toRT();
 
             constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
@@ -55,16 +53,17 @@ namespace picongpu::fields::poissonSolver
                 {
                     /* cell index within the superCell */
                     DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
-                    DataSpace<simDim> const localCellIdx = adjustedSuperCellCellOffset + cellIdx;
+
+                    DataSpace<simDim> const localCellIdx = superCellCellOffset + cellIdx;
+                    DataSpace<simDim> const dataCellIdx = adjustedSuperCellCellOffset + cellIdx;
 
                     for(uint32_t d = 0; d < simDim; ++d)
                     {
                         if(relExchangeDir[d] != 0
                            && (localCellIdx[d] == 0u || localCellIdx[d] == numCellsLocalDomain[d] - 1))
                         {
-                            fieldRhoBox(localCellIdx + numGuardCells)
-                                += fieldVBox(localCellIdx + numGuardCells + relExchangeDir)
-                                   / (sim.pic.getCellSize()[d] * sim.pic.getCellSize()[d]);
+                            fieldRhoBox(dataCellIdx) += fieldVBox(dataCellIdx + relExchangeDir)
+                                                        / (sim.pic.getCellSize()[d] * sim.pic.getCellSize()[d]);
                         }
                     }
                 });

--- a/include/picongpu/fields/poissonSolver/RightHandSideNormalization.hpp
+++ b/include/picongpu/fields/poissonSolver/RightHandSideNormalization.hpp
@@ -23,36 +23,13 @@
 #include "picongpu/fields/FieldTmpOperations.hpp"
 #include "picongpu/fields/poissonSolver/FieldV.hpp"
 
-#include <pmacc/device/Reduce.hpp>
 #include <pmacc/lockstep/lockstep.hpp>
 #include <pmacc/mappings/kernel/ExchangeMapping.hpp>
 #include <pmacc/math/operation.hpp>
-#include <pmacc/memory/boxes/DataBoxDim1Access.hpp>
-#include <pmacc/memory/boxes/DataBoxUnaryTransform.hpp>
 #include <pmacc/memory/dataTypes/Mask.hpp>
-#include <pmacc/mpi/MPIReduce.hpp>
-#include <pmacc/mpi/reduceMethods/Reduce.hpp>
 
 namespace picongpu::fields::poissonSolver
 {
-    struct SolutionFunction
-    {
-        HDINLINE auto operator()(math::Vector<double, simDim> const& totalCellCoordinate) const
-        {
-            if constexpr(simDim == 3u)
-            {
-                return math::sin(totalCellCoordinate.x()) + math::cos(totalCellCoordinate.y())
-                       + 3.0 * math::sin(totalCellCoordinate.z())
-                       + totalCellCoordinate.x() * totalCellCoordinate.productOfComponents() + 10.0;
-            }
-            else if constexpr(simDim == 2u)
-            {
-                return math::sin(totalCellCoordinate.x()) + math::cos(totalCellCoordinate.y())
-                       + totalCellCoordinate.x() * totalCellCoordinate.productOfComponents() + 10.0;
-            }
-        }
-    };
-
     struct RightHandSideNormalizationKernel
     {
         DINLINE auto operator()(auto const& worker, auto const fieldVBox, auto fieldRhoBox, auto const mapper) const
@@ -96,14 +73,6 @@ namespace picongpu::fields::poissonSolver
 
     struct RightHandSideNormalization
     {
-        mpi::MPIReduce mpiReduce;
-        std::unique_ptr<pmacc::device::Reduce> localReduce;
-
-        RightHandSideNormalization() : localReduce{std::make_unique<pmacc::device::Reduce>(1024)}
-        {
-            mpiReduce.participate(true);
-        }
-
         // return residual
         // return number of iterations
         void operator()(FieldV& fieldV, FieldTmp& fieldRho, MappingDesc cellDescription)
@@ -123,59 +92,5 @@ namespace picongpu::fields::poissonSolver
                 }
             }
         }
-
-        auto calcNorm(FieldTmp& fieldRho)
-        {
-            /*define stacked DataBox's for reduce algorithm*/
-            using TransformedBox = DataBoxUnaryTransform<typename FieldTmp::DataBoxType, squareComponentWise>;
-            using Box64bit = DataBoxUnaryTransform<TransformedBox, cast64Bit>;
-            using D1Box = DataBoxDim1Access<Box64bit>;
-
-            /* reduce field E*/
-            DataSpace<simDim> fieldSize = fieldRho.getGridLayout().sizeWithoutGuardND();
-            DataSpace<simDim> fieldGuard = fieldRho.getGridLayout().guardSizeND();
-
-            TransformedBox fieldTransform(fieldRho.getDeviceDataBox().shift(fieldGuard));
-            Box64bit field64bit(fieldTransform);
-            D1Box d1Access(field64bit, fieldSize);
-
-            float_64 fieldRhoNormSquaredLocal
-                = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents()).x();
-
-            // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
-            eventSystem::getTransactionEvent().waitForFinished();
-            float_64 fieldRhoNormSquaredGlobal;
-            mpiReduce(
-                pmacc::math::operation::Add(),
-                &fieldRhoNormSquaredGlobal,
-                &fieldRhoNormSquaredLocal,
-                1,
-                mpi::reduceMethods::AllReduce());
-
-            return math::sqrt(fieldRhoNormSquaredGlobal);
-        }
-
-    private:
-        template<typename T_Type>
-        struct cast64Bit
-        {
-            using result = typename TypeCast<float_64, T_Type>::result;
-
-            HDINLINE result operator()(T_Type const& value) const
-            {
-                return precisionCast<float_64>(value);
-            }
-        };
-
-        template<typename T_Type>
-        struct squareComponentWise
-        {
-            using result = T_Type;
-
-            HDINLINE result operator()(T_Type const& value) const
-            {
-                return value * value;
-            }
-        };
     };
 } // namespace picongpu::fields::poissonSolver

--- a/include/picongpu/fields/poissonSolver/Stencil.hpp
+++ b/include/picongpu/fields/poissonSolver/Stencil.hpp
@@ -1,0 +1,105 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldTmpOperations.hpp"
+#include "picongpu/fields/poissonSolver/FieldV.hpp"
+
+#include <pmacc/lockstep/lockstep.hpp>
+#include <pmacc/mappings/kernel/ExchangeMapping.hpp>
+#include <pmacc/memory/dataTypes/Mask.hpp>
+
+namespace picongpu::fields::poissonSolver
+{
+    struct StencilFunc
+    {
+        HDINLINE auto operator()(auto fieldIn) const
+        {
+            constexpr auto cellSize = sim.pic.getCellSize().shrink<simDim>();
+            constexpr auto cellSizeSquared = cellSize * cellSize;
+            float_64 const fc0 = 2.0 * (1.0 / (cellSizeSquared)).sumOfComponents();
+            if constexpr(simDim == 3u)
+            {
+                constexpr DataSpace<3u> xDir(1, 0, 0);
+                constexpr DataSpace<3u> yDir(0, 1, 0);
+                constexpr DataSpace<3u> zDir(0, 0, 1);
+
+
+                return *fieldIn * fc0 - (fieldIn(-xDir) + fieldIn(xDir)) / cellSizeSquared.x()
+                       - (fieldIn(-yDir) + fieldIn(yDir)) / cellSizeSquared.y()
+                       - (fieldIn(-zDir) + fieldIn(zDir)) / cellSizeSquared.z();
+            }
+            else if constexpr(simDim == 2u)
+            {
+                constexpr DataSpace<2u> xDir(1, 0);
+                constexpr DataSpace<2u> yDir(0, 1);
+
+                return *fieldIn * fc0 - (fieldIn(-xDir) + fieldIn(xDir)) / cellSizeSquared.x()
+                       - (fieldIn(-yDir) + fieldIn(yDir)) / cellSizeSquared.y();
+            }
+        }
+    };
+
+    struct Stencil
+    {
+        DINLINE auto operator()(
+            auto const& worker,
+            auto const mapper,
+            auto const stencilFunctor,
+            auto fieldOut,
+            auto fieldIn) const -> void
+        {
+            DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+            DataSpace<simDim> superCellCellOffset = superCellIdx * SuperCellSize::toRT();
+
+            using Type = typename decltype(fieldIn)::ValueType;
+            using BlockArea = pmacc::SuperCellDescription<
+                SuperCellSize,
+                typename pmacc::math::CT::make_Int<SuperCellSize::dim, 1>::type,
+                typename pmacc::math::CT::make_Int<SuperCellSize::dim, 1>::type>;
+
+            constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+            // use the cached buffer, beacuse I am doing multiple reads, moves the blockArea to shared memory
+            auto cache = pmacc::CachedBox::create<0, Type>(worker, BlockArea());
+            auto buffShifted = fieldIn.shift(superCellCellOffset);
+
+            // the thread collective is a convenience wrapper for lockstep make for each
+            // it deals with the guard offset, subtracts the origin offset
+            auto collective = pmacc::makeThreadCollective<BlockArea>();
+
+            pmacc::math::operation::Assign assign;
+            collective(worker, assign, cache, buffShifted);
+
+            worker.sync();
+
+            auto forEachCellInSupercell = lockstep::makeForEach<cellsPerSuperCell>(worker);
+
+            forEachCellInSupercell(
+                [&](int32_t const linearCellIdx)
+                {
+                    /* cell index within the superCell */
+                    DataSpace<simDim> const cellIdx = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
+                    fieldOut[superCellCellOffset + cellIdx] = stencilFunctor(cache.shift(cellIdx));
+                });
+        }
+    };
+} // namespace picongpu::fields::poissonSolver

--- a/include/picongpu/fields/poissonSolver/Stencil.hpp
+++ b/include/picongpu/fields/poissonSolver/Stencil.hpp
@@ -58,6 +58,39 @@ namespace picongpu::fields::poissonSolver
         }
     };
 
+    struct GetFieldEStencil
+    {
+        HDINLINE auto operator()(auto fieldIn) const
+        {
+            constexpr auto cellSize = sim.pic.getCellSize().shrink<simDim>();
+
+            float3_X eValue;
+            if constexpr(simDim == 3u)
+            {
+                constexpr DataSpace<3u> xDir(1, 0, 0);
+                constexpr DataSpace<3u> yDir(0, 1, 0);
+                constexpr DataSpace<3u> zDir(0, 0, 1);
+
+                eValue.x() = (*fieldIn - fieldIn(xDir)) / cellSize.x();
+                eValue.y() = (*fieldIn - fieldIn(yDir)) / cellSize.y();
+                eValue.z() = (*fieldIn - fieldIn(zDir)) / cellSize.z();
+
+                return eValue;
+            }
+            else if constexpr(simDim == 2u)
+            {
+                constexpr DataSpace<3u> xDir(1, 0, 0);
+                constexpr DataSpace<3u> yDir(0, 1, 0);
+
+                eValue.x() = (*fieldIn - fieldIn(xDir)) / cellSize.x();
+                eValue.y() = (*fieldIn - fieldIn(yDir)) / cellSize.y();
+                eValue.z() = 0.0_X;
+
+                return eValue;
+            }
+        }
+    };
+
     struct Stencil
     {
         DINLINE auto operator()(

--- a/include/picongpu/fields/poissonSolver/Stencil.hpp
+++ b/include/picongpu/fields/poissonSolver/Stencil.hpp
@@ -135,4 +135,13 @@ namespace picongpu::fields::poissonSolver
                 });
         }
     };
+
+    inline void stencil(auto mapper, auto const& functor, auto& outBuffer, auto& inBuffer)
+    {
+        // poisson stencil
+        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+            .config(
+                mapper.getGridDim(),
+                SuperCellSize{})(mapper, functor, outBuffer.getDataBox(), inBuffer.getDataBox());
+    }
 } // namespace picongpu::fields::poissonSolver

--- a/include/picongpu/main.x.cpp
+++ b/include/picongpu/main.x.cpp
@@ -44,25 +44,30 @@ int runSimulation(int argc, char** argv)
 {
     using namespace picongpu;
 
-    auto sim = ::picongpu::
-        SimulationStarter<::picongpu::InitialiserController, ::picongpu::PluginController, ::picongpu::Simulation>{};
-    auto const parserStatus = sim.parseConfigs(argc, argv);
     int errorCode = EXIT_FAILURE;
-
-    switch(parserStatus)
     {
-    case ArgsParser::Status::error:
-        errorCode = EXIT_FAILURE;
-        break;
-    case ArgsParser::Status::success:
-        sim.load();
-        sim.start();
-        sim.unload();
-        [[fallthrough]];
-    case ArgsParser::Status::successExit:
-        errorCode = 0;
-        break;
-    };
+        auto sim = ::picongpu::SimulationStarter<
+            ::picongpu::InitialiserController,
+            ::picongpu::PluginController,
+            ::picongpu::Simulation>{};
+        auto const parserStatus = sim.parseConfigs(argc, argv);
+
+
+        switch(parserStatus)
+        {
+        case ArgsParser::Status::error:
+            errorCode = EXIT_FAILURE;
+            break;
+        case ArgsParser::Status::success:
+            sim.load();
+            sim.start();
+            sim.unload();
+            [[fallthrough]];
+        case ArgsParser::Status::successExit:
+            errorCode = 0;
+            break;
+        };
+    }
 
     // finalize the pmacc context */
     pmacc::Environment<>::get().finalize();

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -154,6 +154,9 @@ namespace picongpu
             fieldBackground.registerHelp(desc);
             particleBoundaries.registerHelp(desc);
             runtimeDensityFile.registerHelp(desc);
+
+            poissonSolver = std::make_shared<simulation::stage::Poisson>();
+            poissonSolver->registerHelp(desc);
         }
 
         virtual void startSimulation() override
@@ -334,8 +337,6 @@ namespace picongpu
 
             synchrotronRadiation = std::make_shared<simulation::stage::SynchrotronRadiation>(*cellDescription);
 
-            poissonSolver = std::make_shared<simulation::stage::Poisson>(*cellDescription);
-
             initFields(dc);
 
             myFieldSolver = std::make_shared<fields::Solver>(*cellDescription);
@@ -350,6 +351,9 @@ namespace picongpu
 
             // initialize runtime density file paths
             runtimeDensityFile.init();
+
+            // create memory for poisson solver
+            poissonSolver->init(*cellDescription);
 
             // create factory for the random number generator
             uint32_t const userSeed = random::seed::ISeed<random::SeedGenerator>{}();
@@ -492,8 +496,8 @@ namespace picongpu
                 {
                     initialiserController->init();
                     simulation::stage::ParticleInit{}(step);
-                    (*poissonSolver)(step);
                     (*atomicPhysics).fixAtomicStateInit(*cellDescription);
+                    (*poissonSolver)(step);
                     // Check Debye resolution
                     particles::debyeLength::check(*cellDescription);
                 }

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -53,6 +53,7 @@
 #include "picongpu/simulation/stage/ParticleInit.hpp"
 #include "picongpu/simulation/stage/ParticleIonization.hpp"
 #include "picongpu/simulation/stage/ParticlePush.hpp"
+#include "picongpu/simulation/stage/Poisson.hpp"
 #include "picongpu/simulation/stage/RuntimeDensityFile.hpp"
 #include "picongpu/simulation/stage/SynchrotronRadiation.hpp"
 #include "picongpu/versionFormat.hpp"
@@ -322,7 +323,7 @@ namespace picongpu
             DataConnector& dc = Environment<>::get().DataConnector();
 
             dc.share(currentInterpolationAndAdditionToEMF);
-
+            
             // This has to be called before initFields()
             currentInterpolationAndAdditionToEMF->init();
 

--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -323,7 +323,7 @@ namespace picongpu
             DataConnector& dc = Environment<>::get().DataConnector();
 
             dc.share(currentInterpolationAndAdditionToEMF);
-            
+
             // This has to be called before initFields()
             currentInterpolationAndAdditionToEMF->init();
 
@@ -333,6 +333,8 @@ namespace picongpu
             atomicPhysics = std::make_shared<simulation::stage::AtomicPhysics>(*cellDescription);
 
             synchrotronRadiation = std::make_shared<simulation::stage::SynchrotronRadiation>(*cellDescription);
+
+            poissonSolver = std::make_shared<simulation::stage::Poisson>(*cellDescription);
 
             initFields(dc);
 
@@ -490,6 +492,7 @@ namespace picongpu
                 {
                     initialiserController->init();
                     simulation::stage::ParticleInit{}(step);
+                    (*poissonSolver)(step);
                     (*atomicPhysics).fixAtomicStateInit(*cellDescription);
                     // Check Debye resolution
                     particles::debyeLength::check(*cellDescription);
@@ -632,6 +635,8 @@ namespace picongpu
         // Runtime density file stage, has to live always as it is used for registering options like a plugin.
         // Because of it, has a special init() method that has to be called during initialization of the simulation
         simulation::stage::RuntimeDensityFile runtimeDensityFile;
+
+        std::shared_ptr<simulation::stage::Poisson> poissonSolver;
 
         IInitPlugin* initialiserController{nullptr};
 

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -1,6 +1,4 @@
-/* Copyright 2013-2024 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Richard Pausch, Alexander Debus, Marco Garten,
- *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -19,143 +17,51 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 
- #include "picongpu/defines.hpp"
- #include "picongpu/fields/FieldJ.hpp"
- #include "picongpu/fields/FieldJ.kernel"
- #include "picongpu/fields/currentDeposition/Deposit.hpp"
- #include "picongpu/particles/filter/filter.hpp"
- #include "picongpu/particles/param.hpp"
- #include "picongpu/fields/FieldTmpOperations.hpp"
- 
- #include <pmacc/Environment.hpp>
- #include <pmacc/dataManagement/DataConnector.hpp>
- #include <pmacc/meta/ForEach.hpp>
- #include <pmacc/particles/traits/FilterByFlag.hpp>
- #include <pmacc/type/Area.hpp>
- 
- #include <cstdint>
- 
- namespace picongpu
- {
-     namespace simulation
-     {
-         namespace stage
-         {
-            //! Functor for the stage of the PIC loop performing charge deposition
-            struct Poisson
-            {
-                /** Compute the current created by particles and add it to the current
-                 *  density
-                 *
-                 * @param currentStep index of time iteration
-                 */
-                void operator()(uint32_t const currentStep) const;
-            };
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+#include "picongpu/fields/FieldJ.kernel"
+#include "picongpu/fields/FieldTmpOperations.hpp"
+#include "picongpu/fields/currentDeposition/Deposit.hpp"
+#include "picongpu/fields/poissonSolver/FieldV.hpp"
+#include "picongpu/particles/filter/filter.hpp"
+#include "picongpu/particles/param.hpp"
 
-            namespace detail
-            {
-                 template<typename T_SpeciesType, typename T_Area>
-                 struct Poisson
-                 {
-                     using SpeciesType = T_SpeciesType;
-                     using FrameType = typename SpeciesType::FrameType;
- 
-                     /** Compute current density created by a species in an area */
-                     HINLINE void operator()(uint32_t const currentStep, FieldJ& fieldJ, pmacc::DataConnector& dc) const
-                     {
-                     }
-                 };
+#include <pmacc/Environment.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/memory/buffers/GridBuffer.hpp>
+#include <pmacc/meta/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/type/Area.hpp>
 
-                 template<typename T_SpeciesType, typename T_Area>
-                struct ComputeChargeDensity
-                {
-                    using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
-                    static uint32_t const area = T_Area::value;
+#include <cstdint>
 
-                    HINLINE void operator()(FieldTmp& fieldTmp, uint32_t const currentStep) const
-                    {
-                        DataConnector& dc = Environment<>::get().DataConnector();
-
-                        /* load species without copying the particle data to the host */
-                        auto speciesTmp = dc.get<SpeciesType>(SpeciesType::FrameType::getName());
-
-                        /* run algorithm */
-                        using ChargeDensitySolver = typename particles::particleToGrid::CreateFieldTmpOperation_t<
-                            SpeciesType,
-                            particles::particleToGrid::derivedAttributes::ChargeDensity>::Solver;
-
-                        computeFieldTmpValue<area, ChargeDensitySolver>(fieldTmp, *speciesTmp, currentStep);
-                    }
-                };
-                
-             } // namespace detail
-             template<typename T>
-             using SpeciesEligibleForChargeDeposition =
-                 typename particles::traits::SpeciesEligibleForSolver<T, simulation::stage::Poisson>::type;
-
-             void Poisson::operator()(uint32_t const currentStep, MappingDesc *cellDescription) const
-             {
-                 using namespace pmacc;
-                 constexpr uint fieldRhoSlot = 0;
-                 DataConnector& dc = Environment<>::get().DataConnector();
-                 auto& fieldRho = *dc.get<FieldTmp>(FieldTmp::getUniqueId(fieldRhoSlot));
-
-                 fieldRho.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
-
-                using EligibleSpecies = pmacc::mp_filter<SpeciesEligibleForChargeDeposition, VectorAllSpecies>;
-
-                // todo: log species that are used / ignored in this plugin with INFO
-
-
-                /* calculate and add the charge density values from all species in FieldTmp */
-                meta::ForEach<
-                    EligibleSpecies,
-                    detail::ComputeChargeDensity<boost::mpl::_1, pmacc::mp_int<CORE + BORDER>>,
-                    boost::mpl::_1>
-                    computeChargeDensity;
-                computeChargeDensity(fieldRho, currentStep);
-
-                /* add results of all species that are still in GUARD to next GPUs BORDER */
-                EventTask fieldTmpEvent = fieldRho.asyncCommunication(eventSystem::getTransactionEvent());
-                eventSystem::setTransactionEvent(fieldTmpEvent);
-
-
-
-
-                constexpr uint fieldVSlot = 1;
-                auto& fieldV = *dc.get<FieldTmp>(FieldTmp::getUniqueId(fieldVSlot));
-                fieldV.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
-
-                BICGStab(fieldV, fieldRho, cellDescription);
-
-
-             }
-         } // namespace stage
-     } // namespace simulation
-     namespace particles
+namespace picongpu::simulation::stage
+{
+    //! Functor for the stage of the PIC loop performing charge deposition
+    struct Poisson
     {
-        namespace traits
-        {
-            template<typename T_Species>
-            struct SpeciesEligibleForSolver<T_Species, simulation::stage::Poisson>
-            {
-                using FrameType = typename T_Species::FrameType;
+        std::unique_ptr<GridBuffer<float_64, simDim>> pkBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> rkBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> r0Buffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> mpkBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> ampkBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> zkBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> azkBuffer;
 
-                // this plugin needs at least the weighting particle attribute
-                using RequiredIdentifiers = MakeSeq_t<weighting>;
 
-                using SpeciesHasIdentifiers =
-                    typename pmacc::traits::HasIdentifiers<FrameType, RequiredIdentifiers>::type;
+        std::shared_ptr<fields::poissonSolver::FieldV> fieldV;
 
-                // and also a charge ratio for a charge density
-                using SpeciesHasFlags = typename pmacc::traits::HasFlag<FrameType, chargeRatio<>>::type;
+        picongpu::MappingDesc const m_mappingDesc;
 
-                using type = pmacc::mp_and<SpeciesHasIdentifiers, SpeciesHasFlags>;
-            };
 
-        } // namespace traits
-    } // namespace particles
- 
-} // namespace picongpu
- 
+        Poisson(picongpu::MappingDesc const mappingDesc);
+        /** Compute the current created by particles and add it to the current
+         *  density
+         *
+         * @param currentStep index of time iteration
+         */
+        void operator()(uint32_t const currentStep) const;
+    };
+} // namespace picongpu::simulation::stage

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -38,6 +38,8 @@
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/type/Area.hpp>
 
+#include <boost/program_options.hpp>
+
 #include <cstdint>
 
 namespace picongpu::simulation::stage
@@ -45,6 +47,31 @@ namespace picongpu::simulation::stage
     //! Functor for the stage of the PIC loop performing charge deposition
     struct Poisson
     {
+        Poisson();
+
+        void init(picongpu::MappingDesc const mappingDesc);
+
+        void registerHelp(po::options_description& desc);
+
+        /** Compute the current created by particles and add it to the current
+         *  density
+         *
+         * @param currentStep index of time iteration
+         */
+        void operator()(uint32_t const currentStep);
+
+        void preconditioner(
+            std::unique_ptr<GridBuffer<float_64, simDim>>& xBuffer,
+            std::unique_ptr<GridBuffer<float_64, simDim>>& bBuffer);
+
+    private:
+        void participate(bool status)
+        {
+            mpiReduce.participate(status);
+        }
+
+        auto reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn);
+
         std::unique_ptr<GridBuffer<float_64, simDim>> pkBuffer;
         std::unique_ptr<GridBuffer<float_64, simDim>> rkBuffer;
         std::unique_ptr<GridBuffer<float_64, simDim>> r0Buffer;
@@ -59,30 +86,17 @@ namespace picongpu::simulation::stage
 
         std::shared_ptr<fields::poissonSolver::FieldV> fieldV;
 
-        picongpu::MappingDesc const m_mappingDesc;
+        std::optional<picongpu::MappingDesc> m_mappingDesc;
 
         mpi::MPIReduce mpiReduce;
         std::unique_ptr<pmacc::device::Reduce> localReduce;
 
+        // defaults will be overwritten by command line arguments
+        bool m_useSolver = false;
+        uint32_t m_maxSolverSteps = 20;
+        float_64 m_solverEpsilon = 1.0e-8;
 
-        Poisson(picongpu::MappingDesc const mappingDesc);
-        /** Compute the current created by particles and add it to the current
-         *  density
-         *
-         * @param currentStep index of time iteration
-         */
-        void operator()(uint32_t const currentStep);
-
-        void participate(bool status)
-        {
-            mpiReduce.participate(status);
-        }
-
-        void preconditioner(
-            std::unique_ptr<GridBuffer<float_64, simDim>>& xBuffer,
-            std::unique_ptr<GridBuffer<float_64, simDim>>& bBuffer);
-
-    private:
-        auto reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn);
+        bool m_disablePreconditioner = false;
+        uint32_t m_maxPreconditionerSteps = 20;
     };
 } // namespace picongpu::simulation::stage

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -53,6 +53,9 @@ namespace picongpu::simulation::stage
         std::unique_ptr<GridBuffer<float_64, simDim>> zkBuffer;
         std::unique_ptr<GridBuffer<float_64, simDim>> azkBuffer;
 
+        std::unique_ptr<GridBuffer<float_64, simDim>> yBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> wBuffer;
+        std::unique_ptr<GridBuffer<float_64, simDim>> zBuffer;
 
         std::shared_ptr<fields::poissonSolver::FieldV> fieldV;
 
@@ -74,6 +77,10 @@ namespace picongpu::simulation::stage
         {
             mpiReduce.participate(status);
         }
+
+        void preconditioner(
+            std::unique_ptr<GridBuffer<float_64, simDim>>& xBuffer,
+            std::unique_ptr<GridBuffer<float_64, simDim>>& bBuffer);
 
     private:
         auto reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn);

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -1,0 +1,150 @@
+/* Copyright 2013-2024 Axel Huebl, Felix Schmitt, Heiko Burau, Rene Widera,
+ *                     Richard Pausch, Alexander Debus, Marco Garten,
+ *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+ #include "picongpu/defines.hpp"
+ #include "picongpu/fields/FieldJ.hpp"
+ #include "picongpu/fields/FieldJ.kernel"
+ #include "picongpu/fields/currentDeposition/Deposit.hpp"
+ #include "picongpu/particles/filter/filter.hpp"
+ #include "picongpu/particles/param.hpp"
+ #include "picongpu/fields/FieldTmpOperations.hpp"
+ 
+ #include <pmacc/Environment.hpp>
+ #include <pmacc/dataManagement/DataConnector.hpp>
+ #include <pmacc/meta/ForEach.hpp>
+ #include <pmacc/particles/traits/FilterByFlag.hpp>
+ #include <pmacc/type/Area.hpp>
+ 
+ #include <cstdint>
+ 
+ namespace picongpu
+ {
+     namespace simulation
+     {
+         namespace stage
+         {
+            //! Functor for the stage of the PIC loop performing charge deposition
+            struct Poisson
+            {
+                /** Compute the current created by particles and add it to the current
+                 *  density
+                 *
+                 * @param currentStep index of time iteration
+                 */
+                void operator()(uint32_t const currentStep) const;
+            };
+
+            namespace detail
+            {
+                 template<typename T_SpeciesType, typename T_Area>
+                 struct Poisson
+                 {
+                     using SpeciesType = T_SpeciesType;
+                     using FrameType = typename SpeciesType::FrameType;
+ 
+                     /** Compute current density created by a species in an area */
+                     HINLINE void operator()(uint32_t const currentStep, FieldJ& fieldJ, pmacc::DataConnector& dc) const
+                     {
+                     }
+                 };
+
+                 template<typename T_SpeciesType, typename T_Area>
+                struct ComputeChargeDensity
+                {
+                    using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
+                    static uint32_t const area = T_Area::value;
+
+                    HINLINE void operator()(FieldTmp& fieldTmp, uint32_t const currentStep) const
+                    {
+                        DataConnector& dc = Environment<>::get().DataConnector();
+
+                        /* load species without copying the particle data to the host */
+                        auto speciesTmp = dc.get<SpeciesType>(SpeciesType::FrameType::getName());
+
+                        /* run algorithm */
+                        using ChargeDensitySolver = typename particles::particleToGrid::CreateFieldTmpOperation_t<
+                            SpeciesType,
+                            particles::particleToGrid::derivedAttributes::ChargeDensity>::Solver;
+
+                        computeFieldTmpValue<area, ChargeDensitySolver>(fieldTmp, *speciesTmp, currentStep);
+                    }
+                };
+                
+             } // namespace detail
+             template<typename T>
+             using SpeciesEligibleForChargeDeposition =
+                 typename particles::traits::SpeciesEligibleForSolver<T, simulation::stage::Poisson>::type;
+
+             void Poisson::operator()(uint32_t const currentStep) const
+             {
+                 using namespace pmacc;
+                 constexpr uint fieldRhoSlot = 0;
+                 DataConnector& dc = Environment<>::get().DataConnector();
+                 auto& fieldRho = *dc.get<FieldTmp>(FieldTmp::getUniqueId(fieldRhoSlot));
+
+                 fieldRho.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
+
+                using EligibleSpecies = pmacc::mp_filter<SpeciesEligibleForChargeDeposition, VectorAllSpecies>;
+
+                // todo: log species that are used / ignored in this plugin with INFO
+
+
+                /* calculate and add the charge density values from all species in FieldTmp */
+                meta::ForEach<
+                    EligibleSpecies,
+                    detail::ComputeChargeDensity<boost::mpl::_1, pmacc::mp_int<CORE + BORDER>>,
+                    boost::mpl::_1>
+                    computeChargeDensity;
+                computeChargeDensity(fieldRho, currentStep);
+
+                /* add results of all species that are still in GUARD to next GPUs BORDER */
+                EventTask fieldTmpEvent = fieldRho.asyncCommunication(eventSystem::getTransactionEvent());
+                eventSystem::setTransactionEvent(fieldTmpEvent);
+             }
+         } // namespace stage
+     } // namespace simulation
+     namespace particles
+    {
+        namespace traits
+        {
+            template<typename T_Species>
+            struct SpeciesEligibleForSolver<T_Species, simulation::stage::Poisson>
+            {
+                using FrameType = typename T_Species::FrameType;
+
+                // this plugin needs at least the weighting particle attribute
+                using RequiredIdentifiers = MakeSeq_t<weighting>;
+
+                using SpeciesHasIdentifiers =
+                    typename pmacc::traits::HasIdentifiers<FrameType, RequiredIdentifiers>::type;
+
+                // and also a charge ratio for a charge density
+                using SpeciesHasFlags = typename pmacc::traits::HasFlag<FrameType, chargeRatio<>>::type;
+
+                using type = pmacc::mp_and<SpeciesHasIdentifiers, SpeciesHasFlags>;
+            };
+
+        } // namespace traits
+    } // namespace particles
+ 
+} // namespace picongpu
+ 

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -30,8 +30,11 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/device/Reduce.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/meta/ForEach.hpp>
+#include <pmacc/mpi/MPIReduce.hpp>
+#include <pmacc/mpi/reduceMethods/Reduce.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/type/Area.hpp>
 
@@ -55,6 +58,9 @@ namespace picongpu::simulation::stage
 
         picongpu::MappingDesc const m_mappingDesc;
 
+        mpi::MPIReduce mpiReduce;
+        std::unique_ptr<pmacc::device::Reduce> localReduce;
+
 
         Poisson(picongpu::MappingDesc const mappingDesc);
         /** Compute the current created by particles and add it to the current
@@ -62,6 +68,14 @@ namespace picongpu::simulation::stage
          *
          * @param currentStep index of time iteration
          */
-        void operator()(uint32_t const currentStep) const;
+        void operator()(uint32_t const currentStep);
+
+        void participate(bool status)
+        {
+            mpiReduce.participate(status);
+        }
+
+    private:
+        auto calcNorm(FieldTmp& fieldRho);
     };
 } // namespace picongpu::simulation::stage

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -31,6 +31,7 @@
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
 #include <pmacc/device/Reduce.hpp>
+#include <pmacc/math/operation.hpp>
 #include <pmacc/memory/buffers/GridBuffer.hpp>
 #include <pmacc/meta/ForEach.hpp>
 #include <pmacc/mpi/MPIReduce.hpp>
@@ -70,7 +71,8 @@ namespace picongpu::simulation::stage
             mpiReduce.participate(status);
         }
 
-        auto reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn);
+        template<typename T_ReduceFunc = pmacc::math::operation::Add>
+        auto reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn, T_ReduceFunc reduceFunctor = T_ReduceFunc{});
 
         std::unique_ptr<GridBuffer<float_64, simDim>> pkBuffer;
         std::unique_ptr<GridBuffer<float_64, simDim>> rkBuffer;

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -76,6 +76,6 @@ namespace picongpu::simulation::stage
         }
 
     private:
-        auto calcNorm(FieldTmp& fieldRho);
+        auto reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn);
     };
 } // namespace picongpu::simulation::stage

--- a/include/picongpu/simulation/stage/Poisson.hpp
+++ b/include/picongpu/simulation/stage/Poisson.hpp
@@ -94,7 +94,7 @@
              using SpeciesEligibleForChargeDeposition =
                  typename particles::traits::SpeciesEligibleForSolver<T, simulation::stage::Poisson>::type;
 
-             void Poisson::operator()(uint32_t const currentStep) const
+             void Poisson::operator()(uint32_t const currentStep, MappingDesc *cellDescription) const
              {
                  using namespace pmacc;
                  constexpr uint fieldRhoSlot = 0;
@@ -119,6 +119,17 @@
                 /* add results of all species that are still in GUARD to next GPUs BORDER */
                 EventTask fieldTmpEvent = fieldRho.asyncCommunication(eventSystem::getTransactionEvent());
                 eventSystem::setTransactionEvent(fieldTmpEvent);
+
+
+
+
+                constexpr uint fieldVSlot = 1;
+                auto& fieldV = *dc.get<FieldTmp>(FieldTmp::getUniqueId(fieldVSlot));
+                fieldV.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
+
+                BICGStab(fieldV, fieldRho, cellDescription);
+
+
              }
          } // namespace stage
      } // namespace simulation

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -1,0 +1,196 @@
+/* Copyright 2025 Tapish Narwal, Luca Pennati, Rene Widera
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picongpu/simulation/stage/Poisson.hpp"
+
+#include "picongpu/defines.hpp"
+#include "picongpu/fields/FieldJ.hpp"
+#include "picongpu/fields/FieldJ.kernel"
+#include "picongpu/fields/FieldTmpOperations.hpp"
+#include "picongpu/fields/currentDeposition/Deposit.hpp"
+#include "picongpu/fields/poissonSolver/BoundaryConditions.hpp"
+#include "picongpu/fields/poissonSolver/RightHandSideNormalization.hpp"
+#include "picongpu/particles/filter/filter.hpp"
+#include "picongpu/particles/param.hpp"
+#include "picongpu/simulation/stage/Poisson.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/meta/ForEach.hpp>
+#include <pmacc/particles/traits/FilterByFlag.hpp>
+#include <pmacc/type/Area.hpp>
+
+#include <cstdint>
+
+namespace picongpu
+{
+    namespace simulation
+    {
+        namespace stage
+        {
+            namespace detail
+            {
+
+                template<typename T_SpeciesType, typename T_Area>
+                struct ComputeChargeDensity
+                {
+                    using SpeciesType = pmacc::particles::meta::FindByNameOrType_t<VectorAllSpecies, T_SpeciesType>;
+                    static uint32_t const area = T_Area::value;
+
+                    HINLINE void operator()(FieldTmp& fieldTmp, uint32_t const currentStep) const
+                    {
+                        DataConnector& dc = Environment<>::get().DataConnector();
+
+                        /* load species without copying the particle data to the host */
+                        auto speciesTmp = dc.get<SpeciesType>(SpeciesType::FrameType::getName());
+
+                        /* run algorithm */
+                        using ChargeDensitySolver = typename particles::particleToGrid::CreateFieldTmpOperation_t<
+                            SpeciesType,
+                            particles::particleToGrid::derivedAttributes::ChargeDensity>::Solver;
+
+                        computeFieldTmpValue<area, ChargeDensitySolver>(fieldTmp, *speciesTmp, currentStep);
+                    }
+                };
+
+            } // namespace detail
+
+            template<typename T>
+            using SpeciesEligibleForChargeDeposition =
+                typename particles::traits::SpeciesEligibleForSolver<T, simulation::stage::Poisson>::type;
+
+            Poisson::Poisson(MappingDesc const mappingDesc) : m_mappingDesc(mappingDesc)
+            {
+                pkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                rkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                r0Buffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                mpkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                ampkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                zkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                azkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                fieldV = std::make_shared<fields::poissonSolver::FieldV>(m_mappingDesc);
+
+                DataConnector& dc = Environment<>::get().DataConnector();
+                dc.share(fieldV);
+            }
+
+            struct NormalizeField
+            {
+                DINLINE auto operator()(auto const& worker, auto fieldBox, float_64 normValue, auto const mapper) const
+                    -> void
+                {
+                    DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+                    DataSpace<simDim> superCellTotalCellOffset = superCellIdx * SuperCellSize::toRT();
+
+                    constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
+
+                    auto forEachCellInSupercell = lockstep::makeForEach<cellsPerSuperCell>(worker);
+
+                    forEachCellInSupercell(
+                        [&](int32_t const linearCellIdx)
+                        {
+                            DataSpace<simDim> const cellIdx
+                                = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
+                            DataSpace<simDim> const dataCellOffset = superCellTotalCellOffset + cellIdx;
+                            fieldBox(dataCellOffset) /= normValue;
+                        });
+                }
+            };
+
+            void Poisson::operator()(uint32_t const currentStep) const
+            {
+                using namespace pmacc;
+                constexpr uint fieldRhoSlot = 0;
+                DataConnector& dc = Environment<>::get().DataConnector();
+                auto& fieldRho = *dc.get<FieldTmp>(FieldTmp::getUniqueId(fieldRhoSlot));
+
+                fieldRho.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
+
+
+                using EligibleSpecies = pmacc::mp_filter<SpeciesEligibleForChargeDeposition, VectorAllSpecies>;
+
+                // todo: log species that are used / ignored in this plugin with INFO
+
+
+                /* calculate and add the charge density values from all species in FieldTmp */
+                meta::ForEach<
+                    EligibleSpecies,
+                    detail::ComputeChargeDensity<boost::mpl::_1, pmacc::mp_int<CORE + BORDER>>,
+                    boost::mpl::_1>
+                    computeChargeDensity;
+                computeChargeDensity(fieldRho, currentStep);
+
+                /* add results of all species that are still in GUARD to next GPUs BORDER */
+                EventTask fieldTmpEvent = fieldRho.asyncCommunication(eventSystem::getTransactionEvent());
+                eventSystem::setTransactionEvent(fieldTmpEvent);
+
+                auto boundaryConditionsDirichlet = fields::poissonSolver::BoundaryConditionsDirichlet{};
+                boundaryConditionsDirichlet(*fieldV.get(), m_mappingDesc);
+
+                auto rightHandSideNormalization = fields::poissonSolver::RightHandSideNormalization{};
+                rightHandSideNormalization(*fieldV.get(), fieldRho, m_mappingDesc);
+                float_64 normRho = rightHandSideNormalization.calcNorm(fieldRho);
+
+                // recalculate rho
+                computeChargeDensity(fieldRho, currentStep);
+                /* add results of all species that are still in GUARD to next GPUs BORDER */
+                eventSystem::setTransactionEvent(fieldRho.asyncCommunication(eventSystem::getTransactionEvent()));
+
+                // normalize rho
+                auto rhoMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc);
+                PMACC_LOCKSTEP_KERNEL(NormalizeField{})
+                    .config(rhoMapper.getGridDim(), SuperCellSize{})(fieldRho.getDeviceDataBox(), normRho, rhoMapper);
+
+                // normalize v
+                auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc);
+                PMACC_LOCKSTEP_KERNEL(NormalizeField{})
+                    .config(
+                        vMapper.getGridDim(),
+                        SuperCellSize{})(fieldV->fieldVBuffer->getDeviceBuffer().getDataBox(), normRho, rhoMapper);
+
+                // BICGStab(fieldV, fieldRho, cellDescription);
+            }
+        } // namespace stage
+    } // namespace simulation
+
+    namespace particles
+    {
+        namespace traits
+        {
+            template<typename T_Species>
+            struct SpeciesEligibleForSolver<T_Species, simulation::stage::Poisson>
+            {
+                using FrameType = typename T_Species::FrameType;
+
+                // this plugin needs at least the weighting particle attribute
+                using RequiredIdentifiers = MakeSeq_t<weighting>;
+
+                using SpeciesHasIdentifiers =
+                    typename pmacc::traits::HasIdentifiers<FrameType, RequiredIdentifiers>::type;
+
+                // and also a charge ratio for a charge density
+                using SpeciesHasFlags = typename pmacc::traits::HasFlag<FrameType, chargeRatio<>>::type;
+
+                using type = pmacc::mp_and<SpeciesHasIdentifiers, SpeciesHasFlags>;
+            };
+
+        } // namespace traits
+    } // namespace particles
+
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -29,6 +29,8 @@
 #include "picongpu/fields/poissonSolver/Stencil.hpp"
 #include "picongpu/particles/filter/filter.hpp"
 #include "picongpu/particles/param.hpp"
+#include "picongpu/particles/particleToGrid/CombinedDerive.hpp"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.hpp"
 #include "picongpu/simulation/stage/Poisson.hpp"
 
 #include <pmacc/Environment.hpp>
@@ -40,6 +42,8 @@
 #include <pmacc/type/Area.hpp>
 
 #include <cstdint>
+
+#include <picongpu/param/particle.param>
 
 namespace picongpu
 {
@@ -74,9 +78,10 @@ namespace picongpu
 
             } // namespace detail
 
+            namespace deriveField = particles::particleToGrid;
             template<typename T>
-            using SpeciesEligibleForChargeDeposition =
-                typename particles::traits::SpeciesEligibleForSolver<T, simulation::stage::Poisson>::type;
+            using SpeciesEligibleForChargeConservation = typename particles::traits::
+                SpeciesEligibleForSolver<T, deriveField::derivedAttributes::ChargeDensity>::type;
 
             Poisson::Poisson(MappingDesc const mappingDesc)
                 : m_mappingDesc(mappingDesc)
@@ -220,22 +225,18 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
                 auto& fieldRho = *dc.get<FieldTmp>(FieldTmp::getUniqueId(fieldRhoSlot));
 
-                fieldRho.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
-
-
-                using EligibleSpecies = pmacc::mp_filter<SpeciesEligibleForChargeDeposition, VectorAllSpecies>;
-
-                // todo: log species that are used / ignored in this plugin with INFO
-
                 DataSpace<simDim> numGuardCells = fieldRho.getGridLayout().guardSizeND();
                 DataSpace<simDim> coreBorderSize = fieldRho.getGridLayout().sizeWithoutGuardND();
 
+                using EligibleSpecies = pmacc::mp_filter<SpeciesEligibleForChargeConservation, VectorAllSpecies>;
                 /* calculate and add the charge density values from all species in FieldTmp */
                 meta::ForEach<
                     EligibleSpecies,
                     detail::ComputeChargeDensity<boost::mpl::_1, pmacc::mp_int<CORE + BORDER>>,
                     boost::mpl::_1>
                     computeChargeDensity;
+
+                fieldRho.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
                 computeChargeDensity(fieldRho, currentStep);
 
                 /* add results of all species that are still in GUARD to next GPUs BORDER */
@@ -259,6 +260,7 @@ namespace picongpu
                     normRho = std::sqrt(reduceGlobal(coreBorderSize, fieldTransform));
                 }
                 // recalculate rho
+                fieldRho.getGridBuffer().getDeviceBuffer().setValue(FieldTmp::ValueType(0.0));
                 computeChargeDensity(fieldRho, currentStep);
                 /* add results of all species that are still in GUARD to next GPUs BORDER */
                 eventSystem::setTransactionEvent(fieldRho.asyncCommunication(eventSystem::getTransactionEvent()));
@@ -486,7 +488,8 @@ namespace picongpu
                     rho0 = rho1;
                     if(std::sqrt(totalSum2) < epsilon)
                     {
-                        std::cout << "Converged after " << i << " iterations" << std::endl;
+                        std::cout << "Converged after " << i << " iterations with norm=" << normRho
+                                  << ", total sum2=" << totalSum2 << std::endl;
                         break;
                     }
                     // pk = rk + beta * (pk - omega * ampk)

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -242,22 +242,20 @@ namespace picongpu
                 DataSpace<simDim> m_offset = DataSpace<simDim>::create(0);
             };
 
-            auto Poisson::reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn)
+            template<typename T_TranformFunctor>
+            inline auto Poisson::reduceGlobal(
+                DataSpace<simDim> fieldSize,
+                auto dataBoxIn,
+                T_TranformFunctor reduceFunctor)
             {
                 DataBoxDim1Access d1Access(dataBoxIn, fieldSize);
 
-                float_64 resultLocal
-                    = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents());
+                float_64 resultLocal = (*localReduce)(reduceFunctor, d1Access, fieldSize.productOfComponents());
 
                 // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
                 eventSystem::getTransactionEvent().waitForFinished();
                 float_64 resultGlobal;
-                mpiReduce(
-                    pmacc::math::operation::Add(),
-                    &resultGlobal,
-                    &resultLocal,
-                    1,
-                    mpi::reduceMethods::AllReduce());
+                mpiReduce(reduceFunctor, &resultGlobal, &resultLocal, 1, mpi::reduceMethods::AllReduce());
 
                 return resultGlobal;
             }
@@ -680,15 +678,6 @@ namespace picongpu
 
                 bool ioRank = mpiReduce.hasResult(mpi::reduceMethods::Reduce());
 
-                int localSolutionFound = foundSolution ? 1 : 0;
-                int allRanksFoundSolution;
-                mpiReduce(
-                    pmacc::math::operation::Min(),
-                    &allRanksFoundSolution,
-                    &localSolutionFound,
-                    1,
-                    mpi::reduceMethods::AllReduce());
-
                 int maxGlobalIterations = 0;
                 mpiReduce(
                     pmacc::math::operation::Max(),
@@ -708,7 +697,7 @@ namespace picongpu
                     1,
                     mpi::reduceMethods::Reduce());
 
-                if(allRanksFoundSolution)
+                if(foundSolution)
                 {
                     if(ioRank)
                         log<picLog::PHYSICS>("  - converged after %1%/%2% iterations with norm=%3%, total epsilon=%4%")
@@ -730,7 +719,7 @@ namespace picongpu
                         poi::GetFieldEStencil{},
                         eField.getGridBuffer().getDeviceBuffer(),
                         fieldV->fieldVBuffer->getDeviceBuffer());
-                    eField.asyncCommunication(eventSystem::getTransactionEvent());
+                    setTransactionEvent(eField.asyncCommunication(eventSystem::getTransactionEvent()));
                 }
 
                 eventSystem::getTransactionEvent().waitForFinished();
@@ -749,13 +738,10 @@ namespace picongpu
                 if(ioRank)
                     log<picLog::PHYSICS>("  - duration %1% sec") % globalMaxDuration;
 
-                if(!foundSolution)
+                if(ioRank && !foundSolution)
                 {
-                    pmacc::GridController<simDim>& gc = pmacc::Environment<simDim>::get().GridController();
-                    pmacc::math::Int<simDim> gpuPos = gc.getPosition();
-                    log<picLog::PHYSICS>("  - compute domain %4% did not converge after %1% iterations with norm=%2%, "
-                                         "total epsilon=%3%")
-                        % maxIterations % normRho % std::sqrt(rho1) % gpuPos.toString();
+                    log<picLog::PHYSICS>("  - not converge after %1% iterations with norm=%2%, total epsilon=%3%")
+                        % maxIterations % normRho % std::sqrt(rho1);
                     throw std::runtime_error("Poisson solver did not converge after max iterations");
                 }
             }

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -26,6 +26,7 @@
 #include "picongpu/fields/currentDeposition/Deposit.hpp"
 #include "picongpu/fields/poissonSolver/BoundaryConditions.hpp"
 #include "picongpu/fields/poissonSolver/RightHandSideNormalization.hpp"
+#include "picongpu/fields/poissonSolver/Stencil.hpp"
 #include "picongpu/particles/filter/filter.hpp"
 #include "picongpu/particles/param.hpp"
 #include "picongpu/simulation/stage/Poisson.hpp"
@@ -90,33 +91,28 @@ namespace picongpu
                 azkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
                 fieldV = std::make_shared<fields::poissonSolver::FieldV>(m_mappingDesc);
 
+                auto const commTag = pmacc::traits::getUniqueId<uint32_t>();
+                /*go over all directions*/
+                for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
+                {
+                    if(FRONT % i == 0)
+                    {
+                        DataSpace<simDim> relativeMask = Mask::getRelativeDirections<simDim>(i);
+                        /* guarding cells depend on direction
+                         * for negative direction use originGuard else endGuard (relative direction ZERO is ignored)
+                         * don't switch end and origin because this is a read buffer and no send buffer
+                         */
+                        auto guardingCells = DataSpace<simDim>::create(0);
+                        for(uint32_t d = 0; d < simDim; ++d)
+                            guardingCells[d] = (relativeMask[d] == 0 ? 0 : 1);
+                        pkBuffer->addExchange(GUARD, i, guardingCells, commTag);
+                    }
+                }
                 DataConnector& dc = Environment<>::get().DataConnector();
                 dc.share(fieldV);
 
                 participate(true);
             }
-
-            template<typename T_Type>
-            struct cast64Bit
-            {
-                using result = typename TypeCast<float_64, T_Type>::result;
-
-                HDINLINE result operator()(T_Type const& value) const
-                {
-                    return precisionCast<float_64>(value);
-                }
-            };
-
-            template<typename T_Type>
-            struct squareComponentWise
-            {
-                using result = T_Type;
-
-                HDINLINE result operator()(T_Type const& value) const
-                {
-                    return value * value;
-                }
-            };
 
             template<typename T_TranformFunctor>
             class TransformDataBox : private T_TranformFunctor
@@ -154,42 +150,33 @@ namespace picongpu
                 DataSpace<simDim> m_offset = DataSpace<simDim>::create(0);
             };
 
-            auto Poisson::calcNorm(FieldTmp& fieldRho)
+            auto Poisson::reduceGlobal(DataSpace<simDim> fieldSize, auto dataBoxIn)
             {
-                /* reduce field E*/
-                DataSpace<simDim> fieldSize = fieldRho.getGridLayout().sizeWithoutGuardND();
-                DataSpace<simDim> fieldGuard = fieldRho.getGridLayout().guardSizeND();
+                DataBoxDim1Access d1Access(dataBoxIn, fieldSize);
 
-                auto rhoDeviceBox = fieldRho.getDeviceDataBox().shift(fieldGuard);
-
-                TransformDataBox fieldTransform(
-                    [rhoDeviceBox] DEVICEONLY(DataSpace<simDim> const& idx)
-                    { return precisionCast<float_64>(rhoDeviceBox[idx] * rhoDeviceBox[idx]); });
-                DataBoxDim1Access d1Access(fieldTransform, fieldSize);
-
-                float_64 fieldRhoNormSquaredLocal
-                    = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents()).x();
+                float_64 resultLocal
+                    = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents());
 
                 // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
                 eventSystem::getTransactionEvent().waitForFinished();
-                float_64 fieldRhoNormSquaredGlobal;
+                float_64 resultGlobal;
                 mpiReduce(
                     pmacc::math::operation::Add(),
-                    &fieldRhoNormSquaredGlobal,
-                    &fieldRhoNormSquaredLocal,
+                    &resultGlobal,
+                    &resultLocal,
                     1,
                     mpi::reduceMethods::AllReduce());
 
-                return math::sqrt(fieldRhoNormSquaredGlobal);
+                return resultGlobal;
             }
 
-            struct NormalizeField
+            struct ForEachKernel
             {
-                DINLINE auto operator()(auto const& worker, auto fieldBox, float_64 normValue, auto const mapper) const
+                DINLINE auto operator()(auto const& worker, auto fieldOut, auto const func, auto const mapper) const
                     -> void
                 {
                     DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
-                    DataSpace<simDim> superCellTotalCellOffset = superCellIdx * SuperCellSize::toRT();
+                    DataSpace<simDim> superCellCellOffset = superCellIdx * SuperCellSize::toRT();
 
                     constexpr uint32_t cellsPerSuperCell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
@@ -200,9 +187,20 @@ namespace picongpu
                         {
                             DataSpace<simDim> const cellIdx
                                 = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
-                            DataSpace<simDim> const dataCellOffset = superCellTotalCellOffset + cellIdx;
-                            fieldBox(dataCellOffset) /= normValue;
+                            DataSpace<simDim> const dataCellOffset = superCellCellOffset + cellIdx;
+                            fieldOut[dataCellOffset] = func(dataCellOffset);
                         });
+                }
+            };
+
+            template<typename T_Func>
+            struct FuncWrapper
+            {
+                T_Func const func;
+
+                HDINLINE auto operator()(auto const&... args) const
+                {
+                    return func(args...);
                 }
             };
 
@@ -220,6 +218,8 @@ namespace picongpu
 
                 // todo: log species that are used / ignored in this plugin with INFO
 
+                DataSpace<simDim> numGuardCells = fieldRho.getGridLayout().guardSizeND();
+                DataSpace<simDim> coreBorderSize = fieldRho.getGridLayout().sizeWithoutGuardND();
 
                 /* calculate and add the charge density values from all species in FieldTmp */
                 meta::ForEach<
@@ -238,26 +238,252 @@ namespace picongpu
 
                 auto rightHandSideNormalization = fields::poissonSolver::RightHandSideNormalization{};
                 rightHandSideNormalization(*fieldV.get(), fieldRho, m_mappingDesc);
-                float_64 normRho = calcNorm(fieldRho);
 
+
+                float_64 normRho;
+                {
+                    auto rhoDeviceBox = fieldRho.getDeviceDataBox().shift(numGuardCells);
+                    TransformDataBox fieldTransform(
+                        [rhoDeviceBox] DEVICEONLY(DataSpace<simDim> const& idx)
+                        { return precisionCast<float_64>(rhoDeviceBox[idx].x() * rhoDeviceBox[idx].x()); });
+
+                    normRho = std::sqrt(reduceGlobal(coreBorderSize, fieldTransform));
+                }
                 // recalculate rho
                 computeChargeDensity(fieldRho, currentStep);
                 /* add results of all species that are still in GUARD to next GPUs BORDER */
                 eventSystem::setTransactionEvent(fieldRho.asyncCommunication(eventSystem::getTransactionEvent()));
 
                 // normalize rho
-                auto rhoMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc);
-                PMACC_LOCKSTEP_KERNEL(NormalizeField{})
-                    .config(rhoMapper.getGridDim(), SuperCellSize{})(fieldRho.getDeviceDataBox(), normRho, rhoMapper);
+                auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc);
+                {
+                    auto rhoBox = fieldRho.getDeviceDataBox();
 
-                // normalize v
-                auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc);
-                PMACC_LOCKSTEP_KERNEL(NormalizeField{})
-                    .config(
-                        vMapper.getGridDim(),
-                        SuperCellSize{})(fieldV->fieldVBuffer->getDeviceBuffer().getDataBox(), normRho, rhoMapper);
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                            rhoBox,
+                            FuncWrapper{[rhoBox, normRho] DEVICEONLY(DataSpace<simDim> idx)
+                                        { return rhoBox[idx].x() / normRho; }},
+                            coreBorderMapper);
+                }
 
-                // BICGStab(fieldV, fieldRho, cellDescription);
+                {
+                    // normalize v
+                    auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc);
+                    auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(vMapper.getGridDim(), SuperCellSize{})(
+                            vField,
+                            FuncWrapper{[vField, normRho] DEVICEONLY(DataSpace<simDim> idx)
+                                        { return vField[idx] / normRho; }},
+                            vMapper);
+                }
+
+                {
+                    auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
+                    auto r0Box = r0Buffer->getDeviceBuffer().getDataBox();
+                    PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+                        .config(
+                            coreBorderMapper.getGridDim(),
+                            SuperCellSize{})(coreBorderMapper, fields::poissonSolver::StencilFunc{}, r0Box, vField);
+
+
+                    auto rhoBox = fieldRho.getDeviceDataBox();
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                            r0Box,
+                            FuncWrapper{[r0Box, rhoBox] DEVICEONLY(DataSpace<simDim> idx)
+                                        { return rhoBox[idx].x() - r0Box[idx]; }},
+                            coreBorderMapper);
+                }
+
+                pkBuffer->getDeviceBuffer().copyFrom(r0Buffer->getDeviceBuffer());
+                rkBuffer->getDeviceBuffer().copyFrom(r0Buffer->getDeviceBuffer());
+
+                float_64 rho0;
+                /* rho reduction */
+                {
+                    auto r0Box = r0Buffer->getDeviceBuffer().getDataBox();
+                    auto r0BoxBorderGuard = r0Box.shift(numGuardCells);
+
+                    TransformDataBox fieldTransform([r0BoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                                                    { return r0BoxBorderGuard[idx] * r0BoxBorderGuard[idx]; });
+
+                    rho0 = reduceGlobal(coreBorderSize, fieldTransform);
+                }
+
+                float_64 rho1 = rho0;
+
+                constexpr int maxIterations = 1000;
+                constexpr float_64 epsilon = 1e-8;
+                for(int i = 0; i < maxIterations; ++i)
+                {
+                    // preconditioner
+                    mpkBuffer->getDeviceBuffer().copyFrom(pkBuffer->getDeviceBuffer());
+                    mpkBuffer->communication();
+
+                    // w = Ap
+                    {
+                        auto mpkBox = mpkBuffer->getDeviceBuffer().getDataBox();
+                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                coreBorderMapper,
+                                fields::poissonSolver::StencilFunc{},
+                                ampkBox,
+                                mpkBox);
+                    }
+
+                    float_64 totalSum1;
+                    /* local p = rw */
+                    {
+                        auto r0Box = r0Buffer->getDeviceBuffer().getDataBox();
+                        auto r0BoxBorderGuard = r0Box.shift(numGuardCells);
+
+                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
+                        auto ampkBoxBorderGuard = ampkBox.shift(numGuardCells);
+
+                        TransformDataBox fieldTransform(
+                            [r0BoxBorderGuard, ampkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                            { return r0BoxBorderGuard[idx] * ampkBoxBorderGuard[idx]; });
+
+                        totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
+                    }
+                    float_64 alpha = rho0 / totalSum1;
+                    // r = r - alpha * w
+                    {
+                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
+                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
+
+                        auto rhoBox = fieldRho.getDeviceDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                rkBox,
+                                FuncWrapper{[rkBox, ampkBox, alpha] DEVICEONLY(DataSpace<simDim> idx)
+                                            { return rkBox[idx] - alpha * ampkBox[idx]; }},
+                                coreBorderMapper);
+                    }
+
+                    // preconditioner
+                    zkBuffer->getDeviceBuffer().copyFrom(rkBuffer->getDeviceBuffer());
+                    zkBuffer->communication();
+
+                    // t = A * r
+                    {
+                        auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
+                        auto zkBox = zkBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                coreBorderMapper,
+                                fields::poissonSolver::StencilFunc{},
+                                azkBox,
+                                zkBox);
+                    }
+
+                    /* totalSum1 = azk * rk */
+                    {
+                        auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
+                        auto azkBoxBorderGuard = azkBox.shift(numGuardCells);
+
+                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
+                        auto rkBoxBorderGuard = rkBox.shift(numGuardCells);
+
+                        TransformDataBox fieldTransform(
+                            [azkBoxBorderGuard, rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                            { return azkBoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
+
+                        totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
+                    }
+
+                    float_64 totalSum2;
+                    /* totalSum1 = azk * azk */
+                    {
+                        auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
+                        auto azkBoxBorderGuard = azkBox.shift(numGuardCells);
+
+                        TransformDataBox fieldTransform([azkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                                                        { return azkBoxBorderGuard[idx] * azkBoxBorderGuard[idx]; });
+
+                        totalSum2 = reduceGlobal(coreBorderSize, fieldTransform);
+                    }
+
+                    float_64 omega = totalSum1 / totalSum2;
+                    // v = v + alpha * mpk + omega * zk
+                    {
+                        auto vFieldBox = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
+                        auto mpkBox = mpkBuffer->getDeviceBuffer().getDataBox();
+                        auto zkBox = zkBuffer->getDeviceBuffer().getDataBox();
+
+                        auto rhoBox = fieldRho.getDeviceDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                vFieldBox,
+                                FuncWrapper{[vFieldBox, mpkBox, zkBox, alpha, omega] DEVICEONLY(DataSpace<simDim> idx)
+                                            { return vFieldBox[idx] + alpha * mpkBox[idx] + omega * zkBox[idx]; }},
+                                coreBorderMapper);
+                    }
+                    // rk = rk -  omega * azk
+                    {
+                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
+                        auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
+
+
+                        auto rhoBox = fieldRho.getDeviceDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                rkBox,
+                                FuncWrapper{[rkBox, azkBox, omega] DEVICEONLY(DataSpace<simDim> idx)
+                                            { return rkBox[idx] - omega * azkBox[idx]; }},
+                                coreBorderMapper);
+                    }
+
+                    /* totalSum1 = r0 * rk */
+                    {
+                        auto r0Box = r0Buffer->getDeviceBuffer().getDataBox();
+                        auto r0BoxBorderGuard = r0Box.shift(numGuardCells);
+
+                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
+                        auto rkBoxBorderGuard = rkBox.shift(numGuardCells);
+
+                        TransformDataBox fieldTransform(
+                            [r0BoxBorderGuard, rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                            { return r0BoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
+
+                        totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
+                    }
+                    /* totalSum2 = rk * rk */
+                    {
+                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
+                        auto rkBoxBorderGuard = rkBox.shift(numGuardCells);
+
+                        TransformDataBox fieldTransform([rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                                                        { return rkBoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
+
+                        totalSum2 = reduceGlobal(coreBorderSize, fieldTransform);
+                    }
+
+                    rho1 = totalSum1;
+                    float_64 beta = rho1 / rho0 * alpha / omega;
+                    rho0 = rho1;
+                    if(std::sqrt(totalSum2) < epsilon)
+                    {
+                        std::cout << "Converged after " << i << " iterations" << std::endl;
+                        break;
+                    }
+                    // pk = rk + beta * (pk - omega * ampk)
+                    {
+                        auto pkBox = pkBuffer->getDeviceBuffer().getDataBox();
+                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
+                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
+
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                pkBox,
+                                FuncWrapper{[pkBox, rkBox, ampkBox, beta, omega] DEVICEONLY(DataSpace<simDim> idx)
+                                            { return rkBox[idx] + beta * (pkBox[idx] - omega * ampkBox[idx]); }},
+                                coreBorderMapper);
+                    }
+                } // for loop
             }
         } // namespace stage
     } // namespace simulation

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -43,6 +43,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <tuple>
 
 #include <picongpu/param/particle.param>
 
@@ -263,8 +264,12 @@ namespace picongpu
 
             struct ForEachKernel
             {
-                DINLINE auto operator()(auto const& worker, auto fieldOut, auto const func, auto const mapper) const
-                    -> void
+                DINLINE auto operator()(
+                    auto const& worker,
+                    auto const& mapper,
+                    auto const& func,
+                    auto outBox,
+                    auto... boxes) const -> void
                 {
                     DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
                     DataSpace<simDim> superCellCellOffset = superCellIdx * SuperCellSize::toRT();
@@ -279,10 +284,20 @@ namespace picongpu
                             DataSpace<simDim> const cellIdx
                                 = pmacc::math::mapToND(SuperCellSize::toRT(), linearCellIdx);
                             DataSpace<simDim> const dataCellOffset = superCellCellOffset + cellIdx;
-                            fieldOut[dataCellOffset] = func(dataCellOffset);
+                            outBox[dataCellOffset] = func(outBox[dataCellOffset], boxes[dataCellOffset]...);
                         });
                 }
             };
+
+            inline void forEachCell(auto mapper, auto const& functor, auto& outBuffer, auto&... buffers)
+            {
+                PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                    .config(mapper.getGridDim(), SuperCellSize{})(
+                        mapper,
+                        DeviceLambda{functor},
+                        outBuffer.getDataBox(),
+                        buffers.getDataBox()...);
+            }
 
             void Poisson::preconditioner(
                 std::unique_ptr<GridBuffer<float_64, simDim>>& xBuffer,
@@ -323,42 +338,33 @@ namespace picongpu
 
                 auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc.value());
 
-                {
-                    auto bBox = bBuffer->getDeviceBuffer().getDataBox();
-                    auto zBox = zBuffer->getDeviceBuffer().getDataBox();
+                namespace poi = fields::poissonSolver;
 
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            zBox,
-                            DeviceLambda{
-                                [bBox, theta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return bBox[idx] / theta; }},
-                            coreBorderMapper);
+                forEachCell(
+                    coreBorderMapper,
+                    [theta] DEVICEONLY(auto, auto const bValue) -> float_64 { return bValue / theta; },
+                    zBuffer->getDeviceBuffer(),
+                    bBuffer->getDeviceBuffer());
 
-                    auto yBox = yBuffer->getDeviceBuffer().getDataBox();
+                poi::stencil(
+                    coreBorderMapper,
+                    poi::StencilFunc{},
+                    yBuffer->getDeviceBuffer(),
+                    bBuffer->getDeviceBuffer());
 
-                    // poisson stencil
-                    PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
-                        .config(
-                            coreBorderMapper.getGridDim(),
-                            SuperCellSize{})(coreBorderMapper, fields::poissonSolver::StencilFunc{}, yBox, bBox);
+                forEachCell(
+                    coreBorderMapper,
+                    [rhoCurrent, theta, delta] DEVICEONLY(auto const yValue) -> float_64
+                    { return -2.0 * rhoCurrent * yValue / theta / delta; },
+                    yBuffer->getDeviceBuffer());
 
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            yBox,
-                            DeviceLambda{
-                                [yBox, rhoCurrent, theta, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return -2.0 * rhoCurrent * yBox[idx] / theta / delta; }},
-                            coreBorderMapper);
+                forEachCell(
+                    coreBorderMapper,
+                    [rhoCurrent, delta] DEVICEONLY(auto const yValue, auto const bValue) -> float_64
+                    { return yValue + 4.0 * bValue * rhoCurrent / delta; },
+                    yBuffer->getDeviceBuffer(),
+                    bBuffer->getDeviceBuffer());
 
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            yBox,
-                            DeviceLambda{
-                                [bBox, yBox, rhoCurrent, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return yBox[idx] + 4.0 * bBox[idx] * rhoCurrent / delta; }},
-                            coreBorderMapper);
-                }
 
                 uint32_t iterMax = m_maxPreconditionerSteps;
                 for(uint32_t i = 2; i < iterMax; ++i)
@@ -367,60 +373,38 @@ namespace picongpu
                     rhoCurrent = 1. / (2. * sigma - rhoOld);
                     yBuffer->communication();
 
-                    {
-                        auto yBox = yBuffer->getDeviceBuffer().getDataBox();
-                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
-                            .config(
-                                coreBorderMapper.getGridDim(),
-                                SuperCellSize{})(coreBorderMapper, fields::poissonSolver::StencilFunc{}, wBox, yBox);
-                    }
-                    {
-                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                wBox,
-                                DeviceLambda{
-                                    [wBox, rhoCurrent, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return -2.0 * rhoCurrent * wBox[idx] / delta; }},
-                                coreBorderMapper);
-                    }
+                    poi::stencil(
+                        coreBorderMapper,
+                        poi::StencilFunc{},
+                        wBuffer->getDeviceBuffer(),
+                        yBuffer->getDeviceBuffer());
 
-                    {
-                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
-                        auto bBox = bBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                wBox,
-                                DeviceLambda{
-                                    [wBox, bBox, rhoCurrent, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return wBox[idx] + 2.0 * rhoCurrent * bBox[idx] / delta; }},
-                                coreBorderMapper);
-                    }
+                    forEachCell(
+                        coreBorderMapper,
+                        [rhoCurrent, delta] DEVICEONLY(auto const wValue) -> float_64
+                        { return -2.0 * rhoCurrent * wValue / delta; },
+                        wBuffer->getDeviceBuffer());
 
-                    {
-                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
-                        auto yBox = yBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                wBox,
-                                DeviceLambda{
-                                    [wBox, yBox, rhoCurrent, sigma] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return wBox[idx] + 2.0 * rhoCurrent * sigma * yBox[idx]; }},
-                                coreBorderMapper);
-                    }
+                    forEachCell(
+                        coreBorderMapper,
+                        [rhoCurrent, delta] DEVICEONLY(auto const wValue, auto const bValue) -> float_64
+                        { return wValue + 2.0 * rhoCurrent * bValue / delta; },
+                        wBuffer->getDeviceBuffer(),
+                        bBuffer->getDeviceBuffer());
 
-                    {
-                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
-                        auto zBox = zBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                wBox,
-                                DeviceLambda{
-                                    [wBox, zBox, rhoCurrent, rhoOld] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return wBox[idx] - rhoCurrent * rhoOld * zBox[idx]; }},
-                                coreBorderMapper);
-                    }
+                    forEachCell(
+                        coreBorderMapper,
+                        [rhoCurrent, sigma] DEVICEONLY(auto const wValue, auto const yValue) -> float_64
+                        { return wValue + 2.0 * rhoCurrent * sigma * yValue; },
+                        wBuffer->getDeviceBuffer(),
+                        yBuffer->getDeviceBuffer());
+
+                    forEachCell(
+                        coreBorderMapper,
+                        [rhoCurrent, rhoOld] DEVICEONLY(auto const wValue, auto const zValue) -> float_64
+                        { return wValue - rhoCurrent * rhoOld * zValue; },
+                        wBuffer->getDeviceBuffer(),
+                        zBuffer->getDeviceBuffer());
 
                     zBuffer->getDeviceBuffer().copyFrom(yBuffer->getDeviceBuffer());
                     yBuffer->getDeviceBuffer().copyFrom(wBuffer->getDeviceBuffer());
@@ -430,6 +414,7 @@ namespace picongpu
 
             void Poisson::operator()(uint32_t const currentStep)
             {
+                namespace poi = fields::poissonSolver;
                 log<picLog::PHYSICS>("Poisson solver:");
                 if(!m_useSolver)
                 {
@@ -462,10 +447,10 @@ namespace picongpu
                 EventTask fieldTmpEvent = fieldRho.asyncCommunication(eventSystem::getTransactionEvent());
                 eventSystem::setTransactionEvent(fieldTmpEvent);
 
-                auto boundaryConditionsDirichlet = fields::poissonSolver::BoundaryConditionsDirichlet{};
+                auto boundaryConditionsDirichlet = poi::BoundaryConditionsDirichlet{};
                 boundaryConditionsDirichlet(*fieldV.get(), m_mappingDesc.value());
 
-                auto rightHandSideNormalization = fields::poissonSolver::RightHandSideNormalization{};
+                auto rightHandSideNormalization = poi::RightHandSideNormalization{};
                 rightHandSideNormalization(*fieldV.get(), fieldRho, m_mappingDesc.value());
 
 
@@ -484,51 +469,34 @@ namespace picongpu
                 /* add results of all species that are still in GUARD to next GPUs BORDER */
                 eventSystem::setTransactionEvent(fieldRho.asyncCommunication(eventSystem::getTransactionEvent()));
 
-                // normalize rho
                 auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc.value());
-                {
-                    auto rhoBox = fieldRho.getDeviceDataBox();
 
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            rhoBox,
-                            DeviceLambda{
-                                [rhoBox, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return rhoBox[idx].x() / normRho; }},
-                            coreBorderMapper);
-                }
+                // normalize rho
+                forEachCell(
+                    coreBorderMapper,
+                    [normRho] DEVICEONLY(auto rhoValue) -> float_64 { return rhoValue.x() / normRho; },
+                    fieldRho.getGridBuffer().getDeviceBuffer());
 
-                {
-                    // normalize v
-                    auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc.value());
-                    auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(vMapper.getGridDim(), SuperCellSize{})(
-                            vField,
-                            DeviceLambda{
-                                [vField, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return vField[idx] / normRho; }},
-                            vMapper);
-                }
+                auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc.value());
 
-                {
-                    auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
-                    auto r0Box = r0Buffer->getDeviceBuffer().getDataBox();
-                    PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
-                        .config(
-                            coreBorderMapper.getGridDim(),
-                            SuperCellSize{})(coreBorderMapper, fields::poissonSolver::StencilFunc{}, r0Box, vField);
+                // normalize v
+                forEachCell(
+                    vMapper,
+                    [normRho] DEVICEONLY(auto const vValue) -> float_64 { return vValue / normRho; },
+                    fieldV->fieldVBuffer->getDeviceBuffer());
 
+                poi::stencil(
+                    coreBorderMapper,
+                    poi::StencilFunc{},
+                    r0Buffer->getDeviceBuffer(),
+                    fieldV->fieldVBuffer->getDeviceBuffer());
 
-                    auto rhoBox = fieldRho.getDeviceDataBox();
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            r0Box,
-                            DeviceLambda{
-                                [r0Box, rhoBox] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return rhoBox[idx].x() - r0Box[idx]; }},
-                            coreBorderMapper);
-                }
+                forEachCell(
+                    coreBorderMapper,
+                    [] DEVICEONLY(auto const r0Value, auto const rhoValue) -> float_64
+                    { return rhoValue.x() - r0Value; },
+                    r0Buffer->getDeviceBuffer(),
+                    fieldRho.getGridBuffer().getDeviceBuffer());
 
                 pkBuffer->getDeviceBuffer().copyFrom(r0Buffer->getDeviceBuffer());
                 rkBuffer->getDeviceBuffer().copyFrom(r0Buffer->getDeviceBuffer());
@@ -562,16 +530,11 @@ namespace picongpu
                     mpkBuffer->communication();
 
                     // w = Ap
-                    {
-                        auto mpkBox = mpkBuffer->getDeviceBuffer().getDataBox();
-                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                coreBorderMapper,
-                                fields::poissonSolver::StencilFunc{},
-                                ampkBox,
-                                mpkBox);
-                    }
+                    poi::stencil(
+                        coreBorderMapper,
+                        poi::StencilFunc{},
+                        ampkBuffer->getDeviceBuffer(),
+                        mpkBuffer->getDeviceBuffer());
 
                     float_64 totalSum1;
                     /* local p = rw */
@@ -590,19 +553,12 @@ namespace picongpu
                     }
                     float_64 alpha = rho0 / totalSum1;
                     // r = r - alpha * w
-                    {
-                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
-                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
-
-                        auto rhoBox = fieldRho.getDeviceDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                rkBox,
-                                DeviceLambda{
-                                    [rkBox, ampkBox, alpha] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return rkBox[idx] - alpha * ampkBox[idx]; }},
-                                coreBorderMapper);
-                    }
+                    forEachCell(
+                        coreBorderMapper,
+                        [alpha] DEVICEONLY(auto const rkValue, auto const ampkValue) -> float_64
+                        { return rkValue - alpha * ampkValue; },
+                        rkBuffer->getDeviceBuffer(),
+                        ampkBuffer->getDeviceBuffer());
 
                     // preconditioner
                     if(m_disablePreconditioner)
@@ -613,16 +569,11 @@ namespace picongpu
                     zkBuffer->communication();
 
                     // t = A * r
-                    {
-                        auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
-                        auto zkBox = zkBuffer->getDeviceBuffer().getDataBox();
-                        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                coreBorderMapper,
-                                fields::poissonSolver::StencilFunc{},
-                                azkBox,
-                                zkBox);
-                    }
+                    poi::stencil(
+                        coreBorderMapper,
+                        poi::StencilFunc{},
+                        azkBuffer->getDeviceBuffer(),
+                        zkBuffer->getDeviceBuffer());
 
                     /* totalSum1 = azk * rk */
                     {
@@ -653,37 +604,24 @@ namespace picongpu
                     }
 
                     float_64 omega = totalSum1 / totalSum2;
+
                     // v = v + alpha * mpk + omega * zk
-                    {
-                        auto vFieldBox = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
-                        auto mpkBox = mpkBuffer->getDeviceBuffer().getDataBox();
-                        auto zkBox = zkBuffer->getDeviceBuffer().getDataBox();
+                    forEachCell(
+                        coreBorderMapper,
+                        [alpha,
+                         omega] DEVICEONLY(auto const vValue, auto const mpkValue, auto const zkValue) -> float_64
+                        { return vValue + alpha * mpkValue + omega * zkValue; },
+                        fieldV->fieldVBuffer->getDeviceBuffer(),
+                        mpkBuffer->getDeviceBuffer(),
+                        zkBuffer->getDeviceBuffer());
 
-                        auto rhoBox = fieldRho.getDeviceDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                vFieldBox,
-                                DeviceLambda{
-                                    [vFieldBox, mpkBox, zkBox, alpha, omega] DEVICEONLY(
-                                        DataSpace<simDim> idx) -> float_64
-                                    { return vFieldBox[idx] + alpha * mpkBox[idx] + omega * zkBox[idx]; }},
-                                coreBorderMapper);
-                    }
                     // rk = rk -  omega * azk
-                    {
-                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
-                        auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
-
-
-                        auto rhoBox = fieldRho.getDeviceDataBox();
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                rkBox,
-                                DeviceLambda{
-                                    [rkBox, azkBox, omega] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return rkBox[idx] - omega * azkBox[idx]; }},
-                                coreBorderMapper);
-                    }
+                    forEachCell(
+                        coreBorderMapper,
+                        [omega] DEVICEONLY(auto const rkValue, auto const azkValue) -> float_64
+                        { return rkValue - omega * azkValue; },
+                        rkBuffer->getDeviceBuffer(),
+                        azkBuffer->getDeviceBuffer());
 
                     /* totalSum1 = r0 * rk */
                     {
@@ -722,44 +660,37 @@ namespace picongpu
                         break;
                     }
                     // pk = rk + beta * (pk - omega * ampk)
-                    {
-                        auto pkBox = pkBuffer->getDeviceBuffer().getDataBox();
-                        auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
-                        auto ampkBox = ampkBuffer->getDeviceBuffer().getDataBox();
+                    forEachCell(
+                        coreBorderMapper,
+                        [beta,
+                         omega] DEVICEONLY(auto const pkValue, auto const rkValue, auto const ampkValue) -> float_64
+                        { return rkValue + beta * (pkValue - omega * ampkValue); },
+                        pkBuffer->getDeviceBuffer(),
+                        rkBuffer->getDeviceBuffer(),
+                        ampkBuffer->getDeviceBuffer());
 
-                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                                pkBox,
-                                DeviceLambda{
-                                    [pkBox, rkBox, ampkBox, beta, omega] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                    { return rkBox[idx] + beta * (pkBox[idx] - omega * ampkBox[idx]); }},
-                                coreBorderMapper);
-                    }
                 } // for loop
 
                 if(foundSolution)
                 {
                     // normalize v back
-                    auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
-                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            vField,
-                            DeviceLambda{
-                                [vField, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return vField[idx] * normRho / sim.pic.getEps0(); }},
-                            coreBorderMapper);
+                    forEachCell(
+                        coreBorderMapper,
+                        [normRho] DEVICEONLY(auto const vValue) -> float_64
+                        { return vValue * normRho / sim.pic.getEps0(); },
+                        fieldV->fieldVBuffer->getDeviceBuffer());
                     fieldV->fieldVBuffer->communication();
 
                     // compute fieldE
                     auto& eField = *dc.get<FieldE>(FieldE::getName());
-                    auto fieldEBox = eField.getDeviceDataBox();
-                    PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
-                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
-                            coreBorderMapper,
-                            fields::poissonSolver::GetFieldEStencil{},
-                            fieldEBox,
-                            vField);
+
+                    poi::stencil(
+                        coreBorderMapper,
+                        poi::GetFieldEStencil{},
+                        eField.getGridBuffer().getDeviceBuffer(),
+                        fieldV->fieldVBuffer->getDeviceBuffer());
                     eField.asyncCommunication(eventSystem::getTransactionEvent());
+
                     eventSystem::getTransactionEvent().waitForFinished();
                 }
                 auto endT = std::chrono::high_resolution_clock::now();

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -91,7 +91,8 @@ namespace picongpu
                 azkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
                 fieldV = std::make_shared<fields::poissonSolver::FieldV>(m_mappingDesc);
 
-                auto const commTag = pmacc::traits::getUniqueId<uint32_t>();
+                auto const commTag0 = pmacc::traits::getUniqueId<uint32_t>();
+                auto const commTag1 = pmacc::traits::getUniqueId<uint32_t>();
                 /*go over all directions*/
                 for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
                 {
@@ -105,7 +106,8 @@ namespace picongpu
                         auto guardingCells = DataSpace<simDim>::create(0);
                         for(uint32_t d = 0; d < simDim; ++d)
                             guardingCells[d] = (relativeMask[d] == 0 ? 0 : 1);
-                        pkBuffer->addExchange(GUARD, i, guardingCells, commTag);
+                        mpkBuffer->addExchange(GUARD, i, guardingCells, commTag0);
+                        zkBuffer->addExchange(GUARD, i, guardingCells, commTag1);
                     }
                 }
                 DataConnector& dc = Environment<>::get().DataConnector();
@@ -194,13 +196,20 @@ namespace picongpu
             };
 
             template<typename T_Func>
-            struct FuncWrapper
+            struct DeviceLambda
             {
                 T_Func const func;
 
-                HDINLINE auto operator()(auto const&... args) const
+                template<typename... T>
+                DEVICEONLY auto operator()(T&&... args) const
                 {
-                    return func(args...);
+                    return func(std::forward<T>(args)...);
+                }
+
+                template<typename... T>
+                DEVICEONLY auto operator()(T&&... args)
+                {
+                    return func(std::forward<T>(args)...);
                 }
             };
 
@@ -244,7 +253,7 @@ namespace picongpu
                 {
                     auto rhoDeviceBox = fieldRho.getDeviceDataBox().shift(numGuardCells);
                     TransformDataBox fieldTransform(
-                        [rhoDeviceBox] DEVICEONLY(DataSpace<simDim> const& idx)
+                        [rhoDeviceBox] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
                         { return precisionCast<float_64>(rhoDeviceBox[idx].x() * rhoDeviceBox[idx].x()); });
 
                     normRho = std::sqrt(reduceGlobal(coreBorderSize, fieldTransform));
@@ -262,8 +271,9 @@ namespace picongpu
                     PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                         .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                             rhoBox,
-                            FuncWrapper{[rhoBox, normRho] DEVICEONLY(DataSpace<simDim> idx)
-                                        { return rhoBox[idx].x() / normRho; }},
+                            DeviceLambda{
+                                [rhoBox, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return rhoBox[idx].x() / normRho; }},
                             coreBorderMapper);
                 }
 
@@ -274,8 +284,9 @@ namespace picongpu
                     PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                         .config(vMapper.getGridDim(), SuperCellSize{})(
                             vField,
-                            FuncWrapper{[vField, normRho] DEVICEONLY(DataSpace<simDim> idx)
-                                        { return vField[idx] / normRho; }},
+                            DeviceLambda{
+                                [vField, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return vField[idx] / normRho; }},
                             vMapper);
                 }
 
@@ -292,8 +303,9 @@ namespace picongpu
                     PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                         .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                             r0Box,
-                            FuncWrapper{[r0Box, rhoBox] DEVICEONLY(DataSpace<simDim> idx)
-                                        { return rhoBox[idx].x() - r0Box[idx]; }},
+                            DeviceLambda{
+                                [r0Box, rhoBox] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return rhoBox[idx].x() - r0Box[idx]; }},
                             coreBorderMapper);
                 }
 
@@ -306,8 +318,9 @@ namespace picongpu
                     auto r0Box = r0Buffer->getDeviceBuffer().getDataBox();
                     auto r0BoxBorderGuard = r0Box.shift(numGuardCells);
 
-                    TransformDataBox fieldTransform([r0BoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
-                                                    { return r0BoxBorderGuard[idx] * r0BoxBorderGuard[idx]; });
+                    TransformDataBox fieldTransform(
+                        [r0BoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
+                        { return r0BoxBorderGuard[idx] * r0BoxBorderGuard[idx]; });
 
                     rho0 = reduceGlobal(coreBorderSize, fieldTransform);
                 }
@@ -344,7 +357,7 @@ namespace picongpu
                         auto ampkBoxBorderGuard = ampkBox.shift(numGuardCells);
 
                         TransformDataBox fieldTransform(
-                            [r0BoxBorderGuard, ampkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                            [r0BoxBorderGuard, ampkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
                             { return r0BoxBorderGuard[idx] * ampkBoxBorderGuard[idx]; });
 
                         totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
@@ -359,8 +372,9 @@ namespace picongpu
                         PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                             .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                                 rkBox,
-                                FuncWrapper{[rkBox, ampkBox, alpha] DEVICEONLY(DataSpace<simDim> idx)
-                                            { return rkBox[idx] - alpha * ampkBox[idx]; }},
+                                DeviceLambda{
+                                    [rkBox, ampkBox, alpha] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return rkBox[idx] - alpha * ampkBox[idx]; }},
                                 coreBorderMapper);
                     }
 
@@ -389,7 +403,7 @@ namespace picongpu
                         auto rkBoxBorderGuard = rkBox.shift(numGuardCells);
 
                         TransformDataBox fieldTransform(
-                            [azkBoxBorderGuard, rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                            [azkBoxBorderGuard, rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
                             { return azkBoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
 
                         totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
@@ -401,8 +415,9 @@ namespace picongpu
                         auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
                         auto azkBoxBorderGuard = azkBox.shift(numGuardCells);
 
-                        TransformDataBox fieldTransform([azkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
-                                                        { return azkBoxBorderGuard[idx] * azkBoxBorderGuard[idx]; });
+                        TransformDataBox fieldTransform(
+                            [azkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
+                            { return azkBoxBorderGuard[idx] * azkBoxBorderGuard[idx]; });
 
                         totalSum2 = reduceGlobal(coreBorderSize, fieldTransform);
                     }
@@ -418,8 +433,10 @@ namespace picongpu
                         PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                             .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                                 vFieldBox,
-                                FuncWrapper{[vFieldBox, mpkBox, zkBox, alpha, omega] DEVICEONLY(DataSpace<simDim> idx)
-                                            { return vFieldBox[idx] + alpha * mpkBox[idx] + omega * zkBox[idx]; }},
+                                DeviceLambda{
+                                    [vFieldBox, mpkBox, zkBox, alpha, omega] DEVICEONLY(
+                                        DataSpace<simDim> idx) -> float_64
+                                    { return vFieldBox[idx] + alpha * mpkBox[idx] + omega * zkBox[idx]; }},
                                 coreBorderMapper);
                     }
                     // rk = rk -  omega * azk
@@ -432,8 +449,9 @@ namespace picongpu
                         PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                             .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                                 rkBox,
-                                FuncWrapper{[rkBox, azkBox, omega] DEVICEONLY(DataSpace<simDim> idx)
-                                            { return rkBox[idx] - omega * azkBox[idx]; }},
+                                DeviceLambda{
+                                    [rkBox, azkBox, omega] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return rkBox[idx] - omega * azkBox[idx]; }},
                                 coreBorderMapper);
                     }
 
@@ -446,7 +464,7 @@ namespace picongpu
                         auto rkBoxBorderGuard = rkBox.shift(numGuardCells);
 
                         TransformDataBox fieldTransform(
-                            [r0BoxBorderGuard, rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
+                            [r0BoxBorderGuard, rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
                             { return r0BoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
 
                         totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
@@ -456,8 +474,9 @@ namespace picongpu
                         auto rkBox = rkBuffer->getDeviceBuffer().getDataBox();
                         auto rkBoxBorderGuard = rkBox.shift(numGuardCells);
 
-                        TransformDataBox fieldTransform([rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx)
-                                                        { return rkBoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
+                        TransformDataBox fieldTransform(
+                            [rkBoxBorderGuard] DEVICEONLY(DataSpace<simDim> const& idx) -> float_64
+                            { return rkBoxBorderGuard[idx] * rkBoxBorderGuard[idx]; });
 
                         totalSum2 = reduceGlobal(coreBorderSize, fieldTransform);
                     }
@@ -479,11 +498,26 @@ namespace picongpu
                         PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                             .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                                 pkBox,
-                                FuncWrapper{[pkBox, rkBox, ampkBox, beta, omega] DEVICEONLY(DataSpace<simDim> idx)
-                                            { return rkBox[idx] + beta * (pkBox[idx] - omega * ampkBox[idx]); }},
+                                DeviceLambda{
+                                    [pkBox, rkBox, ampkBox, beta, omega] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return rkBox[idx] + beta * (pkBox[idx] - omega * ampkBox[idx]); }},
                                 coreBorderMapper);
                     }
                 } // for loop
+
+                {
+                    // normalize v back
+                    auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc);
+                    auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(vMapper.getGridDim(), SuperCellSize{})(
+                            vField,
+                            DeviceLambda{
+                                [vField, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return vField[idx] * normRho; }},
+                            vMapper);
+                    fieldV->fieldVBuffer->communication();
+                }
             }
         } // namespace stage
     } // namespace simulation

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -124,7 +124,7 @@ namespace picongpu
             void Poisson::registerHelp(po::options_description& desc)
             {
                 namespace po = boost::program_options;
-                po::options_description solverDesc("Poisson solver:");
+                po::options_description solverDesc("Poisson solver");
 
                 solverDesc.add_options()(
                     "poisson.activate",

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -130,6 +130,7 @@ namespace picongpu
 
                 auto const commTag0 = pmacc::traits::getUniqueId<uint32_t>();
                 auto const commTag1 = pmacc::traits::getUniqueId<uint32_t>();
+                auto const commTagFieldV = pmacc::traits::getUniqueId<uint32_t>();
                 /*go over all directions*/
                 for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
                 {
@@ -145,6 +146,7 @@ namespace picongpu
                             guardingCells[d] = (relativeMask[d] == 0 ? 0 : 1);
                         mpkBuffer->addExchange(GUARD, i, guardingCells, commTag0);
                         zkBuffer->addExchange(GUARD, i, guardingCells, commTag1);
+                        fieldV->fieldVBuffer->addExchange(GUARD, i, guardingCells, commTagFieldV);
                     }
                 }
                 DataConnector& dc = Environment<>::get().DataConnector();
@@ -503,7 +505,7 @@ namespace picongpu
                     if(std::sqrt(totalSum2) < epsilon)
                     {
                         std::cout << "Converged after " << i << " iterations with norm=" << normRho
-                                  << ", total sum2=" << totalSum2 << std::endl;
+                                  << ", total sum2=" << std::sqrt(totalSum2) << std::endl;
                         break;
                     }
                     // pk = rk + beta * (pk - omega * ampk)
@@ -524,15 +526,14 @@ namespace picongpu
 
                 {
                     // normalize v back
-                    auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc);
                     auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
                     PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
-                        .config(vMapper.getGridDim(), SuperCellSize{})(
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
                             vField,
                             DeviceLambda{
                                 [vField, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
                                 { return vField[idx] * normRho; }},
-                            vMapper);
+                            coreBorderMapper);
                     fieldV->fieldVBuffer->communication();
                 }
             }

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -116,56 +116,93 @@ namespace picongpu
             using SpeciesEligibleForChargeConservation = typename particles::traits::
                 SpeciesEligibleForSolver<T, deriveField::derivedAttributes::ChargeDensity>::type;
 
-            Poisson::Poisson(MappingDesc const mappingDesc)
-                : m_mappingDesc(mappingDesc)
-                , localReduce{std::make_unique<pmacc::device::Reduce>(1024)}
+            Poisson::Poisson() : localReduce{std::make_unique<pmacc::device::Reduce>(1024)}
             {
-                pkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                rkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                r0Buffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                mpkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                ampkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                zkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                azkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                fieldV = std::make_shared<fields::poissonSolver::FieldV>(m_mappingDesc);
+            }
 
-                yBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                wBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
-                zBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+            void Poisson::registerHelp(po::options_description& desc)
+            {
+                namespace po = boost::program_options;
+                po::options_description solverDesc("Poisson solver:");
 
-                auto const commTag0 = pmacc::traits::getUniqueId<uint32_t>();
-                auto const commTag1 = pmacc::traits::getUniqueId<uint32_t>();
-                auto const commTagPk = pmacc::traits::getUniqueId<uint32_t>();
-                auto const commTagRk = pmacc::traits::getUniqueId<uint32_t>();
-                auto const commTagFieldV = pmacc::traits::getUniqueId<uint32_t>();
+                solverDesc.add_options()(
+                    "poisson.activate",
+                    po::value<bool>(&m_useSolver)->zero_tokens(),
+                    "enable poisson solver");
+                solverDesc.add_options()(
+                    "poisson.maxSteps",
+                    po::value<uint32_t>(&m_maxSolverSteps)->default_value(2000),
+                    "maximum number of steps for the preconditioner");
+                solverDesc.add_options()(
+                    "poisson.epsilon",
+                    po::value<float_64>(&m_solverEpsilon)->default_value(1.0e-8),
+                    "maximal allowed error of the poisson solver");
+                // preconitioner
+                solverDesc.add_options()(
+                    "poisson.preconditioner.disable",
+                    po::value<bool>(&m_disablePreconditioner)->zero_tokens(),
+                    "disable poisson solver preconditioner");
+                solverDesc.add_options()(
+                    "poisson.preconditioner.maxSteps",
+                    po::value<uint32_t>(&m_maxPreconditionerSteps)->default_value(20),
+                    "maximum number of steps for the preconditioner");
+                desc.add(solverDesc);
+            }
 
-                auto const commTagY = pmacc::traits::getUniqueId<uint32_t>();
-                /*go over all directions*/
-                for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
+            void Poisson::init(MappingDesc const mappingDesc)
+            {
+                m_mappingDesc = std::make_optional<MappingDesc>(mappingDesc);
+
+                if(m_useSolver)
                 {
-                    if(FRONT % i == 0)
+                    pkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    rkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    r0Buffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    mpkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    ampkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    zkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    azkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    fieldV = std::make_shared<fields::poissonSolver::FieldV>(m_mappingDesc.value());
+
+                    yBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    wBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+                    zBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc->getGridLayout());
+
+                    auto const commTag0 = pmacc::traits::getUniqueId<uint32_t>();
+                    auto const commTag1 = pmacc::traits::getUniqueId<uint32_t>();
+                    auto const commTagPk = pmacc::traits::getUniqueId<uint32_t>();
+                    auto const commTagRk = pmacc::traits::getUniqueId<uint32_t>();
+                    auto const commTagFieldV = pmacc::traits::getUniqueId<uint32_t>();
+
+                    auto const commTagY = pmacc::traits::getUniqueId<uint32_t>();
+                    /*go over all directions*/
+                    for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
                     {
-                        DataSpace<simDim> relativeMask = Mask::getRelativeDirections<simDim>(i);
-                        /* guarding cells depend on direction
-                         * for negative direction use originGuard else endGuard (relative direction ZERO is ignored)
-                         * don't switch end and origin because this is a read buffer and no send buffer
-                         */
-                        auto guardingCells = DataSpace<simDim>::create(0);
-                        for(uint32_t d = 0; d < simDim; ++d)
-                            guardingCells[d] = (relativeMask[d] == 0 ? 0 : 1);
-                        mpkBuffer->addExchange(GUARD, i, guardingCells, commTag0);
-                        zkBuffer->addExchange(GUARD, i, guardingCells, commTag1);
-                        pkBuffer->addExchange(GUARD, i, guardingCells, commTagPk);
-                        rkBuffer->addExchange(GUARD, i, guardingCells, commTagRk);
-                        fieldV->fieldVBuffer->addExchange(GUARD, i, guardingCells, commTagFieldV);
+                        // set communication only for planes
+                        if(FRONT % i == 0)
+                        {
+                            DataSpace<simDim> relativeMask = Mask::getRelativeDirections<simDim>(i);
+                            /* guarding cells depend on direction
+                             * for negative direction use originGuard else endGuard (relative direction ZERO is
+                             * ignored) don't switch end and origin because this is a read buffer and no send buffer
+                             */
+                            auto guardingCells = DataSpace<simDim>::create(0);
+                            for(uint32_t d = 0; d < simDim; ++d)
+                                guardingCells[d] = (relativeMask[d] == 0 ? 0 : 1);
+                            mpkBuffer->addExchange(GUARD, i, guardingCells, commTag0);
+                            zkBuffer->addExchange(GUARD, i, guardingCells, commTag1);
+                            pkBuffer->addExchange(GUARD, i, guardingCells, commTagPk);
+                            rkBuffer->addExchange(GUARD, i, guardingCells, commTagRk);
+                            fieldV->fieldVBuffer->addExchange(GUARD, i, guardingCells, commTagFieldV);
 
-                        yBuffer->addExchange(GUARD, i, guardingCells, commTagY);
+                            yBuffer->addExchange(GUARD, i, guardingCells, commTagY);
+                        }
                     }
-                }
-                DataConnector& dc = Environment<>::get().DataConnector();
-                dc.share(fieldV);
+                    DataConnector& dc = Environment<>::get().DataConnector();
+                    dc.share(fieldV);
 
-                participate(true);
+                    participate(true);
+                }
             }
 
             template<typename T_TranformFunctor>
@@ -284,7 +321,7 @@ namespace picongpu
 
                 bBuffer->communication();
 
-                auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc);
+                auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc.value());
 
                 {
                     auto bBox = bBuffer->getDeviceBuffer().getDataBox();
@@ -323,7 +360,7 @@ namespace picongpu
                             coreBorderMapper);
                 }
 
-                constexpr uint32_t iterMax = 20;
+                uint32_t iterMax = m_maxPreconditionerSteps;
                 for(uint32_t i = 2; i < iterMax; ++i)
                 {
                     rhoOld = rhoCurrent;
@@ -393,6 +430,12 @@ namespace picongpu
 
             void Poisson::operator()(uint32_t const currentStep)
             {
+                log<picLog::PHYSICS>("Poisson solver:");
+                if(!m_useSolver)
+                {
+                    log<picLog::PHYSICS>("  - disabled");
+                    return;
+                }
                 eventSystem::getTransactionEvent().waitForFinished();
                 auto beginT = std::chrono::high_resolution_clock::now();
 
@@ -420,10 +463,10 @@ namespace picongpu
                 eventSystem::setTransactionEvent(fieldTmpEvent);
 
                 auto boundaryConditionsDirichlet = fields::poissonSolver::BoundaryConditionsDirichlet{};
-                boundaryConditionsDirichlet(*fieldV.get(), m_mappingDesc);
+                boundaryConditionsDirichlet(*fieldV.get(), m_mappingDesc.value());
 
                 auto rightHandSideNormalization = fields::poissonSolver::RightHandSideNormalization{};
-                rightHandSideNormalization(*fieldV.get(), fieldRho, m_mappingDesc);
+                rightHandSideNormalization(*fieldV.get(), fieldRho, m_mappingDesc.value());
 
 
                 float_64 normRho;
@@ -442,7 +485,7 @@ namespace picongpu
                 eventSystem::setTransactionEvent(fieldRho.asyncCommunication(eventSystem::getTransactionEvent()));
 
                 // normalize rho
-                auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc);
+                auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc.value());
                 {
                     auto rhoBox = fieldRho.getDeviceDataBox();
 
@@ -457,7 +500,7 @@ namespace picongpu
 
                 {
                     // normalize v
-                    auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc);
+                    auto vMapper = makeAreaMapper<GUARD>(m_mappingDesc.value());
                     auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
                     PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
                         .config(vMapper.getGridDim(), SuperCellSize{})(
@@ -505,18 +548,17 @@ namespace picongpu
 
                 float_64 rho1 = rho0;
 
-                constexpr int maxIterations = 2000;
-                constexpr float_64 epsilon = 1e-8;
+                int maxIterations = m_maxSolverSteps;
 
                 bool foundSolution = false;
                 for(int i = 0; i < maxIterations; ++i)
                 {
                     // preconditioner
-#if 0
-                    mpkBuffer->getDeviceBuffer().copyFrom(pkBuffer->getDeviceBuffer());
-#else
-                    preconditioner(mpkBuffer, pkBuffer);
-#endif
+                    if(m_disablePreconditioner)
+                        mpkBuffer->getDeviceBuffer().copyFrom(pkBuffer->getDeviceBuffer());
+                    else
+                        preconditioner(mpkBuffer, pkBuffer);
+
                     mpkBuffer->communication();
 
                     // w = Ap
@@ -563,11 +605,11 @@ namespace picongpu
                     }
 
                     // preconditioner
-#if 0
-                    zkBuffer->getDeviceBuffer().copyFrom(rkBuffer->getDeviceBuffer());
-#else
-                    preconditioner(zkBuffer, rkBuffer);
-#endif
+                    if(m_disablePreconditioner)
+                        zkBuffer->getDeviceBuffer().copyFrom(rkBuffer->getDeviceBuffer());
+                    else
+                        preconditioner(zkBuffer, rkBuffer);
+
                     zkBuffer->communication();
 
                     // t = A * r
@@ -672,11 +714,11 @@ namespace picongpu
                     rho1 = totalSum1;
                     float_64 beta = rho1 / rho0 * alpha / omega;
                     rho0 = rho1;
-                    if(std::sqrt(totalSum2) < epsilon)
+                    if(std::sqrt(totalSum2) < m_solverEpsilon)
                     {
                         foundSolution = true;
-                        std::cout << "Converged after " << i << " iterations with norm=" << normRho
-                                  << ", total sum2=" << std::sqrt(totalSum2) << std::endl;
+                        log<picLog::PHYSICS>("  - converged after %1%/%2% iterations with norm=%3%, total epsilon=%4%")
+                            % i % maxIterations % normRho % std::sqrt(totalSum2);
                         break;
                     }
                     // pk = rk + beta * (pk - omega * ampk)
@@ -722,13 +764,12 @@ namespace picongpu
                 }
                 auto endT = std::chrono::high_resolution_clock::now();
                 double duration = std::chrono::duration<double>(endT - beginT).count();
-                std::cout << "Time for poisson solver: " << duration << " seconds" << std::endl;
+                log<picLog::PHYSICS>("  - duration %1% sec") % duration;
 
                 if(!foundSolution)
                 {
-                    std::cout << "Poisson solver did not converge after " << maxIterations
-                              << " iterations with norm=" << normRho << ", total sum2=" << std::sqrt(rho1)
-                              << std::endl;
+                    log<picLog::PHYSICS>("  - did not converge after %1% iterations with norm=%2%, total epsilon=%3%")
+                        % maxIterations % normRho % std::sqrt(rho1);
                     throw std::runtime_error("Poisson solver did not converge after max iterations");
                 }
             }

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -415,10 +415,15 @@ namespace picongpu
             void Poisson::operator()(uint32_t const currentStep)
             {
                 namespace poi = fields::poissonSolver;
-                log<picLog::PHYSICS>("Poisson solver:");
+
+                // only one rank is writing status initial information of the poisson solver
+                bool mainRank = Environment<simDim>::get().GridController().getGlobalRank() == 0;
+                if(mainRank)
+                    log<picLog::PHYSICS>("Poisson solver:");
                 if(!m_useSolver)
                 {
-                    log<picLog::PHYSICS>("  - disabled");
+                    if(mainRank)
+                        log<picLog::PHYSICS>("  - disabled");
                     return;
                 }
                 eventSystem::getTransactionEvent().waitForFinished();
@@ -515,11 +520,13 @@ namespace picongpu
                 }
 
                 float_64 rho1 = rho0;
+                float_64 totalSum2;
 
                 int maxIterations = m_maxSolverSteps;
 
                 bool foundSolution = false;
-                for(int i = 0; i < maxIterations; ++i)
+                int iteration = 0;
+                for(; iteration < maxIterations; ++iteration)
                 {
                     // preconditioner
                     if(m_disablePreconditioner)
@@ -590,7 +597,6 @@ namespace picongpu
                         totalSum1 = reduceGlobal(coreBorderSize, fieldTransform);
                     }
 
-                    float_64 totalSum2;
                     /* totalSum1 = azk * azk */
                     {
                         auto azkBox = azkBuffer->getDeviceBuffer().getDataBox();
@@ -655,8 +661,6 @@ namespace picongpu
                     if(std::sqrt(totalSum2) < m_solverEpsilon)
                     {
                         foundSolution = true;
-                        log<picLog::PHYSICS>("  - converged after %1%/%2% iterations with norm=%3%, total epsilon=%4%")
-                            % i % maxIterations % normRho % std::sqrt(totalSum2);
                         break;
                     }
                     // pk = rk + beta * (pk - omega * ampk)
@@ -671,8 +675,45 @@ namespace picongpu
 
                 } // for loop
 
-                if(foundSolution)
+                // avid deadlock due blocking colective MPI operation
+                eventSystem::getTransactionEvent().waitForFinished();
+
+                bool ioRank = mpiReduce.hasResult(mpi::reduceMethods::Reduce());
+
+                int localSolutionFound = foundSolution ? 1 : 0;
+                int allRanksFoundSolution;
+                mpiReduce(
+                    pmacc::math::operation::Min(),
+                    &allRanksFoundSolution,
+                    &localSolutionFound,
+                    1,
+                    mpi::reduceMethods::AllReduce());
+
+                int maxGlobalIterations = 0;
+                mpiReduce(
+                    pmacc::math::operation::Max(),
+                    &maxGlobalIterations,
+                    &iteration,
+                    1,
+                    mpi::reduceMethods::Reduce());
+
+                float_64 maxGlobalNormRho = 0.0;
+                mpiReduce(pmacc::math::operation::Max(), &maxGlobalNormRho, &normRho, 1, mpi::reduceMethods::Reduce());
+
+                float_64 maxGlobalTotalSum2 = 0.0;
+                mpiReduce(
+                    pmacc::math::operation::Max(),
+                    &maxGlobalTotalSum2,
+                    &totalSum2,
+                    1,
+                    mpi::reduceMethods::Reduce());
+
+                if(allRanksFoundSolution)
                 {
+                    if(ioRank)
+                        log<picLog::PHYSICS>("  - converged after %1%/%2% iterations with norm=%3%, total epsilon=%4%")
+                            % maxGlobalIterations % maxIterations % maxGlobalNormRho % std::sqrt(maxGlobalTotalSum2);
+
                     // normalize v back
                     forEachCell(
                         coreBorderMapper,
@@ -690,17 +731,31 @@ namespace picongpu
                         eField.getGridBuffer().getDeviceBuffer(),
                         fieldV->fieldVBuffer->getDeviceBuffer());
                     eField.asyncCommunication(eventSystem::getTransactionEvent());
-
-                    eventSystem::getTransactionEvent().waitForFinished();
                 }
+
+                eventSystem::getTransactionEvent().waitForFinished();
                 auto endT = std::chrono::high_resolution_clock::now();
                 double duration = std::chrono::duration<double>(endT - beginT).count();
-                log<picLog::PHYSICS>("  - duration %1% sec") % duration;
+
+                // avid deadlock due blocking collective MPI operation
+                eventSystem::getTransactionEvent().waitForFinished();
+                double globalMaxDuration = 0.0;
+                mpiReduce(
+                    pmacc::math::operation::Max(),
+                    &globalMaxDuration,
+                    &duration,
+                    1,
+                    mpi::reduceMethods::Reduce());
+                if(ioRank)
+                    log<picLog::PHYSICS>("  - duration %1% sec") % globalMaxDuration;
 
                 if(!foundSolution)
                 {
-                    log<picLog::PHYSICS>("  - did not converge after %1% iterations with norm=%2%, total epsilon=%3%")
-                        % maxIterations % normRho % std::sqrt(rho1);
+                    pmacc::GridController<simDim>& gc = pmacc::Environment<simDim>::get().GridController();
+                    pmacc::math::Int<simDim> gpuPos = gc.getPosition();
+                    log<picLog::PHYSICS>("  - compute domain %4% did not converge after %1% iterations with norm=%2%, "
+                                         "total epsilon=%3%")
+                        % maxIterations % normRho % std::sqrt(rho1) % gpuPos.toString();
                     throw std::runtime_error("Poisson solver did not converge after max iterations");
                 }
             }

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -118,20 +118,54 @@ namespace picongpu
                 }
             };
 
+            template<typename T_TranformFunctor>
+            class TransformDataBox : private T_TranformFunctor
+            {
+            public:
+                using ValueType = decltype(std::declval<T_TranformFunctor>()(DataSpace<simDim>::create(0)));
+
+                static constexpr std::uint32_t Dim = simDim;
+
+                HDINLINE TransformDataBox() = default;
+
+                HDINLINE TransformDataBox(T_TranformFunctor transformFunc) : T_TranformFunctor(transformFunc)
+                {
+                }
+
+                HDINLINE TransformDataBox(TransformDataBox const&) = default;
+
+                HDINLINE ValueType operator()(DataSpace<simDim> const& idx) const
+                {
+                    return T_TranformFunctor::operator()(idx + m_offset);
+                }
+
+                HDINLINE ValueType operator[](DataSpace<simDim> const idx) const
+                {
+                    return T_TranformFunctor::operator()(idx + m_offset);
+                }
+
+                HDINLINE TransformDataBox shift(DataSpace<simDim> const& offset) const
+                {
+                    TransformDataBox result(*this);
+                    result.m_offset += offset;
+                    return result;
+                }
+
+                DataSpace<simDim> m_offset = DataSpace<simDim>::create(0);
+            };
+
             auto Poisson::calcNorm(FieldTmp& fieldRho)
             {
-                /*define stacked DataBox's for reduce algorithm*/
-                using TransformedBox = DataBoxUnaryTransform<typename FieldTmp::DataBoxType, squareComponentWise>;
-                using Box64bit = DataBoxUnaryTransform<TransformedBox, cast64Bit>;
-                using D1Box = DataBoxDim1Access<Box64bit>;
-
                 /* reduce field E*/
                 DataSpace<simDim> fieldSize = fieldRho.getGridLayout().sizeWithoutGuardND();
                 DataSpace<simDim> fieldGuard = fieldRho.getGridLayout().guardSizeND();
 
-                TransformedBox fieldTransform(fieldRho.getDeviceDataBox().shift(fieldGuard));
-                Box64bit field64bit(fieldTransform);
-                D1Box d1Access(field64bit, fieldSize);
+                auto rhoDeviceBox = fieldRho.getDeviceDataBox().shift(fieldGuard);
+
+                TransformDataBox fieldTransform(
+                    [rhoDeviceBox] DEVICEONLY(DataSpace<simDim> const& idx)
+                    { return precisionCast<float_64>(rhoDeviceBox[idx] * rhoDeviceBox[idx]); });
+                DataBoxDim1Access d1Access(fieldTransform, fieldSize);
 
                 float_64 fieldRhoNormSquaredLocal
                     = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents()).x();
@@ -225,5 +259,6 @@ namespace picongpu
 
                 // BICGStab(fieldV, fieldRho, cellDescription);
             }
-        } // namespace simulation
-    } // namespace picongpu
+        } // namespace stage
+    } // namespace simulation
+} // namespace picongpu

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -45,6 +45,38 @@
 
 #include <picongpu/param/particle.param>
 
+namespace picongpu::simulation::stage
+{
+    template<typename T_Func>
+    struct DeviceLambda
+    {
+        T_Func const func;
+
+        template<typename... T>
+        DEVICEONLY auto operator()(T&&... args) const
+        {
+            return func(std::forward<T>(args)...);
+        }
+
+        template<typename... T>
+        DEVICEONLY auto operator()(T&&... args)
+        {
+            return func(std::forward<T>(args)...);
+        }
+    };
+
+    template<typename T_Func>
+    DeviceLambda(T_Func const) -> DeviceLambda<T_Func>;
+} // namespace picongpu::simulation::stage
+
+namespace alpaka
+{
+    template<typename T>
+    struct IsKernelArgumentTriviallyCopyable<picongpu::simulation::stage::DeviceLambda<T>, void> : std::true_type
+    {
+    };
+} // namespace alpaka
+
 namespace picongpu
 {
     namespace simulation
@@ -200,24 +232,6 @@ namespace picongpu
                 }
             };
 
-            template<typename T_Func>
-            struct DeviceLambda
-            {
-                T_Func const func;
-
-                template<typename... T>
-                DEVICEONLY auto operator()(T&&... args) const
-                {
-                    return func(std::forward<T>(args)...);
-                }
-
-                template<typename... T>
-                DEVICEONLY auto operator()(T&&... args)
-                {
-                    return func(std::forward<T>(args)...);
-                }
-            };
-
             void Poisson::operator()(uint32_t const currentStep)
             {
                 using namespace pmacc;
@@ -329,7 +343,7 @@ namespace picongpu
 
                 float_64 rho1 = rho0;
 
-                constexpr int maxIterations = 1000;
+                constexpr int maxIterations = 2000;
                 constexpr float_64 epsilon = 1e-8;
                 for(int i = 0; i < maxIterations; ++i)
                 {

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -535,6 +535,18 @@ namespace picongpu
                                 { return vField[idx] * normRho; }},
                             coreBorderMapper);
                     fieldV->fieldVBuffer->communication();
+
+                    // compute fieldE
+                    auto& eField = *dc.get<FieldE>(FieldE::getName());
+                    auto fieldEBox = eField.getDeviceDataBox();
+                    PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                            coreBorderMapper,
+                            fields::poissonSolver::GetFieldEStencil{},
+                            fieldEBox,
+                            vField);
+                    eField.asyncCommunication(eventSystem::getTransactionEvent());
+                    eventSystem::getTransactionEvent().waitForFinished();
                 }
             }
         } // namespace stage

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -32,6 +32,8 @@
 
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/memory/boxes/DataBoxDim1Access.hpp>
+#include <pmacc/memory/boxes/DataBoxUnaryTransform.hpp>
 #include <pmacc/meta/ForEach.hpp>
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/type/Area.hpp>
@@ -75,7 +77,9 @@ namespace picongpu
             using SpeciesEligibleForChargeDeposition =
                 typename particles::traits::SpeciesEligibleForSolver<T, simulation::stage::Poisson>::type;
 
-            Poisson::Poisson(MappingDesc const mappingDesc) : m_mappingDesc(mappingDesc)
+            Poisson::Poisson(MappingDesc const mappingDesc)
+                : m_mappingDesc(mappingDesc)
+                , localReduce{std::make_unique<pmacc::device::Reduce>(1024)}
             {
                 pkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
                 rkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
@@ -88,6 +92,61 @@ namespace picongpu
 
                 DataConnector& dc = Environment<>::get().DataConnector();
                 dc.share(fieldV);
+
+                participate(true);
+            }
+
+            template<typename T_Type>
+            struct cast64Bit
+            {
+                using result = typename TypeCast<float_64, T_Type>::result;
+
+                HDINLINE result operator()(T_Type const& value) const
+                {
+                    return precisionCast<float_64>(value);
+                }
+            };
+
+            template<typename T_Type>
+            struct squareComponentWise
+            {
+                using result = T_Type;
+
+                HDINLINE result operator()(T_Type const& value) const
+                {
+                    return value * value;
+                }
+            };
+
+            auto Poisson::calcNorm(FieldTmp& fieldRho)
+            {
+                /*define stacked DataBox's for reduce algorithm*/
+                using TransformedBox = DataBoxUnaryTransform<typename FieldTmp::DataBoxType, squareComponentWise>;
+                using Box64bit = DataBoxUnaryTransform<TransformedBox, cast64Bit>;
+                using D1Box = DataBoxDim1Access<Box64bit>;
+
+                /* reduce field E*/
+                DataSpace<simDim> fieldSize = fieldRho.getGridLayout().sizeWithoutGuardND();
+                DataSpace<simDim> fieldGuard = fieldRho.getGridLayout().guardSizeND();
+
+                TransformedBox fieldTransform(fieldRho.getDeviceDataBox().shift(fieldGuard));
+                Box64bit field64bit(fieldTransform);
+                D1Box d1Access(field64bit, fieldSize);
+
+                float_64 fieldRhoNormSquaredLocal
+                    = (*localReduce)(pmacc::math::operation::Add(), d1Access, fieldSize.productOfComponents()).x();
+
+                // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
+                eventSystem::getTransactionEvent().waitForFinished();
+                float_64 fieldRhoNormSquaredGlobal;
+                mpiReduce(
+                    pmacc::math::operation::Add(),
+                    &fieldRhoNormSquaredGlobal,
+                    &fieldRhoNormSquaredLocal,
+                    1,
+                    mpi::reduceMethods::AllReduce());
+
+                return math::sqrt(fieldRhoNormSquaredGlobal);
             }
 
             struct NormalizeField
@@ -113,7 +172,7 @@ namespace picongpu
                 }
             };
 
-            void Poisson::operator()(uint32_t const currentStep) const
+            void Poisson::operator()(uint32_t const currentStep)
             {
                 using namespace pmacc;
                 constexpr uint fieldRhoSlot = 0;
@@ -145,7 +204,7 @@ namespace picongpu
 
                 auto rightHandSideNormalization = fields::poissonSolver::RightHandSideNormalization{};
                 rightHandSideNormalization(*fieldV.get(), fieldRho, m_mappingDesc);
-                float_64 normRho = rightHandSideNormalization.calcNorm(fieldRho);
+                float_64 normRho = calcNorm(fieldRho);
 
                 // recalculate rho
                 computeChargeDensity(fieldRho, currentStep);
@@ -166,31 +225,5 @@ namespace picongpu
 
                 // BICGStab(fieldV, fieldRho, cellDescription);
             }
-        } // namespace stage
-    } // namespace simulation
-
-    namespace particles
-    {
-        namespace traits
-        {
-            template<typename T_Species>
-            struct SpeciesEligibleForSolver<T_Species, simulation::stage::Poisson>
-            {
-                using FrameType = typename T_Species::FrameType;
-
-                // this plugin needs at least the weighting particle attribute
-                using RequiredIdentifiers = MakeSeq_t<weighting>;
-
-                using SpeciesHasIdentifiers =
-                    typename pmacc::traits::HasIdentifiers<FrameType, RequiredIdentifiers>::type;
-
-                // and also a charge ratio for a charge density
-                using SpeciesHasFlags = typename pmacc::traits::HasFlag<FrameType, chargeRatio<>>::type;
-
-                using type = pmacc::mp_and<SpeciesHasIdentifiers, SpeciesHasFlags>;
-            };
-
-        } // namespace traits
-    } // namespace particles
-
-} // namespace picongpu
+        } // namespace simulation
+    } // namespace picongpu

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -128,9 +128,17 @@ namespace picongpu
                 azkBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
                 fieldV = std::make_shared<fields::poissonSolver::FieldV>(m_mappingDesc);
 
+                yBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                wBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+                zBuffer = std::make_unique<GridBuffer<float_64, simDim>>(m_mappingDesc.getGridLayout());
+
                 auto const commTag0 = pmacc::traits::getUniqueId<uint32_t>();
                 auto const commTag1 = pmacc::traits::getUniqueId<uint32_t>();
+                auto const commTagPk = pmacc::traits::getUniqueId<uint32_t>();
+                auto const commTagRk = pmacc::traits::getUniqueId<uint32_t>();
                 auto const commTagFieldV = pmacc::traits::getUniqueId<uint32_t>();
+
+                auto const commTagY = pmacc::traits::getUniqueId<uint32_t>();
                 /*go over all directions*/
                 for(uint32_t i = 1; i < NumberOfExchanges<simDim>::value; ++i)
                 {
@@ -146,7 +154,11 @@ namespace picongpu
                             guardingCells[d] = (relativeMask[d] == 0 ? 0 : 1);
                         mpkBuffer->addExchange(GUARD, i, guardingCells, commTag0);
                         zkBuffer->addExchange(GUARD, i, guardingCells, commTag1);
+                        pkBuffer->addExchange(GUARD, i, guardingCells, commTagPk);
+                        rkBuffer->addExchange(GUARD, i, guardingCells, commTagRk);
                         fieldV->fieldVBuffer->addExchange(GUARD, i, guardingCells, commTagFieldV);
+
+                        yBuffer->addExchange(GUARD, i, guardingCells, commTagY);
                     }
                 }
                 DataConnector& dc = Environment<>::get().DataConnector();
@@ -233,6 +245,150 @@ namespace picongpu
                         });
                 }
             };
+
+            void Poisson::preconditioner(
+                std::unique_ptr<GridBuffer<float_64, simDim>>& xBuffer,
+                std::unique_ptr<GridBuffer<float_64, simDim>>& bBuffer)
+            {
+                yBuffer->getDeviceBuffer().setValue(0.0);
+                wBuffer->getDeviceBuffer().setValue(0.0);
+                zBuffer->getDeviceBuffer().setValue(0.0);
+
+                SubGrid<simDim> const& subGrid = Environment<simDim>::get().SubGrid();
+                auto globalDomain = subGrid.getGlobalDomain().size;
+                auto cellSizeSquared = sim.pic.getCellSize<float_64>() * sim.pic.getCellSize<float_64>();
+
+                float_64 eigenMin = 0.0;
+                float_64 eigenMax = 0.0;
+
+                for(uint32_t d = 0; d < simDim; ++d)
+                {
+                    eigenMin += 4.0 * math::sin(1.0 * pmacc::math::Pi<float_64>::halfValue / (globalDomain[d] + 1))
+                                * math::sin(1.0 * pmacc::math::Pi<float_64>::halfValue / (globalDomain[d] + 1))
+                                / (cellSizeSquared[d]);
+
+                    eigenMax
+                        += 4.0
+                           * math::sin(globalDomain[d] * pmacc::math::Pi<float_64>::halfValue / (globalDomain[d] + 1))
+                           * math::sin(globalDomain[d] * pmacc::math::Pi<float_64>::halfValue / (globalDomain[d] + 1))
+                           / (cellSizeSquared[d]);
+                }
+
+                float_64 const theta = 0.5 * (eigenMax + eigenMin);
+                float_64 const delta = 0.5 * (eigenMax - eigenMin);
+                float_64 const sigma = theta / delta;
+
+                float_64 rhoOld = 1. / sigma;
+                float_64 rhoCurrent = 1. / (2. * sigma - rhoOld);
+
+                bBuffer->communication();
+
+                auto coreBorderMapper = makeAreaMapper<CORE + BORDER>(m_mappingDesc);
+
+                {
+                    auto bBox = bBuffer->getDeviceBuffer().getDataBox();
+                    auto zBox = zBuffer->getDeviceBuffer().getDataBox();
+
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                            zBox,
+                            DeviceLambda{
+                                [bBox, theta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return bBox[idx] / theta; }},
+                            coreBorderMapper);
+
+                    auto yBox = yBuffer->getDeviceBuffer().getDataBox();
+
+                    // poisson stencil
+                    PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+                        .config(
+                            coreBorderMapper.getGridDim(),
+                            SuperCellSize{})(coreBorderMapper, fields::poissonSolver::StencilFunc{}, yBox, bBox);
+
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                            yBox,
+                            DeviceLambda{
+                                [yBox, rhoCurrent, theta, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return -2.0 * rhoCurrent * yBox[idx] / theta / delta; }},
+                            coreBorderMapper);
+
+                    PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                        .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                            yBox,
+                            DeviceLambda{
+                                [bBox, yBox, rhoCurrent, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                { return yBox[idx] + 4.0 * bBox[idx] * rhoCurrent / delta; }},
+                            coreBorderMapper);
+                }
+
+                constexpr uint32_t iterMax = 20;
+                for(uint32_t i = 2; i < iterMax; ++i)
+                {
+                    rhoOld = rhoCurrent;
+                    rhoCurrent = 1. / (2. * sigma - rhoOld);
+                    yBuffer->communication();
+
+                    {
+                        auto yBox = yBuffer->getDeviceBuffer().getDataBox();
+                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(fields::poissonSolver::Stencil{})
+                            .config(
+                                coreBorderMapper.getGridDim(),
+                                SuperCellSize{})(coreBorderMapper, fields::poissonSolver::StencilFunc{}, wBox, yBox);
+                    }
+                    {
+                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                wBox,
+                                DeviceLambda{
+                                    [wBox, rhoCurrent, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return -2.0 * rhoCurrent * wBox[idx] / delta; }},
+                                coreBorderMapper);
+                    }
+
+                    {
+                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
+                        auto bBox = bBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                wBox,
+                                DeviceLambda{
+                                    [wBox, bBox, rhoCurrent, delta] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return wBox[idx] + 2.0 * rhoCurrent * bBox[idx] / delta; }},
+                                coreBorderMapper);
+                    }
+
+                    {
+                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
+                        auto yBox = yBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                wBox,
+                                DeviceLambda{
+                                    [wBox, yBox, rhoCurrent, sigma] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return wBox[idx] + 2.0 * rhoCurrent * sigma * yBox[idx]; }},
+                                coreBorderMapper);
+                    }
+
+                    {
+                        auto wBox = wBuffer->getDeviceBuffer().getDataBox();
+                        auto zBox = zBuffer->getDeviceBuffer().getDataBox();
+                        PMACC_LOCKSTEP_KERNEL(ForEachKernel{})
+                            .config(coreBorderMapper.getGridDim(), SuperCellSize{})(
+                                wBox,
+                                DeviceLambda{
+                                    [wBox, zBox, rhoCurrent, rhoOld] DEVICEONLY(DataSpace<simDim> idx) -> float_64
+                                    { return wBox[idx] - rhoCurrent * rhoOld * zBox[idx]; }},
+                                coreBorderMapper);
+                    }
+
+                    zBuffer->getDeviceBuffer().copyFrom(yBuffer->getDeviceBuffer());
+                    yBuffer->getDeviceBuffer().copyFrom(wBuffer->getDeviceBuffer());
+                } // loop
+                xBuffer->getDeviceBuffer().copyFrom(wBuffer->getDeviceBuffer());
+            }
 
             void Poisson::operator()(uint32_t const currentStep)
             {
@@ -350,7 +506,11 @@ namespace picongpu
                 for(int i = 0; i < maxIterations; ++i)
                 {
                     // preconditioner
+#if 0
                     mpkBuffer->getDeviceBuffer().copyFrom(pkBuffer->getDeviceBuffer());
+#else
+                    preconditioner(mpkBuffer, pkBuffer);
+#endif
                     mpkBuffer->communication();
 
                     // w = Ap
@@ -397,7 +557,11 @@ namespace picongpu
                     }
 
                     // preconditioner
+#if 0
                     zkBuffer->getDeviceBuffer().copyFrom(rkBuffer->getDeviceBuffer());
+#else
+                    preconditioner(zkBuffer, rkBuffer);
+#endif
                     zkBuffer->communication();
 
                     // t = A * r
@@ -532,7 +696,7 @@ namespace picongpu
                             vField,
                             DeviceLambda{
                                 [vField, normRho] DEVICEONLY(DataSpace<simDim> idx) -> float_64
-                                { return vField[idx] * normRho; }},
+                                { return vField[idx] * normRho / sim.pic.getEps0(); }},
                             coreBorderMapper);
                     fieldV->fieldVBuffer->communication();
 

--- a/include/picongpu/simulation/stage/Poisson.x.cpp
+++ b/include/picongpu/simulation/stage/Poisson.x.cpp
@@ -41,6 +41,7 @@
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 #include <pmacc/type/Area.hpp>
 
+#include <chrono>
 #include <cstdint>
 
 #include <picongpu/param/particle.param>
@@ -392,6 +393,9 @@ namespace picongpu
 
             void Poisson::operator()(uint32_t const currentStep)
             {
+                eventSystem::getTransactionEvent().waitForFinished();
+                auto beginT = std::chrono::high_resolution_clock::now();
+
                 using namespace pmacc;
                 constexpr uint fieldRhoSlot = 0;
                 DataConnector& dc = Environment<>::get().DataConnector();
@@ -503,6 +507,8 @@ namespace picongpu
 
                 constexpr int maxIterations = 2000;
                 constexpr float_64 epsilon = 1e-8;
+
+                bool foundSolution = false;
                 for(int i = 0; i < maxIterations; ++i)
                 {
                     // preconditioner
@@ -668,6 +674,7 @@ namespace picongpu
                     rho0 = rho1;
                     if(std::sqrt(totalSum2) < epsilon)
                     {
+                        foundSolution = true;
                         std::cout << "Converged after " << i << " iterations with norm=" << normRho
                                   << ", total sum2=" << std::sqrt(totalSum2) << std::endl;
                         break;
@@ -688,6 +695,7 @@ namespace picongpu
                     }
                 } // for loop
 
+                if(foundSolution)
                 {
                     // normalize v back
                     auto vField = fieldV->fieldVBuffer->getDeviceBuffer().getDataBox();
@@ -711,6 +719,17 @@ namespace picongpu
                             vField);
                     eField.asyncCommunication(eventSystem::getTransactionEvent());
                     eventSystem::getTransactionEvent().waitForFinished();
+                }
+                auto endT = std::chrono::high_resolution_clock::now();
+                double duration = std::chrono::duration<double>(endT - beginT).count();
+                std::cout << "Time for poisson solver: " << duration << " seconds" << std::endl;
+
+                if(!foundSolution)
+                {
+                    std::cout << "Poisson solver did not converge after " << maxIterations
+                              << " iterations with norm=" << normRho << ", total sum2=" << std::sqrt(rho1)
+                              << std::endl;
+                    throw std::runtime_error("Poisson solver did not converge after max iterations");
                 }
             }
         } // namespace stage

--- a/include/pmacc/boundary/Utility.hpp
+++ b/include/pmacc/boundary/Utility.hpp
@@ -33,7 +33,7 @@ namespace pmacc
          *
          * @param exchangeType number characterizing exchange @see pmacc::type::ExchangeType
          */
-        HDINLINE bool isAxisAligned(uint32_t exchangeType)
+        constexpr bool isAxisAligned(uint32_t exchangeType)
         {
             return (FRONT % exchangeType == 0);
         }

--- a/include/pmacc/device/Reduce.hpp
+++ b/include/pmacc/device/Reduce.hpp
@@ -57,6 +57,13 @@ namespace pmacc
             {
             }
 
+            void tmpBufferAlloc()
+            {
+                // lazy allocation of the result buffer
+                if(!reduceBuffer)
+                    reduceBuffer = std::make_unique<GridBuffer<char, DIM1>>(DataSpace<DIM1>(byte));
+            }
+
             /** Reduce elements in global gpu memory
              *
              * @param func binary functor for reduce which takes two arguments, first argument is the source and
@@ -89,8 +96,7 @@ namespace pmacc
                     threads = n;
 
                 // lazy allocation of the result buffer
-                if(!reduceBuffer)
-                    reduceBuffer = std::make_unique<GridBuffer<char, DIM1>>(DataSpace<DIM1>(byte));
+                tmpBufferAlloc();
 
                 auto* dest = (Type*) reduceBuffer->getDeviceBuffer().data();
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fileOutput.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/fileOutput.param
@@ -1,0 +1,123 @@
+/* Copyright 2013-2024 Axel Huebl, Rene Widera, Felix Schmitt,
+ *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
+/* some forward declarations we need */
+#include "picongpu/fields/Fields.def"
+#include "picongpu/particles/filter/filter.def"
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+namespace picongpu
+{
+    /** FieldTmp output (calculated at runtime) *******************************
+     *
+     * Those operations derive scalar field quantities from particle species
+     * at runtime. Each value is mapped per cell. Some operations are identical
+     * up to a constant, so avoid writing those twice to save storage.
+     *
+     * you can choose any of these particle to grid projections:
+     *   - Density: particle position + shape on the grid
+     *   - BoundElectronDensity: density of bound electrons
+     *       note: only makes sense for partially ionized ions
+     *   - ChargeDensity: density * charge
+     *       note: for species that do not change their charge state, this is
+     *             the same as the density times a constant for the charge
+     *   - Energy: sum of kinetic particle energy per cell with respect to shape
+     *   - EnergyDensity: average kinetic particle energy per cell times the
+     *                    particle density
+     *       note: this is the same as the sum of kinetic particle energy
+     *             divided by a constant for the cell volume
+     *   - Momentum: sum of chosen component of momentum per cell with respect to shape
+     *   - MomentumDensity: average chosen component of momentum per cell times the particle density
+     *       note: this is the same as the sum of the chosen momentum component
+     *             divided by a constant for the cell volume
+     *   - LarmorPower: radiated Larmor power
+     *                  (species must contain the attribute `momentumPrev1`)
+     *
+     * for debugging:
+     *   - MidCurrentDensityComponent:
+     *       density * charge * velocity_component
+     *   - Counter: counts point like particles per cell
+     *   - MacroCounter: counts point like macro particles per cell
+     *
+     * combined attributes:
+     *   These attributes are defined as a function of two primary derived attributes.
+     *
+     *   - AverageAttribute: template to compute a per particle average of any derived value
+     *   - RelativisticDensity: equals to 1/gamma^2 * n. Where gamma is the Lorentz factor for the mean kinetic energy
+     *      in the cell and n ist the usual number density. Useful for Faraday Rotation calculation.
+     *
+     *      Example use:
+     *      @code{.cpp}
+     *      using AverageEnergy_Seq = deriveField::CreateEligible_t<
+     *          VectorAllSpecies,
+     *          deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::Energy>>;
+     *      using RelativisticDensity_Seq
+     *          = deriveField::CreateEligible_t<PIC_Electrons, deriveField::combinedAttributes::RelativisticDensity>;
+     *      @endcode
+     *
+     * Filtering:
+     *   You can create derived fields from filtered particles. Only particles passing
+     *   the filter will contribute to the field quantity.
+     *   For that you need to define your filters in `particleFilters.param` and pass a
+     *   filter as the 3rd (optional) template argument in `CreateEligible_t`.
+     *
+     *   Example: This will create charge density field for all species that are
+     *   eligible for the this attribute and the chosen filter.
+     *   @code{.cpp}
+     *   using ChargeDensity_Seq
+         = deriveField::CreateEligible_t< VectorAllSpecies,
+         deriveField::derivedAttributes::ChargeDensity, filter::FilterOfYourChoice>;
+     *   @endcode
+     */
+    namespace deriveField = particles::particleToGrid;
+
+    /* ChargeDensity section */
+    using ChargeDensity_Seq
+        = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::ChargeDensity>;
+
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<ChargeDensity_Seq>;
+
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+
+    /** Possible native fields: FieldE, FieldB, FieldJ
+     */
+    using NativeFileOutputFields = MakeSeq_t<fields::poissonSolver::FieldV>;
+
+    using FileOutputFields = MakeSeq_t<NativeFileOutputFields, FieldTmpSolvers>;
+
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to disable particle output set to
+     *   using FileOutputParticles = MakeSeq_t< >;
+     */
+    using FileOutputParticles = MakeSeq_t<>;
+
+} // namespace picongpu

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
@@ -61,7 +61,7 @@ namespace picongpu
                 static constexpr uint32_t numParticlesPerCell = 25u;
             };
 
-            using Quiet = RandomImpl<RandomParameter>;
+            using Random = RandomImpl<RandomParameter>;
 
         } // namespace startPosition
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
@@ -48,20 +48,20 @@ namespace picongpu
              *
              * Vector is automatically reduced to two dimensions for 2D (x,y) simulations.
              */
-            struct QuietParam
+            struct RandomParameter
             {
-                /** Count of macro-particles per cell per direction at initial state
+                /** Maximum number of macro-particles per cell during density profile evaluation.
                  *
-                 *  unit: none */
-                using numParticlesPerDimension = mCT::shrinkTo<
-                    mCT::Int<TYPICAL_PARTICLES_PER_CELL / 5, TYPICAL_PARTICLES_PER_CELL / 5, 1>,
-                    simDim>::type;
+                 * Determines the weighting of a macro particle as well as the number of
+                 * macro-particles which sample the evolution of the particle distribution
+                 * function in phase space.
+                 *
+                 * unit: none
+                 */
+                static constexpr uint32_t numParticlesPerCell = 25u;
             };
 
-            /** Definition of Quiet start position functor that positions macro-particles regularly on the grid.
-             * No random number generator used.
-             */
-            using Quiet = QuietImpl<QuietParam>;
+            using Quiet = RandomImpl<RandomParameter>;
 
         } // namespace startPosition
 

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
@@ -39,8 +39,8 @@ namespace picongpu
          * the functors are called in order (from first to last functor)
          */
         using InitPipeline = pmacc::mp_list<
-            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>,
-            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Ions>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Random, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Random, PIC_Ions>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::LowerQuarterYPosition>,
             Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleHalfYPosition>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::UpperQuarterYPosition>,

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/speciesInitialization.param
@@ -40,7 +40,7 @@ namespace picongpu
          */
         using InitPipeline = pmacc::mp_list<
             CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>,
-            Derive<PIC_Electrons, PIC_Ions>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Ions>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::LowerQuarterYPosition>,
             Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleHalfYPosition>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::UpperQuarterYPosition>,


### PR DESCRIPTION
Provide poisson solver

- [ ] add unit test
- [ ] move PIConGPU bug fix to independent PRs
  - [ ] main.cpp simulation lifetime
  - [ ] PMacc reduce buffer init
- [ ] move `forEachCell` to PMacc
- [ ] generalize `stencil()` and move it to PMacc (low priority)
- [ ] documentation (this is a task for a physicist)
- [ ] squash commits

The poison solver is only solving the E-Field for the initial gas density not for densities created during the slide!
 
Use `picongpu --help` to see how to enable the poison solver

```
Poisson solver:
  --poisson.activate                    enable poisson solver
  --poisson.maxSteps arg (=2000)        maximum number of steps for the 
                                        preconditioner
  --poisson.epsilon arg (=1e-08)        maximal allowed error of the poisson 
                                        solver
  --poisson.preconditioner.disable      disable poisson solver preconditioner
  --poisson.preconditioner.maxSteps arg (=20)
                                        maximum number of steps for the 
                                        preconditioner
```

## output during execution

```
...
PIConGPUVerbose PHYSICS(1) | Poisson solver:
PIConGPUVerbose PHYSICS(1) |   - converged after 74/100 iterations with norm=509.216, total epsilon=5.15989e-09
PIConGPUVerbose PHYSICS(1) |   - duration 3.5903 sec
...
```