### PR TITLE
Fix integer casting in TimeStepSpec

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/timestepspec.py
+++ b/lib/python/picongpu/picmi/diagnostics/timestepspec.py
@@ -124,7 +124,7 @@ class TimeStepSpec(metaclass=_TimeStepSpecMeta):
             # In PIConGPU, a single integer would be interpreted as
             # slice(None, None, value) but this is unnatural for the
             # Python [] operator.
-            spec if isinstance(spec, slice) else slice(int(spec), int(spec), 1)
+            spec if isinstance(spec, slice) else slice(spec, spec, None)
             for spec in args
         )
         self.specs_in_seconds = tuple(specs_in_seconds)

--- a/test/python/picongpu/quick/picmi/diagnostics/timestepspec.py
+++ b/test/python/picongpu/quick/picmi/diagnostics/timestepspec.py
@@ -276,3 +276,12 @@ class TestTimeStepSpec(unittest.TestCase):
             with self.subTest(ts=ts, indices=indices):
                 with self.assertRaisesRegex(ValueError, "Step size must be >= 1"):
                     ts.get_as_pypicongpu(TIME_STEP_SIZE, INDEX_MAX)
+
+    def test_regression_wrong_int_casting(self):
+        stop_time = 1.1195773740290312e-12
+        dt = 1.749246958411663e-17
+        num_steps = 64004
+
+        as_single = TimeStepSpec[stop_time]("seconds").get_as_pypicongpu(dt, num_steps).specs[0]
+        as_slice = TimeStepSpec[stop_time:stop_time]("seconds").get_as_pypicongpu(dt, num_steps).specs[0]
+        self.assertEqual(as_single, as_slice)


### PR DESCRIPTION
Bug found by @pordyna. The previous code passed my tests because I used easy to read numbers which didn't trigger the case that @pordyna found. I added a quick regression test which should catch the most outrageous of my mistakes. I'll update the tests with numbers better probing our typical regime in the mid-term.