### PR TITLE
Field binning fixes to pass fields and setters to configure binning

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -191,7 +191,7 @@ Species can be instances of a species type or a particle species name as a PMACC
 	auto electronsObj = PMACC_CSTRING("e"){};
 
 Optionally, users can specify a filter to be used with the species. This is a predicate functor, i.e. it is a functor with a signature as described above and which returns a boolean. If the filter returns true it means the particle is included in the binning.
-They can then create a FilteredSpecies object which contains the species and the filter.
+They can then create a ``FilteredSpecies`` object which contains the species and the filter.
 
 .. literalinclude:: ../../../../share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
    :language: c++
@@ -207,7 +207,12 @@ They can then create a FilteredSpecies object which contains the species and the
 Fields
 ------
 PIConGPU fields which should be used in field binning.
-Fields can be instances of a field type. For example,
+Fields must be instances of the ``FieldInfo`` type.
+
+.. doxygenclass:: picongpu::plugins::binning::FieldInfo
+	:members:
+
+For example,
 
 .. literalinclude:: ../../../../share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
    :language: c++
@@ -215,12 +220,17 @@ Fields can be instances of a field type. For example,
    :end-before: doc-include-end: fieldTuple
    :dedent:
 
-Fields are passed to addFieldBinner in the form of a tuple. This is just a collection of field objects and is of arbitrary size.
+Fields are passed to addFieldBinner in the form of a tuple. This is just a collection of ``FieldInfo`` and is of arbitrary size.
 Users can make a fields tuple by using the ``createTuple()`` function and passing in the objects as arguments.
+The functors receive the fields in the form of the field data box, in the order they are passed in the tuple.
 
 .. note::
 
 	It is possible to have an empty tuple for fields when doing field binning, in which case the functor will be called with no fields. This may be useful if you are passing in extra data and want field traversal over it.
+
+.. note::
+
+    It is possible to have field information available while doing particle binning as well. Users can simply pass in ``FieldInfo`` objects in the extra data tuple, and the functor will be called with the field information as well.
 
 Deposited Quantity
 ------------------

--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -222,7 +222,13 @@ For example,
 
 Fields are passed to addFieldBinner in the form of a tuple. This is just a collection of ``FieldInfo`` and is of arbitrary size.
 Users can make a fields tuple by using the ``createTuple()`` function and passing in the objects as arguments.
-The functors receive the fields in the form of the field data box, in the order they are passed in the tuple.
+The functors receive the fields in the form of the field data box, which is the field data on the current GPU including the guard cells, in the order they are passed in the tuple.
+
+.. literalinclude:: ../../../../share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+   :language: c++
+   :start-after: doc-include-start: fieldBox
+   :end-before: doc-include-end: fieldBox
+   :dedent:
 
 .. note::
 

--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -110,7 +110,7 @@ namespace picongpu
              *         This can be used to further configure the binning setup if needed.
              */
             template<typename T_AccumulateOp = alpaka::AtomicAdd, typename T_Extras = std::tuple<>>
