### PR TITLE
Refactor passing parameters from PICMI to PyPIConGPU

### DIFF
--- a/lib/python/picongpu/picmi/copy_attributes.py
+++ b/lib/python/picongpu/picmi/copy_attributes.py
@@ -1,0 +1,121 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import inspect
+from typing import Callable
+
+
+def _sanitize_conversions(conversions, from_instance, to_instance):
+    conversions = conversions or {}
+
+    for new_key, old in conversions.items():
+        if not hasattr(to_instance, new_key):
+            failed_conversion = {new_key: old}
+            message = (
+                f"Conversion failed. '{new_key}' is not a member of the receiver {to_instance}. "
+                f"You gave {failed_conversion}."
+            )
+            raise ValueError(message)
+        if isinstance(old, str) and not hasattr(from_instance, old):
+            failed_conversion = {new_key: old}
+            message = (
+                f"Conversion failed. '{old}' is not a member of the provider {from_instance}. "
+                f"You gave {failed_conversion}."
+            )
+            raise ValueError(message)
+
+    return {name: _value_generator(old) if isinstance(old, str) else old for name, old in conversions.items()}
+
+
+def _value_generator(name):
+    return lambda self: getattr(self, name)
+
+
+def copy_attributes(
+    from_instance, to, conversions: None | dict[str, str | Callable] = None, remove_prefix: str = "", ignore=tuple()
+):
+    """
+    Copy attributes from one object to another.
+
+    This function copies attributes from the `from_instance` to `to` if `to` is an class instance.
+    If `to` is a class, an instance will be created via `to()`, filled and returned.
+
+    This function only copies attributes under the following circumstances:
+        - The attribute exists in `to`.
+        - The attribute is not private in `from_instance`.
+
+    Optionally, `conversions` allows to define custom mappings between attributes.
+    Keys are strings and interpreted as the name of the attribute to be set on `to`.
+    For the values, two semantics are supported:
+        - If a `value` is a string, the `(key, value)` pair is interpreted as renaming, i.e.
+          `to.key = from_instance.value`.
+        - Otherwise, `value` must be a Callable that takes `from_instance` as first and only argument
+          and returns the value that `key` is supposed to have in `to`, i.e.
+          `to.key = value(from_instance)`.
+    """
+    if isinstance(to, type):
+        try:
+            return copy_attributes(
+                from_instance, to(), conversions=conversions, remove_prefix=remove_prefix, ignore=ignore
+            )
+        except TypeError as e:
+            message = (
+                "Instantiation failed. The receiving class must be default constructible. "
+                f"You gave {to} which expects {len(inspect.signature(to.__init__).parameters) - 1} argument in its constructor. "
+                "You can work with an instance instead of a class in this case."
+            )
+            raise ValueError(message) from e
+
+    assignments = {
+        to_name: _value_generator(from_name)
+        for from_name, _ in inspect.getmembers(from_instance)
+        if from_name not in ignore
+        and not from_name.startswith("_")
+        and has_attribute(to, to_name := from_name.removeprefix(remove_prefix))
+    } | _sanitize_conversions(conversions, from_instance, to)
+
+    for key, value_generator in assignments.items():
+        setattr(to, key, value_generator(from_instance))
+    return to
+
+
+def converts_to(to_class, conversions=None, preamble=None, remove_prefix="", ignore=tuple()):
+    """
+    Add a get_as_pypicongpu method that uses copy_attributes.
+
+    This class decorator adds a method `get_as_pypicongpu`
+    that copies the content of `self` to a new instance of `to_class`
+    by virtue of the `copy_attributes` function.
+    See the `copy_attributes` docstring for details.
+
+    If given, it runs `preamble(self)` before copying.
+    """
+    if hasattr(to_class, "get_as_pypicongpu"):
+        message = f"Adding 'get_as_pypicongpu' failed because it already existed on receiving class {to_class}."
+        raise TypeError(message)
+
+    def decorator(cls):
+        def get_as_pypicongpu(self, *args, **kwargs):
+            if preamble:
+                preamble(self, *args, **kwargs)
+            local_conversions = {
+                key: value
+                if isinstance(value, str)
+                # Python binds lambdas by reference, so if we were to use the seemingly obvious implementation,
+                # all lambdas in this dictionary would use the last value of `value`.
+                # That is why we need to force immediate evaluation:
+                else (lambda local_value: lambda self: local_value(self, *args, **kwargs))(value)
+                for key, value in (conversions or {}).items()
+            }
+            return copy_attributes(
+                self, to_class, conversions=local_conversions, remove_prefix=remove_prefix, ignore=ignore
+            )
+
+        cls.get_as_pypicongpu = get_as_pypicongpu
+        return cls
+
+    return decorator

--- a/lib/python/picongpu/picmi/copy_attributes.py
+++ b/lib/python/picongpu/picmi/copy_attributes.py
@@ -15,6 +15,9 @@ def has_attribute(instance, name):
     #     return hasattr(instance, name)
     #
     # But this seems to interact weirdly with our util.build_typesafe_property.
+    #
+    # This version works fine but throws a warning for pydantic models.
+    # We could get rid of this by using instance.model_dump() instead.
     return name in dir(instance)
 
 

--- a/lib/python/picongpu/picmi/copy_attributes.py
+++ b/lib/python/picongpu/picmi/copy_attributes.py
@@ -9,18 +9,27 @@ import inspect
 from typing import Callable
 
 
+def has_attribute(instance, name):
+    # It should be this:
+    #
+    #     return hasattr(instance, name)
+    #
+    # But this seems to interact weirdly with our util.build_typesafe_property.
+    return name in dir(instance)
+
+
 def _sanitize_conversions(conversions, from_instance, to_instance):
     conversions = conversions or {}
 
     for new_key, old in conversions.items():
-        if not hasattr(to_instance, new_key):
+        if not has_attribute(to_instance, new_key):
             failed_conversion = {new_key: old}
             message = (
                 f"Conversion failed. '{new_key}' is not a member of the receiver {to_instance}. "
                 f"You gave {failed_conversion}."
             )
             raise ValueError(message)
