### PR TITLE
Add support for a proper comoving origin in the particle binning

### DIFF
--- a/include/picongpu/plugins/binning/BinningFunctors.hpp
+++ b/include/picongpu/plugins/binning/BinningFunctors.hpp
@@ -105,14 +105,12 @@ namespace picongpu
                 auto const& worker,
                 T_HistBox binningBox,
                 auto particlesBox,
-                pmacc::DataSpace<simDim> const& localOffset,
-                pmacc::DataSpace<simDim> const& globalOffset,
+                DomainInfo<BinningType::Particle> domainInfo,
                 auto const& axisTuple,
                 T_DepositionFunctor const& quantityFunctor,
                 DataSpace<T_nAxes> const& extents,
                 auto const& userFunctorData,
                 auto const& filter,
-                uint32_t const currentStep,
                 T_Mapping const& mapper) const
             {
                 DataSpace<simDim> const superCellIdx(mapper.getSuperCellIndex(worker.blockDomIdxND()));
@@ -121,8 +119,7 @@ namespace picongpu
                 /**
                  * Init the Domain info, here because of the possibility of a moving window
                  */
-                auto const domainInfo
-                    = DomainInfo<BinningType::Particle>{currentStep, globalOffset, localOffset, physicalSuperCellIdx};
+                domainInfo.fillDeviceData(physicalSuperCellIdx);
 
                 auto const functorParticle = FunctorParticle<T_AtomicOp>{};
 
@@ -194,14 +191,12 @@ namespace picongpu
                 T_Worker const& worker,
                 T_HistBox binningBox,
                 TParticlesBox particlesBox,
-                pmacc::DataSpace<simDim> const& localOffset,
-                pmacc::DataSpace<simDim> const& globalOffset,
+                DomainInfo<BinningType::Particle> domainInfo,
                 T_AxisTuple const& axisTuple,
                 T_DepositionFunctor const& quantityFunctor,
                 DataSpace<T_nAxes> const& extents,
                 auto const& userFunctorData,
                 auto const& filter,
-                uint32_t const currentStep,
                 pmacc::DataSpace<simDim> const& beginCellIdxLocal,
                 pmacc::DataSpace<simDim> const& endCellIdxLocal,
                 T_Mapping const& mapper) const
@@ -211,8 +206,7 @@ namespace picongpu
                 // supercell index relative to the border origin
                 auto const physicalSuperCellIdx = superCellIdx - mapper.getGuardingSuperCells();
 
-                auto const domainInfo
-                    = DomainInfo<BinningType::Particle>{currentStep, globalOffset, localOffset, physicalSuperCellIdx};
+                domainInfo.fillDeviceData(physicalSuperCellIdx);
                 auto const functorParticle = FunctorParticle<T_AtomicOp>{};
 
                 auto forEachParticle
@@ -317,13 +311,11 @@ namespace picongpu
             DINLINE void operator()(
                 auto const& worker,
                 T_HistBox binningBox,
-                pmacc::DataSpace<simDim> const& localOffset,
-                pmacc::DataSpace<simDim> const& globalOffset,
+                DomainInfo<BinningType::Field> domainInfo,
                 auto const& axisTuple,
                 auto const& userFunctorData,
                 T_DepositionFunctor const& quantityFunctor,
                 DataSpace<T_nAxes> const& extents,
-                uint32_t const currentStep,
                 T_Mapping const& mapper) const
             {
                 using SuperCellSize = typename T_Mapping::SuperCellSize;
@@ -348,12 +340,7 @@ namespace picongpu
                         /**
                          * Init the Domain info, here because of the possibility of a moving window
                          */
-                        auto const domainInfo = DomainInfo<BinningType::Field>{
-                            currentStep,
-                            globalOffset,
-                            localOffset,
-                            physicalSuperCellIdx,
-                            localCellIndex};
+                        domainInfo.fillDeviceData(physicalSuperCellIdx, localCellIndex);
 
                         functorCell(
                             worker,

--- a/include/picongpu/plugins/binning/binners/FieldBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/FieldBinner.hpp
@@ -62,6 +62,9 @@ namespace picongpu
 
                 auto const globalOffset = Environment<simDim>::get().SubGrid().getGlobalDomain().offset;
                 auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
+                auto& mv = MovingWindow::getInstance();
+                auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
+                auto domainInfo = DomainInfo<BinningType::Field>(currentStep, globalOffset, localOffset, windowOffset);
 
                 auto const axisKernels = tupleMap(
                     this->binningData.axisTuple,
@@ -86,13 +89,11 @@ namespace picongpu
                 PMACC_LOCKSTEP_KERNEL(functorBlock)
                     .config(mapper.getGridDim(), SuperCellSize{})(
                         binningBox,
-                        localOffset,
-                        globalOffset,
+                        domainInfo,
                         axisKernels,
                         userFunctorData,
                         this->binningData.depositionData.functor,
                         this->binningData.axisExtentsND,
-                        currentStep,
                         mapper);
             }
         };

--- a/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
@@ -108,6 +108,10 @@ namespace picongpu
 
                 auto const globalOffset = Environment<simDim>::get().SubGrid().getGlobalDomain().offset;
                 auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
+                auto& mv = MovingWindow::getInstance();
+                auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
+                auto domainInfo
+                    = DomainInfo<BinningType::Particle>(currentStep, globalOffset, localOffset, windowOffset);
 
                 auto const axisKernels = tupleMap(
                     this->binningData.axisTuple,
@@ -123,14 +127,12 @@ namespace picongpu
                     .config(mapper.getGridDim(), particlesBox)(
                         binningBox,
                         particlesBox,
-                        localOffset,
-                        globalOffset,
+                        domainInfo,
                         axisKernels,
                         this->binningData.depositionData.functor,
                         this->binningData.axisExtentsND,
                         extraData,
                         fs.filter,
-                        currentStep,
                         mapper);
             }
 
@@ -160,6 +162,11 @@ namespace picongpu
 
                         auto const globalOffset = Environment<simDim>::get().SubGrid().getGlobalDomain().offset;
                         auto const localOffset = Environment<simDim>::get().SubGrid().getLocalDomain().offset;
+                        auto const currentStep = Environment<>::get().SimulationDescription().getCurrentStep();
+                        auto& mv = MovingWindow::getInstance();
+                        auto const windowOffset = mv.getMovingWindowOriginPositionCells(currentStep);
+                        auto domainInfo
+                            = DomainInfo<BinningType::Particle>(currentStep, globalOffset, localOffset, windowOffset);
 
                         auto const axisKernels = tupleMap(
                             binner->binningData.axisTuple,
@@ -188,14 +195,12 @@ namespace picongpu
                             .config(mapper.getGridDim(), particlesBox)(
                                 binningBox,
                                 particlesBox,
-                                localOffset,
-                                globalOffset,
+                                domainInfo,
                                 axisKernels,
                                 binner->binningData.depositionData.functor,
                                 binner->binningData.axisExtentsND,
                                 extraData,
                                 fs.filter,
-                                Environment<>::get().SimulationDescription().getCurrentStep(),
                                 beginExternalCellsLocal,
                                 endExternalCellsLocal,
                                 mapper);


### PR DESCRIPTION
Added method to get the accurate floating position position of the moving window origin. 

Using this, I added support to the binning plugin for binning in a co-moving frame of the moving window, which obeys the starting and stopping properties of this window.  
This feature is required in #5414 