### PR TITLE
Disable checkpointing properly if openPMD is missing

### DIFF
--- a/include/picongpu/simulation/control/checkpointingState.hpp
+++ b/include/picongpu/simulation/control/checkpointingState.hpp
@@ -19,12 +19,15 @@
 
 #pragma once
 
+#include <pmacc/simulationControl/Checkpointing.hpp>
+
 namespace picongpu
 {
-    static constexpr bool checkpointingEnabled =
+
+    static constexpr pmacc::simulationControl::CheckpointingAvailability checkpointingEnabled =
 #if (ENABLE_OPENPMD == 1)
-        true;
+        pmacc::simulationControl::CheckpointingAvailability::ENABLED;
 #else
-        false;
+        pmacc::simulationControl::CheckpointingAvailability::DISABLED;
 #endif
 } // namespace picongpu

--- a/include/picongpu/simulation/control/checkpointingState.hpp
+++ b/include/picongpu/simulation/control/checkpointingState.hpp
@@ -1,0 +1,30 @@
+/* Copyright 2025 Tapish Narwal
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    static constexpr bool checkpointingEnabled =
+#if (ENABLE_OPENPMD == 1)
+        true;
+#else
+        false;
+#endif
+} // namespace picongpu

--- a/include/pmacc/simulationControl/Checkpointing.hpp
+++ b/include/pmacc/simulationControl/Checkpointing.hpp
@@ -1,0 +1,440 @@
+/* Copyright 2025 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "pmacc/Environment.hpp"
+#include "pmacc/filesystem.hpp"
+#include "pmacc/mappings/simulation/Filesystem.hpp"
+#include "pmacc/mappings/simulation/GridController.hpp"
+#include "pmacc/pluginSystem/Slice.hpp"
+#include "pmacc/pluginSystem/containsStep.hpp"
+#include "pmacc/pluginSystem/toSlice.hpp"
+#include "pmacc/simulationControl/signal.hpp"
+#include "pmacc/types.hpp"
+
+#include <charconv>
+#include <condition_variable>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace pmacc::simulationControl
+{
+    // State of restart.
+    // DISABLED means no restart is attempted.
+    // TRY means a restart is attempted, but the simulation will continue even if restart fails.
+    // FORCE means a restart is attempted, and the simulation will fail if restart fails.
+    // SUCCESS means a restart was successful.
+    // FAILED means a restart failed.
+    enum class RestartState : uint8_t
+    {
+        DISABLED,
+        TRY,
+        FORCE,
+        SUCCESS,
+        FAILED
+    };
+
+    /**
+     * @brief Stream insertion operator for RestartState, converting enum to string.
+     * @param out The output stream.
+     * @param state The RestartState value to write.
+     * @return The output stream.
+     */
+    inline std::ostream& operator<<(std::ostream& out, RestartState const& state)
+    {
+        static std::unordered_map<RestartState, std::string_view> const stateToString
+            = {{RestartState::DISABLED, "disabled"},
+               {RestartState::TRY, "try"},
+               {RestartState::FORCE, "force"},
+               {RestartState::SUCCESS, "success"},
+               {RestartState::FAILED, "failed"}};
+
+        if(auto it = stateToString.find(state); it != stateToString.end())
+        {
+            out << it->second;
+        }
+        else
+        {
+            // Handle unknown enum values gracefully.
+            out << "UNKNOWN_RESTART_STATE(" << static_cast<int>(state) << ")";
+        }
+        return out;
+    }
+
+    /**
+     * @brief Stream extraction operator for RestartState, converting string to enum.
+     * @param in The input stream.
+     * @param state The RestartState variable to populate.
+     * @return The input stream.
+     */
+    inline std::istream& operator>>(std::istream& in, RestartState& state)
+    {
+        static std::unordered_map<std::string, RestartState> const stringToState
+            = {{"disabled", RestartState::DISABLED},
+               {"try", RestartState::TRY},
+               {"force", RestartState::FORCE},
+               {"success", RestartState::SUCCESS},
+               {"failed", RestartState::FAILED}};
+
+        std::string token;
+        in >> token;
+
+        if(auto it = stringToState.find(token); it != stringToState.end())
+        {
+            state = it->second;
+        }
+        else
+        {
+            // If the token is not a valid state, set the stream's failbit.
+            // boost::program_options will catch this and report an error to the user.
+            in.setstate(std::ios_base::failbit);
+        }
+        return in;
+    }
+
+    /**
+     * @brief Manages simulation checkpointing and restarting.
+     *
+     * This class provides functionalities to periodically save the simulation state
+     * (checkpointing) and to resume a simulation from a saved state (restarting).
+     * The checkpointing can be triggered based on simulation steps or wall-clock time.
+     * The entire functionality can be enabled or disabled at compile time via the
+     * `checkpointingEnabled` template parameter.
+     *
+     * @tparam checkpointingEnabled A boolean to enable/disable checkpointing features.
+     */
+    template<bool checkpointingEnabled>
+    struct Checkpointing
+    {
+        using SeqOfTimeSlices = std::vector<pluginSystem::Slice>;
+
+        void registerHelp(po::options_description& desc)
+        {
+            if constexpr(checkpointingEnabled)
+            {
+                // clang-format off
+                desc.add_options()
+                    ("checkpoint.restart.loop", po::value<uint32_t>(&softRestarts)->default_value(0),
+                    "Number of times to restart the simulation after simulation has finished (for presentations). "
+                    "Note: does not yet work with all plugins, see issue #1305")
+                    ("checkpoint.restart", po::value<RestartState>(&restartState)->zero_tokens()->implicit_value(RestartState::FORCE),
+                     "Restart simulation from a checkpoint. Requires a valid checkpoint.")
+                    ("checkpoint.tryRestart", po::value<RestartState>(&restartState)->zero_tokens()->implicit_value(RestartState::TRY),
+                     "Try to restart if a checkpoint is available else start the simulation from scratch.")
+                    ("checkpoint.restart.directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
+                     "Directory containing checkpoints for a restart")
+                    ("checkpoint.restart.step", po::value<int32_t>(&restartStep),
+                     "Checkpoint step to restart from")
+                    ("checkpoint.period", po::value<std::string>(&checkpointPeriod),
+                     "Period for checkpoint creation [interval(s) based on steps]")
+                    ("checkpoint.timePeriod", po::value<std::uint64_t>(&checkpointPeriodMinutes),
+                     "Time periodic checkpoint creation [period in minutes]")
+                    ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
+                     "Directory for checkpoints");
+                // clang-format on
+                // translate checkpointPeriod string into checkpoint intervals
+                seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
+            }
+        }
+
+        void addCheckpoint(uint32_t signalMaxTimestep)
+        {
+            if constexpr(checkpointingEnabled)
+            {
+                seqCheckpointPeriod.push_back(pluginSystem::Slice(signalMaxTimestep, signalMaxTimestep));
+            }
+            else
+            {
+                std::cout << "Checkpointing is disabled, no checkpoint will be created." << std::endl;
+            }
+        }
+
+        template<unsigned DIM>
+        void dump(uint32_t currentStep)
+        {
+            if constexpr(checkpointingEnabled)
+            {
+                /* trigger checkpoint notification */
+                if(pluginSystem::containsStep(seqCheckpointPeriod, currentStep))
+                {
+                    /* first synchronize: if something failed, we can spare the time
+                     * for the checkpoint writing */
+                    alpaka::wait(manager::Device<ComputeDevice>::get().current());
+
+                    // avoid deadlock between not finished PMacc tasks and MPI_Barrier
+                    eventSystem::getTransactionEvent().waitForFinished();
+
+                    GridController<DIM>& gc = Environment<DIM>::get().GridController();
+                    /* can be spared for better scalings, but allows to spare the
+                     * time for checkpointing if some ranks died */
+                    MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
+
+                    /* create directory containing checkpoints  */
+                    if(numCheckpoints == 0 && gc.getGlobalRank() == 0)
+                    {
+                        pmacc::Filesystem::get().createDirectoryWithPermissions(checkpointDirectory);
+                    }
+
+                    Environment<DIM>::get().PluginConnector().checkpointPlugins(currentStep, checkpointDirectory);
+
+                    /* important synchronize: only if no errors occured until this
+                     * point guarantees that a checkpoint is usable */
+                    alpaka::wait(manager::Device<ComputeDevice>::get().current());
+
+                    /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+                    eventSystem::getTransactionEvent().waitForFinished();
+
+                    /* \todo in an ideal world with MPI-3, this would be an
+                     * MPI_Ibarrier call and this function would return a MPI_Request
+                     * that could be checked */
+                    MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
+
+                    if(gc.getGlobalRank() == 0)
+                    {
+                        writeCheckpointStep(currentStep);
+                    }
+                    numCheckpoints++;
+                }
+            }
+        }
+
+        bool doSoftRestart()
+        {
+            static uint32_t nthSoftRestart = 0;
+            if(nthSoftRestart <= softRestarts)
+            {
+                nthSoftRestart++;
+                return true;
+            }
+            return false;
+        }
+
+        void doTimeBasedCheckpointing()
+        {
+            if constexpr(checkpointingEnabled)
+            {
+                // register concurrent thread to perform checkpointing periodically after a user defined time
+                if(checkpointPeriodMinutes != 0)
+                    checkpointTimeThread = std::thread(
+                        [&, this]()
+                        {
+                            std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
+                            while(exitConcurrentThreads.wait_until(
+                                      lk,
+                                      std::chrono::system_clock::now() + std::chrono::minutes(checkpointPeriodMinutes))
+                                  == std::cv_status::timeout)
+                            {
+                                signal::detail::setCreateCheckpoint(1);
+                            }
+                        });
+            }
+        }
+
+        void endTimeBasedCheckpointing()
+        {
+            if constexpr(checkpointingEnabled)
+            {
+                {
+                    // notify all concurrent threads to exit
+                    std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
+                    exitConcurrentThreads.notify_all();
+                }
+                // wait for time triggered checkpoint thread
+                if(checkpointTimeThread.joinable())
+                    checkpointTimeThread.join();
+            }
+        }
+
+        /* Returns whether a restart needs to be performed */
+        bool checkRestart(uint32_t& step)
+        {
+            if constexpr(checkpointingEnabled)
+            {
+                if(restartState != RestartState::TRY && restartState != RestartState::FORCE)
+                {
+                    return false;
+                }
+                std::vector<uint32_t> checkpoints = readCheckpointMasterFile();
+
+                // If no specific restart step is given, default to the latest available checkpoint.
+                if(restartStep < 0)
+                {
+                    if(checkpoints.empty())
+                    {
+                        if(restartState == RestartState::FORCE)
+                        {
+                            throw std::runtime_error(
+                                "Restart failed. No checkpoints found and no '--checkpoint.restart.step' provided.");
+                        }
+                        restartState = RestartState::FAILED;
+                        return false;
+                    }
+                    restartStep = checkpoints.back();
+                }
+
+                // Checkpoints are expected to be sorted chronologically.
+                bool const stepFound = std::binary_search(checkpoints.cbegin(), checkpoints.cend(), restartStep);
+
+                if(!stepFound)
+                {
+                    if(restartState == RestartState::FORCE)
+                    {
+                        throw std::runtime_error(
+                            "Restart failed. Checkpoint for step " + std::to_string(restartStep) + " not found.");
+                    }
+                    restartState = RestartState::FAILED;
+                    return false;
+                }
+
+                // At this point, restart is possible.
+                restartState = RestartState::SUCCESS;
+                return true;
+            }
+            return false;
+        }
+
+        [[nodiscard]] RestartState getRestartState() const
+        {
+            return restartState;
+        }
+
+        [[nodiscard]] int32_t getRestartStep() const
+        {
+            return restartStep;
+        }
+
+        [[nodiscard]] std::string const& getRestartDir() const
+        {
+            return restartDirectory;
+        }
+
+    private:
+        /** Presentations: loop the whole simulation `softRestarts` times from
+         *                 initial step to runSteps */
+        uint32_t softRestarts{0};
+
+        /* period for checkpoint creation [interval(s) based on steps]*/
+        std::string checkpointPeriod;
+
+        /* checkpoint intervals */
+        SeqOfTimeSlices seqCheckpointPeriod;
+
+        /* period for checkpoint creation [period in minutes]
+         * Zero is disabling time depended checkpointing.
+         */
+        std::uint64_t checkpointPeriodMinutes = 0u;
+        std::thread checkpointTimeThread;
+
+        // conditional variable to notify all concurrent threads and signal exit of the simulation
+        std::condition_variable exitConcurrentThreads;
+        std::mutex concurrentThreadMutex;
+
+        /* common directory for checkpoints */
+        std::string checkpointDirectory{"checkpoints"};
+
+        /* number of checkpoints written */
+        uint32_t numCheckpoints{0};
+
+        /* checkpoint step to restart from */
+        int32_t restartStep{-1};
+
+        /* common directory for restarts */
+        std::string restartDirectory{"checkpoints"};
+
+        /* filename for checkpoint master file with all checkpoint timesteps */
+        static constexpr std::string_view CHECKPOINT_MASTER_FILE{"checkpoints.txt"};
+
+        RestartState restartState{RestartState::DISABLED};
+
+        /**
+         * Append \p checkpointStep to the master checkpoint file
+         *
+         * @param checkpointStep current checkpoint step
+         */
+        void writeCheckpointStep(uint32_t const checkpointStep)
+        {
+            stdfs::path const checkpointMasterFile = stdfs::path(checkpointDirectory) / CHECKPOINT_MASTER_FILE;
+
+            std::ofstream file(checkpointMasterFile, std::ofstream::app);
+
+            if(!file)
+            {
+                throw std::runtime_error("Failed to write checkpoint master file: " + checkpointMasterFile.string());
+            }
+
+            file << checkpointStep << '\n';
+        }
+
+        /**
+         * Reads the checkpoint master file if any and returns all found checkpoint steps
+         *
+         * @return vector of found checkpoints steps in order they appear in the file
+         */
+        std::vector<uint32_t> readCheckpointMasterFile()
+        {
+            std::vector<uint32_t> checkpoints;
+
+            stdfs::path const checkpointMasterFile = stdfs::path(restartDirectory) / CHECKPOINT_MASTER_FILE;
+
+            if(!stdfs::exists(checkpointMasterFile))
+            {
+                return checkpoints;
+            }
+
+            std::ifstream file(checkpointMasterFile);
+            if(!file)
+            {
+                std::cerr << "Warning: Could not open checkpoint master file: " << checkpointMasterFile << std::endl;
+                return checkpoints;
+            }
+
+            /* read each line */
+            std::string line;
+            while(std::getline(file, line))
+            {
+                if(line.empty())
+                {
+                    continue;
+                }
+
+                uint32_t step;
+                auto const [ptr, ec] = std::from_chars(line.data(), line.data() + line.size(), step);
+                if(ec == std::errc{} && ptr == line.data() + line.size())
+                {
+                    checkpoints.push_back(step);
+                }
+                else
+                {
+                    std::cerr << "Warning: checkpoint master file contains invalid data (" << line << ")" << std::endl;
+                }
+            }
+
+            return checkpoints;
+        }
+    };
+
+} // namespace pmacc::simulationControl

