### PR TITLE
separate picmi default and yee solver into two files

### DIFF
--- a/lib/python/picongpu/picmi/solver.py
+++ b/lib/python/picongpu/picmi/solver.py
@@ -1,11 +1,11 @@
 """
 This file is part of PIConGPU.
 Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre
+Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+
 """
 
-from ..pypicongpu import util, solver
+from ..pypicongpu import util, field_solver
 
 import picmistandard
 import typeguard
@@ -19,9 +19,9 @@ class ElectromagneticSolver(picmistandard.PICMI_ElectromagneticSolver):
     See PICMI spec for full documentation.
     """
 
-    def get_as_pypicongpu(self) -> solver.Solver:
+    def get_as_pypicongpu(self) -> field_solver.Solver:
         solver_by_method = {
-            "Yee": solver.YeeSolver(),
+            "Yee": field_solver.YeeSolver(),
         }
 
         if self.method not in solver_by_method:

--- a/lib/python/picongpu/pypicongpu/__init__.py
+++ b/lib/python/picongpu/pypicongpu/__init__.py
@@ -9,11 +9,12 @@ from .output.energy_histogram import EnergyHistogram
 from .output.macro_particle_count import MacroParticleCount
 from .output.png import Png
 from .output.checkpoint import Checkpoint
+from .field_solver.DefaultSolver import Solver
+from .field_solver.Yee import YeeSolver
 
 from . import laser
 from . import grid
 from . import rendering
-from . import solver
 from . import species
 from . import util
 from . import output
@@ -25,7 +26,8 @@ __all__ = [
     "laser",
     "output",
     "rendering",
-    "solver",
+    "Solver",
+    "YeeSolver",
     "species",
     "util",
     "grid",

--- a/lib/python/picongpu/pypicongpu/field_solver/DefaultSolver.py
+++ b/lib/python/picongpu/pypicongpu/field_solver/DefaultSolver.py
@@ -1,0 +1,19 @@
+"""
+This file is part of PIConGPU.
+Copyright 2021-2024 PIConGPU contributors
+Authors: Hannes Troepgen, Brian Edward Marre
+License: GPLv3+
+"""
+
+import typeguard
+
+
+@typeguard.typechecked
+class Solver:
+    """
+    represents a field solver
+
+    Parent class for type safety, does not contain anything.
+    """
+
+    pass

--- a/lib/python/picongpu/pypicongpu/field_solver/Yee.py
+++ b/lib/python/picongpu/pypicongpu/field_solver/Yee.py
@@ -5,20 +5,10 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from .rendering import RenderedObject
+from ..rendering import RenderedObject
+from .DefaultSolver import Solver
 
 import typeguard
-
-
-@typeguard.typechecked
-class Solver:
-    """
-    represents a field solver
-
-    Parent class for type safety, does not contain anything.
-    """
-
-    pass
 
 
 @typeguard.typechecked

--- a/lib/python/picongpu/pypicongpu/field_solver/__init__.py
+++ b/lib/python/picongpu/pypicongpu/field_solver/__init__.py
@@ -1,0 +1,2 @@
+from .DefaultSolver import Solver as Solver
+from .Yee import YeeSolver as YeeSolver

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -8,7 +8,7 @@ License: GPLv3+
 from .grid import Grid3D
 from .laser import GaussianLaser
 from .movingwindow import MovingWindow
-from .solver import Solver
+from .field_solver.DefaultSolver import Solver
 from . import species
 from . import util
 from . import output

--- a/share/picongpu/pypicongpu/schema/field_solver/Yee.YeeSolver.json
+++ b/share/picongpu/pypicongpu/schema/field_solver/Yee.YeeSolver.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver",
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.field_solver.Yee.YeeSolver",
   "type": "object",
   "properties": {
     "name": {

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -22,7 +22,11 @@
       "description": "typical number of macroparticles per cell, used for normalization"
     },
     "solver": {
-      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver"
+      "anyOf": [
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.field_solver.Yee.YeeSolver"
+        }
+      ]
     },
     "grid": {
       "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.grid.Grid3D"

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -60,7 +60,7 @@ class TestSimulation(unittest.TestCase):
         sim.laser = None
         sim.custom_user_input = None
         sim.moving_window = None
-        sim.solver = pypicongpu.solver.YeeSolver()
+        sim.solver = pypicongpu.field_solver.Yee.YeeSolver()
         sim.plugins = "auto"
         sim.init_manager = pypicongpu.species.InitManager()
         sim.base_density = 1.0e25

--- a/test/python/picongpu/quick/pypicongpu/rendering/renderedobject.py
+++ b/test/python/picongpu/quick/pypicongpu/rendering/renderedobject.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 from picongpu.pypicongpu.rendering import RenderedObject
 
-from picongpu.pypicongpu.solver import YeeSolver
+from picongpu.pypicongpu.field_solver import YeeSolver
 from picongpu.pypicongpu import Simulation
 
 import unittest
@@ -61,7 +61,7 @@ class TestRenderedObject(unittest.TestCase):
         self.assertEqual(
             RenderedObject._registry.contents(uri),
             {
-                "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.solver.YeeSolver",
+                "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.field_solver.Yee.YeeSolver",
                 "type": "object",
                 "properties": {"name": {"type": "string"}},
                 "required": ["name"],

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 from picongpu.pypicongpu.simulation import Simulation
 from picongpu.pypicongpu.laser import GaussianLaser
-from picongpu.pypicongpu import grid, solver, species, customuserinput
+from picongpu.pypicongpu import grid, YeeSolver, species, customuserinput
 from picongpu.pypicongpu import rendering
 from picongpu.pypicongpu.species.operation.layout import Random
 
@@ -45,7 +45,7 @@ class TestSimulation(unittest.TestCase):
         self.s.grid.boundary_condition_z = grid.BoundaryCondition.PERIODIC
         self.s.grid.super_cell_size = (8, 8, 4)
         self.s.grid.grid_dist = None
-        self.s.solver = solver.YeeSolver()
+        self.s.solver = YeeSolver()
         self.s.laser = None
         self.s.custom_user_input = None
         self.s.moving_window = None

--- a/test/python/picongpu/quick/pypicongpu/solver.py
+++ b/test/python/picongpu/quick/pypicongpu/solver.py
@@ -5,7 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from picongpu.pypicongpu.solver import Solver, YeeSolver
+from picongpu.pypicongpu.field_solver import Solver, YeeSolver
 
 import unittest
 


### PR DESCRIPTION
This pull request is part of the split approach after closing #5426.
It separates the field solvers into different files (which will be later more useful when adding more field solvers such as Lehe) 
