### PR TITLE
add note for users regarding weighting reduction at boundaries

### DIFF
--- a/docs/source/usage/workflows/boundaryConditions.rst
+++ b/docs/source/usage/workflows/boundaryConditions.rst
@@ -47,7 +47,7 @@ To set physical boundary conditions, use the command-line option described above
 .. note::
 
    Note that with the "absorbing" particle boundary conditions (the default in most examples), the weighting of the macro particles decreases exponentially near the field boundaries until it reaches the minimum possible value `MIN_WEIGHTING`.
-   Thus, particles with low or minimum weighting might originate from a low-density region or the boundaries. Keep this in mind when doing data analysis.
+   Thus, particles with low or minimum weighting might originate not only from a low-density region but also due to this effect at the boundaries. Keep this in mind when doing data analysis.
    
 
 

--- a/docs/source/usage/workflows/boundaryConditions.rst
+++ b/docs/source/usage/workflows/boundaryConditions.rst
@@ -44,6 +44,13 @@ The internal treatment of particles in the guard area is controlled by the ``bou
 However, this option is for expert users and generally should not be modified.
 To set physical boundary conditions, use the command-line option described above.
 
+.. note::
+
+   Note that with the "absorbing" particle boundary conditions (the default in most examples), the weighting of the macro particles decreases exponentially near the field boundaries until it reaches the minimum possible value `MIN_WEIGHTING`.
+   Thus, particles with low or minimum weighting might originate from a low-density region or the boundaries. Keep this in mind when doing data analysis.
+   
+
+
 Fields
 """"""
 


### PR DESCRIPTION
This pull request adds a note for users that macro-particle weighting might change close to boundaries. 
