### PR TITLE
fix bug in PICMI ionization configuration for some elements

### DIFF
--- a/lib/python/picongpu/pypicongpu/species/util/element.py
+++ b/lib/python/picongpu/pypicongpu/species/util/element.py
@@ -115,7 +115,7 @@ class Element(RenderedObject, pydantic.BaseModel):
 
         :return: charge in C
         """
-        return self._store.ions[-1] * scipy.constants.elementary_charge
+        return self._store.number * scipy.constants.elementary_charge
 
     def get_atomic_number(self) -> int:
         return self._store.number

--- a/test/python/picongpu/quick/pypicongpu/species/util/element.py
+++ b/test/python/picongpu/quick/pypicongpu/species/util/element.py
@@ -16,24 +16,19 @@ from picongpu.pypicongpu.rendering import RenderedObject
 class TestElement(unittest.TestCase):
     def setUp(self):
         # create test case data
-        self.test_element = ["H", "#2H", "Cu", "#12C", "C"]
-        self.name = ["H", "D", "Cu", "C", "C"]
-        self.picongpu_names = ["Hydrogen", "Deuterium", "Copper", "Carbon", "Carbon"]
+        self.test_element = ["H", "#2H", "Cu", "#12C", "C", "Ne", "Ar"]
+        self.name = ["H", "D", "Cu", "C", "C", "Ne", "Ar"]
+        self.picongpu_names = ["Hydrogen", "Deuterium", "Copper", "Carbon", "Carbon", "Neon", "Argon"]
         self.mass = [
             1.00794 * scipy.constants.atomic_mass,
             2.014101778 * scipy.constants.atomic_mass,
             63.546 * scipy.constants.atomic_mass,
             12.0 * scipy.constants.atomic_mass,
             12.0107 * scipy.constants.atomic_mass,
+            20.1797 * scipy.constants.atomic_mass,
+            39.95 * scipy.constants.atomic_mass,
         ]
-        self.charge = [
-            1.0 * scipy.constants.elementary_charge,
-            1.0 * scipy.constants.elementary_charge,
-            27.0 * scipy.constants.elementary_charge,
-            6.0 * scipy.constants.elementary_charge,
-            6.0 * scipy.constants.elementary_charge,
-        ]
-        self.atomic_number = [1, 1, 29, 6, 6]
+        self.atomic_number = [1, 1, 29, 6, 6, 10, 18]
 
     def test_parse_openpmd(self):
         valid_test_strings = ["#3H", "#15He", "#1H", "#3He", "#56Cu"]
@@ -78,8 +73,10 @@ class TestElement(unittest.TestCase):
 
     def test_charge(self):
         """all elements have charge"""
-        for openpmd_name, charge in zip(self.test_element, self.charge):
-            self.assertAlmostEqual(Element(openpmd_name).get_charge_si(), charge)
+        for openpmd_name, atomic_number in zip(self.test_element, self.atomic_number):
+            self.assertAlmostEqual(
+                Element(openpmd_name).get_charge_si() / scipy.constants.elementary_charge, atomic_number
+            )
 
     def test_atomic_number(self):
         for openpmd_name, atomic_number in zip(self.test_element, self.atomic_number):


### PR DESCRIPTION
I mistakenly assumed that the ``periodictable`` library returns a list of all charge states of an element when calling, ``Element.ions``.
It actually returns typically encountered chemical ion charge states. For example,

```python
periodictable.Be.ions = (1, 2)
periodictable.Ne = ()
periodictable.Cu = (-2, 1, 2, 3, 4)
```

Which throws an error for noble gases and returns  a wrong value for the charge of most species.
This error was obscured by a the ``test_charge`` test comparing two really small number for almost equal, causing the error to go unnoticed.