### PR TITLE
activate warning log output for all picmi examples

### DIFF
--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -9,8 +9,13 @@ from picongpu import picmi
 from picongpu import pypicongpu
 import numpy as np
 from scipy.constants import c
+import logging
 
 from picongpu.pypicongpu.output.png import EMFieldScaleEnum, ColorScaleEnum
+
+# set log level:
+# options (in ascending order) are: DEBUG, INFO, WARNING, ERROR, CRITICAL
+logging.basicConfig(level=logging.WARNING)
 
 """
 @file PICMI user script reproducing the PIConGPU LWFA example

--- a/share/picongpu/pypicongpu/examples/warm_plasma/main.py
+++ b/share/picongpu/pypicongpu/examples/warm_plasma/main.py
@@ -4,9 +4,15 @@ Copyright 2021-2024 PIConGPU contributors
 Authors: Hannes Troepgen
 License: GPLv3+
 """
+import logging
 
 from picongpu import picmi
 from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
+
+# set log level:
+# options (in ascending order) are: DEBUG, INFO, WARNING, ERROR, CRITICAL
+logging.basicConfig(level=logging.WARNING)
+
 
 OUTPUT_DIRECTORY_PATH = "warm_plasma"
 


### PR DESCRIPTION
When using PICMI we now throw a bunch of warnings for bad setups. But these warnings are never printed. 
This PR adds a setter for the logging level to both PICMI examples so that the user can set the value manually. 