-            auto addFieldBinner(
+            auto& addFieldBinner(
                 std::string const& binnerOutputName,
                 auto const& axisTupleObject,
                 auto const& fieldsTupleObject,

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -117,51 +117,51 @@ namespace picongpu
             /** @brief Time average the accumulated data when doing the dump. Defaults to true. */
             Child& setTimeAveraging(bool timeAv)
             {
-                this->timeAveraging = timeAv;
+                timeAveraging = timeAv;
                 return interpretAsChild();
             }
 
             /** @brief The periodicity of the output. Defaults to 1 */
             Child& setNotifyPeriod(std::string notify)
             {
-                this->notifyPeriod = std::move(notify);
+                notifyPeriod = std::move(notify);
                 return interpretAsChild();
             }
 
             /** @brief The number of notify steps to accumulate over. Dump at the end. Defaults to 1. */
             Child& setDumpPeriod(uint32_t dumpXNotifys)
             {
-                this->dumpPeriod = dumpXNotifys;
+                dumpPeriod = dumpXNotifys;
                 return interpretAsChild();
             }
 
-            /** @brief The periodicity of the output. Defaults to 1 */
+            /** @brief Set the file extension for the openPMD output */
             Child& setOpenPMDExtension(std::string extension)
             {
-                this->openPMDExtension = std::move(extension);
+                openPMDExtension = std::move(extension);
                 return interpretAsChild();
             }
 
-            /** @brief The periodicity of the output. Defaults to 1 */
+            /** @brief Set the infix for file names in openPMD output */
             Child& setOpenPMDInfix(std::string infix)
             {
-                this->openPMDInfix = std::move(infix);
+                openPMDInfix = std::move(infix);
                 return interpretAsChild();
             }
 
-            /** @brief The periodicity of the output. Defaults to 1 */
+            /** @brief Call a functor to add custom data to openPMD output */
             Child& setOpenPMDWriteFunctor(
                 std::function<void(::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh)>
-                    writeOpenPMDFunctor)
+                    functor)
             {
-                this->writeOpenPMDFunctor = std::move(writeOpenPMDFunctor);
+                writeOpenPMDFunctor = std::move(functor);
                 return interpretAsChild();
             }
 
-            /** @brief The periodicity of the output. Defaults to 1 */
+            /** @brief Set miscellaneous configuration options for openPMD output */
             Child& setOpenPMDJsonCfg(std::string cfg)
             {
-                this->openPMDJsonCfg = std::move(cfg);
+                openPMDJsonCfg = std::move(cfg);
                 return interpretAsChild();
             }
 
@@ -170,7 +170,7 @@ namespace picongpu
              */
             Child& setHostSideHook(std::function<void()> hookFunc)
             {
-                this->hostHook = std::move(hookFunc);
+                hostHook = std::move(hookFunc);
                 return interpretAsChild();
             }
         };

--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -105,14 +105,12 @@ namespace picongpu
                 auto const& worker,
                 T_HistBox binningBox,
                 auto particlesBox,
-                pmacc::DataSpace<simDim> const& localOffset,
-                pmacc::DataSpace<simDim> const& globalOffset,
+                DomainInfo<BinningType::Particle> domainInfo,
                 auto const& axisTuple,
                 T_DepositionFunctor const& quantityFunctor,
                 DataSpace<T_nAxes> const& extents,
                 auto const& userFunctorData,
                 auto const& filter,
-                uint32_t const currentStep,
                 T_Mapping const& mapper) const
             {
                 DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
@@ -121,8 +119,7 @@ namespace picongpu
                 /**
                  * Init the Domain info, here because of the possibility of a moving window
                  */
-                auto const domainInfo
-                    = DomainInfo<BinningType::Particle>{currentStep, globalOffset, localOffset, physicalSuperCellIdx};
+                domainInfo.fillDeviceData(physicalSuperCellIdx);
 
                 auto const functorParticle = FunctorParticle<T_AtomicOp>{};
 
@@ -194,14 +191,12 @@ namespace picongpu
                 T_Worker const& worker,
                 T_HistBox binningBox,
                 TParticlesBox particlesBox,
-                pmacc::DataSpace<simDim> const& localOffset,
-                pmacc::DataSpace<simDim> const& globalOffset,
+                DomainInfo<BinningType::Particle> domainInfo,
                 T_AxisTuple const& axisTuple,
                 T_DepositionFunctor const& quantityFunctor,
                 DataSpace<T_nAxes> const& extents,
                 auto const& userFunctorData,
                 auto const& filter,
-                uint32_t const currentStep,
                 pmacc::DataSpace<simDim> const& beginCellIdxLocal,
                 pmacc::DataSpace<simDim> const& endCellIdxLocal,
                 T_Mapping const& mapper) const
@@ -211,8 +206,7 @@ namespace picongpu
                 // supercell index relative to the border origin
                 auto const physicalSuperCellIdx = superCellIdx - mapper.getGuardingSuperCells();
 
-                auto const domainInfo
-                    = DomainInfo<BinningType::Particle>{currentStep, globalOffset, localOffset, physicalSuperCellIdx};
+                domainInfo.fillDeviceData(physicalSuperCellIdx);
                 auto const functorParticle = FunctorParticle<T_AtomicOp>{};
 
                 auto forEachParticle
