### PR TITLE
add refence to our python install

### DIFF
--- a/docs/source/postprocessing/python.rst
+++ b/docs/source/postprocessing/python.rst
@@ -3,7 +3,10 @@
 Python
 ======
 
-.. sectionauthor:: Axel Huebl, Klaus Steiniger
+.. sectionauthor:: Axel Huebl, Klaus Steiniger, Richard Pausch
+
+If you are familiar with Python and would like to install the Python libraries that come with PIConGPU, please refer to the install instructions in our :doc:`python utilities section <../usage/python_utils>`.
+
 
 If you are new to python, get your hands on the tutorials of the following important libraries to get started.
 


### PR DESCRIPTION
I found it quite unintuitive that we have a python section in our documentation that has zero references to PIConGPU's python libraries. These are described under usage. 

This PR now adds a small reference to that documentation to reduce confusion. 

- [x] check whether linking actually works correctly 