### PR TITLE
Fix silent parameter dropping for PICMI lasers

### DIFF
--- a/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
@@ -95,7 +95,6 @@ class DispersivePulseLaser(BaseLaser):
             [16, -16],
             [16, -16],
         ],
-        **kw,
     ):
         if waist <= 0:
             raise ValueError(f"waist must be > 0. You gave {waist=}.")

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -71,7 +71,6 @@ class PlaneWaveLaser(BaseLaser):
             [16, -16],
             [16, -16],
         ],
-        **kw,
     ):
         if wavelength <= 0:
             raise ValueError(f"wavelength must be > 0. You gave {wavelength=}.")


### PR DESCRIPTION
Closes #5476 

Copy-paste oversight allows arbitrary keyword arguments to be silently dropped. This has great potential for confusion because typos and wrong parameter names don't raise any exception.