### PR TITLE
Fix alternate reduction operations in the binning plugin

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -355,17 +355,17 @@ Attribute                   Description
 
 Accumulation
 ============
-The binning plugin provides flexible options for accumulating data within bins. Instead of simply adding values to accumulate in a bin, users can utilize any alpaka atomic operation. This includes operations such as subtraction, minimum, maximum, AND, OR, XOR, and more.
+The binning plugin provides flexible options for accumulating data within bins. Instead of simply adding values to accumulate in a bin, users can utilize PMacc operations. This includes operations such as addition, multiplication, minimum, maximum, bitwise AND, bitwise OR, and bitwise XOR.
 This flexibility enables users to tailor the accumulation process to their specific needs. For instance, you might want to track the minimum or maximum value of a certain property within each bin.
-A list of available alpaka atomic operations can be found in the `alpaka documentation <https://alpaka-group.github.io/alpaka/Op_8hpp.html>`_. 
+A list of available PMacc operations can be found under `/include/pmacc/math/operation`. Only operations defining the `getMPI_Op` function and the `AlpakaAtomicOp` and `NeutralElement` traits are supported.
 
 .. note::
 
-	Only binary atomics on arithmetic types are supported. In particular CAS operations are not supported.
+	The operation is only viable if it has a corresponding MPI reduction operation, a neutral element, and a cooresponding alpaka operation. Only binary atomics on arithmetic types are supported. In particular CAS operations are not supported.
 
 
 The accumulate operation is passed as a template parameter to the `createBinner` functions.
-For example, to use the maximum operation for accumulation, you would pass the corresponding Alpaka atomic operation as a template parameter:
+For example, to use the maximum operation for accumulation, you would pass the corresponding PMacc operation as a template parameter:
 
 .. literalinclude:: ../../../../share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
    :language: c++
@@ -373,7 +373,7 @@ For example, to use the maximum operation for accumulation, you would pass the c
    :end-before: doc-include-end: atomics
    :dedent:
 
-Similarly, you can use other alpaka atomic operations such as `alpaka::AtomicMin`, `alpaka::AtomicSub`, `alpaka::AtomicAnd`, `alpaka::AtomicOr`, `alpaka::AtomicXor`, etc.
+Similarly, you can use other PMacc operations such as `pmacc::math::operation::Min`, `pmacc::math::operation::Add`, `pmacc::math::operation::BitwiseAnd`, `pmacc::math::operation::BitwiseOr`, `pmacc::math::operation::BitwiseXor`, etc.
 
 
 Example binning plugin usage: Laser Wakefield electron spectrometer

--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -26,7 +26,7 @@
 #    include "picongpu/plugins/binning/binners/ParticleBinner.hpp"
 #    include "picongpu/plugins/binning/utility.hpp"
 
-#    include <alpaka/atomic/Op.hpp>
+#    include <pmacc/math/operation/Add.hpp>
 
 #    include <memory>
 #    include <vector>
@@ -71,7 +71,7 @@ namespace picongpu
              * @return ParticleBinningData& reference to the created ParticleBinningData object.
              *         This can be used to further configure the binning setup if needed.
              */
