### PR TITLE
Support restarting with old checkpoints which always have fieldBg included

### DIFF
--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -20,16 +20,7 @@
 
 #if (ENABLE_OPENPMD == 1)
 
-#    include "openPMD/openPMD.hpp"
-
-#    include <pmacc/eventSystem/waitForAllTasks.hpp>
-
-#    include <cstdlib> // std::getenv
-#    include <memory>
-#    include <string> // std::stoull
-#    include <utility> // std::declval
-
-#    include <openPMD/RecordComponent.hpp>
+#    include <compare>
 
 namespace picongpu
 {
@@ -44,7 +35,7 @@ namespace picongpu
          *
          * @attention If the version is changed please update openPMDWriter::checkIOFileVersionRestartCompatibility().
          */
-        static constexpr int picongpuIOVersionMajor = 3;
+        static constexpr int picongpuIOVersionMajor = 4;
 
         /** PIConGPU's IO minor file version.
          *
@@ -55,6 +46,16 @@ namespace picongpu
          * if needed.
          */
         static constexpr int picongpuIOVersionMinor = 0;
+
+        /**
+         * The oldest PIConGPU IO implementation major version readable by PIConGPU
+         */
+        static constexpr int minReadableIOVersionMajor{3};
+
+        static_assert(
+            !(picongpuIOVersionMajor < minReadableIOVersionMajor),
+            "Writer version must not be older than the minimum readable version");
+
     } // namespace openPMD
 } // namespace picongpu
 

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -204,9 +204,8 @@ namespace picongpu
         struct LoadFields
         {
         public:
-            HDINLINE void operator()(ThreadParams* params, uint32_t const restartStep)
+            HINLINE void operator()(ThreadParams* params, uint32_t const restartStep)
             {
-#    ifndef __CUDA_ARCH__
                 DataConnector& dc = Environment<>::get().DataConnector();
                 ThreadParams* tp = params;
 
@@ -226,7 +225,6 @@ namespace picongpu
                     tp,
                     restartStep,
                     isDomainBound);
-#    endif
             }
         };
 


### PR DESCRIPTION
Added a last readable IO version to signify forward compatibility of old dumps.
Bump IO Major version which should have been done with #5470 
Closes #5512

Sneaks in an ifdef cleanup in host only code.