### PR TITLE
Add GriddedLayout to PICMI

### DIFF
--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -7,7 +7,7 @@ from .grid import Cartesian3DGrid
 from .solver import ElectromagneticSolver
 from .gaussian_laser import GaussianLaser
 from .species import Species
-from .layout import PseudoRandomLayout
+from .layout import PseudoRandomLayout, GriddedLayout
 from . import constants
 
 from . import diagnostics
@@ -36,6 +36,7 @@ __all__ = [
     "GaussianLaser",
     "Species",
     "PseudoRandomLayout",
+    "GriddedLayout",
     "constants",
     "FoilDistribution",
     "UniformDistribution",

--- a/lib/python/picongpu/picmi/layout.py
+++ b/lib/python/picongpu/picmi/layout.py
@@ -8,6 +8,8 @@ License: GPLv3+
 import picmistandard
 import typeguard
 
+from ..pypicongpu.species.operation.layout import Random, OnePosition
+
 
 @typeguard.typechecked
 class PseudoRandomLayout(picmistandard.PICMI_PseudoRandomLayout):
@@ -24,3 +26,41 @@ class PseudoRandomLayout(picmistandard.PICMI_PseudoRandomLayout):
         assert self.n_macroparticles_per_cell > 0, "at least one particle per cell required"
 
         # Note: Call PICMI check interface once available upstream
+
+    def get_as_pypicongpu(self):
+        return Random()
+
+
+@typeguard.typechecked
+class GriddedLayout(picmistandard.PICMI_GriddedLayout):
+    # note: is translated from outside, does not do any checks itself
+
+    def __init__(self, *args, **kwargs):
+        # The standard seems to have a typo here:
+        # PseudoRandomLayout allows for n_macroparticles_per_cell (with an s)
+        # while this one only has n_macroparticle_per_cell.
+        # We fix this here:
+        if "n_macroparticles_per_cell" in kwargs:
+            if len(args) == 0:
+                args = (kwargs.pop("n_macroparticles_per_cell"),)
+            else:
+                raise ValueError("You provided n_macroparticles_per_cell and an unnamed first arg.")
+        super().__init__(*args, **kwargs)
+        # The standard apparently has a typo in its interface.
+        self.n_macroparticles_per_cell = self.n_macroparticle_per_cell
+        if self.grid is not None:
+            raise NotImplementedError("Non-default grid is not implemented.")
+
+    def check(self):
+        """
+        check validity of self
+
+        if ok pass silently, raise on error
+        """
+        assert self.n_macroparticles_per_cell is not None, "macroparticles per cell must be given"
+        assert self.n_macroparticles_per_cell > 0, "at least one particle per cell required"
+
+        # Note: Call PICMI check interface once available upstream
+
+    def get_as_pypicongpu(self):
+        return OnePosition()

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -219,11 +219,11 @@ class Simulation(picmistandard.PICMI_Simulation):
             picmi_species_by_profile,
         ) in picmi_species_by_profile_by_layout.items():
             for profile, picmi_species_list in picmi_species_by_profile.items():
-                assert isinstance(layout, picmistandard.PICMI_PseudoRandomLayout)
-
                 op = pypicongpu.species.operation.SimpleDensity()
                 op.ppc = layout.n_macroparticles_per_cell
                 op.profile = profile.get_as_pypicongpu()