-            template<typename T_AccumulateOp = alpaka::AtomicAdd, typename T_Extras = std::tuple<>>
+            template<typename T_AccumulateOp = pmacc::math::operation::Add, typename T_Extras = std::tuple<>>
             auto& addParticleBinner(
                 std::string const& binnerOutputName,
                 auto const& axisTupleObject,
@@ -109,7 +109,7 @@ namespace picongpu
              * @return FieldBinningData& reference to the created FieldBinningData object.
              *         This can be used to further configure the binning setup if needed.
              */
-            template<typename T_AccumulateOp = alpaka::AtomicAdd, typename T_Extras = std::tuple<>>
+            template<typename T_AccumulateOp = pmacc::math::operation::Add, typename T_Extras = std::tuple<>>
             auto& addFieldBinner(
                 std::string const& binnerOutputName,
                 auto const& axisTupleObject,

--- a/include/picongpu/plugins/binning/BinningData.hpp
+++ b/include/picongpu/plugins/binning/BinningData.hpp
@@ -24,6 +24,8 @@
 #    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"
 
 #    include <pmacc/dimensions/DataSpace.hpp>
+#    include <pmacc/math/operation/traits.hpp>
+#    include <pmacc/mpi/GetMPI_Op.hpp>
 
 #    include <cstdint>
 #    include <functional>
@@ -55,6 +57,11 @@ namespace picongpu
             typename T_AxisTuple,
             typename T_DepositionData,
             typename T_Extras>
+        requires requires {
+            typename pmacc::math::operation::traits::AlpakaAtomicOp_t<T_AccumulateOp>;
+            pmacc::mpi::getMPI_Op<T_AccumulateOp>();
+            pmacc::math::operation::traits::NeutralElement_v<T_AccumulateOp, typename T_DepositionData::QuantityType>;
+        }
         struct BinningDataBase
         {
             using DepositedQuantityType = typename T_DepositionData::QuantityType;

--- a/include/picongpu/plugins/binning/binners/Binner.hpp
+++ b/include/picongpu/plugins/binning/binners/Binner.hpp
@@ -79,6 +79,9 @@ namespace picongpu
                  */
                 this->histBuffer = std::make_unique<HostDeviceBuffer<TDepositedQuantity, 1>>(
                     binningData.axisExtentsND.productOfComponents());
+                this->histBuffer->getDeviceBuffer().setValue(
+                    pmacc::math::operation::traits::
+                        NeutralElement<typename TBinningData::AccumulationOp, TDepositedQuantity>::value);
                 isMain = reduce.hasResult(mpi::reduceMethods::Reduce());
             }
 
@@ -135,7 +138,7 @@ namespace picongpu
                     auto hReducedBuffer = std::make_unique<HostBuffer<TDepositedQuantity, 1>>(bufferExtent);
 
                     reduce(
-                        pmacc::math::operation::Add(),
+                        typename TBinningData::AccumulationOp(),
                         hReducedBuffer->data(),
                         this->histBuffer->getHostBuffer().data(),
                         bufferExtent[0],
@@ -157,7 +160,9 @@ namespace picongpu
                             currentStep);
                     }
                     // reset device buffer
-                    this->histBuffer->getDeviceBuffer().setValue(TDepositedQuantity(0.0));
+                    this->histBuffer->getDeviceBuffer().setValue(
+                        pmacc::math::operation::traits::
+                            NeutralElement<typename TBinningData::AccumulationOp, TDepositedQuantity>::value);
                     accumulateCounter = 0;
                 }
             }
@@ -186,7 +191,7 @@ namespace picongpu
                 auto hReducedBuffer = std::make_unique<HostBuffer<TDepositedQuantity, 1>>(bufferExtent);
 
                 reduce(
-                    pmacc::math::operation::Add(),
+                    typename TBinningData::AccumulationOp(),
                     hReducedBuffer->data(),
                     this->histBuffer->getHostBuffer().data(),
                     bufferExtent[0], // this is a 1D dataspace, just access it?

--- a/include/picongpu/plugins/binning/binners/FieldBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/FieldBinner.hpp
@@ -75,7 +75,8 @@ namespace picongpu
                     this->binningData.axisTuple,
                     [&](auto const& axis) -> decltype(auto) { return axis.getAxisKernel(); });
 
-                auto const functorBlock = FieldBinningKernel<typename TBinningData::AccumulationOp>{};
+                auto const functorBlock = FieldBinningKernel<
+                    pmacc::math::operation::traits::AlpakaAtomicOp_t<typename TBinningData::AccumulationOp>>{};
 
                 auto const userFunctorData = std::apply(
                     [&](auto&&... fields)

--- a/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
+++ b/include/picongpu/plugins/binning/binners/ParticleBinner.hpp
@@ -128,7 +128,8 @@ namespace picongpu
                             transformFieldInfo(std::forward<decltype(extras)>(extras))...);
                     },
                     this->binningData.extraData);
