### PR TITLE
update particle filter documentation

### DIFF
--- a/docs/source/usage/workflows/particleFilters.rst
+++ b/docs/source/usage/workflows/particleFilters.rst
@@ -28,6 +28,13 @@ Let us select particles with momentum vector within a cone with an opening angle
        {
            static constexpr char const * name = "forwardPinhole";
 
+           /* A filter is deterministic if the filter outcome is equal between evaluations. If so, set this
+            * variable to true, otherwise to false.
+            *
+            * Example: A filter were results depend on a random number generator must return false.
+            */
+	   static constexpr bool isDeterministic = true;
+	 
            template< typename T_Particle >
            HDINLINE bool operator()(
                T_Particle const & particle


### PR DESCRIPTION
When making free particle filters optionally non-deterministic, a bool variable was introduced. This was never added to the documentation. Thus, the example in the documentation does not compile. This pull request fixes this issue. 

Introduced by #4432.