### PR TITLE
Add range checks for parameters in atomicPhysics/IPD

### DIFF
--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
@@ -227,7 +227,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
 
             // (eV * sim.unit.length()) / (eV * sim.unit.length()), not weighted
             // unitless, not weighted
-            float_X const K = constFactor / (temperatureTimesk_Boltzman * debyeLength);
+            float_X const K = (debyeLength <= 0._X || temperatureTimesk_Boltzman <= 0._X)
+                                  ? 0._X
+                                  : constFactor / (temperatureTimesk_Boltzman * debyeLength);
 
             // unitless, not weighted
             float_X const zStar = zStarBox(superCellFieldIdx);

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
@@ -227,7 +227,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
 
             // (eV * sim.unit.length()) / (eV * sim.unit.length()), not weighted
             // unitless, not weighted
-            float_X const K = (debyeLength <= 0._X || temperatureTimesk_Boltzman <= 0._X)
+            float_X const K = (pmacc::math::isApproxZero(temperatureTimesk_Boltzman * debyeLength))
                                   ? 0._X
                                   : constFactor / (temperatureTimesk_Boltzman * debyeLength);
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -30,6 +30,7 @@
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
 #include <cstdint>
+#include <limits>
 
 namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::kernel
 {
@@ -135,7 +136,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 {
                     /* unit: (unitless * weight / typicalNumParticlesPerMacroParticle)
                      *  / (unitless * weight / typicalNumParticlesPerMacroParticle) = unitless */
-                    zStarBox(superCellFieldIdx) = sumChargeNumberSquared / sumChargeNumber;
+                    zStarBox(superCellFieldIdx)
+                        = (math::abs(sumChargeNumber) < std::numeric_limits<float_X>::epsilon())
+                              ? 0._X
+                              : sumChargeNumberSquared / sumChargeNumber;
 
                     // eV / unit_energy
                     constexpr float_X eV = sim.pic.get_eV();
@@ -144,7 +148,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                      *  / (weight / typicalNumParticlesPerMacroParticle) = unit_energy
                      *
                      * k_Boltzman * Temperature, energy equivalent to the local temperature */
-                    float_X const temperatureEnergy_PIC = sumTemperatureTerm / sumWeightAllNormalized;
+                    float_X const temperatureEnergy_PIC
+                        = (sumWeightAllNormalized > 0._X) ? sumTemperatureTerm / sumWeightAllNormalized : 0._X;
 
                     // (eV / unit_energy) * unit_energy = eV
                     temperatureEnergyBox(superCellFieldIdx) = eV * temperatureEnergy_PIC;
@@ -169,9 +174,12 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                      *
                      * unit:  sqrt(unit_length^2 / unit_energy / typicalNumParticlesPerMacroParticle
                      *  * unit_energy / (1/typicalNumParticlesPerMacroParticle)) = unit_length */
-                    debyeLengthBox(superCellFieldIdx) = math::sqrt(
-                        constFactorDebyeLength * temperatureEnergy_PIC
-                        / (sumChargeNumberSquared + sumWeightElectronNormalized));
+                    debyeLengthBox(superCellFieldIdx)
+                        = (math::abs(sumChargeNumberSquared + sumWeightElectronNormalized) < std::numeric_limits<float_X>::epsilon())
+                              ? -1._X
+                              : math::sqrt(
+                                    constFactorDebyeLength * temperatureEnergy_PIC
+                                    / (sumChargeNumberSquared + sumWeightElectronNormalized));
                 });
         }
     };

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -27,10 +27,10 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 
+#include <pmacc/math/isApprox.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
 #include <cstdint>
