### PR TITLE
[Transition PyPIConGPU to pydantic] Proof-of-concept I: Remove `_get_serialized`

### DIFF
--- a/lib/python/picongpu/picmi/copy_attributes.py
+++ b/lib/python/picongpu/picmi/copy_attributes.py
@@ -8,8 +8,13 @@ License: GPLv3+
 import inspect
 from typing import Callable
 
+from pydantic import BaseModel, ValidationError
+
 
 def has_attribute(instance, name):
+    if isinstance(instance, type) and issubclass(instance, BaseModel):
+        return name in instance.model_fields or name in map(lambda x: x.alias, instance.model_fields.values())
+
     # It should be this:
     #
     #     return hasattr(instance, name)
@@ -58,8 +63,8 @@ def copy_attributes(
     """
     Copy attributes from one object to another.
 
-    This function copies attributes from the `from_instance` to `to` if `to` is an class instance.
-    If `to` is a class, an instance will be created via `to()`, filled and returned.
+    This function copies attributes from the `from_instance` to `to` if `to` is a class instance.
+    If `to` is a class, it will try to construct and return an instance filled with values from `from_instance`.
 
     This function only copies attributes under the following circumstances:
         - The attribute exists in `to`.
@@ -73,26 +78,15 @@ def copy_attributes(
         - Otherwise, `value` must be a Callable that takes `from_instance` as first and only argument
           and returns the value that `key` is supposed to have in `to`, i.e.
           `to.key = value(from_instance)`.
-    """
-    if isinstance(to, type):
-        try:
-            to_instance = to()
-        except TypeError as e:
-            message = (
-                "Instantiation failed. The receiving class must be default constructible. "
-                f"You gave {to} which expects {len(inspect.signature(to.__init__).parameters) - 1} argument in its constructor. "
-                "You can work with an instance instead of a class in this case."
-            )
-            raise ValueError(message) from e
-        return copy_attributes(
-            from_instance,
-            to_instance,
-            conversions=conversions,
-            remove_prefix=remove_prefix,
-            ignore=ignore,
-            default_converter=default_converter,
-        )
 
+    Further useful features:
+        - `remove_prefix` allows to remove a prefix from `from_instance` member names
+          before looking them up and inserting them into `to`.
+        - `ignore` allows to ignore some attributes in `from_instance` and not copy them.
+          A custom conversion takes precedence and overrides this behaviour.
+        - `default_converter` is applied to all values retrieved from `from_instance`
+          before they are put into `to`.
+    """
     assignments = {
         to_name: _value_generator(from_name)
         for from_name, _ in inspect.getmembers(from_instance)
@@ -101,9 +95,41 @@ def copy_attributes(
         and has_attribute(to, to_name := from_name.removeprefix(remove_prefix))
     } | _sanitize_conversions(conversions, from_instance, to)
 
-    for key, value_generator in assignments.items():
-        setattr(to, key, default_converter(value_generator(from_instance)))
-    return to
+    # This is a two-pass process because after generating the defaults
+    # we had to apply the custom conversions on top.
+    assignments = {
+        key: default_converter(value_generator(from_instance)) for key, value_generator in assignments.items()
+    }
+
+    if isinstance(to, type):
+        try:
+            # First case: `to` is a class and can be constructed with a fully-qualified constructor call (pydantic.BaseModel).
+            return to(**assignments)
+        except Exception:
+            try:
+                # Second case: `to` is a default-constructible class to which we can copy attributes afterwards.
+                to_instance = to()
+            except (ValidationError, TypeError) as e:
+                message = (
+                    "Instantiation failed. The receiving class must be default constructible. "
+                    f"You gave {to} which expects {len(inspect.signature(to.__init__).parameters) - 1} argument in its constructor. "
+                    "You can work with an instance instead of a class in this case."
+                )
+                raise ValueError(message) from e
+            # We've got an instance now, proceed via the path for instances.
+            return copy_attributes(
+                from_instance,
+                to_instance,
+                conversions=conversions,
+                remove_prefix=remove_prefix,
+                ignore=ignore,
+                default_converter=default_converter,
+            )
+    else:
+        # Third case: We've been given an instance directly. Copy over attributes.
+        for key, value in assignments.items():
+            setattr(to, key, value)
+        return to
 
 
 def converts_to(

--- a/lib/python/picongpu/picmi/copy_attributes.py
+++ b/lib/python/picongpu/picmi/copy_attributes.py
@@ -105,7 +105,7 @@ def copy_attributes(
         try:
             # First case: `to` is a class and can be constructed with a fully-qualified constructor call (pydantic.BaseModel).
             return to(**assignments)
-        except Exception:
+        except TypeError:
             try:
                 # Second case: `to` is a default-constructible class to which we can copy attributes afterwards.
                 to_instance = to()

--- a/lib/python/picongpu/pypicongpu/grid.py
+++ b/lib/python/picongpu/pypicongpu/grid.py
@@ -71,7 +71,7 @@ class Grid3D(BaseModel, RenderedObject):
     cell_size: Vec3_float = Field(alias="cell_size_si")
     """Width of individual cell in each direction"""
 
-    cell_cnt: Vec3_float
+    cell_cnt: Vec3_int
     """total number of cells in each direction"""
 
     boundary_condition: Annotated[

--- a/lib/python/picongpu/pypicongpu/output/auto.py
+++ b/lib/python/picongpu/pypicongpu/output/auto.py
@@ -5,15 +5,12 @@ Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch, Julian Lenz
 License: GPLv3+
 """
 
+from pydantic import BaseModel, PrivateAttr, computed_field
 from .timestepspec import TimeStepSpec
-from .. import util
 from .plugin import Plugin
 
-import typeguard
 
-
-@typeguard.typechecked
-class Auto(Plugin):
+class Auto(Plugin, BaseModel):
     """
     Class to provide output **without further configuration**.
 
@@ -26,27 +23,13 @@ class Auto(Plugin):
     create a separate class.
     """
 
-    period = util.build_typesafe_property(TimeStepSpec)
+    period: TimeStepSpec
     """period to print data at"""
+    _name: str = PrivateAttr("auto")
 
-    _name = "auto"
-
-    def __init__(self):
-        pass
-
-    def check(self) -> None:
-        """
-        validate attributes
-        """
-        pass
-
-    def _get_serialized(self) -> dict:
-        self.check()
-        return {
-            "period": self.period.get_rendering_context(),
-            # helper to avoid repeating code
-            "png_axis": [
-                {"axis": "yx"},
-                {"axis": "yz"},
-            ],
-        }
+    @computed_field
+    def png_axis(self) -> list[dict[str, str]]:
+        return [
+            {"axis": "yx"},
+            {"axis": "yz"},
+        ]

--- a/lib/python/picongpu/pypicongpu/output/timestepspec.py
+++ b/lib/python/picongpu/pypicongpu/output/timestepspec.py
@@ -5,28 +5,33 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
+from typing import Annotated
+from pydantic import BaseModel, PlainSerializer, field_validator
 from ..rendering.renderedobject import RenderedObject
-from ..util import build_typesafe_property
 
 import typeguard
 
 
-def _serialize(spec):
-    if isinstance(spec, slice):
-        return {
-            "start": spec.start if spec.start is not None else 0,
-            "stop": spec.stop if spec.stop is not None else -1,
-            "step": spec.step if spec.step is not None else 1,
-        }
-    raise ValueError(f"Unknown serialization for {spec=} as a time step specifier (--period argument).")
+class Spec(BaseModel):
+    start: Annotated[int | None, PlainSerializer(lambda x: x or 0)]
+    stop: Annotated[int | None, PlainSerializer(lambda x: x or -1)]
+    step: Annotated[int | None, PlainSerializer(lambda x: x or 1)]
 
 
 @typeguard.typechecked
-class TimeStepSpec(RenderedObject):
-    specs = build_typesafe_property(list[slice])
+class TimeStepSpec(RenderedObject, BaseModel):
+    specs: list[Spec]
 
-    def __init__(self, specs: list[slice]):
-        self.specs = specs
+    def __init__(self, *args, **kwargs):
+        # allow to give specs as positional argument
+        if len(args) > 0 and "specs" not in kwargs:
+            kwargs |= {"specs": args[0]}
+        super(TimeStepSpec, self).__init__(*args[1:], **kwargs)
 
-    def _get_serialized(self):
-        return {"specs": list(map(_serialize, self.specs))}
+    @field_validator("specs", mode="before")
+    @classmethod
+    def validate_specs(cls, value) -> list[Spec]:
+        try:
+            return [Spec(start=s.start, stop=s.stop, step=s.step) for s in value]
+        except AttributeError:
+            return value

--- a/lib/python/picongpu/pypicongpu/output/timestepspec.py
+++ b/lib/python/picongpu/pypicongpu/output/timestepspec.py
@@ -13,9 +13,9 @@ import typeguard
 
 
 class Spec(BaseModel):
-    start: Annotated[int | None, PlainSerializer(lambda x: x or 0)]
-    stop: Annotated[int | None, PlainSerializer(lambda x: x or -1)]
-    step: Annotated[int | None, PlainSerializer(lambda x: x or 1)]
+    start: Annotated[int | None, PlainSerializer(lambda x: x if x is not None else 0)]
+    stop: Annotated[int | None, PlainSerializer(lambda x: x if x is not None else -1)]
+    step: Annotated[int | None, PlainSerializer(lambda x: x if x is not None else 1)]
 
 
 @typeguard.typechecked

--- a/lib/python/picongpu/pypicongpu/rendering/renderedobject.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderedobject.py
@@ -5,14 +5,15 @@ Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
-import typeguard
-import typing
-import jsonschema
-import referencing
+import json
 import logging
 import pathlib
 import re
-import json
+import typing
+
+import jsonschema
+import referencing
+import typeguard
 
 
 @typeguard.typechecked
@@ -199,9 +200,16 @@ class RenderedObject:
         :raise RuntimeError: on schema not found
         :return: self as rendering context
         """
-        # to be checked against schema
-        # note: load here, s.t. "not implemented error" is raised first
-        serialized = self._get_serialized()
+        # Temporary transitional refactoring:
+        # We plan to move to pydantic for serialisation
+        # but we don't quite have the infrastructure yet.
+        try:
+            serialized = self._get_serialized()
+        except (AttributeError, NotImplementedError) as first_error:
+            try:
+                serialized = self.model_dump(mode="json")
+            except Exception as second_error:
+                raise first_error from second_error
 
         RenderedObject.check_context_for_type(self.__class__, serialized)
         return serialized

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -87,8 +87,7 @@ class Simulation(RenderedObject):
         """retrieve all output objects"""
 
         if self.plugins == "auto":
-            auto = output.Auto()
-            auto.period = TimeStepSpec([slice(0, None, max(1, int(self.time_steps / 100)))])
+            auto = output.Auto(period=TimeStepSpec([slice(0, None, max(1, int(self.time_steps / 100)))]))
 
             return [auto.get_rendering_context()]
         else:

--- a/test/python/picongpu/compiling/simulation.py
+++ b/test/python/picongpu/compiling/simulation.py
@@ -45,17 +45,18 @@ class TestSimulation(unittest.TestCase):
         sim.delta_t_si = 1.39e-16
         sim.time_steps = steps
         sim.typical_ppc = 1
-        sim.grid = pypicongpu.grid.Grid3D()
-        sim.grid.cell_size_si = 1.776e-07, 4.43e-08, 1.776e-07
-        sim.grid.cell_cnt = (1, 1, 1)
-        sim.grid.n_gpus = (1, 1, 1)
-        sim.grid.boundary_condition = (
-            BoundaryCondition.PERIODIC,
-            BoundaryCondition.PERIODIC,
-            BoundaryCondition.PERIODIC,
+        sim.grid = pypicongpu.grid.Grid3D(
+            cell_size_si=(1.776e-07, 4.43e-08, 1.776e-07),
+            cell_cnt=(1, 1, 1),
+            n_gpus=(1, 1, 1),
+            boundary_condition=(
+                BoundaryCondition.PERIODIC,
+                BoundaryCondition.PERIODIC,
+                BoundaryCondition.PERIODIC,
+            ),
+            super_cell_size=(8, 8, 4),
+            grid_dist=None,
         )
-        sim.grid.super_cell_size = (8, 8, 4)
-        sim.grid.grid_dist = None
         sim.laser = None
         sim.custom_user_input = None
         sim.moving_window = None

--- a/test/python/picongpu/quick/pypicongpu/grid.py
+++ b/test/python/picongpu/quick/pypicongpu/grid.py
@@ -49,6 +49,12 @@ class TestGrid3D(unittest.TestCase):
             Grid3D(
                 **self.kwargs | dict(boundary_condition=(BoundaryCondition.PERIODIC, BoundaryCondition.ABSORBING, {}))
             )
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(cell_cnt=(11.1, 7, 8)))
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(cell_cnt=(6, 11.412, 8)))
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(cell_cnt=(6, 7, 16781123173.12637183)))
 
     def test_gpu_and_cell_cnt_positive(self):
         """test if n_gpus and cell number s are >0"""

--- a/test/python/picongpu/quick/pypicongpu/grid.py
+++ b/test/python/picongpu/quick/pypicongpu/grid.py
@@ -8,28 +8,31 @@ License: GPLv3+
 from picongpu.pypicongpu.grid import Grid3D, BoundaryCondition
 
 import unittest
-import typeguard
+
+from pydantic import ValidationError
 
 
 class TestGrid3D(unittest.TestCase):
     def setUp(self):
         """setup default grid"""
-        self.g = Grid3D()
-        self.g.cell_size_si = (1.2, 2.3, 4.5)
-        self.g.cell_cnt = (6, 7, 8)
-        self.g.boundary_condition = (
-            BoundaryCondition.PERIODIC,
-            BoundaryCondition.ABSORBING,
-            BoundaryCondition.PERIODIC,
+        self.kwargs = dict(
+            cell_size_si=(1.2, 2.3, 4.5),
+            cell_cnt=(6, 7, 8),
+            boundary_condition=(
+                BoundaryCondition.PERIODIC,
+                BoundaryCondition.ABSORBING,
+                BoundaryCondition.PERIODIC,
+            ),
+            n_gpus=(2, 4, 1),
+            super_cell_size=(8, 8, 4),
+            grid_dist=None,
         )
-        self.g.n_gpus = (2, 4, 1)
-        self.g.super_cell_size = (8, 8, 4)
-        self.g.grid_dist = None
+        self.g = Grid3D(**self.kwargs)
 
     def test_basic(self):
         """test default setup"""
         g = self.g
-        self.assertSequenceEqual((1.2, 2.3, 4.5), g.cell_size_si)
+        self.assertSequenceEqual((1.2, 2.3, 4.5), g.cell_size)
         self.assertSequenceEqual((6, 7, 8), g.cell_cnt)
         self.assertSequenceEqual(
             (BoundaryCondition.PERIODIC, BoundaryCondition.ABSORBING, BoundaryCondition.PERIODIC), g.boundary_condition
@@ -37,67 +40,42 @@ class TestGrid3D(unittest.TestCase):
 
     def test_types(self):
         """test raising errors if types are wrong"""
-        g = self.g
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_si = ("54.3", 2.3, 4.5)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_si = (1.2, "2", 4.5)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_si = (1.2, 2.3, "126")
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt = (11.1, 7, 8)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt = (6, 11.412, 8)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt = (6, 7, 16781123173.12637183)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition = ("open", BoundaryCondition.ABSORBING, BoundaryCondition.PERIODIC)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition = (BoundaryCondition.PERIODIC, 1, BoundaryCondition.PERIODIC)
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition = (BoundaryCondition.PERIODIC, BoundaryCondition.ABSORBING, {})
-        with self.assertRaises(typeguard.TypeCheckError):
-            # list not accepted - tuple needed
-            g.n_gpus = [1, 1, 1]
+        with self.assertRaises(ValidationError):
+            Grid3D(
+                **self.kwargs
+                | dict(boundary_condition=("open", BoundaryCondition.ABSORBING, BoundaryCondition.PERIODIC))
+            )
+        with self.assertRaises(ValidationError):
+            Grid3D(
+                **self.kwargs | dict(boundary_condition=(BoundaryCondition.PERIODIC, BoundaryCondition.ABSORBING, {}))
+            )
 
     def test_gpu_and_cell_cnt_positive(self):
         """test if n_gpus and cell number s are >0"""
-        g = self.g
-        with self.assertRaisesRegex(Exception, ".*cell_cnt.*greater than 0.*"):
-            g.cell_cnt = (-1, 7, 8)
-            g.get_rendering_context()
-        # revert changes
-        g.cell_cnt = (6, 7, 8)
+        with self.assertRaisesRegex(ValidationError, ".*cell_cnt.*greater than 0.*"):
+            Grid3D(**self.kwargs | dict(cell_cnt=(-1, 7, 8)))
 
-        with self.assertRaisesRegex(Exception, ".*cell_cnt.*greater than 0.*"):
-            g.cell_cnt = (6, -2, 8)
-            g.get_rendering_context()
-        # revert changes
-        g.cell_cnt = (6, 7, 8)
+        with self.assertRaisesRegex(ValidationError, ".*cell_cnt.*greater than 0.*"):
+            Grid3D(**self.kwargs | dict(cell_cnt=(6, -2, 8)))
 
-        with self.assertRaisesRegex(Exception, ".*cell_cnt.*greater than 0.*"):
-            g.cell_cnt = (6, 7, 0)
-            g.get_rendering_context()
-        # revert changes
-        g.cell_cnt = (6, 7, 8)
+        with self.assertRaisesRegex(ValidationError, ".*cell_cnt.*greater than 0.*"):
+            Grid3D(**self.kwargs | dict(cell_cnt=(6, 7, 0)))
 
         for wrong_n_gpus in [tuple([-1, 1, 1]), tuple([1, 1, 0])]:
-            with self.assertRaisesRegex(Exception, ".*greater than 0.*"):
-                g.n_gpus = wrong_n_gpus
-                g.get_rendering_context()
+            with self.assertRaisesRegex(ValidationError, ".*greater than 0.*"):
+                Grid3D(**self.kwargs | dict(n_gpus=wrong_n_gpus))
 
     def test_mandatory(self):
         """test if None as content fails"""
         # check that mandatory arguments can't be none
-        g = self.g
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_size_si = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.cell_cnt = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.boundary_condition = None
-        with self.assertRaises(typeguard.TypeCheckError):
-            g.n_gpus = None
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(cell_size_si=None))
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(cell_cnt=None))
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(boundary_condition=None))
+        with self.assertRaises(ValidationError):
+            Grid3D(**self.kwargs | dict(n_gpus=None))
 
     def test_get_rendering_context(self):
         """object is correctly serialized"""

--- a/test/python/picongpu/quick/pypicongpu/output/auto.py
+++ b/test/python/picongpu/quick/pypicongpu/output/auto.py
@@ -9,25 +9,21 @@ from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
 from picongpu.pypicongpu.output import Auto
 
 import unittest
-import typeguard
+from pydantic import ValidationError
 
 
 class TestAuto(unittest.TestCase):
     def test_types(self):
         """type safety is ensured"""
-        a = Auto()
 
         invalid_periods = [13.2, [], "2", None, {}, (1)]
         for invalid_period in invalid_periods:
-            with self.assertRaises(typeguard.TypeCheckError):
-                a.period = invalid_periods
-        # ok
-        a.period = TimeStepSpec([slice(0, None, 17)])
+            with self.assertRaises(ValidationError):
+                Auto(period=invalid_period)
 
     def test_rendering(self):
         """data transformed to template-consumable version"""
-        a = Auto()
-        a.period = TimeStepSpec([slice(0, None, 17)])
+        a = Auto(period=TimeStepSpec([slice(0, None, 17)]))
 
         # normal rendering
         context = a.get_rendering_context()

--- a/test/python/picongpu/quick/pypicongpu/output/timestepspec.py
+++ b/test/python/picongpu/quick/pypicongpu/output/timestepspec.py
@@ -6,23 +6,25 @@ License: GPLv3+
 """
 
 from picongpu.pypicongpu.output import TimeStepSpec
+from picongpu.pypicongpu.output.timestepspec import Spec
 import unittest
+
+from pydantic import ValidationError
 
 
 class TestTimeStepSpec(unittest.TestCase):
     def test_init_with_valid_slices(self):
         specs = [slice(0, 10, 1), slice(10, 20, 2)]
-        time_step_spec = TimeStepSpec(specs)
-        self.assertEqual(time_step_spec.specs, specs)
+        time_step_spec = TimeStepSpec(specs=specs)
+        self.assertEqual(time_step_spec.specs, [Spec(start=s.start, stop=s.stop, step=s.step) for s in specs])
 
     def test_init_with_invalid_slices(self):
-        time_step_spec = TimeStepSpec([slice(0, 10, 1), "invalid"])
-        with self.assertRaises(ValueError):
-            time_step_spec.get_rendering_context()
+        with self.assertRaises(ValidationError):
+            TimeStepSpec(specs=[slice(0, 10, 1), "invalid"])
 
     def test_serialize_with_valid_slices(self):
         specs = [slice(0, 10, 1), slice(10, 20, 2)]
-        time_step_spec = TimeStepSpec(specs)
+        time_step_spec = TimeStepSpec(specs=specs)
         serialized = time_step_spec.get_rendering_context()
         expected = {
             "specs": [
@@ -34,7 +36,7 @@ class TestTimeStepSpec(unittest.TestCase):
 
     def test_serialize_with_none_values(self):
         specs = [slice(None, 10, 1), slice(10, None, 2), slice(10, 20, None)]
-        time_step_spec = TimeStepSpec(specs)
+        time_step_spec = TimeStepSpec(specs=specs)
         serialized = time_step_spec.get_rendering_context()
         expected = {
             "specs": [

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -32,17 +32,18 @@ class TestSimulation(unittest.TestCase):
         self.s.delta_t_si = 13.37
         self.s.time_steps = 42
         self.s.typical_ppc = 1
-        self.s.grid = grid.Grid3D()
-        self.s.grid.cell_size_si = (1, 2, 3)
-        self.s.grid.cell_cnt = (4, 5, 6)
-        self.s.grid.n_gpus = (1, 1, 1)
-        self.s.grid.boundary_condition = (
-            grid.BoundaryCondition.PERIODIC,
-            grid.BoundaryCondition.PERIODIC,
-            grid.BoundaryCondition.PERIODIC,
+        self.s.grid = grid.Grid3D(
+            cell_size_si=(1, 2, 3),
+            cell_cnt=(4, 5, 6),
+            n_gpus=(1, 1, 1),
+            boundary_condition=(
+                grid.BoundaryCondition.PERIODIC,
+                grid.BoundaryCondition.PERIODIC,
+                grid.BoundaryCondition.PERIODIC,
+            ),
+            super_cell_size=(8, 8, 4),
+            grid_dist=None,
         )
-        self.s.grid.super_cell_size = (8, 8, 4)
-        self.s.grid.grid_dist = None
         self.s.solver = YeeSolver()
         self.s.laser = None
         self.s.custom_user_input = None


### PR DESCRIPTION
This is the first of a series of PRs relating to #5500.

This introduces 3 new functionalities:
- `copy_attributes` will first attempt to use a constructor to instantiate a class with all the necessary information. This is necessary because `pydantic.BaseModel`s want to be fully and validly instantiated.
- `get_rendering_context` will fall back to `model_dump` if it doesn't find `_get_serialized`.
- A workaround for `SelfRegistering` to work with `pydantic.BaseModel`s. They sure love dark Python voodoo as much as we do. -.-

Afterwards it includes two examples:
- `Grid3D`: Straightforward class but includes some custom transformations and renamings. Medium-term strategy might involve adjusting (names in) the templates to reduce the necessity for such conversion logic but with the laid-out constraints in #5500 this workaround is the best we can get.
- `Auto` plugin: This one was a little trickier. It includes a non-trivially typed member (`TimeStepSpec`) which had to be converted to Pydantic as well and also relies on the self-registering feature.

Some tests were adjusted to reflect the new interface and more forgiving interface.

Each commit consists of one of the mentioned above and you might want to review each commit individually.