### PR TITLE
change LWFA example laser to linear polarized

### DIFF
--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -186,7 +186,7 @@ namespace picongpu
                  *
                  * Note: we use spelling 'Polarisation' for consistency with other lasers.
                  */
-                static constexpr PolarisationType Polarisation = PolarisationType::Circular;
+                static constexpr PolarisationType Polarisation = PolarisationType::Linear;
 
                 /** Unit E polarization direction
                  *

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/speciesDefinition.param
@@ -83,7 +83,7 @@ namespace picongpu
 #if (PARAM_IONIZATION == 1)
         ionizers<MakeSeq_t<
             particles::ionization::BSIEffectiveZ<PIC_Electrons, particles::ionization::current::None>,
-            particles::ionization::ADKCircPol<PIC_Electrons, particles::ionization::current::None>>>,
+            particles::ionization::ADKLinPol<PIC_Electrons, particles::ionization::current::None>>>,
         ionizationEnergies<ionization::energies::AU::Hydrogen_t>,
         effectiveNuclearCharge<ionization::effectiveNuclearCharge::Hydrogen_t>,
 #endif

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -69,7 +69,7 @@ laser = picmi.GaussianLaser(
         -0.5 * pulse_init * laser_duration * c,
         float(numberCells[2] * cellSize[2] / 2.0),
     ],
-    picongpu_polarization_type=pypicongpu.laser.GaussianLaser.PolarizationType.CIRCULAR,
+    picongpu_polarization_type=pypicongpu.laser.GaussianLaser.PolarizationType.LINEAR,
     a0=8.0,
     picongpu_phase=0.0,
 )
@@ -111,7 +111,7 @@ else:
     species_list.append((electrons, None))
 
     adk_ionization_model = picmi.ADK(
-        ADK_variant=picmi.ADKVariant.CircularPolarization,
+        ADK_variant=picmi.ADKVariant.LinearPolarization,
         ion_species=hydrogen_with_ionization,
         ionization_electron_species=electrons,
         ionization_current=None,


### PR DESCRIPTION
This pull request just changes:
 - the laser polarization from circular to linear
 - the ADK model from circular to linear
 
 since the more common use case is a linear-polarized laser. 
 This should help avoid wrong setups based on this example. 