@@ -317,13 +311,11 @@ namespace picongpu
             DINLINE void operator()(
                 auto const& worker,
                 T_HistBox binningBox,
-                pmacc::DataSpace<simDim> const& localOffset,
-                pmacc::DataSpace<simDim> const& globalOffset,
+                DomainInfo<BinningType::Field> domainInfo,
                 auto const& axisTuple,
                 auto const& userFunctorData,
                 T_DepositionFunctor const& quantityFunctor,
                 DataSpace<T_nAxes> const& extents,
-                uint32_t const currentStep,
                 T_Mapping const& mapper) const
             {
                 using SuperCellSize = typename T_Mapping::SuperCellSize;
@@ -348,12 +340,7 @@ namespace picongpu
                         /**
                          * Init the Domain info, here because of the possibility of a moving window
                          */
-                        auto const domainInfo = DomainInfo<BinningType::Field>{
-                            currentStep,
-                            globalOffset,
-                            localOffset,
-                            physicalSuperCellIdx,
-                            localCellIndex};
+                        domainInfo.fillDeviceData(physicalSuperCellIdx, localCellIndex);
 
                         functorCell(
                             worker,

--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -114,8 +114,9 @@ namespace picongpu
                 T_Mapping const& mapper) const
             {
                 DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+                auto const guardingSuperCells = mapper.getGuardingSuperCells();
                 // supercell index relative to the border origin
-                auto const physicalSuperCellIdx = superCellIdx - mapper.getGuardingSuperCells();
+                auto const physicalSuperCellIdx = superCellIdx - guardingSuperCells;
                 /**
                  * Init the Domain info, here because of the possibility of a moving window
                  */
@@ -203,8 +204,9 @@ namespace picongpu
             {
                 /* multi-dimensional offset vector from local domain origin on GPU in units of super cells */
                 pmacc::DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+                auto const guardingSuperCells = mapper.getGuardingSuperCells();
                 // supercell index relative to the border origin
-                auto const physicalSuperCellIdx = superCellIdx - mapper.getGuardingSuperCells();
+                auto const physicalSuperCellIdx = superCellIdx - guardingSuperCells;
 
                 domainInfo.fillDeviceData(physicalSuperCellIdx);
                 auto const functorParticle = FunctorParticle<T_AtomicOp>{};
@@ -322,8 +324,9 @@ namespace picongpu
                 constexpr uint32_t cellsPerSupercell = pmacc::math::CT::volume<SuperCellSize>::type::value;
 
                 DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
+                auto const guardingSuperCells = mapper.getGuardingSuperCells();
                 // supercell index relative to the border origin
-                auto const physicalSuperCellIdx = superCellIdx - mapper.getGuardingSuperCells();
+                auto const physicalSuperCellIdx = superCellIdx - guardingSuperCells;
 
                 using SuperCellSize = typename T_Mapping::SuperCellSize;
 

--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -184,18 +184,25 @@ namespace picongpu
 
                 auto pos = localCellIdx + relative_cellpos;
 
+                using DistanceReturnType = std::common_type_t<
+                    typename std::decay_t<decltype(sim.si.getCellSize())>::type,
+                    typename std::decay_t<decltype(pos)>::type>;
+
                 if constexpr(T_Units == PositionUnits::SI)
                 {
-                    return precisionCast<typename std::decay_t<decltype(sim.si.getCellSize())>::type>(pos)
-                           * sim.si.getCellSize().shrink<simDim>();
+                    return precisionCast<DistanceReturnType>(pos)
+                           * precisionCast<DistanceReturnType>(sim.si.getCellSize().shrink<simDim>());
                 }
-                if constexpr(T_Units == PositionUnits::PIC)
+                else if constexpr(T_Units == PositionUnits::PIC)
                 {
-                    return precisionCast<typename std::decay_t<decltype(sim.pic.getCellSize())>::type>(pos)
-                           * sim.pic.getCellSize().shrink<simDim>();
+                    return precisionCast<DistanceReturnType>(pos)
+                           * precisionCast<DistanceReturnType>(sim.pic.getCellSize().shrink<simDim>());
                 }
-
-                return pos;
+                // else T_Units == PositionUnits::Cell
+                else
+                {
+                    return pos;
+                }
             }
         };
 
@@ -296,32 +303,43 @@ namespace picongpu
                 if constexpr(T_Units == PositionUnits::SI)
                 {
                     auto cellSize = sim.si.getCellSize().shrink<simDim>();
-                    return precisionCast<typename std::decay_t<decltype(cellSize)>::type>(pos) * cellSize;
+                    return precisionCast<DistanceReturnType>(pos) * precisionCast<DistanceReturnType>(cellSize);
                 }
                 else if constexpr(T_Units == PositionUnits::PIC)
                 {
                     auto cellSize = sim.pic.getCellSize().shrink<simDim>();
-                    return precisionCast<typename std::decay_t<decltype(cellSize)>::type>(pos) * cellSize;
+                    return precisionCast<DistanceReturnType>(pos) * precisionCast<DistanceReturnType>(cellSize);
                 }
+                // else T_Units == PositionUnits::Cell
                 else
                 {
                     return pos;
                 }
             }
