### PR TITLE
add walltime option to picmi / pypicongpu

### DIFF
--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -518,7 +518,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         if self.picongpu_walltime is None:
             s.walltime = None
         else:
-            s.walltime = self.picongpu_walltime
+            s.walltime = pypicongpu.walltime.Walltime(walltime=self.picongpu_walltime)
 
         return s
 

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -23,6 +23,7 @@ import typeguard
 import pathlib
 import logging
 import typing
+import datetime
 
 
 # may not use pydantic since inherits from _DocumentedMetaClass
@@ -76,6 +77,9 @@ class Simulation(picmistandard.PICMI_Simulation):
     picongpu_base_density = pypicongpu.util.build_typesafe_property(typing.Optional[float])
     """value to normalise densities with"""
 
+    picongpu_walltime = pypicongpu.util.build_typesafe_property(typing.Optional[datetime.timedelta])
+    """time after which the cluster scheduler will stop the simulation"""
+
     __runner = pypicongpu.util.build_typesafe_property(typing.Optional[pypicongpu.runner.Runner])
 
     # @todo remove boiler plate constructor argument list once picmistandard reference implementation switches to
@@ -88,6 +92,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         picongpu_moving_window_stop_iteration: typing.Optional[int] = None,
         picongpu_interaction: typing.Optional[Interaction] = None,
         picongpu_base_density: typing.Optional[float] = None,
+        picongpu_walltime: typing.Optional[datetime.timedelta] = None,
         **keyword_arguments,
     ):
         if picongpu_template_dir is not None:
@@ -100,6 +105,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         self.picongpu_moving_window_stop_iteration = picongpu_moving_window_stop_iteration
         self.picongpu_interaction = picongpu_interaction
         self.picongpu_base_density = picongpu_base_density
+        self.picongpu_walltime = picongpu_walltime
         self.picongpu_custom_user_input = None
         self.__runner = None
 
@@ -508,6 +514,11 @@ class Simulation(picmistandard.PICMI_Simulation):
                 move_point=self.picongpu_moving_window_move_point,
                 stop_iteration=self.picongpu_moving_window_stop_iteration,
             )
+
+        if self.picongpu_walltime is None:
+            s.walltime = datetime.timedelta(hours=1)
+        else:
+            s.walltime = self.picongpu_walltime
 
         return s
 

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -516,7 +516,7 @@ class Simulation(picmistandard.PICMI_Simulation):
             )
 
         if self.picongpu_walltime is None:
-            s.walltime = datetime.timedelta(hours=1)
+            s.walltime = None
         else:
             s.walltime = self.picongpu_walltime
 

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -73,7 +73,7 @@ class Simulation(RenderedObject):
     moving_window = util.build_typesafe_property(typing.Optional[MovingWindow])
     """used moving Window, set to None to disable"""
 
-    walltime = util.build_typesafe_property(typing.Optional[datetime.timedelta])
+    walltime = util.build_typesafe_property(typing.Optional[Walltime])
     """time limit of the simulation run"""
 
     plugins = util.build_typesafe_property(typing.Optional[list[Plugin] | typing.Literal["auto"]])
@@ -144,7 +144,7 @@ class Simulation(RenderedObject):
             serialized["moving_window"] = None
 
         if self.walltime is not None:
-            serialized["walltime"] = Walltime(walltime=self.walltime).get_rendering_context()
+            serialized["walltime"] = self.walltime.get_rendering_context()
         else:
             serialized["walltime"] = Walltime(walltime=datetime.timedelta(hours=1)).get_rendering_context()
 

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -73,7 +73,7 @@ class Simulation(RenderedObject):
     moving_window = util.build_typesafe_property(typing.Optional[MovingWindow])
     """used moving Window, set to None to disable"""
 
-    walltime = util.build_typesafe_property(typing.Optional[Walltime])
+    walltime = util.build_typesafe_property(typing.Optional[datetime.timedelta])
     """time limit of the simulation run"""
 
     plugins = util.build_typesafe_property(typing.Optional[list[Plugin] | typing.Literal["auto"]])
@@ -144,7 +144,7 @@ class Simulation(RenderedObject):
             serialized["moving_window"] = None
 
         if self.walltime is not None:
