### PR TITLE
Fix picmi a0/E0 logic check

### DIFF
--- a/lib/python/picongpu/picmi/lasers/base_laser.py
+++ b/lib/python/picongpu/picmi/lasers/base_laser.py
@@ -37,10 +37,10 @@ class BaseLaser:
         return length_of_cross_product < 1.0e-5
 
     def _compute_E0_and_a0(self, k0, E0, a0):
-        if E0 is not None or a0 is not None:
-            raise ValueError(f"One of E0 or a0 must be speficied. You gave {E0=} and {a0=}.")
-        if E0 is not None and a0 is not None:
-            raise ValueError("At least one of E0 or a0 must be specified.")
+        if (E0 is None) and (a0 is None):
+            raise ValueError("Both E0 or a0 are None. You must specify exactly one.")
+        if (E0 is not None) and (a0 is not None):
+            raise ValueError("Only one of E0 or a0 should be specified. You set both.")
 
         if E0 is None:
             E0 = a0 * constants.m_e * constants.c**2 * k0 / constants.q_e

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -5,6 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
 License: GPLv3+
 """
 
+import math
 import typing
 
 import picmistandard
@@ -28,6 +29,8 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         polarization_direction,
         focal_position,
         centroid_position,
+        a0=None,
+        E0=None,
         picongpu_polarization_type=(PolarizationType.LINEAR),
         picongpu_laguerre_modes: typing.Optional[typing.List[float]] = None,
         picongpu_laguerre_phases: typing.Optional[typing.List[float]] = None,
@@ -61,6 +64,12 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         self.picongpu_laguerre_modes = picongpu_laguerre_modes
         self.picongpu_laguerre_phases = picongpu_laguerre_phases
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+
+        # Calculate a0 and E0 using our base laser, as the PICMI standard does not provide consistency checks.
+        self.k0 = 2.0 * math.pi / wavelength
+        self.a0, self.E0 = self._compute_E0_and_a0(self.k0, E0, a0)
+        kw["E0"] = self.E0
+        kw["a0"] = self.a0
 
         super().__init__(
             wavelength,

--- a/test/python/picongpu/quick/picmi/gaussian_laser.py
+++ b/test/python/picongpu/quick/picmi/gaussian_laser.py
@@ -332,3 +332,33 @@ class TestPicmiGaussianLaser(unittest.TestCase):
 
         # translates without issue:
         self.assertNotEqual({}, sim_valid.get_as_pypicongpu().get_rendering_context())
+
+    def test_overdefinition_a0_E0(self):
+        """only either a0 or E0 allowed to be set"""
+
+        with self.assertRaisesRegex(ValueError, "Only one of E0 or a0 should be specified. You set both."):
+            picmi.GaussianLaser(
+                1,
+                2,
+                3,
+                focal_position=[0.5, 0, 0.5],
+                centroid_position=[0.5, 0, 0.5],
+                propagation_direction=[0, 1, 0],
+                polarization_direction=[1, 0, 0],
+                E0=1,
+                a0=1,
+            )
+
+    def test_no_a0_E0(self):
+        """either a0 or E0 have to be set"""
+
+        with self.assertRaisesRegex(ValueError, "Both E0 or a0 are None. You must specify exactly one."):
+            picmi.GaussianLaser(
+                1,
+                2,
+                3,
+                focal_position=[0.5, 0, 0.5],
+                centroid_position=[0.5, 0, 0.5],
+                propagation_direction=[0, 1, 0],
+                polarization_direction=[1, 0, 0],
+            )


### PR DESCRIPTION
This closes #5466. 
As reported in this issue, we had two problems:
 - the logic check for setting $a_0$ and $E_0$ was broken for all but the Gauss laser
 - for the Gauss laser, the same checks/calculations were performed by the PICMI standard, which is however also inconsistent (https://github.com/picmi-standard/picmi/issues/126)
 
 This PR: 
  - fixes the logic of checking whether the user only proved $a_0$ **xor** $E_0$.
  - adds that logic and thus our computational method to the Gauss laser
  - tests both failure causes (`None` and `None`; `value` and `value`) using the Gauss laser 
  
  If you want me to add these checks for all other lasers as well, please let me know. I think they are not needed since we now compute them always using our base laser implementation.   
