### PR TITLE
Add particle binning to picmi

### DIFF
--- a/include/picongpu/plugins/binning/DomainInfo.hpp
+++ b/include/picongpu/plugins/binning/DomainInfo.hpp
@@ -233,7 +233,12 @@ namespace picongpu
 
             template<DomainOrigin Origin, PositionPrecision Precision>
             concept ValidPositionRequest
-                = OneOf<Origin, DomainOrigin::TOTAL, DomainOrigin::LOCAL, DomainOrigin::GLOBAL>
+                = OneOf<
+                      Origin,
+                      DomainOrigin::TOTAL,
+                      DomainOrigin::LOCAL,
+                      DomainOrigin::GLOBAL,
+                      DomainOrigin::LOCAL_WITH_GUARDS>
                   || (Origin == DomainOrigin::MOVING_WINDOW && Precision == PositionPrecision::SUB_CELL);
         } // namespace concepts
 

--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -6,6 +6,7 @@ License: GPLv3+
 """
 
 from .auto import Auto
+from .binning import Binning
 from .phase_space import PhaseSpace
 from .energy_histogram import EnergyHistogram
 from .macro_particle_count import MacroParticleCount
@@ -15,6 +16,7 @@ from .checkpoint import Checkpoint
 
 __all__ = [
     "Auto",
+    "Binning",
     "PhaseSpace",
     "EnergyHistogram",
     "MacroParticleCount",

--- a/lib/python/picongpu/picmi/diagnostics/binning.py
+++ b/lib/python/picongpu/picmi/diagnostics/binning.py
@@ -1,0 +1,191 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import sympy
+from ...pypicongpu.output.binning import (
+    Binning as PyPIConGPUBinning,
+    BinningFunctor as PyPIConGPUBinningFunctor,
+    BinningAxis as PyPIConGPUBinningAxis,
+    BinSpec as PyPIConGPUBinSpec,
+)
+from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
+
+from ..species import Species as PICMISpecies
+from typing import Callable, Any, Optional
+from .timestepspec import TimeStepSpec
+import typeguard
+
+_COORDINATE_SYSTEM = {
+    (
+        origin.lower(),
+        precision.lower(),
+        unit.lower(),
+    ): tuple(sympy.Symbol(f"{c}_{precision.lower()}_{unit.lower()}") for c in coords)
+    for (origin, coords) in (
+        ("TOTAL", ("xt", "yt", "zt")),
+        ("GLOBAL", ("xg", "yg", "zg")),
+        ("LOCAL", ("xl", "yl", "zl")),
+        ("MOVING_WINDOW", ("xmw", "ymw", "zmw")),
+        ("LOCAL_WITH_GUARDS", ("xlg", "ylg", "zlg")),
+    )
+    for precision in ("CELL", "SUB_CELL")
+    for unit in ("CELL", "PIC", "SI")
+}
+
+
+class BinningParticle:
+    def __init__(self):
+        self.used_attributes = {}
+
+    def get_attribute_map(self):
+        return self.used_attributes
+
+    def get(self, attribute, **kwargs):
+        if attribute == "position":
+            origin = kwargs.get("origin", "total")
+            precision = kwargs.get("precision", "cell")
+            unit = kwargs.get("unit", "cell")
+            symbols = _COORDINATE_SYSTEM[(origin, precision, unit)]
+            self.used_attributes |= {symbols: ("position", origin, precision, unit)}
+
+        elif attribute == "momentum":
+            symbols = sympy.symbols("px,py,pz")
+            self.used_attributes |= {symbols: "momentum"}
+
+        elif attribute in ["gamma", "kinetic energy", "velocity"]:
+            # This relies on python dictionaries having a stable ordering.
+            # We first add mass and momentum
+            # and later use their symbols inside of the same preamble.
+            self.get("mass")
+            self.get("momentum")
+            if attribute == "gamma":
+                symbols = sympy.Symbol("gamma")
+            if attribute == "kinetic energy":
+                symbols = sympy.Symbol("Ekin")
+            if attribute == "velocity":
+                symbols = sympy.symbols("vx,vy,vz")
+            self.used_attributes |= {symbols: attribute}
+
+        else:
+            symbols = sympy.Symbol(attribute)
+            self.used_attributes |= {symbols: attribute}
+
+        return symbols
+
+
+@typeguard.typechecked
+class BinningFunctor:
+    def check(self):
+        pass
+
+    def __init__(
+        self,
+        name: str,
+        functor: Callable[[BinningParticle], Any],
+        return_type: type | str,
+    ):
+        self.name = name
+        self.functor = functor
+        self.return_type = return_type
+
+    def get_as_pypicongpu(self) -> PyPIConGPUBinningFunctor:
+        self.check()
+        particle = BinningParticle()
+        functor_expression = self.functor(particle)
+        return PyPIConGPUBinningFunctor(
+            name=self.name,
+            functor_expression=functor_expression,
+            attribute_mapping=particle.get_attribute_map(),
+            return_type=self.return_type,
+        )
+
+
+@typeguard.typechecked
+class BinSpec:
+    def __init__(self, kind, start, stop, nsteps):
+        self.kind = kind
+        self.start = start
+        self.stop = stop
+        self.nsteps = nsteps
+
+    def get_as_pypicongpu(self):
+        return PyPIConGPUBinSpec(self.kind.lower().capitalize(), self.start, self.stop, self.nsteps)
+
+
+@typeguard.typechecked
+class BinningAxis:
+    def __init__(
+        self,
+        functor: BinningFunctor,
+        bin_spec: BinSpec,
+        name: str | None = None,
+        use_overflow_bins: bool = True,
+    ):
+        self.functor = functor
+        self.bin_spec = bin_spec
+        self.name = name or functor.name
+        self.use_overflow_bins = use_overflow_bins
+
+    def get_as_pypicongpu(self) -> PyPIConGPUBinningAxis:
+        return PyPIConGPUBinningAxis(
+            name=self.name,
+            functor=self.functor.get_as_pypicongpu(),
+            bin_spec=self.bin_spec.get_as_pypicongpu(),
+            use_overflow_bins=self.use_overflow_bins,
+        )
+
+
+@typeguard.typechecked
+class Binning:
+    def __init__(
+        self,
+        name: str,
+        deposition_functor: BinningFunctor,
+        axes: list[BinningAxis],
+        species: PICMISpecies | list[PICMISpecies],
+        period: Optional[TimeStepSpec] = None,
+        openPMD: Optional[dict] = None,
+        openPMDExt: Optional[str] = None,
+        openPMDInfix: Optional[str] = None,
+        timeAveraging: bool = True,
+        dumpPeriod: int = 1,
+    ):
+        self.name = name
+        self.deposition_functor = deposition_functor
+        self.axes = axes
+        if isinstance(species, PICMISpecies):
+            species = [species]
+        self.species = species
+        self.period = period or TimeStepSpec[:]
+        self.openPMD = openPMD
+        self.openPMDExt = openPMDExt
+        self.openPMDInfix = openPMDInfix
+        self.timeAveraging = timeAveraging
+        self.dumpPeriod = dumpPeriod
+
+    def get_as_pypicongpu(
+        self,
+        dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
+        time_step_size,
+        num_steps,
+    ) -> PyPIConGPUBinning:
+        if len(not_found := [s for s in self.species if s not in dict_species_picmi_to_pypicongpu.keys()]) > 0:
+            raise ValueError(f"Species {not_found} are not known to Simulation")
+        pypic_species = list(map(dict_species_picmi_to_pypicongpu.get, self.species))
+
+        return PyPIConGPUBinning(
+            name=self.name,
+            deposition_functor=self.deposition_functor.get_as_pypicongpu(),
+            axes=list(map(BinningAxis.get_as_pypicongpu, self.axes)),
+            species=pypic_species,
+            period=self.period.get_as_pypicongpu(time_step_size, num_steps),
+            openPMD=self.openPMD,
+            openPMDExt=self.openPMDExt,
+            openPMDInfix=self.openPMDInfix,
+            timeAveraging=self.timeAveraging,
+            dumpPeriod=self.dumpPeriod,
+        )

--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -1,0 +1,177 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import json
+import numbers
+
+from typing import Optional
+from .timestepspec import TimeStepSpec
+from ..rendering.renderedobject import RenderedObject
+from ..rendering.pmaccprinter import PMAccPrinter
+from ..species import Species
+from .. import util
+from .plugin import Plugin
+
+import typeguard
+
+
+def by_bracket(attribute):
+    return f"particle[{attribute}_]"
+
+
+ACCESSORS = {
+    (
+        "position",
+        origin.lower(),
+        precision.lower(),
+        unit.lower(),
+    ): f"getParticlePosition<DomainOrigin::{origin}, PositionPrecision::{precision}, PositionUnits::{unit}>(domainInfo, particle)"
+    for origin in ("TOTAL", "GLOBAL", "LOCAL", "MOVING_WINDOW", "LOCAL_WITH_GUARDS")
+    for precision in ("CELL", "SUB_CELL")
+    for unit in ("CELL", "PIC", "SI")
+} | {
+    "mass": "picongpu::traits::attribute::getMass(particle[weighting_], particle)",
+    # CAUTION: The names in the gamma formula are currently hardcoded.
+    # We'll certainly trip over this, should we ever dare to change the internal names.
+    "gamma": "picongpu::Gamma()(momentum::type{px, py, pz}, mass)",
+    "kinetic energy": "picongpu::KinEnergy()(momentum::type{px, py, pz}, mass)",
+    "velocity": "picongpu::Velocity()(momentum::type{px, py, pz}, mass)",
+    "charge": "picongpu::traits::attribute::getCharge(particle[weighting_], particle)",
+    "charge_state": "picongpu::traits::attribute::getChargeState(particle)",
+    "damped_weighting": "picongpu::traits::attribute::getDampedWeighting(particle)",
+    "timestep": "domainInfo.currentStep",
+}
+
+
+def symbol_to_string(symbol):
+    return str(symbol) if not isinstance(symbol, tuple) else "[" + ",".join(map(str, symbol)) + "]"
+
+
+def generate_preamble(attribute_mapping):
+    return [
+        {"statement": f"auto const {symbol_to_string(symbol)} = {ACCESSORS.get(attribute, by_bracket(attribute))};"}
+        for symbol, attribute in attribute_mapping.items()
+    ]
+
+
+def translate_to_cpp_type(return_type):
+    try:
+        if issubclass(return_type, numbers.Integral):
+            return "int"
+        if issubclass(return_type, numbers.Real):
+            return "float_X"
+        if issubclass(return_type, bool):
+            return "bool"
+    except TypeError:
+        pass
+    if isinstance(return_type, str):
+        return return_type
+    raise ValueError(f"Cannot translate {return_type=} to a C++ type.")
+
+
+class BinningFunctor(RenderedObject):
+    def __init__(self, name, functor_expression, attribute_mapping, return_type):
+        self.name = name
+        self.functor_expression = functor_expression
+        self.attribute_mapping = attribute_mapping
+        self.return_type = return_type
+
+    def _get_serialized(self):
+        return {
+            "name": self.name,
+            "functor_expression": PMAccPrinter().doprint(self.functor_expression),
+            "functor_preamble": generate_preamble(self.attribute_mapping),
+            "return_type": translate_to_cpp_type(self.return_type),
+        }
+
+
+class BinSpec(RenderedObject):
+    def __init__(self, kind, start, stop, nsteps):
+        self.kind = kind
+        self.start = start
+        self.stop = stop
+        self.nsteps = nsteps
+
+    def _get_serialized(self):
+        return {
+            "kind": self.kind,
+            "start": self.start,
+            "stop": self.stop,
+            "nsteps": self.nsteps,
+        }
+
+
+class BinningAxis(RenderedObject):
+    name: str
+    bin_spec: BinSpec
+    functor: BinningFunctor
+
+    def __init__(self, name, bin_spec, functor, use_overflow_bins):
+        self.name = name
+        self.bin_spec = bin_spec
+        self.functor = functor
+        self.use_overflow_bins = use_overflow_bins
+
+    def _get_serialized(self):
+        return {
+            "axis_name": self.name,
+            "bin_spec": self.bin_spec.get_rendering_context(),
+            "axis_functor": self.functor.get_rendering_context(),
+            "use_overflow_bins": self.use_overflow_bins,
+        }
+
+
+@typeguard.typechecked
+class Binning(Plugin):
+    name = util.build_typesafe_property(str)
+    species = util.build_typesafe_property(list[Species])
+    period = util.build_typesafe_property(TimeStepSpec)
+    openPMD = util.build_typesafe_property(Optional[dict])
+    openPMDExt = util.build_typesafe_property(Optional[str])
+    openPMDInfix = util.build_typesafe_property(Optional[str])
+    timeAveraging = util.build_typesafe_property(bool)
+    dumpPeriod = util.build_typesafe_property(int)
+
+    _name = "binning"
+
+    def __init__(
+        self,
+        name,
+        deposition_functor,
+        axes,
+        species,
+        period,
+        openPMD,
+        openPMDExt,
+        openPMDInfix,
+        timeAveraging,
+        dumpPeriod,
+    ):
+        self.name = name
+        self.deposition_functor = deposition_functor
+        self.axes = axes
+        self.species = species
+        self.period = period
+        self.openPMD = openPMD
+        self.openPMDExt = openPMDExt
+        self.openPMDInfix = openPMDInfix
+        self.timeAveraging = timeAveraging
+        self.dumpPeriod = dumpPeriod
+
+    def _get_serialized(self) -> dict:
+        return {
+            "binner_name": self.name,
+            "deposition_functor": self.deposition_functor.get_rendering_context(),
+            "axes": list(map(BinningAxis.get_rendering_context, self.axes)),
+            "species": list(map(Species.get_rendering_context, self.species)),
+            "period": self.period.get_rendering_context(),
+            "openPMD": json.dumps(self.openPMD) if self.openPMD else self.openPMD,
+            "openPMDExtension": self.openPMDExt,
+            "openPMDInfix": self.openPMDInfix,
+            "timeAveraging": self.timeAveraging,
+            "dumpPeriod": self.dumpPeriod,
+        }

--- a/share/picongpu/pypicongpu/schema/output/binning.BinSpec.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.BinSpec.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinSpec",
+  "type": "object",
+  "description": "Flexible binning",
+  "unevaluatedProperties": false,
+  "required": [
+    "kind",
+    "start",
+    "stop",
+    "nsteps"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "Linear",
+        "Log"
+      ]
+    },
+    "start": {
+      "type": "number"
+    },
+    "stop": {
+      "type": "number"
+    },
+    "nsteps": {
+      "type": "number"
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/output/binning.Binning.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.Binning.json
@@ -1,0 +1,71 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.Binning",
+  "type": "object",
+  "description": "Flexible binning",
+  "unevaluatedProperties": false,
+  "required": [
+    "binner_name",
+    "deposition_functor",
+    "axes",
+    "species"
+  ],
+  "properties": {
+    "binner_name": {
+      "type": "string",
+      "description": "Name of the binner"
+    },
+    "deposition_functor": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor"
+    },
+    "axes": {
+      "type": "array",
+      "items": {
+        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningAxis"
+      }
+    },
+    "species": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.species.Species"
+      },
+      "description": "Species to bin"
+    },
+    "period": {
+      "type": [
+        "object"
+      ],
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.timestepspec.TimeStepSpec",
+      "description": "Create binning output on specified steps"
+    },
+    "openPMD": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Additional options for openPMD IO-backend"
+    },
+    "openPMDExtension": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "File extension for openPMD output"
+    },
+    "openPMDInfix": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Infix for openPMD output files"
+    },
+    "timeAveraging": {
+      "type": "boolean",
+      "description": "Time average the accumulated data when doing the dump"
+    },
+    "dumpPeriod": {
+      "type": "integer",
+      "description": "The number of notify steps to accumulate over. Dump at the end."
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/output/binning.BinningAxis.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.BinningAxis.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningAxis",
+  "type": "object",
+  "description": "Flexible binning",
+  "unevaluatedProperties": false,
+  "required": [
+    "axis_name",
+    "axis_functor",
+    "use_overflow_bins",
+    "bin_spec"
+  ],
+  "properties": {
+    "axis_name": {
+      "type": "string",
+      "description": "Name of the binner"
+    },
+    "axis_functor": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor"
+    },
+    "use_overflow_bins": {
+      "type": "boolean"
+    },
+    "bin_spec": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinSpec"
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/output/binning.BinningFunctor.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.BinningFunctor.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor",
+  "type": "object",
+  "description": "Functor for flexible binning",
+  "unevaluatedProperties": false,
+  "required": [
+    "name",
+    "functor_preamble",
+    "functor_expression",
+    "return_type"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the functor"
+    },
+    "functor_preamble": {
+      "type": "array",
+      "description": "array of preamble statements defining the variables used in the functor_expression",
+      "items": {
+        "type": "object",
+        "properties": {
+          "statement": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "return_type": {
+      "type": "string"
+    },
+    "functor_expression": {
+      "type": "string",
+      "description": "C code to compute the return value"
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/output/plugin.Plugin.json
+++ b/share/picongpu/pypicongpu/schema/output/plugin.Plugin.json
@@ -17,6 +17,7 @@
         "energyhistogram",
         "macroparticlecount",
         "png",
+        "binning",
         "checkpoint"
       ],
       "unevaluatedProperties": false,
@@ -34,6 +35,9 @@
           "type": "boolean"
         },
         "png": {
+          "type": "boolean"
+        },
+        "binning": {
           "type": "boolean"
         },
         "checkpoint": {
@@ -58,6 +62,9 @@
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.png.Png"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.Binning"
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.checkpoint.Checkpoint"

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
@@ -1,0 +1,106 @@
+/* Copyright 2023-2024 Tapish Narwal
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/plugins/binning/binnerPlugin.hpp"
+
+namespace picongpu::plugins::binning
+{
+  {{#output}}
+  {{#typeID.binning}}
+  {{#data}}
+  inline void {{{binner_name}}}(BinningCreator& binningCreator)
+  {
+      auto speciesTuple = createSpeciesTuple(
+          {{#species}}
+          PMACC_CSTRING("{{{name}}}"){}{{^_last}},{{/_last}}
+          {{/species}}
+      );
+
+      // Starting axes
+      {{#axes}}
+      auto axis_{{{axis_name}}} = axis::create{{{bin_spec.kind}}}(
+        axis::AxisSplitting(
+            axis::Range<{{{axis_functor.return_type}}}>{ {{{bin_spec.start}}}, {{{bin_spec.stop}}} },
+            {{{bin_spec.nsteps}}},
+            {{#use_overflow_bins}}true{{/use_overflow_bins}}{{^use_overflow_bins}}false{{/use_overflow_bins}}
+        ),
+        createFunctorDescription<{{{axis_functor.return_type}}}>(
+            [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> {{{axis_functor.return_type}}}
+              {
+                {{#axis_functor.functor_preamble}}
+                {{{statement}}}
+                {{/axis_functor.functor_preamble}}
+                return {{{axis_functor.functor_expression}}};
+              },
+            "{{{axis_name}}}"
+        )
+      );
+      {{/axes}}
+      auto axisTuple = createTuple({{#axes}}axis_{{{axis_name}}}{{^_last}},{{/_last}}{{/axes}});
+
+      // Starting deposition
+      auto deposition = createFunctorDescription<{{{deposition_functor.return_type}}}>(
+        [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> {{{deposition_functor.return_type}}}
+          {
+            {{#deposition_functor.functor_preamble}}
+            {{{statement}}}
+            {{/deposition_functor.functor_preamble}}
+            return {{{deposition_functor.functor_expression}}};
+          },
+          "{{{deposition_functor.name}}}"
+      );
+
+      binningCreator.addParticleBinner(
+          "{{{binner_name}}}",
+          axisTuple,
+          speciesTuple,
+          deposition
+      )
+      .setNotifyPeriod("{{#period.specs}}{{{start}}}:{{{stop}}}:{{{step}}}{{^_last}},{{/_last}}{{/period.specs}}")
+      {{#openPMD}}
+      .setOpenPMDJsonCfg(R"({{{openPMD}}})")
+      {{/openPMD}}
+      {{#openPMDExtension}}
+      .setOpenPMDExtension("{{{openPMDExtension}}}")
+      {{/openPMDExtension}}
+      {{#openPMDInfix}}
+      .setOpenPMDInfix("{{{openPMDInfix}}}")
+      {{/openPMDInfix}}
+      .setDumpPeriod({{{dumpPeriod}}})
+      .setTimeAveraging({{#timeAveraging}}true{{/timeAveraging}}{{^timeAveraging}}false{{/timeAveraging}})
+      ;
+  }
+  {{/data}}
+  {{/typeID.binning}}
+  {{/output}}
+
+  inline void getBinning(BinningCreator& binningCreator)
+  {
+      {{#output}}
+      {{#typeID.binning}}
+      {{#data}}
+      {{{binner_name}}}(binningCreator);
+      {{/data}}
+      {{/typeID.binning}}
+      {{/output}}
+  }
+} // namespace picongpu::plugins::binning

--- a/test/python/picongpu/end-to-end/arbitrary_parameters.py
+++ b/test/python/picongpu/end-to-end/arbitrary_parameters.py
@@ -1,0 +1,19 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import numpy as np
+
+NUMBER_OF_CELLS = [64, 64, 32]
+UPPER_BOUNDARY = np.array([64.0, 66.0, 74.0])
+CELL_SIZE = UPPER_BOUNDARY / NUMBER_OF_CELLS
+
+ALL_ORIGINS = ["total", "global", "local", "moving_window", "local_with_guards"]
+ALL_ORIGINS_WITHOUT_GUARDS = [origin for origin in ALL_ORIGINS if not origin.endswith("guards")]
+ALL_PRECISIONS = ["cell", "sub_cell"]
+ALL_UNITS = ["cell", "si", "pic"]
+NUMBER_OF_GUARD_CELLS = [8, 8, 4]
+EPSILON = 1.0e-5

--- a/test/python/picongpu/end-to-end/binning_functors.py
+++ b/test/python/picongpu/end-to-end/binning_functors.py
@@ -1,0 +1,200 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from functools import partial
+import numpy as np
+import sympy
+from picongpu.picmi.diagnostics.binning import (
+    Binning,
+    BinningAxis,
+    BinningFunctor,
+    BinSpec,
+)
+from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
+from scipy.constants import speed_of_light
+
+from .arbitrary_parameters import (
+    ALL_ORIGINS_WITHOUT_GUARDS,
+    ALL_PRECISIONS,
+    ALL_UNITS,
+    CELL_SIZE,
+    EPSILON,
+    NUMBER_OF_CELLS,
+    NUMBER_OF_GUARD_CELLS,
+)
+
+
+def particle_density(particle):
+    return particle.get("weighting")
+
+
+def origin_no_guards_check(particle):
+    positions = {
+        (precision, unit): {
+            origin: np.array(particle.get("position", origin=origin, precision=precision, unit=unit))
+            for origin in ALL_ORIGINS_WITHOUT_GUARDS
+            if origin != "moving_window" or precision == "sub_cell"
+        }
+        for precision in ALL_PRECISIONS
+        for unit in ALL_UNITS
+    }
+
+    all_combinations = tuple(
+        x for ps in positions.values() for a in ps.values() for b in ps.values() for x in zip(a, b)
+    )
+    return sum(sympy.Piecewise((1, sympy.Eq(*x)), (0, True)) for x in all_combinations) / len(all_combinations)
+
+
+def _subtract_guards(position, unit, timestep):
+    if unit == "cell":
+        return position - NUMBER_OF_GUARD_CELLS
+
+    if unit == "si":
+        return position - NUMBER_OF_GUARD_CELLS * CELL_SIZE
+
+    if unit == "pic":
+        return position - NUMBER_OF_GUARD_CELLS * CELL_SIZE / (timestep * speed_of_light)
+
+
+def origin_with_guards_check(particle, timestep):
+    positions = {
+        (precision, unit): {
+            origin: np.array(particle.get("position", origin=origin, precision=precision, unit=unit))
+            for origin in ["local_with_guards", "local"]
+            if origin != "moving_window" or precision == "sub_cell"
+        }
+        for precision in ALL_PRECISIONS
+        for unit in ALL_UNITS
+    }
+
+    all_combinations = sum(
+        (
+            tuple(zip(p["local"], _subtract_guards(p["local_with_guards"], unit, timestep)))
+            for (_, unit), p in positions.items()
+        ),
+        tuple(),
+    )
+    return sum(sympy.Piecewise((1, sympy.Eq(*x)), (0, True)) for x in all_combinations) / len(all_combinations)
+
+
+def unit_no_guards_check(particle, timestep):
+    positions = {
+        (precision, origin): {
+            unit: particle.get("position", origin=origin, precision=precision, unit=unit) for unit in ALL_UNITS
+        }
+        for precision in ALL_PRECISIONS
+        for origin in ALL_ORIGINS_WITHOUT_GUARDS
+        if origin != "moving_window" or precision == "sub_cell"
+    }
+    return sum(
+        sympy.Piecewise(
+            (1, sympy.Abs(ps["cell"][i] * CELL_SIZE[i] - ps["si"][i]) < EPSILON),
+            (0, True),
+        )
+        + sympy.Piecewise(
+            (
+                1,
+                sympy.Abs(ps["pic"][i] * speed_of_light * timestep - ps["si"][i]) < EPSILON,
+            ),
+            (0, True),
+        )
+        for ps in positions.values()
+        for i in range(len(NUMBER_OF_CELLS))
+    ) / (2 * len(NUMBER_OF_CELLS) * len(positions))
+
+
+def position(particle, i, origin, precision, unit):
+    return particle.get("position", origin=origin, precision=precision, unit=unit)[i]
+
+
+def position_binning_for(species, timestep):
+    # Sorry, this way of testing is not really great to debug.
+    # The deposition_functors we'll use perform a number of checks at once.
+    # They'll count the number of passed checks and normalise it at the end.
+    # So, they'll return 1 for each particle, i.e., the number of particles after accumulation.
+    # This is awful to debug, I'm aware of that.
+    # But unfortunately, the other ways I could come up with were quite intensive in their resource usage.
+    # The best I could come up with for debugging is cd'ing into the setup directory
+    # and manually changing the generated C++ files.
+    # That worked quite okay.
+    kwargs = dict(
+        axes=[
+            BinningAxis(
+                functor=BinningFunctor(name="dummy", functor=lambda x: 0, return_type=float),
+                bin_spec=BinSpec("linear", -0.5, 0.5, 1),
+            )
+        ],
+        species=species,
+        period=TimeStepSpec[:],
+        openPMD={"hdf5": {"dataset": {"chunks": "auto"}}},
+        openPMDExt="h5",
+    )
+    return [
+        Binning(
+            name=f"origin_{species.name}",
+            deposition_functor=BinningFunctor(
+                name="origin_check",
+                functor=partial(origin_no_guards_check),
+                return_type="double",
+            ),
+            **kwargs,
+        ),
+        Binning(
+            name=f"unit_{species.name}",
+            deposition_functor=BinningFunctor(
+                name="unit_check",
+                functor=partial(unit_no_guards_check, timestep=timestep),
+                return_type="double",
+            ),
+            **kwargs,
+        ),
+        Binning(
+            name=f"origin_guards_{species.name}",
+            deposition_functor=BinningFunctor(
+                name="origin_with_guards_check",
+                functor=partial(origin_with_guards_check, timestep=timestep),
+                return_type="double",
+            ),
+            **kwargs,
+        ),
+    ]
+
+
+POSITION_AXES = [
+    BinningAxis(
+        BinningFunctor(
+            # We prefer `partial` over lambda functions in this situation
+            # because of lambda's late binding.
+            name=f"position{i}",
+            functor=partial(position, i=i, origin="total", precision="cell", unit="cell"),
+            return_type="double",
+        ),
+        BinSpec("linear", 0, NUMBER_OF_CELLS[i], NUMBER_OF_CELLS[i]),
+        use_overflow_bins=False,
+    )
+    for i in range(3)
+]
+
+
+def density_binning_for(species):
+    return [
+        Binning(
+            name=f"particleDensity_{species.name}",
+            deposition_functor=BinningFunctor(
+                name=f"particle_density_{species.name}",
+                functor=particle_density,
+                return_type=float,
+            ),
+            # Reversing this list is more convenient for comparison with openPMD data.
+            axes=POSITION_AXES[::-1],
+            species=species,
+        )
+    ]
+
+
+def binning_diagnostics(all_species, timestep):
+    return sum((density_binning_for(species) + position_binning_for(species, timestep) for species in all_species), [])

--- a/test/python/picongpu/end-to-end/distributions.py
+++ b/test/python/picongpu/end-to-end/distributions.py
@@ -1,0 +1,261 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import sympy
+from picongpu import picmi
+from sympy.vector import CoordSys3D, Vector
+
+from .arbitrary_parameters import CELL_SIZE
+
+
+# This is just meant as a form of namespace to bundle the setups together.
+class Gaussian:
+    def __init__(self):
+        self.parameters = {
+            "density": 1.0e25,
+            # cell size is 1, so we don't need to distinguish
+            # between number of cells and value in SI
+            "vacuum_front": 14.0,
+            "center_front": 29,
+            "center_rear": 54,
+            "sigma_front": 10,
+            "sigma_rear": 3,
+            "power": 2.0,
+            "factor": -2.0,
+        }
+        self.distributions = {
+            "predefined": picmi.GaussianDistribution(**self.parameters),
+            "free_form": picmi.AnalyticDistribution(
+                lambda x, y, z: self.free_form(y, cell_size_y=CELL_SIZE[1], **self.parameters)
+            ),
+        }
+
+    @staticmethod
+    def free_form(
+        y,
+        density,
+        cell_size_y,
+        vacuum_front,
+        center_front,
+        center_rear,
+        sigma_front,
+        sigma_rear,
+        power,
+        factor,
+    ):
+        # apparently, our SI position is the centre of the cell
+        y += -0.5 * cell_size_y
+        # The last term undoes the shift to the cell origin.
+        vacuum_y = int(vacuum_front / cell_size_y) * cell_size_y - 0.5 * cell_size_y
+
+        exponent = sympy.Piecewise(
+            (sympy.Abs((y - center_front) / sigma_front), y < center_front),
+            (sympy.Abs((y - center_rear) / sigma_rear), y >= center_rear),
+            (0.0, True),
+        )
+        return sympy.Piecewise((0.0, y < vacuum_y), (density * sympy.exp(factor * exponent**power), True))
+
+
+# This is just meant as a form of namespace to bundle the setups together.
+class Uniform:
+    def __init__(self):
+        self.arbitrary_value = 8.0e24
+        self.distributions = {
+            "predefined": picmi.UniformDistribution(density=self.arbitrary_value),
+            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.arbitrary_value),
+        }
+
+
+class Foil:
+    def __init__(self):
+        self.parameters = dict(
+            density=8.0e24,
+            front=10,
+            thickness=17,
+            exponential_pre_plasma_length=12,
+            exponential_pre_plasma_cutoff=14,
+            exponential_post_plasma_length=5,
+            exponential_post_plasma_cutoff=16,
+        )
+        self.distributions = {
+            "predefined": picmi.FoilDistribution(**self.parameters),
+            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(y, **self.parameters)),
+        }
+
+    @staticmethod
+    def free_form(
+        y,
+        density,
+        front,
+        thickness,
+        exponential_pre_plasma_length,
+        exponential_pre_plasma_cutoff,
+        exponential_post_plasma_length,
+        exponential_post_plasma_cutoff,
+    ):
+        pre_plasma_ramp = (
+            # expression
+            sympy.exp((y - front) / exponential_pre_plasma_length)
+            if exponential_pre_plasma_length is not None
+            else 0.0,
+            # condition
+            sympy.And(y < front, y > front - exponential_pre_plasma_cutoff),
+        )
+
+        post_plasma_ramp = (
+            # expression
+            sympy.exp((front + thickness - y) / exponential_post_plasma_length)
+            if exponential_post_plasma_length is not None
+            else 0.0,
+            # condition
+            sympy.And(
+                y > front + thickness,
+                y < front + thickness + exponential_post_plasma_cutoff,
+            ),
+        )
+
+        foil = (1.0, sympy.And(y >= front, y <= front + thickness))
+        vacuum = (0.0, True)
+
+        return density * sympy.Piecewise(pre_plasma_ramp, foil, post_plasma_ramp, vacuum)
+
+
+def _make_vector(coefficients, basis_vectors):
+    # In sympy, vectors are represented as linear combinations of basis vectors.
+    # The last argument is important.
+    # Otherwise Python tries to start from an integer (scalar) 0 which is not well-defined.
+    return sum((coeff * vec for coeff, vec in zip(coefficients, basis_vectors)), Vector.zero)
+
+
+class Cylinder:
+    def __init__(self):
+        self.parameters = dict(
+            density=8.0e24,
+            center_position=(17.0, 23.0, 45.0),
+            radius=10,
+            cylinder_axis=(1.0, 2.0, 3.0),
+            exponential_pre_plasma_length=5.0,
+            exponential_pre_plasma_cutoff=3.0,
+        )
+        self.distributions = {
+            "predefined": picmi.CylindricalDistribution(**self.parameters),
+            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(x, y, z, **self.parameters)),
+        }
+
+    @staticmethod
+    def free_form(
+        x,
+        y,
+        z,
+        density,
+        center_position,
+        radius,
+        cylinder_axis,
+        exponential_pre_plasma_length,
+        exponential_pre_plasma_cutoff,
+    ):
+        # The definition of this density uses the origin of the cell
+        # while the call operator uses the center.
+        x += -0.5 * CELL_SIZE[0]
+        y += -0.5 * CELL_SIZE[1]
+        z += -0.5 * CELL_SIZE[2]
+
+        # Handling vectors in sympy starts from a coordinate system.
+        e = CoordSys3D("e")
+
+        # Every vector is expressed as a linear combination of basis vectors.
+        # This is abstracted away in `_make_vector`.
+        cylinder_axis = _make_vector(cylinder_axis, e).normalize()
+        r = (_make_vector([x, y, z], e) - _make_vector(center_position, e)).cross(cylinder_axis).magnitude()
+        radius = (
+            sympy.sqrt(radius**2 - exponential_pre_plasma_length**2) - exponential_pre_plasma_length
+            if exponential_pre_plasma_cutoff > 0.0 and exponential_pre_plasma_length > 0.0
+            else radius
+        )
+
+        cylinder = (1.0, r < radius)
+
+        pre_plasma_ramp = (
+            # expression
+            sympy.exp((radius - r) / exponential_pre_plasma_length)
+            if exponential_pre_plasma_cutoff > 0.0 and exponential_pre_plasma_length > 0.0
+            else 0.0,
+            # condition
+            sympy.And(r > radius, r < radius + exponential_pre_plasma_cutoff),
+        )
+        vacuum = (0.0, True)
+
+        return density * sympy.Piecewise(cylinder, pre_plasma_ramp, vacuum)
+
+
+# This is a predefined setup within PIConGPU but not PICMI.
+class LinearExponential:
+    def __init__(self):
+        self.parameters = dict(
+            density=8.0e24,
+            vacuum_y=14.0,
+            gas_a=10.0,
+            gas_b=12.0,
+            gas_d=-0.1,
+            gas_y_max=25.0,
+        )
+        self.distributions = {
+            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(y, **self.parameters)),
+        }
+
+    @staticmethod
+    def free_form(y, density, vacuum_y, gas_a, gas_b, gas_d, gas_y_max):
+        # move to the origin of the cell
+        y += -0.5 * CELL_SIZE[1]
+
+        vacuum = (0.0, y < vacuum_y)
+        linear_slope = (
+            sympy.Max(0.0, gas_a * y + gas_b),
+            sympy.And(y >= vacuum_y, y < gas_y_max),
+        )
+        exponential_slope = (sympy.exp(gas_d * (y - gas_y_max)), True)
+
+        return density * sympy.Piecewise(vacuum, linear_slope, exponential_slope)
+
+
+# This is a predefined setup within PIConGPU but not PICMI.
+class SphereFlanks:
+    def __init__(self):
+        self.parameters = dict(
+            density=8.0e24,
+            vacuum_y=14.0,
+            center=[10.0, 40.0, 35.0],
+            r=20.0,
+            ri=10.0,
+            exponent=1.0,
+        )
+        self.distributions = {
+            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(x, y, z, **self.parameters)),
+        }
+
+    @staticmethod
+    def free_form(x, y, z, density, vacuum_y, center, r, ri, exponent):
+        # move to the origin of the cell
+        y += -0.5 * CELL_SIZE[1]
+
+        distance = sympy.sqrt((x - center[0]) ** 2 + (y - center[1]) ** 2 + (z - center[2]) ** 2)
+        front_vacuum = (0.0, y < vacuum_y)
+        inner_vacuum = (0.0, distance < ri)
+        sphere = (1.0, distance <= r)
+        flanks = (sympy.exp(exponent * (r - distance)), True)
+
+        return density * sympy.Piecewise(front_vacuum, inner_vacuum, sphere, flanks)
+
+
+DISTRIBUTIONS = {
+    "Uniform": Uniform().distributions,
+    "Gaussian": Gaussian().distributions,
+    "Foil": Foil().distributions,
+    "LinearExponential": LinearExponential().distributions,
+    "SphereFlanks": SphereFlanks().distributions,
+    "Cylinder": Cylinder().distributions,
+}

--- a/test/python/picongpu/end-to-end/free_formula_density.py
+++ b/test/python/picongpu/end-to-end/free_formula_density.py
@@ -9,298 +9,77 @@ import unittest
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
-import sympy
-from sympy.vector import CoordSys3D, Vector
-from .compare_particles import compare_particles, compute_densities_from_particles
 from picongpu import picmi
 from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
 
-NUMBER_OF_CELLS = [64, 64, 32]
-UPPER_BOUNDARY = np.array([64.0, 66.0, 74.0])
-CELL_SIZE = UPPER_BOUNDARY / NUMBER_OF_CELLS
+from .arbitrary_parameters import (
+    CELL_SIZE,
+    NUMBER_OF_CELLS,
+    UPPER_BOUNDARY,
+)
+from .binning_functors import binning_diagnostics
+from .compare_particles import (
+    compare_particles,
+    read_binning,
+    read_densities_into_mesh,
+    read_particles,
+    read_position_check,
+)
+from .distributions import DISTRIBUTIONS
+
+LAYOUT = picmi.GriddedLayout(n_macroparticles_per_cell=2)
 
 
-# This is just meant as a form of namespace to bundle the setups together.
-class Gaussian:
-    def __init__(self):
-        self.parameters = {
-            "density": 1.0e25,
-            # cell size is 1, so we don't need to distinguish
-            # between number of cells and value in SI
-            "vacuum_front": 14.0,
-            "center_front": 29,
-            "center_rear": 54,
-            "sigma_front": 10,
-            "sigma_rear": 3,
-            "power": 2.0,
-            "factor": -2.0,
-        }
-        self.distributions = {
-            "predefined": picmi.GaussianDistribution(**self.parameters),
-            "free_form": picmi.AnalyticDistribution(
-                lambda x, y, z: self.free_form(y, cell_size_y=CELL_SIZE[1], **self.parameters)
+def basic_simulation():
+    return picmi.Simulation(
+        max_steps=0,
+        solver=picmi.ElectromagneticSolver(
+            method="Yee",
+            cfl=1.0,
+            grid=picmi.Cartesian3DGrid(
+                number_of_cells=NUMBER_OF_CELLS,
+                lower_bound=[0, 0, 0],
+                # cell size is slightly different from 1
+                upper_bound=UPPER_BOUNDARY,
+                lower_boundary_conditions=["open", "open", "open"],
+                upper_boundary_conditions=["open", "open", "open"],
             ),
-        }
-
-    @staticmethod
-    def free_form(
-        y,
-        density,
-        cell_size_y,
-        vacuum_front,
-        center_front,
-        center_rear,
-        sigma_front,
-        sigma_rear,
-        power,
-        factor,
-    ):
-        # apparently, our SI position is the centre of the cell
-        y += -0.5 * cell_size_y
-        # The last term undoes the shift to the cell origin.
-        vacuum_y = int(vacuum_front / cell_size_y) * cell_size_y - 0.5 * cell_size_y
-
-        exponent = sympy.Piecewise(
-            (sympy.Abs((y - center_front) / sigma_front), y < center_front),
-            (sympy.Abs((y - center_rear) / sigma_rear), y >= center_rear),
-            (0.0, True),
-        )
-        return sympy.Piecewise((0.0, y < vacuum_y), (density * sympy.exp(factor * exponent**power), True))
-
-
-# This is just meant as a form of namespace to bundle the setups together.
-class Uniform:
-    def __init__(self):
-        self.arbitrary_value = 8.0e24
-        self.distributions = {
-            "predefined": picmi.UniformDistribution(density=self.arbitrary_value),
-            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.arbitrary_value),
-        }
-
-
-class Foil:
-    def __init__(self):
-        self.parameters = dict(
-            density=8.0e24,
-            front=10,
-            thickness=17,
-            exponential_pre_plasma_length=12,
-            exponential_pre_plasma_cutoff=14,
-            exponential_post_plasma_length=5,
-            exponential_post_plasma_cutoff=16,
-        )
-        self.distributions = {
-            "predefined": picmi.FoilDistribution(**self.parameters),
-            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(y, **self.parameters)),
-        }
-
-    @staticmethod
-    def free_form(
-        y,
-        density,
-        front,
-        thickness,
-        exponential_pre_plasma_length,
-        exponential_pre_plasma_cutoff,
-        exponential_post_plasma_length,
-        exponential_post_plasma_cutoff,
-    ):
-        pre_plasma_ramp = (
-            # expression
-            sympy.exp((y - front) / exponential_pre_plasma_length)
-            if exponential_pre_plasma_length is not None
-            else 0.0,
-            # condition
-            sympy.And(y < front, y > front - exponential_pre_plasma_cutoff),
-        )
-
-        post_plasma_ramp = (
-            # expression
-            sympy.exp((front + thickness - y) / exponential_post_plasma_length)
-            if exponential_post_plasma_length is not None
-            else 0.0,
-            # condition
-            sympy.And(
-                y > front + thickness,
-                y < front + thickness + exponential_post_plasma_cutoff,
-            ),
-        )
-
-        foil = (1.0, sympy.And(y >= front, y <= front + thickness))
-        vacuum = (0.0, True)
-
-        return density * sympy.Piecewise(pre_plasma_ramp, foil, post_plasma_ramp, vacuum)
-
-
-def _make_vector(coefficients, basis_vectors):
-    # In sympy, vectors are represented as linear combinations of basis vectors.
-    # The last argument is important.
-    # Otherwise Python tries to start from an integer (scalar) 0 which is not well-defined.
-    return sum((coeff * vec for coeff, vec in zip(coefficients, basis_vectors)), Vector.zero)
-
-
-class Cylinder:
-    def __init__(self):
-        self.parameters = dict(
-            density=8.0e24,
-            center_position=(17.0, 23.0, 45.0),
-            radius=10,
-            cylinder_axis=(1.0, 2.0, 3.0),
-            exponential_pre_plasma_length=5.0,
-            exponential_pre_plasma_cutoff=3.0,
-        )
-        self.distributions = {
-            "predefined": picmi.CylindricalDistribution(**self.parameters),
-            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(x, y, z, **self.parameters)),
-        }
-
-    @staticmethod
-    def free_form(
-        x,
-        y,
-        z,
-        density,
-        center_position,
-        radius,
-        cylinder_axis,
-        exponential_pre_plasma_length,
-        exponential_pre_plasma_cutoff,
-    ):
-        # The definition of this density uses the origin of the cell
-        # while the call operator uses the center.
-        x += -0.5 * CELL_SIZE[0]
-        y += -0.5 * CELL_SIZE[1]
-        z += -0.5 * CELL_SIZE[2]
-
-        # Handling vectors in sympy starts from a coordinate system.
-        e = CoordSys3D("e")
-
-        # Every vector is expressed as a linear combination of basis vectors.
-        # This is abstracted away in `_make_vector`.
-        cylinder_axis = _make_vector(cylinder_axis, e).normalize()
-        r = (_make_vector([x, y, z], e) - _make_vector(center_position, e)).cross(cylinder_axis).magnitude()
-        radius = (
-            sympy.sqrt(radius**2 - exponential_pre_plasma_length**2) - exponential_pre_plasma_length
-            if exponential_pre_plasma_cutoff > 0.0 and exponential_pre_plasma_length > 0.0
-            else radius
-        )
-
-        cylinder = (1.0, r < radius)
-
-        pre_plasma_ramp = (
-            # expression
-            sympy.exp((radius - r) / exponential_pre_plasma_length)
-            if exponential_pre_plasma_cutoff > 0.0 and exponential_pre_plasma_length > 0.0
-            else 0.0,
-            # condition
-            sympy.And(r > radius, r < radius + exponential_pre_plasma_cutoff),
-        )
-        vacuum = (0.0, True)
-
-        return density * sympy.Piecewise(cylinder, pre_plasma_ramp, vacuum)
-
-
-# This is a predefined setup within PIConGPU but not PICMI.
-class LinearExponential:
-    def __init__(self):
-        self.parameters = dict(
-            density=8.0e24,
-            vacuum_y=14.0,
-            gas_a=10.0,
-            gas_b=12.0,
-            gas_d=-0.1,
-            gas_y_max=25.0,
-        )
-        self.distributions = {
-            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(y, **self.parameters)),
-        }
-
-    @staticmethod
-    def free_form(y, density, vacuum_y, gas_a, gas_b, gas_d, gas_y_max):
-        # move to the origin of the cell
-        y += -0.5 * CELL_SIZE[1]
-
-        vacuum = (0.0, y < vacuum_y)
-        linear_slope = (
-            sympy.Max(0.0, gas_a * y + gas_b),
-            sympy.And(y >= vacuum_y, y < gas_y_max),
-        )
-        exponential_slope = (sympy.exp(gas_d * (y - gas_y_max)), True)
-
-        return density * sympy.Piecewise(vacuum, linear_slope, exponential_slope)
-
-
-# This is a predefined setup within PIConGPU but not PICMI.
-class SphereFlanks:
-    def __init__(self):
-        self.parameters = dict(
-            density=8.0e24,
-            vacuum_y=14.0,
-            center=[10.0, 40.0, 35.0],
-            r=20.0,
-            ri=10.0,
-            exponent=1.0,
-        )
-        self.distributions = {
-            "free_form": picmi.AnalyticDistribution(lambda x, y, z: self.free_form(x, y, z, **self.parameters)),
-        }
-
-    @staticmethod
-    def free_form(x, y, z, density, vacuum_y, center, r, ri, exponent):
-        # move to the origin of the cell
-        y += -0.5 * CELL_SIZE[1]
-
-        distance = sympy.sqrt((x - center[0]) ** 2 + (y - center[1]) ** 2 + (z - center[2]) ** 2)
-        front_vacuum = (0.0, y < vacuum_y)
-        inner_vacuum = (0.0, distance < ri)
-        sphere = (1.0, distance <= r)
-        flanks = (sympy.exp(exponent * (r - distance)), True)
-
-        return density * sympy.Piecewise(front_vacuum, inner_vacuum, sphere, flanks)
-
-
-DISTRIBUTIONS = {
-    "Uniform": Uniform().distributions,
-    "Gaussian": Gaussian().distributions,
-    "Foil": Foil().distributions,
-    "LinearExponential": LinearExponential().distributions,
-    "SphereFlanks": SphereFlanks().distributions,
-    "Cylinder": Cylinder().distributions,
-}
+        ),
+    )
 
 
 def generate_name(name, suffix):
     return name + "_" + suffix
 
 
-def add(sim, name, **distributions):
-    random_layout = picmi.GriddedLayout(n_macroparticles_per_cell=2)
-    for suffix, distribution in distributions.items():
-        species_hydrogen = picmi.Species(
-            name=generate_name(name, suffix),
+def generate_species(name, distribution):
+    return [
+        picmi.Species(
+            name=name,
             particle_type="H",
             initial_distribution=distribution,
             picongpu_fixed_charge=True,
         )
-        sim.add_species(species_hydrogen, random_layout)
+    ]
 
 
 def setup_sim():
-    grid = picmi.Cartesian3DGrid(
-        number_of_cells=NUMBER_OF_CELLS,
-        lower_bound=[0, 0, 0],
-        # cell size is slightly different from 1
-        upper_bound=UPPER_BOUNDARY,
-        lower_boundary_conditions=["open", "open", "open"],
-        upper_boundary_conditions=["open", "open", "open"],
-    )
-    solver = picmi.ElectromagneticSolver(method="Yee", grid=grid, cfl=1.0)
-    sim = picmi.Simulation(max_steps=0, solver=solver)
-    sim.diagnostics = [picmi.diagnostics.Checkpoint(TimeStepSpec[:])]
+    sim = basic_simulation()
 
-    for name, distributions in DISTRIBUTIONS.items():
-        add(sim, name, **distributions)
+    species = sum(
+        (
+            generate_species(generate_name(name, suffix), dist)
+            for name, distributions in DISTRIBUTIONS.items()
+            for suffix, dist in distributions.items()
+        ),
+        [],
+    )
+
+    diagnostics = [picmi.diagnostics.Checkpoint(TimeStepSpec[:])] + binning_diagnostics(species, sim.time_step_size)
+
+    for s in species:
+        sim.add_species(s, LAYOUT)
+    sim.diagnostics = diagnostics
 
     sim.step(0)
     return sim
@@ -311,45 +90,118 @@ SIM = None
 
 
 class TestFreeFormulaDensity(unittest.TestCase):
+    _result_path = None
+
     def setUp(self):
-        global SIM
-        if SIM is None:
-            SIM = setup_sim()
-        self.sim = SIM
+        if self._result_path is None:
+            global SIM
+            if SIM is None:
+                SIM = setup_sim()
+            self.sim = SIM
+        else:
+            for d in DISTRIBUTIONS:
+                for f in DISTRIBUTIONS[d].values():
+                    f.cell_size = CELL_SIZE
 
     @property
     def result_path(self):
-        return Path(self.sim._Simulation__runner.run_dir) / "simOutput" / "checkpoints" / "checkpoint_000000.bp5"
+        if self._result_path is None:
+            self._result_path = Path(self.sim._Simulation__runner.run_dir)
+        return self._result_path
 
     def test_compare_particles_pairwise(self):
-        self.assertTrue(compare_particles(self.result_path))
+        self.assertTrue(compare_particles(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5"))
 
     def test_compare_particles_against_call_operator(self):
-        densities = compute_densities_from_particles(self.result_path).to_frame().rename(
-            {"weighting": "found"}, axis=1
-        ) / np.prod(CELL_SIZE)
-        densities["expected"] = (
-            densities.reset_index(drop=False)
-            .groupby(["setup", "impl"])
-            .apply(
-                lambda df: pd.Series(
-                    # We add 0.5 because the density is evaluated at the centre of the cell.
-                    DISTRIBUTIONS[df.name[0]][df.name[1]](
-                        df.positionOffset_x.to_numpy() + 0.5 * CELL_SIZE[0],
-                        df.positionOffset_y.to_numpy() + 0.5 * CELL_SIZE[1],
-                        df.positionOffset_z.to_numpy() + 0.5 * CELL_SIZE[2],
-                    ),
-                    index=df.set_index(
-                        ["positionOffset_x", "positionOffset_y", "positionOffset_z"],
-                        drop=True,
-                    ).index,
-                ).astype(float),
-                include_groups=False,
-            )
+        particles = read_densities_into_mesh(
+            self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5",
+            NUMBER_OF_CELLS,
+            CELL_SIZE,
+        )
+        for setup, dists in DISTRIBUTIONS.items():
+            for impl, func in dists.items():
+                density = particles.loc(axis=0)[setup][impl]
+                values = func(*(np.indices(density.shape) + 0.5) * np.reshape(CELL_SIZE, (3, 1, 1, 1)))
+                np.testing.assert_allclose(density, values, rtol=1.0e-4)
+
+    def test_compare_binning_against_call_operator(self):
+        for setup, dists in DISTRIBUTIONS.items():
+            for impl, func in dists.items():
+                mesh = read_binning(
+                    self.result_path
+                    / "simOutput"
+                    / "binningOpenPMD"
+                    / f"particleDensity_{generate_name(setup, impl)}_000000.bp5",
+                    CELL_SIZE,
+                )
+                values = func(*(np.indices(mesh.shape) + 0.5) * np.reshape(CELL_SIZE, (3, 1, 1, 1)))
+
+                np.testing.assert_allclose(mesh, values, rtol=1.0e-4)
+
+    def test_compare_binning_against_particle_density(self):
+        particles = read_densities_into_mesh(
+            self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5",
+            NUMBER_OF_CELLS,
+            CELL_SIZE,
         )
 
-        # The Gaussian rear tail somehow has a bad accuracy.
-        np.testing.assert_allclose(densities.found, densities.expected, rtol=1.0e-4)
+        for setup, dists in DISTRIBUTIONS.items():
+            for impl in dists.keys():
+                mesh = read_binning(
+                    self.result_path
+                    / "simOutput"
+                    / "binningOpenPMD"
+                    / f"particleDensity_{generate_name(setup, impl)}_000000.bp5",
+                    CELL_SIZE,
+                )
+                np.testing.assert_allclose(mesh, particles.loc(axis=0)[setup, impl])
+
+    def test_origins_are_all_the_same(self):
+        # This test is not very meaningful,
+        # only in the way that it compiles and doesn't yield completely bogus results.
+        # The different variations of position origins only refer to different things
+        # if we have multiple ranks and moving window activated.
+        # As we don't in this test, there isn't really much to test
+        # except for the fact that all the different coordinates must be identical.
+        # The position_check functor does so by counting the correct ones.
+        number_of_particles = (
+            read_particles(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")["weighting"]
+            .groupby(["setup", "impl"])
+            .count()
+        )
+
+        for (setup, impl), count in number_of_particles.items():
+            self.assertEqual(
+                round(
+                    read_position_check(
+                        self.result_path
+                        / "simOutput"
+                        / "binningOpenPMD"
+                        / f"origin_{generate_name(setup, impl)}_000000.h5"
+                    )
+                ),
+                count,
+            )
+
+    def test_unit_conversions_by_hand(self):
+        number_of_particles = (
+            read_particles(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")["weighting"]
+            .groupby(["setup", "impl"])
+            .count()
+        )
+
+        for (setup, impl), count in number_of_particles.items():
+            self.assertEqual(
+                round(
+                    read_position_check(
+                        self.result_path
+                        / "simOutput"
+                        / "binningOpenPMD"
+                        / f"unit_{generate_name(setup, impl)}_000000.h5"
+                    )
+                ),
+                count,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Particle Binning for PICMI

This PR adds initial support for particle binning to PICMI. This support is not yet complete, see list below for what's missing. The interface is to be considered experimental and subject to change (because it is yet unclear if the interface will have to distinguish between particle and field binning explicitly). Because of that there's no documentation at the moment. Power-users like @pordyna will figure it out and others can look at the description in this PR. Experienced users should check the generated C++ code if things don't do what's expected.

### Status of this PR and your mission

Please review, test and start using this PR, so we can get decent feedback about this. ~~It's not completely polished yet as it would benefit from some rebasing and working on this has uncovered some bugs that probably have to be fixed in C++ world. I'll leave this as green, so people will actually care to look at it. But I expect no review to pass in every detail yet.~~


### UI Description

The UI can be seen in the end-to-end test. Users can add an arbitrary number of `picmi.diagnostics.binning.Binning` objects to `sim.diagnostics` each of which contains four necessary pieces of information:
```python
            Binning(
                name="particle_density",
                deposition_functor=BinningFunctor(
                    name="particle_density",
                    functor=lambda particle: particle.get("weighting"),
                    # Can be arithmetic python types or a string which would be inserted literally:
                    return_type=float,
                ),
                axes=[BinningAxis(...), ...],
                # could be a list:
                species=species_hydrogen,
                # and more with defaults...
                period=TimeStepSpec[:],
                # ...most of the other things that the `Binner` has as setters...
            )
```
This will produce the desired binning output in the folder `${run_dir}/simOutput/binningOpenPMD/${Binning.name}_${infix}.${extension}`. Some details:
- The `BinningFunctor` takes a function with the signature `def functor(particle)`. The particle passed to the function exposes a `.get` method that can take any particle attribute name as string (anything that we'd get via `particle[attribute_]` in C++) as well as `position`, `timestep` and the attributes implemented as traits like `picongpu::traits::attribute::getMass`. For `position` it can take additional keyword arguments `origin`, `precision` and `unit` (but see below because that's not yet fully functional). The return value of `particle.get` is either a `sympy.Symbol` or a tuple of `sympy.Symbol` (depending on whether a scalar or a vector was asked for). We might find a more appropriate collection later on. The obvious candidates `sympy.Vector` and/or `sympy.Point` unfortunately have their own quirks and bugs and also a relatively bulky interface, so I'm not yet sure about what's the best interface here.
- The `BinningAxis` class bundles a `BinningFunctor` and a `BinSpec(kind="linear"/"log", start, stop, nsteps)`.
- The further configuration options include all the simple things like `timeaveraging`, openPMD configuration (as a dictionary that's converted to a json string for code generation) and so on. It does not contain the tricky stuff like host-side hooks and openPMD functors. These will likely never get exposed but will only be used internally as means to provide higher level features in the frontend.


### Implementation details

The translation of functors from the UI to the generated code is roughly organised as follows:
- On the PICMI level, the interface is provided. Upon translation into the PyPIConGPU layer via `.get_as_pypicongpu`, the `BinningFunctor` calls the given functor with an opaque `BinningParticle` object. While it returns the corresponding symbols from the `.get` method, it keeps track of the requested properties and handed out symbols. The sympy expression as well as a dictionary mapping symbols to attributes is passed to PyPIConGPU.
- On the PyPIConGPU level, the `functor_expression` is handled as in the free-formula density case via the `PMAccPrinter`. This produces an expression containing the variables as they were handed out as `sympy.Symbol`s above. In order to declare and define these variables, PyPIConGPU's `BinningFunctor` generates a custom preamble to preceed the generated `functor_expression` in the generated code. It roughly looks like this (wherein, of course, only statements for actually used variables are generated)
```C++
auto const weighting = particle[weighting_];
auto const [px, py, pz] = particle[momentum_];
// but also things like...
auto const [x_cell_cell,y_cell_cell,z_cell_cell] = getParticlePosition<DomainOrigin::TOTAL, PositionPrecision::Cell, PositionUnits::Cell>(domainInfo, particle);
```
- The template organises each `Binner` into its own function and calls all those functions in `getBinning` at the end.

The other data are straightforwardly passed through the layers and not much magic is happening. I have also restrained from putting in strong guardrails at the moment because a number of aspects are planned as (or at least conceivable as) extension points or even explicitly allow for arbitrary strings to be passed through.


### Testing
Tests for this feature are built on the infrastructure set up for free-formula densities and are expected to suffer from the same problems in CI, so there's no point in activating them at the moment. This makes it even more important that the reviewers please run the tests! I will come up with a better separation of concerns in the process of bringing the tests into CI.

The main test again computes the particle density and compares to the other methods that already existed. I'm planning to add some further tests for different functionalities but success in this direction was limited by the backend bugs described below. As submitted, the tests currently do not succeed but fail at compile time. Deactivating the (as of now unused-in-the-tests) position binnings makes them pass.


### Missing features
In general, this PR does not yet attempt to add field binning. Furthermore, not all details from the particle binning are implemented as of now. This is the list of missing feature I'm aware of. Please ping me and add to this list if there's anything I've overlooked.
- Add units to binning.
- Species filtering.
~~- Add supercell as precision and potentially local cell index as origin, etc.~~
- Accumulate operation is not configurable.


~~Backend Bugs~~

~~Flexible binning is a relatively young feature by itself, so there's still some bugs in the backend that have been triggered by the systematic testing for this PR:~~

~~- Some initial tests ran into segfaults with more than 5 axes. @ikbuibui is supposed to investigate this further.~~
~~- The position functors which are currently added but not yet tested lead to compile-time errors about inconvertible return types. @ikbuibui is supposed to investigate this further.~~