### PR TITLE
WIP: Prototype for "poor man's" load balancing

### DIFF
--- a/include/picongpu/plugins/Checkpoint.x.cpp
+++ b/include/picongpu/plugins/Checkpoint.x.cpp
@@ -123,33 +123,37 @@ namespace picongpu
         void checkpoint(uint32_t currentStep, std::string const checkpointDirectory) override
         {
             auto cBackend = ioBackends.find(checkpointBackendName);
-            if(cBackend != ioBackends.end())
+            if(cBackend == ioBackends.end())
             {
-                // Must set PIC_USE_THREADED_MPI=MPI_THREAD_MULTIPLE for this
-                // verify this programmatically somehow
-                // maybe run one of these on the main thread
+                return;
+            }
+
+            int mpiInitialized;
+            MPI_CHECK(MPI_Query_thread(&mpiInitialized));
+
+            if(mpiInitialized < MPI_THREAD_MULTIPLE)
+            {
+                cBackend->second->dumpCheckpoint(currentStep, checkpointDirectory, checkpointFilename, std::nullopt);
+            }
+            else
+            {
                 std::atomic<signed int> synchronization = 0;
-                auto checkpointFuture = std::async(
-                    std::launch::async,
-                    [&cBackend,
-                     currentStep,
-                     cpDir = checkpointDirectory,
-                     cpFilename = checkpointFilename,
-                     sync = &synchronization]()
-                    { cBackend->second->dumpCheckpoint(currentStep, cpDir, cpFilename, {sync}); });
+
                 // need to copy the plugin temporarily to avoid race conditions
-                auto copiedBackend = cBackend;
                 auto restartFuture = std::async(
                     std::launch::async,
-                    [&copiedBackend,
-                     currentStep,
-                     cpDir = checkpointDirectory,
-                     chunkSize = restartChunkSize,
-                     cpFilename = checkpointFilename,
-                     sync = &synchronization]()
-                    { copiedBackend->second->doRestart(currentStep, cpDir, cpFilename, chunkSize, {sync}); });
+                    [this, copiedBackend = cBackend, currentStep, &checkpointDirectory, &synchronization]()
+                    {
+                        copiedBackend->second->doRestart(
+                            currentStep,
+                            checkpointDirectory,
+                            this->checkpointFilename,
+                            this->restartChunkSize,
+                            {&synchronization});
+                    });
+                cBackend->second
+                    ->dumpCheckpoint(currentStep, checkpointDirectory, checkpointFilename, {&synchronization});
                 restartFuture.wait();
-                checkpointFuture.wait();
             }
         }
 

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -174,11 +174,12 @@ namespace picongpu
                 DataSpace<simDim> gridPos = Environment<simDim>::get().GridController().getPosition();
                 ::openPMD::Offset start;
                 ::openPMD::Extent count;
+                ::openPMD::Extent extent = mrc.getExtent();
                 start.reserve(ndim);
                 count.reserve(ndim);
                 for(int d = 0; d < ndim; ++d)
                 {
-                    start.push_back(gridPos.revert()[d]);
+                    start.push_back(gridPos.revert()[d] % extent[d]); // well well well, TODO fix this but how
                     count.push_back(1);
                 }
 

--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -89,7 +89,7 @@ namespace picongpu
                     localDomainOffset[d] = Environment<simDim>::get().GridController().getPosition()[d];
                 }
 
-                ::openPMD::Series& series = *params.openPMDSeries;
+                ::openPMD::Series& series = *params.writeOpenPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
                     = series.writeIterations()[currentStep].meshes[baseName + "_" + group][dataset];
 
@@ -125,7 +125,7 @@ namespace picongpu
                     std::make_shared<T_Scalar>(value),
                     std::move(std::get<1>(tuple)),
                     std::move(std::get<2>(tuple)));
-                params.openPMDSeries->flush(PreferredFlushTarget::Buffer);
+                std::get<0>(tuple).seriesFlush(PreferredFlushTarget::Buffer);
             }
 
         private:
@@ -162,7 +162,7 @@ namespace picongpu
 
 
                 auto datasetName = baseName + "/" + group + "/" + dataset;
