### PR TITLE
Add unit dimension vector to binning diagnostic in picmi

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -16,6 +16,7 @@ from .checkpoint import Checkpoint
 from .particle_dump import ParticleDump
 from .field_dump import FieldDump
 from .backend_config import BackendConfig, OpenPMDConfig
+from .unit import Unit
 
 __all__ = [
     "Auto",
@@ -30,4 +31,5 @@ __all__ = [
     "Png",
     "TimeStepSpec",
     "Checkpoint",
+    "Unit",
 ]

--- a/lib/python/picongpu/picmi/diagnostics/binning.py
+++ b/lib/python/picongpu/picmi/diagnostics/binning.py
@@ -19,6 +19,7 @@ from ...pypicongpu.output.binning import (
 from ...pypicongpu.species.species import Species as PyPIConGPUSpecies
 from ..species import Species as PICMISpecies
 from .timestepspec import TimeStepSpec
+from .unit import Unit
 
 _COORDINATE_SYSTEM = {
     (
@@ -88,7 +89,7 @@ class BinningFunctor:
         name: str,
         functor: Callable[[BinningParticle], Any],
         return_type: type | str,
-        unit_dimension: list[float] | None = None,
+        unit_dimension: type(Unit()) | None = None,
     ):
         self.name = name
         self.functor = functor

--- a/lib/python/picongpu/picmi/diagnostics/binning.py
+++ b/lib/python/picongpu/picmi/diagnostics/binning.py
@@ -88,10 +88,12 @@ class BinningFunctor:
         name: str,
         functor: Callable[[BinningParticle], Any],
         return_type: type | str,
+        unit_dimension: list[float] | None = None,
     ):
         self.name = name
         self.functor = functor
         self.return_type = return_type
+        self.unit_dimension = unit_dimension
 
     def get_as_pypicongpu(self) -> PyPIConGPUBinningFunctor:
         self.check()
@@ -102,6 +104,7 @@ class BinningFunctor:
             functor_expression=functor_expression,
             attribute_mapping=particle.get_attribute_map(),
             return_type=self.return_type,
+            unit_dimension=self.unit_dimension,
         )
 
 

--- a/lib/python/picongpu/picmi/diagnostics/unit.py
+++ b/lib/python/picongpu/picmi/diagnostics/unit.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+class Unit:
+    """
+    class to describe units
+    """
+    
+    # number of unit dimension
+    N_unit_dim = 7
+    
+    """
+    The unit index map associates names with array indices.
+    The name definition can be found at https://en.wikipedia.org/wiki/SI_base_unit.
+    The array index order follows that of PIConGPU:
+    include/picongpu/plugins/binning/UnitConversion.hpp, lines 40–48.
+    """    
+    _unit_index_map = {
+        "length": 0, "L": 0,
+        "mass": 1, "M": 1,
+        "time": 2, "T": 2,
+        "electric current": 3, "I": 3,
+        "thermodynamic temperature": 4, "Θ": 4,
+        "amount of substance": 5, "N": 5,
+        "luminous intensity": 6, "J": 6
+    }    
+    
+    def __init__(self, name = None):
+        """set unit vector either empty or by name"""
+        self.unit_vector = np.zeros((self.N_unit_dim))
+
+        if name != None:
+            index = self._unit_index_map.get(name)
+            if index is not None:
+                self.unit_vector[index] = 1.0
+            else:
+                raise ValueError(f"Unknown unit name: {name}")
+
+    def __getitem__(self, name):
+        """access component by name"""
+        index = self._unit_index_map.get(name)
+        if index is None:
+            raise KeyError(f"Unknown unit name: {name}")
+        return self.unit_vector[index]
+
+    def __iter__(self):
+        """return iterator of unit based on PIConGPU order: LMTIΘNJ"""
+        return iter(self.unit_vector)
+
+    def __str__(self):
+        """return string representation that only outputs relevant units"""
+        output = ""
+        # invert from (name to index) to (index to (short) name)
+        inverted = {v: k for k, v in self._unit_index_map.items()}
+
+        for i in range(self.N_unit_dim):
+            if self.unit_vector[i] != 0.0:
+                output += f"{inverted[i]}^{self.unit_vector[i]} "
+        return output
+    
+    def __pow__(self, exponent):
+        """rase unit to a power"""
+        result = Unit()
+        result.unit_vector = self.unit_vector * exponent
+        return result
+    
+    def __mul__(self, factor):
+        """multiply units with each other"""
+        result = Unit()        
+        result.unit_vector = self.unit_vector + factor.unit_vector
+        return result
+        
+    def __truediv__(self, divisor):
+        """divide one unit by another"""
+        result = Unit()
+        result.unit_vector = self.unit_vector - divisor.unit_vector
+        return result 
+
+# predefined units 
+T = Unit("T")
+M = Unit("M")
+L = Unit("L")
+I = Unit("I")

--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -74,6 +74,10 @@ def translate_to_cpp_type(return_type):
 
 
 def translate_to_cpp_unitDimVec(unit_dimension):
+    if unit_dimension == None:
+        # catch picmi default input
+        unit_dimension = [0., 0., 0., 0., 0., 0., 0.]
+
     if (isinstance(unit_dimension, list) and
         len(unit_dimension) == 7 and
         all(isinstance(item, float) for item in unit_dimension)):

--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -15,6 +15,7 @@ from ..rendering.pmaccprinter import PMAccPrinter
 from ..species import Species
 from .. import util
 from .plugin import Plugin
+from ...picmi.diagnostics.unit import Unit
 
 import typeguard
 
@@ -76,22 +77,20 @@ def translate_to_cpp_type(return_type):
 def translate_to_cpp_unitDimVec(unit_dimension):
     if unit_dimension == None:
         # catch picmi default input
-        unit_dimension = [0., 0., 0., 0., 0., 0., 0.]
+        unit_dimension = Unit()
 
-    if (isinstance(unit_dimension, list) and
-        len(unit_dimension) == 7 and
-        all(isinstance(item, float) for item in unit_dimension)):
+    if isinstance(unit_dimension, type(Unit())):
         result = "std::array<double, 7>{ "
         for num in unit_dimension:
             result += f"{num}, "
         result += "}"
         return result
     else:
-        raise ValueError(f"The input {unit_dimension} is not a list of 7 floats.")
+        raise ValueError(f"The input {unit_dimension} is not a unit class.")
 
 
 class BinningFunctor(RenderedObject):
-    def __init__(self, name, functor_expression, attribute_mapping, return_type, unit_dimension=[0., 0., 0., 0., 0., 0., 0.]):
+    def __init__(self, name, functor_expression, attribute_mapping, return_type, unit_dimension=Unit()):
         self.name = name
         self.functor_expression = functor_expression
         self.attribute_mapping = attribute_mapping

--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -73,12 +73,26 @@ def translate_to_cpp_type(return_type):
     raise ValueError(f"Cannot translate {return_type=} to a C++ type.")
 
 
+def translate_to_cpp_unitDimVec(unit_dimension):
+    if (isinstance(unit_dimension, list) and
+        len(unit_dimension) == 7 and
+        all(isinstance(item, float) for item in unit_dimension)):
+        result = "std::array<double, 7>{ "
+        for num in unit_dimension:
+            result += f"{num}, "
+        result += "}"
+        return result
+    else:
+        raise ValueError(f"The input {unit_dimension} is not a list of 7 floats.")
+
+
 class BinningFunctor(RenderedObject):
-    def __init__(self, name, functor_expression, attribute_mapping, return_type):
+    def __init__(self, name, functor_expression, attribute_mapping, return_type, unit_dimension=[0., 0., 0., 0., 0., 0., 0.]):
         self.name = name
         self.functor_expression = functor_expression
         self.attribute_mapping = attribute_mapping
         self.return_type = return_type
+        self.unit_dimension = unit_dimension
 
     def _get_serialized(self):
         return {
@@ -86,6 +100,7 @@ class BinningFunctor(RenderedObject):
             "functor_expression": PMAccPrinter().doprint(self.functor_expression),
             "functor_preamble": generate_preamble(self.attribute_mapping),
             "return_type": translate_to_cpp_type(self.return_type),
+            "unit_dimension": translate_to_cpp_unitDimVec(self.unit_dimension),
         }
 
 

--- a/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
+++ b/share/picongpu/pypicongpu/examples/laser_wakefield/main.py
@@ -8,11 +8,14 @@ License: GPLv3+
 from picongpu import picmi
 from picongpu import pypicongpu
 import numpy as np
-from scipy.constants import c
+from scipy.constants import c, elementary_charge
+import sympy
 import logging
 import datetime
 
 from picongpu.pypicongpu.output.png import EMFieldScaleEnum, ColorScaleEnum
+from picongpu.picmi.diagnostics import binning
+from picongpu.picmi.diagnostics.unit import L, M, T, I
 
 # set log level:
 # options (in ascending order) are: DEBUG, INFO, WARNING, ERROR, CRITICAL
@@ -149,7 +152,46 @@ sim = picmi.Simulation(
 for species, layout in species_list:
     sim.add_species(species, layout=layout)
 
+
+# define e-spec binning plugin
+def computeEnergy(particle):
+    return particle.get("kinetic energy")
+
+def computeAngle(particle):
+    px, py, pz = particle.get("momentum")
+    return sympy.atan2(px, py)
+
+def computeCharge(particle):
+    return particle.get("charge")
+
+energyFunctor = binning.BinningFunctor(name="energy", functor=computeEnergy, return_type=float,
+                                       unit_dimension=L**2 * M * T**-2)
+thetaFunctor = binning.BinningFunctor(name="theta", functor=computeAngle, return_type=float, )
+
+maxEnergy_MeV = 100.0
+energyRange = binning.BinSpec("linear", 0.0, maxEnergy_MeV * 1e6 * elementary_charge, 800)  # convert MeV to Joule
+thetaRange = binning.BinSpec("linear", -0.250, +0.250, 256)  # in rad
+
+energyAxis = binning.BinningAxis(functor=energyFunctor, bin_spec=energyRange, name="energy")
+thetaAxis = binning.BinningAxis(functor=thetaFunctor, bin_spec=thetaRange, name="theta")
+
+eSpec_deposition_functor = binning.BinningFunctor(
+    name="eSpec",
+    functor=computeCharge,
+    return_type=float,
+    unit_dimension=I * T)
+
+eSPec_binning = binning.Binning(
+    name="eSpec",
+    deposition_functor=eSpec_deposition_functor,
+    axes=[energyAxis, thetaAxis],
+    species=species,
+    period=picmi.diagnostics.TimeStepSpec[::100],
+)
+
+
 sim.diagnostics = [
+    eSPec_binning,
     picmi.diagnostics.PhaseSpace(
         species=electrons,
         # Resulting values for period:

--- a/share/picongpu/pypicongpu/schema/output/binning.BinningAxis.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.BinningAxis.json
@@ -17,7 +17,7 @@
     "axis_functor": {
       "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor"
     },
-    "use_overflow_bins": {
+   "use_overflow_bins": {
       "type": "boolean"
     },
     "bin_spec": {

--- a/share/picongpu/pypicongpu/schema/output/binning.BinningFunctor.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.BinningFunctor.json
@@ -5,6 +5,7 @@
   "unevaluatedProperties": false,
   "required": [
     "name",
+    "unit_dimension",
     "functor_preamble",
     "functor_expression",
     "return_type"
@@ -13,6 +14,10 @@
     "name": {
       "type": "string",
       "description": "Name of the functor"
+    },
+    "unit_dimension": {
+      "type": "string",
+      "description": "c++ code for unit dimension vector"
     },
     "functor_preamble": {
       "type": "array",

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
@@ -67,7 +67,8 @@ namespace picongpu::plugins::binning
             {{/deposition_functor.functor_preamble}}
             return {{{deposition_functor.functor_expression}}};
           },
-          "{{{deposition_functor.name}}}"
+          "{{{deposition_functor.name}}}",
+	{{{deposition_functor.unit_dimension}}}
       );
 
       binningCreator.addParticleBinner(

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
@@ -51,7 +51,8 @@ namespace picongpu::plugins::binning
                 {{/axis_functor.functor_preamble}}
                 return {{{axis_functor.functor_expression}}};
               },
-            "{{{axis_name}}}"
+            "{{{axis_name}}}",
+	  {{{axis_functor.unit_dimension}}}
         )
       );
       {{/axes}}


### PR DESCRIPTION
This pull request adds a rudimentary unit system to the PICMI / pypicongpu binning diagnostic. 
Right now, it still uses a list of seven ~~deadly sins~~ floats. This should probably be changed before merging to a class that can allow setting units without knowledge about [the order of the unit vector (L, M, T, I, ?,? ?)](https://github.com/ComputationalRadiationPhysics/picongpu/blob/ea3ffaaf766f1bfa8a1dcb823c3eb2ff8e6b4326/include/picongpu/plugins/binning/UnitConversion.hpp#L40-L48)

So far, it also comes without test, as the test infrastructure will change with #5500