### PR TITLE
Add rudimentary shape support to picmi

### DIFF
--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -5,6 +5,7 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
+from picongpu.pypicongpu.species.species import Shape
 from .predefinedparticletypeproperties import PredefinedParticleTypeProperties
 from .interaction import Interaction
 
@@ -239,7 +240,6 @@ class Species(picmistandard.PICMI_Species):
 
         # error on unsupported options
         pypicongpu.util.unsupported("method", self.method)
-        pypicongpu.util.unsupported("particle shape", self.particle_shape)
         # @note placement params are respected in associated simulation object
 
         self.check(interaction)
@@ -283,6 +283,8 @@ class Species(picmistandard.PICMI_Species):
             s.constants.extend(interaction_constants)
         else:
             pypicongpu_model_by_picmi_model = None
+
+        s.shape = Shape[(self.particle_shape or "TSC").upper()]
 
         return s, pypicongpu_model_by_picmi_model
 

--- a/lib/python/picongpu/pypicongpu/species/species.py
+++ b/lib/python/picongpu/pypicongpu/species/species.py
@@ -5,14 +5,32 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from ..rendering import RenderedObject
-from .attribute import Attribute, Position, Momentum
-from .constant import Constant, Charge, Mass, DensityRatio, GroundStateIonization, ElementProperties
-from .. import util
+import re
+import typing
+from enum import Enum
 
 import typeguard
-import typing
-import re
+
+from .. import util
+from ..rendering import RenderedObject
+from .attribute import Attribute, Momentum, Position
+from .constant import (
+    Charge,
+    Constant,
+    DensityRatio,
+    ElementProperties,
+    GroundStateIonization,
+    Mass,
+)
+
+
+class Shape(Enum):
+    CIC = "CIC"
+    COUNTER = "Counter"
+    NGP = "NGP"
+    PCS = "PCS"
+    PQS = "PQS"
+    TSC = "TSC"
 
 
 @typeguard.typechecked
@@ -40,6 +58,8 @@ class Species(RenderedObject):
 
     name = util.build_typesafe_property(str)
     """name of the species"""
+
+    shape = util.build_typesafe_property(Shape)
 
     def __str__(self) -> str:
         try:
@@ -191,9 +211,15 @@ class Species(RenderedObject):
             else:
                 constants_context[constant_name] = None
 
+        try:
+            shape = self.shape
+        except AttributeError:
+            shape = Shape["TSC"]
+
         return {
             "name": self.name,
             "typename": self.get_cxx_typename(),
+            "shape": shape.value,
             "attributes": list(map(lambda attr: {"picongpu_name": attr.PICONGPU_NAME}, self.attributes)),
             "constants": constants_context,
         }

--- a/share/picongpu/pypicongpu/schema/species/species.Species.json
+++ b/share/picongpu/pypicongpu/schema/species/species.Species.json
@@ -7,6 +7,7 @@
     "name",
     "typename",
     "attributes",
+    "shape",
     "constants"
   ],
   "properties": {
@@ -21,6 +22,9 @@
       "description": "name of c++ species type",
       "minLength": 1,
       "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "shape": {
+      "type": "string"
     },
     "attributes": {
       "type": "array",

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/speciesDefinition.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/speciesDefinition.param.mustache
@@ -83,7 +83,7 @@ namespace picongpu
             {{/constants}}
 
             particlePusher<UsedParticlePusher>,
-            shape<UsedParticleShape>,
+            shape<{{#shape}}particles::shapes::{{{shape}}}{{/shape}}{{^shape}}UsedParticleShape{{/shape}}>,
             interpolation<UsedField2Particle>,
             current<UsedParticleCurrentSolver>>;
 

--- a/test/python/picongpu/quick/pypicongpu/species/constant/groundstateionization.py
+++ b/test/python/picongpu/quick/pypicongpu/species/constant/groundstateionization.py
@@ -120,6 +120,7 @@ class TestGroundStateIonization(unittest.TestCase):
                     "ionizer_picongpu_name": "BSI",
                     "ionization_electron_species": {
                         "name": "e",
+                        "shape": "TSC",
                         "typename": "species_e",
                         "attributes": [
                             {"picongpu_name": "position<position_pic>"},


### PR DESCRIPTION
This is a very simple fall-out implementation from the work on supporting derived-field dumps via openPMD. I needed the `Counter` shape for simplifying testing, so I implemented this. Very basic implementation, just an enum. The schema is not very strict.