### PR TITLE
Add ParticleDump and FieldDump (openPMD plugin) to PICMI

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -13,13 +13,20 @@ from .macro_particle_count import MacroParticleCount
 from .png import Png
 from .timestepspec import TimeStepSpec
 from .checkpoint import Checkpoint
+from .particle_dump import ParticleDump
+from .field_dump import FieldDump
+from .backend_config import BackendConfig, OpenPMDConfig
 
 __all__ = [
     "Auto",
+    "BackendConfig",
+    "OpenPMDConfig",
     "Binning",
     "PhaseSpace",
     "EnergyHistogram",
     "MacroParticleCount",
+    "ParticleDump",
+    "FieldDump",
     "Png",
     "TimeStepSpec",
     "Checkpoint",

--- a/lib/python/picongpu/picmi/diagnostics/backend_config.py
+++ b/lib/python/picongpu/picmi/diagnostics/backend_config.py
@@ -1,0 +1,18 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from picongpu.pypicongpu.output.openpmd_plugin import OpenPMDConfig as PyPIConGPUOpenPMDConfig
+
+
+class BackendConfig:
+    def result_path(self, prefix_path):
+        raise NotImplementedError()
+
+
+class OpenPMDConfig(PyPIConGPUOpenPMDConfig, BackendConfig):
+    def __init__(self, *args, **kwargs):
+        super(PyPIConGPUOpenPMDConfig, self).__init__(*args, **kwargs)

--- a/lib/python/picongpu/picmi/diagnostics/field_dump.py
+++ b/lib/python/picongpu/picmi/diagnostics/field_dump.py
@@ -1,0 +1,27 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from os import PathLike
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .backend_config import BackendConfig, OpenPMDConfig
+from .timestepspec import TimeStepSpec
+
+
+class FieldDump(BaseModel):
+    fieldname: Literal["E", "B", "J"]
+    period: TimeStepSpec = TimeStepSpec[:]("steps")
+    options: BackendConfig = OpenPMDConfig(file="simData")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def result_path(self, prefix_path: PathLike):
+        return self.options.result_path(prefix_path=Path(prefix_path) / "simOutput" / "openPMD")

--- a/lib/python/picongpu/picmi/diagnostics/particle_dump.py
+++ b/lib/python/picongpu/picmi/diagnostics/particle_dump.py
@@ -1,0 +1,28 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from os import PathLike
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from picongpu.picmi.species import Species
+
+from .backend_config import BackendConfig, OpenPMDConfig
+from .timestepspec import TimeStepSpec
+
+
+class ParticleDump(BaseModel):
+    species: Species
+    period: TimeStepSpec = TimeStepSpec[:]("steps")
+    options: BackendConfig = OpenPMDConfig(file="simData")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def result_path(self, prefix_path: PathLike):
+        return self.options.result_path(prefix_path=Path(prefix_path) / "simOutput" / "openPMD")

--- a/lib/python/picongpu/pypicongpu/output/__init__.py
+++ b/lib/python/picongpu/pypicongpu/output/__init__.py
@@ -5,9 +5,13 @@ from .macro_particle_count import MacroParticleCount
 from .png import Png
 from .timestepspec import TimeStepSpec
 from .checkpoint import Checkpoint
+from .openpmd_plugin import OpenPMDPlugin
+from .plugin import Plugin
 
 __all__ = [
     "Auto",
+    "OpenPMDPlugin",
+    "Plugin",
     "PhaseSpace",
     "EnergyHistogram",
     "MacroParticleCount",

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -1,0 +1,119 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from functools import reduce
+from os import PathLike
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Annotated, Iterable, Literal
+from hashlib import sha256
+
+import tomli_w
+from pydantic import AfterValidator, BaseModel
+
+from picongpu.pypicongpu.output.plugin import Plugin
+from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
+from picongpu.pypicongpu.species.species import Species
+
+
+class OpenPMDConfig(BaseModel):
+    file: PathLike | str
+    infix: str = "_%06T"
+    ext: Annotated[str, AfterValidator(lambda s: s.strip("."))] = "h5"
+    backend_config: PathLike | None = None
+    data_preparation_strategy: Literal["mappedMemory", "doubleBuffer"] = "mappedMemory"
+    range: None = None
+
+    def full_filename(self):
+        return f"{self.file}{self.infix}.{self.ext}"
+
+    def result_path(self, prefix_path: PathLike = Path()):
+        filename = self.full_filename()
+        if Path(filename).is_absolute():
+            return filename
+        return (Path(prefix_path) / filename).absolute()
+
+
+def to_string(timestepspec: TimeStepSpec):
+    return ",".join(
+        map(
+            lambda x: "{start}:{stop}:{step}".format(**x),
+            timestepspec.get_rendering_context()["specs"],
+        )
+    )
+
+
+class FieldDump(BaseModel):
+    name: str
+
+    def get_rendering_context(self) -> dict:
+        return self.model_dump(mode="json")
+
+
+class OpenPMDPlugin(Plugin):
+    _name = "openPMD"
+
+    sources: list[tuple[TimeStepSpec, Iterable[Species]]]
+    config: OpenPMDConfig = OpenPMDConfig(file="simData")
+    _setup_dir: Path | None = None
+    # We're using a negation here because now `False` and `None` (evaluating to `False`)
+    # both mean that we can't rely on `setup_dir` being anything permanent:
+    _setup_dir_is_not_temporary: bool | None = None
+
+    def config_filename(self, content, context: Literal["runtime", "setup"]):
+        filename = f"openPMD_config_{sha256(tomli_w.dumps(content).encode()).hexdigest()}.toml"
+        if not self._setup_dir_is_not_temporary or context == "setup":
+            return self.setup_dir / "etc" / filename
+        if context == "runtime":
+            return Path("..") / "input" / "etc" / filename
+        raise ValueError(f"Unknown {context=} upon requesting the openPMD config filename.")
+
+    @property
+    def setup_dir(self):
+        if self._setup_dir_is_not_temporary is None:
+            self._setup_dir_is_not_temporary = self._setup_dir is not None
+
+        if self._setup_dir is None:
+            self._setup_dir = Path(TemporaryDirectory(delete=False).name).absolute()
+
+        return self._setup_dir
+
+    @setup_dir.setter
+    def setup_dir(self, other):
+        self._setup_dir = Path(other)
+
+    def __init__(self, sources, config):
+        self.sources = sources
+        self.config = config
+
+    def _generate_config_file(self):
+        # There's some strange interaction with the custom hashing of TimeStepSpec
+        # that's implemented on RenderedObject
+        # hindering the storage of this data structure.
+        # As a workaround, we're computing this on the fly.
+        # Shouldn't be performance critical but it would be more elegant to normalise early on.
+        sources = reduce(
+            lambda dictionary, key_val: dictionary.setdefault(to_string(key_val[0]), []).append(
+                key_val[1].get_rendering_context()["name"]
+            )
+            or dictionary,
+            self.sources,
+            {},
+        )
+        content = self.config.model_dump(mode="json", exclude_none=True) | {
+            "sink": {"dummy_application_name": {"period": sources}}
+        }
+        with self.config_filename(content, context="setup").open("wb") as file:
+            tomli_w.dump(content, file)
+        return content
+
+    def _get_serialized(self) -> dict | None:
+        content = self._generate_config_file()
+        return {"config_filename": str(self.config_filename(content, context="runtime"))}
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -5,22 +5,22 @@ Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch
 License: GPLv3+
 """
 
-from .simulation import Simulation
-from . import util
-from .rendering import Renderer
-
-from os import path, environ, chdir
+import datetime
+import json
+import logging
+import pathlib
+import re
+import subprocess
+import tempfile
+import typing
+from os import chdir, environ, path
 from pathlib import Path
 
 import typeguard
-import tempfile
-import subprocess
-import logging
-import typing
-import re
-import datetime
-import pathlib
-import json
+
+from . import util
+from .rendering import Renderer
+from .simulation import Simulation
 
 DEFAULT_TEMPLATE_DIRECTORY = (Path(__file__).parents[4] / "share" / "picongpu" / "pypicongpu" / "template").absolute()
 
@@ -289,6 +289,8 @@ class Runner:
         Delegates work to Renderer(), see there for details.
         """
         logging.info("rendering templates...")
+        # This is kind of a dirty hack:
+        self.sim.spread_directory_information(self.setup_dir)
         # check 1 (implicit): according to schema?
         context = self.sim.get_rendering_context()
         # check 2: structure suitable for renderer?

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -5,23 +5,28 @@ Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
-from .grid import Grid3D
-from .laser import DispersivePulseLaser, FromOpenPMDPulseLaser, GaussianLaser, PlaneWaveLaser
-from .movingwindow import MovingWindow
-from .field_solver.DefaultSolver import Solver
-from . import species
-from . import util
-from . import output
-from .rendering import RenderedObject
-from .customuserinput import InterfaceCustomUserInput
-from .output.plugin import Plugin
-from .output.timestepspec import TimeStepSpec
-from .walltime import Walltime
-
-import typing
-import typeguard
-import logging
 import datetime
+import logging
+import typing
+from pathlib import Path
+
+import typeguard
+
+from . import output, species, util
+from .customuserinput import InterfaceCustomUserInput
+from .field_solver.DefaultSolver import Solver
+from .grid import Grid3D
+from .laser import (
+    DispersivePulseLaser,
+    FromOpenPMDPulseLaser,
+    GaussianLaser,
+    PlaneWaveLaser,
+)
+from .movingwindow import MovingWindow
+from .output import Plugin, OpenPMDPlugin
+from .output.timestepspec import TimeStepSpec
+from .rendering import RenderedObject
+from .walltime import Walltime
 
 
 @typeguard.typechecked
@@ -120,6 +125,11 @@ class Simulation(RenderedObject):
             + "\t WARNING: custom input is not checked, it is the user's responsibility to check inputs and generated input.\n"
             + "\t WARNING: custom templates are required if using custom user input.\n"
         )
+
+    def spread_directory_information(self, setup_dir):
+        for plugin in self.plugins:
+            if isinstance(plugin, OpenPMDPlugin):
+                plugin.setup_dir = Path(setup_dir)
 
     def _get_serialized(self) -> dict:
         serialized = {

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
   # Included from: picongpu/extra/utils/FLYonPICRateCalculationReference/requirements.txt
   "scipy>=1.12",
   "sympy>=1.14",
+  "tomli-w>=1.2",
   "typeguard>=4.2.1",
 ]
 

--- a/share/picongpu/pypicongpu/schema/output/openpmd_plugin.OpenPMDPlugin.json
+++ b/share/picongpu/pypicongpu/schema/output/openpmd_plugin.OpenPMDPlugin.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.openpmd_plugin.OpenPMDPlugin",
+  "type": "object",
+  "description": "OpenPMD plugin",
+  "unevaluatedProperties": false,
+  "required": [
+    "config_filename"
+  ],
+  "properties": {
+    "config_filename": {
+      "type": "string"
+    }
+  }
+}