--- a/include/pmacc/simulationControl/Checkpointing.hpp
+++ b/include/pmacc/simulationControl/Checkpointing.hpp
@@ -32,13 +32,16 @@
 #include "pmacc/simulationControl/signal.hpp"
 #include "pmacc/types.hpp"
 
+#include <algorithm>
+#include <array>
 #include <charconv>
 #include <condition_variable>
 #include <cstdint>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <string_view>
-#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace pmacc::simulationControl
@@ -58,6 +61,14 @@ namespace pmacc::simulationControl
         FAILED
     };
 
+    // enum-to-string mapping
+    constexpr std::array<std::pair<RestartState, std::string_view>, 5> restartStateMappings{
+        {{RestartState::DISABLED, "disabled"},
+         {RestartState::TRY, "try"},
+         {RestartState::FORCE, "force"},
+         {RestartState::SUCCESS, "success"},
+         {RestartState::FAILED, "failed"}}};
+
     /**
      * @brief Stream insertion operator for RestartState, converting enum to string.
      * @param out The output stream.
@@ -66,14 +77,10 @@ namespace pmacc::simulationControl
      */
     inline std::ostream& operator<<(std::ostream& out, RestartState const& state)
     {
-        static std::unordered_map<RestartState, std::string_view> const stateToString
-            = {{RestartState::DISABLED, "disabled"},
-               {RestartState::TRY, "try"},
-               {RestartState::FORCE, "force"},
-               {RestartState::SUCCESS, "success"},
-               {RestartState::FAILED, "failed"}};
+        auto const it
+            = std::ranges::find_if(restartStateMappings, [&](auto const& pair) { return pair.first == state; });
 
-        if(auto it = stateToString.find(state); it != stateToString.end())
+        if(it != restartStateMappings.end())
         {
             out << it->second;
         }
@@ -93,19 +100,15 @@ namespace pmacc::simulationControl
      */
     inline std::istream& operator>>(std::istream& in, RestartState& state)
     {
-        static std::unordered_map<std::string, RestartState> const stringToState
-            = {{"disabled", RestartState::DISABLED},
-               {"try", RestartState::TRY},
-               {"force", RestartState::FORCE},
-               {"success", RestartState::SUCCESS},
-               {"failed", RestartState::FAILED}};
-
         std::string token;
         in >> token;
 
-        if(auto it = stringToState.find(token); it != stringToState.end())
+        auto const it
+            = std::ranges::find_if(restartStateMappings, [&](auto const& pair) { return pair.second == token; });
+
+        if(it != restartStateMappings.end())
         {
-            state = it->second;
+            state = it->first;
         }
         else
         {
@@ -134,95 +137,82 @@ namespace pmacc::simulationControl
 
         void registerHelp(po::options_description& desc)
         {
-            if constexpr(checkpointingEnabled)
-            {
-                // clang-format off
-                desc.add_options()
-                    ("checkpoint.restart.loop", po::value<uint32_t>(&softRestarts)->default_value(0),
-                    "Number of times to restart the simulation after simulation has finished (for presentations). "
-                    "Note: does not yet work with all plugins, see issue #1305")
-                    ("checkpoint.restart", po::value<RestartState>(&restartState)->zero_tokens()->implicit_value(RestartState::FORCE),
-                     "Restart simulation from a checkpoint. Requires a valid checkpoint.")
-                    ("checkpoint.tryRestart", po::value<RestartState>(&restartState)->zero_tokens()->implicit_value(RestartState::TRY),
-                     "Try to restart if a checkpoint is available else start the simulation from scratch.")
-                    ("checkpoint.restart.directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
-                     "Directory containing checkpoints for a restart")
-                    ("checkpoint.restart.step", po::value<int32_t>(&restartStep),
-                     "Checkpoint step to restart from")
-                    ("checkpoint.period", po::value<std::string>(&checkpointPeriod),
-                     "Period for checkpoint creation [interval(s) based on steps]")
-                    ("checkpoint.timePeriod", po::value<std::uint64_t>(&checkpointPeriodMinutes),
-                     "Time periodic checkpoint creation [period in minutes]")
-                    ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
-                     "Directory for checkpoints");
-                // clang-format on
-                // translate checkpointPeriod string into checkpoint intervals
-                seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
-            }
+            // clang-format off
+            desc.add_options()
+                ("checkpoint.restart.loop", po::value<uint32_t>(&softRestarts)->default_value(0),
+                "Number of times to restart the simulation after simulation has finished (for presentations). "
+                "Note: does not yet work with all plugins, see issue #1305")
+                ("checkpoint.restart", po::value<RestartState>(&restartState)->zero_tokens()->implicit_value(RestartState::FORCE),
+                    "Restart simulation from a checkpoint. Requires a valid checkpoint.")
+                ("checkpoint.tryRestart", po::value<RestartState>(&restartState)->zero_tokens()->implicit_value(RestartState::TRY),
+                    "Try to restart if a checkpoint is available else start the simulation from scratch.")
+                ("checkpoint.restart.directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
+                    "Directory containing checkpoints for a restart")
+                ("checkpoint.restart.step", po::value<int32_t>(&restartStep),
+                    "Checkpoint step to restart from")
+                ("checkpoint.period", po::value<std::string>(&checkpointPeriod),
+                    "Period for checkpoint creation [interval(s) based on steps]")
+                ("checkpoint.timePeriod", po::value<std::uint64_t>(&checkpointPeriodMinutes),
+                    "Time periodic checkpoint creation [period in minutes]")
+                ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
+                    "Directory for checkpoints");
+            // clang-format on
+            // translate checkpointPeriod string into checkpoint intervals
+            seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
         }
 
         void addCheckpoint(uint32_t signalMaxTimestep)
         {
-            if constexpr(checkpointingEnabled)
-            {
-                seqCheckpointPeriod.push_back(pluginSystem::Slice(signalMaxTimestep, signalMaxTimestep));
-            }
-            else
-            {
-                std::cout << "Checkpointing is disabled, no checkpoint will be created." << std::endl;
-            }
+            seqCheckpointPeriod.push_back(pluginSystem::Slice(signalMaxTimestep, signalMaxTimestep));
         }
 
         template<unsigned DIM>
         void dump(uint32_t currentStep)
         {
-            if constexpr(checkpointingEnabled)
+            /* trigger checkpoint notification */
+            if(pluginSystem::containsStep(seqCheckpointPeriod, currentStep))
             {
-                /* trigger checkpoint notification */
-                if(pluginSystem::containsStep(seqCheckpointPeriod, currentStep))
+                /* first synchronize: if something failed, we can spare the time
+                 * for the checkpoint writing */
+                alpaka::wait(manager::Device<ComputeDevice>::get().current());
+
+                // avoid deadlock between not finished PMacc tasks and MPI_Barrier
+                eventSystem::getTransactionEvent().waitForFinished();
+
+                GridController<DIM>& gc = Environment<DIM>::get().GridController();
+                /* can be spared for better scalings, but allows to spare the
+                 * time for checkpointing if some ranks died */
+                MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
+
+                /* create directory containing checkpoints  */
+                if(numCheckpoints == 0 && gc.getGlobalRank() == 0)
                 {
-                    /* first synchronize: if something failed, we can spare the time
-                     * for the checkpoint writing */
-                    alpaka::wait(manager::Device<ComputeDevice>::get().current());
-
-                    // avoid deadlock between not finished PMacc tasks and MPI_Barrier
-                    eventSystem::getTransactionEvent().waitForFinished();
-
-                    GridController<DIM>& gc = Environment<DIM>::get().GridController();
-                    /* can be spared for better scalings, but allows to spare the
-                     * time for checkpointing if some ranks died */
-                    MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
-
-                    /* create directory containing checkpoints  */
-                    if(numCheckpoints == 0 && gc.getGlobalRank() == 0)
-                    {
-                        pmacc::Filesystem::get().createDirectoryWithPermissions(checkpointDirectory);
-                    }
-
-                    Environment<DIM>::get().PluginConnector().checkpointPlugins(currentStep, checkpointDirectory);
-
-                    /* important synchronize: only if no errors occured until this
-                     * point guarantees that a checkpoint is usable */
-                    alpaka::wait(manager::Device<ComputeDevice>::get().current());
-
-                    /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
-                    eventSystem::getTransactionEvent().waitForFinished();
-
-                    /* \todo in an ideal world with MPI-3, this would be an
-                     * MPI_Ibarrier call and this function would return a MPI_Request
-                     * that could be checked */
-                    MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
-
-                    if(gc.getGlobalRank() == 0)
-                    {
-                        writeCheckpointStep(currentStep);
-                    }
-                    numCheckpoints++;
+                    pmacc::Filesystem::get().createDirectoryWithPermissions(checkpointDirectory);
                 }
+
+                Environment<DIM>::get().PluginConnector().checkpointPlugins(currentStep, checkpointDirectory);
+
+                /* important synchronize: only if no errors occured until this
+                 * point guarantees that a checkpoint is usable */
+                alpaka::wait(manager::Device<ComputeDevice>::get().current());
+
+                /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
+                eventSystem::getTransactionEvent().waitForFinished();
+
+                /* \todo in an ideal world with MPI-3, this would be an
+                 * MPI_Ibarrier call and this function would return a MPI_Request
+                 * that could be checked */
+                MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
+
+                if(gc.getGlobalRank() == 0)
+                {
+                    writeCheckpointStep(currentStep);
+                }
+                numCheckpoints++;
             }
         }
 
-        bool doSoftRestart()
+        bool tryConsumeRestartAttempt()
         {
             static uint32_t nthSoftRestart = 0;
             if(nthSoftRestart <= softRestarts)
@@ -233,88 +223,78 @@ namespace pmacc::simulationControl
             return false;
         }
 
-        void doTimeBasedCheckpointing()
+        void startTimeBasedCheckpointing()
         {
-            if constexpr(checkpointingEnabled)
-            {
-                // register concurrent thread to perform checkpointing periodically after a user defined time
-                if(checkpointPeriodMinutes != 0)
-                    checkpointTimeThread = std::thread(
-                        [&, this]()
+            // register concurrent thread to perform checkpointing periodically after a user defined time
+            if(checkpointPeriodMinutes != 0)
+                checkpointTimeThread = std::thread(
+                    [&, this]()
+                    {
+                        std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
+                        while(exitConcurrentThreads.wait_until(
+                                  lk,
+                                  std::chrono::system_clock::now() + std::chrono::minutes(checkpointPeriodMinutes))
+                              == std::cv_status::timeout)
                         {
-                            std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
-                            while(exitConcurrentThreads.wait_until(
-                                      lk,
-                                      std::chrono::system_clock::now() + std::chrono::minutes(checkpointPeriodMinutes))
-                                  == std::cv_status::timeout)
-                            {
-                                signal::detail::setCreateCheckpoint(1);
-                            }
-                        });
-            }
+                            signal::detail::setCreateCheckpoint(1);
+                        }
+                    });
         }
 