-        if isinstance(old, str) and not hasattr(from_instance, old):
+        if isinstance(old, str) and not has_attribute(from_instance, old):
             failed_conversion = {new_key: old}
             message = (
                 f"Conversion failed. '{old}' is not a member of the provider {from_instance}. "
@@ -94,7 +103,7 @@ def converts_to(to_class, conversions=None, preamble=None, remove_prefix="", ign
 
     If given, it runs `preamble(self)` before copying.
     """
-    if hasattr(to_class, "get_as_pypicongpu"):
+    if has_attribute(to_class, "get_as_pypicongpu"):
         message = f"Adding 'get_as_pypicongpu' failed because it already existed on receiving class {to_class}."
         raise TypeError(message)
 

--- a/lib/python/picongpu/picmi/diagnostics/auto.py
+++ b/lib/python/picongpu/picmi/diagnostics/auto.py
@@ -5,15 +5,14 @@ Authors: Pawel Ordyna
 License: GPLv3+
 """
 
-from ...pypicongpu.output.auto import Auto as PyPIConGPUAuto
-from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
-
-from ..species import Species as PICMISpecies
-from .timestepspec import TimeStepSpec
-
 import typeguard
 
+from ...pypicongpu.output.auto import Auto as PyPIConGPUAuto
+from ..copy_attributes import default_converts_to
+from .timestepspec import TimeStepSpec
 
+
+@default_converts_to(PyPIConGPUAuto)
 @typeguard.typechecked
 class Auto:
     """
@@ -32,17 +31,5 @@ class Auto:
     def __init__(self, period: TimeStepSpec) -> None:
         self.period = period
 
-    def check(self):
+    def check(self, *args, **kwargs):
         pass
-
-    def get_as_pypicongpu(
-        self,
-        # not used here, but needed for the interface
-        dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
-        time_step_size,
-        num_steps,
-    ) -> PyPIConGPUAuto:
-        self.check()
-        pypicongpu_auto = PyPIConGPUAuto()
-        pypicongpu_auto.period = self.period.get_as_pypicongpu(time_step_size, num_steps)
-        return pypicongpu_auto

--- a/lib/python/picongpu/picmi/diagnostics/auto.py
+++ b/lib/python/picongpu/picmi/diagnostics/auto.py
@@ -30,6 +30,3 @@ class Auto:
 
     def __init__(self, period: TimeStepSpec) -> None:
         self.period = period
-
-    def check(self, *args, **kwargs):
-        pass

--- a/lib/python/picongpu/picmi/diagnostics/binning.py
+++ b/lib/python/picongpu/picmi/diagnostics/binning.py
@@ -12,14 +12,8 @@ import typeguard
 
 from ...pypicongpu.output.binning import (
     Binning as PyPIConGPUBinning,
-)
-from ...pypicongpu.output.binning import (
     BinningAxis as PyPIConGPUBinningAxis,
-)
-from ...pypicongpu.output.binning import (
     BinningFunctor as PyPIConGPUBinningFunctor,
-)
-from ...pypicongpu.output.binning import (
     BinSpec as PyPIConGPUBinSpec,
 )
 from ...pypicongpu.species.species import Species as PyPIConGPUSpecies

--- a/lib/python/picongpu/picmi/diagnostics/binning.py
+++ b/lib/python/picongpu/picmi/diagnostics/binning.py
@@ -5,19 +5,26 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
+from typing import Any, Callable, Optional
+
 import sympy
+import typeguard
+
 from ...pypicongpu.output.binning import (
     Binning as PyPIConGPUBinning,
-    BinningFunctor as PyPIConGPUBinningFunctor,
+)
+from ...pypicongpu.output.binning import (
     BinningAxis as PyPIConGPUBinningAxis,
+)
+from ...pypicongpu.output.binning import (
+    BinningFunctor as PyPIConGPUBinningFunctor,
+)
+from ...pypicongpu.output.binning import (
     BinSpec as PyPIConGPUBinSpec,
 )
 from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
-
 from ..species import Species as PICMISpecies
-from typing import Callable, Any, Optional
 from .timestepspec import TimeStepSpec
-import typeguard
 
 _COORDINATE_SYSTEM = {
     (

--- a/lib/python/picongpu/picmi/diagnostics/checkpoint.py
+++ b/lib/python/picongpu/picmi/diagnostics/checkpoint.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
 Copyright 2021-2025 PIConGPU contributors
-Authors: Masoud Afshari
+Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/diagnostics/checkpoint.py
+++ b/lib/python/picongpu/picmi/diagnostics/checkpoint.py
@@ -5,6 +5,7 @@ Authors: Masoud Afshari
 License: GPLv3+
 """
 
+from picongpu.picmi.copy_attributes import converts_to
 from ...pypicongpu.output.checkpoint import Checkpoint as PyPIConGPUCheckpoint
 from .timestepspec import TimeStepSpec
 
@@ -12,6 +13,15 @@ import typeguard
 from typing import Optional, Dict
 
 
+@converts_to(
+    PyPIConGPUCheckpoint,
+    conversions={
+        "period": lambda self, _, time_step_size, num_steps: self.period.get_as_pypicongpu(time_step_size, num_steps)
+        if self.period is not None
+        else None
+    },
+    preamble=lambda self, *args, **kwargs: self.check(),
+)
 @typeguard.typechecked
 class Checkpoint:
     """
@@ -102,29 +112,3 @@ class Checkpoint:
         self.restartChunkSize = restartChunkSize
         self.restartLoop = restartLoop
         self.openPMD = openPMD
-
-    def get_as_pypicongpu(
-        self,
-        pypicongpu_by_picmi_species: Dict,
-        time_step_size: float,
-        num_steps: int,
-    ) -> PyPIConGPUCheckpoint:
-        self.check()
-
-        pypicongpu_checkpoint = PyPIConGPUCheckpoint()
-        pypicongpu_checkpoint.period = (
-            self.period.get_as_pypicongpu(time_step_size, num_steps) if self.period is not None else None
-        )
-        pypicongpu_checkpoint.timePeriod = self.timePeriod
-        pypicongpu_checkpoint.directory = self.directory
-        pypicongpu_checkpoint.file = self.file
-        pypicongpu_checkpoint.restart = self.restart
-        pypicongpu_checkpoint.tryRestart = self.tryRestart
-        pypicongpu_checkpoint.restartStep = self.restartStep
-        pypicongpu_checkpoint.restartDirectory = self.restartDirectory
-        pypicongpu_checkpoint.restartFile = self.restartFile
-        pypicongpu_checkpoint.restartChunkSize = self.restartChunkSize
-        pypicongpu_checkpoint.restartLoop = self.restartLoop
-        pypicongpu_checkpoint.openPMD = self.openPMD
-
-        return pypicongpu_checkpoint

--- a/lib/python/picongpu/picmi/diagnostics/checkpoint.py
+++ b/lib/python/picongpu/picmi/diagnostics/checkpoint.py
@@ -5,23 +5,17 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from picongpu.picmi.copy_attributes import converts_to
+from typing import Dict, Optional
+
+import typeguard
+
+from picongpu.picmi.copy_attributes import default_converts_to
+
 from ...pypicongpu.output.checkpoint import Checkpoint as PyPIConGPUCheckpoint
 from .timestepspec import TimeStepSpec
 
-import typeguard
-from typing import Optional, Dict
 
-
-@converts_to(
-    PyPIConGPUCheckpoint,
-    conversions={
-        "period": lambda self, _, time_step_size, num_steps: self.period.get_as_pypicongpu(time_step_size, num_steps)
-        if self.period is not None
-        else None
-    },
-    preamble=lambda self, *args, **kwargs: self.check(),
-)
+@default_converts_to(PyPIConGPUCheckpoint)
 @typeguard.typechecked
 class Checkpoint:
     """
@@ -73,7 +67,7 @@ class Checkpoint:
         Dictionary of openPMD-specific settings (e.g., ext, json, infix).
     """
 
-    def check(self):
+    def check(self, *args, **kwargs):
         if self.period is None and self.timePeriod is None:
             raise ValueError("At least one of period or timePeriod must be provided")
         if self.timePeriod is not None and self.timePeriod < 0:

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Masoud Afshari
+Copyright 2021-2025 PIConGPU contributors
+Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -5,11 +5,11 @@ Authors: Masoud Afshari
 License: GPLv3+
 """
 
+from picongpu.picmi.copy_attributes import converts_to
 from .timestepspec import TimeStepSpec
 from ...pypicongpu.output.energy_histogram import (
     EnergyHistogram as PyPIConGPUEnergyHistogram,
 )
-from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
 
 
 from ..species import Species as PICMISpecies
@@ -17,6 +17,14 @@ from ..species import Species as PICMISpecies
 import typeguard
 
 
+@converts_to(
+    PyPIConGPUEnergyHistogram,
+    conversions={
+        "period": lambda self, _, time_step_size, num_steps: self.period.get_as_pypicongpu(time_step_size, num_steps),
+        "species": lambda self, d, *args: d.get(self.species),
+    },
+    preamble=lambda self, d, *args: self.check(d),
+)
 @typeguard.typechecked
 class EnergyHistogram:
     """
@@ -53,11 +61,13 @@ class EnergyHistogram:
         Optional name for the energy histogram plugin.
     """
 
-    def check(self):
+    def check(self, dict_species_picmi_to_pypicongpu):
         if self.min_energy >= self.max_energy:
             raise ValueError("min_energy must be less than max_energy")
         if self.bin_count <= 0:
             raise ValueError("bin_count must be > 0")
+        if self.species not in dict_species_picmi_to_pypicongpu.keys():
+            raise ValueError(f"Species {self.species} is not known to Simulation")
 
     def __init__(
         self,
@@ -72,30 +82,3 @@ class EnergyHistogram:
         self.bin_count = bin_count
         self.min_energy = min_energy
         self.max_energy = max_energy
-
-    def get_as_pypicongpu(
-        # to get the corresponding PyPIConGPUSpecies instance for the given PICMISpecies.
-        self,
-        dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies],
-        time_step_size,
-        num_steps,
-    ) -> PyPIConGPUEnergyHistogram:
-        self.check()
-
-        if self.species not in dict_species_picmi_to_pypicongpu.keys():
-            raise ValueError(f"Species {self.species} is not known to Simulation")
-
-        # checks if PICMISpecies instance exists in the dictionary. If yes, it returns the corresponding PyPIConGPUSpecies instance.
-        pypicongpu_species = dict_species_picmi_to_pypicongpu.get(self.species)
-
-        if pypicongpu_species is None:
-            raise ValueError(f"Species {self.species} is not mapped to a PyPIConGPUSpecies.")
-
-        pypicongpu_energy_histogram = PyPIConGPUEnergyHistogram()
-        pypicongpu_energy_histogram.species = pypicongpu_species
-        pypicongpu_energy_histogram.period = self.period.get_as_pypicongpu(time_step_size, num_steps)
-        pypicongpu_energy_histogram.bin_count = self.bin_count
-        pypicongpu_energy_histogram.min_energy = self.min_energy
-        pypicongpu_energy_histogram.max_energy = self.max_energy
-
-        return pypicongpu_energy_histogram

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -17,13 +17,7 @@ from ..species import Species as PICMISpecies
 import typeguard
 
 
-@default_converts_to(
-    PyPIConGPUEnergyHistogram,
-    conversions={
-        "period": lambda self, _, time_step_size, num_steps: self.period.get_as_pypicongpu(time_step_size, num_steps),
-        "species": lambda self, d, *args: d.get(self.species),
-    },
-)
+@default_converts_to(PyPIConGPUEnergyHistogram, conversions={"species": lambda self, d, *args: d.get(self.species)})
 @typeguard.typechecked
 class EnergyHistogram:
     """

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -5,7 +5,7 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from picongpu.picmi.copy_attributes import converts_to
+from picongpu.picmi.copy_attributes import default_converts_to
 from .timestepspec import TimeStepSpec
 from ...pypicongpu.output.energy_histogram import (
     EnergyHistogram as PyPIConGPUEnergyHistogram,
@@ -17,13 +17,12 @@ from ..species import Species as PICMISpecies
 import typeguard
 
 
-@converts_to(
+@default_converts_to(
     PyPIConGPUEnergyHistogram,
     conversions={
         "period": lambda self, _, time_step_size, num_steps: self.period.get_as_pypicongpu(time_step_size, num_steps),
         "species": lambda self, d, *args: d.get(self.species),
     },
-    preamble=lambda self, d, *args: self.check(d),
 )
 @typeguard.typechecked
 class EnergyHistogram:
@@ -61,7 +60,7 @@ class EnergyHistogram:
         Optional name for the energy histogram plugin.
     """
 
-    def check(self, dict_species_picmi_to_pypicongpu):
+    def check(self, dict_species_picmi_to_pypicongpu, *args, **kwargs):
         if self.min_energy >= self.max_energy:
             raise ValueError("min_energy must be less than max_energy")
         if self.bin_count <= 0:

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -5,19 +5,18 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from picongpu.picmi.copy_attributes import default_converts_to
-from .timestepspec import TimeStepSpec
+import typeguard
+
+from picongpu.picmi.diagnostics.util import diagnostic_converts_to
+
 from ...pypicongpu.output.energy_histogram import (
     EnergyHistogram as PyPIConGPUEnergyHistogram,
 )
-
-
 from ..species import Species as PICMISpecies
+from .timestepspec import TimeStepSpec
 
-import typeguard
 
-
-@default_converts_to(PyPIConGPUEnergyHistogram, conversions={"species": lambda self, d, *args: d.get(self.species)})
+@diagnostic_converts_to(PyPIConGPUEnergyHistogram)
 @typeguard.typechecked
 class EnergyHistogram:
     """

--- a/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
+++ b/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Masoud Afshari
+Copyright 2021-2025 PIConGPU contributors
+Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
+++ b/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
@@ -37,9 +37,6 @@ class MacroParticleCount:
         Optional name for the macro particle count plugin.
     """
 
-    def check(self):
-        pass
-
     def __init__(self, species: PICMISpecies, period: TimeStepSpec):
         self.species = species
         self.period = period
@@ -50,8 +47,6 @@ class MacroParticleCount:
         time_step_size,
         num_steps,
     ) -> PyPIConGPUMacroParticleCount:
-        self.check()
-
         if self.species not in dict_species_picmi_to_pypicongpu.keys():
             raise ValueError(f"Species {self.species} is not known to Simulation")
 

--- a/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
+++ b/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 import typeguard
 
-from picongpu.picmi.copy_attributes import default_converts_to
+from picongpu.picmi.diagnostics.util import diagnostic_converts_to
 
 from ...pypicongpu.output.macro_particle_count import (
     MacroParticleCount as PyPIConGPUMacroParticleCount,
@@ -17,7 +17,7 @@ from ..species import Species as PICMISpecies
 from .timestepspec import TimeStepSpec
 
 
-@default_converts_to(PyPIConGPUMacroParticleCount, conversions={"species": lambda self, d, *args: d.get(self.species)})
+@diagnostic_converts_to(PyPIConGPUMacroParticleCount)
 @typeguard.typechecked
 class MacroParticleCount:
     """
@@ -43,9 +43,7 @@ class MacroParticleCount:
         self.species = species
         self.period = period
 
-    def check(
-        self, dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies], *args, **kwargs
-    ) -> PyPIConGPUMacroParticleCount:
+    def check(self, dict_species_picmi_to_pypicongpu: dict[PICMISpecies, PyPIConGPUSpecies], *args, **kwargs):
         if self.species not in dict_species_picmi_to_pypicongpu.keys():
             raise ValueError(f"Species {self.species} is not known to Simulation")
         pypicongpu_species = dict_species_picmi_to_pypicongpu.get(self.species)

--- a/lib/python/picongpu/picmi/diagnostics/phase_space.py
+++ b/lib/python/picongpu/picmi/diagnostics/phase_space.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Masoud Afshari
+Copyright 2021-2025 PIConGPU contributors
+Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/diagnostics/phase_space.py
+++ b/lib/python/picongpu/picmi/diagnostics/phase_space.py
@@ -5,25 +5,18 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from picongpu.picmi.copy_attributes import converts_to
-from ...pypicongpu.output.phase_space import PhaseSpace as PyPIConGPUPhaseSpace
+from typing import Literal
 
+import typeguard
+
+from picongpu.picmi.copy_attributes import default_converts_to
+
+from ...pypicongpu.output.phase_space import PhaseSpace as PyPIConGPUPhaseSpace
 from ..species import Species as PICMISpecies
 from .timestepspec import TimeStepSpec
 
-import typeguard
-from typing import Literal
 
-
-@converts_to(
-    PyPIConGPUPhaseSpace,
-    conversions={
-        "species": lambda self, d, *args: d.get(self.species),
-        "period": lambda self, _, *args: self.period.get_as_pypicongpu(*args),
-    },
-    preamble=lambda self, d, *args: self.check(d),
-    ignore=["check"],
-)
+@default_converts_to(PyPIConGPUPhaseSpace, conversions={"species": lambda self, d, *args: d.get(self.species)})
 @typeguard.typechecked
 class PhaseSpace:
     """

--- a/lib/python/picongpu/picmi/diagnostics/phase_space.py
+++ b/lib/python/picongpu/picmi/diagnostics/phase_space.py
@@ -9,14 +9,14 @@ from typing import Literal
 
 import typeguard
 
-from picongpu.picmi.copy_attributes import default_converts_to
+from picongpu.picmi.diagnostics.util import diagnostic_converts_to
 
 from ...pypicongpu.output.phase_space import PhaseSpace as PyPIConGPUPhaseSpace
 from ..species import Species as PICMISpecies
 from .timestepspec import TimeStepSpec
 
 
-@default_converts_to(PyPIConGPUPhaseSpace, conversions={"species": lambda self, d, *args: d.get(self.species)})
+@diagnostic_converts_to(PyPIConGPUPhaseSpace)
 @typeguard.typechecked
 class PhaseSpace:
     """
@@ -52,7 +52,7 @@ class PhaseSpace:
         Optional name for the phase-space plugin.
     """
 
-    def check(self, dict_species_picmi_to_pypicongpu):
+    def check(self, dict_species_picmi_to_pypicongpu, *args, **kwargs):
         if self.min_momentum >= self.max_momentum:
             raise ValueError("min_momentum must be less than max_momentum")
 

--- a/lib/python/picongpu/picmi/diagnostics/png.py
+++ b/lib/python/picongpu/picmi/diagnostics/png.py
@@ -9,7 +9,7 @@ from typing import List
 
 import typeguard
 
-from picongpu.picmi.copy_attributes import default_converts_to
+from picongpu.picmi.diagnostics.util import diagnostic_converts_to
 
 from ...pypicongpu.output.png import ColorScaleEnum, EMFieldScaleEnum
 from ...pypicongpu.output.png import Png as PyPIConGPUPNG
@@ -17,7 +17,7 @@ from ..species import Species as PICMISpecies
 from .timestepspec import TimeStepSpec
 
 
-@default_converts_to(PyPIConGPUPNG, conversions={"species": lambda self, d, *args: d.get(self.species)})
+@diagnostic_converts_to(PyPIConGPUPNG)
 @typeguard.typechecked
 class Png:
     """

--- a/lib/python/picongpu/picmi/diagnostics/png.py
+++ b/lib/python/picongpu/picmi/diagnostics/png.py
@@ -5,18 +5,19 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from picongpu.picmi.copy_attributes import converts_to
-from ...pypicongpu.output.png import Png as PyPIConGPUPNG
-from ...pypicongpu.output.png import EMFieldScaleEnum, ColorScaleEnum
+from typing import List
 
+import typeguard
+
+from picongpu.picmi.copy_attributes import default_converts_to
+
+from ...pypicongpu.output.png import ColorScaleEnum, EMFieldScaleEnum
+from ...pypicongpu.output.png import Png as PyPIConGPUPNG
 from ..species import Species as PICMISpecies
 from .timestepspec import TimeStepSpec
 
-import typeguard
-from typing import List
 
-
-@converts_to(PyPIConGPUPNG, conversions={"species": lambda self, d, *args: d.get(self.species)})
+@default_converts_to(PyPIConGPUPNG, conversions={"species": lambda self, d, *args: d.get(self.species)})
 @typeguard.typechecked
 class Png:
     """

--- a/lib/python/picongpu/picmi/diagnostics/png.py
+++ b/lib/python/picongpu/picmi/diagnostics/png.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Masoud Afshari
+Copyright 2021-2025 PIConGPU contributors
+Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/diagnostics/png.py
+++ b/lib/python/picongpu/picmi/diagnostics/png.py
@@ -16,15 +16,7 @@ import typeguard
 from typing import List
 
 
-@converts_to(
-    PyPIConGPUPNG,
-    conversions={
-        "species": lambda self, d, *args: d.get(self.species),
-        "period": lambda self, _, *args: self.period.get_as_pypicongpu(*args),
-    },
-    preamble=lambda self, d, *args: self.check(d),
-    ignore=["check"],
-)
+@converts_to(PyPIConGPUPNG, conversions={"species": lambda self, d, *args: d.get(self.species)})
 @typeguard.typechecked
 class Png:
     """
@@ -112,7 +104,7 @@ class Png:
         Custom expression for channel 3.
     """
 
-    def check(self, dict_species_picmi_to_pypicongpu):
+    def check(self, dict_species_picmi_to_pypicongpu, *args, **kwargs):
         if not (0.0 <= self.slice_point <= 1.0):
             raise ValueError("Slice point must be between 0.0 and 1.0")
 

--- a/lib/python/picongpu/picmi/diagnostics/timestepspec.py
+++ b/lib/python/picongpu/picmi/diagnostics/timestepspec.py
@@ -186,7 +186,7 @@ class TimeStepSpec(metaclass=_TimeStepSpecMeta):
             spec.step,
         )
 
-    def get_as_pypicongpu(self, time_step_size, num_steps):
+    def get_as_pypicongpu(self, time_step_size, num_steps, **kwargs):
         """
         Creates the corresponding pypicongpu object by translating every specification
         into non-negative (except for -1) slices in units of steps. It takes `time_step_size`

--- a/lib/python/picongpu/picmi/diagnostics/util.py
+++ b/lib/python/picongpu/picmi/diagnostics/util.py
@@ -1,0 +1,15 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from picongpu.picmi.copy_attributes import default_converts_to
+
+
+def diagnostic_converts_to(*args, **kwargs):
+    kwargs["conversions"] = {
+        "species": lambda self, *args, **kwargs: kwargs["dict_species_picmi_to_pypicongpu"].get(self.species)
+    } | kwargs.get("conversions", {})
+    return default_converts_to(*args, **kwargs)

--- a/lib/python/picongpu/picmi/grid.py
+++ b/lib/python/picongpu/picmi/grid.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
+Copyright 2021-2025 PIConGPU contributors
+Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
@@ -11,10 +11,12 @@ import typing
 import typeguard
 
 from ...pypicongpu import laser
+from ..copy_attributes import default_converts_to
 from .base_laser import BaseLaser
 from .polarization_type import PolarizationType
 
 
+@default_converts_to(laser.DispersivePulseLaser)
 @typeguard.typechecked
 class DispersivePulseLaser(BaseLaser):
     """
@@ -122,30 +124,11 @@ class DispersivePulseLaser(BaseLaser):
         self.picongpu_gdd_si = picongpu_gdd_si
         self.picongpu_tod_si = picongpu_tod_si
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+        self._validate_common_properties()
+        self.pulse_init = self._compute_pulse_init()
 
-    def get_as_pypicongpu(self) -> laser.DispersivePulseLaser:
+    def check(self):
         self._validate_common_properties()
         assert self._propagation_connects_centroid_and_focus(), (
             "propagation_direction must connect centroid_position and focus_position"
         )
-        pypicongpu_laser = laser.DispersivePulseLaser()
-        pypicongpu_laser.wavelength = self.wavelength
-        pypicongpu_laser.waist = self.waist
-        pypicongpu_laser.duration = self.duration
-        pypicongpu_laser.focus_pos = self.focal_position
-        pypicongpu_laser.phase = self.phi0
-        pypicongpu_laser.E0 = self.E0
-        pypicongpu_laser.pulse_init = self._compute_pulse_init()
-        pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
-        pypicongpu_laser.polarization_direction = self.polarization_direction
-        pypicongpu_laser.propagation_direction = self.propagation_direction
-
-        pypicongpu_laser.spectral_support = self.picongpu_spectral_support
-        pypicongpu_laser.sd_si = self.picongpu_sd_si
-        pypicongpu_laser.ad_si = self.picongpu_ad_si
-        pypicongpu_laser.gdd_si = self.picongpu_gdd_si
-        pypicongpu_laser.tod_si = self.picongpu_tod_si
-
-        pypicongpu_laser.huygens_surface_positions = self.picongpu_huygens_surface_positions
-
-        return pypicongpu_laser

--- a/lib/python/picongpu/picmi/lasers/from_openpmd_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/from_openpmd_pulse_laser.py
@@ -5,11 +5,13 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from ...pypicongpu import laser
-
 import typeguard
 
+from ...pypicongpu import laser
+from ..copy_attributes import default_converts_to
 
+
+@default_converts_to(laser.FromOpenPMDPulseLaser)
 @typeguard.typechecked
 class FromOpenPMDPulseLaser:
     """PICMI object for FromOpenPMDPulseLaser"""
@@ -46,18 +48,3 @@ class FromOpenPMDPulseLaser:
         self.polarisationAxisOpenPMD = polarisationAxisOpenPMD
         self.propagationAxisOpenPMD = propagationAxisOpenPMD
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
-
-    def get_as_pypicongpu(self) -> laser.FromOpenPMDPulseLaser:
-        pypicongpu_laser = laser.FromOpenPMDPulseLaser()
-        pypicongpu_laser.propagation_direction = self.propagation_direction
-        pypicongpu_laser.polarization_direction = self.polarization_direction
-        pypicongpu_laser.file_path = self.file_path
-        pypicongpu_laser.iteration = self.iteration
-        pypicongpu_laser.dataset_name = self.dataset_name
-        pypicongpu_laser.datatype = self.datatype
-        pypicongpu_laser.time_offset_si = self.time_offset_si
-        pypicongpu_laser.polarisationAxisOpenPMD = self.polarisationAxisOpenPMD
-        pypicongpu_laser.propagationAxisOpenPMD = self.propagationAxisOpenPMD
-        pypicongpu_laser.huygens_surface_positions = self.picongpu_huygens_surface_positions
-
-        return pypicongpu_laser

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -55,9 +55,7 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         if duration <= 0:
             raise ValueError(f"laser pulse duration must be > 0. You gave {duration=}.")
 
-        assert (
-            picongpu_laguerre_modes is None and picongpu_laguerre_phases is None
-        ) or (
+        assert (picongpu_laguerre_modes is None and picongpu_laguerre_phases is None) or (
             picongpu_laguerre_modes is not None and picongpu_laguerre_phases is not None
         ), (
             "laguerre_modes and laguerre_phases MUST BE both set or both \

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -11,10 +11,12 @@ import typing
 import typeguard
 
 from ...pypicongpu import laser
+from ..copy_attributes import default_converts_to
 from .base_laser import BaseLaser
 from .polarization_type import PolarizationType
 
 
+@default_converts_to(laser.PlaneWaveLaser)
 @typeguard.typechecked
 class PlaneWaveLaser(BaseLaser):
     """
@@ -90,24 +92,11 @@ class PlaneWaveLaser(BaseLaser):
         self.picongpu_plateau_duration = picongpu_plateau_duration
         self.picongpu_polarization_type = picongpu_polarization_type
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+        self.focus_pos = [0.0, 0.0, 0.0]
+        self._validate_common_properties()
+        self.pulse_init = self._compute_pulse_init()
 
     """PICMI object for Plane Wave Laser"""
 
-    def get_as_pypicongpu(self) -> laser.PlaneWaveLaser:
+    def check(self):
         self._validate_common_properties()
-
-        pypicongpu_laser = laser.PlaneWaveLaser()
-        pypicongpu_laser.wavelength = self.wavelength
-        pypicongpu_laser.duration = self.duration
-        pypicongpu_laser.focus_pos = [0.0, 0.0, 0.0]
-        pypicongpu_laser.phase = self.phi0
-        pypicongpu_laser.E0 = self.E0
-        pypicongpu_laser.pulse_init = self._compute_pulse_init()
-        pypicongpu_laser.polarization_type = self.picongpu_polarization_type.get_as_pypicongpu()
-        pypicongpu_laser.polarization_direction = self.polarization_direction
-        pypicongpu_laser.laser_nofocus_constant_si = self.picongpu_plateau_duration
-        pypicongpu_laser.propagation_direction = self.propagation_direction
-
-        pypicongpu_laser.huygens_surface_positions = self.picongpu_huygens_surface_positions
-
-        return pypicongpu_laser

--- a/lib/python/picongpu/picmi/lasers/polarization_type.py
+++ b/lib/python/picongpu/picmi/lasers/polarization_type.py
@@ -6,6 +6,7 @@ License: GPLv3+
 """
 
 from enum import Enum
+
 from ...pypicongpu.laser import PolarizationType as PyPIConGPUPolarizationType
 
 

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -524,7 +524,11 @@ class Simulation(picmistandard.PICMI_Simulation):
         s.init_manager, pypicongpu_by_picmi_species = self.__get_init_manager()
 
         s.plugins = [
-            entry.get_as_pypicongpu(pypicongpu_by_picmi_species, self.time_step_size, s.time_steps)
+            entry.get_as_pypicongpu(
+                dict_species_picmi_to_pypicongpu=pypicongpu_by_picmi_species,
+                time_step_size=self.time_step_size,
+                num_steps=s.time_steps,
+            )
             for entry in self.diagnostics
         ]
 

--- a/lib/python/picongpu/pypicongpu/grid.py
+++ b/lib/python/picongpu/pypicongpu/grid.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
+Copyright 2021-2025 PIConGPU contributors
+Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/pypicongpu/grid.py
+++ b/lib/python/picongpu/pypicongpu/grid.py
@@ -48,26 +48,14 @@ class Grid3D(RenderedObject):
     The bounding box is implicitly given as TODO.
     """
 
-    cell_size_x_si = util.build_typesafe_property(float)
-    """Width of individual cell in X direction"""
-    cell_size_y_si = util.build_typesafe_property(float)
-    """Width of individual cell in Y direction"""
-    cell_size_z_si = util.build_typesafe_property(float)
-    """Width of individual cell in Z direction"""
+    cell_size_si = util.build_typesafe_property(tuple[float, float, float])
+    """Width of individual cell in each direction"""
 
-    cell_cnt_x = util.build_typesafe_property(int)
-    """total number of cells in X direction"""
-    cell_cnt_y = util.build_typesafe_property(int)
-    """total number of cells in Y direction"""
-    cell_cnt_z = util.build_typesafe_property(int)
-    """total number of cells in Z direction"""
+    cell_cnt = util.build_typesafe_property(tuple[int, int, int])
+    """total number of cells in each direction"""
 
-    boundary_condition_x = util.build_typesafe_property(BoundaryCondition)
-    """behavior towards particles crossing the X boundary"""
-    boundary_condition_y = util.build_typesafe_property(BoundaryCondition)
-    """behavior towards particles crossing the Y boundary"""
-    boundary_condition_z = util.build_typesafe_property(BoundaryCondition)
-    """behavior towards particles crossing the Z boundary"""
+    boundary_condition = util.build_typesafe_property(tuple[BoundaryCondition, BoundaryCondition, BoundaryCondition])
+    """behavior towards particles crossing each boundary"""
 
     n_gpus = util.build_typesafe_property(typing.Tuple[int, int, int])
     """number of GPUs in x y and z direction as 3-integer tuple"""
@@ -80,42 +68,19 @@ class Grid3D(RenderedObject):
 
     def _get_serialized(self) -> dict:
         """serialized representation provided for RenderedObject"""
-        assert self.cell_cnt_x > 0, "cell_cnt_x must be greater than 0"
-        assert self.cell_cnt_y > 0, "cell_cnt_y must be greater than 0"
-        assert self.cell_cnt_z > 0, "cell_cnt_z must be greater than 0"
-        for i in range(3):
-            assert self.n_gpus[i] > 0, "all n_gpus entries must be greater than 0"
+        assert all(x > 0 for x in self.cell_cnt), "cell_cnt must be greater than 0"
+        assert all(x > 0 for x in self.n_gpus), "all n_gpus entries must be greater than 0"
         if self.grid_dist is not None:
-            assert sum(self.grid_dist[0]) == self.cell_cnt_x, "sum of grid_dists in x must be equal to number_of_cells"
-            assert sum(self.grid_dist[1]) == self.cell_cnt_y, "sum of grid_dists in y must be equal to number_of_cells"
-            assert sum(self.grid_dist[2]) == self.cell_cnt_z, "sum of grid_dists in z must be equal to number_of_cells"
+            assert sum(self.grid_dist[0]) == self.cell_cnt[0], "sum of grid_dists in x must be equal to number_of_cells"
+            assert sum(self.grid_dist[1]) == self.cell_cnt[1], "sum of grid_dists in y must be equal to number_of_cells"
+            assert sum(self.grid_dist[2]) == self.cell_cnt[2], "sum of grid_dists in z must be equal to number_of_cells"
 
         result_dict = {
-            "cell_size": {
-                "x": self.cell_size_x_si,
-                "y": self.cell_size_y_si,
-                "z": self.cell_size_z_si,
-            },
-            "cell_cnt": {
-                "x": self.cell_cnt_x,
-                "y": self.cell_cnt_y,
-                "z": self.cell_cnt_z,
-            },
-            "boundary_condition": {
-                "x": self.boundary_condition_x.get_cfg_str(),
-                "y": self.boundary_condition_y.get_cfg_str(),
-                "z": self.boundary_condition_z.get_cfg_str(),
-            },
-            "gpu_cnt": {
-                "x": self.n_gpus[0],
-                "y": self.n_gpus[1],
-                "z": self.n_gpus[2],
-            },
-            "super_cell_size": {
-                "x": self.super_cell_size[0],
-                "y": self.super_cell_size[1],
-                "z": self.super_cell_size[2],
-            },
+            "cell_size": dict(zip("xyz", self.cell_size_si)),
+            "cell_cnt": dict(zip("xyz", self.cell_cnt)),
+            "boundary_condition": dict(zip("xyz", map(BoundaryCondition.get_cfg_str, self.boundary_condition))),
+            "gpu_cnt": dict(zip("xyz", self.n_gpus)),
+            "super_cell_size": dict(zip("xyz", self.super_cell_size)),
         }
         if self.grid_dist is not None:
             result_dict["grid_dist"] = {

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -65,10 +65,10 @@ class _BaseLaser(Laser):
     """wave length in m"""
     duration = util.build_typesafe_property(float)
     """duration in s (1 sigma)"""
-    focus_pos = util.build_typesafe_property(typing.List[float])
+    focal_position = util.build_typesafe_property(typing.List[float])
     """focus position vector in m"""
-    phase = util.build_typesafe_property(float)
-    """phase in rad, periodic in 2*pi"""
+    phi0 = util.build_typesafe_property(float)
+    """phi0 in rad, periodic in 2*pi"""
     E0 = util.build_typesafe_property(float)
     """E0 in V/m"""
     pulse_init = util.build_typesafe_property(float)
@@ -84,8 +84,8 @@ class _BaseLaser(Laser):
         return {
             "wave_length_si": self.wavelength,
             "pulse_duration_si": self.duration,
-            "focus_pos_si": list(map(lambda x: {"component": x}, self.focus_pos)),
-            "phase": self.phase,
+            "focus_pos_si": list(map(lambda x: {"component": x}, self.focal_position)),
+            "phase": self.phi0,
             "E0_si": self.E0,
             "pulse_init": self.pulse_init,
             "propagation_direction": list(map(lambda x: {"component": x}, self.propagation_direction)),

--- a/lib/python/picongpu/pypicongpu/output/png.py
+++ b/lib/python/picongpu/pypicongpu/output/png.py
@@ -1,7 +1,7 @@
 """
 This file is part of PIConGPU.
-Copyright 2021-2024 PIConGPU contributors
-Authors: Masoud Afshari
+Copyright 2021-2025 PIConGPU contributors
+Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 

--- a/lib/python/picongpu/pypicongpu/output/png.py
+++ b/lib/python/picongpu/pypicongpu/output/png.py
@@ -54,26 +54,26 @@ class Png(Plugin):
     species = util.build_typesafe_property(Species)
     period = util.build_typesafe_property(TimeStepSpec)
     axis = util.build_typesafe_property(str)
-    slicePoint = util.build_typesafe_property(float)
-    folder = util.build_typesafe_property(str)
+    slice_point = util.build_typesafe_property(float)
+    folder_name = util.build_typesafe_property(str)
     scale_image = util.build_typesafe_property(float)
     scale_to_cellsize = util.build_typesafe_property(bool)
-    white_box_per_GPU = util.build_typesafe_property(bool)
-    EM_FIELD_SCALE_CHANNEL1 = util.build_typesafe_property(EMFieldScaleEnum)
-    EM_FIELD_SCALE_CHANNEL2 = util.build_typesafe_property(EMFieldScaleEnum)
-    EM_FIELD_SCALE_CHANNEL3 = util.build_typesafe_property(EMFieldScaleEnum)
-    preParticleDensCol = util.build_typesafe_property(ColorScaleEnum)
-    preChannel1Col = util.build_typesafe_property(ColorScaleEnum)
-    preChannel2Col = util.build_typesafe_property(ColorScaleEnum)
-    preChannel3Col = util.build_typesafe_property(ColorScaleEnum)
-    customNormalizationSI = util.build_typesafe_property(typing.List[float])
-    preParticleDens_opacity = util.build_typesafe_property(float)
-    preChannel1_opacity = util.build_typesafe_property(float)
-    preChannel2_opacity = util.build_typesafe_property(float)
-    preChannel3_opacity = util.build_typesafe_property(float)
-    preChannel1 = util.build_typesafe_property(str)
-    preChannel2 = util.build_typesafe_property(str)
-    preChannel3 = util.build_typesafe_property(str)
+    white_box_per_gpu = util.build_typesafe_property(bool)
+    em_field_scale_channel1 = util.build_typesafe_property(EMFieldScaleEnum)
+    em_field_scale_channel2 = util.build_typesafe_property(EMFieldScaleEnum)
+    em_field_scale_channel3 = util.build_typesafe_property(EMFieldScaleEnum)
+    pre_particle_density_color_scales = util.build_typesafe_property(ColorScaleEnum)
+    pre_channel1_color_scales = util.build_typesafe_property(ColorScaleEnum)
+    pre_channel2_color_scales = util.build_typesafe_property(ColorScaleEnum)
+    pre_channel3_color_scales = util.build_typesafe_property(ColorScaleEnum)
+    custom_normalization_si = util.build_typesafe_property(typing.List[float])
+    pre_particle_density_opacity = util.build_typesafe_property(float)
+    pre_channel1_opacity = util.build_typesafe_property(float)
+    pre_channel2_opacity = util.build_typesafe_property(float)
+    pre_channel3_opacity = util.build_typesafe_property(float)
+    pre_channel1 = util.build_typesafe_property(str)
+    pre_channel2 = util.build_typesafe_property(str)
+    pre_channel3 = util.build_typesafe_property(str)
 
     _name = "png"
 
@@ -84,30 +84,30 @@ class Png(Plugin):
         """Return the serialized representation of the object."""
 
         # Transform customNormalizationSI into a list of dictionaries
-        custom_normalization_si_serialized = [{"value": val} for val in self.customNormalizationSI]
+        custom_normalization_si_serialized = [{"value": val} for val in self.custom_normalization_si]
 
         return {
             "species": self.species.get_rendering_context(),
             "period": self.period.get_rendering_context(),
             "axis": self.axis,
-            "slicePoint": self.slicePoint,
-            "folder": self.folder,
+            "slicePoint": self.slice_point,
+            "folder": self.folder_name,
             "scale_image": self.scale_image,
             "scale_to_cellsize": self.scale_to_cellsize,
-            "white_box_per_GPU": self.white_box_per_GPU,
-            "EM_FIELD_SCALE_CHANNEL1": self.EM_FIELD_SCALE_CHANNEL1.value,
-            "EM_FIELD_SCALE_CHANNEL2": self.EM_FIELD_SCALE_CHANNEL2.value,
-            "EM_FIELD_SCALE_CHANNEL3": self.EM_FIELD_SCALE_CHANNEL3.value,
-            "preParticleDensCol": self.preParticleDensCol.value,
-            "preChannel1Col": self.preChannel1Col.value,
-            "preChannel2Col": self.preChannel2Col.value,
-            "preChannel3Col": self.preChannel3Col.value,
+            "white_box_per_GPU": self.white_box_per_gpu,
+            "EM_FIELD_SCALE_CHANNEL1": self.em_field_scale_channel1.value,
+            "EM_FIELD_SCALE_CHANNEL2": self.em_field_scale_channel2.value,
+            "EM_FIELD_SCALE_CHANNEL3": self.em_field_scale_channel3.value,
+            "preParticleDensCol": self.pre_particle_density_color_scales.value,
+            "preChannel1Col": self.pre_channel1_color_scales.value,
+            "preChannel2Col": self.pre_channel2_color_scales.value,
+            "preChannel3Col": self.pre_channel3_color_scales.value,
             "customNormalizationSI": custom_normalization_si_serialized,
-            "preParticleDens_opacity": self.preParticleDens_opacity,
-            "preChannel1_opacity": self.preChannel1_opacity,
-            "preChannel2_opacity": self.preChannel2_opacity,
-            "preChannel3_opacity": self.preChannel3_opacity,
-            "preChannel1": self.preChannel1,
-            "preChannel2": self.preChannel2,
-            "preChannel3": self.preChannel3,
+            "preParticleDens_opacity": self.pre_particle_density_opacity,
+            "preChannel1_opacity": self.pre_channel1_opacity,
+            "preChannel2_opacity": self.pre_channel2_opacity,
+            "preChannel3_opacity": self.pre_channel3_opacity,
+            "preChannel1": self.pre_channel1,
+            "preChannel2": self.pre_channel2,
+            "preChannel3": self.pre_channel3,
         }

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -23,22 +23,22 @@ class Gaussian(DensityProfile):
 
     _name = "gaussian"
 
-    gas_center_front = util.build_typesafe_property(float)
+    center_front = util.build_typesafe_property(float)
     """position of the front edge of the constant middle of the density profile, [m]"""
 
-    gas_center_rear = util.build_typesafe_property(float)
+    center_rear = util.build_typesafe_property(float)
     """position of the rear edge of the constant middle of the density profile, [m]"""
 
-    gas_sigma_front = util.build_typesafe_property(float)
+    sigma_front = util.build_typesafe_property(float)
     """distance from gasCenterFront until the gas density decreases to its 1/e-th part, [m]"""
 
-    gas_sigma_rear = util.build_typesafe_property(float)
+    sigma_rear = util.build_typesafe_property(float)
     """distance from gasCenterRear until the gas density decreases to its 1/e-th part, [m]"""
 
-    gas_factor = util.build_typesafe_property(float)
+    factor = util.build_typesafe_property(float)
     """exponential scaling factor, see formula above"""
 
-    gas_power = util.build_typesafe_property(float)
+    power = util.build_typesafe_property(float)
     """power-exponent in exponent of density function"""
 
     vacuum_cells_front = util.build_typesafe_property(int)
@@ -51,21 +51,21 @@ class Gaussian(DensityProfile):
         if self.density <= 0:
             raise ValueError("density must be > 0")
 
-        if self.gas_center_front < 0:
+        if self.center_front < 0:
             raise ValueError("gas_center_front must be >= 0")
-        if self.gas_center_rear < 0:
+        if self.center_rear < 0:
             raise ValueError("gas_center_rear must be >= 0")
-        if self.gas_center_rear < self.gas_center_front:
+        if self.center_rear < self.center_front:
             raise ValueError("gas_center_rear must be >= gas_center_front")
 
-        if self.gas_sigma_front == 0:
+        if self.sigma_front == 0:
             raise ValueError("gas_sigma_front must be != 0")
-        if self.gas_sigma_rear == 0:
+        if self.sigma_rear == 0:
             raise ValueError("gas_sigma_rear must be != 0")
 
-        if self.gas_factor >= 0:
+        if self.factor >= 0:
             raise ValueError("gas_factor must be < 0")
-        if self.gas_power == 0:
+        if self.power == 0:
             raise ValueError("gas_power must be != 0")
 
         if self.vacuum_cells_front < 0:
@@ -75,12 +75,12 @@ class Gaussian(DensityProfile):
         self.check()
 
         return {
-            "gas_center_front": self.gas_center_front,
-            "gas_center_rear": self.gas_center_rear,
-            "gas_sigma_front": self.gas_sigma_front,
-            "gas_sigma_rear": self.gas_sigma_rear,
-            "gas_factor": self.gas_factor,
-            "gas_power": self.gas_power,
+            "gas_center_front": self.center_front,
+            "gas_center_rear": self.center_rear,
+            "gas_sigma_front": self.sigma_front,
+            "gas_sigma_rear": self.sigma_rear,
+            "gas_factor": self.factor,
+            "gas_power": self.power,
             "vacuum_cells_front": self.vacuum_cells_front,
             "density": self.density,
         }

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import typeguard
 from picongpu import picmi, pypicongpu
+from picongpu.pypicongpu.grid import BoundaryCondition
 
 
 @typeguard.typechecked
@@ -45,16 +46,14 @@ class TestSimulation(unittest.TestCase):
         sim.time_steps = steps
         sim.typical_ppc = 1
         sim.grid = pypicongpu.grid.Grid3D()
-        sim.grid.cell_size_x_si = 1.776e-07
-        sim.grid.cell_size_y_si = 4.43e-08
-        sim.grid.cell_size_z_si = 1.776e-07
-        sim.grid.cell_cnt_x = 1
-        sim.grid.cell_cnt_y = 1
-        sim.grid.cell_cnt_z = 1
+        sim.grid.cell_size_si = 1.776e-07, 4.43e-08, 1.776e-07
+        sim.grid.cell_cnt = (1, 1, 1)
         sim.grid.n_gpus = (1, 1, 1)
-        sim.grid.boundary_condition_x = pypicongpu.grid.BoundaryCondition.PERIODIC
-        sim.grid.boundary_condition_y = pypicongpu.grid.BoundaryCondition.PERIODIC
-        sim.grid.boundary_condition_z = pypicongpu.grid.BoundaryCondition.PERIODIC
+        sim.grid.boundary_condition = (
+            BoundaryCondition.PERIODIC,
+            BoundaryCondition.PERIODIC,
+            BoundaryCondition.PERIODIC,
+        )
         sim.grid.super_cell_size = (8, 8, 4)
         sim.grid.grid_dist = None
         sim.laser = None

--- a/test/python/picongpu/quick/picmi/__init__.py
+++ b/test/python/picongpu/quick/picmi/__init__.py
@@ -7,3 +7,4 @@ from .gaussian_laser import *  # pyflakes.ignore
 from .grid import *  # pyflakes.ignore
 from .diagnostics import *  # pyflakes.ignore
 from .normalise_template_dir import *  # pyflakes.ignore
+from .copy_attributes import *  # pyflakes.ignore

--- a/test/python/picongpu/quick/picmi/copy_attributes.py
+++ b/test/python/picongpu/quick/picmi/copy_attributes.py
@@ -1,0 +1,275 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import unittest
+import inspect
+from picongpu.picmi.copy_attributes import copy_attributes, converts_to
+
+CLASS_NAME = "TmpClass"
+ARBITRARY_VALUE = 42
+
+
+def custom_conversion(self):
+    return 2 * self.arbitrary_name
+
+
+def gen_class(attributes=None, use_values=True):
+    attributes = {key: value if use_values else None for key, value in (attributes or {}).items()}
+    return type(CLASS_NAME, tuple(), attributes)
+
+
+def gen_two_classes(common_attributes=None, only_provider=None, only_receiver=None):
+    return gen_class((common_attributes or {}) | (only_provider or {})), gen_class(
+        use_values=False, attributes=(common_attributes or {}) | (only_receiver or {})
+    )
+
+
+def gen_provider_and_matching_receiver_class(common_attributes=None, only_provider=None, only_receiver=None):
+    classes = gen_two_classes(
+        common_attributes=common_attributes or {}, only_provider=only_provider or {}, only_receiver=only_receiver or {}
+    )
+    return classes[0](), classes[1]
+
+
+class MiniMock:
+    counter = 0
+    args = None
+    kwargs = None
+
+    def __call__(self, *args, **kwargs):
+        self.counter += 1
+        self.args = args
+        self.kwargs = kwargs
+
+
+class TestCopyAttributes(unittest.TestCase):
+    def test_returns_instance_of_correct_class(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class()
+        self.assertTrue(isinstance(copy_attributes(dummy_provider, DummyReceiver), DummyReceiver))
+
+    def test_receiving_classes_must_be_default_constructible(self):
+        # This does not apply to instances!
+
+        def custom_init(self, _):
+            # Setting this as __init__ makes the class expect one argument upon instantiation.
+            # It is thus no longer default constructible.
+            pass
+
+        dummy_provider = gen_class()()
+        DummyReceiver = gen_class(attributes={"__init__": custom_init})
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Instantiation failed. The receiving class must be default constructible. "
+            f"You gave .*{CLASS_NAME}.* which expects 1 argument in its constructor. "
+            "You can work with an instance instead of a class in this case.",
+        ):
+            # This fails because it tries to instantiate DummyReceiver as DummyReceiver().
+            copy_attributes(dummy_provider, DummyReceiver)
+            # This would have worked:
+            # copy_attributes(dummy_provider, DummyReceiver(1))
+
+    def test_returns_identical_instance(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class()
+        dummy_receiver = DummyReceiver()
+        self.assertTrue(copy_attributes(dummy_provider, dummy_receiver) is dummy_receiver)
+
+    def test_copies_single_attribute(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE}
+        )
+
+        # precondition, just to check that our test infrastructure works:
+        self.assertEqual(dummy_provider.arbitrary_name, ARBITRARY_VALUE)
+        self.assertNotEqual(dummy_provider.arbitrary_name, DummyReceiver().arbitrary_name)
+
+        self.assertEqual(copy_attributes(dummy_provider, DummyReceiver).arbitrary_name, ARBITRARY_VALUE)
+
+    def test_does_not_copy_private_attributes(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE, "_private_attribute": ARBITRARY_VALUE}
+        )
+
+        self.assertNotEqual(
+            copy_attributes(dummy_provider, DummyReceiver)._private_attribute, dummy_provider._private_attribute
+        )
+
+    def test_does_create_new_attributes(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE},
+            only_provider={"additional_argument": ARBITRARY_VALUE},
+        )
+
+        self.assertFalse(hasattr(copy_attributes(dummy_provider, DummyReceiver), "additional_argument"))
+
+    def test_copies_multiple_attributes(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            common_attributes={"arbitrary_name1": ARBITRARY_VALUE, "arbitrary_name2": "arbitrary_string"}
+        )
+
+        self.assertEqual(copy_attributes(dummy_provider, DummyReceiver).arbitrary_name1, dummy_provider.arbitrary_name1)
+        self.assertEqual(copy_attributes(dummy_provider, DummyReceiver).arbitrary_name2, dummy_provider.arbitrary_name2)
+
+    def test_applies_custom_renaming(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            only_provider={"provider_name": ARBITRARY_VALUE}, only_receiver={"receiver_name": "arbitrary_string"}
+        )
+
+        self.assertEqual(
+            copy_attributes(
+                dummy_provider, DummyReceiver, conversions={"receiver_name": "provider_name"}
+            ).receiver_name,
+            dummy_provider.provider_name,
+        )
+
+    def test_custom_renaming_fails_for_missing_receiving_counterpart(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            only_provider={"provider_name": ARBITRARY_VALUE}
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"Conversion failed. 'receiver_name' is not a member of the receiver <.*{CLASS_NAME}.*>. "
+            "You gave {'receiver_name': 'provider_name'}.",
+        ):
+            copy_attributes(dummy_provider, DummyReceiver, conversions={"receiver_name": "provider_name"})
+
+    def test_custom_renaming_fails_for_missing_provider_counterpart(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            only_receiver={"receiver_name": ARBITRARY_VALUE}
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            f"Conversion failed. 'provider_name' is not a member of the provider {dummy_provider}. "
+            "You gave {'receiver_name': 'provider_name'}.",
+        ):
+            copy_attributes(dummy_provider, DummyReceiver, conversions={"receiver_name": "provider_name"})
+
+    def test_custom_conversion_function(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE}
+        )
+
+        self.assertEqual(
+            copy_attributes(
+                dummy_provider, DummyReceiver, conversions={"arbitrary_name": custom_conversion}
+            ).arbitrary_name,
+            custom_conversion(dummy_provider),
+        )
+
+    def test_removes_prefix(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            only_provider={"prefixed_arbitrary_name": ARBITRARY_VALUE}, only_receiver={"arbitrary_name": None}
+        )
+
+        self.assertEqual(
+            copy_attributes(dummy_provider, DummyReceiver, remove_prefix="prefixed_").arbitrary_name,
+            dummy_provider.prefixed_arbitrary_name,
+        )
+
+    def test_ignore_attributes(self):
+        dummy_provider, DummyReceiver = gen_provider_and_matching_receiver_class(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE}
+        )
+        self.assertEqual(copy_attributes(dummy_provider, DummyReceiver, ignore=["arbitrary_name"]).arbitrary_name, None)
+
+
+class TestConvertsTo(unittest.TestCase):
+    def test_returns_same_class(self):
+        DummyProvider, DummyReceiver = gen_two_classes()
+        self.assertTrue(converts_to(DummyReceiver)(DummyProvider) is DummyProvider)
+
+    def test_adds_attribute_get_as_pypicongpu(self):
+        DummyProvider, DummyReceiver = gen_two_classes()
+        self.assertTrue(hasattr(converts_to(DummyReceiver)(DummyProvider), "get_as_pypicongpu"))
+
+    def test_fails_if_get_as_pypicongpu_exists(self):
+        DummyProvider, DummyReceiver = gen_two_classes(only_receiver={"get_as_pypicongpu": ARBITRARY_VALUE})
+        with self.assertRaisesRegex(
+            TypeError,
+            f"Adding 'get_as_pypicongpu' failed because it already existed on receiving class .*{CLASS_NAME}.*.",
+        ):
+            converts_to(DummyReceiver)(DummyProvider)
+
+    def _extract_relevant_members(self, lhs):
+        return tuple(x for x in inspect.getmembers(lhs) if not x[0].startswith("__"))
+
+    def assertInstancesEqual(self, lhs, rhs):
+        self.assertEqual(type(lhs), type(rhs))
+        self.assertSequenceEqual(self._extract_relevant_members(lhs), self._extract_relevant_members(rhs))
+
+    def test_get_as_pypicongpu_acts_like_copy_attributes(self):
+        arbitrary_value2 = "arbitrary_string"
+        arbitrary_value3 = 1234.5678
+
+        DummyProvider, DummyReceiver = gen_two_classes(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE},
+            only_provider={"provider_name": arbitrary_value2, "_private_member": ARBITRARY_VALUE},
+            only_receiver={"receiver_name": arbitrary_value3},
+        )
+        dummy_provider = converts_to(DummyReceiver)(DummyProvider)()
+
+        self.assertInstancesEqual(dummy_provider.get_as_pypicongpu(), copy_attributes(dummy_provider, DummyReceiver))
+
+    def test_handles_custom_conversions(self):
+        arbitrary_value2 = "arbitrary_string"
+        arbitrary_value3 = 1234.5678
+        conversions = {"arbitrary_name": custom_conversion, "receiver_name": "provider_name"}
+
+        DummyProvider, DummyReceiver = gen_two_classes(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE},
+            only_provider={"provider_name": arbitrary_value2, "_private_member": ARBITRARY_VALUE},
+            only_receiver={"receiver_name": arbitrary_value3},
+        )
+
+        dummy_provider = converts_to(DummyReceiver, conversions=conversions)(DummyProvider)()
+        self.assertInstancesEqual(
+            dummy_provider.get_as_pypicongpu(), copy_attributes(dummy_provider, DummyReceiver, conversions=conversions)
+        )
+
+    def test_runs_a_preamble(self):
+        preamble = MiniMock()
+        DummyProvider, DummyReceiver = gen_two_classes()
+
+        dummy_provider = converts_to(DummyReceiver, preamble=preamble)(DummyProvider)()
+        self.assertEqual(preamble.counter, 0)
+        dummy_provider.get_as_pypicongpu()
+        self.assertEqual(preamble.counter, 1)
+
+    def test_passes_through_arbitrary_arguments_to_conversions(self):
+        conversions = {"arbitrary_name": lambda self, x: self.arbitrary_name - x}
+
+        DummyProvider, DummyReceiver = gen_two_classes(
+            common_attributes={"arbitrary_name": ARBITRARY_VALUE},
+        )
+
+        dummy_provider = converts_to(DummyReceiver, conversions=conversions)(DummyProvider)()
+        self.assertEqual(
+            dummy_provider.get_as_pypicongpu(ARBITRARY_VALUE).arbitrary_name,
+            conversions["arbitrary_name"](dummy_provider, ARBITRARY_VALUE),
+        )
+
+    def test_passes_through_arbitrary_arguments_to_preamble(self):
+        preamble = MiniMock()
+        DummyProvider, DummyReceiver = gen_two_classes()
+
+        dummy_provider = converts_to(DummyReceiver, preamble=preamble)(DummyProvider)()
+        self.assertEqual(preamble.args, None)
+        self.assertEqual(preamble.kwargs, None)
+        dummy_provider.get_as_pypicongpu(ARBITRARY_VALUE, arbitrary_kwarg=ARBITRARY_VALUE)
+        self.assertEqual(preamble.args[1:], (ARBITRARY_VALUE,))
+        self.assertEqual(preamble.kwargs, {"arbitrary_kwarg": ARBITRARY_VALUE})
+
+    def test_ignore_attributes(self):
+        DummyProvider, DummyReceiver = gen_two_classes(common_attributes={"arbitrary_name": ARBITRARY_VALUE})
+        dummy_provider = converts_to(DummyReceiver, ignore=["arbitrary_name"])(DummyProvider)()
+        self.assertEqual(dummy_provider.get_as_pypicongpu().arbitrary_name, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/picongpu/quick/picmi/copy_attributes.py
+++ b/test/python/picongpu/quick/picmi/copy_attributes.py
@@ -206,15 +206,23 @@ class TestConvertsTo(unittest.TestCase):
     def test_get_as_pypicongpu_acts_like_copy_attributes(self):
         arbitrary_value2 = "arbitrary_string"
         arbitrary_value3 = 1234.5678
+        arbitrary_value4 = True
 
         DummyProvider, DummyReceiver = gen_two_classes(
             common_attributes={"arbitrary_name": ARBITRARY_VALUE},
-            only_provider={"provider_name": arbitrary_value2, "_private_member": ARBITRARY_VALUE},
-            only_receiver={"receiver_name": arbitrary_value3},
+            only_provider={
+                "prefixed_other_name": arbitrary_value4,
+                "provider_name": arbitrary_value2,
+                "_private_member": ARBITRARY_VALUE,
+            },
+            only_receiver={"receiver_name": arbitrary_value3, "other_name": None},
         )
-        dummy_provider = converts_to(DummyReceiver)(DummyProvider)()
+        dummy_provider = converts_to(DummyReceiver, remove_prefix="prefixed_")(DummyProvider)()
 
-        self.assertInstancesEqual(dummy_provider.get_as_pypicongpu(), copy_attributes(dummy_provider, DummyReceiver))
+        self.assertInstancesEqual(
+            dummy_provider.get_as_pypicongpu(),
+            copy_attributes(dummy_provider, DummyReceiver, remove_prefix="prefixed_"),
+        )
 
     def test_handles_custom_conversions(self):
         arbitrary_value2 = "arbitrary_string"

--- a/test/python/picongpu/quick/picmi/distribution.py
+++ b/test/python/picongpu/quick/picmi/distribution.py
@@ -411,12 +411,12 @@ class TestPicmiGaussianDistribution(unittest.TestCase, HelperTestPicmiBoundaries
         self.assertTrue(isinstance(pypic, species.operation.densityprofile.Gaussian))
 
         self.assertEqual(self.values["density"], pypic.density)
-        self.assertEqual(self.values["center_front"], pypic.gas_center_front)
-        self.assertEqual(self.values["center_rear"], pypic.gas_center_rear)
-        self.assertEqual(self.values["sigma_front"], pypic.gas_sigma_front)
-        self.assertEqual(self.values["sigma_rear"], pypic.gas_sigma_rear)
-        self.assertEqual(self.values["power"], pypic.gas_power)
-        self.assertEqual(self.values["factor"], pypic.gas_factor)
+        self.assertEqual(self.values["center_front"], pypic.center_front)
+        self.assertEqual(self.values["center_rear"], pypic.center_rear)
+        self.assertEqual(self.values["sigma_front"], pypic.sigma_front)
+        self.assertEqual(self.values["sigma_rear"], pypic.sigma_rear)
+        self.assertEqual(self.values["power"], pypic.power)
+        self.assertEqual(self.values["factor"], pypic.factor)
         self.assertEqual(self.values["vacuum_front"], pypic.vacuum_cells_front)
 
         # @todo repect bounding boxes, Brian Marre, 2024

--- a/test/python/picongpu/quick/picmi/gaussian_laser.py
+++ b/test/python/picongpu/quick/picmi/gaussian_laser.py
@@ -37,7 +37,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         self.assertEqual(3, pypic_laser.duration)
         self.assertEqual([0, 1, 0], pypic_laser.propagation_direction)
         self.assertEqual([0, 0, 1], pypic_laser.polarization_direction)
-        self.assertEqual([5, 4, 5], pypic_laser.focus_pos)
+        self.assertEqual([5, 4, 5], pypic_laser.focal_position)
         # centroid is not a picongpu input
         self.assertEqual(5, pypic_laser.E0)
         self.assertEqual(
@@ -46,7 +46,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         )
         self.assertEqual([2.0, 3.0], pypic_laser.laguerre_modes)
         self.assertEqual([4.0, 5.0], pypic_laser.laguerre_phases)
-        self.assertEqual(-2, pypic_laser.phase)
+        self.assertEqual(-2, pypic_laser.phi0)
         self.assertEqual([[1, -1], [1, -1], [1, -1]], pypic_laser.huygens_surface_positions)
 
         # computed values
@@ -84,9 +84,9 @@ class TestPicmiGaussianLaser(unittest.TestCase):
             polarization_direction=[1, 0, 0],
             E0=1,
         )
-        self.assertEqual(1, picmi_laser.get_as_pypicongpu().focus_pos[0])
-        self.assertEqual(2, picmi_laser.get_as_pypicongpu().focus_pos[1])
-        self.assertEqual(-5, picmi_laser.get_as_pypicongpu().focus_pos[2])
+        self.assertEqual(1, picmi_laser.get_as_pypicongpu().focal_position[0])
+        self.assertEqual(2, picmi_laser.get_as_pypicongpu().focal_position[1])
+        self.assertEqual(-5, picmi_laser.get_as_pypicongpu().focal_position[2])
 
     def test_values_propagation_direction(self):
         """only propagation in y+ permitted"""
@@ -101,21 +101,20 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         ]
 
         for invalid_propagation_vector in invalid_propagation_vectors:
