### PR TITLE
control simulation lifetime

### DIFF
--- a/include/picongpu/main.x.cpp
+++ b/include/picongpu/main.x.cpp
@@ -44,25 +44,30 @@ int runSimulation(int argc, char** argv)
 {
     using namespace picongpu;
 
-    auto sim = ::picongpu::
-        SimulationStarter<::picongpu::InitialiserController, ::picongpu::PluginController, ::picongpu::Simulation>{};
-    auto const parserStatus = sim.parseConfigs(argc, argv);
     int errorCode = EXIT_FAILURE;
-
-    switch(parserStatus)
+    // control the simulation lifetime
     {
-    case ArgsParser::Status::error:
-        errorCode = EXIT_FAILURE;
-        break;
-    case ArgsParser::Status::success:
-        sim.load();
-        sim.start();
-        sim.unload();
-        [[fallthrough]];
-    case ArgsParser::Status::successExit:
-        errorCode = 0;
-        break;
-    };
+        auto sim = ::picongpu::SimulationStarter<
+            ::picongpu::InitialiserController,
+            ::picongpu::PluginController,
+            ::picongpu::Simulation>{};
+        auto const parserStatus = sim.parseConfigs(argc, argv);
+
+        switch(parserStatus)
+        {
+        case ArgsParser::Status::error:
+            errorCode = EXIT_FAILURE;
+            break;
+        case ArgsParser::Status::success:
+            sim.load();
+            sim.start();
+            sim.unload();
+            [[fallthrough]];
+        case ArgsParser::Status::successExit:
+            errorCode = 0;
+            break;
+        };
+    }
 
     // finalize the pmacc context */
     pmacc::Environment<>::get().finalize();


### PR DESCRIPTION
Objects stored as member in the SimulationStarter could life until the end of the main function. This ca create issues with the call to pmacc `finalize()` where the event system is stopped and the accelerator context is destroyed.