### PR TITLE
Add a table in the binning documentation describing config options 

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -318,6 +318,42 @@ OpenPMD JSON Configuration
 --------------------------
 Users can set a json configuration string for the OpenPMD output format using the ``setOpenPMDJsonCfg`` setter method.
 
+Configuration Options Summary
+-----------------------------
+The following table summarizes the configuration options available for the binner object returned by `addParticleBinner()` or `addFieldBinner()`. These methods allow for fine-tuning the behavior of the binning plugin.
+
+.. list-table:: Binning Configuration Options
+   :widths: 30 50 20
+   :header-rows: 1
+
+   * - Option
+     - Description
+     - Default Value
+   * - ``setNotifyPeriod``
+     - Sets the periodicity of the output. Follows the period syntax defined :ref:`here <usage/plugins:period syntax>`.
+     - ``"1"`` (every time step)
+   * - ``setDumpPeriod``
+     - Defines the number of notify steps to reduce over before dumping. A value of 0 or 1 means dump on every notify.
+     - ``0u``
+   * - ``setHostSideHook``
+     - Sets a host-side hook (lambda/functor) to execute code before binning at each notify step.
+     - An empty lambda ``[]{}``.
+   * - ``enableRegion`` / ``disableRegion``
+     - Configures binning for particles inside (``Bounded``) or leaving (``Leaving``) the simulation volume. This is only for particle binning.
+     - ``Bounded`` region is enabled.
+   * - ``setOpenPMDWriteFunctor``
+     - Sets a functor to write custom data to the openPMD output file.
+     - An empty functor.
+   * - ``setOpenPMDJsonCfg``
+     - Sets a JSON configuration string for the openPMD output format.
+     - ``"{}"``
+   * - ``setOpenPMDExtension``
+     - Sets the file extension for the openPMD output.
+     - Default OpenPMD extension (e.g., ``.bp`` or ``.h5``).
+   * - ``setOpenPMDInfix``
+     - Sets the infix for file names in openPMD output. The default uses ``%06T`` for the time step.
+     - ``"_%06T."``
+
 OpenPMD Output
 ==============
 The binning outputs are stored in HDF5 files in ``simOutput/binningOpenPMD/`` directory.

--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -10,6 +10,7 @@ Users can
 	- Choose which species are used for particle binning
 	- Choose which fields are used for field binning
 	- Choose how frequently they want the binning to be executed
+	- Choose how many times the binned quantity should be combined over time before dumping
 	- Write custom output to file, for example other quantities related to the simulation which the user is interested in
 	- Execute multiple binnings at the same time
 	- Pass extra parameters as a tuple, if additional information is required by the kernels to do binning.
@@ -39,7 +40,7 @@ The basic building block for the binning plugin is the Functor Description objec
 It describes the properties which we find interesting and how we can calculate/get this property from the particle or field.
 A functor description is created using createFunctorDescription.
 
-.. doxygenfunction:: picongpu::plugins::binning::createFunctorDescription
+.. doxygenfunction:: picongpu::plugins::binning::createFunctorDescription(FunctorType functor, std::string const& name, std::array<double, numUnits> units)
 
 
 Functor
@@ -208,7 +209,7 @@ Fields
 PIConGPU fields which should be used in field binning.
 Fields must be instances of the ``FieldInfo`` type.
 
-.. doxygenclass:: picongpu::plugins::binning::FieldInfo
+.. doxygenstruct:: picongpu::plugins::binning::FieldInfo
 	:members:
 
 For example,

--- a/include/picongpu/plugins/binning/BinningCreator.hpp
+++ b/include/picongpu/plugins/binning/BinningCreator.hpp
@@ -59,15 +59,16 @@ namespace picongpu
              * The Particle binner will bin particle quantities to create histograms on a grid defined by axes.
              * The results will be written to openPMD files.
              *
+             * @tparam T_BinaryOp The binary operation to be used for reduction. Optional. Defaults to addition.
              * @param binnerOutputName filename and dataset name for openPMD output. Must be unique to avoid overwrites
              * during data dumps and undefined behaviour during restarts.
              * @param axisTupleObject tuple holding the axes. Each element in the tuple describes an axis for binning.
              * @param speciesTupleObject tuple holding the species to bin. Each element specifies a species to be
              * included in the binning.
-             * @param depositionData functor description of the deposited quantity.  Defines which particle property to
+             * @param depositionData functor description of the deposited quantity. Defines which particle property to
              * bin.
              * @param extraData tuple holding extra data to be passed to the binner. Can be used for optional
-             * configurations.
+             * configurations. Optional. Defaults to an empty tuple.
              * @return ParticleBinningData& reference to the created ParticleBinningData object.
              *         This can be used to further configure the binning setup if needed.
              */
@@ -97,15 +98,16 @@ namespace picongpu
              * The Field binner will bin field quantities to create histograms on a grid defined by axes.
              * The results will be written to openPMD files.
              *
+             * @tparam T_BinaryOp The binary operation to be used for reduction. Optional. Defaults to addition.
              * @param binnerOutputName filename and dataset name for openPMD output. Must be unique to avoid overwrites
              * during data dumps and undefined behaviour during restarts.
              * @param axisTupleObject tuple holding the axes. Each element in the tuple describes an axis for binning.
              * @param fieldsTupleObject tuple holding the fields to bin. Each element specifies a field to be
              * included in the binning.
-             * @param depositionData functor description of the deposited quantity.  Defines which field property to
+             * @param depositionData functor description of the deposited quantity. Defines which field property to
              * bin.
              * @param extraData tuple holding extra data to be passed to the binner. Can be used for optional
-             * configurations.
+             * configurations. Optional. Defaults to an empty tuple.
              * @return FieldBinningData& reference to the created FieldBinningData object.
              *         This can be used to further configure the binning setup if needed.
              */


### PR DESCRIPTION
Adds a table to the binning documentation giving an overview of the configuration options available, and their default values. 