-#include <limits>
 
 namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::kernel
 {
@@ -136,10 +136,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 {
                     /* unit: (unitless * weight / typicalNumParticlesPerMacroParticle)
                      *  / (unitless * weight / typicalNumParticlesPerMacroParticle) = unitless */
-                    zStarBox(superCellFieldIdx)
-                        = (math::abs(sumChargeNumber) < std::numeric_limits<float_X>::epsilon())
-                              ? 0._X
-                              : sumChargeNumberSquared / sumChargeNumber;
+                    zStarBox(superCellFieldIdx) = (!pmacc::math::isApproxZero(sumChargeNumber))
+                                                      ? sumChargeNumberSquared / sumChargeNumber
+                                                      : 0._X;
 
                     // eV / unit_energy
                     constexpr float_X eV = sim.pic.get_eV();
@@ -148,8 +147,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                      *  / (weight / typicalNumParticlesPerMacroParticle) = unit_energy
                      *
                      * k_Boltzman * Temperature, energy equivalent to the local temperature */
-                    float_X const temperatureEnergy_PIC
-                        = (sumWeightAllNormalized > 0._X) ? sumTemperatureTerm / sumWeightAllNormalized : 0._X;
+                    float_X const temperatureEnergy_PIC = (!pmacc::math::isApproxZero(sumWeightAllNormalized))
+                                                              ? sumTemperatureTerm / sumWeightAllNormalized
+                                                              : 0._X;
 
                     // (eV / unit_energy) * unit_energy = eV
                     temperatureEnergyBox(superCellFieldIdx) = eV * temperatureEnergy_PIC;
@@ -175,11 +175,12 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                      * unit:  sqrt(unit_length^2 / unit_energy / typicalNumParticlesPerMacroParticle
                      *  * unit_energy / (1/typicalNumParticlesPerMacroParticle)) = unit_length */
                     debyeLengthBox(superCellFieldIdx)
-                        = (math::abs(sumChargeNumberSquared + sumWeightElectronNormalized) < std::numeric_limits<float_X>::epsilon())
-                              ? -1._X
-                              : math::sqrt(
+                        = (!pmacc::math::isApproxZero(sumChargeNumberSquared + sumWeightElectronNormalized))
+                              ? math::sqrt(
                                     constFactorDebyeLength * temperatureEnergy_PIC
-                                    / (sumChargeNumberSquared + sumWeightElectronNormalized));
+                                    / (sumChargeNumberSquared + sumWeightElectronNormalized))
+                              : -1._X;
+                    ;
                 });
         }
     };

--- a/include/pmacc/math/isApprox.hpp
+++ b/include/pmacc/math/isApprox.hpp
@@ -1,0 +1,85 @@
+/* Copyright 2025 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/math/math.hpp"
+
+#include <cmath>
+#include <concepts>
+
+namespace pmacc::math
+{
+
+    // type specific default tolerances
+    template<std::floating_point T>
+    struct DefaultTolerances;
+
+    template<>
+    struct DefaultTolerances<float>
+    {
+        static constexpr float rtol = 1.0e-5f;
+        static constexpr float atol = 1.0e-8f;
+    };
+
+    template<>
+    struct DefaultTolerances<double>
+    {
+        static constexpr double rtol = 1.0e-9;
+        static constexpr double atol = 1.0e-12;
+    };
+
+    /**
+     * @brief Checks if two floating point numbers are approximately equal
+     * @details Implements the check: abs(a - b) <= (atol + rtol * max(abs(a), abs(b)))
+     * For non-finite numbers: inf == inf, nan != anything
+     * @tparam T Floating-point type
+     * @param a Value to compare
+     * @param b Value to compare
+     * @param rtol Relative tolerance
+     * @param atol Absolute tolerance
+     * @return True if the values are approximately equal, false otherwise.
+     */
+    template<std::floating_point T>
+    constexpr bool isApproxEqual(T a, T b, T rtol = DefaultTolerances<T>::rtol, T atol = DefaultTolerances<T>::atol)
+    {
+        if(!std::isfinite(a) || !std::isfinite(b))
+        {
+            return a == b;
+        }
+
+        return pmacc::math::abs(a - b) <= (atol + rtol * pmacc::math::max(pmacc::math::abs(a), pmacc::math::abs(b)));
+    }
+
+    /**
+     * @brief Checks if a floating point number is approximately equal to zero
+     * @tparam T Floating-point type
+     * @param value Value to check
+     * @param atol Absolute tolerance
+     * @return True if the value is approximately zero, false otherwise
+     */
+    template<std::floating_point T>
+    constexpr bool isApproxZero(T value, T atol = DefaultTolerances<T>::atol)
+    {
+        return pmacc::math::abs(value) <= atol;
+    }
+
+} // namespace pmacc::math


### PR DESCRIPTION
Avoids division by zero in computations.