### PR TITLE
By using zsh one would get the following error:

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -1,6 +1,5 @@
 # Name and Path of this Script ############################### (DO NOT change!)
-export PIC_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
-
+export PIC_PROFILE=$(cd $(dirname ${BASH_SOURCE:-$0}) && pwd)/$(basename ${BASH_SOURCE:-$0}) # for compatibility with both zsh and bash
 # User Information ################################# (edit the following lines)
 #   - automatically add your name and contact to output file meta data
 #   - send me a mail on batch system jobs: NONE, BEGIN, END, FAIL, REQUEUE, ALL,


### PR DESCRIPTION
When using zsh the following error occurred:

```
dirname: missing operand
Try 'dirname --help' for more information.
basename: missing operand
Try 'basename --help' for more information
```

The error occurs because the script uses Bash-specific syntax ($BASH_SOURCE) which is not available in zsh

`export PIC_PROFILE=$(cd $(dirname ${BASH_SOURCE:-$0}) && pwd)/$(basename ${BASH_SOURCE:-$0})`

$0 in Zsh contains the path to the current script, similar to $BASH_SOURCE in Bash.
dirname $0 extracts the directory path of the script.
basename $0 extracts the script's filename.
$(cd $(dirname $0) && pwd) changes to the script's directory and outputs the full path, ensuring it's absolute.

This checks for $BASH_SOURCE (for Bash) and falls back to $0 (for Zsh)