### PR TITLE
update frontier libaries and add fftw

### DIFF
--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -30,8 +30,8 @@ export PIC_NODE_OVERSUBSCRIPTION_PT=2
 # The following modules just add to these.
 
 module load PrgEnv-cray/8.6.0 # Compiling with cray compiler wrapper CC
-module load craype-accel-amd-gfx90a
-module load rocm/6.4.1
+module load craype-accel-amd-gfx940
+module load rocm/6.4.2
 
 export MPICH_GPU_SUPPORT_ENABLED=1
 module load cray-mpich/8.1.31
@@ -40,6 +40,11 @@ module load boost/1.86.0
 module load zlib/1.3.1
 module load cmake/3.30.5
 module load git
+module load adios2/2.10.2-mpi
+# Please use a self compiled openpmd-api with adios2 if you need blosc2 support
+module load openpmd-api/0.16.0
+module load cray-fftw
+module load libpng/1.6.39
 
 ## set environment variables required for compiling and linking
 ##   see (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#compiling-with-hipcc)
@@ -57,12 +62,6 @@ export LDFLAGS="$LDFLAGS -L${MPICH_DIR}/lib -lmpi ${PE_MPICH_GTL_DIR_amd_gfx90a}
 
 # Other Software ##############################################################
 #
-module load libpng/1.6.39
-
-# Please use your self compiled openpmd-api with adios2 and blosc2 support.
-# ORNL is providing spack generated modules without blosc2 support.
-#
-# module load openpmd-api/0.16.X
 
 # Self-Build Software #########################################################
 # Optional, not required.


### PR DESCRIPTION
Thanks to @anagainaru for testing PIConGPU on frontier. She found out that we run into issues with our self build fftw and could instead use the provide module. And thanks @AnonNick for testing it right away. 

This PR 
 - updates a few module library versions and
 - adds fftw via the module system
 - add openPMD-api with a warning that for blosc you need to build it yourself. 
 
 