### PR TITLE
Allow multiple lasers in picmi

### DIFF
--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -510,13 +510,8 @@ class Simulation(picmistandard.PICMI_Simulation):
         if len(self.laser_injection_methods) != self.laser_injection_methods.count(None):
             pypicongpu.util.unsupported("laser injection method", self.laser_injection_methods, [])
 
-        # pypicongpu interface currently only supports one laser, @todo change Brian Marre, 2024
-        if len(self.lasers) > 1:
-            pypicongpu.util.unsupported("more than one laser")
-
-        if len(self.lasers) == 1:
-            # check requires grid, so grid is translated (and thereby also checked) above
-            s.laser = self.lasers[0].get_as_pypicongpu()
+        if len(self.lasers) > 0:
+            s.laser = [ll.get_as_pypicongpu() for ll in self.lasers]
         else:
             # explictly disable laser (as required by pypicongpu)
             s.laser = None

--- a/lib/python/picongpu/pypicongpu/rendering/renderer.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderer.py
@@ -129,6 +129,7 @@ class Renderer:
                     elem = Renderer.__get_context_preprocessed_recursive(value[i])
                     elem["_first"] = 0 == i
                     elem["_last"] = len(value) - 1 == i
+                    elem["_idx"] = i
                     new_list.append(elem)
                 pp[key] = new_list
             elif type(value) in [int, float]:

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -24,6 +24,9 @@ import logging
 import datetime
 
 
