### PR TITLE
add another vim/emacs backup file type to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # tmp files
 *~
+\#*#
 
 # netbeans project files
 /nbproject/


### PR DESCRIPTION
Since I now accidentally added such backup files twice, here is the updated gitignore. 