### PR TITLE
Improved FLYonPIC debug printing

### DIFF
--- a/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
+++ b/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
@@ -764,14 +764,16 @@ namespace picongpu::particles::atomicPhysics::atomicData
                        lastTransitionTuple))
                 {
                     // print debug info
+                    std::cout << "last Transition:" << std::endl;
                     picongpu::particles::atomicPhysics::debug::
                         printTransitionTupleToConsole<T_TransitionTuple, Idx, TypeValue, ConfigNumber>(
                             lastTransitionTuple);
+                    std::cout << "current Transition:" << std::endl;
                     picongpu::particles::atomicPhysics::debug::
                         printTransitionTupleToConsole<T_TransitionTuple, Idx, TypeValue, ConfigNumber>(
                             currentTransitionTuple);
 
-                    throw std::runtime_error("atomicPhysics ERROR: wrong ordering of input data");
+                    throw std::runtime_error("atomicPhysics ERROR: wrong ordering of transition input data");
                 }
 
                 // move to next entry for comparison

--- a/include/picongpu/particles/atomicPhysics/debug/PrintAtomicDataToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/PrintAtomicDataToConsole.hpp
@@ -107,7 +107,8 @@ namespace picongpu::particles::atomicPhysics::debug
 
         // state data
         std::cout << "AtomicState Data" << std::endl;
-        std::cout << "index : [ConfigNumber, chargeState, levelVector]: E_overGround, IPDIonizationState[index, "
+        std::cout << "index : [ConfigNumber, chargeState, levelVector]: E_overGround, multiplicity, "
+                     "IPDIonizationState[index, "
                      "chargeState, configNumber]"
                   << std::endl;
         std::cout << "\t b/f/a: [#TransitionsUp/]#TransitionsDown, [startIndexUp/]startIndexDown" << std::endl;
@@ -122,11 +123,12 @@ namespace picongpu::particles::atomicPhysics::debug
                 = S_ConfigNumber::getLevelVector(atomicStateDataBox.configNumber(ipdIonizationStateCollectionIndex));
             auto const chargeStateIPDIonizationVector
                 = S_ConfigNumber::getChargeState(atomicStateDataBox.configNumber(ipdIonizationStateCollectionIndex));
+            auto const multiplicity = static_cast<uint64_t>(atomicStateDataBox.multiplicity(stateCollectionIndex));
 
             std::cout << "\t" << stateCollectionIndex << " : [" << stateConfigNumber << ", "
                       << static_cast<uint16_t>(S_ConfigNumber::getChargeState(stateConfigNumber)) << ", "
                       << precisionCast<uint16_t>(stateLevelVector).toString(",", "()")
-                      << "]: " << atomicStateDataBox.energy(stateCollectionIndex) << ",\t"
+                      << "]: " << atomicStateDataBox.energy(stateCollectionIndex) << ", " << multiplicity << ",\t"
                       << "[" << ipdIonizationStateCollectionIndex << ", "
                       << static_cast<uint16_t>(chargeStateIPDIonizationVector) << ", "
                       << precisionCast<uint16_t>(levelVectorIPDIonizationState).toString(",", "()") << "]"

--- a/include/picongpu/particles/atomicPhysics/debug/PrintTransitionTupleToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/PrintTransitionTupleToConsole.hpp
@@ -39,7 +39,7 @@ namespace picongpu::particles::atomicPhysics::debug
         uint8_t const upperChargeState = T_ConfigNumber::getChargeState(upperAtomicState);
         uint8_t const lowerChargeState = T_ConfigNumber::getChargeState(lowerAtomicState);
 
-        std::cout << "State : " << static_cast<uint16_t>(lowerChargeState) << ", " << lowerAtomicState << ", "
-                  << static_cast<uint16_t>(upperChargeState) << ", " << upperAtomicState << std::endl;
+        std::cout << "Transition: (" << static_cast<uint16_t>(lowerChargeState) << ": " << lowerAtomicState << ") -> ("
+                  << static_cast<uint16_t>(upperChargeState) << ":" << upperAtomicState << ")" << std::endl;
     }
 } // namespace picongpu::particles::atomicPhysics::debug

--- a/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
@@ -236,7 +236,9 @@ namespace picongpu::particles::atomicPhysics::debug
 
             if constexpr(T_consoleOutput)
             {
-                std::cout << "[relative error]" << descriptionQuantity << ":\t" << relativeError << std::endl;
+                std::cout << "[relative error] " << descriptionQuantity << ":\t" << relativeError << std::endl;
+                std::cout << "\t is:        " << testValue << std::endl;
+                std::cout << "\t should be: " << correctValue << std::endl;
             }
 
             if(std::isnan(relativeError))

--- a/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/BoundFreeCollisionalTransitions.py
+++ b/lib/python/picongpu/extra/utils/FLYonPICRateCalculationReference/BoundFreeCollisionalTransitions.py
@@ -59,11 +59,6 @@ class BoundFreeCollisionalTransitions:
             lowerStateLevelVector, upperStateLevelVector
         )
 
-        print("\t\t ionizationEnergy: {:.4}".format(ionizationEnergy))
-        print("\t\t energyDifference: {:.4}".format(energyDifference))
-        print("\t\t U: {:.4}".format(U))
-        print("\t\t wFactor: {:.4}".format(BoundFreeCollisionalTransitions._wFactor(U, screenedCharge)))
-
         rate = 0
         # m^2 * (eV/(eV))^2 * 1/(eV/eV) * unitless * unitless / (m^2/1e6b) = 1e6b
         if U > 1:


### PR DESCRIPTION
several minor improvements in the FLYonPIC debug printing:
- remove debug prints in the FLYonPIC rate calculation reference
- make error message for wrong order of transitions in the atomic data import more helpful, now explicitly mentions that the ordering of the transitions is wrong
- print the multiplicity of each atomic state in the debug print of the atomic data
- explicitly label the debug print of a transition tuple as transition related
- print expected value and actual value in addition to relative error in FLYonPIC rate calculation unit test