### PR TITLE
Fix file output path for binningplugin  end of run dump

### DIFF
--- a/include/picongpu/plugins/binning/binners/Binner.hpp
+++ b/include/picongpu/plugins/binning/binners/Binner.hpp
@@ -250,7 +250,7 @@ namespace picongpu
                         histWriter(
                             unload_series,
                             OpenPMDWriteParams{
-                                std::string("/binningOpenPMD/"),
+                                std::string("binningOpenPMD/"),
                                 std::string("end_of_run_") + binningData.binnerOutputName,
                                 binningData.openPMDInfix,
                                 binningData.openPMDExtension,


### PR DESCRIPTION
This PR removes the leading `/` to now use the correct relative path instead of pointing to the root directory 

@BrianMarre faced this bug and encountered a file creation error
```
[0->0x2837c218] CREATE_FILE: end_of_run_atomicStateBinning_000000
[AbstractIOHandlerImpl] IO Task CREATE_FILE failed with exception. Clearing IO queue and passing on the exception.
full simulation time: 57sec 669msec = 57.669 sec
Unhandled exception of type 'St13runtime_error' with message '[HDF5] Internal error: Failed to create directories during HDF5 file creation', terminating
``` 
