### PR TITLE
add missing exit codes pic-create

### DIFF
--- a/bin/pic-create
+++ b/bin/pic-create
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013-2024 Axel Huebl, Rene Widera
+# Copyright 2013-2024 Axel Huebl, Rene Widera, Richard Pausch
 #
 # This file is part of PIConGPU.
 #
@@ -85,7 +85,7 @@ cmake_path="$*"
 
 if [ $# -eq 0 ] || [ $# -gt 2 ] ; then
     echo "Missing destination directory or too many directories were given." >&2
-    exit
+    exit 2
 fi
 
 if [ $# -eq 2 ] ; then
@@ -131,7 +131,7 @@ if [ -d "$dst_path" ] && [ "$force_param" -eq 0 ] ; then
     input=`echo "$input" | tr '[:upper:]' '[:lower:]'`
     if [ $input != "yes" ] ; then
         echo "Abort!" >&2
-        exit
+        exit 5
     fi
 else
     if [ ! -d "$dst_path" ] ; then


### PR DESCRIPTION
Some exit codes for errors trown when `pic-create` runs into issues were not defined resulting in return values of `0`.
Since e.g. `picmi`/`pypicongpu` logging relies on non-zero return values when errors occur, logging for PICMI was broken. 
see #5439 