### PR TITLE
Add lasers to picmi

### DIFF
--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -7,6 +7,7 @@ from .grid import Cartesian3DGrid
 from .solver import ElectromagneticSolver
 from .gaussian_laser import GaussianLaser
 from .plane_wave_laser import PlaneWaveLaser
+from .dispersive_pulse_laser import DispersivePulseLaser
 from .species import Species
 from .layout import PseudoRandomLayout, GriddedLayout
 from . import constants
@@ -43,6 +44,7 @@ __all__ = [
     "ElectromagneticSolver",
     "GaussianLaser",
     "PlaneWaveLaser",
+    "DispersivePulseLaser",
     "Species",
     "PseudoRandomLayout",
     "GriddedLayout",

--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -5,9 +5,7 @@ PICMI for PIConGPU
 from .simulation import Simulation
 from .grid import Cartesian3DGrid
 from .solver import ElectromagneticSolver
-from .gaussian_laser import GaussianLaser
-from .plane_wave_laser import PlaneWaveLaser
-from .dispersive_pulse_laser import DispersivePulseLaser
+from .lasers import DispersivePulseLaser, GaussianLaser, PlaneWaveLaser, FromOpenPMDPulseLaser
 from .species import Species
 from .layout import PseudoRandomLayout, GriddedLayout
 from . import constants
@@ -42,9 +40,10 @@ __all__ = [
     "Simulation",
     "Cartesian3DGrid",
     "ElectromagneticSolver",
+    "DispersivePulseLaser",
+    "FromOpenPMDPulseLaser",
     "GaussianLaser",
     "PlaneWaveLaser",
-    "DispersivePulseLaser",
     "Species",
     "PseudoRandomLayout",
     "GriddedLayout",

--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -6,6 +6,7 @@ from .simulation import Simulation
 from .grid import Cartesian3DGrid
 from .solver import ElectromagneticSolver
 from .gaussian_laser import GaussianLaser
+from .plane_wave_laser import PlaneWaveLaser
 from .species import Species
 from .layout import PseudoRandomLayout, GriddedLayout
 from . import constants
@@ -41,6 +42,7 @@ __all__ = [
     "Cartesian3DGrid",
     "ElectromagneticSolver",
     "GaussianLaser",
+    "PlaneWaveLaser",
     "Species",
     "PseudoRandomLayout",
     "GriddedLayout",

--- a/lib/python/picongpu/picmi/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/dispersive_pulse_laser.py
@@ -1,0 +1,217 @@
+"""
+This file is part of PIConGPU.
+Copyright 2021-2024 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from ..pypicongpu import laser
+from . import constants
+
+import math
+
+import typeguard
+import typing
+
+
+@typeguard.typechecked
+class DispersivePulseLaser:
+    """
+    Specifies a dispersive Gaussian pulse with dispersion parameters
+
+    Parameters
+    ----------
+    wavelength: float
+        Laser wavelength [m], defined as :math:`\\lambda_0` in the above formula
+
+    duration: float
+        Duration of the Gaussian pulse [s], defined as :math:`\\tau` in the above formula
+
+    propagation_direction: unit vector of length 3 of floats
+        Direction of propagation [1]
+
+    polarization_direction: unit vector of length 3 of floats
+        Direction of polarization [1]
+
+    focal_position: vector of length 3 of floats
+        Position of the laser focus [m]
+
+    centroid_position: vector of length 3 of floats
+        Position of the laser centroid at time 0 [m]
+
+    a0: float
+        Normalized vector potential at focus
+        Specify either a0 or E0 (E0 takes precedence).
+
+    E0: float
+        Maximum amplitude of the laser field [V/m]
+        Specify either a0 or E0 (E0 takes precedence).
+
+    phi0: float
+        Carrier envelope phase (CEP) [rad]
+
+    spectral_support: float
+        Width of the spectral support for the discrete Fourier transform [none]
+
+    sd_si: float
+        Spatial dispersion in focus [m*s]
+
+    ad_si: float
+        Angular dispersion in focus [rad*s]
+
+    gdd_si: float
+        Group velocity dispersion in focus [s^2]
+
+    tod_si: float
+        Third order dispersion in focus [s^3]
+    """
+
+    def __init__(
+        self,
+        waist,
+        wavelength,
+        duration,
+        propagation_direction,
+        polarization_direction,
+        focal_position,
+        centroid_position,
+        a0=None,
+        E0=None,
+        phi0=None,
+        picongpu_phase: float = 0.0,
+        picongpu_polarization_type=(laser.DispersivePulseLaser.PolarizationType.LINEAR),
+        picongpu_spectral_support: float = 6.0,
+        picongpu_sd_si: float = 0.0,
+        picongpu_ad_si: float = 0.0,
+        picongpu_gdd_si: float = 0.0,
+        picongpu_tod_si: float = 0.0,
+        # make sure to always place Huygens-surface inside PML-boundaries,
+        # default is valid for standard PMLs
+        # @todo create check for insufficient dimension
+        # @todo create check in simulation for conflict between PMLs and
+        # Huygens-surfaces
+        picongpu_huygens_surface_positions: typing.List[typing.List[int]] = [
+            [16, -16],
+            [16, -16],
+            [16, -16],
+        ],
+        **kw,
+    ):
+        assert E0 is not None or a0 is not None, "One of E0 or a0 must be speficied"
+
+        k0 = 2.0 * math.pi / wavelength
+        if E0 is None:
+            E0 = a0 * constants.m_e * constants.c**2 * k0 / constants.q_e
+        if a0 is None:
+            a0 = E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
+
+        self.waist = waist
+        self.wavelength = wavelength
+        self.k0 = k0
+        self.duration = duration
+        self.focal_position = focal_position
+        self.centroid_position = centroid_position
+        self.propagation_direction = propagation_direction
+        self.polarization_direction = polarization_direction
+        self.a0 = a0
+        self.E0 = E0
+        self.phi0 = phi0
+
+        self.picongpu_phase = picongpu_phase
+        self.picongpu_polarization_type = picongpu_polarization_type
+        self.picongpu_spectral_support = picongpu_spectral_support
+        self.picongpu_sd_si = picongpu_sd_si
+        self.picongpu_ad_si = picongpu_ad_si
+        self.picongpu_gdd_si = picongpu_gdd_si
+        self.picongpu_tod_si = picongpu_tod_si
+        self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+
+    """PICMI object for Dispersive Pulse Laser"""
+
+    def scalarProduct(self, a: typing.List[float], b: typing.List[float]) -> float:
+        assert len(a) == len(b), "the scalar product is only defined for two \
+            vector of equal dimension"
+
+        result = 0.0
+        for i in range(len(a)):
+            result += a[i] * b[i]
+
+        return result
+
+    @staticmethod
+    def testRelativeError(trueValue, testValue, relativeErrorLimit):
+        return abs((testValue - trueValue) / trueValue) < relativeErrorLimit
+
+    def get_as_pypicongpu(self) -> laser.DispersivePulseLaser:
+        assert self.testRelativeError(
+            1,
+            self.scalarProduct(self.polarization_direction, self.polarization_direction),
+            1e-9,
+        ), "the polarization direction vector must be normalized"
+
+        # check for excessive phase values to avoid numerical precision errors
+        assert abs(self.picongpu_phase) <= 2 * math.pi, "abs(phase) must be < 2*pi"
+
+        # check that initialising from y_min-plane only is sensible
+        assert (
+            self.scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) > 0.0
+        ), "laser propagation parallel to the y-plane or pointing outside \
+            from the inside of the simulation box is not supported by this \
+            laser in PIConGPU"
+        assert self.testRelativeError(
+            1,
+            (
+                self.propagation_direction[0] ** 2
+                + self.propagation_direction[1] ** 2
+                + self.propagation_direction[2] ** 2
+            ),
+            1e-9,
+        ), "propagation vector must be normalized"
+
+        # check centroid outside box
+        assert self.centroid_position[1] <= 0, "the laser maximum must be \
+            outside of the \
+            simulation box, otherwise it is impossible to correctly initialize\
+            it using a huygens surface in the box, centroid_y <= 0"
+        # @todo implement check that laser field strength sufficiently small
+        # at simulation box boundary
+
+        # check polarization vector normalization
+
+        assert self.testRelativeError(
+            1,
+            (
+                self.propagation_direction[0] ** 2
+                + self.propagation_direction[1] ** 2
+                + self.propagation_direction[2] ** 2
+            ),
+            1e-9,
+        ), "polarization vector must be normalized"
+
+        pypicongpu_laser = laser.DispersivePulseLaser()
+        pypicongpu_laser.wavelength = self.wavelength
+        pypicongpu_laser.waist = self.waist
+        pypicongpu_laser.duration = self.duration
+        pypicongpu_laser.focus_pos = self.focal_position
+        pypicongpu_laser.phase = self.picongpu_phase
+        pypicongpu_laser.E0 = self.E0
+
+        pypicongpu_laser.pulse_init = max(
+            -2 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration,
+            15,
+        )
+        # unit: duration
+
+        pypicongpu_laser.polarization_type = self.picongpu_polarization_type
+        pypicongpu_laser.polarization_direction = self.polarization_direction
+        pypicongpu_laser.propagation_direction = self.propagation_direction
+
+        pypicongpu_laser.spectral_support = self.picongpu_spectral_support
+        pypicongpu_laser.sd_si = self.picongpu_sd_si
+        pypicongpu_laser.ad_si = self.picongpu_ad_si
+        pypicongpu_laser.gdd_si = self.picongpu_gdd_si
+        pypicongpu_laser.tod_si = self.picongpu_tod_si
+
+        pypicongpu_laser.huygens_surface_positions = self.picongpu_huygens_surface_positions
+
+        return pypicongpu_laser

--- a/lib/python/picongpu/picmi/lasers/__init__.py
+++ b/lib/python/picongpu/picmi/lasers/__init__.py
@@ -1,0 +1,13 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .dispersive_pulse_laser import DispersivePulseLaser
+from .from_openpmd_pulse_laser import FromOpenPMDPulseLaser
+from .gaussian_laser import GaussianLaser
+from .plane_wave_laser import PlaneWaveLaser
+
+__all__ = ["DispersivePulseLaser", "FromOpenPMDPulseLaser", "GaussianLaser", "PlaneWaveLaser"]

--- a/lib/python/picongpu/picmi/lasers/__init__.py
+++ b/lib/python/picongpu/picmi/lasers/__init__.py
@@ -9,5 +9,6 @@ from .dispersive_pulse_laser import DispersivePulseLaser
 from .from_openpmd_pulse_laser import FromOpenPMDPulseLaser
 from .gaussian_laser import GaussianLaser
 from .plane_wave_laser import PlaneWaveLaser
+from .polarization_type import PolarizationType
 
-__all__ = ["DispersivePulseLaser", "FromOpenPMDPulseLaser", "GaussianLaser", "PlaneWaveLaser"]
+__all__ = ["DispersivePulseLaser", "FromOpenPMDPulseLaser", "GaussianLaser", "PlaneWaveLaser", "PolarizationType"]

--- a/lib/python/picongpu/picmi/lasers/base_laser.py
+++ b/lib/python/picongpu/picmi/lasers/base_laser.py
@@ -1,0 +1,84 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+
+import math
+import typing
+
+import numpy as np
+
+from .. import constants
+
+
+class BaseLaser:
+    """
+    Base class for all PICMI laser implementations to reduce code duplication
+    """
+
+    def _propagation_connects_centroid_and_focus(self):
+        # check that propagation_direction is parallel to the difference of focal_position and centroid_position
+        diff_vec = self.difference(self.focal_position, self.centroid_position)
+        cross_vec = self.crossProduct(diff_vec, self.propagation_direction)
+        length_of_cross_product = self.scalarProduct(cross_vec, cross_vec)
+        return length_of_cross_product < 1.0e-5
+
+    def _compute_E0_and_a0(self, k0, E0, a0):
+        if E0 is not None or a0 is not None:
+            raise ValueError(f"One of E0 or a0 must be speficied. You gave {E0=} and {a0=}.")
+        if E0 is not None and a0 is not None:
+            raise ValueError("At least one of E0 or a0 must be specified.")
+
+        if E0 is None:
+            E0 = a0 * constants.m_e * constants.c**2 * k0 / constants.q_e
+        if a0 is None:
+            a0 = E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
+        return a0, E0
+
+    def scalarProduct(self, a: typing.List[float], b: typing.List[float]) -> float:
+        return np.dot(a, b).tolist()
+
+    def crossProduct(self, a: typing.List[float], b: typing.List[float]) -> typing.List[float]:
+        return np.linalg.cross(a, b).tolist()
+
+    def difference(self, a: typing.List[float], b: typing.List[float]) -> typing.List[float]:
+        return (np.asarray(a) - b).tolist()
+
+    @staticmethod
+    def testRelativeError(trueValue, testValue, relativeErrorLimit):
+        return abs((testValue - trueValue) / trueValue) < relativeErrorLimit
+
+    def _validate_common_properties(self):
+        """Common validation logic for all lasers"""
+        if not np.allclose(n := np.linalg.norm(self.polarization_direction), 1):
+            raise ValueError(
+                "The polarization direction vector must be normalized. "
+                f"You gave {self.polarization_direction=} with norm {n}."
+            )
+
+        if not np.allclose(n := np.linalg.norm(self.propagation_direction), 1):
+            raise ValueError(
+                "The propagation direction vector must be normalized. "
+                f"You gave {self.propagation_direction=} with norm {n}."
+            )
+
+        if abs(self.phi0) > 2 * math.pi:
+            raise ValueError(f"abs(phase) must be < 2*pi. You gave{self.phi0=}.")
+
+        if self.scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) <= 0.0:
+            raise ValueError(
+                "Laser propagation parallel to the y-plane or pointing outside "
+                "from the inside of the simulation box is not supported by this "
+                f"laser in PIConGPU. You gave {self.propagation_direction=}."
+            )
+
+        if self.centroid_position[1] > 0:
+            raise ValueError(
+                "The laser maximum must be outside of the "
+                "simulation box, otherwise it is impossible to correctly initialize"
+                "it using a huygens surface in the box, centroid_y <= 0. "
+                f"You gave {self.centroid_position=}."
+            )

--- a/lib/python/picongpu/picmi/lasers/base_laser.py
+++ b/lib/python/picongpu/picmi/lasers/base_laser.py
@@ -5,13 +5,23 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-
-import math
-import typing
+import logging
 
 import numpy as np
 
 from .. import constants
+
+
+def scalarProduct(a: list[float], b: list[float]) -> float:
+    return np.dot(a, b).tolist()
+
+
+def crossProduct(a: list[float], b: list[float]) -> list[float]:
+    return np.cross(a, b).tolist()
+
+
+def difference(a: list[float], b: list[float]) -> list[float]:
+    return (np.asarray(a) - b).tolist()
 
 
 class BaseLaser:
@@ -21,9 +31,9 @@ class BaseLaser:
 
     def _propagation_connects_centroid_and_focus(self):
         # check that propagation_direction is parallel to the difference of focal_position and centroid_position
-        diff_vec = self.difference(self.focal_position, self.centroid_position)
-        cross_vec = self.crossProduct(diff_vec, self.propagation_direction)
-        length_of_cross_product = self.scalarProduct(cross_vec, cross_vec)
+        diff_vec = difference(self.focal_position, self.centroid_position)
+        cross_vec = crossProduct(diff_vec, self.propagation_direction)
+        length_of_cross_product = scalarProduct(cross_vec, cross_vec)
         return length_of_cross_product < 1.0e-5
 
     def _compute_E0_and_a0(self, k0, E0, a0):
@@ -38,21 +48,22 @@ class BaseLaser:
             a0 = E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
         return a0, E0
 
-    def scalarProduct(self, a: typing.List[float], b: typing.List[float]) -> float:
-        return np.dot(a, b).tolist()
-
-    def crossProduct(self, a: typing.List[float], b: typing.List[float]) -> typing.List[float]:
-        return np.linalg.cross(a, b).tolist()
-
-    def difference(self, a: typing.List[float], b: typing.List[float]) -> typing.List[float]:
-        return (np.asarray(a) - b).tolist()
-
-    @staticmethod
-    def testRelativeError(trueValue, testValue, relativeErrorLimit):
-        return abs((testValue - trueValue) / trueValue) < relativeErrorLimit
+    def _compute_pulse_init(self):
+        pulse_init = (
+            -2.0 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration
+        )  # unit: multiple of laser pulse duration
+        # @todo extend this to other propagation directions than +y
+        if pulse_init < 3.0:
+            logging.warning(
+                "set centroid_position and propagation_direction indicate that laser "
+                + "initalization might be too short.\n"
+                + f"Details: {pulse_init=} < 3"
+            )
+        return pulse_init
 
     def _validate_common_properties(self):
         """Common validation logic for all lasers"""
+
         if not np.allclose(n := np.linalg.norm(self.polarization_direction), 1):
             raise ValueError(
                 "The polarization direction vector must be normalized. "
@@ -65,14 +76,11 @@ class BaseLaser:
                 f"You gave {self.propagation_direction=} with norm {n}."
             )
 
-        if abs(self.phi0) > 2 * math.pi:
-            raise ValueError(f"abs(phase) must be < 2*pi. You gave{self.phi0=}.")
-
-        if self.scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) <= 0.0:
+        if scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) <= 0.0:
             raise ValueError(
                 "Laser propagation parallel to the y-plane or pointing outside "
                 "from the inside of the simulation box is not supported by this "
-                f"laser in PIConGPU. You gave {self.propagation_direction=}."
+                f"laser in PICMI. You gave {self.propagation_direction=}."
             )
 
         if self.centroid_position[1] > 0:

--- a/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
@@ -11,7 +11,6 @@ import typing
 import typeguard
 
 from ...pypicongpu import laser
-from .. import constants
 from .base_laser import BaseLaser
 from .polarization_type import PolarizationType
 
@@ -136,13 +135,7 @@ class DispersivePulseLaser(BaseLaser):
         pypicongpu_laser.focus_pos = self.focal_position
         pypicongpu_laser.phase = self.phi0
         pypicongpu_laser.E0 = self.E0
-
-        pypicongpu_laser.pulse_init = max(
-            -2 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration,
-            15,
-        )
-        # unit: duration
-
+        pypicongpu_laser.pulse_init = self._compute_pulse_init()
         pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
         pypicongpu_laser.polarization_direction = self.polarization_direction
         pypicongpu_laser.propagation_direction = self.propagation_direction

--- a/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
@@ -5,17 +5,19 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from ...pypicongpu import laser
-from .. import constants
-
 import math
+import typing
 
 import typeguard
-import typing
+
+from ...pypicongpu import laser
+from .. import constants
+from .base_laser import BaseLaser
+from .polarization_type import PolarizationType
 
 
 @typeguard.typechecked
-class DispersivePulseLaser:
+class DispersivePulseLaser(BaseLaser):
     """
     Specifies a dispersive Gaussian pulse with dispersion parameters
 
@@ -77,9 +79,8 @@ class DispersivePulseLaser:
         centroid_position,
         a0=None,
         E0=None,
-        phi0=None,
-        picongpu_phase: float = 0.0,
-        picongpu_polarization_type=(laser.DispersivePulseLaser.PolarizationType.LINEAR),
+        phi0: float = 0.0,
+        picongpu_polarization_type=(PolarizationType.LINEAR),
         picongpu_spectral_support: float = 6.0,
         picongpu_sd_si: float = 0.0,
         picongpu_ad_si: float = 0.0,
@@ -97,27 +98,24 @@ class DispersivePulseLaser:
         ],
         **kw,
     ):
-        assert E0 is not None or a0 is not None, "One of E0 or a0 must be speficied"
-
-        k0 = 2.0 * math.pi / wavelength
-        if E0 is None:
-            E0 = a0 * constants.m_e * constants.c**2 * k0 / constants.q_e
-        if a0 is None:
-            a0 = E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
+        if waist <= 0:
+            raise ValueError(f"waist must be > 0. You gave {waist=}.")
+        if wavelength <= 0:
+            raise ValueError(f"wavelength must be > 0. You gave {wavelength=}.")
+        if duration <= 0:
+            raise ValueError(f"laser pulse duration must be > 0. You gave {duration=}.")
 
         self.waist = waist
         self.wavelength = wavelength
-        self.k0 = k0
+        self.k0 = 2.0 * math.pi / wavelength
         self.duration = duration
         self.focal_position = focal_position
         self.centroid_position = centroid_position
         self.propagation_direction = propagation_direction
         self.polarization_direction = polarization_direction
-        self.a0 = a0
-        self.E0 = E0
+        self.a0, self.E0 = self._compute_E0_and_a0(self.k0, E0, a0)
         self.phi0 = phi0
 
-        self.picongpu_phase = picongpu_phase
         self.picongpu_polarization_type = picongpu_polarization_type
         self.picongpu_spectral_support = picongpu_spectral_support
         self.picongpu_sd_si = picongpu_sd_si
@@ -126,74 +124,17 @@ class DispersivePulseLaser:
         self.picongpu_tod_si = picongpu_tod_si
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
 
-    """PICMI object for Dispersive Pulse Laser"""
-
-    def scalarProduct(self, a: typing.List[float], b: typing.List[float]) -> float:
-        assert len(a) == len(b), "the scalar product is only defined for two \
-            vector of equal dimension"
-
-        result = 0.0
-        for i in range(len(a)):
-            result += a[i] * b[i]
-
-        return result
-
-    @staticmethod
-    def testRelativeError(trueValue, testValue, relativeErrorLimit):
-        return abs((testValue - trueValue) / trueValue) < relativeErrorLimit
-
     def get_as_pypicongpu(self) -> laser.DispersivePulseLaser:
-        assert self.testRelativeError(
-            1,
-            self.scalarProduct(self.polarization_direction, self.polarization_direction),
-            1e-9,
-        ), "the polarization direction vector must be normalized"
-
-        # check for excessive phase values to avoid numerical precision errors
-        assert abs(self.picongpu_phase) <= 2 * math.pi, "abs(phase) must be < 2*pi"
-
-        # check that initialising from y_min-plane only is sensible
+        self._validate_common_properties()
         assert (
-            self.scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) > 0.0
-        ), "laser propagation parallel to the y-plane or pointing outside \
-            from the inside of the simulation box is not supported by this \
-            laser in PIConGPU"
-        assert self.testRelativeError(
-            1,
-            (
-                self.propagation_direction[0] ** 2
-                + self.propagation_direction[1] ** 2
-                + self.propagation_direction[2] ** 2
-            ),
-            1e-9,
-        ), "propagation vector must be normalized"
-
-        # check centroid outside box
-        assert self.centroid_position[1] <= 0, "the laser maximum must be \
-            outside of the \
-            simulation box, otherwise it is impossible to correctly initialize\
-            it using a huygens surface in the box, centroid_y <= 0"
-        # @todo implement check that laser field strength sufficiently small
-        # at simulation box boundary
-
-        # check polarization vector normalization
-
-        assert self.testRelativeError(
-            1,
-            (
-                self.propagation_direction[0] ** 2
-                + self.propagation_direction[1] ** 2
-                + self.propagation_direction[2] ** 2
-            ),
-            1e-9,
-        ), "polarization vector must be normalized"
-
+            self._propagation_connects_centroid_and_focus()
+        ), "propagation_direction must connect centroid_position and focus_position"
         pypicongpu_laser = laser.DispersivePulseLaser()
         pypicongpu_laser.wavelength = self.wavelength
         pypicongpu_laser.waist = self.waist
         pypicongpu_laser.duration = self.duration
         pypicongpu_laser.focus_pos = self.focal_position