-                ::openPMD::Series& series = *params.openPMDSeries;
+                ::openPMD::Series& series = *params.readOpenPMDSeries;
                 ::openPMD::MeshRecordComponent mrc
                     = series.iterations[currentStep].open().meshes[baseName + "_" + group][dataset];
                 auto ndim = mrc.getDimensionality();

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -345,7 +345,7 @@ namespace picongpu
                 auto speciesTmp = dc.get<ThisSpecies>(ThisSpecies::FrameType::getName());
                 std::string const speciesGroup(T_Species::getName());
 
-                ::openPMD::Series& series = *params->openPMDSeries;
+                ::openPMD::Series& series = *params->writeOpenPMDSeries;
                 ::openPMD::Iteration iteration = series.writeIterations()[currentStep];
                 std::string const basename = series.particlesPath() + speciesGroup;
 
@@ -519,7 +519,7 @@ namespace picongpu
                         eventSystem::getTransactionEvent().waitForFinished();
                         params->m_dumpTimes.now<std::chrono::milliseconds>(
                             "\tslice " + std::to_string(dumpIteration) + " flush");
-                        params->openPMDSeries->flush(PreferredFlushTarget::Disk);
+                        particleSpecies.seriesFlush(PreferredFlushTarget::Disk);
                         params->m_dumpTimes.now<std::chrono::milliseconds>(
                             "\tslice " + std::to_string(dumpIteration) + " end");
 
@@ -587,7 +587,7 @@ namespace picongpu
                         series.particlesPath() + speciesGroup);
                     params->m_dumpTimes.now<std::chrono::milliseconds>(
                         "\tFlush species " + T_SpeciesFilter::getName());
-                    params->openPMDSeries->flush(PreferredFlushTarget::Buffer);
+                    particleSpecies.seriesFlush(PreferredFlushTarget::Buffer);
                     params->m_dumpTimes.now<std::chrono::milliseconds>("\tFinished flush species");
                 }
 

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -855,7 +855,10 @@ namespace picongpu
                     for(uint32_t d = 0; d < simDim; ++d)
                     {
                         bufferExtent[d][i] = singlePatchExtent[d];
-                        bufferOffset[d][i] = totalPatchOffset[d] + index_t(singlePatchExtent[d] * superCellIdxND[d]);
+                        // No idea why the -1 is needed, but the results do not fit otherwise
+                        // Something weird going on in supercell indexing
+                        bufferOffset[d][i]
+                            = totalPatchOffset[d] + index_t(singlePatchExtent[d] * (superCellIdxND[d] - 1));
                     }
                 }
 
@@ -883,6 +886,7 @@ namespace picongpu
                     extent_x.resetDataset(ds);
 
                     offset_x.storeChunk(bufferOffset[d], {mpiRank * numPatches}, {numPatches});
+                    // TODO: Maybe use a constant record for this
                     extent_x.storeChunk(bufferExtent[d], {mpiRank * numPatches}, {numPatches});
                 }
 

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -1148,6 +1148,7 @@ namespace picongpu
                     }
                 }
 
