### PR TITLE
Fix picmi png plugin

### DIFF
--- a/share/picongpu/pypicongpu/template/include/picongpu/param/png.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/png.param.mustache
@@ -87,53 +87,19 @@ constexpr bool white_box_per_GPU = {{#white_box_per_GPU}}true{{/white_box_per_GP
             return {{{preChannel3}}};
         }
     } // namespace visPreview
+
+// The implements the algorithm `x = any((plugin is png) for plugin in output)`.
+// In the case where `not x`, we'll need to provide some defaults below.
+#define PNG_PLUGIN_EXISTS
 {{/typeID.png}}
-
-{{#typeID.auto}}
-/*scale image before write to file, only scale if value is not 1.0*/
-    constexpr float_64 scale_image = 1.0;
-    /*if true image is scaled if cellsize is not quadratic, else no scale*/
-    constexpr bool scale_to_cellsize = true;
-    constexpr bool white_box_per_GPU = false;
-
-namespace visPreview
-{
-    #define EM_FIELD_SCALE_CHANNEL1 -1
-    #define EM_FIELD_SCALE_CHANNEL2 -1
-    #define EM_FIELD_SCALE_CHANNEL3 -1
-    constexpr float_X customNormalizationSI[3] = {5.0e12 / sim.si.getSpeedOfLight(), 5.0e12, 15.0};
-    constexpr float_X preParticleDens_opacity = 0.25_X;
-    constexpr float_X preChannel1_opacity = 1.0_X;
-    constexpr float_X preChannel2_opacity = 1.0_X;
-    constexpr float_X preChannel3_opacity = 1.0_X;
-    namespace preParticleDensCol = colorScales::red;
-    namespace preChannel1Col = colorScales::blue;
-    namespace preChannel2Col = colorScales::green;
-    namespace preChannel3Col = colorScales::none;
-    DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
-    {
-        return pmacc::math::l2norm2(field_Current);
-    }
-    DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
-    {
-        return field_E.x() * field_E.x();
-    }
-    DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
-    {
-        return -1.0_X * field_E.y();
-    }
-} // namespace visPreview
-{{/typeID.auto}}
-
 {{/data}}
 {{/output}}
 
-{{^output}}
-
-// default png.param: picongpu/include/picongpu/param/png.param
+// Translates into `if not any( (plugin is png) for plugin in output)`
+#ifndef PNG_PLUGIN_EXISTS
 
     constexpr float_64 scale_image = 1.0;
-    constexpr bool scale_to_cellsize = true;
+    constexpr bool scale_to_cellsize = false;
     constexpr bool white_box_per_GPU = false;
 
     namespace visPreview
@@ -142,47 +108,30 @@ namespace visPreview
 #define EM_FIELD_SCALE_CHANNEL2 -1
 #define EM_FIELD_SCALE_CHANNEL3 -1
 
-        /** SI values to be used for Custom normalization
-         *
-         * The order of normalization values is: B, E, current (note - current, not current density).
-         * This variable must always be defined, but has no effect for other normalization types.
-         */
-        constexpr float_X customNormalizationSI[3] = {5.0e12 / sim.si.getSpeedOfLight(), 5.0e12, 15.0};
-
-        // multiply highest undisturbed particle density with factor
-        constexpr float_X preParticleDens_opacity = 0.25_X;
-        constexpr float_X preChannel1_opacity = 1.0_X;
-        constexpr float_X preChannel2_opacity = 1.0_X;
-        constexpr float_X preChannel3_opacity = 1.0_X;
-
-        // specify color scales for each channel
-        namespace preParticleDensCol = colorScales::red;
-        namespace preChannel1Col = colorScales::blue;
-        namespace preChannel2Col = colorScales::green;
+        constexpr float_X customNormalizationSI[3] = {1.,1.,1.};
+        constexpr float_X preParticleDens_opacity = 0.0_X;
+        constexpr float_X preChannel1_opacity = 0.0_X;
+        constexpr float_X preChannel2_opacity = 0.0_X;
+        constexpr float_X preChannel3_opacity = 0.0_X;
+        namespace preParticleDensCol = colorScales::none;
+        namespace preChannel1Col = colorScales::none;
+        namespace preChannel2Col = colorScales::none;
         namespace preChannel3Col = colorScales::none;
 
-        /** Calculate values for png channels for given field values
-         *
-         * @param field_B normalized magnetic field value
-         * @param field_E normalized electric field value
-         * @param field_Current normalized electric current value (note - not current density)
-         *
-         * @{
-         */
         DINLINE float_X preChannel1(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
         {
-            return pmacc::math::l2norm2(field_Current);
+            return 0.;
         }
 
         DINLINE float_X preChannel2(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
         {
-            return field_E.x() * field_E.x();
+            return 0.;
         }
 
         DINLINE float_X preChannel3(const float3_X& field_B, const float3_X& field_E, const float3_X& field_Current)
         {
-            return -1.0_X * field_E.y();
+            return 0.;
         }
     } // namespace visPreview
-    {{/output}}
+#endif
 } // namespace picongpu


### PR DESCRIPTION
There was a bug in our PNG template: For any configuration, there must be content in that file. That content is either provided by the PNG configuration if given and otherwise there needs to be some default. So, the correct condition is
```
if any( (plugin is png) for plugin in output):
    ... use configuration from png plugin...
else:
    ... use default...
```
(We are currently not handling the case where there's more than one PNG plugin given in the PICMI configuration. I suspect that that would be problematic as well. That would be adding a check for that somewhere in Python world but as we don't really want users to use this plugin anyways, it's fine with me if it has some rough edges.)