-        pypicongpu_laser.phase = self.picongpu_phase
+        pypicongpu_laser.phase = self.phi0
         pypicongpu_laser.E0 = self.E0
 
         pypicongpu_laser.pulse_init = max(
@@ -202,7 +143,7 @@ class DispersivePulseLaser:
         )
         # unit: duration
 
-        pypicongpu_laser.polarization_type = self.picongpu_polarization_type
+        pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
         pypicongpu_laser.polarization_direction = self.polarization_direction
         pypicongpu_laser.propagation_direction = self.propagation_direction
 

--- a/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
@@ -1,12 +1,12 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
+Copyright 2025 PIConGPU contributors
 Authors: Julian Lenz
 License: GPLv3+
 """
 
-from ..pypicongpu import laser
-from . import constants
+from ...pypicongpu import laser
+from .. import constants
 
 import math
 

--- a/lib/python/picongpu/picmi/lasers/from_openpmd_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/from_openpmd_pulse_laser.py
@@ -1,0 +1,63 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from ...pypicongpu import laser
+
+import typeguard
+
+
+@typeguard.typechecked
+class FromOpenPMDPulseLaser:
+    """PICMI object for FromOpenPMDPulseLaser"""
+
+    def __init__(
+        self,
+        propagation_direction,
+        polarization_direction,
+        time_offset_si,
+        file_path,
+        iteration,
+        dataset_name,
+        datatype,
+        polarisationAxisOpenPMD,
+        propagationAxisOpenPMD,
+        # make sure to always place Huygens-surface inside PML-boundaries,
+        # default is valid for standard PMLs
+        # @todo create check for insufficient dimension
+        # @todo create check in simulation for conflict between PMLs and
+        # Huygens-surfaces
+        picongpu_huygens_surface_positions: list[list[int]] = [
+            [16, -16],
+            [16, -16],
+            [16, -16],
+        ],
+    ):
+        self.propagation_direction = propagation_direction
+        self.polarization_direction = polarization_direction
+        self.file_path = file_path
+        self.iteration = iteration
+        self.dataset_name = dataset_name
+        self.datatype = datatype
+        self.time_offset_si = time_offset_si
+        self.polarisationAxisOpenPMD = polarisationAxisOpenPMD
+        self.propagationAxisOpenPMD = propagationAxisOpenPMD
+        self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+
+    def get_as_pypicongpu(self) -> laser.FromOpenPMDPulseLaser:
+        pypicongpu_laser = laser.FromOpenPMDPulseLaser()
+        pypicongpu_laser.propagation_direction = self.propagation_direction
+        pypicongpu_laser.polarization_direction = self.polarization_direction
+        pypicongpu_laser.file_path = self.file_path
+        pypicongpu_laser.iteration = self.iteration
+        pypicongpu_laser.dataset_name = self.dataset_name
+        pypicongpu_laser.datatype = self.datatype
+        pypicongpu_laser.time_offset_si = self.time_offset_si
+        pypicongpu_laser.polarisationAxisOpenPMD = self.polarisationAxisOpenPMD
+        pypicongpu_laser.propagationAxisOpenPMD = self.propagationAxisOpenPMD
+        pypicongpu_laser.huygens_surface_positions = self.picongpu_huygens_surface_positions
+
+        return pypicongpu_laser

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -5,14 +5,12 @@ Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+
 """
 