-                auto const functorBlock = ParticleBinningKernel<typename TBinningData::AccumulationOp>{};
+                auto const functorBlock = ParticleBinningKernel<
+                    pmacc::math::operation::traits::AlpakaAtomicOp_t<typename TBinningData::AccumulationOp>>{};
 
                 PMACC_LOCKSTEP_KERNEL(functorBlock)
                     .config(mapper.getGridDim(), particlesBox)(
@@ -199,8 +200,8 @@ namespace picongpu
                             { return pmacc::memory::tuple::make_tuple(std::forward<decltype(extras)>(extras)...); },
                             binner->binningData.extraData);
 
-                        auto const functorLeaving
-                            = LeavingParticleBinningKernel<typename TBinningData::AccumulationOp>{};
+                        auto const functorLeaving = LeavingParticleBinningKernel<
+                            pmacc::math::operation::traits::AlpakaAtomicOp_t<typename TBinningData::AccumulationOp>>{};
 
                         PMACC_LOCKSTEP_KERNEL(functorLeaving)
                             .config(mapper.getGridDim(), particlesBox)(

--- a/include/pmacc/math/operation/Add.hpp
+++ b/include/pmacc/math/operation/Add.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/math/operation/traits.hpp"
 #include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
@@ -44,6 +45,27 @@ namespace pmacc
                     dst += src;
                 }
             };
+
+            namespace traits
+            {
+                template<>
+                struct AlpakaAtomicOp<Add>
+                {
+                    using type = alpaka::AtomicAdd;
+                };
+
+                /**
+                 * @brief The neutral element for addition is 0.
+                 * @tparam T_Value The value type for which to get the neutral element.
+                 */
+                template<typename T_Value>
+                struct NeutralElement<Add, T_Value>
+                {
+                    static constexpr T_Value value = T_Value(0);
+                };
+
+            } // namespace traits
+
         } // namespace operation
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/operation/BitwiseAnd.hpp
+++ b/include/pmacc/math/operation/BitwiseAnd.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre
+/* Copyright 2025 Tapish Narwal
  *
  * This file is part of PMacc.
  *
@@ -25,31 +25,50 @@
 #include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
-#include <cstdint>
-
 namespace pmacc::math::operation
 {
-    //! logical and
-    struct And
+    //! Bitwise and
+    struct BitwiseAnd
     {
-        HDINLINE void operator()(uint32_t& destination, uint32_t const& source) const
+        HDINLINE void operator()(auto& destination, auto const& source) const
         {
-            destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
+            destination &= source;
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
+        HDINLINE void operator()(T_Worker const&, auto& destination, auto const& source) const
         {
-            destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
+            destination &= source;
         }
     };
+
+    namespace traits
+    {
+        template<>
+        struct AlpakaAtomicOp<BitwiseAnd>
+        {
+            using type = alpaka::AtomicAnd;
+        };
+
+        /**
+         * @brief The neutral element for BitwiseAnd is ~0 (all bits are 1).
+         * @tparam T_Value The value type for which to get the neutral element.
+         */
+        template<typename T_Value>
+        struct NeutralElement<BitwiseAnd, T_Value>
+        {
+            static constexpr T_Value value = T_Value(~0);
+        };
+
+    } // namespace traits
+
 } // namespace pmacc::math::operation
 
 namespace pmacc::mpi
 {
     template<>
-    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::And>()
+    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::BitwiseAnd>()
     {
-        return MPI_LAND;
+        return MPI_BAND;
     }
 } // namespace pmacc::mpi

