### PR TITLE
openPMD plugin: Restart from checkpoint with non-matching domain decomposition

### DIFF
--- a/include/picongpu/plugins/openPMD/NDScalars.hpp
+++ b/include/picongpu/plugins/openPMD/NDScalars.hpp
@@ -174,11 +174,17 @@ namespace picongpu
                 DataSpace<simDim> gridPos = Environment<simDim>::get().GridController().getPosition();
                 ::openPMD::Offset start;
                 ::openPMD::Extent count;
+                ::openPMD::Extent extent = mrc.getExtent();
                 start.reserve(ndim);
                 count.reserve(ndim);
                 for(int d = 0; d < ndim; ++d)
                 {
-                    start.push_back(gridPos.revert()[d]);
+                    /*
+                     * When restarting with more parallel processes than the checkpoint had originally been written
+                     * with, we must take care not to index past the dataset boundaries. Just loop around to the start
+                     * in that case. Not the finest way, but it does the job for now..
+                     */
+                    start.push_back(gridPos.revert()[d] % extent[d]);
                     count.push_back(1);
                 }
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1024,6 +1024,12 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 {
                     loadRngStatesImpl(&mThreadParams, restartStep);
                 }
+                catch(std::exception const& e)
+                {
+                    log<picLog::INPUT_OUTPUT>("openPMD: loading RNG states failed, they will be re-initialized "
+                                              "instead. Original error:\n\t%1%")
+                        % e.what();
+                }
                 catch(...)
                 {
                     log<picLog::INPUT_OUTPUT>(

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -96,7 +96,8 @@ namespace picongpu
                 auto positionOffset = loadedData.getIdentifier(totalCellIdx()).getPointer();
 
                 // grid-strided loop over the chunked data
-                for(int dataBlock = worker.blockDomIdx(); dataBlock < numDataBlocks; dataBlock += worker.gridDomSize())
+                for(uint32_t dataBlock = worker.blockDomIdx(); dataBlock < numDataBlocks;
+                    dataBlock += worker.gridDomSize())
                 {
                     auto dataBlockOffset = dataBlock * blockDomSize;
                     auto forEach = pmacc::lockstep::makeForEach(worker);

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -355,8 +355,9 @@ namespace picongpu
                                 numParticlesCurrentBatch,
                                 filterRemove);
 
-                            std::cout << "Filtered " << remapCurrent << " out of " << numParticlesCurrentBatch
-                                      << " particles" << std::endl;
+                            log<picLog::INPUT_OUTPUT>(
+                                "openPMD: Keeping %1% of the current batch's %2% particles after filtering.")
+                                % remapCurrent % numParticlesCurrentBatch;
 
                             pmacc::particles::operations::splitIntoListOfFrames(
                                 *speciesTmp,
@@ -531,11 +532,10 @@ namespace picongpu
                     }
                 }
 
-                // std::cout << "\n\n"
-                //           << fullMatches.size() << " full matches, " << partialMatches.size() << " partial
-                //           matches,
-                //           "
-                //           << noMatches << " unmatched." << std ::endl;
+                log<picLog::INPUT_OUTPUT>(
+                    "openPMD: Found %1% fully and %2% partially matching particle patch(es). %3% "
+                    "patch was / patches were not matched.")
+                    % fullMatches.size() % partialMatches.size() % noMatches;
 
                 return std::make_pair(std::move(fullMatches), std::move(partialMatches));
             }

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -48,45 +48,8 @@ namespace picongpu
     {
         using namespace pmacc;
 
-#    if false
-        struct RedistributeFilteredParticlesKernel
-        {
-            template<typename T_Worker, typename T_DataBox>
-            HDINLINE void operator()(T_Worker const& worker, T_DataBox data, uint32_t size) const
-            {
-                constexpr uint32_t blockDomSize = T_Worker::blockDomSize();
-                auto numDataBlocks = (size + blockDomSize - 1u) / blockDomSize;
-
-                uint32_t* s_mem = ::alpaka::getDynSharedMem<uint32_t>(worker.getAcc());
-
-                // grid-strided loop over the chunked data
-                for(int dataBlock = worker.blockDomIdx(); dataBlock < numDataBlocks; dataBlock += worker.gridDomSize())
-                {
-                    auto dataBlockOffset = dataBlock * blockDomSize;
-                    auto forEach = pmacc::lockstep::makeForEach(worker);
-                    forEach(
-                        [&](uint32_t const inBlockIdx)
-                        {
-                            auto idx = dataBlockOffset + inBlockIdx;
-                            s_mem[inBlockIdx] = idx;
-                            if(idx < size)
-                            {
-                                // ensure that each block is not overwriting data from other blocks
-                                PMACC_DEVICE_VERIFY_MSG(
-                                    data[idx] == 0u,
-                                    "%s\n",
-                                    "Result buffer not valid initialized!");
-                                data[idx] = s_mem[inBlockIdx];
-                            }
-                        });
-                }
-            }
-        };
-#    endif
-
         template<typename T_Identifier>
         struct RedistributeFilteredParticles
-
         {
             template<typename FrameType, typename FilterType, typename RemapType>
             HINLINE void operator()(
@@ -99,10 +62,6 @@ namespace picongpu
                 using Identifier = T_Identifier;
                 using ValueType = typename pmacc::traits::Resolve<Identifier>::type::type;
                 using ComponentType = typename GetComponentsType<ValueType>::type;
-
-
-                constexpr uint32_t = decltype(lockstep::makeBlockCfg<DIM1>())::blockDomSize();
-
 
                 ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer();
 
@@ -391,6 +350,8 @@ namespace picongpu
                                     numParticlesCurrentBatch);
 
                                 // now filter
+                                auto position_ = mappedFrame.getIdentifier(position()).getPointer();
+                                auto positionOffset = mappedFrame.getIdentifier(totalCellIdx()).getPointer();
 
                                 constexpr char filterKeep{1}, filterRemove{0};
                                 PMACC_LOCKSTEP_KERNEL(KernelFilterParticles{})

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -318,10 +318,6 @@ namespace picongpu
                                 particleLoadOffset,
                                 numParticlesCurrentBatch);
 
-                            // now filter
-                            auto position_ = mappedFrame.getIdentifier(position()).getPointer();
-                            auto positionOffset = mappedFrame.getIdentifier(totalCellIdx()).getPointer();
-
                             constexpr char filterKeep{1}, filterRemove{0};
                             PMACC_LOCKSTEP_KERNEL(KernelFilterParticles{})
                                 .config<DIM1>(pmacc::math::Vector{numParticlesCurrentBatch})(
@@ -385,7 +381,6 @@ namespace picongpu
                 std::string const speciesName = FrameType::getName();
                 log<picLog::INPUT_OUTPUT>("openPMD: (begin) load species: %1%") % speciesName;
                 DataConnector& dc = Environment<>::get().DataConnector();
-                GridController<simDim>& gc = Environment<simDim>::get().GridController();
 
                 ::openPMD::Series& series = *params->openPMDSeries;
                 ::openPMD::Container<::openPMD::ParticleSpecies>& particles
@@ -402,8 +397,6 @@ namespace picongpu
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 eventSystem::getTransactionEvent().waitForFinished();
-
-                auto numRanks = gc.getGlobalSize();
 
                 auto [fullMatches, partialMatches] = getPatchIdx(params, particleSpecies);
 

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -112,7 +112,7 @@ namespace picongpu
                                 for(size_t d = 0; d < simDim; ++d)
                                 {
                                     auto positionInD = positionVec[d] + positionOffsetVec[d];
-                                    if(positionInD < patchTotalOffset[d] || positionInD > patchUpperCorner[d])
+                                    if(positionInD < patchTotalOffset[d] || positionInD >= patchUpperCorner[d])
                                     {
                                         filterCurrent = filterRemove;
                                         break;

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -48,56 +48,41 @@ namespace picongpu
     {
         using namespace pmacc;
 
+#    if false
         struct RedistributeFilteredParticlesKernel
         {
-            template<typename T_Worker, typename ValueType, typename FilterType, typename RemapType>
-            HDINLINE void operator()(
-                T_Worker const& worker,
-                ValueType* dataPtr,
-                FilterType&& filter,
-                RemapType&& remap,
-                MemIdxType const size,
-                char const filterRemove) const
+            template<typename T_Worker, typename T_DataBox>
+            HDINLINE void operator()(T_Worker const& worker, T_DataBox data, uint32_t size) const
             {
                 constexpr uint32_t blockDomSize = T_Worker::blockDomSize();
                 auto numDataBlocks = (size + blockDomSize - 1u) / blockDomSize;
 
-                ValueType* s_mem = ::alpaka::getDynSharedMem<ValueType>(worker.getAcc());
+                uint32_t* s_mem = ::alpaka::getDynSharedMem<uint32_t>(worker.getAcc());
 
                 // grid-strided loop over the chunked data
                 for(int dataBlock = worker.blockDomIdx(); dataBlock < numDataBlocks; dataBlock += worker.gridDomSize())
                 {
                     auto dataBlockOffset = dataBlock * blockDomSize;
                     auto forEach = pmacc::lockstep::makeForEach(worker);
-                    // read
                     forEach(
                         [&](uint32_t const inBlockIdx)
                         {
                             auto idx = dataBlockOffset + inBlockIdx;
+                            s_mem[inBlockIdx] = idx;
                             if(idx < size)
                             {
-                                s_mem[inBlockIdx] = dataPtr[idx];
+                                // ensure that each block is not overwriting data from other blocks
+                                PMACC_DEVICE_VERIFY_MSG(
+                                    data[idx] == 0u,
+                                    "%s\n",
+                                    "Result buffer not valid initialized!");
+                                data[idx] = s_mem[inBlockIdx];
                             }
                         });
-                    worker.sync();
-
-                    // write
-                    forEach(
-                        [&](uint32_t const inBlockIdx)
-                        {
-                            auto idx = dataBlockOffset + inBlockIdx;
-                            if(idx < size && filter[idx] != filterRemove)
-                            {
-                                dataPtr[remap[idx]] = s_mem[inBlockIdx];
-                            }
-                        });
-
-                    // The next Iteration of the outer for loop does not depend on the data overwritten until now.
-                    // Filtering moves data only to lower indexes and each of the outer loop's iterations deals with a
-                    // contiguous chunk of data.
                 }
             }
         };
+#    endif
 
         template<typename T_Identifier>
         struct RedistributeFilteredParticles
@@ -116,18 +101,19 @@ namespace picongpu
                 using ComponentType = typename GetComponentsType<ValueType>::type;
 
 
-                constexpr uint32_t blockDomSize = decltype(lockstep::makeBlockCfg<DIM1>())::blockDomSize();
-                constexpr size_t requiredSharedMemBytes = blockDomSize * sizeof(ValueType);
+                constexpr uint32_t = decltype(lockstep::makeBlockCfg<DIM1>())::blockDomSize();
+
 
                 ValueType* dataPtr = frame.getIdentifier(Identifier()).getPointer();
 
-                PMACC_LOCKSTEP_KERNEL(RedistributeFilteredParticlesKernel{})
-                    .configSMem<DIM1>(pmacc::math::Vector{numParticlesCurrentBatch}, requiredSharedMemBytes)(
-                        dataPtr,
-                        alpaka::getPtrNative(filter),
-                        alpaka::getPtrNative(remap),
-                        numParticlesCurrentBatch,
-                        filterRemove);
+                for(size_t particleIndex = 0; particleIndex < numParticlesCurrentBatch; ++particleIndex)
+                {
+                    if(filter[particleIndex] == filterRemove)
+                    {
+                        continue;
+                    }
+                    dataPtr[remap[particleIndex]] = dataPtr[particleIndex];
+                }
             }
         };
 
@@ -419,7 +405,6 @@ namespace picongpu
                                 eventSystem::getTransactionEvent().waitForFinished();
 
                                 // This part is inherently sequential, keep it on CPU
-                                // (maybe run also this on GPU to avoid multiple data copies)
                                 // std::cout << "REMAP: ";
                                 MemIdxType remapCurrent = 0;
                                 for(size_t particleIndex = 0; particleIndex < numParticlesCurrentBatch;

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -219,6 +219,13 @@ namespace picongpu
 
                 /* load from openPMD */
                 bool const isDomainBound = traits::IsFieldDomainBound<T_Field>::value;
+
+                // Skip PML fields for load balancing purposes
+                if(!isDomainBound)
+                {
+                    return;
+                }
+
                 RestartFieldLoader::loadField(
                     field->getGridBuffer(),
                     (uint32_t) T_Field::numComponents,

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -77,6 +77,9 @@ namespace picongpu
                 DataSpace<simDim> local_domain_size = params->window.localDimensions.size;
                 bool useLinearIdxAsDestination = false;
 
+                ::openPMD::Series& series = *params->openPMDSeries;
+                ::openPMD::Mesh& mesh = series.iterations[currentStep].open().meshes[objectName];
+
                 /* Patch for non-domain-bound fields
                  * This is an ugly fix to allow output of reduced 1d PML buffers
                  */
@@ -85,6 +88,7 @@ namespace picongpu
                     auto const field_layout = field.getGridLayout();
                     auto const field_no_guard = field_layout.sizeWithoutGuardND();
                     auto const elementCount = field_no_guard.productOfComponents();
+                    uint64_t pmlTotalSize = 0;
 
                     /* Scan the PML buffer local size along all local domains
                      * This code is symmetric to one in Field::writeField()
@@ -112,8 +116,19 @@ namespace picongpu
                     {
                         if(localSizes.at(2u * r + 1u) < rank)
                             domainOffset += localSizes.at(2u * r);
+                        pmlTotalSize += localSizes.at(2u * r);
                     }
                     log<picLog::INPUT_OUTPUT>("openPMD:  (end) collect PML sizes for %1%") % objectName;
+
+                    if(auto const& extentOnDisk = mesh.begin()->second.getExtent();
+                       extentOnDisk != ::openPMD::Extent{1, 1, pmlTotalSize})
+                    {
+                        log<picLog::INPUT_OUTPUT>(
+                            "openPMD:  Skip loading for PML fields. Expecting extent %1%, found extent %2% on disk. "
+                            "This may happen when restarting with a different domain decomposition.")
+                            % pmlTotalSize % extentOnDisk.at(2);
+                        return;
+                    }
 
                     domain_offset = DataSpace<simDim>::create(0);
                     domain_offset[0] = domainOffset;
@@ -121,9 +136,6 @@ namespace picongpu
                     local_domain_size[0] = elementCount;
                     useLinearIdxAsDestination = true;
                 }
-
-                ::openPMD::Series& series = *params->openPMDSeries;
-                ::openPMD::Container<::openPMD::Mesh>& meshes = series.iterations[currentStep].open().meshes;
 
                 auto destBox = field.getHostBuffer().getDataBox();
                 for(uint32_t n = 0; n < numComponents; ++n)
@@ -133,9 +145,8 @@ namespace picongpu
                     // data.
                     log<picLog::INPUT_OUTPUT>("openPMD: Read from domain: offset=%1% size=%2%") % domain_offset
                         % local_domain_size;
-                    ::openPMD::RecordComponent rc = numComponents > 1
-                                                        ? meshes[objectName][name_lookup_tpl[n]]
-                                                        : meshes[objectName][::openPMD::RecordComponent::SCALAR];
+                    ::openPMD::RecordComponent rc
+                        = numComponents > 1 ? mesh[name_lookup_tpl[n]] : mesh[::openPMD::RecordComponent::SCALAR];
 
                     log<picLog::INPUT_OUTPUT>("openPMD: Read from field '%1%'") % objectName;
 
@@ -158,7 +169,7 @@ namespace picongpu
                     std::shared_ptr<float_X> field_container = rc.loadChunk<float_X>(start, count);
 
                     /* start a blocking read of all scheduled variables */
-                    meshes.seriesFlush();
+                    mesh.seriesFlush();
 
 
                     int const elementCount = local_domain_size.productOfComponents();
@@ -219,12 +230,6 @@ namespace picongpu
 
                 /* load from openPMD */
                 bool const isDomainBound = traits::IsFieldDomainBound<T_Field>::value;
-
-                // Skip PML fields for load balancing purposes
-                if(!isDomainBound)
-                {
-                    return;
-                }
 
                 RestartFieldLoader::loadField(
                     field->getGridBuffer(),


### PR DESCRIPTION
Factored out of #5405 as a standalone feature.

Different domain decomposition means a different distribution of parallel processes over the simulation domain. The number of parallel processes may vary in between runs.

* Fields: Mostly support this already, just do random IO accesses into the sub-grid of interest. The PML fields do not support this, skip them (for now?).
* Particles: So far, the restart logic expected that there would be exactly one precisely matching particle patch. The new logic now accepts any number of particle patches and filters the patches if they only overlap with the local domain.

TODO:

- [x] Auto-detect if PML load operations should be skipped
- [ ] Maybe someone has a good test case for this

To reviewers, please also check the comments below