-import logging
 import typing
 
 import picmistandard
 import typeguard
 
 from ...pypicongpu import laser, util
-from .. import constants
 from .base_laser import BaseLaser
 from .polarization_type import PolarizationType
 
@@ -95,18 +93,7 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         pypicongpu_laser.focus_pos = self.focal_position
         pypicongpu_laser.phase = self.phi0
         pypicongpu_laser.E0 = self.E0
-
-        pypicongpu_laser.pulse_init = (
-            -2.0 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration
-        )  # unit: multiple of laser pulse duration
-        # @todo extend this to other propagation directions than +y
-        if pypicongpu_laser.pulse_init < 3.0:
-            logging.warning(
-                "set centroid_position and propagation_direction indicate that laser "
-                + "initalization might be too short.\n"
-                + f"Details: laser.pulse_init = {pypicongpu_laser.pulse_init} < 3"
-            )
-
+        pypicongpu_laser.pulse_init = self._compute_pulse_init()
         pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
         pypicongpu_laser.polarization_direction = self.polarization_direction
 

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -5,8 +5,8 @@ Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+
 """
 
-from ..pypicongpu import util, laser
-from . import constants
+from ...pypicongpu import util, laser
+from .. import constants
 
 import picmistandard
 import math

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -5,45 +5,21 @@ Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+
 """
 
-from ...pypicongpu import util, laser
-from .. import constants
+import logging
+import typing
 
 import picmistandard
-import math
-
 import typeguard
-import typing
-import logging
+
+from ...pypicongpu import laser, util
+from .. import constants
+from .base_laser import BaseLaser
+from .polarization_type import PolarizationType
 
 
 @typeguard.typechecked
-class GaussianLaser(picmistandard.PICMI_GaussianLaser):
+class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
     """PICMI object for Gaussian Laser"""
-
-    def scalarProduct(self, a: typing.List[float], b: typing.List[float]) -> float:
-        assert len(a) == len(b), "the scalar product is only defined for two \
-            vector of equal dimension"
-
-        result = 0.0
-        for i in range(len(a)):
-            result += a[i] * b[i]
-
-        return result
-
-    def crossProduct(self, a: typing.List[float], b: typing.List[float]) -> typing.List[float]:
-        assert len(a) == len(b) == 3, "the cross product is only defined for 3d vectors"
-        return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
-
-    def difference(self, a: typing.List[float], b: typing.List[float]) -> typing.List[float]:
-        assert len(a) == len(b), "the difference between two vectors is only defined if they have the same length"
-        result = []
-        for i in range(len(a)):
-            result.append(a[i] - b[i])
-        return result
-
-    @staticmethod
-    def testRelativeError(trueValue, testValue, relativeErrorLimit):
-        return abs((testValue - trueValue) / trueValue) < relativeErrorLimit
 
     def __init__(
         self,
@@ -54,10 +30,9 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         polarization_direction,
         focal_position,
         centroid_position,
-        picongpu_polarization_type=(laser.GaussianLaser.PolarizationType.LINEAR),
+        picongpu_polarization_type=(PolarizationType.LINEAR),
         picongpu_laguerre_modes: typing.Optional[typing.List[float]] = None,
         picongpu_laguerre_phases: typing.Optional[typing.List[float]] = None,
-        picongpu_phase: float = 0.0,
         # make sure to always place Huygens-surface inside PML-boundaries,
         # default is valid for standard PMLs
         # @todo create check for insufficient dimension
@@ -71,11 +46,11 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         **kw,
     ):
         if waist <= 0:
-            raise ValueError("waist must be > 0")
+            raise ValueError(f"waist must be > 0. You gave {waist=}.")
         if wavelength <= 0:
-            raise ValueError("wavelength must be > 0")
+            raise ValueError(f"wavelength must be > 0. You gave {wavelength=}.")
         if duration <= 0:
-            raise ValueError("laser pulse duration must be > 0")
+            raise ValueError(f"laser pulse duration must be > 0. You gave {duration=}.")
 
         assert (picongpu_laguerre_modes is None and picongpu_laguerre_phases is None) or (
             picongpu_laguerre_modes is not None and picongpu_laguerre_phases is not None
@@ -85,7 +60,6 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         self.picongpu_polarization_type = picongpu_polarization_type
         self.picongpu_laguerre_modes = picongpu_laguerre_modes
         self.picongpu_laguerre_phases = picongpu_laguerre_phases
-        self.picongpu_phase = picongpu_phase
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
 
         super().__init__(
@@ -99,6 +73,8 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
             **kw,
         )
 
+        self.phi0 = self.phi0 or 0.0
+
     def get_as_pypicongpu(self) -> laser.GaussianLaser:
         util.unsupported("laser name", self.name)
         util.unsupported("laser zeta", self.zeta)
@@ -107,66 +83,17 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         # unsupported: fill_in (do not warn, b/c we don't know if it has been
         # set explicitly, and always warning is bad)
 
-        assert self.testRelativeError(
-            1,
-            self.scalarProduct(self.polarization_direction, self.polarization_direction),
-            1e-9,
-        ), "the polarization direction vector must be normalized"
-
-        # check for excessive phase values to avoid numerical precision errors
-        assert abs(self.picongpu_phase) <= 2 * math.pi, "abs(phase) must be < 2*pi"
-
-        # check that initialising from y_min-plane only is sensible
+        self._validate_common_properties()
         assert (
-            self.scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) > 0.0
-        ), "laser propagation parallel to the y-plane or pointing outside \
-            from the inside of the simulation box is not supported by this \
-            laser in PIConGPU"
-        assert self.testRelativeError(
-            1,
-            (
-                self.propagation_direction[0] ** 2
-                + self.propagation_direction[1] ** 2
-                + self.propagation_direction[2] ** 2
-            ),
-            1e-9,
-        ), "propagation vector must be normalized"
-
-        # check centroid outside box
-        assert self.centroid_position[1] <= 0, "the laser maximum must be \
-            outside of the \
-            simulation box, otherwise it is impossible to correctly initialize\
-            it using a huygens surface in the box, centroid_y <= 0"
-        # @todo implement check that laser field strength sufficiently small
-        # at simulation box boundary
-        # @todo extend this to other propagation directions than +y
-
-        # check polarization vector normalization
-
-        assert self.testRelativeError(
-            1,
-            (
-                self.propagation_direction[0] ** 2
-                + self.propagation_direction[1] ** 2
-                + self.propagation_direction[2] ** 2
-            ),
-            1e-9,
-        ), "polarization vector must be normalized"
-
-        # check that propagation_direction is parallel to the difference of focal_position and centroid_position
-        diff_vec = self.difference(self.focal_position, self.centroid_position)
-        cross_vec = self.crossProduct(diff_vec, self.propagation_direction)
-        length_of_cross_product = self.scalarProduct(cross_vec, cross_vec)
-
-        assert length_of_cross_product < 1e-5, "propagation_direction must connect centroid_position and focus_position"
-        del (diff_vec, cross_vec, length_of_cross_product)  # clean up
+            self._propagation_connects_centroid_and_focus()
+        ), "propagation_direction must connect centroid_position and focus_position"
 
         pypicongpu_laser = laser.GaussianLaser()
         pypicongpu_laser.wavelength = self.wavelength
         pypicongpu_laser.waist = self.waist
         pypicongpu_laser.duration = self.duration
         pypicongpu_laser.focus_pos = self.focal_position
-        pypicongpu_laser.phase = self.picongpu_phase
+        pypicongpu_laser.phase = self.phi0
         pypicongpu_laser.E0 = self.E0
 
         pypicongpu_laser.pulse_init = (
@@ -180,7 +107,7 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
                 + f"Details: laser.pulse_init = {pypicongpu_laser.pulse_init} < 3"
             )
 
-        pypicongpu_laser.polarization_type = self.picongpu_polarization_type
+        pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
         pypicongpu_laser.polarization_direction = self.polarization_direction
 
         pypicongpu_laser.propagation_direction = self.propagation_direction

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -11,7 +11,6 @@ import typing
 import typeguard
 
 from ...pypicongpu import laser
-from .. import constants
 from .base_laser import BaseLaser
 from .polarization_type import PolarizationType
 
@@ -103,13 +102,7 @@ class PlaneWaveLaser(BaseLaser):
         pypicongpu_laser.focus_pos = [0.0, 0.0, 0.0]
         pypicongpu_laser.phase = self.phi0
         pypicongpu_laser.E0 = self.E0
-
-        pypicongpu_laser.pulse_init = max(
-            -2 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration,
-            15,
-        )
-        # unit: duration
-
+        pypicongpu_laser.pulse_init = self._compute_pulse_init()
         pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
         pypicongpu_laser.polarization_direction = self.polarization_direction
         pypicongpu_laser.laser_nofocus_constant_si = self.picongpu_plateau_duration

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -5,8 +5,8 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from ..pypicongpu import laser
-from . import constants
+from ...pypicongpu import laser
+from .. import constants
 
 import math
 

--- a/lib/python/picongpu/picmi/lasers/polarization_type.py
+++ b/lib/python/picongpu/picmi/lasers/polarization_type.py
@@ -1,0 +1,22 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from enum import Enum
+from ...pypicongpu.laser import PolarizationType as PyPIConGPUPolarizationType
+
+
+class PolarizationType(Enum):
+    """represents a polarization of a laser"""
+
+    LINEAR = 1
+    CIRCULAR = 2
+
+    def get_as_pypicongpu(self):
+        if self == PolarizationType.LINEAR:
+            return PyPIConGPUPolarizationType.LINEAR
+        if self == PolarizationType.CIRCULAR:
+            return PyPIConGPUPolarizationType.CIRCULAR

