### PR TITLE
fix picmi laser centroid to laser init calculation

### DIFF
--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -13,6 +13,7 @@ import math
 
 import typeguard
 import typing
+import logging
 
 
 @typeguard.typechecked
@@ -173,6 +174,10 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
                                        / (self.propagation_direction[1] * constants.c) 
                                        / self.duration) # unit: multiple of laser pulse duration
         # @todo extend this to other propagation directions than +y
+        if pypicongpu_laser.pulse_init < 3.:
+            logging.warning("set centroid_position and propagation_direction indicate that laser "
+                            + "initalization might be too short.\n"
+                            + f"Details: laser.pulse_init = {pypicongpu_laser.pulse_init} < 3")
 
         pypicongpu_laser.polarization_type = self.picongpu_polarization_type
         pypicongpu_laser.polarization_direction = self.polarization_direction

--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus
+Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -141,7 +141,6 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         # at simulation box boundary
         # @todo extend this to other propagation directions than +y
 
-
         # check polarization vector normalization
 
         assert self.testRelativeError(
@@ -170,14 +169,16 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         pypicongpu_laser.phase = self.picongpu_phase
         pypicongpu_laser.E0 = self.E0
 
-        pypicongpu_laser.pulse_init = (-2.0 * self.centroid_position[1] 
-                                       / (self.propagation_direction[1] * constants.c) 
-                                       / self.duration) # unit: multiple of laser pulse duration
+        pypicongpu_laser.pulse_init = (
+            -2.0 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration
+        )  # unit: multiple of laser pulse duration
         # @todo extend this to other propagation directions than +y
-        if pypicongpu_laser.pulse_init < 3.:
-            logging.warning("set centroid_position and propagation_direction indicate that laser "
-                            + "initalization might be too short.\n"
-                            + f"Details: laser.pulse_init = {pypicongpu_laser.pulse_init} < 3")
+        if pypicongpu_laser.pulse_init < 3.0:
+            logging.warning(
+                "set centroid_position and propagation_direction indicate that laser "
+                + "initalization might be too short.\n"
+                + f"Details: laser.pulse_init = {pypicongpu_laser.pulse_init} < 3"
+            )
 
         pypicongpu_laser.polarization_type = self.picongpu_polarization_type
         pypicongpu_laser.polarization_direction = self.polarization_direction

--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -169,11 +169,10 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
         pypicongpu_laser.phase = self.picongpu_phase
         pypicongpu_laser.E0 = self.E0
 
-        pypicongpu_laser.pulse_init = max(
-            -2 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration,
-            15,
-        )
-        # unit: duration
+        pypicongpu_laser.pulse_init = (-2.0 * self.centroid_position[1] 
+                                       / (self.propagation_direction[1] * constants.c) 
+                                       / self.duration) # unit: multiple of laser pulse duration
+        # @todo extend this to other propagation directions than +y
 
         pypicongpu_laser.polarization_type = self.picongpu_polarization_type
         pypicongpu_laser.polarization_direction = self.polarization_direction

--- a/lib/python/picongpu/picmi/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/gaussian_laser.py
@@ -138,6 +138,8 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser):
             it using a huygens surface in the box, centroid_y <= 0"
         # @todo implement check that laser field strength sufficiently small
         # at simulation box boundary
+        # @todo extend this to other propagation directions than +y
+
 
         # check polarization vector normalization
 

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 Copyright 2024 PIConGPU contributors
-Authors: Masoud Afshari, Brian Edward Marre
+Authors: Masoud Afshari, Brian Edward Marre, Richard Pausch
 License: GPLv3+
 """
 

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -51,10 +51,12 @@ gaussianProfile = picmi.distribution.GaussianDistribution(
 
 solver = picmi.ElectromagneticSolver(grid=grid, method="Yee")
 
+laser_duration = 5.0e-15
+pulse_init = 15.
 laser = picmi.GaussianLaser(
     wavelength=0.8e-6,
     waist=5.0e-6 / 1.17741,
-    duration=5.0e-15,
+    duration=laser_duration,
     propagation_direction=[0.0, 1.0, 0.0],
     polarization_direction=[1.0, 0.0, 0.0],
     focal_position=[
@@ -64,7 +66,7 @@ laser = picmi.GaussianLaser(
     ],
     centroid_position=[
         float(numberCells[0] * cellSize[0] / 2.0),
-        0.0,
+        -0.5 * pulse_init * laser_duration,
         float(numberCells[2] * cellSize[2] / 2.0),
     ],
     picongpu_polarization_type=pypicongpu.laser.GaussianLaser.PolarizationType.CIRCULAR,

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -52,7 +52,7 @@ gaussianProfile = picmi.distribution.GaussianDistribution(
 solver = picmi.ElectromagneticSolver(grid=grid, method="Yee")
 
 laser_duration = 5.0e-15
-pulse_init = 15.
+pulse_init = 15.0
 laser = picmi.GaussianLaser(
     wavelength=0.8e-6,
     waist=5.0e-6 / 1.17741,

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -211,7 +211,8 @@ if ADD_CUSTOM_INPUT:
     output_configuration = pypicongpu.customuserinput.CustomUserInput()
 
     output_configuration.addToCustomInput(
-        {"openPMD_period": 100, "openPMD_file": "simData", "openPMD_extension": "bp"}, "openPMD plugin configuration"
+        {"openPMD_period": 100, "openPMD_file": "simData", "openPMD_extension": "bp"},
+        "openPMD plugin configuration",
     )
 
     sim.picongpu_add_custom_user_input(output_configuration)

--- a/test/python/picongpu/compiling/species.py
+++ b/test/python/picongpu/compiling/species.py
@@ -6,6 +6,7 @@ License: GPLv3+
 """
 
 from picongpu import picmi
