### PR TITLE
Allow multiple custom templates

### DIFF
--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -6,24 +6,58 @@ License: GPLv3+
 """
 
 # make pypicongpu classes accessible for conversion to pypicongpu
-from .. import pypicongpu
-from .species import Species
-from .interaction.ionization import IonizationModel
+import datetime
+import logging
+import math
+import typing
+from pathlib import Path
+
+import picmistandard
+import typeguard
 
 from picongpu.pypicongpu.species.initmanager import InitManager
 
+from .. import pypicongpu
 from . import constants
 from .grid import Cartesian3DGrid
 from .interaction import Interaction
+from .interaction.ionization import IonizationModel
+from .species import Species
 
-import picmistandard
 
-import math
-import typeguard
-import pathlib
-import logging
-import typing
-import datetime
+def is_iterable(obj):
+    try:
+        iter(obj)
+        return True
+    except TypeError:
+        return False
+
+
+def _not_allowed_template_directories(directories: tuple[Path]):
+    return set(directories) - set(filter(Path.is_dir, directories))
+
+
+def _normalise_template_dir(directory: None | str | Path | typing.Iterable[str | Path]) -> tuple[Path]:
+    """
+    Allow strings, Paths and an iterable thereof and return tuple[Path].
+    """
+    # The ordering of these recursions matters!
+    if directory is None:
+        return tuple()
+    elif isinstance(directory, str):
+        return _normalise_template_dir(Path(directory))
+
+    if isinstance(directory, Path):
+        result = (directory,)
+    elif is_iterable(directory):
+        result = sum(map(_normalise_template_dir, directory), tuple())
+    else:
+        raise ValueError(
+            f"Can't understand {directory=} of {type(directory)=}. Must be one of str, Path or iterable thereof."
+        )
+    if not_allowed := _not_allowed_template_directories(result):
+        raise ValueError(f"Found {not_allowed=} as values for template directories. These are invalid.")
+    return result
 
 
 # may not use pydantic since inherits from _DocumentedMetaClass
@@ -57,7 +91,7 @@ class Simulation(picmistandard.PICMI_Simulation):
     optional, if set to None, will be set to median ppc of all species ppcs
     """
 
-    picongpu_template_dir = pypicongpu.util.build_typesafe_property(typing.Optional[str])
+    picongpu_template_dir = pypicongpu.util.build_typesafe_property(typing.Iterable[Path])
     """directory containing templates to use for generating picongpu setups"""
 
     picongpu_moving_window_move_point = pypicongpu.util.build_typesafe_property(typing.Optional[float])
@@ -89,7 +123,7 @@ class Simulation(picmistandard.PICMI_Simulation):
     #   pydantic, Brian Marre, 2024
     def __init__(
         self,
-        picongpu_template_dir: typing.Optional[typing.Union[str, pathlib.Path]] = None,
+        picongpu_template_dir: typing.Optional[str | Path | typing.Iterable[str | Path]] = None,
         picongpu_typical_ppc: typing.Optional[int] = None,
         picongpu_moving_window_move_point: typing.Optional[float] = None,
         picongpu_moving_window_stop_iteration: typing.Optional[int] = None,
@@ -99,11 +133,7 @@ class Simulation(picmistandard.PICMI_Simulation):
         picongpu_binomial_current_interpolation: bool = False,
         **keyword_arguments,
     ):
-        if picongpu_template_dir is not None:
-            self.picongpu_template_dir = str(picongpu_template_dir)
-        else:
-            self.picongpu_template_dir = picongpu_template_dir
-
+        self.picongpu_template_dir = _normalise_template_dir(picongpu_template_dir)
         self.picongpu_typical_ppc = picongpu_typical_ppc
         self.picongpu_moving_window_move_point = picongpu_moving_window_move_point
         self.picongpu_moving_window_stop_iteration = picongpu_moving_window_stop_iteration
@@ -124,15 +154,6 @@ class Simulation(picmistandard.PICMI_Simulation):
             and isinstance(self.solver.grid, Cartesian3DGrid)
         ):
             self.__yee_compute_cfl_or_delta_t()
