### PR TITLE
remove exponential ramp laser from LWFA example

### DIFF
--- a/share/picongpu/examples/LaserWakefield/cmakeFlags
+++ b/share/picongpu/examples/LaserWakefield/cmakeFlags
@@ -35,7 +35,6 @@ flags[0]=""
 if [ -z  "$PIC_CI_MAINLINE" ] ; then
   flags[1]="-DPARAM_OVERWRITES:LIST='-DPARAM_DIMENSION=DIM2'"
   flags[2]="-DPARAM_OVERWRITES:LIST='-DPARAM_IONS=1;-DPARAM_IONIZATION=1'"
-  flags[3]="-DPARAM_OVERWRITES:LIST='-DPARAM_LASERPROFILE=GaussianBeamWithContrastCurve'"
 fi
 
 ################################################################################

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/incidentField.param
@@ -73,9 +73,6 @@
 #    define PARAM_PULSE_DURATION_SI 5.e-15
 #endif
 
-#ifndef PARAM_LASERPROFILE
-#    define PARAM_LASERPROFILE GaussianProfile
-#endif
 
 namespace picongpu
 {
@@ -253,61 +250,13 @@ namespace picongpu
                 };
             };
 
-            //! Laser Profile is taking plane wave param configuration and is overwriting only a few settings
-            struct ExpRampWithPrepulseEnvelopeParam : public LwfaGaussianPulseBaseParams
-            {
-                /** Stretch temporal profile by a constant plateau between the up and downramp
-                 *  unit: seconds */
-                static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = 0.0;
-
-                /** Intensities of prepulse and exponential preramp
-                 *
-                 * @{
-                 */
-                static constexpr float_X INT_RATIO_PREPULSE = 0.;
-                static constexpr float_X INT_RATIO_POINT_1 = 1.e-8;
-                static constexpr float_X INT_RATIO_POINT_2 = 1.e-4;
-                static constexpr float_X INT_RATIO_POINT_3 = 1.e-4;
-                /** @} */
-
-                /** Time-positions of prepulse and preramps points
-                 *
-                 * @{
-                 */
-                static constexpr float_64 TIME_PREPULSE_SI = -950.0e-15;
-                static constexpr float_64 TIME_PEAKPULSE_SI = 0.0e-15;
-                static constexpr float_64 TIME_POINT_1_SI = -1000.0e-15;
-                static constexpr float_64 TIME_POINT_2_SI = -300.0e-15;
-                static constexpr float_64 TIME_POINT_3_SI = -100.0e-15;
-                /** @} */
-
-                /** Pulse duration: sigma of std. gauss for intensity (E^2)
-                 *  PREPULSE_DURATION_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-                 *                                          [    2.354820045     ]
-                 *  Info:             FWHM_of_Intensity = FWHM_Illumination
-                 *                      = what an experimentalist calls "pulse duration"
-                 *  unit: seconds (1 sigma)
-                 */
-                static constexpr float_64 PREPULSE_DURATION_SI = LwfaGaussianPulseBaseParams::PULSE_DURATION_SI;
-
-                /** The laser pulse will be initialized RAMP_INIT times the PULSE_DURATION before
-                 * plateau and half at the end of the plateau
-                 *
-                 * unit: none
-                 */
-                static constexpr float_64 RAMP_INIT = 8.0;
-            };
-
             using GaussianProfile = profiles::GaussianPulse<GaussianPulseParam>;
-            using GaussianBeamWithContrastCurve = profiles::GaussianPulse<
-                GaussianPulseParam,
-                profiles::ExpRampWithPrepulseLongitudinal<ExpRampWithPrepulseEnvelopeParam>>;
 
             /**@{*/
             //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
             using XMin = profiles::None;
             using XMax = profiles::None;
-            using YMin = PARAM_LASERPROFILE;
+            using YMin = GaussianProfile;
             using YMax = profiles::None;
             using ZMin = profiles::None;
             using ZMax = profiles::None;


### PR DESCRIPTION
This pull request removes the exponential ramp laser from the LWFA example because:
 - it is not relevant for LWFA
 - and @pordyna also stated that one should use a different approach anyway
  
If one wants to keep this laser as a reference in an example, I could add it to FoilLCT. 