+AnyLaser = DispersivePulseLaser | FromOpenPMDPulseLaser | GaussianLaser | PlaneWaveLaser
+
+
 @typeguard.typechecked
 class Simulation(RenderedObject):
     """
@@ -47,9 +50,7 @@ class Simulation(RenderedObject):
     grid = util.build_typesafe_property(typing.Union[Grid3D])
     """Used grid Object"""
 
-    laser = util.build_typesafe_property(
-        typing.Union[DispersivePulseLaser, FromOpenPMDPulseLaser, GaussianLaser, PlaneWaveLaser, None]
-    )
+    laser = util.build_typesafe_property(typing.Optional[list[AnyLaser]])
     """Used (gaussian) Laser"""
 
     solver = util.build_typesafe_property(Solver)
@@ -138,7 +139,7 @@ class Simulation(RenderedObject):
             serialized["output"] = None
 
         if self.laser is not None:
-            serialized["laser"] = self.laser.get_rendering_context()
+            serialized["laser"] = [ll.get_rendering_context() for ll in self.laser]
         else:
             serialized["laser"] = None
 

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -51,7 +51,7 @@ class Simulation(RenderedObject):
     """Used grid Object"""
 
     laser = util.build_typesafe_property(typing.Optional[list[AnyLaser]])
-    """Used (gaussian) Laser"""
+    """List of laser objects to use in the simulation, or None to disable lasers"""
 
     solver = util.build_typesafe_property(Solver)
     """Used Solver"""

--- a/share/picongpu/pypicongpu/schema/simulation.Simulation.json
+++ b/share/picongpu/pypicongpu/schema/simulation.Simulation.json
@@ -38,7 +38,10 @@
           "type": "null"
         },
         {
-          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.Laser"
+          "type": "array",
+          "items": {
+            "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.Laser"
+          }
         }
       ]
     },

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -25,9 +25,8 @@ namespace picongpu::fields::incidentField
 {
     {{#laser}}
     {{#laser.data}}
-
     {{^laser.typeID.fromOpenPMDPulse}}
-    struct PyPIConGPULaserBaseParam : public profiles::BaseParam
+    struct PyPIConGPULaserBaseParam_{{{laser._idx}}} : public profiles::BaseParam
     {
         static constexpr float_64 WAVE_LENGTH_SI = {{{wave_length_si}}}; // m
         static constexpr float_64 AMPLITUDE_SI = {{{E0_si}}}; // V/m
@@ -66,7 +65,7 @@ namespace picongpu::fields::incidentField
     {{/laser.typeID.fromOpenPMDPulse}}
 
     {{#typeID.gaussian}}
-    struct PyPIConGPUGaussianPulseParam : public PyPIConGPULaserBaseParam
+    struct PyPIConGPUGaussianPulseParam_{{{laser._idx}}} : public PyPIConGPULaserBaseParam_{{{laser._idx}}}
     {
         static constexpr float_64 W0_SI = {{{waist_si}}};
         static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
@@ -85,7 +84,7 @@ namespace picongpu::fields::incidentField
     {{/typeID.gaussian}}
 
     {{#typeID.planewave}}
-    struct PyPIConGPUPlaneWaveParam : public PyPIConGPULaserBaseParam
+    struct PyPIConGPUPlaneWaveParam_{{{laser._idx}}} : public PyPIConGPULaserBaseParam_{{{laser._idx}}}
     {
         static constexpr float_64 RAMP_INIT = {{{pulse_init}}};
         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = {{{laser_nofocus_constant_si}}};
@@ -93,7 +92,7 @@ namespace picongpu::fields::incidentField
     {{/typeID.planewave}}
 
     {{#typeID.dispersive}}
-    struct PyPIConGPUDispersivePulseParam : public PyPIConGPULaserBaseParam
+    struct PyPIConGPUDispersivePulseParam_{{{laser._idx}}} : public PyPIConGPULaserBaseParam_{{{laser._idx}}}
     {
         static constexpr float_64 W0_SI = {{{waist_si}}};
         static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
@@ -106,7 +105,7 @@ namespace picongpu::fields::incidentField
     {{/typeID.dispersive}}
 
     {{#typeID.fromOpenPMDPulse}}
-    struct PyPIConGPUFromOpenPMDPulseParam
+    struct PyPIConGPUFromOpenPMDPulseParam_{{{laser._idx}}}
     {
         static constexpr char const* filename = "{{{file_path}}}";
         static constexpr uint32_t iteration = {{{iteration}}};
@@ -139,7 +138,21 @@ namespace picongpu::fields::incidentField
     };
     {{/typeID.fromOpenPMDPulse}}
 
+    {{#typeID.gaussian}}
+    using LaserProfile_{{{laser._idx}}} = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam_{{{laser._idx}}}>;
+    {{/typeID.gaussian}}
+    {{#typeID.planewave}}
+    using LaserProfile_{{{laser._idx}}} = profiles::PlaneWave<PyPIConGPUPlaneWaveParam_{{{laser._idx}}}>;
+    {{/typeID.planewave}}
+    {{#typeID.dispersive}}
+    using LaserProfile_{{{laser._idx}}} = profiles::DispersivePulse<PyPIConGPUDispersivePulseParam_{{{laser._idx}}}>;
+    {{/typeID.dispersive}}
+    {{#typeID.fromOpenPMDPulse}}
+    using LaserProfile_{{{laser._idx}}} = profiles::FromOpenPMDPulse<PyPIConGPUFromOpenPMDPulseParam_{{{laser._idx}}}>;
+    {{/typeID.fromOpenPMDPulse}}
 
+    // TODO: find a better solution and move it into simulation class, or add a check that all lasers use the same positions
+    {{#laser._first}}
     /** Position in cells of the Huygens surface relative to start of the total domain
      *
      * The position is set as an offset, in cells, counted from the start of the total domain.
@@ -172,23 +185,21 @@ namespace picongpu::fields::incidentField
         {{/row_z}}
         {{/huygens_surface_positions}}
     };
+    {{/laser._first}}
 
     /**@{*/
     //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
-    {{#typeID.gaussian}}
-    using YMin = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam>;
-    {{/typeID.gaussian}}
-    {{#typeID.planewave}}
-    using YMin = profiles::PlaneWave<PyPIConGPUPlaneWaveParam>;
-    {{/typeID.planewave}}
-    {{#typeID.dispersive}}
-    using YMin = profiles::DispersivePulse<PyPIConGPUDispersivePulseParam>;
-    {{/typeID.dispersive}}
-    {{#typeID.fromOpenPMDPulse}}
-    using YMin = profiles::FromOpenPMDPulse<PyPIConGPUFromOpenPMDPulseParam>;
-    {{/typeID.fromOpenPMDPulse}}
     {{/laser.data}}
     {{/laser}}
+
+
+    using YMin = MakeSeq_t<
+    {{#laser}}
+        LaserProfile_{{{laser._idx}}},
+    {{/laser}}
+    profiles::None
+    >;
+
     {{^laser}}
     // no laser defined case
     constexpr int32_t POSITION[3][2] = {
@@ -197,7 +208,6 @@ namespace picongpu::fields::incidentField
                 {16, -16} // z direction [negative, positive]
     };
 
-    using YMin = profiles::None;
     {{/laser}}
     using XMin = profiles::None;
     using XMax = profiles::None;

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -24,10 +24,10 @@
 namespace picongpu::fields::incidentField
 {
     {{#laser}}
-    {{#laser.data}}
-    {{^laser.typeID.fromOpenPMDPulse}}
-    struct PyPIConGPULaserBaseParam_{{{laser._idx}}} : public profiles::BaseParam
+    {{^typeID.fromOpenPMDPulse}}
+    struct PyPIConGPULaserBaseParam_{{{_idx}}} : public profiles::BaseParam
     {
+        {{#data}}
         static constexpr float_64 WAVE_LENGTH_SI = {{{wave_length_si}}}; // m
         static constexpr float_64 AMPLITUDE_SI = {{{E0_si}}}; // V/m
         static constexpr float_64 PULSE_DURATION_SI = {{{pulse_duration_si}}}; // s (1 sigma)
@@ -61,12 +61,14 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_X = polarisation_direction[0];
         static constexpr float_64 POLARISATION_DIRECTION_Y = polarisation_direction[1];
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
+        {{/data}}
     };
-    {{/laser.typeID.fromOpenPMDPulse}}
+    {{/typeID.fromOpenPMDPulse}}
 
     {{#typeID.gaussian}}
-    struct PyPIConGPUGaussianPulseParam_{{{laser._idx}}} : public PyPIConGPULaserBaseParam_{{{laser._idx}}}
+    struct PyPIConGPUGaussianPulseParam_{{{_idx}}} : public PyPIConGPULaserBaseParam_{{{_idx}}}
     {
+        {{#data}}
         static constexpr float_64 W0_SI = {{{waist_si}}};
         static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
         static constexpr uint32_t numModes = {{{modenumber}}};
@@ -80,20 +82,24 @@ namespace picongpu::fields::incidentField
             {{{single_laguerre_phase}}}{{^_last}},{{/_last}}
             {{/laguerre_phases}}
             );
+        {{/data}}
     };
     {{/typeID.gaussian}}
 
     {{#typeID.planewave}}
-    struct PyPIConGPUPlaneWaveParam_{{{laser._idx}}} : public PyPIConGPULaserBaseParam_{{{laser._idx}}}
+    struct PyPIConGPUPlaneWaveParam_{{{_idx}}} : public PyPIConGPULaserBaseParam_{{{_idx}}}
     {
+        {{#data}}
         static constexpr float_64 RAMP_INIT = {{{pulse_init}}};
         static constexpr float_64 LASER_NOFOCUS_CONSTANT_SI = {{{laser_nofocus_constant_si}}};
+        {{/data}}
     };
     {{/typeID.planewave}}
 
     {{#typeID.dispersive}}
-    struct PyPIConGPUDispersivePulseParam_{{{laser._idx}}} : public PyPIConGPULaserBaseParam_{{{laser._idx}}}
+    struct PyPIConGPUDispersivePulseParam_{{{_idx}}} : public PyPIConGPULaserBaseParam_{{{_idx}}}
     {
+        {{#data}}
         static constexpr float_64 W0_SI = {{{waist_si}}};
         static constexpr float_64 PULSE_INIT = {{{pulse_init}}};
         static constexpr float_X SPECTRAL_SUPPORT = {{{spectral_support}}};
@@ -101,12 +107,14 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 AD_SI = {{{ad_si}}};
         static constexpr float_64 GDD_SI = {{{gdd_si}}};
         static constexpr float_64 TOD_SI = {{{tod_si}}};
+        {{/data}}
     };
     {{/typeID.dispersive}}
 
     {{#typeID.fromOpenPMDPulse}}
-    struct PyPIConGPUFromOpenPMDPulseParam_{{{laser._idx}}}
+    struct PyPIConGPUFromOpenPMDPulseParam_{{{_idx}}}
     {
+        {{#data}}
         static constexpr char const* filename = "{{{file_path}}}";
         static constexpr uint32_t iteration = {{{iteration}}};
         static constexpr char const* datasetEName = "{{{dataset_name}}}";
@@ -135,24 +143,27 @@ namespace picongpu::fields::incidentField
         static constexpr float_64 POLARISATION_DIRECTION_Z = polarisation_direction[2];
 
         static constexpr float_64 TIME_DELAY_SI = {{{time_offset_si}}};
+        {{/data}}
     };
     {{/typeID.fromOpenPMDPulse}}
 
     {{#typeID.gaussian}}
-    using LaserProfile_{{{laser._idx}}} = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam_{{{laser._idx}}}>;
+    using LaserProfile_{{{_idx}}} = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam_{{{_idx}}}>;
     {{/typeID.gaussian}}
     {{#typeID.planewave}}
-    using LaserProfile_{{{laser._idx}}} = profiles::PlaneWave<PyPIConGPUPlaneWaveParam_{{{laser._idx}}}>;
+    using LaserProfile_{{{_idx}}} = profiles::PlaneWave<PyPIConGPUPlaneWaveParam_{{{_idx}}}>;
     {{/typeID.planewave}}
     {{#typeID.dispersive}}
-    using LaserProfile_{{{laser._idx}}} = profiles::DispersivePulse<PyPIConGPUDispersivePulseParam_{{{laser._idx}}}>;
+    using LaserProfile_{{{_idx}}} = profiles::DispersivePulse<PyPIConGPUDispersivePulseParam_{{{_idx}}}>;
     {{/typeID.dispersive}}
     {{#typeID.fromOpenPMDPulse}}
-    using LaserProfile_{{{laser._idx}}} = profiles::FromOpenPMDPulse<PyPIConGPUFromOpenPMDPulseParam_{{{laser._idx}}}>;
+    using LaserProfile_{{{_idx}}} = profiles::FromOpenPMDPulse<PyPIConGPUFromOpenPMDPulseParam_{{{_idx}}}>;
     {{/typeID.fromOpenPMDPulse}}
 
     // TODO: find a better solution and move it into simulation class, or add a check that all lasers use the same positions
-    {{#laser._first}}
+    {{/laser}}
+    {{#laser}}
+    {{#_first}}
     /** Position in cells of the Huygens surface relative to start of the total domain
      *
      * The position is set as an offset, in cells, counted from the start of the total domain.
@@ -173,7 +184,7 @@ namespace picongpu::fields::incidentField
      * source matching such a case.
      */
     constexpr int32_t POSITION[3][2] = {
-        {{#huygens_surface_positions}}
+        {{#data.huygens_surface_positions}}
         {{#row_x}}
             { {{{negative}}}, {{{positive}}} },
         {{/row_x}}
@@ -183,19 +194,18 @@ namespace picongpu::fields::incidentField
         {{#row_z}}
             { {{{negative}}}, {{{positive}}} }
         {{/row_z}}
-        {{/huygens_surface_positions}}
+        {{/data.huygens_surface_positions}}
     };
-    {{/laser._first}}
+    {{/_first}}
 
     /**@{*/
     //! Incident field profile types along each boundary, these 6 types (or aliases) are required.
-    {{/laser.data}}
     {{/laser}}
 
 
     using YMin = MakeSeq_t<
     {{#laser}}
-        LaserProfile_{{{laser._idx}}},
+        LaserProfile_{{{_idx}}},
     {{/laser}}
     profiles::None
     >;

--- a/test/python/picongpu/quick/pypicongpu/laser.py
+++ b/test/python/picongpu/quick/pypicongpu/laser.py
@@ -19,20 +19,21 @@ import typeguard
 
 class TestGaussianLaser(unittest.TestCase):
     def setUp(self):
-        self.laser = GaussianLaser()
-        self.laser.wavelength = 1.2
-        self.laser.waist = 3.4
-        self.laser.duration = 5.6
-        self.laser.focal_position = [0, 7.8, 0]
-        self.laser.phi0 = 2.9
-        self.laser.E0 = 9.0
-        self.laser.pulse_init = 1.3
-        self.laser.propagation_direction = [0.0, 1.0, 0.0]
-        self.laser.polarization_type = PolarizationType.LINEAR
-        self.laser.polarization_direction = [0.0, 1.0, 0.0]
-        self.laser.laguerre_modes = [1.0]
-        self.laser.laguerre_phases = [0.0]
-        self.laser.huygens_surface_positions = [[1, -1], [1, -1], [1, -1]]
+        laser = GaussianLaser()
+        laser.wavelength = 1.2
+        laser.waist = 3.4
+        laser.duration = 5.6
+        laser.focal_position = [0, 7.8, 0]
+        laser.phi0 = 2.9
+        laser.E0 = 9.0
+        laser.pulse_init = 1.3
+        laser.propagation_direction = [0.0, 1.0, 0.0]
+        laser.polarization_type = PolarizationType.LINEAR
+        laser.polarization_direction = [0.0, 1.0, 0.0]
+        laser.laguerre_modes = [1.0]
+        laser.laguerre_phases = [0.0]
+        laser.huygens_surface_positions = [[1, -1], [1, -1], [1, -1]]
+        self.laser = [laser]
 
     def test_types(self):
         """invalid types are rejected"""
@@ -93,7 +94,7 @@ class TestGaussianLaser(unittest.TestCase):
         """Huygens surfaces must be described as
         [[x_min:int, x_max:int], [y_min:int,y_max:int],
         [z_min:int, z_max:int]]"""
-        laser = self.laser
+        laser = self.laser[0]
 
         invalid_elements = [None, [], [1.2, 3.4]]
         valid_rump = [[5, 6], [7, 8]]
@@ -111,7 +112,7 @@ class TestGaussianLaser(unittest.TestCase):
 
     def test_invalid_laguerre_modes_empty(self):
         """laguerre modes must be set non-empty"""
-        laser = self.laser
+        laser = self.laser[0]
         laser.laguerre_modes = []
         with self.assertRaisesRegex(ValueError, ".*mode.*empty.*"):
             laser.get_rendering_context()
@@ -122,7 +123,7 @@ class TestGaussianLaser(unittest.TestCase):
 
     def test_invalid_laguerre_modes_invalid_length(self):
         """num of laguerre modes/phases must be equal"""
-        laser = self.laser
+        laser = self.laser[0]
         laser.laguerre_modes = [1.0]
         laser.laguerre_phases = [2, 3]
 
@@ -135,7 +136,7 @@ class TestGaussianLaser(unittest.TestCase):
 
     def test_positive_definite_laguerre_modes(self):
         """test whether laguerre modes are positive definite"""
-        laser = self.laser
+        laser = self.laser[0]
         laser.laguerre_modes = [-1.0]
         with self.assertLogs(level="WARNING") as caught_logs:
             # valid, but warns
@@ -156,36 +157,36 @@ class TestGaussianLaser(unittest.TestCase):
     def test_translation(self):
         """is translated to context object"""
         # note: implicitly checks against schema
-        context = self.laser.get_rendering_context()["data"]
-        self.assertEqual(context["wave_length_si"], self.laser.wavelength)
-        self.assertEqual(context["waist_si"], self.laser.waist)
-        self.assertEqual(context["pulse_duration_si"], self.laser.duration)
+        context = self.laser[0].get_rendering_context()["data"]
+        self.assertEqual(context["wave_length_si"], self.laser[0].wavelength)
+        self.assertEqual(context["waist_si"], self.laser[0].waist)
+        self.assertEqual(context["pulse_duration_si"], self.laser[0].duration)
         self.assertEqual(
             context["focus_pos_si"],
             [
-                {"component": self.laser.focal_position[0]},
-                {"component": self.laser.focal_position[1]},
-                {"component": self.laser.focal_position[2]},
+                {"component": self.laser[0].focal_position[0]},
+                {"component": self.laser[0].focal_position[1]},
+                {"component": self.laser[0].focal_position[2]},
             ],
         )
-        self.assertEqual(context["phase"], self.laser.phi0)
-        self.assertEqual(context["E0_si"], self.laser.E0)
-        self.assertEqual(context["pulse_init"], self.laser.pulse_init)
+        self.assertEqual(context["phase"], self.laser[0].phi0)
+        self.assertEqual(context["E0_si"], self.laser[0].E0)
+        self.assertEqual(context["pulse_init"], self.laser[0].pulse_init)
         self.assertEqual(
             context["propagation_direction"],
             [
-                {"component": self.laser.propagation_direction[0]},
-                {"component": self.laser.propagation_direction[1]},
-                {"component": self.laser.propagation_direction[2]},
+                {"component": self.laser[0].propagation_direction[0]},
+                {"component": self.laser[0].propagation_direction[1]},
+                {"component": self.laser[0].propagation_direction[2]},
             ],
         )
-        self.assertEqual(context["polarization_type"], self.laser.polarization_type.get_cpp_str())
+        self.assertEqual(context["polarization_type"], self.laser[0].polarization_type.get_cpp_str())
         self.assertEqual(
             context["polarization_direction"],
             [
-                {"component": self.laser.polarization_direction[0]},
-                {"component": self.laser.polarization_direction[1]},
-                {"component": self.laser.polarization_direction[2]},
+                {"component": self.laser[0].polarization_direction[0]},
+                {"component": self.laser[0].polarization_direction[1]},
+                {"component": self.laser[0].polarization_direction[2]},
             ],
         )
         self.assertEqual(context["laguerre_modes"], [{"single_laguerre_mode": 1.0}])
@@ -195,16 +196,16 @@ class TestGaussianLaser(unittest.TestCase):
             context["huygens_surface_positions"],
             {
                 "row_x": {
-                    "negative": self.laser.huygens_surface_positions[0][0],
-                    "positive": self.laser.huygens_surface_positions[0][1],
+                    "negative": self.laser[0].huygens_surface_positions[0][0],
+                    "positive": self.laser[0].huygens_surface_positions[0][1],
                 },
                 "row_y": {
-                    "negative": self.laser.huygens_surface_positions[1][0],
-                    "positive": self.laser.huygens_surface_positions[1][1],
+                    "negative": self.laser[0].huygens_surface_positions[1][0],
+                    "positive": self.laser[0].huygens_surface_positions[1][1],
                 },
                 "row_z": {
-                    "negative": self.laser.huygens_surface_positions[2][0],
-                    "positive": self.laser.huygens_surface_positions[2][1],
+                    "negative": self.laser[0].huygens_surface_positions[2][0],
+                    "positive": self.laser[0].huygens_surface_positions[2][1],
                 },
             },
         )

--- a/test/python/picongpu/quick/pypicongpu/simulation.py
+++ b/test/python/picongpu/quick/pypicongpu/simulation.py
@@ -54,21 +54,22 @@ class TestSimulation(unittest.TestCase):
         self.s.init_manager = species.InitManager()
         self.s.base_density = 1.0e25
 
-        self.laser = GaussianLaser()
-        self.laser.wavelength = 1.2
-        self.laser.waist = 3.4
-        self.laser.duration = 5.6
-        self.laser.focal_position = [0, 7.8, 0]
-        self.laser.centroid_position = [0, 0, 0]
-        self.laser.phi0 = 2.9
-        self.laser.E0 = 9.0
-        self.laser.pulse_init = 1.3
-        self.laser.propagation_direction = [0, 1, 0]
-        self.laser.polarization_type = PolarizationType.LINEAR
-        self.laser.polarization_direction = [0, 0, 1]
-        self.laser.laguerre_modes = [1.2, 2.4]
-        self.laser.laguerre_phases = [2.4, 3.4]
-        self.laser.huygens_surface_positions = [[1, -1], [1, -1], [1, -1]]
+        laser = GaussianLaser()
+        laser.wavelength = 1.2
+        laser.waist = 3.4
+        laser.duration = 5.6
+        laser.focal_position = [0, 7.8, 0]
+        laser.centroid_position = [0, 0, 0]
+        laser.phi0 = 2.9
+        laser.E0 = 9.0
+        laser.pulse_init = 1.3
+        laser.propagation_direction = [0, 1, 0]
+        laser.polarization_type = PolarizationType.LINEAR
+        laser.polarization_direction = [0, 0, 1]
+        laser.laguerre_modes = [1.2, 2.4]
+        laser.laguerre_phases = [2.4, 3.4]
+        laser.huygens_surface_positions = [[1, -1], [1, -1], [1, -1]]
+        self.laser = [laser]
 
         self.customData_1 = [{"test_data_1": 1}, "tag_1"]
         self.customData_2 = [{"test_data_2": 2}, "tag_2"]
@@ -207,8 +208,8 @@ class TestSimulation(unittest.TestCase):
         sim = self.s
         sim.laser = self.laser
         context = sim.get_rendering_context()
-        laser_context = sim.laser.get_rendering_context()
-        self.assertEqual(context["laser"], laser_context)
+        laser_context = sim.laser[0].get_rendering_context()
+        self.assertEqual(context["laser"][0], laser_context)
 
     def test_output_auto_short_duration(self):
         """period is always at least one"""


### PR DESCRIPTION
Adds support for multiple lasers in picmi. Also adds an ` _idx` field to all `pypicongpu` context lists. 

It turned out I don't need it right now in the end, so there is no pressure to merge this. But, since it is already there @chillenzer maybe you want to take a look. 