--- a/share/picongpu/pypicongpu/schema/output/plugin.Plugin.json
+++ b/share/picongpu/pypicongpu/schema/output/plugin.Plugin.json
@@ -18,6 +18,7 @@
         "macroparticlecount",
         "png",
         "binning",
+        "openPMD",
         "checkpoint"
       ],
       "unevaluatedProperties": false,
@@ -38,6 +39,9 @@
           "type": "boolean"
         },
         "binning": {
+          "type": "boolean"
+        },
+        "openPMD": {
           "type": "boolean"
         },
         "checkpoint": {
@@ -65,6 +69,9 @@
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.Binning"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.openpmd_plugin.OpenPMDPlugin"
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.checkpoint.Checkpoint"

--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -201,6 +201,9 @@ pypicongpu_output_with_newlines="
 {{/openPMD}}
 {{/typeID.checkpoint}}
 
+{{#typeID.openPMD}}
+--openPMD.toml {{{config_filename}}}
+{{/typeID.openPMD}}
 
     {{/data}}
   {{/output}}

--- a/test/python/picongpu/end-to-end/__init__.py
+++ b/test/python/picongpu/end-to-end/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 from .free_formula_density import *  # pyflakes.ignore
 from .compare_particles import *  # pyflakes.ignore
+from .diagnostics import *  # pyflakes.ignore

--- a/test/python/picongpu/end-to-end/diagnostics.py
+++ b/test/python/picongpu/end-to-end/diagnostics.py
@@ -1,0 +1,133 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import logging
+from pathlib import Path
+from unittest import TestCase, main
+
+import numpy as np
+from .arbitrary_parameters import (
+    NUMBER_OF_CELLS,
+    UPPER_BOUNDARY,
+)
+from .compare_particles import load_diagnostic_result, read_particles, sort_particles, read_fields
+from .distributions import Gaussian, SphereFlanks
+from picongpu.picmi import (
+    Cartesian3DGrid,
+    ElectromagneticSolver,
+    GriddedLayout,
+    Simulation,
+    Species,
+)
+from picongpu.picmi.diagnostics import (
+    Checkpoint,
+    FieldDump,
+    OpenPMDConfig,
+    ParticleDump,
+    TimeStepSpec,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+LAYOUT = GriddedLayout(n_macroparticles_per_cell=2)
+SPECIES = [
+    Species(
+        name="Gaussian_predefined",
+        particle_type="electron",
+        initial_distribution=Gaussian().distributions["predefined"],
+    ),
+    Species(
+        name="SphereFlanks_free_form",
+        particle_type="electron",
+        initial_distribution=SphereFlanks().distributions["free_form"],
+    ),
+]
+
+
+def basic_simulation():
+    return Simulation(
+        max_steps=0,
+        solver=ElectromagneticSolver(
+            method="Yee",
+            cfl=1.0,
+            grid=Cartesian3DGrid(
+                number_of_cells=NUMBER_OF_CELLS,
+                lower_bound=[0, 0, 0],
+                # cell size is slightly different from 1
+                upper_bound=UPPER_BOUNDARY,
+                lower_boundary_conditions=["open", "open", "open"],
+                upper_boundary_conditions=["open", "open", "open"],
+            ),
+        ),
+    )
+
+
+def generate_diagnostics(species):
+    options = OpenPMDConfig(file="other_name", ext=".h5", infix="", data_preparation_strategy="doubleBuffer")
+    particles = [ParticleDump(species=s) for s in species] + [
+        ParticleDump(species=species[0], options=options),
+    ]
+    native_fields = [FieldDump(fieldname=fieldname) for fieldname in ["E", "B"]]
+    derived_fields = []
+    return particles + native_fields + derived_fields
+
+
+RUN_DIR = ""
+
+
+def setup_sim():
+    sim = basic_simulation()
+    for species in SPECIES:
+        sim.add_species(species, LAYOUT)
+    sim.diagnostics = [Checkpoint(TimeStepSpec[:])] + generate_diagnostics(SPECIES)
+    if RUN_DIR:
+        sim.picongpu_get_runner().run_dir = RUN_DIR
+    else:
+        sim.step(0)
+    return sim
+
+
+SIM = None
+
+
+class TestDiagnostics(TestCase):
+    _result_path = None
+
+    def setUp(self):
+        global SIM
+        if SIM is None:
+            SIM = setup_sim()
+        self.sim = SIM
+
+    @property
+    def result_path(self):
+        if self._result_path is None:
+            self._result_path = Path(self.sim.picongpu_get_runner().run_dir)
+        return self._result_path
+
+    def test_particle_dump(self):
+        for diag in self.sim.diagnostics:
+            if isinstance(diag, ParticleDump):
+                from_checkpoint = sort_particles(
+                    read_particles(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")
+                ).loc(axis=0)[*diag.species.name.split("_", maxsplit=1)]
+                from_diagnostics = sort_particles(load_diagnostic_result(diag, self.result_path))
+                np.testing.assert_allclose(from_checkpoint, from_diagnostics)
+
+    def test_field_dump(self):
+        for diag in self.sim.diagnostics:
+            if isinstance(diag, FieldDump):
+                np.testing.assert_allclose(
+                    load_diagnostic_result(diag, self.result_path),
+                    read_fields(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")[
+                        diag.fieldname
+                    ],
+                )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds rudimentary support for output via the openPMD plugin.

Available capabilities:
- `ParticleDump(species)` with native species
- `FieldDump(fieldname)` with native fields
- `OpenPMDConfig` except for `range` (and `backend_config` untested)

Missing capabilities:
- `DerivedFieldDump` from particles
- `RangeSpec` for modelling ranges
- `Filter`
- Potentially convenience interfaces like `species_all`, `fields_all`.
- Due to an oversight the current field `J` cannot yet be dumped. This will be added in a future PR.

Some explanations:
- In discussion with @franzpoeschel we decided that the best implementation is to generate a `.toml` file for each instance of the openPMD plugin that PIConGPU is supposed to use. This is straightforward to achieve but is not quite aligned with the pypicongpu approach to rendering:
    - In pypicongpu, the runner is responsible for handling the creation of a hardcoded (!) set of files in a specific location. The individual components are only supposed to provide some content to fill in.
    - With the current implementation, the individual component is allowed to create an arbitrary set of files. I have hacked in a way to spread the information about the location where to put them. It's not particularly nice but the alternative ain't pretty either. Open for discussions here.
- In above approach, most information circumvents the `pypicongpu.json` by being directly located inside of the `.toml` files. This means a two-step approach would be necessary to get the full information from the `pypicongpu.json`: 1. Parse `pypicongpu.json` and 2. extract the corresponding `.toml` file's name and parse that as well. If parsing `pypicongpu.json` is relevant to your workflow, there are two options:
    - My current sketches for database integration, etc., have a reporting capability built-in at a later stage in which the plugins explicitly report which output is to be expected where. As I provide tooling to easily extract that information, no parsing is necessary at all and we are free to adjust the internal structure.
    - We could add redundant information to the `pypicongpu.json` file that's not necessary for rendering the templates but just meant to inform the user after the fact. I typically don't fancy this kind of solution. 
- The user interface in PIConGPU and PICMI differs: PIConGPU has a technical perspective in which the user explicitly instantiates plugins inside of PIConGPU while PICMI has a more semantic perspective in which the user describes what physical output they want to see. Translation from one to the other is done by `picmi/simulation.py` which gathers all diagnostics getting dumped into the same file(s) into one instance of the openPMD plugin.
- I have written another end-to-end test for testing this feature. As they are not yet run in CI, please be so kind to run them upon review. I'll eventually take the time to figure out how to fix running them in CI, I promise!

CAUTION: The handling of `range`s is still inconsistent (because it's not yet implemented). Should you manage to somehow pass a `range` through the different layers (not sure if anything's hindering you), an `OpenPMDConfig` instance that's identical up to `range` would be treated as different. This implies that there would be two `OpenPMDWriter` instances in PIConGPU writing to the same file. I'll take care of this once `range` is properly fleshed out.