### PR TITLE
Revert try restart state bug introduced in #5470

### DIFF
--- a/include/picongpu/simulation/control/Simulation.hpp
+++ b/include/picongpu/simulation/control/Simulation.hpp
@@ -480,7 +480,10 @@ namespace picongpu
                         else
                             this->restartStep = checkpoints.back();
                     }
+                }
 
+                if(this->restartRequested)
+                {
                     initialiserController->restart((uint32_t) this->restartStep, this->restartDirectory);
                     step = this->restartStep;
                 }


### PR DESCRIPTION
Partially fixes #5487. I say partially, because the code is back to the pre #5470 working state, but still if you specify try restart with a specific step, and that step doesn't exist then the simulation hard fails. Will fix in a follow up PR. This PR only reverts a bug which I introduced below..
Revert change - https://github.com/ComputationalRadiationPhysics/picongpu/commit/efc82d49dcf42e59fb808f3143761f1ec0bbbdf1#r166655540 . Thanks to @psychocoderHPC for catching this