-            serialized["walltime"] = self.walltime.get_rendering_context()
+            serialized["walltime"] = Walltime(walltime=self.walltime).get_rendering_context()
         else:
             serialized["walltime"] = Walltime(walltime=datetime.timedelta(hours=1)).get_rendering_context()
 

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -16,10 +16,12 @@ from .rendering import RenderedObject
 from .customuserinput import InterfaceCustomUserInput
 from .output.plugin import Plugin
 from .output.timestepspec import TimeStepSpec
+from .walltime import Walltime
 
 import typing
 import typeguard
 import logging
+import datetime
 
 
 @typeguard.typechecked
@@ -70,6 +72,9 @@ class Simulation(RenderedObject):
 
     moving_window = util.build_typesafe_property(typing.Optional[MovingWindow])
     """used moving Window, set to None to disable"""
+
+    walltime = util.build_typesafe_property(typing.Optional[Walltime])
+    """time limit of the simulation run"""
 
     plugins = util.build_typesafe_property(typing.Optional[list[Plugin] | typing.Literal["auto"]])
 
@@ -137,6 +142,11 @@ class Simulation(RenderedObject):
             serialized["moving_window"] = self.moving_window.get_rendering_context()
         else:
             serialized["moving_window"] = None
+
+        if self.walltime is not None:
+            serialized["walltime"] = self.walltime.get_rendering_context()
+        else:
+            serialized["walltime"] = Walltime(walltime=datetime.timedelta(hours=1)).get_rendering_context()
 
         if self.custom_user_input is not None:
             serialized["customuserinput"] = self.__render_custom_user_input_list()

--- a/lib/python/picongpu/pypicongpu/walltime.py
+++ b/lib/python/picongpu/pypicongpu/walltime.py
@@ -15,16 +15,16 @@ class Walltime(RenderedObject, pydantic.BaseModel):
     walltime: datetime.timedelta
     """time after which the cluster scheduler will stop the simulation"""
 
+    HOUR = datetime.timedelta(hours=1.0)
+    MINUTE = datetime.timedelta(minutes=1.0)
+    SECOND = datetime.timedelta(seconds=1.0)
+
     def check(self) -> None:
         if self.walltime.total_seconds() <= 0.0:
             raise ValueError("walltime must be > 0.")
 
     def _get_serialized(self) -> dict:
