### PR TITLE
Minor overhaul binning in picmi

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .auto import Auto
-from .binning import Binning
+from .binning import Binning, BinningAxis, BinSpec
 from .phase_space import PhaseSpace
 from .energy_histogram import EnergyHistogram
 from .macro_particle_count import MacroParticleCount
@@ -22,6 +22,8 @@ __all__ = [
     "BackendConfig",
     "OpenPMDConfig",
     "Binning",
+    "BinningAxis",
+    "BinSpec",
     "PhaseSpace",
     "EnergyHistogram",
     "MacroParticleCount",

--- a/lib/python/picongpu/picmi/diagnostics/particle_functor.py
+++ b/lib/python/picongpu/picmi/diagnostics/particle_functor.py
@@ -1,0 +1,118 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from typing import Any, Callable, Iterable
+
+from sympy import Expr, Symbol, symbols
+from typeguard import typechecked
+
+from ...pypicongpu.output.binning import (
+    BinningFunctor as PyPIConGPUParticleFunctor,
+)
+
+_COORDINATE_SYSTEM = {
+    (
+        origin.lower(),
+        precision.lower(),
+        unit.lower(),
+    ): tuple(Symbol(f"{c}_{precision.lower()}_{unit.lower()}") for c in coords)
+    for (origin, coords) in (
+        ("TOTAL", ("xt", "yt", "zt")),
+        ("GLOBAL", ("xg", "yg", "zg")),
+        ("LOCAL", ("xl", "yl", "zl")),
+        ("MOVING_WINDOW", ("xmw", "ymw", "zmw")),
+        ("LOCAL_WITH_GUARDS", ("xlg", "ylg", "zlg")),
+    )
+    for precision in ("CELL", "SUB_CELL")
+    for unit in ("CELL", "PIC", "SI")
+}
+
+
+class Particle:
+    def get(self, attribute, **kwargs) -> Expr | Iterable[Expr]:
+        NotImplementedError()
+
+
+@typechecked
+class AbstractParticle(Particle):
+    def __init__(self):
+        self.used_attributes = {}
+
+    def get_attribute_map(self):
+        return self.used_attributes
+
+    def get(self, attribute, **kwargs) -> Expr | Iterable[Expr]:
+        if attribute == "position":
+            origin = kwargs.get("origin", "total")
+            precision = kwargs.get("precision", "cell")
+            unit = kwargs.get("unit", "cell")
+            my_symbols = _COORDINATE_SYSTEM[(origin, precision, unit)]
+            self.used_attributes |= {my_symbols: ("position", origin, precision, unit)}
+
+        elif attribute == "momentum":
+            my_symbols = symbols("px,py,pz")
+            self.used_attributes |= {my_symbols: "momentum"}
+
+        elif attribute == "momentumPrev1":
+            my_symbols = symbols("p1x,p1y,p1z")
+            self.used_attributes |= {my_symbols: "momentumPrev1"}
+
+        elif attribute in ["gamma", "kinetic energy", "velocity"]:
+            # This relies on python dictionaries having a stable ordering.
+            # We first add mass and momentum
+            # and later use their symbols inside of the same preamble.
+            self.get("mass")
+            self.get("momentum")
+            if attribute == "gamma":
+                my_symbols = Symbol("gamma")
+            elif attribute == "kinetic energy":
+                my_symbols = Symbol("Ekin")
+            elif attribute == "velocity":
+                my_symbols = symbols("vx,vy,vz")
+            else:
+                raise ValueError("Reached impossible path.")
+            self.used_attributes |= {my_symbols: attribute}
+
+        else:
+            my_symbols = Symbol(attribute)
+            self.used_attributes |= {my_symbols: attribute}
+
+        return my_symbols
+
+    def finalize(self, expression, name=None, return_type=None):
+        return expression
+
+
+@typechecked
+class ParticleFunctor:
+    def check(self):
+        pass
+
+    def __init__(
+        self,
+        name: str,
+        functor: Callable[[Particle], Any],
+        return_type: type | str = float,
+    ):
+        self.name = name
+        self.functor = functor
+        self.return_type = return_type
+
+    def get_as_pypicongpu(self) -> PyPIConGPUParticleFunctor:
+        self.check()
+        particle = AbstractParticle()
+        functor_expression = self(particle)
+        return PyPIConGPUParticleFunctor(
+            name=self.name,
+            functor_expression=functor_expression,
+            attribute_mapping=particle.get_attribute_map(),
+            return_type=self.return_type,
+        )
+
+    def __call__(self, particle):
+        expression = self.functor(particle)
+        return particle.finalize(expression, self.name, self.return_type)

--- a/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
@@ -5,15 +5,15 @@ Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
-from numpy import vectorize
-from ...pypicongpu import species
-
-
 import logging
-import typeguard
-import typing
-import sympy
 import traceback
+import typing
+
+import sympy
+import typeguard
+from numpy import vectorize
+
+from ...pypicongpu import species
 
 """
 note on rms_velocity:

--- a/lib/python/picongpu/picmi/grid.py
+++ b/lib/python/picongpu/picmi/grid.py
@@ -5,13 +5,11 @@ Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch, Julian Lenz
 License: GPLv3+
 """
 
-from ..pypicongpu import grid
-from ..pypicongpu import util
-
-from .copy_attributes import converts_to
-
 import picmistandard
 import typeguard
+
+from ..pypicongpu import grid, util
+from .copy_attributes import converts_to
 
 
 def _normalise_type(kw, key, t):

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -6,11 +6,11 @@ License: GPLv3+
 """
 
 from functools import reduce
+from hashlib import sha256
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Annotated, Iterable, Literal
-from hashlib import sha256
 
 import tomli_w
 from pydantic import AfterValidator, BaseModel
@@ -65,12 +65,16 @@ class OpenPMDPlugin(Plugin):
     _setup_dir_is_not_temporary: bool | None = None
 
     def config_filename(self, content, context: Literal["runtime", "setup"]):
-        filename = f"openPMD_config_{sha256(tomli_w.dumps(content).encode()).hexdigest()}.toml"
+        filename = (
+            f"openPMD_config_{sha256(tomli_w.dumps(content).encode()).hexdigest()}.toml"
+        )
         if not self._setup_dir_is_not_temporary or context == "setup":
             return self.setup_dir / "etc" / filename
         if context == "runtime":
             return Path("..") / "input" / "etc" / filename
-        raise ValueError(f"Unknown {context=} upon requesting the openPMD config filename.")
+        raise ValueError(
+            f"Unknown {context=} upon requesting the openPMD config filename."
+        )
 
     @property
     def setup_dir(self):
@@ -97,9 +101,9 @@ class OpenPMDPlugin(Plugin):
         # As a workaround, we're computing this on the fly.
         # Shouldn't be performance critical but it would be more elegant to normalise early on.
         sources = reduce(
-            lambda dictionary, key_val: dictionary.setdefault(to_string(key_val[0]), []).append(
-                key_val[1].get_rendering_context()["name"]
-            )
+            lambda dictionary, key_val: dictionary.setdefault(
+                to_string(key_val[0]), []
+            ).append(key_val[1].get_rendering_context()["name"])
             or dictionary,
             self.sources,
             {},
@@ -113,7 +117,9 @@ class OpenPMDPlugin(Plugin):
 
     def _get_serialized(self) -> dict | None:
         content = self._generate_config_file()
-        return {"config_filename": str(self.config_filename(content, context="runtime"))}
+        return {
+            "config_filename": str(self.config_filename(content, context="runtime"))
+        }
 
     class Config:
         arbitrary_types_allowed = True

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -65,16 +65,12 @@ class OpenPMDPlugin(Plugin):
     _setup_dir_is_not_temporary: bool | None = None
 
     def config_filename(self, content, context: Literal["runtime", "setup"]):
-        filename = (
-            f"openPMD_config_{sha256(tomli_w.dumps(content).encode()).hexdigest()}.toml"
-        )
+        filename = f"openPMD_config_{sha256(tomli_w.dumps(content).encode()).hexdigest()}.toml"
         if not self._setup_dir_is_not_temporary or context == "setup":
             return self.setup_dir / "etc" / filename
         if context == "runtime":
             return Path("..") / "input" / "etc" / filename
-        raise ValueError(
-            f"Unknown {context=} upon requesting the openPMD config filename."
-        )
+        raise ValueError(f"Unknown {context=} upon requesting the openPMD config filename.")
 
     @property
     def setup_dir(self):
@@ -101,9 +97,9 @@ class OpenPMDPlugin(Plugin):
         # As a workaround, we're computing this on the fly.
         # Shouldn't be performance critical but it would be more elegant to normalise early on.
         sources = reduce(
-            lambda dictionary, key_val: dictionary.setdefault(
-                to_string(key_val[0]), []
-            ).append(key_val[1].get_rendering_context()["name"])
+            lambda dictionary, key_val: dictionary.setdefault(to_string(key_val[0]), []).append(
+                key_val[1].get_rendering_context()["name"]
+            )
             or dictionary,
             self.sources,
             {},
@@ -117,9 +113,7 @@ class OpenPMDPlugin(Plugin):
 
     def _get_serialized(self) -> dict | None:
         content = self._generate_config_file()
-        return {
-            "config_filename": str(self.config_filename(content, context="runtime"))
-        }
+        return {"config_filename": str(self.config_filename(content, context="runtime"))}
 
     class Config:
         arbitrary_types_allowed = True

--- a/lib/python/picongpu/pypicongpu/output/particle_functor.py
+++ b/lib/python/picongpu/pypicongpu/output/particle_functor.py
@@ -1,0 +1,87 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import numbers
+
+from pydantic import BaseModel
+
+from ..rendering.pmaccprinter import PMAccPrinter
+from ..rendering.renderedobject import RenderedObject
+
+
+def by_bracket(attribute):
+    return f"particle[{attribute}_]"
+
+
+ACCESSORS = {
+    (
+        "position",
+        origin.lower(),
+        precision.lower(),
+        unit.lower(),
+    ): f"getParticlePosition<DomainOrigin::{origin}, PositionPrecision::{precision}, PositionUnits::{unit}>(domainInfo, particle)"
+    for origin in ("TOTAL", "GLOBAL", "LOCAL", "MOVING_WINDOW", "LOCAL_WITH_GUARDS")
+    for precision in ("CELL", "SUB_CELL")
+    for unit in ("CELL", "PIC", "SI")
+} | {
+    "mass": "picongpu::traits::attribute::getMass(particle[weighting_], particle)",
+    # CAUTION: The names in the gamma formula are currently hardcoded.
+    # We'll certainly trip over this, should we ever dare to change the internal names.
+    "gamma": "picongpu::Gamma()(momentum::type{px, py, pz}, mass)",
+    "kinetic energy": "picongpu::KinEnergy()(momentum::type{px, py, pz}, mass)",
+    "velocity": "picongpu::Velocity()(momentum::type{px, py, pz}, mass)",
+    "charge": "picongpu::traits::attribute::getCharge(particle[weighting_], particle)",
+    "charge_state": "picongpu::traits::attribute::getChargeState(particle)",
+    "damped_weighting": "picongpu::traits::attribute::getDampedWeighting(particle)",
+    "timestep": "domainInfo.currentStep",
+    "timestep_size": "sim.pic.getDt()",
+}
+
+
+def symbol_to_string(symbol):
+    return str(symbol) if not isinstance(symbol, tuple) else "[" + ",".join(map(str, symbol)) + "]"
+
+
+def generate_preamble(attribute_mapping):
+    return [
+        {"statement": f"auto const {symbol_to_string(symbol)} = {ACCESSORS.get(attribute, by_bracket(attribute))};"}
+        for symbol, attribute in attribute_mapping.items()
+    ]
+
+
+def translate_to_cpp_type(return_type):
+    try:
+        if issubclass(return_type, numbers.Integral):
+            return "int"
+        if issubclass(return_type, numbers.Real):
+            return "float_X"
+        if issubclass(return_type, bool):
+            return "bool"
+    except TypeError:
+        pass
+    if isinstance(return_type, str):
+        return return_type
+    raise ValueError(f"Cannot translate {return_type=} to a C++ type.")
+
+
+class ParticleFunctor(RenderedObject, BaseModel):
+    name: str
+    functor_expression: str
+    functor_preamble: list[dict[str, str]]
+    return_type: str
+
+    def __init__(self, name, functor_expression, attribute_mapping, return_type):
+        name = name
+        functor_expression = PMAccPrinter().doprint(functor_expression)
+        functor_preamble = generate_preamble(attribute_mapping)
+        return_type = translate_to_cpp_type(return_type)
+        super().__init__(
+            name=name, functor_expression=functor_expression, functor_preamble=functor_preamble, return_type=return_type
+        )
+
+    def _get_serialized(self):
+        return self.model_dump(mode="json")

--- a/share/picongpu/pypicongpu/schema/output/binning.Binning.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.Binning.json
@@ -15,7 +15,7 @@
       "description": "Name of the binner"
     },
     "deposition_functor": {
-      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor"
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.particle_functor.ParticleFunctor"
     },
     "axes": {
       "type": "array",

--- a/share/picongpu/pypicongpu/schema/output/binning.BinningAxis.json
+++ b/share/picongpu/pypicongpu/schema/output/binning.BinningAxis.json
@@ -15,7 +15,7 @@
       "description": "Name of the binner"
     },
     "axis_functor": {
-      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor"
+      "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.particle_functor.ParticleFunctor"
     },
     "use_overflow_bins": {
       "type": "boolean"

--- a/share/picongpu/pypicongpu/schema/output/particle_functor.ParticleFunctor.json
+++ b/share/picongpu/pypicongpu/schema/output/particle_functor.ParticleFunctor.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.binning.BinningFunctor",
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.output.particle_functor.ParticleFunctor",
   "type": "object",
   "description": "Functor for flexible binning",
   "unevaluatedProperties": false,


### PR DESCRIPTION
Second fall-out PR from working on derived fields. This is a minor overhaul of the `Binning` implementation in PICMI. The main reason is to extract the `ParticleFunctor` into a separate file (and have a more general name) to then use it for the derived fields. I've taken the liberty to include a bit of maintenance like ordering imports, modernising the codebase, stuff like that.

As a tiny feature, the `Binning` can now report its `result_path`. It doesn't yet use the sneaked in `OpenPMDConfig` object in the front- or backend. This will be a separate PR (or added to this one if you aren't fast enough to review this here.) This should be handy for workflows in general but was mostly needed to automate the tests. Also, the `ParticleFunctor` got a `__call__` operator which currently just returns the sympy expression. It will get a second functionality with derived fields.