### PR TITLE
storeChunk: Workaround for bug with parallel flushing

### DIFF
--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -159,8 +159,10 @@ namespace picongpu
                 {
                     // accumulateWrittenBytes += 0;
 
-                    // Since Span-based storeChunk needs to interact with the openPMD backend (potentially opening it),
-                    // this cannot be skipped in parallel setups
+#    if !OPENPMDAPI_VERSION_GE(0, 17, 0)
+                    // Workaround for this bug: https://github.com/openPMD/openPMD-api/pull/1794
+                    // In the affected versions of the openPMD-api, Span-based storeChunk must be
+                    // treated as an MPI-collective call.
                     for(uint32_t d = 0; d < components; d++)
                     {
                         ::openPMD::RecordComponent recordComponent
@@ -170,6 +172,7 @@ namespace picongpu
                             ::openPMD::Offset{globalOffset},
                             ::openPMD::Extent{elements});
                     }
+#    endif
                     return;
                 }
 

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -158,6 +158,18 @@ namespace picongpu
                 if(elements == 0)
                 {
                     // accumulateWrittenBytes += 0;
+
+                    // Since Span-based storeChunk needs to interact with the openPMD backend (potentially opening it),
+                    // this cannot be skipped in parallel setups
+                    for(uint32_t d = 0; d < components; d++)
+                    {
+                        ::openPMD::RecordComponent recordComponent
+                            = components > 1 ? record[name_lookup[d]] : record[::openPMD::MeshRecordComponent::SCALAR];
+
+                        recordComponent.storeChunk<ComponentType>(
+                            ::openPMD::Offset{globalOffset},
+                            ::openPMD::Extent{elements});
+                    }
                     return;
                 }
 

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -159,8 +159,8 @@ namespace picongpu
                 {
                     // accumulateWrittenBytes += 0;
 
-#    if !OPENPMDAPI_VERSION_GE(0, 17, 0)
                     // Workaround for this bug: https://github.com/openPMD/openPMD-api/pull/1794
+                    // and also this one for good measure https://github.com/openPMD/openPMD-api/pull/1862
                     // In the affected versions of the openPMD-api, Span-based storeChunk must be
                     // treated as an MPI-collective call.
                     for(uint32_t d = 0; d < components; d++)
@@ -172,7 +172,6 @@ namespace picongpu
                             ::openPMD::Offset{globalOffset},
                             ::openPMD::Extent{elements});
                     }
-#    endif
                     return;
                 }
 


### PR DESCRIPTION
Workaround for this bug: https://github.com/openPMD/openPMD-api/pull/1794

I think that this has little importance for PIConGPU since we process Iterations collectively anyway, making it unlikely to happen. 
But I did stumble over this issue a while ago. Of course I did not document it and have no reproducer at hand now…

TODO:

- [x] Check if other places are affected. I think not, only the particles may have zero contributions from some ranks only.
- [x] Check for a reproducer.. I guess replacing `.writeIterations()` with `.snapshots()` and using `WRITE_RANDOM_ACCESS` might trigger the issue, but in that case it would be restricted to dev versions of openPMD, hence not so important.

Reproducer: Either find a simulation that does not write particles on some rank, or fake it:

```diff
diff --git a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
index 6435b6e86..ae35be4f3 100644
--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -155,7 +155,11 @@ namespace picongpu
                     float_X const timeOffset = 0.0;
                     record.setAttribute("timeOffset", timeOffset);
                 }
-                if(elements == 0)
+                DataConnector& dc = Environment<>::get().DataConnector();
+                GridController<simDim>& gc = Environment<simDim>::get().GridController();
+                uint64_t mpiSize = gc.getGlobalSize();
+                uint64_t mpiRank = gc.getGlobalRank();
+                if(elements == 0 || mpiRank != 0)
                 {
                     // accumulateWrittenBytes += 0;
 ```
Then `mpirun -n 2 picongpu -g 192 192 192 -d 1 2 1 --openPMD.period 100:100 -s 100 --openPMD.ext h5` e.g. within a LaserWakefield simulation.