--- a/lib/python/picongpu/picmi/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/plane_wave_laser.py
@@ -1,0 +1,184 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from ..pypicongpu import laser
+from . import constants
+
+import math
+
+import typeguard
+import typing
+
+
+@typeguard.typechecked
+class PlaneWaveLaser:
+    """
+    Specifies a plane wave with a temporal shape
+
+    Parameters
+    ----------
+    wavelength: float
+        Laser wavelength [m], defined as :math:`\\lambda_0` in the above formula
+
+    duration: float
+        Duration of the Gaussian pulse [s], defined as :math:`\\tau` in the above formula
+
+    propagation_direction: unit vector of length 3 of floats
+        Direction of propagation [1]
+
+    polarization_direction: unit vector of length 3 of floats
+        Direction of polarization [1]
+
+    focal_position: vector of length 3 of floats
+        Position of the laser focus [m]
+
+    centroid_position: vector of length 3 of floats
+        Position of the laser centroid at time 0 [m]
+
+    a0: float
+        Normalized vector potential at focus
+        Specify either a0 or E0 (E0 takes precedence).
+
+    E0: float
+        Maximum amplitude of the laser field [V/m]
+        Specify either a0 or E0 (E0 takes precedence).
+
+    phi0: float
+        Carrier envelope phase (CEP) [rad]
+    """
+
+    def __init__(
+        self,
+        wavelength,
+        duration,
+        propagation_direction,
+        polarization_direction,
+        centroid_position,
+        a0=None,
+        E0=None,
+        phi0=None,
+        picongpu_phase: float = 0.0,
+        picongpu_polarization_type=(laser.PlaneWaveLaser.PolarizationType.LINEAR),
+        picongpu_plateau_duration=0.0,
+        # make sure to always place Huygens-surface inside PML-boundaries,
+        # default is valid for standard PMLs
+        # @todo create check for insufficient dimension
+        # @todo create check in simulation for conflict between PMLs and
+        # Huygens-surfaces
+        picongpu_huygens_surface_positions: typing.List[typing.List[int]] = [
+            [16, -16],
+            [16, -16],
+            [16, -16],
+        ],
+        **kw,
+    ):
+        assert E0 is not None or a0 is not None, "One of E0 or a0 must be speficied"
+
+        k0 = 2.0 * math.pi / wavelength
+        if E0 is None:
+            E0 = a0 * constants.m_e * constants.c**2 * k0 / constants.q_e
+        if a0 is None:
+            a0 = E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
+
+        self.wavelength = wavelength
+        self.k0 = k0
+        self.duration = duration
+        self.centroid_position = centroid_position
+        self.propagation_direction = propagation_direction
+        self.polarization_direction = polarization_direction
+        self.a0 = a0
+        self.E0 = E0
+        self.phi0 = phi0
+
+        self.picongpu_phase = picongpu_phase
+        self.picongpu_plateau_duration = picongpu_plateau_duration
+        self.picongpu_polarization_type = picongpu_polarization_type
+        self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+
+    """PICMI object for Plane Wave Laser"""
+
+    def scalarProduct(self, a: typing.List[float], b: typing.List[float]) -> float:
+        assert len(a) == len(b), "the scalar product is only defined for two \
+            vector of equal dimension"
+
+        result = 0.0
+        for i in range(len(a)):
+            result += a[i] * b[i]
+
+        return result
+
+    @staticmethod
+    def testRelativeError(trueValue, testValue, relativeErrorLimit):
+        return abs((testValue - trueValue) / trueValue) < relativeErrorLimit
+
+    def get_as_pypicongpu(self) -> laser.PlaneWaveLaser:
+        assert self.testRelativeError(
+            1,
+            self.scalarProduct(self.polarization_direction, self.polarization_direction),
+            1e-9,
+        ), "the polarization direction vector must be normalized"
+
+        # check for excessive phase values to avoid numerical precision errors
+        assert abs(self.picongpu_phase) <= 2 * math.pi, "abs(phase) must be < 2*pi"
+
+        # check that initialising from y_min-plane only is sensible
+        assert (
+            self.scalarProduct(self.propagation_direction, [0.0, 1.0, 0.0]) > 0.0
+        ), "laser propagation parallel to the y-plane or pointing outside \
+            from the inside of the simulation box is not supported by this \
+            laser in PIConGPU"
+        assert self.testRelativeError(
+            1,
+            (
+                self.propagation_direction[0] ** 2
+                + self.propagation_direction[1] ** 2
+                + self.propagation_direction[2] ** 2
+            ),
+            1e-9,
+        ), "propagation vector must be normalized"
+
+        # check centroid outside box
+        assert self.centroid_position[1] <= 0, "the laser maximum must be \
+            outside of the \
+            simulation box, otherwise it is impossible to correctly initialize\
+            it using a huygens surface in the box, centroid_y <= 0"
+        # @todo implement check that laser field strength sufficiently small
+        # at simulation box boundary
+
+        # check polarization vector normalization
+
+        assert self.testRelativeError(
+            1,
+            (
+                self.propagation_direction[0] ** 2
+                + self.propagation_direction[1] ** 2
+                + self.propagation_direction[2] ** 2
+            ),
+            1e-9,
+        ), "polarization vector must be normalized"
+
+        pypicongpu_laser = laser.PlaneWaveLaser()
+        pypicongpu_laser.wavelength = self.wavelength
+        pypicongpu_laser.duration = self.duration
+        pypicongpu_laser.focus_pos = [0.0, 0.0, 0.0]
+        pypicongpu_laser.phase = self.picongpu_phase
+        pypicongpu_laser.E0 = self.E0
+
+        pypicongpu_laser.pulse_init = max(
+            -2 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration,
+            15,
+        )
+        # unit: duration
+
+        pypicongpu_laser.polarization_type = self.picongpu_polarization_type
+        pypicongpu_laser.polarization_direction = self.polarization_direction
+        pypicongpu_laser.laser_nofocus_constant_si = self.picongpu_plateau_duration
+        pypicongpu_laser.propagation_direction = self.propagation_direction
+
+        pypicongpu_laser.huygens_surface_positions = self.picongpu_huygens_surface_positions
+
+        return pypicongpu_laser

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -185,3 +185,95 @@ class PlaneWaveLaser(Laser):
                 },
             },
         }
+
+
+@typeguard.typechecked
+class DispersivePulseLaser(Laser):
+    """
+    PIConGPU Dispersive Pulse Laser
+
+    Holds Parameters to specify a dispersive Gaussian laser pulse with dispersion parameters
+    """
+
+    _name = "dispersive"
+
+    class PolarizationType(enum.Enum):
+        """represents a polarization of a laser (for PIConGPU)"""
+
+        LINEAR = 1
+        CIRCULAR = 2
+
+        def get_cpp_str(self) -> str:
+            """retrieve name as used in c++ param files"""
+            cpp_by_ptype = {
+                DispersivePulseLaser.PolarizationType.LINEAR: "Linear",
+                DispersivePulseLaser.PolarizationType.CIRCULAR: "Circular",
+            }
+            return cpp_by_ptype[self]
+
+    wavelength = util.build_typesafe_property(float)
+    """wave length in m"""
+    waist = util.build_typesafe_property(float)
+    """beam waist in m"""
+    duration = util.build_typesafe_property(float)
+    """duration in s (1 sigma)"""
+    focus_pos = util.build_typesafe_property(typing.List[float])
+    """focus position vector in m"""
+    phase = util.build_typesafe_property(float)
+    """phase in rad, periodic in 2*pi"""
+    E0 = util.build_typesafe_property(float)
+    """E0 in V/m"""
+    pulse_init = util.build_typesafe_property(float)
+    """laser will be initialized pulse_init times of duration (unitless)"""
+    propagation_direction = util.build_typesafe_property(typing.List[float])
+    """propagation direction(normalized vector)"""
+    polarization_type = util.build_typesafe_property(PolarizationType)
+    """laser polarization"""
+    polarization_direction = util.build_typesafe_property(typing.List[float])
+    """direction of polarization(normalized vector)"""
+    spectral_support = util.build_typesafe_property(float)
+    """width of the spectral support for the discrete Fourier transform [none]"""
+    sd_si = util.build_typesafe_property(float)
+    """spatial dispersion in focus [m*s]"""
+    ad_si = util.build_typesafe_property(float)
+    """angular dispersion in focus [rad*s]"""
+    gdd_si = util.build_typesafe_property(float)
+    """group velocity dispersion in focus [s^2]"""
+    tod_si = util.build_typesafe_property(float)
+    """third order dispersion in focus [s^3]"""
+    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
+    """Position in cells of the Huygens surface relative to start/
+       edge(negative numbers) of the total domain"""
+
+    def _get_serialized(self) -> dict:
+        return {
+            "wave_length_si": self.wavelength,
+            "waist_si": self.waist,
+            "pulse_duration_si": self.duration,
+            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
+            "phase": self.phase,
+            "E0_si": self.E0,
+            "pulse_init": self.pulse_init,
+            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
+            "polarization_type": self.polarization_type.get_cpp_str(),
+            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
+            "spectral_support": self.spectral_support,
+            "sd_si": self.sd_si,
+            "ad_si": self.ad_si,
+            "gdd_si": self.gdd_si,
+            "tod_si": self.tod_si,
+            "huygens_surface_positions": {
+                "row_x": {
+                    "negative": self.huygens_surface_positions[0][0],
+                    "positive": self.huygens_surface_positions[0][1],
+                },
+                "row_y": {
+                    "negative": self.huygens_surface_positions[1][0],
+                    "positive": self.huygens_surface_positions[1][1],
+                },
+                "row_z": {
+                    "negative": self.huygens_surface_positions[2][0],
+                    "positive": self.huygens_surface_positions[2][1],
+                },
+            },
+        }

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus
+Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Julian Lenz
 License: GPLv3+
 """
 
@@ -87,6 +87,81 @@ class GaussianLaser(RenderedObject):
             "laguerre_modes": list(map(lambda x: {"single_laguerre_mode": x}, self.laguerre_modes)),
             "laguerre_phases": list(map(lambda x: {"single_laguerre_phase": x}, self.laguerre_phases)),
             "modenumber": len(self.laguerre_modes) - 1,
+            "huygens_surface_positions": {
+                "row_x": {
+                    "negative": self.huygens_surface_positions[0][0],
+                    "positive": self.huygens_surface_positions[0][1],
+                },
+                "row_y": {
+                    "negative": self.huygens_surface_positions[1][0],
+                    "positive": self.huygens_surface_positions[1][1],
+                },
+                "row_z": {
+                    "negative": self.huygens_surface_positions[2][0],
+                    "positive": self.huygens_surface_positions[2][1],
+                },
+            },
+        }
+
+
+@typeguard.typechecked
+class PlaneWaveLaser(RenderedObject):
+    """
+    PIConGPU Plane Wave Laser
+
+    Holds Parameters to specify a plane wave laser
+    """
+
+    class PolarizationType(enum.Enum):
+        """represents a polarization of a laser (for PIConGPU)"""
+
+        LINEAR = 1
+        CIRCULAR = 2
+
+        def get_cpp_str(self) -> str:
+            """retrieve name as used in c++ param files"""
+            cpp_by_ptype = {
+                PlaneWaveLaser.PolarizationType.LINEAR: "Linear",
+                PlaneWaveLaser.PolarizationType.CIRCULAR: "Circular",
+            }
+            return cpp_by_ptype[self]
+
+    wavelength = util.build_typesafe_property(float)
+    """wave length in m"""
+    duration = util.build_typesafe_property(float)
+    """duration in s (1 sigma)"""
+    focus_pos = util.build_typesafe_property(typing.List[float])
+    """focus position vector in m"""
+    phase = util.build_typesafe_property(float)
+    """phase in rad, periodic in 2*pi"""
+    E0 = util.build_typesafe_property(float)
+    """E0 in V/m"""
+    pulse_init = util.build_typesafe_property(float)
+    """laser will be initialized pulse_init times of duration (unitless)"""
+    propagation_direction = util.build_typesafe_property(typing.List[float])
+    """propagation direction(normalized vector)"""
+    polarization_type = util.build_typesafe_property(PolarizationType)
+    """laser polarization"""
+    polarization_direction = util.build_typesafe_property(typing.List[float])
+    """direction of polarization(normalized vector)"""
+    laser_nofocus_constant_si = util.build_typesafe_property(float)
+    """constant for plane wave laser without focus (unitless)"""
+    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
+    """Position in cells of the Huygens surface relative to start/
+       edge(negative numbers) of the total domain"""
+
+    def _get_serialized(self) -> dict:
+        return {
+            "wave_length_si": self.wavelength,
+            "pulse_duration_si": self.duration,
+            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
+            "phase": self.phase,
+            "E0_si": self.E0,
+            "pulse_init": self.pulse_init,
+            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
+            "polarization_type": self.polarization_type.get_cpp_str(),
+            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
+            "laser_nofocus_constant_si": self.laser_nofocus_constant_si,
             "huygens_surface_positions": {
                 "row_x": {
                     "negative": self.huygens_surface_positions[0][0],

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -5,8 +5,8 @@ Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Julian Lenz
 License: GPLv3+
 """
 
+from .rendering import SelfRegisteringRenderedObject
 from . import util
-from .rendering import RenderedObject
 
 import enum
 import typing
@@ -14,13 +14,19 @@ import typeguard
 import logging
 
 
+class Laser(SelfRegisteringRenderedObject):
+    pass
+
+
 @typeguard.typechecked
-class GaussianLaser(RenderedObject):
+class GaussianLaser(Laser):
     """
     PIConGPU Gaussian Laser
 
     Holds Parameters to specify a gaussian laser
     """
+
+    _name = "gaussian"
 
     class PolarizationType(enum.Enum):
         """represents a polarization of a laser (for PIConGPU)"""
@@ -105,12 +111,14 @@ class GaussianLaser(RenderedObject):
 
 
 @typeguard.typechecked
-class PlaneWaveLaser(RenderedObject):
+class PlaneWaveLaser(Laser):
     """
     PIConGPU Plane Wave Laser
 
     Holds Parameters to specify a plane wave laser
     """
+
+    _name = "planewave"
 
     class PolarizationType(enum.Enum):
         """represents a polarization of a laser (for PIConGPU)"""

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -14,38 +14,55 @@ import typeguard
 import logging
 
 
+class PolarizationType(enum.Enum):
+    """represents a polarization of a laser (for PIConGPU)"""
+
+    LINEAR = 1
+    CIRCULAR = 2
+
+    def get_cpp_str(self) -> str:
+        """retrieve name as used in c++ param files"""
+        cpp_by_ptype = {
+            PolarizationType.LINEAR: "Linear",
+            PolarizationType.CIRCULAR: "Circular",
+        }
+        return cpp_by_ptype[self]
+
+
+def _get_huygens_surface_serialized(huygens_surface_positions) -> dict:
+    """Serialize huygens surface positions for all laser types"""
+    return {
+        "row_x": {
+            "negative": huygens_surface_positions[0][0],
+            "positive": huygens_surface_positions[0][1],
+        },
+        "row_y": {
+            "negative": huygens_surface_positions[1][0],
+            "positive": huygens_surface_positions[1][1],
+        },
+        "row_z": {
+            "negative": huygens_surface_positions[2][0],
+            "positive": huygens_surface_positions[2][1],
+        },
+    }
+
+
 class Laser(SelfRegisteringRenderedObject):
     pass
 
 
