### PR TITLE
Fix test discovery

### DIFF
--- a/test/python/picongpu/__init__.py
+++ b/test/python/picongpu/__init__.py
@@ -1,3 +1,6 @@
-# flake8: noqa
-from .quick import *
-from .compiling import *
+from . import quick, compiling
+
+
+def load_tests(loader, standard_tests, pattern):
+    standard_tests.addTests((loader.loadTestsFromModule(module, pattern=pattern) for module in (quick, compiling)))
+    return standard_tests

--- a/test/python/picongpu/quick/__init__.py
+++ b/test/python/picongpu/quick/__init__.py
@@ -1,3 +1,6 @@
-# flake8: noqa
-from .pypicongpu import *  # pyflakes.ignore
-from .picmi import *  # pyflakes.ignore
+from . import picmi, pypicongpu
+
+
+def load_tests(loader, standard_tests, pattern):
+    standard_tests.addTests((loader.loadTestsFromModule(module, pattern=pattern) for module in (picmi, pypicongpu)))
+    return standard_tests

--- a/test/python/picongpu/quick/pypicongpu/species/attribute/boundelectrons.py
+++ b/test/python/picongpu/quick/pypicongpu/species/attribute/boundelectrons.py
@@ -10,7 +10,7 @@ from picongpu.pypicongpu.species.attribute import BoundElectrons, Attribute
 import unittest
 
 
-class TestPosition(unittest.TestCase):
+class TestBoundElectrons(unittest.TestCase):
     def test_is_attr(self):
         """is an attribute"""
         self.assertTrue(isinstance(BoundElectrons(), Attribute))


### PR DESCRIPTION
@mafshari64 has pointed me towards the fact that automatic test discovery for our non-standard setup fails if there exist multiple identically named test cases. Currently, this seems to happen a few times:
```bash
$ cd /path/to/picongpu/test/python/picongpu/
$ grep -r TestCase 2>/dev/null -h | sed 's/class //g; s/(.*$//g' | sort | uniq -c | grep '[2-9] '
      2 TestPosition
      2 TestRunner
      2 TestSimulation
      2 TestSpecies
      2 TestTimeStepSpec
```
Of those 5, `Runner`, `Simulation` and `Species` are from `quick` and `compiling`, respectively, so most workflows probably wouldn't have run into a discovery failure. `TestPosition` is a misnomer because one of those happened to be a test about `BoundElectrons`, so likely a copy-paste mistake. Only `TestTimeStepSpec` does, in fact, exist twice (once on the `picmi` level and once on the `pypicongpu` level).

Indeed there are 6 additional tests run with the new method:
```bash
# before the change
$ python -m quick -v 2>&1 | sort > tmp1.txt
# after the change
$ python -m quick -v 2>&1 | sort > tmp2.txt

$ diff tmp1.txt tmp2.txt
136a137
> is an attribute ... ok
212c213
< Ran 451 tests in 1.892s
---
> Ran 457 tests in 1.902s
312c313
< test_basic (quick.pypicongpu.species.attribute.boundelectrons.TestPosition.test_basic) ... ok
---
> test_basic (quick.pypicongpu.species.attribute.boundelectrons.TestBoundElectrons.test_basic) ... ok
313a315
> test_basic (quick.pypicongpu.species.attribute.position.TestPosition.test_basic) ... ok
518a521,522
> test_init_with_invalid_slices (quick.pypicongpu.output.timestepspec.TestTimeStepSpec.test_init_with_invalid_slices) ... ok
> test_init_with_valid_slices (quick.pypicongpu.output.timestepspec.TestTimeStepSpec.test_init_with_valid_slices) ... ok
536c540
< test_is_attr (quick.pypicongpu.species.attribute.boundelectrons.TestPosition.test_is_attr)
---
> test_is_attr (quick.pypicongpu.species.attribute.boundelectrons.TestBoundElectrons.test_is_attr)
537a542
> test_is_attr (quick.pypicongpu.species.attribute.position.TestPosition.test_is_attr)
661a667,668
> test_serialize_with_none_values (quick.pypicongpu.output.timestepspec.TestTimeStepSpec.test_serialize_with_none_values) ... ok
> test_serialize_with_valid_slices (quick.pypicongpu.output.timestepspec.TestTimeStepSpec.test_serialize_with_valid_slices) ... ok
```