### PR TITLE
add J field for PICMI

### DIFF
--- a/share/picongpu/pypicongpu/template/include/picongpu/param/fileOutput.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/fileOutput.param.mustache
@@ -1,0 +1,127 @@
+/* Copyright 2013-2024 Axel Huebl, Rene Widera, Felix Schmitt,
+ *                     Benjamin Worpitz, Richard Pausch, Pawel Ordyna
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <pmacc/meta/conversion/MakeSeq.hpp>
+
+/* some forward declarations we need */
+#include "picongpu/fields/Fields.def"
+#include "picongpu/particles/filter/filter.def"
+#include "picongpu/particles/particleToGrid/CombinedDerive.def"
+#include "picongpu/particles/particleToGrid/ComputeGridValuePerFrame.def"
+
+namespace picongpu
+{
+    /** FieldTmp output (calculated at runtime) *******************************
+     *
+     * Those operations derive scalar field quantities from particle species
+     * at runtime. Each value is mapped per cell. Some operations are identical
+     * up to a constant, so avoid writing those twice to save storage.
+     *
+     * you can choose any of these particle to grid projections:
+     *   - Density: particle position + shape on the grid
+     *   - BoundElectronDensity: density of bound electrons
+     *       note: only makes sense for partially ionized ions
+     *   - ChargeDensity: density * charge
+     *       note: for species that do not change their charge state, this is
+     *             the same as the density times a constant for the charge
+     *   - Energy: sum of kinetic particle energy per cell with respect to shape
+     *   - EnergyDensity: average kinetic particle energy per cell times the
+     *                    particle density
+     *       note: this is the same as the sum of kinetic particle energy
+     *             divided by a constant for the cell volume
+     *   - Momentum: sum of chosen component of momentum per cell with respect to shape
+     *   - MomentumDensity: average chosen component of momentum per cell times the particle density
+     *       note: this is the same as the sum of the chosen momentum component
+     *             divided by a constant for the cell volume
+     *   - LarmorPower: radiated Larmor power
+     *                  (species must contain the attribute `momentumPrev1`)
+     *
+     * for debugging:
+     *   - MidCurrentDensityComponent:
+     *       density * charge * velocity_component
+     *   - Counter: counts point like particles per cell
+     *   - MacroCounter: counts point like macro particles per cell
+     *
+     * combined attributes:
+     *   These attributes are defined as a function of two primary derived attributes.
+     *
+     *   - AverageAttribute: template to compute a per particle average of any derived value
+     *   - RelativisticDensity: equals to 1/gamma^2 * n. Where gamma is the Lorentz factor for the mean kinetic energy
+     *      in the cell and n ist the usual number density. Useful for Faraday Rotation calculation.
+     *
+     *      Example use:
+     *      @code{.cpp}
+     *      using AverageEnergy_Seq = deriveField::CreateEligible_t<
+     *          VectorAllSpecies,
+     *          deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::Energy>>;
+     *      using RelativisticDensity_Seq
+     *          = deriveField::CreateEligible_t<PIC_Electrons, deriveField::combinedAttributes::RelativisticDensity>;
+     *      @endcode
+     *
+     * Filtering:
+     *   You can create derived fields from filtered particles. Only particles passing
+     *   the filter will contribute to the field quantity.
+     *   For that you need to define your filters in `particleFilters.param` and pass a
+     *   filter as the 3rd (optional) template argument in `CreateEligible_t`.
+     *
+     *   Example: This will create charge density field for all species that are
+     *   eligible for the this attribute and the chosen filter.
+     *   @code{.cpp}
+     *   using ChargeDensity_Seq
+         = deriveField::CreateEligible_t< VectorAllSpecies,
+         deriveField::derivedAttributes::ChargeDensity, filter::FilterOfYourChoice>;
+     *   @endcode
+     */
+    namespace deriveField = particles::particleToGrid;
+
+    /* ChargeDensity section */
+    using ChargeDensity_Seq
+        = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::ChargeDensity>;
+
+    /* EnergyDensity section */
+    using EnergyDensity_Seq
+        = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::EnergyDensity>;
+
+    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
+     *
+     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
+     */
+    using FieldTmpSolvers = MakeSeq_t<ChargeDensity_Seq, EnergyDensity_Seq>;
+
+
+    /** FileOutputFields: Groups all Fields that shall be dumped *************/
+
+    /** Possible native fields: FieldE, FieldB, FieldJ
+     */
+    using NativeFileOutputFields = MakeSeq_t<FieldE, FieldB, FieldJ>;
+
+    using FileOutputFields = MakeSeq_t<NativeFileOutputFields, FieldTmpSolvers>;
+
+
+    /** FileOutputParticles: Groups all Species that shall be dumped **********
+     *
+     * hint: to disable particle output set to
+     *   using FileOutputParticles = MakeSeq_t< >;
+     */
+    using FileOutputParticles = VectorAllSpecies;
+
+} // namespace picongpu


### PR DESCRIPTION
Minor fix that allows to use `J` as output in PICMI openPMD native fields. 
This will be improved to actually only allow fields that were selected in a later PR. 