-@typeguard.typechecked
-class GaussianLaser(Laser):
-    """
-    PIConGPU Gaussian Laser
+class _BaseLaser(Laser):
+    """Base class for all laser types with common properties and serialization logic"""
 
-    Holds Parameters to specify a gaussian laser
-    """
-
-    _name = "gaussian"
-
-    class PolarizationType(enum.Enum):
-        """represents a polarization of a laser (for PIConGPU)"""
-
-        LINEAR = 1
-        CIRCULAR = 2
-
-        def get_cpp_str(self) -> str:
-            """retrieve name as used in c++ param files"""
-            cpp_by_ptype = {
-                GaussianLaser.PolarizationType.LINEAR: "Linear",
-                GaussianLaser.PolarizationType.CIRCULAR: "Circular",
-            }
-            return cpp_by_ptype[self]
-
+    # Common properties for all lasers
+    propagation_direction = util.build_typesafe_property(typing.List[float])
+    """propagation direction (normalized vector)"""
+    polarization_direction = util.build_typesafe_property(typing.List[float])
+    """direction of polarization (normalized vector)"""
+    polarization_type = util.build_typesafe_property(PolarizationType)
+    """laser polarization"""
     wavelength = util.build_typesafe_property(float)
     """wave length in m"""
-    waist = util.build_typesafe_property(float)
-    """beam waist in m"""
     duration = util.build_typesafe_property(float)
     """duration in s (1 sigma)"""
     focus_pos = util.build_typesafe_property(typing.List[float])
@@ -56,19 +73,44 @@ class GaussianLaser(Laser):
     """E0 in V/m"""
     pulse_init = util.build_typesafe_property(float)
     """laser will be initialized pulse_init times of duration (unitless)"""
-    propagation_direction = util.build_typesafe_property(typing.List[float])
-    """propagation direction(normalized vector)"""
-    polarization_type = util.build_typesafe_property(PolarizationType)
-    """laser polarization"""
-    polarization_direction = util.build_typesafe_property(typing.List[float])
-    """direction of polarization(normalized vector)"""
+
+    # Huygens surface position (common to all lasers)
+    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
+    """Position in cells of the Huygens surface relative to start/
+       edge(negative numbers) of the total domain"""
+
+    def _get_common_serialized_fields(self) -> dict:
+        """Get all common serialized fields for lasers"""
+        return {
+            "wave_length_si": self.wavelength,
+            "pulse_duration_si": self.duration,
+            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
+            "phase": self.phase,
+            "E0_si": self.E0,
+            "pulse_init": self.pulse_init,
+            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
+            "polarization_type": self.polarization_type.get_cpp_str(),
+            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
+            "huygens_surface_positions": _get_huygens_surface_serialized(self.huygens_surface_positions),
+        }
+
+
+@typeguard.typechecked
+class GaussianLaser(_BaseLaser):
+    """
+    PIConGPU Gaussian Laser
+
+    Holds Parameters to specify a gaussian laser
+    """
+
+    _name = "gaussian"
+
+    waist = util.build_typesafe_property(float)
+    """beam waist in m"""
     laguerre_modes = util.build_typesafe_property(typing.List[float])
     """array containing the magnitudes of radial Laguerre-modes"""
     laguerre_phases = util.build_typesafe_property(typing.List[float])
     """array containing the phases of radial Laguerre-modes"""
-    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
-    """Position in cells of the Huygens surface relative to start/
-       edge(negative numbers) of the total domain"""
 
     def _get_serialized(self) -> dict:
         if [] == self.laguerre_modes:
@@ -79,39 +121,18 @@ class GaussianLaser(Laser):
             raise ValueError("Laguerre modes and Laguerre phases MUST BE " "arrays of equal length.")
         if len(list(filter(lambda x: x < 0, self.laguerre_modes))) > 0:
             logging.warning("Laguerre mode magnitudes SHOULD BE positive definite.")
-        return {
-            "wave_length_si": self.wavelength,
+
+        # Build on the common fields
+        return self._get_common_serialized_fields() | {
             "waist_si": self.waist,
-            "pulse_duration_si": self.duration,
-            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
-            "phase": self.phase,
-            "E0_si": self.E0,
-            "pulse_init": self.pulse_init,
-            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
-            "polarization_type": self.polarization_type.get_cpp_str(),
-            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
             "laguerre_modes": list(map(lambda x: {"single_laguerre_mode": x}, self.laguerre_modes)),
             "laguerre_phases": list(map(lambda x: {"single_laguerre_phase": x}, self.laguerre_phases)),
             "modenumber": len(self.laguerre_modes) - 1,
-            "huygens_surface_positions": {
-                "row_x": {
-                    "negative": self.huygens_surface_positions[0][0],
-                    "positive": self.huygens_surface_positions[0][1],
-                },
-                "row_y": {
-                    "negative": self.huygens_surface_positions[1][0],
-                    "positive": self.huygens_surface_positions[1][1],
-                },
-                "row_z": {
-                    "negative": self.huygens_surface_positions[2][0],
-                    "positive": self.huygens_surface_positions[2][1],
-                },
-            },
         }
 
 
 @typeguard.typechecked
-class PlaneWaveLaser(Laser):
+class PlaneWaveLaser(_BaseLaser):
     """
     PIConGPU Plane Wave Laser
 
@@ -120,75 +141,17 @@ class PlaneWaveLaser(Laser):
 
     _name = "planewave"
 
-    class PolarizationType(enum.Enum):
-        """represents a polarization of a laser (for PIConGPU)"""
-
-        LINEAR = 1
-        CIRCULAR = 2
-
-        def get_cpp_str(self) -> str:
-            """retrieve name as used in c++ param files"""
-            cpp_by_ptype = {
-                PlaneWaveLaser.PolarizationType.LINEAR: "Linear",
-                PlaneWaveLaser.PolarizationType.CIRCULAR: "Circular",
-            }
-            return cpp_by_ptype[self]
-
-    wavelength = util.build_typesafe_property(float)
-    """wave length in m"""
-    duration = util.build_typesafe_property(float)
-    """duration in s (1 sigma)"""
-    focus_pos = util.build_typesafe_property(typing.List[float])
-    """focus position vector in m"""
-    phase = util.build_typesafe_property(float)
-    """phase in rad, periodic in 2*pi"""
-    E0 = util.build_typesafe_property(float)
-    """E0 in V/m"""
-    pulse_init = util.build_typesafe_property(float)
-    """laser will be initialized pulse_init times of duration (unitless)"""
-    propagation_direction = util.build_typesafe_property(typing.List[float])
-    """propagation direction(normalized vector)"""
-    polarization_type = util.build_typesafe_property(PolarizationType)
-    """laser polarization"""
-    polarization_direction = util.build_typesafe_property(typing.List[float])
-    """direction of polarization(normalized vector)"""
     laser_nofocus_constant_si = util.build_typesafe_property(float)
     """constant for plane wave laser without focus (unitless)"""
-    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
-    """Position in cells of the Huygens surface relative to start/
-       edge(negative numbers) of the total domain"""
 
     def _get_serialized(self) -> dict:
-        return {
-            "wave_length_si": self.wavelength,
-            "pulse_duration_si": self.duration,
-            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
-            "phase": self.phase,
-            "E0_si": self.E0,
-            "pulse_init": self.pulse_init,
-            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
-            "polarization_type": self.polarization_type.get_cpp_str(),
-            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
+        return self._get_common_serialized_fields() | {
             "laser_nofocus_constant_si": self.laser_nofocus_constant_si,
-            "huygens_surface_positions": {
-                "row_x": {
-                    "negative": self.huygens_surface_positions[0][0],
-                    "positive": self.huygens_surface_positions[0][1],
-                },
-                "row_y": {
-                    "negative": self.huygens_surface_positions[1][0],
-                    "positive": self.huygens_surface_positions[1][1],
-                },
-                "row_z": {
-                    "negative": self.huygens_surface_positions[2][0],
-                    "positive": self.huygens_surface_positions[2][1],
-                },
-            },
         }
 
 
 @typeguard.typechecked
-class DispersivePulseLaser(Laser):
+class DispersivePulseLaser(_BaseLaser):
     """
     PIConGPU Dispersive Pulse Laser
 
@@ -197,40 +160,8 @@ class DispersivePulseLaser(Laser):
 
     _name = "dispersive"
 
-    class PolarizationType(enum.Enum):
-        """represents a polarization of a laser (for PIConGPU)"""
-
-        LINEAR = 1
-        CIRCULAR = 2
-
-        def get_cpp_str(self) -> str:
-            """retrieve name as used in c++ param files"""
-            cpp_by_ptype = {
-                DispersivePulseLaser.PolarizationType.LINEAR: "Linear",
-                DispersivePulseLaser.PolarizationType.CIRCULAR: "Circular",
-            }
-            return cpp_by_ptype[self]
-
-    wavelength = util.build_typesafe_property(float)
-    """wave length in m"""
     waist = util.build_typesafe_property(float)
     """beam waist in m"""
-    duration = util.build_typesafe_property(float)
-    """duration in s (1 sigma)"""
-    focus_pos = util.build_typesafe_property(typing.List[float])
-    """focus position vector in m"""
-    phase = util.build_typesafe_property(float)
-    """phase in rad, periodic in 2*pi"""
-    E0 = util.build_typesafe_property(float)
-    """E0 in V/m"""
-    pulse_init = util.build_typesafe_property(float)
-    """laser will be initialized pulse_init times of duration (unitless)"""
-    propagation_direction = util.build_typesafe_property(typing.List[float])
-    """propagation direction(normalized vector)"""
-    polarization_type = util.build_typesafe_property(PolarizationType)
-    """laser polarization"""
-    polarization_direction = util.build_typesafe_property(typing.List[float])
-    """direction of polarization(normalized vector)"""
     spectral_support = util.build_typesafe_property(float)
     """width of the spectral support for the discrete Fourier transform [none]"""
     sd_si = util.build_typesafe_property(float)
@@ -241,41 +172,15 @@ class DispersivePulseLaser(Laser):
     """group velocity dispersion in focus [s^2]"""
     tod_si = util.build_typesafe_property(float)
     """third order dispersion in focus [s^3]"""
-    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
-    """Position in cells of the Huygens surface relative to start/
-       edge(negative numbers) of the total domain"""
 
     def _get_serialized(self) -> dict:
-        return {
-            "wave_length_si": self.wavelength,
+        return self._get_common_serialized_fields() | {
             "waist_si": self.waist,
-            "pulse_duration_si": self.duration,
-            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
-            "phase": self.phase,
-            "E0_si": self.E0,
-            "pulse_init": self.pulse_init,
-            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
-            "polarization_type": self.polarization_type.get_cpp_str(),
-            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
             "spectral_support": self.spectral_support,
             "sd_si": self.sd_si,
             "ad_si": self.ad_si,
             "gdd_si": self.gdd_si,
             "tod_si": self.tod_si,
-            "huygens_surface_positions": {
-                "row_x": {
-                    "negative": self.huygens_surface_positions[0][0],
-                    "positive": self.huygens_surface_positions[0][1],
-                },
-                "row_y": {
-                    "negative": self.huygens_surface_positions[1][0],
-                    "positive": self.huygens_surface_positions[1][1],
-                },
-                "row_z": {
-                    "negative": self.huygens_surface_positions[2][0],
-                    "positive": self.huygens_surface_positions[2][1],
-                },
-            },
         }
 
 
@@ -322,18 +227,5 @@ class FromOpenPMDPulseLaser(Laser):
             "time_offset_si": self.time_offset_si,
             "polarisationAxisOpenPMD": self.polarisationAxisOpenPMD,
             "propagationAxisOpenPMD": self.propagationAxisOpenPMD,
-            "huygens_surface_positions": {
-                "row_x": {
-                    "negative": self.huygens_surface_positions[0][0],
-                    "positive": self.huygens_surface_positions[0][1],
-                },
-                "row_y": {
-                    "negative": self.huygens_surface_positions[1][0],
-                    "positive": self.huygens_surface_positions[1][1],
-                },
-                "row_z": {
-                    "negative": self.huygens_surface_positions[2][0],
-                    "positive": self.huygens_surface_positions[2][1],
-                },
-            },
+            "huygens_surface_positions": _get_huygens_surface_serialized(self.huygens_surface_positions),
         }

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -277,3 +277,63 @@ class DispersivePulseLaser(Laser):
                 },
             },
         }