-
-        # checks on picongpu specific stuff
-        ## template_path is valid
-        if picongpu_template_dir == "":
-            raise ValueError("picongpu_template_dir MUST NOT be empty string")
-        if picongpu_template_dir is not None:
-            template_path = pathlib.Path(picongpu_template_dir)
-            if not template_path.is_dir():
-                raise ValueError("picongpu_template_dir must be existing directory")
 
     def __yee_compute_cfl_or_delta_t(self) -> None:
         """

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -5,13 +5,13 @@ Authors: Hannes Troepgen, Brian Edward Marre, Simeon Ehrig
 License: GPLv3+
 """
 
-from picongpu import pypicongpu, picmi
+import logging
+import tempfile
+import unittest
+from pathlib import Path
 
 import typeguard
-import unittest
-import tempfile
-import os
-import logging
+from picongpu import picmi, pypicongpu
 
 
 @typeguard.typechecked
@@ -118,8 +118,8 @@ class TestSimulation(unittest.TestCase):
         runner = sim.picongpu_get_runner()
 
         # check for generated (rendered) dir
-        self.assertTrue(os.path.isdir(runner.setup_dir))
-        self.assertEqual(
-            os.path.abspath(template_dir_name),
-            os.path.abspath(runner._Runner__pypicongpu_template_dir),
+        self.assertTrue(Path(runner.setup_dir).is_dir())
+        self.assertSequenceEqual(
+            [Path(template_dir_name).absolute()],
+            list(map(Path.absolute, runner._pypicongpu_template_dir)),
         )

--- a/test/python/picongpu/quick/picmi/__init__.py
+++ b/test/python/picongpu/quick/picmi/__init__.py
@@ -6,3 +6,4 @@ from .distribution import *  # pyflakes.ignore
 from .gaussian_laser import *  # pyflakes.ignore
 from .grid import *  # pyflakes.ignore
 from .diagnostics import *  # pyflakes.ignore
+from .normalise_template_dir import *  # pyflakes.ignore

--- a/test/python/picongpu/quick/picmi/normalise_template_dir.py
+++ b/test/python/picongpu/quick/picmi/normalise_template_dir.py
@@ -1,0 +1,40 @@
+"""
+This file is part of PIConGPU.
+Copyright 2021-2025 PIConGPU contributors
+Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
+License: GPLv3+
+"""
+
+import unittest
+from pathlib import Path
+
+from picongpu.picmi.simulation import _normalise_template_dir
+
+
+class TestNormaliseTemplateDir(unittest.TestCase):
+    def test_single_string(self):
+        existing_dir_string = "."
+        self.assertSequenceEqual(_normalise_template_dir(existing_dir_string), (Path(existing_dir_string),))
+
+    def test_none(self):
+        self.assertSequenceEqual(_normalise_template_dir(None), tuple())
+
+    def test_path(self):
+        existing_dir = Path()
+        self.assertSequenceEqual(_normalise_template_dir(existing_dir), (existing_dir,))
+
+    def test_mixed_iterable(self):
+        mixed_iter = [".", Path(), None]
+        self.assertSequenceEqual(_normalise_template_dir(mixed_iter), (Path(), Path()))
+
+    def test_disallows_non_existent_paths(self):
+        non_existent_dir = Path("non_existent_dir").absolute()
+        if non_existent_dir.exists():
+            # If this ever happens, we must come up with a more robust way of handling this.
+            raise ValueError(f"Test could not proceed because {non_existent_dir=} does exist.")
+        with self.assertRaisesRegex(ValueError, ".*is not an existing directory.*"):
+            _normalise_template_dir(non_existent_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Feature request by @PrometheusPi 

`template_dir` can now be any `PathLike` or iterable thereof and they will be used in the order as given to patch the templates. Most likely usecase:
```python
from picongpu.pypicongpu.runner import DEFAULT_TEMPLATE_DIRECTORY

picmi.Simulation(
    # ...
    picongpu_template_dir=(DEFAULT_TEMPLATE_DIRECTORY, "/my/one/little/patch/")
    # ...
)
```
will result in using the default templates overridden by any files found in `/my/one/little/patch`.

Also some minor refactorings I stumbled across along the way.