### PR TITLE
fix broken cmd flag list

### DIFF
--- a/docs/source/usage/plugins/radiation.rst
+++ b/docs/source/usage/plugins/radiation.rst
@@ -301,8 +301,8 @@ Command line option                                      Description
                                                          Default: ``{}`` (no JSON/TOML configuration used)
 ``--<species>_radiation.distributedAmplitude``           Activate the optional output of distributed amplitudes per MPI rank.  in the openPMD output.
                                                          Default: ``0`` (deactivated/no additional output)
-					  
-========================================= ==============================================================================================================================
+
+======================================================== ==============================================================================================================================
 
 Memory Complexity
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The radiation plugin documentation did not show the command line flags needed for the radiation plugin. The table with all flags was included in the `radiation.rst` but was not rendered. This was most likely caused by a not standard conform table format. Thanks to @paschk31 w/o her, I would not have seen this bug. 

- [x] check if table is rendered correctly now 