-        void endTimeBasedCheckpointing()
+        void finishTimeBasedCheckpointing()
         {
-            if constexpr(checkpointingEnabled)
             {
-                {
-                    // notify all concurrent threads to exit
-                    std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
-                    exitConcurrentThreads.notify_all();
-                }
-                // wait for time triggered checkpoint thread
-                if(checkpointTimeThread.joinable())
-                    checkpointTimeThread.join();
+                // notify all concurrent threads to exit
+                std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
+                exitConcurrentThreads.notify_all();
             }
+            // wait for time triggered checkpoint thread
+            if(checkpointTimeThread.joinable())
+                checkpointTimeThread.join();
         }
 
         /* Returns whether a restart needs to be performed */
         bool checkRestart(uint32_t& step)
         {
-            if constexpr(checkpointingEnabled)
+            if(restartState != RestartState::TRY && restartState != RestartState::FORCE)
             {
-                if(restartState != RestartState::TRY && restartState != RestartState::FORCE)
-                {
-                    return false;
-                }
-                std::vector<uint32_t> checkpoints = readCheckpointMasterFile();
+                return false;
+            }
+            std::vector<uint32_t> checkpoints = readCheckpointMasterFile();
 
-                // If no specific restart step is given, default to the latest available checkpoint.
-                if(restartStep < 0)
-                {
-                    if(checkpoints.empty())
-                    {
-                        if(restartState == RestartState::FORCE)
-                        {
-                            throw std::runtime_error(
-                                "Restart failed. No checkpoints found and no '--checkpoint.restart.step' provided.");
-                        }
-                        restartState = RestartState::FAILED;
-                        return false;
-                    }
-                    restartStep = checkpoints.back();
-                }
-
-                // Checkpoints are expected to be sorted chronologically.
-                bool const stepFound = std::binary_search(checkpoints.cbegin(), checkpoints.cend(), restartStep);
-
-                if(!stepFound)
+            // If no specific restart step is given, default to the latest available checkpoint.
+            if(restartStep < 0)
+            {
+                if(checkpoints.empty())
                 {
                     if(restartState == RestartState::FORCE)
                     {
                         throw std::runtime_error(
-                            "Restart failed. Checkpoint for step " + std::to_string(restartStep) + " not found.");
+                            "Restart failed. No checkpoints found and no '--checkpoint.restart.step' provided.");
                     }
                     restartState = RestartState::FAILED;
                     return false;
                 }
-
-                // At this point, restart is possible.
-                restartState = RestartState::SUCCESS;
-                return true;
+                restartStep = checkpoints.back();
             }
