### PR TITLE
Get interactive sessions faster on Frontier

### DIFF
--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -107,7 +107,7 @@ function getNode() {
     else
         numNodes=$1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks=$((numNodes * 8)) --gres=gpu:$((numNodes * 8)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=$numNodes --ntasks=$((numNodes * 8)) --gres=gpu:$((numNodes * 8)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug --pty bash
 }
 
 # allocate an interactive shell for one hour
@@ -123,7 +123,7 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID --pty bash
+    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
Adds the `debug` quality of service (QOS) class according to [Frontier Scheduling Policy](https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#scheduling-policy) to the aliases `getNode` and `getDevice`. This allows to access Frontier’s compute resources for short non-production debug tasks with higher priority (much faster!) at maximum one single job per user at any given time.