--- a/include/pmacc/math/operation/BitwiseOr.hpp
+++ b/include/pmacc/math/operation/BitwiseOr.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre
+/* Copyright 2025 Tapish Narwal
  *
  * This file is part of PMacc.
  *
@@ -25,31 +25,50 @@
 #include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
-#include <cstdint>
-
 namespace pmacc::math::operation
 {
-    //! logical and
-    struct And
+    //! Bitwise or
+    struct BitwiseOr
     {
-        HDINLINE void operator()(uint32_t& destination, uint32_t const& source) const
+        HDINLINE void operator()(auto& destination, auto const& source) const
         {
-            destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
+            destination |= source;
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
+        HDINLINE void operator()(T_Worker const&, auto& destination, auto const& source) const
         {
-            destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
+            destination |= source;
         }
     };
+
+    namespace traits
+    {
+        template<>
+        struct AlpakaAtomicOp<BitwiseOr>
+        {
+            using type = alpaka::AtomicOr;
+        };
+
+        /**
+         * @brief The neutral element for BitwiseOr is 0.
+         * @tparam T_Value The value type for which to get the neutral element.
+         */
+        template<typename T_Value>
+        struct NeutralElement<BitwiseOr, T_Value>
+        {
+            static constexpr T_Value value = T_Value(0);
+        };
+
+    } // namespace traits
+
 } // namespace pmacc::math::operation
 
 namespace pmacc::mpi
 {
     template<>
-    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::And>()
+    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::BitwiseOr>()
     {
-        return MPI_LAND;
+        return MPI_BOR;
     }
 } // namespace pmacc::mpi

--- a/include/pmacc/math/operation/BitwiseXor.hpp
+++ b/include/pmacc/math/operation/BitwiseXor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Brian Marre
+/* Copyright 2025 Tapish Narwal
  *
  * This file is part of PMacc.
  *
@@ -25,31 +25,51 @@
 #include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
-#include <cstdint>
-
 namespace pmacc::math::operation
 {
-    //! logical and
-    struct And
+    //! Bitwise Xor
+    struct BitwiseXor
     {
-        HDINLINE void operator()(uint32_t& destination, uint32_t const& source) const
+        HDINLINE void operator()(auto& destination, auto const& source) const
         {
-            destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
+            destination ^= source;
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
+        HDINLINE void operator()(T_Worker const&, auto& destination, auto const& source) const
         {
-            destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
+            destination ^= source;
         }
     };
+
+    namespace traits
+    {
+        template<>
+        struct AlpakaAtomicOp<BitwiseXor>
+        {
+            using type = alpaka::AtomicXor;
+        };
+
+        /**
+         * @brief The neutral element for BitwiseXor is 0.
+         * @tparam T_Value The value type for which to get the neutral element.
+         */
+        template<typename T_Value>
+        struct NeutralElement<BitwiseXor, T_Value>
+        {
+            static constexpr T_Value value = T_Value(0);
+        };
+
+
+    } // namespace traits
+
 } // namespace pmacc::math::operation
 
 namespace pmacc::mpi
 {
     template<>
-    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::And>()
+    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::BitwiseXor>()
     {
-        return MPI_LAND;
+        return MPI_BXOR;
     }
 } // namespace pmacc::mpi

--- a/include/pmacc/math/operation/Max.hpp
+++ b/include/pmacc/math/operation/Max.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/algorithms/math.hpp"
+#include "pmacc/math/operation/traits.hpp"
 #include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
@@ -45,6 +46,28 @@ namespace pmacc
                     dst = alpaka::math::max(worker.getAcc(), dst, src);
                 }
             };
+
+            namespace traits
+            {
+                template<>
+                struct AlpakaAtomicOp<Max>
+                {
+                    using type = alpaka::AtomicMax;
+                };
+
+                /**
+                 * @brief The neutral element for Max is the minimum representable number.
+                 * @tparam T_Value The value type for which to get the neutral element.
+                 */
+                template<typename T_Value>
+                struct NeutralElement<Max, T_Value>
+                {
+                    static constexpr T_Value value = T_Value(std::numeric_limits<T_Value>::min());
+                };
+
+
+            } // namespace traits
+
         } // namespace operation
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/operation/Min.hpp
+++ b/include/pmacc/math/operation/Min.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "pmacc/algorithms/math.hpp"
+#include "pmacc/math/operation/traits.hpp"
 #include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