+            // T_Precision == PositionPrecision::Cell
             else
             {
+                using DistanceReturnType = std::common_type_t<
+                    typename std::decay_t<decltype(sim.si.getCellSize())>::type,
+                    typename std::decay_t<decltype(relative_cellpos)>::type>;
+
                 if constexpr(T_Units == PositionUnits::SI)
                 {
                     auto cellSize = sim.si.getCellSize().shrink<simDim>();
-                    return precisionCast<typename std::decay_t<decltype(cellSize)>::type>(relative_cellpos) * cellSize;
+                    return precisionCast<DistanceReturnType>(relative_cellpos)
+                           * precisionCast<DistanceReturnType>(cellSize);
                 }
-                if constexpr(T_Units == PositionUnits::PIC)
+                else if constexpr(T_Units == PositionUnits::PIC)
                 {
                     auto cellSize = sim.pic.getCellSize().shrink<simDim>();
-                    return precisionCast<typename std::decay_t<decltype(cellSize)>::type>(relative_cellpos) * cellSize;
+                    return precisionCast<DistanceReturnType>(relative_cellpos)
+                           * precisionCast<DistanceReturnType>(cellSize);
                 }
-
-                return relative_cellpos;
+                // else T_Units == PositionUnits::Cell
+                else
+                {
+                    return relative_cellpos;
+                }
             }
         }
     } // namespace plugins::binning

--- a/include/picongpu/plugins/binning/FieldInfo.hpp
+++ b/include/picongpu/plugins/binning/FieldInfo.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "picongpu/plugins/binning/utility.hpp"
-
 #include <pmacc/Environment.hpp>
 #include <pmacc/dataManagement/DataConnector.hpp>
+#include <pmacc/traits/IsSpecializationOf.hpp>
 
 #include <string>
 #include <string_view>
@@ -33,9 +32,9 @@ namespace picongpu::plugins::binning
         }
     };
 
