### PR TITLE
Documentation fixes for perlmutter-nersc

### DIFF
--- a/etc/picongpu/perlmutter-nersc/README.md
+++ b/etc/picongpu/perlmutter-nersc/README.md
@@ -27,7 +27,7 @@ First-Time Setup:
 
 Subsequent Use:
 
--  Simply source the `gpu.profile` each time before using PICONGPU:
+-  Simply source the `gpu.profile` each time before using PIConGPU:
    ```bash
    source gpu.profile
    ```

--- a/etc/picongpu/perlmutter-nersc/README.md
+++ b/etc/picongpu/perlmutter-nersc/README.md
@@ -19,7 +19,7 @@ First-Time Setup:
    ```bash
    export PIC_PROFILE=/path/to/gpu.profile
    ```
-2. Install missing dependecies from source with `dependencies_autoinstall.sh` 
+2. Install missing dependencies from source with `dependencies_autoinstall.sh` 
    ```bash
    source dependencies_autoinstall.sh
    ```

--- a/etc/picongpu/perlmutter-nersc/README.md
+++ b/etc/picongpu/perlmutter-nersc/README.md
@@ -3,7 +3,35 @@
 PIConGPU can be compiled on a login node, but remember to limit the number of used CPU cores. `pic-build -j 16` works fine; reduce the number if the compiler gets killed.
 
 ## Installing Dependencies
-Missing dependencies can be installed from source with `dependencies_autoinstall.sh`. Change the project number in the `gpu.profile`, source it, and execute the install script on a login node.
+
+Before you begin, update the following in the `gpu.profile` file:
+- Change the project number (`export proj` variable)
+  ```bash
+  export proj="m0000"
+  ```
+- Change path to PICONGPU repository (`PICSRC` variable)
+  ```bash
+  export PICSRC=$HOME/src/picongpu
+  ```
+
+First-Time Setup:
+1. Set the `PIC_PROFILE` environment variable to the path of your `gpu.profile` file:  
+   ```bash
+   export PIC_PROFILE=/path/to/gpu.profile
+   ```
+2. Install missing dependecies from source with `dependencies_autoinstall.sh` 
+   ```bash
+   source dependencies_autoinstall.sh
+   ```
+
+
+Subsequent Use:
+
+-  Simply source the `gpu.profile` each time before using PICONGPU:
+   ```bash
+   source gpu.profile
+   ```
+
 
 ## Preemptive Jobs
 When using preemptive queues, you should uncomment the `sleep 120` command at the end of the tpl file.

--- a/etc/picongpu/perlmutter-nersc/README.md
+++ b/etc/picongpu/perlmutter-nersc/README.md
@@ -9,7 +9,7 @@ Before you begin, update the following in the `gpu.profile` file:
   ```bash
   export proj="m0000"
   ```
-- Change path to PICONGPU repository (`PICSRC` variable)
+- Change path to PIConGPU repository (`PICSRC` variable)
   ```bash
   export PICSRC=$HOME/src/picongpu
   ```

--- a/etc/picongpu/perlmutter-nersc/README.md
+++ b/etc/picongpu/perlmutter-nersc/README.md
@@ -19,7 +19,7 @@ First-Time Setup:
    ```bash
    export PIC_PROFILE=/path/to/gpu.profile
    ```
-2. Install missing dependencies from source with `dependencies_autoinstall.sh` 
+2. Install missing dependencies from source with `dependencies_autoinstall.sh`, this can be done on a login node: 
    ```bash
    source dependencies_autoinstall.sh
    ```


### PR DESCRIPTION
Modified perlmutter-nersc documentation to address the following:

- Changes required in the `gpu.profile` (project number and PICONGPU repository location)
- First time setup not including sourcing `gpu.profile` as `dependencies_autoinstall.sh` handles it
- Informing the user that sourcing `gpu.profile` is required for subsequent use 
- Adding code snippets to make it easier for the user