-            return false;
+
+            // Checkpoints are expected to be sorted chronologically.
+            bool const stepFound = std::binary_search(checkpoints.cbegin(), checkpoints.cend(), restartStep);
+
+            if(!stepFound)
+            {
+                if(restartState == RestartState::FORCE)
+                {
+                    throw std::runtime_error(
+                        "Restart failed. Checkpoint for step " + std::to_string(restartStep) + " not found.");
+                }
+                restartState = RestartState::FAILED;
+                return false;
+            }
+
+            // At this point, restart is possible.
+            restartState = RestartState::SUCCESS;
+            return true;
         }
 
         [[nodiscard]] RestartState getRestartState() const
@@ -435,6 +415,84 @@ namespace pmacc::simulationControl
 
             return checkpoints;
         }
+    };
+
+    template<>
+    struct Checkpointing<false>
+    {
+        using SeqOfTimeSlices = std::vector<pluginSystem::Slice>;
+
+        void registerHelp(po::options_description& desc)
+        {
+            desc.add_options()(
+                "checkpoint.restart.loop",
+                po::value<uint32_t>(&softRestarts)->default_value(0),
+                "Number of times to restart the simulation after simulation has finished (for presentations). "
+                "Note: does not yet work with all plugins, see issue #1305");
+        }
+
+        void addCheckpoint(uint32_t signalMaxTimestep)
+        {
+            std::cout << "Checkpointing is disabled, no checkpoint will be created." << std::endl;
+        }
+
+        template<unsigned DIM>
+        void dump(uint32_t currentStep)
+        {
+        }
+
+        bool tryConsumeRestartAttempt()
+        {
+            static uint32_t nthSoftRestart = 0;
+            if(nthSoftRestart <= softRestarts)
+            {
+                nthSoftRestart++;
+                return true;
+            }
+            return false;
+        }
+
+        void startTimeBasedCheckpointing()
+        {
+        }
+
+        void finishTimeBasedCheckpointing()
+        {
+        }
+
+        /* Returns whether a restart needs to be performed */
+        bool checkRestart(uint32_t& step)
+        {
+            return false;
+        }
+
+        [[nodiscard]] RestartState getRestartState() const
+        {
+            return restartState;
+        }
+
+        [[nodiscard]] int32_t getRestartStep() const
+        {
+            return restartStep;
+        }
+
+        [[nodiscard]] std::string const& getRestartDir() const
+        {
+            return restartDirectory;
+        }
+
+    private:
+        /** Presentations: loop the whole simulation `softRestarts` times from
+         *                 initial step to runSteps */
+        uint32_t softRestarts{0};
+
+        RestartState restartState{RestartState::DISABLED};
+
+        /* checkpoint step to restart from */
+        int32_t restartStep{-1};
+
+        /* common directory for restarts */
+        std::string restartDirectory{"checkpoints"};
     };
 
 } // namespace pmacc::simulationControl

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -53,7 +53,7 @@ namespace pmacc
     template<unsigned DIM, typename CheckpointingClass>
     SimulationHelper<DIM, CheckpointingClass>::~SimulationHelper()
     {
-        checkpointing.endTimeBasedCheckpointing();
+        checkpointing.finishTimeBasedCheckpointing();
         tSimulation.toggleEnd();
         if(output)
         {
@@ -123,7 +123,7 @@ namespace pmacc
         // Install a signal handler
         signal::activate();
 
-        checkpointing.doTimeBasedCheckpointing();
+        checkpointing.startTimeBasedCheckpointing();
 
         uint64_t maxRanks = Environment<DIM>::get().GridController().getGpuNodes().productOfComponents();
         uint64_t rank = Environment<DIM>::get().GridController().getScalarPosition();
@@ -134,7 +134,7 @@ namespace pmacc
 
         init();
 
-        while(checkpointing.doSoftRestart())
+        while(checkpointing.tryConsumeRestartAttempt())
         {
             /* Global offset is updated during the simulation. In case we perform a soft restart we need to reset
              * the offset here to be valid for the next simulation run.

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -134,7 +134,7 @@ namespace pmacc
 
         init();
 
-        while(checkpointing.tryConsumeRestartAttempt())
+        while(checkpointing.hasSoftRestartAttemptsLeft())
         {
             /* Global offset is updated during the simulation. In case we perform a soft restart we need to reset
              * the offset here to be valid for the next simulation run.
@@ -352,9 +352,16 @@ namespace pmacc
 
 
     // Explicit template instantiation to provide symbols for usage together with PMacc
-    template class SimulationHelper<DIM2, simulationControl::Checkpointing<true>>;
-    template class SimulationHelper<DIM3, simulationControl::Checkpointing<true>>;
-    template class SimulationHelper<DIM2, simulationControl::Checkpointing<false>>;
-    template class SimulationHelper<DIM3, simulationControl::Checkpointing<false>>;
-
+    template class SimulationHelper<
+        DIM2,
+        simulationControl::Checkpointing<simulationControl::CheckpointingAvailability::ENABLED>>;
+    template class SimulationHelper<
+        DIM3,
+        simulationControl::Checkpointing<simulationControl::CheckpointingAvailability::ENABLED>>;
+    template class SimulationHelper<
+        DIM2,
+        simulationControl::Checkpointing<simulationControl::CheckpointingAvailability::DISABLED>>;
+    template class SimulationHelper<
+        DIM3,
+        simulationControl::Checkpointing<simulationControl::CheckpointingAvailability::DISABLED>>;
 } // namespace pmacc

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -27,52 +27,33 @@
 #include "pmacc/dataManagement/DataConnector.hpp"
 #include "pmacc/dimensions/DataSpace.hpp"
 #include "pmacc/eventSystem/Manager.hpp"
-#include "pmacc/filesystem.hpp"
-#include "pmacc/mappings/simulation/Filesystem.hpp"
-#include "pmacc/mappings/simulation/GridController.hpp"
 #include "pmacc/particles/IdProvider.hpp"
 #include "pmacc/pluginSystem/IPlugin.hpp"
 #include "pmacc/pluginSystem/containsStep.hpp"
 #include "pmacc/pluginSystem/toSlice.hpp"
+#include "pmacc/simulationControl/Checkpointing.hpp"
 #include "pmacc/simulationControl/signal.hpp"
 #include "pmacc/types.hpp"
 
 #include <chrono>
-#include <condition_variable>
-#include <csignal>
-#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <string>
 #include <thread>
-#include <vector>
 
 namespace pmacc
 {
-    template<unsigned DIM>
-    SimulationHelper<DIM>::SimulationHelper()
-        : checkpointDirectory("checkpoints")
-        , restartDirectory("checkpoints")
-        , CHECKPOINT_MASTER_FILE("checkpoints.txt")
-        , author("")
-
+    template<unsigned DIM, typename CheckpointingClass>
+    SimulationHelper<DIM, CheckpointingClass>::SimulationHelper() : author("")
     {
         tSimulation.toggleStart();
         tInit.toggleStart();
     }
 
-    template<unsigned DIM>
-    SimulationHelper<DIM>::~SimulationHelper()
+    template<unsigned DIM, typename CheckpointingClass>
+    SimulationHelper<DIM, CheckpointingClass>::~SimulationHelper()
     {
-        {
-            // notify all concurrent threads to exit
-            std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
-            exitConcurrentThreads.notify_all();
-        }
-        // wait for time triggered checkpoint thread
-        if(checkpointTimeThread.joinable())
-            checkpointTimeThread.join();
-
+        checkpointing.endTimeBasedCheckpointing();
         tSimulation.toggleEnd();
         if(output)
         {
@@ -82,8 +63,8 @@ namespace pmacc
         }
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::notifyPlugins(uint32_t currentStep)
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::notifyPlugins(uint32_t currentStep)
     {
         Environment<DIM>::get().PluginConnector().notifyPlugins(currentStep);
         /* Handle signals after we executed the plugins but before checkpointing, this will result into lower
@@ -92,54 +73,14 @@ namespace pmacc
         checkSignals(currentStep);
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::dumpOneStep(uint32_t currentStep)
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::dumpOneStep(uint32_t currentStep)
     {
-        /* trigger checkpoint notification */
-        if(pluginSystem::containsStep(seqCheckpointPeriod, currentStep))
-        {
-            /* first synchronize: if something failed, we can spare the time
-             * for the checkpoint writing */
-            alpaka::wait(manager::Device<ComputeDevice>::get().current());
-
-            // avoid deadlock between not finished PMacc tasks and MPI_Barrier
-            eventSystem::getTransactionEvent().waitForFinished();
-
-            GridController<DIM>& gc = Environment<DIM>::get().GridController();
-            /* can be spared for better scalings, but allows to spare the
-             * time for checkpointing if some ranks died */
-            MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
-
-            /* create directory containing checkpoints  */
-            if(numCheckpoints == 0 && gc.getGlobalRank() == 0)
-            {
-                pmacc::Filesystem::get().createDirectoryWithPermissions(checkpointDirectory);
-            }
-
-            Environment<DIM>::get().PluginConnector().checkpointPlugins(currentStep, checkpointDirectory);
-
-            /* important synchronize: only if no errors occured until this
-             * point guarantees that a checkpoint is usable */
-            alpaka::wait(manager::Device<ComputeDevice>::get().current());
-
-            /* avoid deadlock between not finished PMacc tasks and MPI_Barrier */
-            eventSystem::getTransactionEvent().waitForFinished();
-
-            /* \todo in an ideal world with MPI-3, this would be an
-             * MPI_Ibarrier call and this function would return a MPI_Request
-             * that could be checked */
-            MPI_CHECK(MPI_Barrier(gc.getCommunicator().getMPIComm()));
-
-            if(gc.getGlobalRank() == 0)
-            {
-                writeCheckpointStep(currentStep);
-            }
-            numCheckpoints++;
-        }
+        checkpointing.template dump<DIM>(currentStep);
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::dumpTimes(
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::dumpTimes(
         TimeIntervall& tSimCalculation,
         TimeIntervall&,
         double& roundAvg,
@@ -173,8 +114,8 @@ namespace pmacc
         }
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::startSimulation()
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::startSimulation()
     {
         if(useMpiDirect)
             Environment<>::get().enableMpiDirect();
@@ -182,20 +123,7 @@ namespace pmacc
         // Install a signal handler
         signal::activate();
 
-        // register concurrent thread to perform checkpointing periodically after a user defined time
-        if(checkpointPeriodMinutes != 0)
-            checkpointTimeThread = std::thread(
-                [&, this]()
-                {
-                    std::unique_lock<std::mutex> lk(this->concurrentThreadMutex);
-                    while(exitConcurrentThreads.wait_until(
-                              lk,
-                              std::chrono::system_clock::now() + std::chrono::minutes(checkpointPeriodMinutes))
-                          == std::cv_status::timeout)
-                    {
-                        signal::detail::setCreateCheckpoint(1);
-                    }
-                });
+        checkpointing.doTimeBasedCheckpointing();
 
         uint64_t maxRanks = Environment<DIM>::get().GridController().getGpuNodes().productOfComponents();
         uint64_t rank = Environment<DIM>::get().GridController().getScalarPosition();
@@ -206,10 +134,7 @@ namespace pmacc
 
         init();
 
-        // translate checkpointPeriod string into checkpoint intervals
-        seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
-
-        for(uint32_t nthSoftRestart = 0; nthSoftRestart <= softRestarts; ++nthSoftRestart)
+        while(checkpointing.doSoftRestart())
         {
             /* Global offset is updated during the simulation. In case we perform a soft restart we need to reset
              * the offset here to be valid for the next simulation run.
@@ -239,7 +164,7 @@ namespace pmacc
             movingWindowCheck(currentStep);
 
             /* call plugins and dump initial step if simulation starts without restart */
-            if(!restartRequested)
+            if(checkpointing.getRestartState() != simulationControl::RestartState::SUCCESS)
             {
                 notifyPlugins(currentStep);
                 dumpOneStep(currentStep);
@@ -292,42 +217,26 @@ namespace pmacc
         } // softRestarts loop
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::pluginRegisterHelp(po::options_description& desc)
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::pluginRegisterHelp(po::options_description& desc)
     {
         // clang-format off
             desc.add_options()
                 ("steps,s", po::value<uint32_t>(&runSteps), "Simulation steps")
-                ("checkpoint.restart.loop", po::value<uint32_t>(&softRestarts)->default_value(0),
-                 "Number of times to restart the simulation after simulation has finished (for presentations). "
-                 "Note: does not yet work with all plugins, see issue #1305")
                 ("percent,p", po::value<uint16_t>(&progress)->default_value(5),
                  "Print time statistics after p percent to stdout")
                 ("progressPeriod",po::value<std::string>(&progressPeriod),
                 "write progress [for each n-th step], plugin period syntax can be used here.")
-                ("checkpoint.restart", po::value<bool>(&restartRequested)->zero_tokens(),
-                 "Restart simulation from a checkpoint. Requires a valid checkpoint.")
-                ("checkpoint.tryRestart", po::value<bool>(&tryRestart)->zero_tokens(),
-                 "Try to restart if a checkpoint is available else start the simulation from scratch.")
-                ("checkpoint.restart.directory", po::value<std::string>(&restartDirectory)->default_value(restartDirectory),
-                 "Directory containing checkpoints for a restart")
-                ("checkpoint.restart.step", po::value<int32_t>(&restartStep),
-                 "Checkpoint step to restart from")
-                ("checkpoint.period", po::value<std::string>(&checkpointPeriod),
-                 "Period for checkpoint creation [interval(s) based on steps]")
-                ("checkpoint.timePeriod", po::value<std::uint64_t>(&checkpointPeriodMinutes),
-                 "Time periodic checkpoint creation [period in minutes]")
-                ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
-                 "Directory for checkpoints")
                 ("author", po::value<std::string>(&author)->default_value(std::string("")),
                  "The author that runs the simulation and is responsible for created output files")
                 ("mpiDirect", po::value<bool>(&useMpiDirect)->zero_tokens(),
                  "use device direct for MPI communication e.g. GPU direct");
         // clang-format on
+        checkpointing.registerHelp(desc);
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::pluginLoad()
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::pluginLoad()
     {
         Environment<>::get().SimulationDescription().setRunSteps(runSteps);
         Environment<>::get().SimulationDescription().setAuthor(author);
@@ -338,13 +247,10 @@ namespace pmacc
             seqProgressPeriod = pluginSystem::toTimeSlice(progressPeriod);
 
         output = (getGridController().getGlobalRank() == 0);
-
-        if(tryRestart)
-            restartRequested = true;
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::checkSignals(uint32_t const currentStep)
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::checkSignals(uint32_t const currentStep)
     {
         /* Avoid signal handling if the last signal is still processed.
          * Signal handling in the first step is always allowed.
@@ -420,7 +326,7 @@ namespace pmacc
                 signalCreateCheckpoint = false;
 
                 // add a new checkpoint
-                seqCheckpointPeriod.push_back(pluginSystem::Slice(signalMaxTimestep, signalMaxTimestep));
+                checkpointing.addCheckpoint(signalMaxTimestep);
             }
             if(signalStopSimulation)
             {
@@ -432,8 +338,8 @@ namespace pmacc
         }
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::calcProgress()
+    template<unsigned DIM, typename CheckpointingClass>
+    void SimulationHelper<DIM, CheckpointingClass>::calcProgress()
     {
         if(progress == 0 || progress > 100)
             progress = 100;
@@ -444,55 +350,11 @@ namespace pmacc
             showProgressAnyStep = 1;
     }
 
-    template<unsigned DIM>
-    void SimulationHelper<DIM>::writeCheckpointStep(uint32_t const checkpointStep)
-    {
-        std::ofstream file;
-        std::string const checkpointMasterFile = checkpointDirectory + std::string("/") + CHECKPOINT_MASTER_FILE;
-
-        file.open(checkpointMasterFile.c_str(), std::ofstream::app);
-
-        if(!file)
-            throw std::runtime_error("Failed to write checkpoint master file");
-
-        file << checkpointStep << std::endl;
-        file.close();
-    }
-
-    template<unsigned DIM>
-    std::vector<uint32_t> SimulationHelper<DIM>::readCheckpointMasterFile()
-    {
-        std::vector<uint32_t> checkpoints;
-
-        std::string const checkpointMasterFile
-            = this->restartDirectory + std::string("/") + this->CHECKPOINT_MASTER_FILE;
-
-        if(!stdfs::exists(checkpointMasterFile))
-            return checkpoints;
-
-        std::ifstream file(checkpointMasterFile.c_str());
-
-        /* read each line */
-        std::string line;
-        while(std::getline(file, line))
-        {
-            if(line.empty())
-                continue;
-            try
-            {
-                checkpoints.push_back(boost::lexical_cast<uint32_t>(line));
-            }
-            catch(boost::bad_lexical_cast const&)
-            {
-                std::cerr << "Warning: checkpoint master file contains invalid data (" << line << ")" << std::endl;
-            }
-        }
-
-        return checkpoints;
-    }
 
     // Explicit template instantiation to provide symbols for usage together with PMacc
-    template class SimulationHelper<DIM2>;
-    template class SimulationHelper<DIM3>;
+    template class SimulationHelper<DIM2, simulationControl::Checkpointing<true>>;
+    template class SimulationHelper<DIM3, simulationControl::Checkpointing<true>>;
+    template class SimulationHelper<DIM2, simulationControl::Checkpointing<false>>;
+    template class SimulationHelper<DIM3, simulationControl::Checkpointing<false>>;
 
 } // namespace pmacc


### PR DESCRIPTION
- [x]  #5492 needs to be merged before this.

Moves checkpointing simulation control in its own class
Checkpoint class now has a compile time toggle to disable checkpoint/restart functionality (fixes #5480)
Simplified restart state management and changed from using bools to an enum tracking state