### PR TITLE
Fix isaac

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -426,7 +426,6 @@ PIC_dependency_set_status(PNGwriter ${PNGwriter_FOUND})
 PIC_dependency(ISAAC "Framework to in-situ visualize PIConGPU during the execution." OFF)
 
 if(PIC_SEARCH_ISAAC)
-    message(WARNING "ISAAC is currently not supporting alpaka 1.2.0+ if you are not fixing the ISSAC you should not enable this dependency.")
     find_package(ISAAC 1.4.0 CONFIG QUIET)
     if(ISAAC_FOUND)
         message(STATUS "Found ISAAC: ${ISAAC_DIR}")

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -423,7 +423,7 @@ PIC_dependency_set_status(PNGwriter ${PNGwriter_FOUND})
 # ISAAC
 ################################################################################
 
-PIC_dependency(ISAAC "Framework to in-situ visualize PIConGPU during the execution." OFF)
+PIC_dependency(ISAAC "Framework to in-situ visualize PIConGPU during the execution." AUTO)
 
 if(PIC_SEARCH_ISAAC)
     find_package(ISAAC 1.4.0 CONFIG QUIET)

--- a/include/picongpu/param/isaac.param
+++ b/include/picongpu/param/isaac.param
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include "picongpu/particles/param.hpp"
 #include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
 
 namespace picongpu

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -858,5 +858,24 @@ namespace picongpu
     } // namespace isaacP
 } // namespace picongpu
 
+namespace alpaka
+{
+
+    template<typename... T>
+    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::SourceList> : std::true_type
+    {
+    };
+
+    template<typename... T>
+    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorSourceList> : std::true_type
+    {
+    };
+
+    template<typename... T>
+    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::ParticleList> : std::true_type
+    {
+    };
+} // namespace alpaka
+
 PIC_REGISTER_PLUGIN(isaacP::IsaacPlugin);
 #endif

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -861,17 +861,14 @@ namespace picongpu
 namespace alpaka
 {
 
-    template<typename... T>
     struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::SourceList> : std::true_type
     {
     };
 
-    template<typename... T>
     struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorSourceList> : std::true_type
     {
     };
 
-    template<typename... T>
     struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::ParticleList> : std::true_type
     {
     };

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -861,14 +861,17 @@ namespace picongpu
 namespace alpaka
 {
 
+    template<>
     struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::SourceList> : std::true_type
     {
     };
 
-    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorSourceList> : std::true_type
+    template<>
+    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList> : std::true_type
     {
     };
 
+    template<>
     struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::ParticleList> : std::true_type
     {
     };

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -417,8 +417,8 @@ namespace picongpu
                     int min = std::numeric_limits<int>::max();
                     int max = 0;
                     int average = 0;
-                    int times[numProc];
-                    MPI_Gather(&time, 1, MPI_INT, times, 1, MPI_INT, 0, MPI_COMM_WORLD);
+                    std::vector<int> times(numProc);
+                    MPI_Gather(&time, 1, MPI_INT, times.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
                     for(int i = 0; i < numProc; i++)
                     {
                         min = (times[i] < min) ? times[i] : min;
@@ -867,7 +867,8 @@ namespace alpaka
     };
 
     template<>
-    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList> : std::true_type
+    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList>
+        : std::true_type
     {
     };
 

--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -19,7 +19,7 @@ if [ -z "$DISABLE_ISAAC" ] ; then
     cd $CI_PROJECT_DIR
     git clone https://github.com/ComputationalRadiationPhysics/isaac.git
     cd isaac
-    git checkout 6bf8e189142da7ab16f8367316fb21dcaa7e3b78
+    git checkout 9c8f710fd054690385d58ce89b353f3bb066979d
     mkdir build_isaac
     cd build_isaac
     cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT

--- a/share/ci/run_picongpu_tests.sh
+++ b/share/ci/run_picongpu_tests.sh
@@ -66,13 +66,11 @@ else
         CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_openPMD=ON -DPIC_USE_PNGwriter=ON -DPIC_USE_FFTW3=ON"
     fi
     # ISAAC together with the example FoilLCT is to complex therefore the CI is always running out of memory.
-    # ISAAC is disabled until someone adds support for alpaka 1.2.0
-    # re-enable tho following code if somene fixes the ISAAC issues.
-    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
     if [[ "$PIC_TEST_CASE_FOLDER" =~ .*FoilLCT.* ]] ; then
-         export CI_CPUS=1
-    #elif [ -z "$DISABLE_ISAAC" ] ; then
-    #    CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
+        CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=OFF"
+        export CI_CPUS=1
+    elif [ -z "$DISABLE_ISAAC" ] ; then
+        CMAKE_ARGS="$CMAKE_ARGS -DPIC_USE_ISAAC=ON"
     fi
 fi
 


### PR DESCRIPTION
There's not really something wrong on the PIConGPU side of things. Only a missing header. Once the corresponding ISAAC PR (https://github.com/ComputationalRadiationPhysics/isaac/pull/184) is through, ISAAC should be usable. Important learning from my experiments: I needs sufficient GPU memory, so increasing `reservedGpuMemorySize` in `memory.param` is necessary. On our dev-Server, this led to a clear out-of-memory error message but in larger runs by @BeyondEspresso the simulation seems to have run but no data was transferred.