+
+
+@typeguard.typechecked
+class FromOpenPMDPulseLaser(Laser):
+    """
+    PIConGPU FromOpenPMDPulseLaser
+
+    Holds Parameters to specify a laser pulse from an OpenPMD file
+    """
+
+    _name = "fromOpenPMDPulse"
+
+    propagation_direction = util.build_typesafe_property(typing.List[float])
+    """propagation direction (normalized vector)"""
+    polarization_direction = util.build_typesafe_property(typing.List[float])
+    """direction of polarization (normalized vector)"""
+    file_path = util.build_typesafe_property(str)
+    """File path to the OpenPMD file containing the pulse data"""
+    iteration = util.build_typesafe_property(int)
+    """Iteration in the OpenPMD file to use"""
+    dataset_name = util.build_typesafe_property(str)
+    """Name of the dataset in the OpenPMD file containing the pulse data"""
+    datatype = util.build_typesafe_property(str)
+    """Data type of the pulse data"""
+    time_offset_si = util.build_typesafe_property(float)
+    """Time offset in seconds to apply to the pulse data [s]"""
+    polarisationAxisOpenPMD = util.build_typesafe_property(str)
+    """Polarization axis name in the OpenPMD file"""
+    propagationAxisOpenPMD = util.build_typesafe_property(str)
+    """Propagation axis name in the OpenPMD file"""
+    huygens_surface_positions = util.build_typesafe_property(typing.List[typing.List[int]])
+    """Position in cells of the Huygens surface relative to start/
+       edge(negative numbers) of the total domain"""
+
+    def _get_serialized(self) -> dict:
+        return {
+            "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),
+            "polarization_direction": list(map(lambda x: {"component": x}, self.polarization_direction)),
+            "file_path": self.file_path,
+            "iteration": self.iteration,
+            "dataset_name": self.dataset_name,
+            "datatype": self.datatype,
+            "time_offset_si": self.time_offset_si,
+            "polarisationAxisOpenPMD": self.polarisationAxisOpenPMD,
+            "propagationAxisOpenPMD": self.propagationAxisOpenPMD,
+            "huygens_surface_positions": {
+                "row_x": {
+                    "negative": self.huygens_surface_positions[0][0],
+                    "positive": self.huygens_surface_positions[0][1],
+                },
+                "row_y": {
+                    "negative": self.huygens_surface_positions[1][0],
+                    "positive": self.huygens_surface_positions[1][1],
+                },
+                "row_z": {
+                    "negative": self.huygens_surface_positions[2][0],
+                    "positive": self.huygens_surface_positions[2][1],
+                },
+            },
+        }

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .grid import Grid3D
-from .laser import GaussianLaser
+from .laser import GaussianLaser, PlaneWaveLaser
 from .movingwindow import MovingWindow
 from .field_solver.DefaultSolver import Solver
 from . import species
@@ -45,7 +45,7 @@ class Simulation(RenderedObject):
     grid = util.build_typesafe_property(typing.Union[Grid3D])
     """Used grid Object"""
 
-    laser = util.build_typesafe_property(typing.Optional[GaussianLaser])
+    laser = util.build_typesafe_property(typing.Union[GaussianLaser, PlaneWaveLaser, None])
     """Used (gaussian) Laser"""
 
     solver = util.build_typesafe_property(Solver)

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .grid import Grid3D
-from .laser import GaussianLaser, PlaneWaveLaser
+from .laser import DispersivePulseLaser, GaussianLaser, PlaneWaveLaser
 from .movingwindow import MovingWindow
 from .field_solver.DefaultSolver import Solver
 from . import species
@@ -45,7 +45,7 @@ class Simulation(RenderedObject):
     grid = util.build_typesafe_property(typing.Union[Grid3D])
     """Used grid Object"""
 
-    laser = util.build_typesafe_property(typing.Union[GaussianLaser, PlaneWaveLaser, None])
+    laser = util.build_typesafe_property(typing.Union[GaussianLaser, PlaneWaveLaser, DispersivePulseLaser, None])
     """Used (gaussian) Laser"""
 
     solver = util.build_typesafe_property(Solver)

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .grid import Grid3D
-from .laser import DispersivePulseLaser, GaussianLaser, PlaneWaveLaser
+from .laser import DispersivePulseLaser, FromOpenPMDPulseLaser, GaussianLaser, PlaneWaveLaser
 from .movingwindow import MovingWindow
 from .field_solver.DefaultSolver import Solver
 from . import species
@@ -45,7 +45,9 @@ class Simulation(RenderedObject):
     grid = util.build_typesafe_property(typing.Union[Grid3D])
     """Used grid Object"""
 
-    laser = util.build_typesafe_property(typing.Union[GaussianLaser, PlaneWaveLaser, DispersivePulseLaser, None])
+    laser = util.build_typesafe_property(
+        typing.Union[DispersivePulseLaser, FromOpenPMDPulseLaser, GaussianLaser, PlaneWaveLaser, None]
+    )
     """Used (gaussian) Laser"""
 
     solver = util.build_typesafe_property(Solver)

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -74,9 +74,9 @@ laser = picmi.GaussianLaser(
         -0.5 * pulse_init * laser_duration * c,
         float(numberCells[2] * cellSize[2] / 2.0),
     ],
-    picongpu_polarization_type=pypicongpu.laser.GaussianLaser.PolarizationType.LINEAR,
+    picongpu_polarization_type=picmi.lasers.PolarizationType.LINEAR,
     a0=8.0,
-    picongpu_phase=0.0,
+    phi0=0.0,
 )
 
 random_layout = picmi.PseudoRandomLayout(n_macroparticles_per_cell=2)
@@ -89,9 +89,7 @@ species_list = []
 if not ENABLE_IONIZATION:
     interaction = None
 
-    electrons = picmi.Species(
-        particle_type="electron", name="electron", initial_distribution=gaussianProfile
-    )
+    electrons = picmi.Species(particle_type="electron", name="electron", initial_distribution=gaussianProfile)
     species_list.append((electrons, random_layout))
 
     if ENABLE_IONS:
@@ -114,9 +112,7 @@ else:
     )
     species_list.append((hydrogen_with_ionization, random_layout))
 
-    electrons = picmi.Species(
-        particle_type="electron", name="electron", initial_distribution=None
-    )
+    electrons = picmi.Species(particle_type="electron", name="electron", initial_distribution=None)
     species_list.append((electrons, None))
 
     adk_ionization_model = picmi.ADK(

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -89,7 +89,9 @@ species_list = []
 if not ENABLE_IONIZATION:
     interaction = None
 
-    electrons = picmi.Species(particle_type="electron", name="electron", initial_distribution=gaussianProfile)
+    electrons = picmi.Species(
+        particle_type="electron", name="electron", initial_distribution=gaussianProfile
+    )
     species_list.append((electrons, random_layout))
 
     if ENABLE_IONS:
@@ -112,7 +114,9 @@ else:
     )
     species_list.append((hydrogen_with_ionization, random_layout))
 
