### PR TITLE
Tiny refactorings in header files 

### DIFF
--- a/include/picongpu/plugins/output/images/param.hpp
+++ b/include/picongpu/plugins/output/images/param.hpp
@@ -21,10 +21,8 @@
 
 #include "picongpu/defines.hpp"
 
-// clang-format off
 
 #include "picongpu/param/pngColorScales.param"
 #include "picongpu/param/png.param"
 
 #include "picongpu/unitless/png.unitless"
-// clang-format on

--- a/include/picongpu/plugins/radiation/param.hpp
+++ b/include/picongpu/plugins/radiation/param.hpp
@@ -21,8 +21,6 @@
 
 #include "picongpu/defines.hpp"
 
-// clang-format off
 #include "picongpu/param/radiation.param"
 #include "picongpu/param/radiationObserver.param"
 #include "picongpu/unitless/radiation.unitless"
-// clang-format on

--- a/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
+++ b/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
@@ -21,11 +21,7 @@
 #include "picongpu/defines.hpp"
 
 #if (SIMDIM == DIM3 && PIC_ENABLE_FFTW3 == 1 && ENABLE_OPENPMD == 1)
-
-// clang-format of
 #    include "picongpu/param/shadowgraphy.param"
-// clang-format on
-
 #    include "picongpu/fields/FieldB.hpp"
 #    include "picongpu/fields/FieldE.hpp"
 #    include "picongpu/plugins/PluginRegistry.hpp"


### PR DESCRIPTION
Removed redundant `clang-format` comments in header files as referenced in #5169 