+                // writeParticlesByChunks(
                 writeParticlesBySupercells(
                     params,
                     currentStep,

--- a/include/picongpu/plugins/openPMD/openPMDWriter.def
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.def
@@ -79,7 +79,9 @@ namespace picongpu
         struct ThreadParams : PluginParameters
         {
 #if (ENABLE_OPENPMD == 1)
-            std::unique_ptr<::openPMD::Series> openPMDSeries; /* is null iff there is no series currently open */
+            // might be needed at the same time for load balancing purposes
+            std::optional<::openPMD::Series> writeOpenPMDSeries; /* is null iff there is no series currently open */
+            std::optional<::openPMD::Series> readOpenPMDSeries; /* is null iff there is no series currently open */
 #endif
             /** current dump is a checkpoint */
             bool isCheckpoint;
@@ -161,7 +163,7 @@ namespace picongpu
 #endif
             };
 
-            void closeSeries();
+            void closeSeries(::openPMD::Access);
 
             /*
              * If file is empty, read from command line parameters.

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1045,6 +1045,12 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 {
                     loadRngStatesImpl(&mThreadParams, restartStep);
                 }
+                catch(std::exception const& e)
+                {
+                    log<picLog::INPUT_OUTPUT>("openPMD: loading RNG states failed, they will be re-initialized "
+                                              "instead. Original error:\n\t%1%")
+                        % e.what();
+                }
                 catch(...)
                 {
                     log<picLog::INPUT_OUTPUT>(

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1510,6 +1510,16 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                 write(&mThreadParams, currentStep, mpiTransportParams, sync);
 
+                // TODO: add a better keepalive logic for in-situ-restarting,
+                // e.g. keep Series alive on writer AND reader and use proper streaming API
+                // for now, every load/balance step opens a new stream (and each reader additionally opens a new copy
+                // of the IO plugin to avoid race conditions
+
+                if(sync.has_value())
+                {
+                    mThreadParams.closeSeries(::openPMD::Access::CREATE);
+                }
+
                 endWrite();
                 timer.toggleEnd();
                 double interval = timer.getInterval();

--- a/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
@@ -107,7 +107,7 @@ namespace picongpu
                      *  (this is collective call in many methods of openPMD
                      * backends)
                      */
-                    params->openPMDSeries->flush();
+                    record.seriesFlush();
 
                     uint64_t globalNumElements = 1;
                     for(auto ext : rc.getExtent())

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -83,7 +83,7 @@ namespace picongpu
                 DataConnector& dc = Environment<>::get().DataConnector();
                 GridController<simDim>& gc = Environment<simDim>::get().GridController();
 
-                ::openPMD::Series& series = *params->openPMDSeries;
+                ::openPMD::Series& series = *params->readOpenPMDSeries;
                 ::openPMD::Container<::openPMD::ParticleSpecies>& particles
                     = series.iterations[currentStep].open().particles;
                 ::openPMD::ParticleSpecies particleSpecies = particles[speciesName];

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -219,6 +219,13 @@ namespace picongpu
 
                 /* load from openPMD */
                 bool const isDomainBound = traits::IsFieldDomainBound<T_Field>::value;
+
+                // Skip PML fields for load balancing purposes
+                if(!isDomainBound)
+                {
+                    return;
+                }
+
                 RestartFieldLoader::loadField(
                     field->getGridBuffer(),
                     (uint32_t) T_Field::numComponents,

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -122,7 +122,7 @@ namespace picongpu
                     useLinearIdxAsDestination = true;
                 }
 
-                ::openPMD::Series& series = *params->openPMDSeries;
+                ::openPMD::Series& series = *params->readOpenPMDSeries;
                 ::openPMD::Container<::openPMD::Mesh>& meshes = series.iterations[currentStep].open().meshes;
 
                 auto destBox = field.getHostBuffer().getDataBox();

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -34,6 +34,8 @@
 #    include <pmacc/traits/GetNComponents.hpp>
 #    include <pmacc/traits/Resolve.hpp>
 
+#    include <algorithm>
+
 namespace picongpu
 {
     namespace openPMD
@@ -166,6 +168,15 @@ namespace picongpu
                     {
                         ::openPMD::RecordComponent recordComponent
                             = components > 1 ? record[name_lookup[d]] : record[::openPMD::MeshRecordComponent::SCALAR];
+
+                        /*
+                         * storeChunk() on constant components (this includes empty datasets) are illegal, so skip in
+                         * that case.
+                         */
+                        if(std::ranges::any_of(recordComponent.getExtent(), [](auto const e) { return e == 0; }))
+                        {
+                            continue;
+                        }
 
                         recordComponent.storeChunk<ComponentType>(
                             ::openPMD::Offset{globalOffset},

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -159,6 +159,18 @@ namespace picongpu
                 if(elements == 0)
                 {
                     // accumulateWrittenBytes += 0;
+
+                    // Since Span-based storeChunk needs to interact with the openPMD backend (potentially opening it),
+                    // this cannot be skipped in parallel setups
+                    for(uint32_t d = 0; d < components; d++)
+                    {
+                        ::openPMD::RecordComponent recordComponent
+                            = components > 1 ? record[name_lookup[d]] : record[::openPMD::MeshRecordComponent::SCALAR];
+
+                        recordComponent.storeChunk<ComponentType>(
+                            ::openPMD::Offset{globalOffset},
+                            ::openPMD::Extent{elements});
+                    }
                     return;
                 }
 

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -130,7 +130,8 @@ namespace picongpu
                 size_t const elements,
                 size_t const globalElements,
                 size_t const globalOffset,
-                size_t& accumulateWrittenBytes)
+                size_t& accumulateWrittenBytes,
+                bool verbose_log)
             {
                 using Identifier = T_Identifier;
                 using ValueType = typename pmacc::traits::Resolve<Identifier>::type::type;
@@ -161,7 +162,11 @@ namespace picongpu
                     return;
                 }
 
-                log<picLog::INPUT_OUTPUT>("openPMD:  (begin) write species attribute: %1%") % Identifier::getName();
+                if(verbose_log)
+                {
+                    log<picLog::INPUT_OUTPUT>("openPMD:  (begin) write species attribute: %1%")
+                        % Identifier::getName();
+                }
 
                 accumulateWrittenBytes += components * elements * sizeof(ComponentType);
 
@@ -186,7 +191,11 @@ namespace picongpu
                     }
                 }
 
