### PR TITLE
rename log level 0 to mandatory

### DIFF
--- a/include/picongpu/debug/PIConGPUVerbose.hpp
+++ b/include/picongpu/debug/PIConGPUVerbose.hpp
@@ -33,13 +33,13 @@ namespace picongpu
     DEFINE_VERBOSE_CLASS(PIConGPUVerbose)
     (
         /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0, NOTHING); DEFINE_LOGLVL(1, PHYSICS); DEFINE_LOGLVL(2, DOMAINS); DEFINE_LOGLVL(4, CRITICAL);
+         * e.g. log<pmaccLogLvl::MANDATORY>("TEXT");*/
+        DEFINE_LOGLVL(0, MANDATORY); DEFINE_LOGLVL(1, PHYSICS); DEFINE_LOGLVL(2, DOMAINS); DEFINE_LOGLVL(4, CRITICAL);
         DEFINE_LOGLVL(8, MEMORY);
         DEFINE_LOGLVL(16, SIMULATION_STATE);
         DEFINE_LOGLVL(32, INPUT_OUTPUT);)
         /*set default verbose lvl (integer number)*/
-        (NOTHING::lvl | PIC_VERBOSE_LVL);
+        (MANDATORY::lvl | PIC_VERBOSE_LVL);
 
 
 } /* namespace picongpu */

--- a/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -36,12 +36,12 @@ namespace picongpu
             DEFINE_VERBOSE_CLASS(PIConGPUVerboseRadiation)
             (
                 /* define log levels for later use
-                 * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-                DEFINE_LOGLVL(0, NOTHING); DEFINE_LOGLVL(1, PHYSICS); DEFINE_LOGLVL(2, SIMULATION_STATE);
+                 * e.g. log<pmaccLogLvl::MANDATORY>("TEXT");*/
+                DEFINE_LOGLVL(0, MANDATORY); DEFINE_LOGLVL(1, PHYSICS); DEFINE_LOGLVL(2, SIMULATION_STATE);
                 DEFINE_LOGLVL(4, MEMORY);
                 DEFINE_LOGLVL(8, CRITICAL);)
                 /*set default verbose levels (integer number)*/
-                (NOTHING::lvl | PIC_VERBOSE_RADIATION);
+                (MANDATORY::lvl | PIC_VERBOSE_RADIATION);
 
         } // namespace radiation
     } // namespace plugins

--- a/include/pmacc/debug/PMaccVerbose.hpp
+++ b/include/pmacc/debug/PMaccVerbose.hpp
@@ -35,14 +35,14 @@ namespace pmacc
     DEFINE_VERBOSE_CLASS(PMaccVerbose)
     (
         /* define log lvl for later use
-         * e.g. log<pmaccLogLvl::NOTHING>("TEXT");*/
-        DEFINE_LOGLVL(0, NOTHING); DEFINE_LOGLVL(1, MEMORY); DEFINE_LOGLVL(2, INFO); DEFINE_LOGLVL(4, CRITICAL);
+         * e.g. log<pmaccLogLvl::MANDATORY>("TEXT");*/
+        DEFINE_LOGLVL(0, MANDATORY); DEFINE_LOGLVL(1, MEMORY); DEFINE_LOGLVL(2, INFO); DEFINE_LOGLVL(4, CRITICAL);
         DEFINE_LOGLVL(8, MPI);
         DEFINE_LOGLVL(16, CUDA_RT);
         DEFINE_LOGLVL(32, COMMUNICATION);
         DEFINE_LOGLVL(64, EVENT);)
         /*set default verbose lvl (integer number)*/
-        (NOTHING::lvl | PMACC_VERBOSE_LVL);
+        (MANDATORY::lvl | PMACC_VERBOSE_LVL);
 
     // short name for access verbose types of PMacc
     using ggLog = PMaccVerbose;


### PR DESCRIPTION
Rename the log level which is always active to `MANDATORY` instead of `NOTHING`. This level hasn't been used anywhere in the code.