### PR TITLE
Fix unitSI of omega in openPMD output of transition radiation plugin

### DIFF
--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
@@ -607,7 +607,7 @@ namespace picongpu
                     auto omega = meshOmega[::openPMD::RecordComponent::SCALAR];
                     omega.resetDataset(datasetOmega);
 
-                    omega.setUnitSI(1.0);
+                    omega.setUnitSI(1.0 / sim.unit.time());
 
                     auto spanOmega = omega.storeChunk<float_X>(offsetOmega, extentOmega);
                     auto spanBufferOmega = spanOmega.currentBuffer();


### PR DESCRIPTION
This PR fixes the Issue [5295](https://github.com/ComputationalRadiationPhysics/picongpu/issues/5295).

The frequency omega is multiplied by `sim.unit.time()` in `transitionRadiation.unitless`, so its unit in the openPMD output has to be adjusted accordingly.