-    auto transformFieldInfo(auto&& arg) -> decltype(auto)
+    decltype(auto) transformFieldInfo(auto&& arg)
     {
-        if constexpr(IsSpecializationOf<std::decay_t<decltype(arg)>, FieldInfo>)
+        if constexpr(pmacc::concepts::SpecializationOf<std::decay_t<decltype(arg)>, FieldInfo>)
         {
             pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
             return dc

--- a/include/picongpu/plugins/binning/FieldInfo.hpp
+++ b/include/picongpu/plugins/binning/FieldInfo.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "picongpu/plugins/binning/utility.hpp"
+
+#include <pmacc/Environment.hpp>
+#include <pmacc/dataManagement/DataConnector.hpp>
+
+#include <string>
+#include <string_view>
+
+namespace picongpu::plugins::binning
+{
+    /** @brief Struct to hold information about a field
+     *  @tparam Field The type of the field
+     *  The constructor takes a id which describes how to get the field from the DataConnector
+     */
+    template<typename Field>
+    struct FieldInfo
+    {
+        using FieldType = Field;
+        std::string id;
+
+        FieldInfo(std::string_view id) : id(id)
+        {
+        }
+
+        std::string getId() const
+        {
+            return id;
+        }
+    };
+
+    auto transformFieldInfo(auto&& arg) -> decltype(auto)
+    {
+        if constexpr(IsSpecializationOf<std::decay_t<decltype(arg)>, FieldInfo>)
+        {
+            pmacc::DataConnector& dc = pmacc::Environment<>::get().DataConnector();
+            return dc
+                .get<typename std::remove_cvref_t<decltype(arg)>::FieldType>(std::forward<decltype(arg)>(arg).getId())
+                ->getDeviceDataBox();
+        }
+        else
+        {
+            return std::forward<decltype(arg)>(arg);
+        }
+    };
+
+} // namespace picongpu::plugins::binning

--- a/include/picongpu/plugins/binning/FieldInfo.hpp
+++ b/include/picongpu/plugins/binning/FieldInfo.hpp
@@ -10,9 +10,12 @@
 
 namespace picongpu::plugins::binning
 {
-    /** @brief Struct to hold information about a field
-     *  @tparam Field The type of the field
+    /**
+     *  @brief Struct to hold information about a field
+     *
      *  The constructor takes a id which describes how to get the field from the DataConnector
+     *  @tparam Field The type of the field
+     *
      */
     template<typename Field>
     struct FieldInfo

--- a/include/picongpu/plugins/binning/axis/LinearAxis.hpp
+++ b/include/picongpu/plugins/binning/axis/LinearAxis.hpp
@@ -114,7 +114,12 @@ namespace picongpu
                                 if constexpr(std::is_integral_v<T_Attribute>)
                                 {
                                     // using only integer operations
-                                    binIdx = ((val - picRange.min) * scaling) / picRange.getRange();
+                                    using PromotedType
+                                        = std::conditional_t<std::is_signed_v<T_Attribute>, int64_t, uint64_t>;
+
+                                    PromotedType const diff = val - picRange.min;
+                                    PromotedType const scaled_diff = diff * scaling;
+                                    binIdx = scaled_diff / picRange.getRange();
                                 }
                                 else
                                 {

--- a/include/picongpu/plugins/binning/binnerPlugin.hpp
+++ b/include/picongpu/plugins/binning/binnerPlugin.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/plugins/binning/BinningCreator.hpp"
 #include "picongpu/plugins/binning/DomainInfo.hpp"
+#include "picongpu/plugins/binning/FieldInfo.hpp"
 #include "picongpu/plugins/binning/FilteredSpecies.hpp"
 #include "picongpu/plugins/binning/FunctorDescription.hpp"
 #include "picongpu/plugins/binning/UnitConversion.hpp"

--- a/include/picongpu/plugins/binning/binners/FieldBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/FieldBinner.hpp
@@ -79,7 +79,7 @@ namespace picongpu
                             [&](auto&&... extras)
                             {
                                 return pmacc::memory::tuple::make_tuple(
-                                    std::forward<decltype(fields)>(fields)...,
+                                    transformFieldInfo(std::forward<decltype(fields)>(fields))...,
                                     std::forward<decltype(extras)>(extras)...);
                             },
                             this->binningData.extraData);

--- a/include/picongpu/plugins/binning/binners/FieldBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/FieldBinner.hpp
@@ -62,6 +62,9 @@ namespace picongpu
 
                 auto const globalOffset = Environment<simDim>::get().SubGrid().getGlobalDomain().offset;
                 auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
+                auto& mv = MovingWindow::getInstance();
+                auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
+                auto domainInfo = DomainInfo<BinningType::Field>(currentStep, globalOffset, localOffset, windowOffset);
 
                 auto const axisKernels = tupleMap(
                     this->binningData.axisTuple,
@@ -86,13 +89,11 @@ namespace picongpu
                 PMACC_LOCKSTEP_KERNEL(functorBlock)
                     .config(mapper.getGridDim(), SuperCellSize{})(
                         binningBox,
-                        localOffset,
-                        globalOffset,
+                        domainInfo,
                         axisKernels,
                         userFunctorData,
                         this->binningData.depositionData.functor,
                         this->binningData.axisExtentsND,
-                        currentStep,
                         mapper);
             }
         };

--- a/include/picongpu/plugins/binning/binners/FieldBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/FieldBinner.hpp
@@ -64,7 +64,12 @@ namespace picongpu
                 auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
                 auto& mv = MovingWindow::getInstance();
                 auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
-                auto domainInfo = DomainInfo<BinningType::Field>(currentStep, globalOffset, localOffset, windowOffset);
+                auto domainInfo = DomainInfo<BinningType::Field>(
+                    currentStep,
+                    globalOffset,
+                    localOffset,
+                    mapper.getGuardingSuperCells(),
+                    windowOffset);
 
                 auto const axisKernels = tupleMap(
                     this->binningData.axisTuple,

--- a/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
@@ -119,7 +119,10 @@ namespace picongpu
 
                 auto const extraData = std::apply(
                     [&](auto&&... extras)
-                    { return pmacc::memory::tuple::make_tuple(std::forward<decltype(extras)>(extras)...); },
+                    {
+                        return pmacc::memory::tuple::make_tuple(
+                            transformFieldInfo(std::forward<decltype(extras)>(extras))...);
+                    },
                     this->binningData.extraData);
                 auto const functorBlock = ParticleBinningKernel<typename TBinningData::AccumulationOp>{};
 

--- a/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
@@ -110,8 +110,12 @@ namespace picongpu
                 auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
                 auto& mv = MovingWindow::getInstance();
                 auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
-                auto domainInfo
-                    = DomainInfo<BinningType::Particle>(currentStep, globalOffset, localOffset, windowOffset);
+                auto domainInfo = DomainInfo<BinningType::Particle>(
+                    currentStep,
+                    globalOffset,
+                    localOffset,
+                    mapper.getGuardingSuperCells(),
+                    windowOffset);
 
                 auto const axisKernels = tupleMap(
                     this->binningData.axisTuple,
@@ -168,8 +172,12 @@ namespace picongpu
                         auto const currentStep = Environment<>::get().SimulationDescription().getCurrentStep();
                         auto& mv = MovingWindow::getInstance();
                         auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
-                        auto domainInfo
-                            = DomainInfo<BinningType::Particle>(currentStep, globalOffset, localOffset, windowOffset);
+                        auto domainInfo = DomainInfo<BinningType::Particle>(
+                            currentStep,
+                            globalOffset,
+                            localOffset,
+                            mapper.getGuardingSuperCells(),
+                            windowOffset);
 
                         auto const axisKernels = tupleMap(
                             binner->binningData.axisTuple,

--- a/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
@@ -108,6 +108,10 @@ namespace picongpu
 
                 auto const globalOffset = Environment<simDim>::get().SubGrid().getGlobalDomain().offset;
                 auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
+                auto& mv = MovingWindow::getInstance();
+                auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
+                auto domainInfo
+                    = DomainInfo<BinningType::Particle>(currentStep, globalOffset, localOffset, windowOffset);
 
                 auto const axisKernels = tupleMap(
                     this->binningData.axisTuple,
@@ -123,14 +127,12 @@ namespace picongpu
                     .config(mapper.getGridDim(), particlesBox)(
                         binningBox,
                         particlesBox,
-                        localOffset,
-                        globalOffset,
+                        domainInfo,
                         axisKernels,
                         this->binningData.depositionData.functor,
                         this->binningData.axisExtentsND,
                         extraData,
                         fs.filter,
-                        currentStep,
                         mapper);
             }
 
@@ -160,6 +162,11 @@ namespace picongpu
 
                         auto const globalOffset = Environment<simDim>::get().SubGrid().getGlobalDomain().offset;
                         auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
+                        auto const currentStep = Environment<>::get().SimulationDescription().getCurrentStep();
+                        auto& mv = MovingWindow::getInstance();
+                        auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
+                        auto domainInfo
+                            = DomainInfo<BinningType::Particle>(currentStep, globalOffset, localOffset, windowOffset);
 
                         auto const axisKernels = tupleMap(
                             binner->binningData.axisTuple,
@@ -188,14 +195,12 @@ namespace picongpu
                             .config(mapper.getGridDim(), particlesBox)(
                                 binningBox,
                                 particlesBox,
-                                localOffset,
-                                globalOffset,
+                                domainInfo,
                                 axisKernels,
                                 binner->binningData.depositionData.functor,
                                 binner->binningData.axisExtentsND,
                                 extraData,
                                 fs.filter,
-                                Environment<>::get().SimulationDescription().getCurrentStep(),
                                 beginExternalCellsLocal,
                                 endExternalCellsLocal,
                                 mapper);

--- a/include/picongpu/plugins/binning/utility.hpp
+++ b/include/picongpu/plugins/binning/utility.hpp
@@ -107,22 +107,5 @@ namespace picongpu
             return std::unique_ptr<std::remove_cvref_t<decltype(*ptr)>>(ptr);
         }
 
-        template<typename, template<typename...> typename>
-        struct is_specialization_of : std::false_type
-        {
-        };
-
-        template<template<typename...> typename Template, typename... Args>
-        struct is_specialization_of<Template<Args...>, Template> : std::true_type
-        {
-        };
-
-        // TODO reverse this order
-        template<typename T, template<typename...> typename Template>
-        inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
-
-        template<typename T, template<typename...> typename Template>
-        concept IsSpecializationOf = is_specialization_of_v<T, Template>;
-
     } // namespace plugins::binning
 } // namespace picongpu

--- a/include/picongpu/plugins/binning/utility.hpp
+++ b/include/picongpu/plugins/binning/utility.hpp
@@ -76,7 +76,7 @@ namespace picongpu
             constexpr auto tupleMapHelper(
                 std::index_sequence<Is...>,
                 std::tuple<Args...> const& tuple,
-                Functor&& functor) noexcept
+                Functor&& functor)
             {
                 return pmacc::memory::tuple::make_tuple(std::forward<Functor>(functor)(std::get<Is>(tuple))...);
             }
@@ -86,7 +86,7 @@ namespace picongpu
          * @brief create a new tuple from the return value of a functor applied on all arguments of a tuple
          */
         template<typename... Args, typename Functor>
-        constexpr auto tupleMap(std::tuple<Args...> const& tuple, Functor&& functor) noexcept
+        constexpr auto tupleMap(std::tuple<Args...> const& tuple, Functor&& functor)
         {
             return detail::tupleMapHelper(
                 std::make_index_sequence<sizeof...(Args)>{},
@@ -95,7 +95,7 @@ namespace picongpu
         }
 
         template<typename... Args>
-        constexpr auto createTuple(Args&&... args) noexcept
+        constexpr auto createTuple(Args&&... args)
         {
             return std::make_tuple(std::forward<Args>(args)...);
         }
@@ -107,6 +107,22 @@ namespace picongpu
             return std::unique_ptr<std::remove_cvref_t<decltype(*ptr)>>(ptr);
         }
 
+        template<typename, template<typename...> typename>
+        struct is_specialization_of : std::false_type
+        {
+        };
+
+        template<template<typename...> typename Template, typename... Args>
+        struct is_specialization_of<Template<Args...>, Template> : std::true_type
+        {
+        };
+
+        // TODO reverse this order
+        template<typename T, template<typename...> typename Template>
+        inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
+
+        template<typename T, template<typename...> typename Template>
+        concept IsSpecializationOf = is_specialization_of_v<T, Template>;
 
     } // namespace plugins::binning
 } // namespace picongpu