+                op.layout = layout.get_as_pypicongpu()
+                op.layout.ppc = layout.n_macroparticles_per_cell
 
                 op.species = set(
                     map(

--- a/lib/python/picongpu/pypicongpu/species/operation/layout/__init__.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/layout/__init__.py
@@ -1,0 +1,12 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .layout import Layout
+from .random import Random
+from .one_position import OnePosition
+
+__all__ = ["Layout", "Random", "OnePosition"]

--- a/lib/python/picongpu/pypicongpu/species/operation/layout/layout.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/layout/layout.py
@@ -1,0 +1,21 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from ....rendering import SelfRegisteringRenderedObject
+
+import typeguard
+
+
+@typeguard.typechecked
+class Layout(SelfRegisteringRenderedObject):
+    """
+    (abstract) parent class of all layouts
+
+    A layout describes the particle layout within a cell.
+    """
+
+    pass

--- a/lib/python/picongpu/pypicongpu/species/operation/layout/one_position.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/layout/one_position.py
@@ -1,0 +1,20 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .layout import Layout
+
+from .... import util
+
+
+class OnePosition(Layout):
+    _name = "one_position"
+
+    ppc = util.build_typesafe_property(int)
+    """particles per cell (random layout), >0"""
+
+    def _get_serialized(self) -> dict | None:
+        return {"ppc": self.ppc}

--- a/lib/python/picongpu/pypicongpu/species/operation/layout/random.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/layout/random.py
@@ -1,0 +1,20 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .layout import Layout
+
+from .... import util
+
+
+class Random(Layout):
+    _name = "random"
+
+    ppc = util.build_typesafe_property(int)
+    """particles per cell (random layout), >0"""
+
+    def _get_serialized(self) -> dict | None:
+        return {"ppc": self.ppc}

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -5,6 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
+from .layout import Layout
 from .densityoperation import DensityOperation
 from .densityprofile import DensityProfile
 from ..species import Species
@@ -41,6 +42,8 @@ class SimpleDensity(DensityOperation):
 
     species = util.build_typesafe_property(typing.Set[Species])
     """species to be placed"""
+
+    layout = util.build_typesafe_property(Layout)
 
     def __init__(self):
         # nothing to do
@@ -120,6 +123,7 @@ class SimpleDensity(DensityOperation):
 
         return {
             "ppc": self.ppc,
+            "layout": self.layout.get_rendering_context(),
             "profile": self.profile.get_rendering_context(),
             "placed_species_initial": placed_species[0],
             "placed_species_copied": placed_species[1:],

--- a/share/picongpu/pypicongpu/schema/species/operation/layout/layout.Layout.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/layout/layout.Layout.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.layout.layout.Layout",
+  "description": "Any layout. Consists of (1) the type of layout used and (2) the actual data for that layout.",
+  "type": "object",
+  "required": [
+    "typeID",
+    "data"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "typeID": {
+      "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
+      "type": "object",
+      "required": [
+        "random",
+        "one_position"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "random": {
+          "type": "boolean"
+        },
+        "one_position": {
+          "type": "boolean"
+        }
+      }
+    },
+    "data": {
+      "description": "data as provided by any density profile (schema)",
+      "anyOf": [
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.layout.random.Random"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.layout.one_position.one_position"
+        }
+      ]
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/species/operation/layout/one_position.OnePosition.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/layout/one_position.OnePosition.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.layout.one_position.OnePosition",
+  "type": "object",
+  "description": "Describes a one position layout",
+  "unevaluatedProperties": false,
+  "required": [
+    "ppc"
+  ],
+  "properties": {
+    "ppc": {
+      "type": "integer",
+      "description": "particles per cell",
+      "exclusiveMinimum": 0
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/species/operation/layout/random.Random.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/layout/random.Random.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.layout.random.Random",
+  "type": "object",
+  "description": "Describes a random layout",
+  "unevaluatedProperties": false,
+  "required": [
+    "ppc"
+  ],
+  "properties": {
+    "ppc": {
+      "type": "integer",
+      "description": "particles per cell",
+      "exclusiveMinimum": 0
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/species/operation/simpledensity.SimpleDensity.json
+++ b/share/picongpu/pypicongpu/schema/species/operation/simpledensity.SimpleDensity.json
@@ -4,6 +4,7 @@
   "unevaluatedProperties": false,
   "required": [
     "ppc",
+    "layout",
     "profile",
     "placed_species_initial",
     "placed_species_copied"
@@ -13,6 +14,9 @@
       "description": "Number of macro particles per cell (random position).",
       "type": "integer",
       "exclusiveMinimum": 0
+    },
+    "layout": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.layout.layout.Layout"
     },
     "profile": {
       "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.operation.densityprofile.densityprofile.DensityProfile"

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/particle.param.mustache
@@ -45,6 +45,7 @@ namespace picongpu
             namespace pypicongpu
             {
                 {{#species_initmanager.operations.simple_density}}
+                {{#layout.typeID.random}}
                     struct random_ppc_{{{placed_species_initial.typename}}}
                     {
                         /** Maximum number of macro-particles per cell during density profile evaluation.
@@ -58,6 +59,34 @@ namespace picongpu
                         static constexpr uint32_t numParticlesPerCell = {{{ppc}}};
                     };
                     using init_{{{placed_species_initial.typename}}} = RandomImpl<random_ppc_{{{placed_species_initial.typename}}}>;
+                {{/layout.typeID.random}}
+
+                {{#layout.typeID.one_position}}
+                    struct one_position_{{{placed_species_initial.typename}}}
+                    {
+                        /** Maximum number of macro-particles per cell during density profile evaluation.
+                         *
+                         * Determines the weighting of a macro particle as well as the number of
+                         * macro-particles which sample the evolution of the particle distribution
+                         * function in phase space.
+                         *
+                         * unit: none
+                         */
+                        static constexpr uint32_t numParticlesPerCell = {{{ppc}}};
+
+                        /** each x, y, z in-cell position component in range [0.0, 1.0)
+                         *
+                         * @details in 2D the last component is ignored
+                         */
+                        static constexpr auto inCellOffset = float3_X(0., 0., 0.);
+                    };
+
+                    /** Definition of OnePosition start position functor that
+                     * places macro-particles at the initial in-cell position defined above.
+                     */
+                    using init_{{{placed_species_initial.typename}}} = OnePositionImpl<one_position_{{{placed_species_initial.typename}}}>;
+                {{/layout.typeID.one_position}}
+
                 {{/species_initmanager.operations.simple_density}}
             } // namespace pypicongpu
         } // namespace startPosition

--- a/test/python/picongpu/quick/picmi/layout.py
+++ b/test/python/picongpu/quick/picmi/layout.py
@@ -14,20 +14,36 @@ class TestPicmiPseudoRandomLayout(unittest.TestCase):
     def test_basic(self):
         """simple translation"""
         layout = picmi.PseudoRandomLayout(n_macroparticles_per_cell=7)
+        layout.ppc = 1
         layout.check()
-
-    def test_not_translated(self):
-        """pseudo random layout is not translated directly itself"""
-        layout = picmi.PseudoRandomLayout(n_macroparticles_per_cell=7)
-        with self.assertRaises(AttributeError):
-            layout.get_as_pypicongpu()
 
     def test_invalid(self):
         """erros for invalid params entered"""
         with self.assertRaisesRegex(Exception, ".*per.*"):
             layout = picmi.PseudoRandomLayout(n_macroparticles=700)
+            layout.ppc = 1
             layout.check()
 
         with self.assertRaises(AssertionError):
             layout = picmi.PseudoRandomLayout(n_macroparticles_per_cell=0)
+            layout.ppc = 1
+            layout.check()
+
+
+class TestPicmiGriddedLayout(unittest.TestCase):
+    def test_basic(self):
+        """simple translation"""
+        layout = picmi.GriddedLayout(n_macroparticle_per_cell=7)
+        layout.ppc = 1
+        layout.check()
+
+    def test_invalid(self):
+        """erros for invalid params entered"""
+        with self.assertRaisesRegex(Exception, ".*per.*"):
+            layout = picmi.GriddedLayout(n_macroparticles=700)
+            layout.ppc = 1
+            layout.check()
+
+        with self.assertRaises(AssertionError):
+            layout = picmi.GriddedLayout(n_macroparticle_per_cell=0)
             layout.check()

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -9,6 +9,7 @@ from picongpu.pypicongpu.simulation import Simulation
 from picongpu.pypicongpu.laser import GaussianLaser
 from picongpu.pypicongpu import grid, solver, species, customuserinput
 from picongpu.pypicongpu import rendering
+from picongpu.pypicongpu.species.operation.layout import Random
 
 import unittest
 import typeguard
@@ -166,6 +167,8 @@ class TestSimulation(unittest.TestCase):
         op_density.species = {
             species_dummy,
         }
+        op_density.layout = Random()
+        op_density.layout.ppc = 1
 
         op_momentum = species.operation.SimpleMomentum()
         op_momentum.species = species_dummy

--- a/test/python/picongpu/quick/pypicongpu/species/initmanager.py
+++ b/test/python/picongpu/quick/pypicongpu/species/initmanager.py
@@ -20,6 +20,7 @@ from picongpu.pypicongpu.species.operation import (
     NotPlaced,
     densityprofile,
 )
+from picongpu.pypicongpu.species.operation.layout import Random
 
 import typing
 import typeguard
@@ -507,6 +508,8 @@ class TestInitManager(unittest.TestCase):
             self.species1,
             self.species2,
         }
+        simple_density.layout = Random()
+        simple_density.layout.ppc = 1
         momentum_ops = []
         for single_species in initmgr.all_species:
             simple_momentum = SimpleMomentum()
@@ -543,6 +546,8 @@ class TestInitManager(unittest.TestCase):
         simple_density.species = {
             self.species1,
         }
+        simple_density.layout = Random()
+        simple_density.layout.ppc = 1
         initmgr.all_operations.append(simple_density)
 
         # store momentum ops separately for assertion later

--- a/test/python/picongpu/quick/pypicongpu/species/operation/simpledensity.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/simpledensity.py
@@ -12,6 +12,7 @@ import typeguard
 
 from picongpu.pypicongpu.species import Species
 from picongpu.pypicongpu.species.operation import densityprofile
+from picongpu.pypicongpu.species.operation.layout import Random
 from picongpu.pypicongpu.species.attribute import Position, Weighting, Momentum
 from picongpu.pypicongpu.species.constant import DensityRatio
 
@@ -53,6 +54,9 @@ class TestSimpleDensity(unittest.TestCase):
             self.species2,
             self.species4,
         }
+
+        self.sd.layout = Random()
+        self.sd.layout.ppc = 1
 
     def test_basic(self):
         """simple scenario"""
@@ -210,6 +214,9 @@ class TestSimpleDensity(unittest.TestCase):
         sd.profile = self.profile
         sd.ppc = 1
         sd.species = {species}
+
+        sd.layout = Random()
+        sd.layout.ppc = 1
 
         # would normally be performed by init manager:
         species.attributes = [Momentum()]


### PR DESCRIPTION
Adds a `GriddedLayout` to PICMI which translates into the `OnePosition` layout inside of PIConGPU. This is a partial implementation, only containing features necessary for reliably testing particle distributions.