### PR TITLE
fix CI

### DIFF
--- a/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/GaussianImpl.hpp
@@ -47,7 +47,7 @@ namespace picongpu
              */
             HDINLINE float_X operator()(DataSpace<simDim> const& totalCellOffset)
             {
-                if(totalCellOffset.y() < ParamClass::vacuumCellsY)
+                if(static_cast<uint32_t>(totalCellOffset.y()) < ParamClass::vacuumCellsY)
                 {
                     return 0._X;
                 }


### PR DESCRIPTION
bug introduced with #5370

ci: full-compile

```
/builds/hzdr/crp/picongpu/include/picongpu/../picongpu/particles/densityProfiles/GaussianImpl.hpp:50:40: error: comparison of integer expressions of different signedness: 'const pmacc::math::Vector<int, 3, pmacc::math::ArrayStorage<int, 3> >::type' {aka 'const int'} and 'const uint32_t' {aka 'const unsigned int'} [-Werror=sign-compare]
   50 |                 if(totalCellOffset.y() < ParamClass::vacuumCellsY)
      |                    ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```