### PR TITLE
allow restart/remove outdated check in tpl w/o cuda_memtest

### DIFF
--- a/etc/picongpu/davinci-rice/picongpu.tpl
+++ b/etc/picongpu/davinci-rice/picongpu.tpl
@@ -45,7 +45,7 @@
 # settings that can be controlled by environment variables before submit
 .TBG_mailSettings=${MY_MAILNOTIFY:-"n"}
 .TBG_mailAddress=${MY_MAIL:-"someone@example.com"}
-.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}"
+.TBG_author=${MY_NAME:+--author \"${MY_NAME}\"}
 .TBG_profile=${PIC_PROFILE:-"~/picongpu.profile"}
 
 ## end tbg calculation

--- a/etc/picongpu/hemera-hzdr/defq.tpl
+++ b/etc/picongpu/hemera-hzdr/defq.tpl
@@ -98,8 +98,7 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \
-    !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
-fi
+
+# Run PIConGPU
+source !TBG_dstPath/tbg/handleSlurmSignals.sh mpiexec -np !TBG_tasks --bind-to none !TBG_dstPath/tbg/cpuNumaStarter.sh \
+       !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams

--- a/etc/picongpu/jureca-jsc/batch.tpl
+++ b/etc/picongpu/jureca-jsc/batch.tpl
@@ -86,8 +86,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  export OMP_NUM_THREADS=24
-  srun --cpu_bind=sockets !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
-fi
+# Run PIConGPU
+export OMP_NUM_THREADS=24
+srun --cpu_bind=sockets !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams

--- a/etc/picongpu/jureca-jsc/booster.tpl
+++ b/etc/picongpu/jureca-jsc/booster.tpl
@@ -86,8 +86,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  export OMP_NUM_THREADS=34
-  srun !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
-fi
+# Run PIConGPU
+export OMP_NUM_THREADS=34
+srun !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams

--- a/etc/picongpu/juwels-jsc/batch.tpl
+++ b/etc/picongpu/juwels-jsc/batch.tpl
@@ -86,8 +86,6 @@ mkdir simOutput 2> /dev/null
 cd simOutput
 ln -s ../stdout output
 
-if [ $? -eq 0 ] ; then
-  # Run PIConGPU
-  export OMP_NUM_THREADS=48
-  srun --cpu_bind=sockets !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
-fi
+# Run PIConGPU
+export OMP_NUM_THREADS=48
+srun --cpu_bind=sockets !TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams


### PR DESCRIPTION
When investigating #5443, I ran into the issue that rerunning / restarting of a PIConGPU simulation on hemera's `defq` never ran PIConGPU a second time. This bug was caused by an outdated check for `cuda_memtest`, that prevented `picongou` to run, if the GPUs showed any errors. However, on CPUs, we do not perform this test, but the guard was kept, thus checking if the linking to `stdout` was successful, which it never is an a second run, because the link already exists on the second attempt.  

I will check, whether other `*.tpls` are affected by this as well. 