+from scipy.constants import c
 
 import unittest
 
@@ -29,7 +30,7 @@ class TestSpecies(unittest.TestCase):
             a0=8,
             propagation_direction=[0, 1, 0],
             polarization_direction=[1, 0, 0],
-            centroid_position=[0.5 * grid.upper_bound[0], 0, 0.5 * grid.upper_bound[2]],
+            centroid_position=[0.5 * grid.upper_bound[0], -10 * 5.0e-15 / c, 0.5 * grid.upper_bound[2]],
             focal_position=[
                 0.5 * grid.upper_bound[0],
                 4.62e-5,

--- a/test/python/picongpu/quick/picmi/gaussian_laser.py
+++ b/test/python/picongpu/quick/picmi/gaussian_laser.py
@@ -51,8 +51,10 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         self.assertEqual([[1, -1], [1, -1], [1, -1]], pypic_laser.huygens_surface_positions)
 
         # computed values
-        self.assertAlmostEqual(-2. *  picmi_laser.centroid_position[1] / picmi_laser.propagation_direction[1] 
-                               / c / picmi_laser.duration, pypic_laser.pulse_init)
+        self.assertAlmostEqual(
+            -2.0 * picmi_laser.centroid_position[1] / picmi_laser.propagation_direction[1] / c / picmi_laser.duration,
+            pypic_laser.pulse_init,
+        )
 
     def test_scalar_values_negative(self):
         """waist, duration and wavelelngth must be > 0"""

--- a/test/python/picongpu/quick/picmi/gaussian_laser.py
+++ b/test/python/picongpu/quick/picmi/gaussian_laser.py
@@ -10,6 +10,7 @@ from picongpu import picmi
 import unittest
 from picongpu import pypicongpu
 from math import sqrt
+from scipy.constants import c
 
 
 class TestPicmiGaussianLaser(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
             propagation_direction=[0, 1, 0],
             polarization_direction=[0, 0, 1],
             focal_position=[5, 4, 5],
-            centroid_position=[5, 0, 5],
+            centroid_position=[5, -1.5, 5],
             E0=5,
             picongpu_laguerre_modes=[2.0, 3.0],
             picongpu_laguerre_phases=[4.0, 5.0],
@@ -50,7 +51,8 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         self.assertEqual([[1, -1], [1, -1], [1, -1]], pypic_laser.huygens_surface_positions)
 
         # computed values
-        self.assertEqual(15, pypic_laser.pulse_init)
+        self.assertAlmostEqual(-2. *  picmi_laser.centroid_position[1] / picmi_laser.propagation_direction[1] 
+                               / c / picmi_laser.duration, pypic_laser.pulse_init)
 
     def test_scalar_values_negative(self):
         """waist, duration and wavelelngth must be > 0"""
@@ -171,7 +173,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
             2,
             3,
             focal_position=[0, 0, 0],
-            centroid_position=[0, 0, 0],
+            centroid_position=[0, -1, 0],
             propagation_direction=[0, 1, 0],
             polarization_direction=[1, 0, 0],
             E0=1,


### PR DESCRIPTION
The current implementation of the Gauss laser used a "cheat" `max()`-evaluation that resulted in a fallback to a `PULSE_INIT` of 15 in most cases and `PULSE_INIT` could never be set lower than 15. 
This PR removes that fallback and hands over the accountability to the user. It just throws a warning if we initialize for less than 3 half-pulse-durations. 