### PR TITLE
Fix max steps

### DIFF
--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -481,7 +481,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         s.init_manager, pypicongpu_by_picmi_species = self.__get_init_manager()
 
         s.plugins = [
-            entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, self.max_steps)
+            entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, s.time_steps)
             for entry in self.diagnostics
         ]
 


### PR DESCRIPTION
@pordyna reported the following error message running via PICMI using `max_time` instead of `max_steps`.
```
Traceback (most recent call last):
  File "/home/pawel/Work/LOCAL/PIConGPU-git/picongpu-setups/setup/input/picmi_input.py", line 389, in <module>
    sim.write_input_file(str(output_directory_path.absolute().resolve()))
  File "/home/pawel/Work/LOCAL/PIConGPU-git/picongpu-setups/picongpu/lib/python/picongpu/picmi/simulation.py", line 417, in write_input_file
    pypicongpu_simulation = self.get_as_pypicongpu()
                            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pawel/Work/LOCAL/PIConGPU-git/picongpu-setups/picongpu/lib/python/picongpu/picmi/simulation.py", line 484, in get_as_pypicongpu
    entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, self.max_steps)
  File "/home/pawel/Work/LOCAL/PIConGPU-git/picongpu-setups/picongpu/lib/python/picongpu/picmi/diagnostics/checkpoint.py", line 106, in get_as_pypicongpu
    def get_as_pypicongpu(
  File "/home/pawel/Work/LOCAL/PIConGPU-git/.venv/lib64/python3.12/site-packages/typeguard/_functions.py", line 137, in check_argument_types
    check_type_internal(value, annotation, memo)
  File "/home/pawel/Work/LOCAL/PIConGPU-git/.venv/lib64/python3.12/site-packages/typeguard/_checkers.py", line 956, in check_type_internal
    raise TypeCheckError(f"is not an instance of {qualified_name(origin_type)}")
typeguard.TypeCheckError: argument "num_steps" (None) is not an instance of int
Traceback (most recent call last):
  File "/home/pawel/Work/LOCAL/PIConGPU-git/picongpu-setups/setup/input/gen_input_for_task.py", line 30, in <module>
    subprocess.run(command, check=True)
  File "/usr/lib64/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/pawel/Work/LOCAL/PIConGPU-git/.venv/bin/python', PosixPath('input/picmi_input.py'), '--a0=3.0', '--scale_length=5.0000000000000004e-08', '--half_in_plane_box_size=8e-06', '--output=projects/sim_0']' returned non-zero exit status 1.
```