@@ -46,6 +47,27 @@ namespace pmacc
                     dst = alpaka::math::min(worker.getAcc(), dst, src);
                 }
             };
+
+            namespace traits
+            {
+                template<>
+                struct AlpakaAtomicOp<Min>
+                {
+                    using type = alpaka::AtomicMin;
+                };
+
+                /**
+                 * @brief The neutral element for Min is the maximum representable number.
+                 * @tparam T_Value The value type for which to get the neutral element.
+                 */
+                template<typename T_Value>
+                struct NeutralElement<Min, T_Value>
+                {
+                    static constexpr T_Value value = T_Value(std::numeric_limits<T_Value>::max());
+                };
+
+            } // namespace traits
+
         } // namespace operation
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/operation/Or.hpp
+++ b/include/pmacc/math/operation/Or.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/mpi/GetMPI_Op.hpp"
 #include "pmacc/types.hpp"
 
 #include <cstdint>
@@ -42,3 +43,12 @@ namespace pmacc::math::operation
         }
     };
 } // namespace pmacc::math::operation
+
+namespace pmacc::mpi
+{
+    template<>
+    HINLINE MPI_Op getMPI_Op<pmacc::math::operation::Or>()
+    {
+        return MPI_LOR;
+    }
+} // namespace pmacc::mpi

--- a/include/pmacc/math/operation/Sub.hpp
+++ b/include/pmacc/math/operation/Sub.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "pmacc/math/operation/traits.hpp"
 #include "pmacc/types.hpp"
 
 namespace pmacc
@@ -43,6 +44,16 @@ namespace pmacc
                     dst -= src;
                 }
             };
+
+            namespace traits
+            {
+                template<>
+                struct AlpakaAtomicOp<Sub>
+                {
+                    using type = alpaka::AtomicSub;
+                };
+            } // namespace traits
+
         } // namespace operation
     } // namespace math
 } // namespace pmacc

--- a/include/pmacc/math/operation/traits.hpp
+++ b/include/pmacc/math/operation/traits.hpp
@@ -1,0 +1,49 @@
+/* Copyright 2025 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace pmacc::math::operation::traits
+{
+
+    /**
+     * @brief Trait to get the alpaka atomic operation for a pmacc math operation
+     * @tparam T_Op The mathematical operation (e.g. pmacc::math::operation::Add)
+     */
+    template<typename T_Op>
+    struct AlpakaAtomicOp;
+
+    template<typename T_Op>
+    using AlpakaAtomicOp_t = typename AlpakaAtomicOp<T_Op>::type;
+
+    /**
+     * @brief Trait to get the neutral element for a mathematical operation.
+     * @tparam T_Op The mathematical operation (e.g. pmacc::math::operation::Add)
+     * @tparam T_Value The value type for which to get the neutral element.
+     */
+    template<typename T_Op, typename T_Value>
+    struct NeutralElement;
+
+    template<typename T_Op, typename T_Value>
+    inline constexpr T_Value NeutralElement_v = NeutralElement<T_Op, T_Value>::value;
+
+
+} // namespace pmacc::math::operation::traits

--- a/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/binningSetup.param
@@ -178,7 +178,7 @@ namespace picongpu
 
             // doc-include-start: atomics
             binningCreator
-                .addParticleBinner<alpaka::AtomicMax>(
+                .addParticleBinner<pmacc::math::operation::Max>(
                     "particleBinning",
                     createTuple(ax_timeStep, ax_py),
                     speciesTuple,


### PR DESCRIPTION
The binning plugin now correctly reduces the histograms. Earlier the MPI reduction between GPUs was always done by addition and the neutral element for all reduction operations was assumed to be zero.
This was broken since the feature release in #5289.
This is fixed now and binning uses the correct MPI op and neutral element.

For users, this means that they must use `pmacc::math::operation`s now as the accumulate op, instead of alpaka atomics.
Documentation has been updated with valid ops. 