-        return {
-            "walltime": "{:d}:{:02d}:{:02d}".format(
-                int(self.walltime.total_seconds() // 3600),  # hours
-                int(self.walltime.total_seconds() % 3600 // 60),  # minutes
-                int(self.walltime.total_seconds() % 3600),  # seconds
-            )
-        }  # @todo: might be cluster specific
-        # @todo might be better to use a version of __str__()
+        hours, rest = divmod(self.walltime, Walltime.HOUR)
+        minutes, rest = divmod(rest, Walltime.MINUTE)
+        seconds, _ = divmod(rest, Walltime.SECOND)
+        return {"walltime": "{:d}:{:02d}:{:02d}".format(hours, minutes, seconds)}  # @todo: might be cluster specific

--- a/lib/python/picongpu/pypicongpu/walltime.py
+++ b/lib/python/picongpu/pypicongpu/walltime.py
@@ -15,16 +15,16 @@ class Walltime(RenderedObject, pydantic.BaseModel):
     walltime: datetime.timedelta
     """time after which the cluster scheduler will stop the simulation"""
 
-    HOUR = datetime.timedelta(hours=1.0)
-    MINUTE = datetime.timedelta(minutes=1.0)
-    SECOND = datetime.timedelta(seconds=1.0)
-
     def check(self) -> None:
         if self.walltime.total_seconds() <= 0.0:
             raise ValueError("walltime must be > 0.")
 
     def _get_serialized(self) -> dict:
-        hours, rest = divmod(self.walltime, Walltime.HOUR)
-        minutes, rest = divmod(rest, Walltime.MINUTE)
-        seconds, _ = divmod(rest, Walltime.SECOND)
+        HOUR = datetime.timedelta(hours=1.0)
+        MINUTE = datetime.timedelta(minutes=1.0)
+        SECOND = datetime.timedelta(seconds=1.0)
+
+        hours, rest = divmod(self.walltime, HOUR)
+        minutes, rest = divmod(rest, MINUTE)
+        seconds, _ = divmod(rest, SECOND)
         return {"walltime": "{:d}:{:02d}:{:02d}".format(hours, minutes, seconds)}  # @todo: might be cluster specific

--- a/lib/python/picongpu/pypicongpu/walltime.py
+++ b/lib/python/picongpu/pypicongpu/walltime.py
@@ -1,0 +1,30 @@
+"""
+This file is part of the PIConGPU.
+Copyright 2024-2024 PIConGPU contributors
+Authors: Brian Edward Marre, Richard Pausch
+License: GPLv3+
+"""
+
+import pydantic
+import datetime
+
+from .rendering import RenderedObject
+
+
+class Walltime(RenderedObject, pydantic.BaseModel):
+    walltime: datetime.timedelta
+    """time after which the cluster scheduler will stop the simulation"""
+
+    def check(self) -> None:
+        if self.walltime.total_seconds() <= 0.0:
+            raise ValueError("walltime must be > 0.")
+
+    def _get_serialized(self) -> dict:
+        return {
+            "walltime": "{:d}:{:02d}:{:02d}".format(
+                int(self.walltime.total_seconds() // 3600),  # hours
+                int(self.walltime.total_seconds() % 3600 // 60),  # minutes
+                int(self.walltime.total_seconds() % 3600),  # seconds
+            )
+        }  # @todo: might be cluster specific
+        # @todo might be better to use a version of __str__()

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -10,6 +10,7 @@ from picongpu import pypicongpu
 import numpy as np
 from scipy.constants import c
 import logging
+import datetime
 
 from picongpu.pypicongpu.output.png import EMFieldScaleEnum, ColorScaleEnum
 
@@ -141,6 +142,7 @@ sim = picmi.Simulation(
     max_steps=4000,
     time_step_size=1.39e-16,
     picongpu_moving_window_move_point=0.9,
+    picongpu_walltime=datetime.timedelta(hours=2.),
     picongpu_interaction=interaction,
 )
 

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -142,7 +142,7 @@ sim = picmi.Simulation(
     max_steps=4000,
     time_step_size=1.39e-16,
     picongpu_moving_window_move_point=0.9,
-    picongpu_walltime=datetime.timedelta(hours=2.),
+    picongpu_walltime=datetime.timedelta(hours=2.0),
     picongpu_interaction=interaction,
 )
 

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -54,6 +54,9 @@
         }
       ]
     },
+    "walltime": {
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.walltime.Walltime"
+    },
     "species_initmanager": {
       "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.species.initmanager.InitManager"
     },
@@ -91,6 +94,7 @@
     "grid",
     "laser",
     "moving_window",
+    "walltime",
     "customuserinput"
   ],
   "unevaluatedProperties": false

--- a/share/picongpu/pypicongpu/schema/walltime.Walltime.json
+++ b/share/picongpu/pypicongpu/schema/walltime.Walltime.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.walltime.Walltime",
+  "type": "object",
+  "description": "walltime for picongpu simulation",
+  "unevaluatedProperties": false,
+  "required": [
+    "walltime"
+  ],
+  "properties": {
+    "walltime": {
+      "type": "string"
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -47,7 +47,9 @@ set -u
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime={{{walltime}}}
+{{#walltime}}
+TBG_wallTime="{{{walltime}}}"
+{{/walltime}}
 
 {{#grid.gpu_cnt}}
   TBG_devices_x={{{x}}}

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -47,7 +47,7 @@ set -u
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="1:00:00"
+TBG_wallTime={{{walltime}}}
 
 {{#grid.gpu_cnt}}
   TBG_devices_x={{{x}}}

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -60,6 +60,7 @@ class TestSimulation(unittest.TestCase):
         sim.laser = None
         sim.custom_user_input = None
         sim.moving_window = None
+        sim.walltime = None
         sim.solver = pypicongpu.field_solver.Yee.YeeSolver()
         sim.plugins = "auto"
         sim.init_manager = pypicongpu.species.InitManager()
@@ -71,6 +72,7 @@ class TestSimulation(unittest.TestCase):
         sim = self._set_up_minimal_sim()
 
         runner = pypicongpu.Runner(sim)
+
         runner.generate(printDirToConsole=True)
         runner.build()
         runner.run()

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -49,6 +49,7 @@ class TestSimulation(unittest.TestCase):
         self.s.laser = None
         self.s.custom_user_input = None
         self.s.moving_window = None
+        self.s.walltime = None
         self.s.plugins = "auto"
         self.s.init_manager = species.InitManager()
         self.s.base_density = 1.0e25


### PR DESCRIPTION
This pull request closes #5438  by adding the option to set the simulation walltime via picmi and pypicongpu.