--- a/include/pmacc/traits/IsSpecializationOf.hpp
+++ b/include/pmacc/traits/IsSpecializationOf.hpp
@@ -1,0 +1,61 @@
+/* Copyright 2025 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace pmacc
+{
+    namespace traits
+    {
+
+        /**
+         * Type trait to check if a type is a specialization of a template
+         * Similar to P2078 - https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r0.pdf
+         * Note that this cant be used with template types which have NTTPs
+         * To fix this limitation we need PR1985 Universal Template Parameters
+         * https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1985r3.pdf
+         */
+
+        template<typename, template<typename...> typename>
+        struct IsSpecializationOf : std::false_type
+        {
+        };
+
+        template<template<typename...> typename Template, typename... Args>
+        struct IsSpecializationOf<Template<Args...>, Template> : std::true_type
+        {
+        };
+
+    } // namespace traits
+
+    template<typename T, template<typename...> typename Template>
+    inline constexpr bool isSpecializationOf_v = traits::IsSpecializationOf<T, Template>::value;
+
+    namespace concepts
+    {
+        template<typename T, template<typename...> typename Template>
+        concept SpecializationOf = isSpecializationOf_v<T, Template>;
+
+    } // namespace concepts
+
+} // namespace pmacc

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -199,7 +199,7 @@ namespace picongpu
                 = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
                 -> float_X
             {
-                auto fieldValue = field1(domainInfo.template getCellIndex<DomainOrigin::TOTAL>());
+                auto fieldValue = field1(domainInfo.template getCellIndex<DomainOrigin::LOCAL_WITH_GUARDS>());
                 auto squaredSum = fieldValue.x() * fieldValue.x() + fieldValue.y() * fieldValue.y()
                                   + fieldValue.z() * fieldValue.z();
                 return squaredSum;
@@ -240,9 +240,11 @@ namespace picongpu
             /**
              * Define deposited quantity here
              */
+            // doc-include-start: fieldBox
             auto getFieldX
                 = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2)
