### PR TITLE
fix  broken test case

### DIFF
--- a/include/picongpu/param/isaac.param
+++ b/include/picongpu/param/isaac.param
@@ -40,6 +40,7 @@
 #pragma once
 
 #include "picongpu/particles/param.hpp"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
 
 namespace picongpu

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -21,6 +21,8 @@
 // required for SIMDIM definition
 #include "picongpu/defines.hpp"
 
+#include <concepts>
+
 #if (ENABLE_ISAAC == 1) && (SIMDIM == DIM3)
 
 #    include "picongpu/param/isaac.param"
@@ -861,19 +863,35 @@ namespace picongpu
 namespace alpaka
 {
 
-    template<>
-    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::SourceList> : std::true_type
+    /** Define these lists as trivially copyable but only if they differ to other lists used by ISAAC to avoid multiple
+     * definitions.
+     */
+    template<typename T>
+    requires(std::same_as<T, typename picongpu::isaacP::IsaacPlugin::SourceList>)
+    struct IsKernelArgumentTriviallyCopyable<T> : std::true_type
     {
     };
 
-    template<>
-    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList>
-        : std::true_type
+    template<typename T>
+    requires(
+        std::same_as<T, typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList>
+        && !std::same_as<
+            typename picongpu::isaacP::IsaacPlugin::SourceList,
+            typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList>)
+    struct IsKernelArgumentTriviallyCopyable<T> : std::true_type
     {
     };
 
-    template<>
-    struct IsKernelArgumentTriviallyCopyable<typename picongpu::isaacP::IsaacPlugin::ParticleList> : std::true_type
+    template<typename T>
+    requires(
+        std::same_as<T, typename picongpu::isaacP::IsaacPlugin::ParticleList>
+        && !std::same_as<
+            typename picongpu::isaacP::IsaacPlugin::SourceList,
+            typename picongpu::isaacP::IsaacPlugin::ParticleList>
+        && !std::same_as<
+            typename picongpu::isaacP::IsaacPlugin::VectorFieldSourceList,
+            typename picongpu::isaacP::IsaacPlugin::ParticleList>)
+    struct IsKernelArgumentTriviallyCopyable<T> : std::true_type
     {
     };
 } // namespace alpaka

--- a/share/picongpu/tests/compile/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compile/include/picongpu/param/isaac.param
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
 
 namespace picongpu

--- a/share/picongpu/tests/compileLaser/include/picongpu/param/isaac.param
+++ b/share/picongpu/tests/compileLaser/include/picongpu/param/isaac.param
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
 #include "picongpu/particles/particleToGrid/derivedAttributes/DerivedAttributes.def"
 
 namespace picongpu


### PR DESCRIPTION
Since the reactivation of the ISAAC plugin #5389 the `compileLaser` test case is not compiling because of a missing include.

PR is tested with `ci: full-compile`