### PR TITLE
add exclusive flag

### DIFF
--- a/etc/picongpu/frontier-ornl/batch.tpl
+++ b/etc/picongpu/frontier-ornl/batch.tpl
@@ -32,6 +32,7 @@
 #SBATCH --ntasks-per-gpu=1
 #SBATCH --gpu-bind=closest
 #SBATCH --gres=gpu:!TBG_devicesPerNode
+#SBATCH --exclusive
 
 #SBATCH --mail-type=!TBG_mailSettings
 #SBATCH --mail-user=!TBG_mailAddress


### PR DESCRIPTION
It seems that PIConGPU crashes due to an out-of-memory error on host side when we run without the SLURM `--exclusive` flag. This PR adds this flag. 

- [ ] perform further tests - this solution seems to be too simple 

**Do not merge yet.**