-    electrons = picmi.Species(particle_type="electron", name="electron", initial_distribution=None)
+    electrons = picmi.Species(
+        particle_type="electron", name="electron", initial_distribution=None
+    )
     species_list.append((electrons, None))
 
     adk_ionization_model = picmi.ADK(

--- a/share/picongpu/pypicongpu/schema/laser.DispersivePulseLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.DispersivePulseLaser.json
@@ -1,0 +1,169 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.DispersivePulseLaser",
+  "description": "Specification of a dispersive Gaussian laser pulse with dispersion parameters",
+  "type": "object",
+  "properties": {
+    "wave_length_si": {
+      "type": "number",
+      "description": "wavelength of laser [m]",
+      "exclusiveMinimum": 0
+    },
+    "waist_si": {
+      "type": "number",
+      "description": "Waist of the Gaussian pulse at focus [m]",
+      "exclusiveMinimum": 0
+    },
+    "pulse_duration_si": {
+      "type": "number",
+      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "exclusiveMinimum": 0
+    },
+    "focus_pos_si": {
+      "description": "position of focus in total coordinate system, [m]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "phase": {
+      "type": "number",
+      "minimum": -3.1416,
+      "exclusiveMaximum": 6.2832
+    },
+    "E0_si": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "pulse_init": {
+      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "propagation_direction": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "polarization_type": {
+      "description": "type of polarization, not direction!",
+      "type": "string",
+      "pattern": "^(Linear|Circular)$"
+    },
+    "polarization_direction": {
+      "description": "Unit E polarization direction",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "spectral_support": {
+      "description": "Width of the spectral support for the discrete Fourier transform [none]",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "sd_si": {
+      "description": "Spatial dispersion in focus [m*s]",
+      "type": "number"
+    },
+    "ad_si": {
+      "description": "Angular dispersion in focus [rad*s]",
+      "type": "number"
+    },
+    "gdd_si": {
+      "description": "Group velocity dispersion in focus [s^2]",
+      "type": "number"
+    },
+    "tod_si": {
+      "description": "Third order dispersion in focus [s^3]",
+      "type": "number"
+    },
+    "huygens_surface_positions": {
+      "description": "position of the huygens surface relative from domain boundaries",
+      "type": "object",
+      "required": [
+        "row_x",
+        "row_y",
+        "row_z"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "row_x": {
+          "$anchor": "row_hygens_surface",
+          "type": "object",
+          "required": [
+            "negative",
+            "positive"
+          ],
+          "unevaluatedProperties": false,
+          "properties": {
+            "negative": {
+              "type": "integer"
+            },
+            "positive": {
+              "type": "integer"
+            }
+          }
+        },
+        "row_y": {
+          "$ref": "#row_hygens_surface"
+        },
+        "row_z": {
+          "$ref": "#row_hygens_surface"
+        }
+      }
+    }
+  },
+  "required": [
+    "wave_length_si",
+    "waist_si",
+    "pulse_duration_si",
+    "focus_pos_si",
+    "phase",
+    "E0_si",
+    "pulse_init",
+    "propagation_direction",
+    "polarization_type",
+    "polarization_direction",
+    "spectral_support",
+    "sd_si",
+    "ad_si",
+    "gdd_si",
+    "tod_si",
+    "huygens_surface_positions"
+  ],
+  "unevaluatedProperties": false
+}

--- a/share/picongpu/pypicongpu/schema/laser.DispersivePulseLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.DispersivePulseLaser.json
@@ -37,9 +37,7 @@
       }
     },
     "phase": {
-      "type": "number",
-      "minimum": -3.1416,
-      "exclusiveMaximum": 6.2832
+      "type": "number"
     },
     "E0_si": {
       "type": "number",

--- a/share/picongpu/pypicongpu/schema/laser.FromOpenPMDPulseLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.FromOpenPMDPulseLaser.json
@@ -1,0 +1,113 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.FromOpenPMDPulseLaser",
+  "description": "Specification of a laser pulse from an OpenPMD file",
+  "type": "object",
+  "properties": {
+    "propagation_direction": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "polarization_direction": {
+      "description": "Unit E polarization direction",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "file_path": {
+      "type": "string",
+      "description": "File path to the OpenPMD file containing the pulse data"
+    },
+    "iteration": {
+      "type": "integer"
+    },
+    "dataset_name": {
+      "type": "string",
+      "description": "Name of the dataset in the OpenPMD file containing the pulse data"
+    },
+    "datatype": {
+      "type": "string"
+    },
+    "time_offset_si": {
+      "type": "number",
+      "description": "Time offset in seconds to apply to the pulse data [s]"
+    },
+    "polarisationAxisOpenPMD": {
+      "type": "string"
+    },
+    "propagationAxisOpenPMD": {
+      "type": "string"
+    },
+    "huygens_surface_positions": {
+      "description": "Position in cells of the Huygens surface relative to start/edge(negative numbers) of the total domain",
+      "type": "object",
+      "required": [
+        "row_x",
+        "row_y",
+        "row_z"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "row_x": {
+          "$anchor": "row_hygens_surface",
+          "type": "object",
+          "required": [
+            "negative",
+            "positive"
+          ],
+          "unevaluatedProperties": false,
+          "properties": {
+            "negative": {
+              "type": "integer"
+            },
+            "positive": {
+              "type": "integer"
+            }
+          }
+        },
+        "row_y": {
+          "$ref": "#row_hygens_surface"
+        },
+        "row_z": {
+          "$ref": "#row_hygens_surface"
+        }
+      }
+    }
+  },
+  "required": [
+    "propagation_direction",
+    "polarization_direction",
+    "file_path",
+    "dataset_name",
+    "datatype",
+    "time_offset_si",
+    "polarisationAxisOpenPMD",
+    "propagationAxisOpenPMD",
+    "huygens_surface_positions"
+  ],
+  "unevaluatedProperties": false
+}

--- a/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
@@ -37,9 +37,7 @@
       }
     },
     "phase": {
-      "type": "number",
-      "minimum": -3.1416,
-      "exclusiveMaximum": 6.2832
+      "type": "number"
     },
     "E0_si": {
       "type": "number",

--- a/share/picongpu/pypicongpu/schema/laser.Laser.json
+++ b/share/picongpu/pypicongpu/schema/laser.Laser.json
@@ -12,11 +12,15 @@
       "type": "object",
       "required": [
         "gaussian",
+        "dispersive",
         "planewave"
       ],
       "unevaluatedProperties": false,
       "properties": {
         "gaussian": {
+          "type": "boolean"
+        },
+        "dispersive": {
           "type": "boolean"
         },
         "planewave": {
@@ -29,6 +33,9 @@
       "anyOf": [
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.DispersivePulseLaser"
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser"

--- a/share/picongpu/pypicongpu/schema/laser.Laser.json
+++ b/share/picongpu/pypicongpu/schema/laser.Laser.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.Laser",
+  "type": "object",
+  "required": [
+    "typeID",
+    "data"
+  ],
+  "unevaluatedProperties": false,
+  "properties": {
+    "typeID": {
+      "description": "Enum-equivalent of selected type. Note that only one entry should be marked as true, and all others as false, but that is not enforced by the schema.",
+      "type": "object",
+      "required": [
+        "gaussian",
+        "planewave"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "gaussian": {
+          "type": "boolean"
+        },
+        "planewave": {
+          "type": "boolean"
+        }
+      }
+    },
+    "data": {
+      "description": "configuration data of laser",
+      "anyOf": [
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser"
+        }
+      ]
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/laser.Laser.json
+++ b/share/picongpu/pypicongpu/schema/laser.Laser.json
@@ -17,10 +17,13 @@
       ],
       "unevaluatedProperties": false,
       "properties": {
-        "gaussian": {
+        "dispersive": {
           "type": "boolean"
         },
-        "dispersive": {
+        "fromOpenPMDPulse": {
+          "type": "boolean"
+        },
+        "gaussian": {
           "type": "boolean"
         },
         "planewave": {
@@ -32,10 +35,13 @@
       "description": "configuration data of laser",
       "anyOf": [
         {
-          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.DispersivePulseLaser"
         },
         {
-          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.DispersivePulseLaser"
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.FromOpenPMDPulseLaser"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser"

--- a/share/picongpu/pypicongpu/schema/laser.PlaneWaveLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.PlaneWaveLaser.json
@@ -32,9 +32,7 @@
       }
     },
     "phase": {
-      "type": "number",
-      "minimum": -3.1416,
-      "exclusiveMaximum": 6.2832
+      "type": "number"
     },
     "E0_si": {
       "type": "number",

--- a/share/picongpu/pypicongpu/schema/laser.PlaneWaveLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.PlaneWaveLaser.json
@@ -1,0 +1,141 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser",
+  "description": "Specification of a plane wave laser",
+  "type": "object",
+  "properties": {
+    "wave_length_si": {
+      "type": "number",
+      "description": "wavelength of laser [m]",
+      "exclusiveMinimum": 0
+    },
+    "pulse_duration_si": {
+      "type": "number",
+      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "exclusiveMinimum": 0
+    },
+    "focus_pos_si": {
+      "description": "position of focus in total coordinate system, [m]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "phase": {
+      "type": "number",
+      "minimum": -3.1416,
+      "exclusiveMaximum": 6.2832
+    },
+    "E0_si": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "pulse_init": {
+      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "propagation_direction": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "polarization_type": {
+      "description": "type of polarization, not direction!",
+      "type": "string",
+      "pattern": "^(Linear|Circular)$"
+    },
+    "polarization_direction": {
+      "description": "Unit E polarization direction",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "laser_nofocus_constant_si": {
+      "description": "constant for plane wave laser without focus (unitless)",
+      "type": "number"
+    },
+    "huygens_surface_positions": {
+      "description": "position of the huygens surface relative from domain boundaries",
+      "type": "object",
+      "required": [
+        "row_x",
+        "row_y",
+        "row_z"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "row_x": {
+          "$anchor": "row_hygens_surface",
+          "type": "object",
+          "required": [
+            "negative",
+            "positive"
+          ],
+          "unevaluatedProperties": false,
+          "properties": {
+            "negative": {
+              "type": "integer"
+            },
+            "positive": {
+              "type": "integer"
+            }
+          }
+        },
+        "row_y": {
+          "$ref": "#row_hygens_surface"
+        },
+        "row_z": {
+          "$ref": "#row_hygens_surface"
+        }
+      }
+    }
+  },
+  "required": [
+    "wave_length_si",
+    "pulse_duration_si",
+    "focus_pos_si",
+    "phase",
+    "E0_si",
+    "pulse_init",
+    "propagation_direction",
+    "polarization_type",
+    "polarization_direction",
+    "huygens_surface_positions"
+  ],
+  "unevaluatedProperties": false
+}

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -40,10 +40,7 @@
           "type": "null"
         },
         {
-          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
-        },
-        {
-          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser"
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.Laser"
         }
       ]
     },

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -41,6 +41,9 @@
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.GaussianLaser"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser"
         }
       ]
     },

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -1,4 +1,4 @@
-/* Copyright 2020-2024 Sergei Bastrakov, Rene Widera, Brian Marre
+/* Copyright 2020-2025 Sergei Bastrakov, Rene Widera, Brian Marre, Julian Lenz
  *
  * This file is part of PIConGPU.
  *
@@ -17,46 +17,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file incidentField.param
- *
- * Configure incident field profile and offset of the Huygens surface for each boundary.
- *
- * Available profiles:
- *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
- * in focus. That is, SD, AD, GDD, and TOD, respectively.
- *  - profiles::ExpRampWithPrepulse<> : exponential ramp with prepulse wavepacket with given parameters
- *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
- *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
- *  - profiles::None                  : no incident field
- *  - profiles::PlaneWave<>           : plane wave profile with given parameters
- *  - profiles::Polynom<>             : wavepacket with a polynomial temporal intensity shape profile with given
- * parameters
- *  - profiles::Wavepacket<>          : wavepacket with Gaussian spatial and temporal envelope profile with given
- * parameters
- *
- * All profiles but `Free<>` and `None` are parametrized with a profile-specific structure.
- * Their interfaces are defined in the corresponding `.def` files inside directory
- * picongpu/fields/incidentField/profiles/. Note that all these parameter structures inherit common base structures
- * from `BaseParam.def`. Thus, a user-provided structure must also define all members according to the base struct.
- *
- * In the end, this file needs to define `XMin`, `XMax`, `YMin`, `YMax`, `ZMin`, `ZMax` (the latter two can be skipped
- * in 2d) type aliases in namespace `picongpu::fields::incidentField`. Each of them could be a single profile or a
- * typelist of profiles created with `MakeSeq_t`. In case a typelist is used, the resulting field is a sum of
- * effects of all profiles in the list. This file also has to define constexpr array `POSITION` that controls
- * positioning of the generating surface relative to total domain. For example:
- *
- * @code{.cpp}
- * using XMin = profiles::Free<UserFunctorIncidentE, UserFunctorIncidentB>;
- * using XMax = profiles::None;
- * using YMin = MakeSeq_t<profiles::PlaneWave<UserPlaneWaveParams>, profiles::Wavepacket<UserWavepacketParams>>;
- * using YMax = profiles::None;
- * using ZMin = profiles::Polynom<UserPolynomParams>;
- * using ZMax = profiles::GaussianPulse<UserGaussianPulseParams>;
- *
- * constexpr int32_t POSITION[3][2] = { {16, -16}, {16, -16}, {16, -16} };
- * @endcode
- */
-
 #pragma once
 
 #include "picongpu/fields/incidentField/profiles/profiles.def"
@@ -67,11 +27,6 @@ namespace picongpu::fields::incidentField
     {{#laser.data}}
 
     {{^laser.typeID.fromOpenPMDPulse}}
-    /** Base structure for parameters of most lasers
-     *
-     * The particular used parameter structures do not have to inherit this, but must define same members
-     * with same meaning.
-     */
     struct PyPIConGPULaserBaseParam : public profiles::BaseParam
     {
         static constexpr float_64 WAVE_LENGTH_SI = {{{wave_length_si}}}; // m
@@ -113,26 +68,8 @@ namespace picongpu::fields::incidentField
     {{#typeID.gaussian}}
     struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
     {
-        /** Beam waist: distance from the axis where the pulse intensity (E^2)
-         *              decreases to its 1/e^2-th part,
-         *              at the focus position of the laser
-         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
-         *                             [   1.17741    ]
-         *
-         * unit: meter
-         */
         static constexpr float_64 W0_SI = {{{waist_si}}};
-
-        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
-         *
-         *  unit: none
-         */
         static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
-
-        /** Laguerre mode parameters
-         *
-         * @{
-         */
         static constexpr uint32_t numModes = {{{modenumber}}};
         static constexpr auto laguerreModes = floatN_X<numModes+1>(
             {{#laguerre_modes}}
@@ -144,17 +81,12 @@ namespace picongpu::fields::incidentField
             {{{single_laguerre_phase}}}{{^_last}},{{/_last}}
             {{/laguerre_phases}}
             );
-        /** @} */
     };
     {{/typeID.gaussian}}
 
     {{#typeID.planewave}}
     struct PyPIConGPUPlaneWaveParam : public PyPIConGPULaserBaseParam
     {
-        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
-         *
-         *  unit: none
-         */
         static constexpr float_64 RAMP_INIT = {{{pulse_init}}};
         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = {{{laser_nofocus_constant_si}}};
     };
@@ -163,75 +95,12 @@ namespace picongpu::fields::incidentField
     {{#typeID.dispersive}}
     struct PyPIConGPUDispersivePulseParam : public PyPIConGPULaserBaseParam
     {
-        /** Beam waist: distance from the axis where the pulse intensity (E^2)
-         *              decreases to its 1/e^2-th part,
-         *              at the focus position of the laser
-         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
-         *                             [   1.17741    ]
-         *
-         * unit: meter
-         */
         static constexpr float_64 W0_SI = {{{waist_si}}};
-
-        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
-         * TIME_DELAY_SI.
-         * WATCH OUT! Dispersion parameters may lead to pulse lenghtening
-         * Please ensure to choose a value high enough to cover the whole pulse,
-         * otherwise the Fourier Transformation will misbehave.
-         *
-         *  unit: none
-         */
         static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
-
-        /** Width of the spectral support for the discrete Fourier transform of the pulse's field
-         * from frequency-space domain to time-space domain.
-         * Defined as number of sigmas of the laser pulse spectrum.
-         * NOTE: A too small value will artificially increase the pulse duration and
-         * too high values will increase the time per step during initialization of the pulse.
-         *
-         * unit: none
-         */
         static constexpr float_X SPECTRAL_SUPPORT = {{{spectral_support}}};
-
-        // Dispersion Parameters
-
-        /** SD: spatial dispersion in focus
-         * = d x_0 / d Omega
-         *
-         * Dispersion is along the polarization axis.
-         *
-         * unit: m * s
-         */
         static constexpr float_64 SD_SI = {{{sd_si}}};
-
-        /** AD: angular dispersion in focus
-         * d theta / d Omega, e.g.
-         * AD = tan(alpha_tilt) / Omega_0
-         *
-         * Resulting pulse-front tilt is along the polarization axis.
-         *
-         * unit: rad * s
-         */
         static constexpr float_64 AD_SI = {{{ad_si}}};
-
-        /** GDD: Dispersion of group velocity in focus
-         *     = (d^2 phi / d Omega^2)
-         * with phi being the spectral laser phase.
-         * The pulse's electric field in frequency domain is therefore
-         * ~ exp(-i * 1/2 * GDD*(Omega - Omega_0)^2)
-         *
-         * unit: s^2
-         */
         static constexpr float_64 GDD_SI = {{{gdd_si}}};
-
-        /** TOD: third order dispersion in focus
-         *     = (d^3 phi / d Omega^3)
-         * with phi being the spectral laser phase.
-         * The pulse's electric field in frequency domain is therefore
-         * ~ exp(-i * 1/6 * TOD*(Omega - Omega_0)^3)
-         *
-         * unit: s^3
-         */
         static constexpr float_64 TOD_SI = {{{tod_si}}};
     };
     {{/typeID.dispersive}}
@@ -336,4 +205,4 @@ namespace picongpu::fields::incidentField
     using ZMin = profiles::None;
     using ZMax = profiles::None;
     /**@}*/
-}
+} // namespace picongpu::fields::incidentField

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -106,6 +106,7 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
     };
 
+    {{#is_gaussian}}
     struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
     {
         /** Beam waist: distance from the axis where the pulse intensity (E^2)
@@ -141,6 +142,19 @@ namespace picongpu::fields::incidentField
             );
         /** @} */
     };
+    {{/is_gaussian}}
+
+    {{^is_gaussian}}
+    struct PyPIConGPUPlaneWaveParam : public PyPIConGPULaserBaseParam
+    {
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
+         *
+         *  unit: none
+         */
+        static constexpr float_64 RAMP_INIT = {{{pulse_init}}};
+        static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = {{{laser_nofocus_constant_si}}};
+    };
+    {{/is_gaussian}}
 
     /** Position in cells of the Huygens surface relative to start of the total domain
      *
@@ -177,7 +191,7 @@ namespace picongpu::fields::incidentField
 
     /**@{*/
     //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
-    using YMin = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>;
+    using YMin = {{#is_gaussian}}profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>{{/is_gaussian}}{{^is_gaussian}}profiles::PlaneWave<PyPIConGPUPlaneWaveParam>{{/is_gaussian}};
     {{/laser}}
     {{^laser}}
     // no laser defined case
@@ -195,4 +209,4 @@ namespace picongpu::fields::incidentField
     using ZMin = profiles::None;
     using ZMax = profiles::None;
     /**@}*/
-} // namespace picongpu::fields::incidentField
+}

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -65,7 +65,9 @@ namespace picongpu::fields::incidentField
 {
     {{#laser}}
     {{#laser.data}}
-    /** Base structure for parameters of all lasers
+
+    {{^laser.typeID.fromOpenPMDPulse}}
+    /** Base structure for parameters of most lasers
      *
      * The particular used parameter structures do not have to inherit this, but must define same members
      * with same meaning.
@@ -106,6 +108,7 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_Y = polarisation_direction[1];
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
     };
+    {{/laser.typeID.fromOpenPMDPulse}}
 
     {{#typeID.gaussian}}
     struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
@@ -233,6 +236,41 @@ namespace picongpu::fields::incidentField
     };
     {{/typeID.dispersive}}
 
+    {{#typeID.fromOpenPMDPulse}}
+    struct PyPIConGPUFromOpenPMDPulseParam
+    {
+        static constexpr char const* filename = "{{{file_path}}}";
+        static constexpr uint32_t iteration = {{{iteration}}};
+        static constexpr char const* datasetEName = "{{{dataset_name}}}";
+
+        using dataType = {{{datatype}}};
+
+        static constexpr char const* polarisationAxisOpenPMD = "{{{polarisationAxisOpenPMD}}}";
+        static constexpr char const* propagationAxisOpenPMD = "{{{propagationAxisOpenPMD}}}";
+
+        static constexpr float_64 propagation_direction[3u] = {
+                {{#propagation_direction}}
+                {{{component}}}{{^_last}},{{/_last}}
+                {{/propagation_direction}}
+            };
+        static constexpr float_64 DIRECTION_X = propagation_direction[0];
+        static constexpr float_64 DIRECTION_Y = propagation_direction[1];
+        static constexpr float_64 DIRECTION_Z = propagation_direction[2];
+
+        static constexpr float_64 polarisation_direction[3u] = {
+                {{#polarization_direction}}
+                {{{component}}}{{^_last}},{{/_last}}
+                {{/polarization_direction}}
+            };
+        static constexpr float_64 POLARISATION_DIRECTION_X = polarisation_direction[0];
+        static constexpr float_64 POLARISATION_DIRECTION_Y = polarisation_direction[1];
+        static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
+
+        static constexpr float_64 TIME_DELAY_SI = {{{time_offset_si}}};
+    };
+    {{/typeID.fromOpenPMDPulse}}
+
+
     /** Position in cells of the Huygens surface relative to start of the total domain
      *
      * The position is set as an offset, in cells, counted from the start of the total domain.
@@ -277,6 +315,9 @@ namespace picongpu::fields::incidentField
     {{#typeID.dispersive}}
     using YMin = profiles::DispersivePulse<PyPIConGPUDispersivePulseParam>;
     {{/typeID.dispersive}}
+    {{#typeID.fromOpenPMDPulse}}
+    using YMin = profiles::FromOpenPMDPulse<PyPIConGPUFromOpenPMDPulseParam>;
+    {{/typeID.fromOpenPMDPulse}}
     {{/laser.data}}
     {{/laser}}
     {{^laser}}

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -157,6 +157,82 @@ namespace picongpu::fields::incidentField
     };
     {{/typeID.planewave}}
 
+    {{#typeID.dispersive}}
+    struct PyPIConGPUDispersivePulseParam : public PyPIConGPULaserBaseParam
+    {
+        /** Beam waist: distance from the axis where the pulse intensity (E^2)
+         *              decreases to its 1/e^2-th part,
+         *              at the focus position of the laser
+         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+         *                             [   1.17741    ]
+         *
+         * unit: meter
+         */
+        static constexpr float_64 W0_SI = {{{waist_si}}};
+
+        /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION after
+         * TIME_DELAY_SI.
+         * WATCH OUT! Dispersion parameters may lead to pulse lenghtening
+         * Please ensure to choose a value high enough to cover the whole pulse,
+         * otherwise the Fourier Transformation will misbehave.
+         *
+         *  unit: none
+         */
+        static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
+
+        /** Width of the spectral support for the discrete Fourier transform of the pulse's field
+         * from frequency-space domain to time-space domain.
+         * Defined as number of sigmas of the laser pulse spectrum.
+         * NOTE: A too small value will artificially increase the pulse duration and
+         * too high values will increase the time per step during initialization of the pulse.
+         *
+         * unit: none
+         */
+        static constexpr float_X SPECTRAL_SUPPORT = {{{spectral_support}}};
+
+        // Dispersion Parameters
+
+        /** SD: spatial dispersion in focus
+         * = d x_0 / d Omega
+         *
+         * Dispersion is along the polarization axis.
+         *
+         * unit: m * s
+         */
+        static constexpr float_64 SD_SI = {{{sd_si}}};
+
+        /** AD: angular dispersion in focus
+         * d theta / d Omega, e.g.
+         * AD = tan(alpha_tilt) / Omega_0
+         *
+         * Resulting pulse-front tilt is along the polarization axis.
+         *
+         * unit: rad * s
+         */
+        static constexpr float_64 AD_SI = {{{ad_si}}};
+
+        /** GDD: Dispersion of group velocity in focus
+         *     = (d^2 phi / d Omega^2)
+         * with phi being the spectral laser phase.
+         * The pulse's electric field in frequency domain is therefore
+         * ~ exp(-i * 1/2 * GDD*(Omega - Omega_0)^2)
+         *
+         * unit: s^2
+         */
+        static constexpr float_64 GDD_SI = {{{gdd_si}}};
+
+        /** TOD: third order dispersion in focus
+         *     = (d^3 phi / d Omega^3)
+         * with phi being the spectral laser phase.
+         * The pulse's electric field in frequency domain is therefore
+         * ~ exp(-i * 1/6 * TOD*(Omega - Omega_0)^3)
+         *
+         * unit: s^3
+         */
+        static constexpr float_64 TOD_SI = {{{tod_si}}};
+    };
+    {{/typeID.dispersive}}
+
     /** Position in cells of the Huygens surface relative to start of the total domain
      *
      * The position is set as an offset, in cells, counted from the start of the total domain.
@@ -198,6 +274,9 @@ namespace picongpu::fields::incidentField
     {{#typeID.planewave}}
     using YMin = profiles::PlaneWave<PyPIConGPUPlaneWaveParam>;
     {{/typeID.planewave}}
+    {{#typeID.dispersive}}
+    using YMin = profiles::DispersivePulse<PyPIConGPUDispersivePulseParam>;
+    {{/typeID.dispersive}}
     {{/laser.data}}
     {{/laser}}
     {{^laser}}

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -64,6 +64,7 @@
 namespace picongpu::fields::incidentField
 {
     {{#laser}}
+    {{#laser.data}}
     /** Base structure for parameters of all lasers
      *
      * The particular used parameter structures do not have to inherit this, but must define same members
@@ -106,7 +107,7 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
     };
 
-    {{#is_gaussian}}
+    {{#typeID.gaussian}}
     struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
     {
         /** Beam waist: distance from the axis where the pulse intensity (E^2)
@@ -142,9 +143,9 @@ namespace picongpu::fields::incidentField
             );
         /** @} */
     };
-    {{/is_gaussian}}
+    {{/typeID.gaussian}}
 
-    {{^is_gaussian}}
+    {{#typeID.planewave}}
     struct PyPIConGPUPlaneWaveParam : public PyPIConGPULaserBaseParam
     {
         /** The laser pulse will be initialized PULSE_INIT times of the PULSE_DURATION
@@ -154,7 +155,7 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 RAMP_INIT = {{{pulse_init}}};
         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = {{{laser_nofocus_constant_si}}};
     };
-    {{/is_gaussian}}
+    {{/typeID.planewave}}
 
     /** Position in cells of the Huygens surface relative to start of the total domain
      *
@@ -191,7 +192,13 @@ namespace picongpu::fields::incidentField
 
     /**@{*/
     //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
-    using YMin = {{#is_gaussian}}profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>{{/is_gaussian}}{{^is_gaussian}}profiles::PlaneWave<PyPIConGPUPlaneWaveParam>{{/is_gaussian}};
+    {{#typeID.gaussian}}
+    using YMin = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>;
+    {{/typeID.gaussian}}
+    {{#typeID.planewave}}
+    using YMin = profiles::PlaneWave<PyPIConGPUPlaneWaveParam>;
+    {{/typeID.planewave}}
+    {{/laser.data}}
     {{/laser}}
     {{^laser}}
     // no laser defined case

--- a/test/python/picongpu/quick/picmi/gaussian_laser.py
+++ b/test/python/picongpu/quick/picmi/gaussian_laser.py
@@ -8,7 +8,6 @@ License: GPLv3+
 from picongpu import picmi
 
 import unittest
-from picongpu import pypicongpu
 from math import sqrt
 from scipy.constants import c
 
@@ -27,7 +26,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
             E0=5,
             picongpu_laguerre_modes=[2.0, 3.0],
             picongpu_laguerre_phases=[4.0, 5.0],
-            picongpu_phase=-2,
+            phi0=-2,
             picongpu_huygens_surface_positions=[[1, -1], [1, -1], [1, -1]],
         )
 
@@ -42,7 +41,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         # centroid is not a picongpu input
         self.assertEqual(5, pypic_laser.E0)
         self.assertEqual(
-            pypicongpu.laser.GaussianLaser.PolarizationType.LINEAR,
+            picmi.lasers.PolarizationType.LINEAR.get_as_pypicongpu(),
             pypic_laser.polarization_type,
         )
         self.assertEqual([2.0, 3.0], pypic_laser.laguerre_modes)

--- a/test/python/picongpu/quick/pypicongpu/laser.py
+++ b/test/python/picongpu/quick/pypicongpu/laser.py
@@ -5,7 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus
 License: GPLv3+
 """
 
-from picongpu.pypicongpu.laser import GaussianLaser
+from picongpu.pypicongpu.laser import GaussianLaser, PolarizationType
 
 import unittest
 import logging
@@ -28,7 +28,7 @@ class TestGaussianLaser(unittest.TestCase):
         self.laser.E0 = 9.0
         self.laser.pulse_init = 1.3
         self.laser.propagation_direction = [0.0, 1.0, 0.0]
-        self.laser.polarization_type = GaussianLaser.PolarizationType.LINEAR
+        self.laser.polarization_type = PolarizationType.LINEAR
         self.laser.polarization_direction = [0.0, 1.0, 0.0]
         self.laser.laguerre_modes = [1.0]
         self.laser.laguerre_phases = [0.0]
@@ -79,8 +79,8 @@ class TestGaussianLaser(unittest.TestCase):
 
     def test_polarization_type(self):
         """polarization type enum sanity checks"""
-        lin = GaussianLaser.PolarizationType.LINEAR
-        circular = GaussianLaser.PolarizationType.CIRCULAR
+        lin = PolarizationType.LINEAR
+        circular = PolarizationType.CIRCULAR
 
         self.assertNotEqual(lin, circular)
 

--- a/test/python/picongpu/quick/pypicongpu/laser.py
+++ b/test/python/picongpu/quick/pypicongpu/laser.py
@@ -156,7 +156,7 @@ class TestGaussianLaser(unittest.TestCase):
     def test_translation(self):
         """is translated to context object"""
         # note: implicitly checks against schema
-        context = self.laser.get_rendering_context()
+        context = self.laser.get_rendering_context()["data"]
         self.assertEqual(context["wave_length_si"], self.laser.wavelength)
         self.assertEqual(context["waist_si"], self.laser.waist)
         self.assertEqual(context["pulse_duration_si"], self.laser.duration)

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from picongpu.pypicongpu.simulation import Simulation
-from picongpu.pypicongpu.laser import GaussianLaser
+from picongpu.pypicongpu.laser import GaussianLaser, PolarizationType
 from picongpu.pypicongpu import grid, YeeSolver, species, customuserinput
 from picongpu.pypicongpu import rendering
 from picongpu.pypicongpu.species.operation.layout import Random
@@ -63,7 +63,7 @@ class TestSimulation(unittest.TestCase):
         self.laser.E0 = 9.0
         self.laser.pulse_init = 1.3
         self.laser.propagation_direction = [0, 1, 0]
-        self.laser.polarization_type = GaussianLaser.PolarizationType.LINEAR
+        self.laser.polarization_type = PolarizationType.LINEAR
         self.laser.polarization_direction = [0, 0, 1]
         self.laser.laguerre_modes = [1.2, 2.4]
         self.laser.laguerre_phases = [2.4, 3.4]


### PR DESCRIPTION
This PR adds the PlaneWaveLaser, DispersivePulse and FromOpenPMDPulse to the PICMI interface and sets up the infrastructure for further lasers.