-                log<picLog::INPUT_OUTPUT>("openPMD:  ( end ) write species attribute: %1%") % Identifier::getName();
+                if(verbose_log)
+                {
+                    log<picLog::INPUT_OUTPUT>("openPMD:  ( end ) write species attribute: %1%")
+                        % Identifier::getName();
+                }
             }
         };
 

--- a/include/picongpu/plugins/output/IIOBackend.hpp
+++ b/include/picongpu/plugins/output/IIOBackend.hpp
@@ -21,6 +21,7 @@
 
 #include "picongpu/plugins/multi/IInstance.hpp"
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -38,7 +39,8 @@ namespace picongpu
         virtual void dumpCheckpoint(
             uint32_t currentStep,
             std::string const& checkpointDirectory,
-            std::string const& checkpointFilename)
+            std::string const& checkpointFilename,
+            std::optional<std::atomic<signed int>*> synchronization)
             = 0;
 
         //! restart from a checkpoint
@@ -46,7 +48,8 @@ namespace picongpu
             uint32_t restartStep,
             std::string const& restartDirectory,
             std::string const& restartFilename,
-            uint32_t restartChunkSize)
+            uint32_t restartChunkSize,
+            std::optional<std::atomic<signed int>*> synchronization)
             = 0;
     };
 


### PR DESCRIPTION
PIConGPU is at its core not a load-balanced code and there is good reason not to change that. 
However, there are use cases which require at least some basic form of load balancing; and a chance for implementing a simple (and maybe even somewhat simplistic) load balancing scheme is found as a somewhat low-hanging fruit from the existing checkpoint-restart mechanism.

Schematic idea for load balancing:

1. Halt the simulation
2. *Virtually* write a checkpoint (see below)
3. Restart from that same checkpoint, but repartition the domain in the process, i.e. load data in a more balanced decomposition

Virtual checkpoint: The openPMD plugin can read/write data to/from disk, but also from a stream. Disk access can hence be avoided by in-situ restarting and streaming the data to "yourself", and to apply a different domain decomposition in the process.

Note that (1) in-situ restarting and (2) load-balanced restarting are orthogonal features, they just both play into this use case.

*There is currently no use in reviewing code structure. This is experimental. I'm opening the PR to have a place for discussing the idea.*

Plan:

- [x] In-situ restarting from a virtual checkpoint 
    - [ ] I'm currently abusing the `--checkpoint.period` option for this, there is no CLI control atm
- [x] Writing checkpoints with higher granularity: One patch per supercell, not per MPI process
- [x] Restarting from checkpoints with "dynamic" particle patches, i.e. multiple patches that fall into the local subdomain. This by now already allows relaunching PIConGPU with a different number of MPI processes.
    - [x] Patches that fall only partially into the local subdomain are currently ignored. This is fine for the first prototype, as we don't need to go below the supercell level for load balancing, at least for now.