-                -> float_X { return field1(domainInfo.localCellIdx).x(); };
+                -> float_X { return field1(domainInfo.template getCellIndex<DomainOrigin::LOCAL_WITH_GUARDS>()).x(); };
+            // doc-include-end: fieldBox
 
             std::array<double, numUnits> depositedUnits{}; // Tell user the 7 dimensional format
             depositedUnits[SIBaseUnits::length] = -3.0;
@@ -259,7 +261,7 @@ namespace picongpu
 
             };
 
-            binningCreator.addFieldBinner("chargeDensityBinning", axisTuple, fieldsTuple, fieldX)
+            binningCreator.addFieldBinner("fieldBinning", axisTuple, fieldsTuple, fieldX)
                 .setNotifyPeriod("1:500")
                 .setHostSideHook(fillFieldsHook);
         }

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -233,10 +233,8 @@ namespace picongpu
 
             // doc-include-start: fieldTuple
             // Bring the fields together in a tuple
-            DataConnector& dc = Environment<>::get().DataConnector();
-            auto fieldsTuple = createTuple(
-                dc.get<FieldB>(FieldB::getName())->getDeviceDataBox(),
-                dc.get<FieldTmp>(FieldTmp::getUniqueId(0))->getDeviceDataBox());
+            auto fieldsTuple
+                = createTuple(FieldInfo<FieldB>(FieldB::getName()), FieldInfo<FieldTmp>(FieldTmp::getUniqueId(0)));
             // doc-include-end: fieldTuple
 
             /**


### PR DESCRIPTION
- Added a type called ``FieldInfo`` which is how users are now supposed to pass fields to the binning plugin. 
This was necessary because users cant directly access the field data box from the binning setup. This is because binning setup is called on plugin load, and this happens before the fields are registered with the data connector.
The ``FieldInfo`` object is only passed to the binning functors AFTER being transformed to the corresponding field databox.
Similarly, for passing field information when doing particle binning, passing a ``FieldInfo`` object as extra data will provide the user with access to the field databox.
- Fixed setters of field binning data configuration not working (for example dump period)
- Made the integer linear axis binning more robust against overflows by using 64 bit types internally (thanks @pordyna for testing an axis with almost a million bins)
- Add a domain origin `LOCAL_WITH_GUARDS` to be used with `DomainInfo`, mainly with the view of making local field boxes correctly usable more easily. Added an example to the documentation which shows how to use field binning correctly
- Fix `getParticlePosition` missing a cast, fixes cases where integral cell sizes are used