### PR TITLE
fix pypicongpu translation of ADK linear polarization

### DIFF
--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ADKlinearpolarization.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ADKlinearpolarization.py
@@ -21,7 +21,7 @@ class ADKLinearPolarization(IonizationModel):
         high intensity laser fields.
     """
 
-    PICONGPU_NAME: str = "ADKLinearPol"
+    PICONGPU_NAME: str = "ADKLinPol"
     """C++ Code type name of ionizer"""
 
     ionization_current: IonizationCurrent


### PR DESCRIPTION
Currently, the picmi ADK ionization model for linearly polarized lasers is translated wrongly by pypicongpu resulting in a compile error when building PIConGPU. 
The C++ name should change  `ADKLinearPol` -> `ADKLinPol`.
This also points to the fact that this is not tested. 