### PR TITLE
 Tiny refactorings in header files #5491 

### DIFF
--- a/include/picongpu/plugins/output/images/param.hpp
+++ b/include/picongpu/plugins/output/images/param.hpp
@@ -20,9 +20,6 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
-
-
-#include "picongpu/param/pngColorScales.param"
 #include "picongpu/param/png.param"
-
+#include "picongpu/param/pngColorScales.param"
 #include "picongpu/unitless/png.unitless"

--- a/include/picongpu/plugins/output/images/param.hpp
+++ b/include/picongpu/plugins/output/images/param.hpp
@@ -21,10 +21,8 @@
 
 #include "picongpu/defines.hpp"
 
-// clang-format off
 
 #include "picongpu/param/pngColorScales.param"
 #include "picongpu/param/png.param"
 
 #include "picongpu/unitless/png.unitless"
-// clang-format on

--- a/include/picongpu/plugins/radiation/param.hpp
+++ b/include/picongpu/plugins/radiation/param.hpp
@@ -21,8 +21,6 @@
 
 #include "picongpu/defines.hpp"
 
-// clang-format off
 #include "picongpu/param/radiation.param"
 #include "picongpu/param/radiationObserver.param"
 #include "picongpu/unitless/radiation.unitless"
-// clang-format on

--- a/include/picongpu/plugins/radiation/param.hpp
+++ b/include/picongpu/plugins/radiation/param.hpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
-
 #include "picongpu/param/radiation.param"
 #include "picongpu/param/radiationObserver.param"
 #include "picongpu/unitless/radiation.unitless"

--- a/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
+++ b/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
@@ -21,11 +21,7 @@
 #include "picongpu/defines.hpp"
 
 #if (SIMDIM == DIM3 && PIC_ENABLE_FFTW3 == 1 && ENABLE_OPENPMD == 1)
-
-// clang-format of
 #    include "picongpu/param/shadowgraphy.param"
-// clang-format on
-
 #    include "picongpu/fields/FieldB.hpp"
 #    include "picongpu/fields/FieldE.hpp"
 #    include "picongpu/plugins/PluginRegistry.hpp"

--- a/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
+++ b/include/picongpu/plugins/shadowgraphy/Shadowgraphy.x.cpp
@@ -21,9 +21,9 @@
 #include "picongpu/defines.hpp"
 
 #if (SIMDIM == DIM3 && PIC_ENABLE_FFTW3 == 1 && ENABLE_OPENPMD == 1)
-#    include "picongpu/param/shadowgraphy.param"
 #    include "picongpu/fields/FieldB.hpp"
 #    include "picongpu/fields/FieldE.hpp"
+#    include "picongpu/param/shadowgraphy.param"
 #    include "picongpu/plugins/PluginRegistry.hpp"
 #    include "picongpu/plugins/common/openPMDAttributes.hpp"
 #    include "picongpu/plugins/common/openPMDDefaultExtension.hpp"


### PR DESCRIPTION
Removed redundant clang-format comments in header files as referenced in https://github.com/ComputationalRadiationPhysics/picongpu/issues/5169. 