### PR TITLE
Add configuration to enable/disable background field for plugins and dumps

### DIFF
--- a/include/picongpu/main.x.cpp
+++ b/include/picongpu/main.x.cpp
@@ -30,8 +30,8 @@
 #include <pmacc/types.hpp>
 
 #include <cstdlib>
+#include <exception>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 #include <typeinfo>
 

--- a/include/picongpu/plugins/common/openPMDWriteMeta.hpp
+++ b/include/picongpu/plugins/common/openPMDWriteMeta.hpp
@@ -28,6 +28,7 @@
 #    include "picongpu/plugins/common/openPMDVersion.def"
 #    include "picongpu/plugins/common/stringHelpers.hpp"
 #    include "picongpu/plugins/openPMD/openPMDWriter.def"
+#    include "picongpu/simulation/stage/FieldBackground.hpp"
 #    include "picongpu/traits/SIBaseUnits.hpp"
 
 #    include <pmacc/Environment.hpp>
@@ -179,6 +180,9 @@ namespace picongpu
 
                     meshes.setAttribute("fieldBoundary", listFieldBoundary);
                     meshes.setAttribute("fieldBoundaryParameters", listFieldBoundaryParam);
+                    DataConnector& dc = Environment<>::get().DataConnector();
+                    auto fieldBackground = dc.get<simulation::stage::FieldBackground>("FieldBackground");
+                    meshes.setAttribute("BackgroundFieldIncluded", fieldBackground->getInfluencesDumps());
                 }
 
                 if(writeParticleMeta)

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -54,6 +54,7 @@
 #    include "picongpu/plugins/output/IIOBackend.hpp"
 #    include "picongpu/plugins/output/param.hpp"
 #    include "picongpu/simulation/control/MovingWindow.hpp"
+#    include "picongpu/simulation/stage/FieldBackground.hpp"
 #    include "picongpu/traits/IsFieldDomainBound.hpp"
 #    include "picongpu/traits/IsFieldOutputOptional.hpp"
 #    include "picongpu/unitless/checkpoints.unitless"
@@ -1367,6 +1368,9 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 log<picLog::INPUT_OUTPUT>("Setting next free id on current rank: %1%") % idProvState.nextId;
                 idProvider->setState(idProvState);
 
+                auto fieldBackground = dc.get<simulation::stage::FieldBackground>("FieldBackground");
+                ::openPMD::Container<::openPMD::Mesh>& meshes = iteration.meshes;
+                fieldBackground->restart(meshes.getAttribute("BackgroundFieldIncluded").get<bool>());
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 eventSystem::getTransactionEvent().waitForFinished();

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -101,7 +101,7 @@ namespace pmacc
          *
          * @param currentStep simulation step
          */
-        void notifyPlugins(uint32_t currentStep);
+        virtual void notifyPlugins(uint32_t currentStep);
 
         /** Write a checkpoint if needed for the given step
          *


### PR DESCRIPTION
Add state to `FieldBackground`.
Add config options to `fieldBackground.param` to enable it for plugins and dumps

Feature requested by @PrometheusPi 