-            picmi_laser = picmi.GaussianLaser(
-                1,
-                2,
-                3,
-                focal_position=[0.5, 0, 0.5],
-                centroid_position=[0.5, 0, 0.5],
-                propagation_direction=invalid_propagation_vector,
-                polarization_direction=[1, 0, 0],
-                E0=1,
-            )
-            with self.assertRaisesRegex(Exception, ".*propagation.*"):
-                picmi_laser.get_as_pypicongpu()
+            with self.assertRaisesRegex(ValueError, ".*propagation.*"):
+                picmi.GaussianLaser(
+                    1,
+                    2,
+                    3,
+                    focal_position=[0.5, 0, 0.5],
+                    centroid_position=[0.5, 0, 0.5],
+                    propagation_direction=invalid_propagation_vector,
+                    polarization_direction=[1, 0, 0],
+                    E0=1,
+                )
 
         # positive direction works
-        picmi_laser = picmi.GaussianLaser(
+        picmi.GaussianLaser(
             1,
             2,
             3,
@@ -136,18 +135,17 @@ class TestPicmiGaussianLaser(unittest.TestCase):
         ]
 
         for invalid_polarization in invalid_polarizations:
-            picmi_laser = picmi.GaussianLaser(
-                1,
-                2,
-                3,
-                focal_position=[0, 0, 0],
-                centroid_position=[0, 0, 0],
-                propagation_direction=[0, 1, 0],
-                polarization_direction=invalid_polarization,
-                E0=1,
-            )
-            with self.assertRaisesRegex(Exception, ".*polarization.*"):
-                picmi_laser.get_as_pypicongpu()
+            with self.assertRaisesRegex(ValueError, ".*polarization.*"):
+                picmi.GaussianLaser(
+                    1,
+                    2,
+                    3,
+                    focal_position=[0, 0, 0],
+                    centroid_position=[0, 0, 0],
+                    propagation_direction=[0, 1, 0],
+                    polarization_direction=invalid_polarization,
+                    E0=1,
+                )
 
         # valid examples:
         valid_polarization_vectors = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
@@ -185,7 +183,7 @@ class TestPicmiGaussianLaser(unittest.TestCase):
     def test_values_centroid_position_y_smaller_equal_zero(self):
         """centroid position must have y<=0"""
 
-        with self.assertRaisesRegex(Exception, ".*centroid.*[yY].*(zero|0).*"):
+        with self.assertRaisesRegex(ValueError, ".*centroid.*[yY].*(zero|0).*"):
             picmi.GaussianLaser(
                 1,
                 2,

--- a/test/python/picongpu/quick/picmi/grid.py
+++ b/test/python/picongpu/quick/picmi/grid.py
@@ -69,13 +69,12 @@ class TestCartesian3DGrid(unittest.TestCase):
     def test_n_gpus_wrong_numbers(self):
         """test negativ numbers or zero as number of gpus"""
         for not_ngpus_dist in [[0], [1, 1, 0], [-1], [-1, 1, 1], [-7]]:
-            grid = picmi.Cartesian3DGrid(
-                number_of_cells=[192, 2048, 12],
-                picongpu_n_gpus=not_ngpus_dist,
-                **self.COMMON_KWARGS,
-            )
-            with self.assertRaisesRegex(Exception, ".*number of gpus must be positive integer.*"):
-                grid.get_as_pypicongpu()
+            with self.assertRaisesRegex(Exception, ".*Number of gpus must be positive integer.*"):
+                picmi.Cartesian3DGrid(
+                    number_of_cells=[192, 2048, 12],
+                    picongpu_n_gpus=not_ngpus_dist,
+                    **self.COMMON_KWARGS,
+                )
 
     def test_supercell(self):
         """test explicitly setting the super cell size default value"""

--- a/test/python/picongpu/quick/pypicongpu/grid.py
+++ b/test/python/picongpu/quick/pypicongpu/grid.py
@@ -15,53 +15,47 @@ class TestGrid3D(unittest.TestCase):
     def setUp(self):
         """setup default grid"""
         self.g = Grid3D()
-        self.g.cell_size_x_si = 1.2
-        self.g.cell_size_y_si = 2.3
-        self.g.cell_size_z_si = 4.5
-        self.g.cell_cnt_x = 6
-        self.g.cell_cnt_y = 7
-        self.g.cell_cnt_z = 8
-        self.g.boundary_condition_x = BoundaryCondition.PERIODIC
-        self.g.boundary_condition_y = BoundaryCondition.ABSORBING
-        self.g.boundary_condition_z = BoundaryCondition.PERIODIC
-        self.g.n_gpus = tuple([2, 4, 1])
+        self.g.cell_size_si = (1.2, 2.3, 4.5)
+        self.g.cell_cnt = (6, 7, 8)
+        self.g.boundary_condition = (
+            BoundaryCondition.PERIODIC,
+            BoundaryCondition.ABSORBING,
+            BoundaryCondition.PERIODIC,
+        )
+        self.g.n_gpus = (2, 4, 1)
         self.g.super_cell_size = (8, 8, 4)
         self.g.grid_dist = None
 
     def test_basic(self):
         """test default setup"""
         g = self.g
-        self.assertEqual(1.2, g.cell_size_x_si)
-        self.assertEqual(2.3, g.cell_size_y_si)
-        self.assertEqual(4.5, g.cell_size_z_si)
-        self.assertEqual(6, g.cell_cnt_x)
-        self.assertEqual(7, g.cell_cnt_y)
-        self.assertEqual(8, g.cell_cnt_z)
-        self.assertEqual(BoundaryCondition.PERIODIC, g.boundary_condition_x)
-        self.assertEqual(BoundaryCondition.ABSORBING, g.boundary_condition_y)
-        self.assertEqual(BoundaryCondition.PERIODIC, g.boundary_condition_z)
+        self.assertSequenceEqual((1.2, 2.3, 4.5), g.cell_size_si)
+        self.assertSequenceEqual((6, 7, 8), g.cell_cnt)
+        self.assertSequenceEqual(
+            (BoundaryCondition.PERIODIC, BoundaryCondition.ABSORBING, BoundaryCondition.PERIODIC), g.boundary_condition
+        )
 
     def test_types(self):
         """test raising errors if types are wrong"""
         g = self.g
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_x_si = "54.3"
+            g.cell_size_si = ("54.3", 2.3, 4.5)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_y_si = "2"
+            g.cell_size_si = (1.2, "2", 4.5)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_z_si = "126"
+            g.cell_size_si = (1.2, 2.3, "126")
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt_x = 11.1
+            g.cell_cnt = (11.1, 7, 8)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt_y = 11.412
+            g.cell_cnt = (6, 11.412, 8)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt_z = 16781123173.12637183
+            g.cell_cnt = (6, 7, 16781123173.12637183)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition_x = "open"
+            g.boundary_condition = ("open", BoundaryCondition.ABSORBING, BoundaryCondition.PERIODIC)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition_y = 1
+            g.boundary_condition = (BoundaryCondition.PERIODIC, 1, BoundaryCondition.PERIODIC)
         with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition_z = {}
+            g.boundary_condition = (BoundaryCondition.PERIODIC, BoundaryCondition.ABSORBING, {})
         with self.assertRaises(typeguard.TypeCheckError):
             # list not accepted - tuple needed
             g.n_gpus = [1, 1, 1]
@@ -69,51 +63,39 @@ class TestGrid3D(unittest.TestCase):
     def test_gpu_and_cell_cnt_positive(self):
         """test if n_gpus and cell number s are >0"""
         g = self.g
-        with self.assertRaisesRegex(Exception, ".*cell_cnt_x.*greater than 0.*"):
-            g.cell_cnt_x = -1
-            g._get_serialized()
+        with self.assertRaisesRegex(Exception, ".*cell_cnt.*greater than 0.*"):
+            g.cell_cnt = (-1, 7, 8)
+            g.get_rendering_context()
         # revert changes
-        g.cell_cnt_x = 6
+        g.cell_cnt = (6, 7, 8)
 
-        with self.assertRaisesRegex(Exception, ".*cell_cnt_y.*greater than 0.*"):
-            g.cell_cnt_y = -2
-            g._get_serialized()
+        with self.assertRaisesRegex(Exception, ".*cell_cnt.*greater than 0.*"):
+            g.cell_cnt = (6, -2, 8)
+            g.get_rendering_context()
         # revert changes
-        g.cell_cnt_y = 7
+        g.cell_cnt = (6, 7, 8)
 
-        with self.assertRaisesRegex(Exception, ".*cell_cnt_z.*greater than 0.*"):
-            g.cell_cnt_z = 0
-            g._get_serialized()
+        with self.assertRaisesRegex(Exception, ".*cell_cnt.*greater than 0.*"):
+            g.cell_cnt = (6, 7, 0)
+            g.get_rendering_context()
         # revert changes
-        g.cell_cnt_z = 8
+        g.cell_cnt = (6, 7, 8)
 
         for wrong_n_gpus in [tuple([-1, 1, 1]), tuple([1, 1, 0])]:
             with self.assertRaisesRegex(Exception, ".*greater than 0.*"):
                 g.n_gpus = wrong_n_gpus
-                g._get_serialized()
+                g.get_rendering_context()
 
     def test_mandatory(self):
         """test if None as content fails"""
         # check that mandatory arguments can't be none
         g = self.g
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_x_si = None
+            g.cell_size_si = None
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_y_si = None
+            g.cell_cnt = None
         with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_z_si = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt_x = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt_y = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt_x = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition_x = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition_y = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition_z = None
+            g.boundary_condition = None
         with self.assertRaises(typeguard.TypeCheckError):
             g.n_gpus = None
 

--- a/test/python/picongpu/quick/pypicongpu/laser.py
+++ b/test/python/picongpu/quick/pypicongpu/laser.py
@@ -23,8 +23,8 @@ class TestGaussianLaser(unittest.TestCase):
         self.laser.wavelength = 1.2
         self.laser.waist = 3.4
         self.laser.duration = 5.6
-        self.laser.focus_pos = [0, 7.8, 0]
-        self.laser.phase = 2.9
+        self.laser.focal_position = [0, 7.8, 0]
+        self.laser.phi0 = 2.9
         self.laser.E0 = 9.0
         self.laser.pulse_init = 1.3
         self.laser.propagation_direction = [0.0, 1.0, 0.0]
@@ -45,7 +45,7 @@ class TestGaussianLaser(unittest.TestCase):
             with self.assertRaises(typeguard.TypeCheckError):
                 laser.duration = not_float
             with self.assertRaises(typeguard.TypeCheckError):
-                laser.phase = not_float
+                laser.phi0 = not_float
             with self.assertRaises(typeguard.TypeCheckError):
                 laser.E0 = not_float
             with self.assertRaises(typeguard.TypeCheckError):
@@ -53,7 +53,7 @@ class TestGaussianLaser(unittest.TestCase):
 
         for not_position_vector in [1, 1.0, None, ["string"]]:
             with self.assertRaises(typeguard.TypeCheckError):
-                laser.focus_pos = not_position_vector
+                laser.focal_position = not_position_vector
 
         for not_polarization_type in [1, 1.3, None, "", []]:
             with self.assertRaises(typeguard.TypeCheckError):
@@ -163,12 +163,12 @@ class TestGaussianLaser(unittest.TestCase):
         self.assertEqual(
             context["focus_pos_si"],
             [
-                {"component": self.laser.focus_pos[0]},
-                {"component": self.laser.focus_pos[1]},
-                {"component": self.laser.focus_pos[2]},
+                {"component": self.laser.focal_position[0]},
+                {"component": self.laser.focal_position[1]},
+                {"component": self.laser.focal_position[2]},
             ],
         )
-        self.assertEqual(context["phase"], self.laser.phase)
+        self.assertEqual(context["phase"], self.laser.phi0)
         self.assertEqual(context["E0_si"], self.laser.E0)
         self.assertEqual(context["pulse_init"], self.laser.pulse_init)
         self.assertEqual(

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -57,9 +57,9 @@ class TestSimulation(unittest.TestCase):
         self.laser.wavelength = 1.2
         self.laser.waist = 3.4
         self.laser.duration = 5.6
-        self.laser.focus_pos = [0, 7.8, 0]
+        self.laser.focal_position = [0, 7.8, 0]
         self.laser.centroid_position = [0, 0, 0]
-        self.laser.phase = 2.9
+        self.laser.phi0 = 2.9
         self.laser.E0 = 9.0
         self.laser.pulse_init = 1.3
         self.laser.propagation_direction = [0, 1, 0]

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -33,16 +33,14 @@ class TestSimulation(unittest.TestCase):
         self.s.time_steps = 42
         self.s.typical_ppc = 1
         self.s.grid = grid.Grid3D()
-        self.s.grid.cell_size_x_si = 1
-        self.s.grid.cell_size_y_si = 2
-        self.s.grid.cell_size_z_si = 3
-        self.s.grid.cell_cnt_x = 4
-        self.s.grid.cell_cnt_y = 5
-        self.s.grid.cell_cnt_z = 6
-        self.s.grid.n_gpus = tuple([1, 1, 1])
-        self.s.grid.boundary_condition_x = grid.BoundaryCondition.PERIODIC
-        self.s.grid.boundary_condition_y = grid.BoundaryCondition.PERIODIC
-        self.s.grid.boundary_condition_z = grid.BoundaryCondition.PERIODIC
+        self.s.grid.cell_size_si = (1, 2, 3)
+        self.s.grid.cell_cnt = (4, 5, 6)
+        self.s.grid.n_gpus = (1, 1, 1)
+        self.s.grid.boundary_condition = (
+            grid.BoundaryCondition.PERIODIC,
+            grid.BoundaryCondition.PERIODIC,
+            grid.BoundaryCondition.PERIODIC,
+        )
         self.s.grid.super_cell_size = (8, 8, 4)
         self.s.grid.grid_dist = None
         self.s.solver = YeeSolver()

--- a/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/test/python/picongpu/quick/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -29,12 +29,12 @@ class TestGaussian(unittest.TestCase):
     def _getGaussian(self):
         g = Gaussian()
 
-        g.gas_center_front = self.values["gas_center_front"]
-        g.gas_center_rear = self.values["gas_center_rear"]
-        g.gas_sigma_front = self.values["gas_sigma_front"]
-        g.gas_sigma_rear = self.values["gas_sigma_rear"]
-        g.gas_power = self.values["gas_power"]
-        g.gas_factor = self.values["gas_factor"]
+        g.center_front = self.values["gas_center_front"]
+        g.center_rear = self.values["gas_center_rear"]
+        g.sigma_front = self.values["gas_sigma_front"]
+        g.sigma_rear = self.values["gas_sigma_rear"]
+        g.power = self.values["gas_power"]
+        g.factor = self.values["gas_factor"]
         g.vacuum_cells_front = self.values["vacuum_cells_front"]
         g.density = self.values["density"]
         return g
@@ -54,12 +54,12 @@ class TestGaussian(unittest.TestCase):
         """values are passed through"""
         g = self._getGaussian()
 
-        self.assertAlmostEqual(self.values["gas_center_front"], g.gas_center_front)
-        self.assertAlmostEqual(self.values["gas_center_rear"], g.gas_center_rear)
-        self.assertAlmostEqual(self.values["gas_sigma_front"], g.gas_sigma_front)
-        self.assertAlmostEqual(self.values["gas_sigma_rear"], g.gas_sigma_rear)
-        self.assertAlmostEqual(self.values["gas_power"], g.gas_power)
-        self.assertAlmostEqual(self.values["gas_factor"], g.gas_factor)
+        self.assertAlmostEqual(self.values["gas_center_front"], g.center_front)
+        self.assertAlmostEqual(self.values["gas_center_rear"], g.center_rear)
+        self.assertAlmostEqual(self.values["gas_sigma_front"], g.sigma_front)
+        self.assertAlmostEqual(self.values["gas_sigma_rear"], g.sigma_rear)
+        self.assertAlmostEqual(self.values["gas_power"], g.power)
+        self.assertAlmostEqual(self.values["gas_factor"], g.factor)
         self.assertEqual(self.values["vacuum_cells_front"], g.vacuum_cells_front)
         self.assertAlmostEqual(self.values["density"], g.density)
 
@@ -77,27 +77,27 @@ class TestGaussian(unittest.TestCase):
 
         for invalid in [None, "1", [], {}]:
             with self.assertRaises(typeguard.TypeCheckError):
-                g.gas_factor = invalid
+                g.factor = invalid
 
         for invalid in [None, "1", [], {}]:
             with self.assertRaises(typeguard.TypeCheckError):
-                g.gas_power = invalid
+                g.power = invalid
 
         for invalid in [None, "1", [], {}]:
             with self.assertRaises(typeguard.TypeCheckError):
-                g.gas_sigma_front = invalid
+                g.sigma_front = invalid
 
         for invalid in [None, "1", [], {}]:
             with self.assertRaises(typeguard.TypeCheckError):
-                g.gas_sigma_rear = invalid
+                g.sigma_rear = invalid
 
         for invalid in [None, "1", [], {}]:
             with self.assertRaises(typeguard.TypeCheckError):
-                g.gas_center_front = invalid
+                g.center_front = invalid
 
         for invalid in [None, "1", [], {}]:
             with self.assertRaises(typeguard.TypeCheckError):
-                g.gas_center_rear = invalid
+                g.center_rear = invalid
 
     def test_check_unsetParameters(self):
         """validity check on self for no parameters set"""
@@ -137,7 +137,7 @@ class TestGaussian(unittest.TestCase):
         # invalid gas_factor
         for invalid in [0.0, 1.0]:
             # assignment passes, but check catches the error
-            g.gas_factor = invalid
+            g.factor = invalid
             with self.assertRaisesRegex(ValueError, ".*gas_factor.* < 0.*"):
                 g.check()
 
@@ -148,7 +148,7 @@ class TestGaussian(unittest.TestCase):
         # invalid gas_power
         for invalid in [0.0]:
             # assignment passes, but check catches the error
-            g.gas_power = invalid
+            g.power = invalid
             with self.assertRaisesRegex(ValueError, ".*gas_power.* != 0.*"):
                 g.check()
 
@@ -159,7 +159,7 @@ class TestGaussian(unittest.TestCase):
         # invalid gas_sigma_rear
         for invalid in [0.0]:
             # assignment passes, but check catches the error
-            g.gas_sigma_rear = invalid
+            g.sigma_rear = invalid
             with self.assertRaisesRegex(ValueError, ".*gas_sigma_rear.* != 0.*"):
                 g.check()
 
@@ -170,7 +170,7 @@ class TestGaussian(unittest.TestCase):
         # invalid gas_sigma_front
         for invalid in [0.0]:
             # assignment passes, but check catches the error
-            g.gas_sigma_front = invalid
+            g.sigma_front = invalid
             with self.assertRaisesRegex(ValueError, ".*gas_sigma_front.* != 0.*"):
                 g.check()
 
@@ -181,13 +181,13 @@ class TestGaussian(unittest.TestCase):
         # invalid gas_center_rear
         for invalid in [-1.0]:
             # assignment passes, but check catches the error
-            g.gas_center_rear = invalid
+            g.center_rear = invalid
             with self.assertRaisesRegex(ValueError, ".*gas_center_rear.* >= 0.*"):
                 g.check()
 
         # rear < front
         # assignment passes, but check catches the error
-        g.gas_center_rear = 0.9 * self.values["gas_center_front"]
+        g.center_rear = 0.9 * self.values["gas_center_front"]
         with self.assertRaisesRegex(ValueError, ".*gas_center_rear.* >= gas_center_front.*"):
             g.check()
 
@@ -198,13 +198,13 @@ class TestGaussian(unittest.TestCase):
         # invalid gas_center_front
         for invalid in [-1.0]:
             # assignment passes, but check catches the error
-            g.gas_center_front = invalid
+            g.center_front = invalid
             with self.assertRaisesRegex(ValueError, ".*gas_center_front.* >= 0.*"):
                 g.check()
 
         # front > rear
         # assignment passes, but check catches the error
-        g.gas_center_front = 1.1 * self.values["gas_center_rear"]
+        g.center_front = 1.1 * self.values["gas_center_rear"]
         with self.assertRaisesRegex(ValueError, ".*gas_center_rear.* >= gas_center_front.*"):
             g.check()
 
@@ -215,12 +215,12 @@ class TestGaussian(unittest.TestCase):
         context = g.get_rendering_context()
         self.assertTrue(context["typeID"]["gaussian"])
         context = context["data"]
-        self.assertAlmostEqual(g.gas_center_front, context["gas_center_front"])
-        self.assertAlmostEqual(g.gas_center_rear, context["gas_center_rear"])
-        self.assertAlmostEqual(g.gas_sigma_front, context["gas_sigma_front"])
-        self.assertAlmostEqual(g.gas_sigma_rear, context["gas_sigma_rear"])
-        self.assertAlmostEqual(g.gas_power, context["gas_power"])
-        self.assertAlmostEqual(g.gas_factor, context["gas_factor"])
+        self.assertAlmostEqual(g.center_front, context["gas_center_front"])
+        self.assertAlmostEqual(g.center_rear, context["gas_center_rear"])
+        self.assertAlmostEqual(g.sigma_front, context["gas_sigma_front"])
+        self.assertAlmostEqual(g.sigma_rear, context["gas_sigma_rear"])
+        self.assertAlmostEqual(g.power, context["gas_power"])
+        self.assertAlmostEqual(g.factor, context["gas_factor"])
         self.assertEqual(g.vacuum_cells_front, context["vacuum_cells_front"])
         self.assertAlmostEqual(g.density, context["density"])
 


### PR DESCRIPTION
This is a major refactoring to simplify passing through identical parameters from PICMI to PyPIConGPU. With the currently style of development, we often run into the case where many classes on the two levels are basically identical in their data content. Writing out the conversion by hand is tedious and error-prone.

I propose to add a helper decorator `converts_to` that transforms a class as follows:
```python
class A:
    attribute=0
    # ... many more attributes
    
@converts_to(A)
class B:
    attribute=42
    # ... many more attributes
    
# results in:
class B:
    attribute=42
    # ... many more attributes
    
    def get_as_pypicongpu(self, *args, **kwargs):
        a = A()
        a.attribute = self.attribute
        # ... many more attributes
        return a
```
There's a number of customisation options available like renamings, custom conversion functions, etc. as well as a few convenient conventions that are documented in the docstring and the tests. The `default_converts_to` adds some more tailored defaults for our codebase.

The main contribution is `picmi/copy_attributes.py` which has a corresponding `quick/picmi/copy_attributes.py` test file. Carefully read the tests to understand the interface and functionality.

Other than that, most changes are concerned with applying the new functionality throughout some parts of the codebase that lend themselves particularly well to it. So, if you want to see it in action, have a look at the laser or plugin implementations.

It should be noted that over time our PICMI interface will probably develop into a more independent ecosystem such that this kind of technology might be needed less (or at least might be contained to a subset of functionality as present today) in the distant future. Also, it can -- admittedly -- make some edge cases harder to debug.

I have applied some renamings on the PyPIConGPU side for convenience and also let `ruff` reorder imports into canonical order while I was at it.