- [ ] Actually load-balance: This involves:
    1. Figuring out a new domain decomposition (no canonical answer for this)
    2. Somehow changing the simulations's domain decomposition from within the IO plugin (I will probably need help with that)

Minor side-Todos:

- [ ] This works with the SST engine. SSC might be more adequate, but I could not make it work at first try, so I gave up for now.
- [ ] Maybe check if we can control the startup of the SST engine more finely. This currently needs to use fully threaded MPI; if we could control MPI operations a bit more finely at that moment, we might be able to relax that.
- [ ] Take stuff like id_provider, rng states out of restarting

These above points will (hopefully) result in a very basic, yet still unoptimized and also somewhat incomplete load-balancing implementation. These below points are an outline for work after this PR:

* Particle patches: These will be the main scaling issue of the first version of load balancing. Two reasons for this:
    * Communication patterns: Particle patches are written by everyone, and every reader reads everything. This is not a problem when writing checkpointing files since files are a form of aggregation. In streaming however, this implies an N->N communication pattern.
        1. Simple solution: Do not stream the particle patches. They are small and can go to a file on the parallel filesystem.
        2. Overengineered solution: Aggregate and deaggregate particle patches. I see no use in this for now.
        4. Solution without using the parallel file system: Use ADIOS2 Local Values (see [this PR](https://github.com/openPMD/openPMD-api/pull/1601)). Those participate in metadata aggregation, but are restricted to a single value per process. That needs not be a problem, see below.
    * Number of particle patches: Since we now write patches at a much finer granularity, there are many more of them, by orders of magnitude. The solution here would be to write particle patches in two levels:
        1. Lower level: One patch per supercell
        2. Higher level: One patch per process. The patch does not point into the particle regions, but into the lower level patches regions. Only the higher level needs to be communicated in an N->N pattern, but it is small and can be written as an ADIOS2 LocalValue dataset, so it is not a problem.
* Sizes of IO operations: Currently, writing and reading a checkpoint takes a long time since each supercell has a separate IO operation. We can expect this to overload the cluster networks at some point. IO operations should be merged as much as possible, in reading and writing -- while staying logically distinct through particle patches.
* Memory consumption: Is manageable, but large. When using the SST engine in ADIOS2, the major memory consumption will be the host-side streaming buffers which need to be filled with the entire simulation volume and particles, i.e. roughly a clone of the GPU's simulation volume to CPU. Writing to and reading from openPMD can by now be controlled very finely due to René's work on slicing.
    We should investigate if we can make the BP5 serializer of SST use the node SSDs as a streaming buffer instead of the RAM. This would be a project in ADIOS2, but it would benefit other streaming use cases, too. No idea though if memmaps and RDMA play nice together.
    Workarounds until then:
    1. Don't completely fill up the GPU memory.
    2. If you want to completely fill up the GPU memory, use an actual disk checkpoint instead.
* PML fields: Have weird geometries, ignored for now.
* Other plugins that participate in checkpoint-restart: Not considered at all for now.

Note to myself:
```bash
FABRIC_PROVIDER=shm FABRIC_IFACE=shm PIC_USE_THREADED_MPI=MPI_THREAD_MULTIPLE picongpu -s 100 -g 32 32 32 -d 1 1 1 --checkpoint.period 50:50 --checkpoint.openPMD.ext sst --checkpoint.openPMD.json '{"adios2":{"engine":{"parameters":{"DataTransport": "fabric"}}}}'

UCX_TLS=shm UCX_POSIX_USE_PROC_LINK=n PIC_USE_THREADED_MPI=MPI_THREAD_MULTIPLE picongpu -s 100 -g 32 32 32 -d 1 1 1 --checkpoint.period 50:50 --checkpoint.openPMD.ext sst --checkpoint.openPMD.json '{"adios2":{"engine":{"parameters":{"DataTransport": "ucx"}}}}'
```