### PR TITLE
Remove circular include in logging

### DIFF
--- a/include/picongpu/debug/PIConGPUVerbose.hpp
+++ b/include/picongpu/debug/PIConGPUVerbose.hpp
@@ -19,9 +19,7 @@
 
 #pragma once
 
-#include <pmacc/debug/VerboseLog.hpp>
-
-#include <cstdint>
+#include <pmacc/debug/VerboseLogMakros.hpp>
 
 namespace picongpu
 {

--- a/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
+++ b/include/picongpu/plugins/radiation/debug/PIConGPUVerboseLogRadiation.hpp
@@ -22,9 +22,7 @@
 
 #include "picongpu/plugins/radiation/param.hpp"
 
-#include <pmacc/debug/VerboseLog.hpp>
-
-#include <cstdint>
+#include <pmacc/debug/VerboseLogMakros.hpp>
 
 namespace picongpu
 {

--- a/include/pmacc/debug/PMaccVerbose.hpp
+++ b/include/pmacc/debug/PMaccVerbose.hpp
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
-
-#include <cstdint>
+#include "pmacc/debug/VerboseLogMakros.hpp"
 
 #ifndef PMACC_VERBOSE_LVL
 #    define PMACC_VERBOSE_LVL 0

--- a/include/pmacc/debug/VerboseLog.hpp
+++ b/include/pmacc/debug/VerboseLog.hpp
@@ -23,13 +23,10 @@
 
 #include <pmacc/boost_workaround.hpp>
 
-#include "pmacc/debug/VerboseLogMakros.hpp"
-
 #include <boost/format.hpp>
 
 #include <cstdint>
 #include <iostream>
-#include <sstream>
 #include <string>
 
 namespace pmacc
@@ -45,22 +42,6 @@ namespace pmacc
     {
         return std::string("UNDEFINED_LVL");
     }
-
-    namespace verboseLog_detail
-    {
-        template<typename X, typename Y>
-        struct IsSameClassType
-        {
-            static constexpr bool result = false;
-        };
-
-        template<typename X>
-        struct IsSameClassType<X, X>
-        {
-            static constexpr bool result = true;
-        };
-
-    } // namespace verboseLog_detail
 
     template<uint64_t lvl_, class membership_>
     struct LogLvl
@@ -99,7 +80,7 @@ namespace pmacc
                  * If you get an linker error in the next two lines you have not used
                  * DEFINE_LOGLVL makro to define a named logLvl
                  */
-                if(logLvl & LogParent::log_level) /*compile-time check*/
+                if constexpr(static_cast<bool>(logLvl & LogParent::log_level))
                 {
                     std::cout << LogParent::getName() << " " << getLogName(LogClass()) << "("
                               << (logLvl & LogParent::log_level) << ")"
@@ -110,7 +91,7 @@ namespace pmacc
             template<typename T>
             VerboseLog& operator%(T value)
             {
-                if(logLvl & LogParent::log_level) /*compile-time check*/
+                if constexpr(static_cast<bool>(logLvl & LogParent::log_level))
                     fmt % value;
                 return *this;
             }

--- a/include/pmacc/eventSystem/events/EventPool.hpp
+++ b/include/pmacc/eventSystem/events/EventPool.hpp
@@ -23,13 +23,12 @@
 #pragma once
 
 #include "pmacc/Environment.def"
-#include "pmacc/debug/VerboseLog.hpp"
+#include "pmacc/debug/PMaccVerbose.hpp"
 #include "pmacc/eventSystem/events/ComputeEvent.hpp"
 #include "pmacc/eventSystem/events/ComputeEventHandle.hpp"
 #include "pmacc/types.hpp"
 
 #include <list>
-#include <stdexcept>
 #include <vector>
 
 namespace pmacc

--- a/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
+++ b/include/pmacc/particles/operations/splitIntoListOfFrames.kernel
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include "pmacc/debug/VerboseLog.hpp"
 #include "pmacc/kernel/atomic.hpp"
 #include "pmacc/lockstep.hpp"
 #include "pmacc/math/Vector.hpp"


### PR DESCRIPTION
`pmacc/debug/VerboseLog` and `pmacc/debug/VerboseLogMakros` were circularly included. The latter file still includes the former but not the other way around anymore.
Also fixes some includes, remove unsused code, and enforce constexpr if