### PR TITLE
add per charge state number of transitions to debug print of atomic data

### DIFF
--- a/include/picongpu/particles/atomicPhysics/debug/PrintAtomicDataToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/PrintAtomicDataToConsole.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Brian Marre
+/* Copyright 2024-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -32,16 +32,137 @@ namespace picongpu::particles::atomicPhysics::debug
 {
     namespace enums = picongpu::particles::atomicPhysics::enums;
 
-    /** debug only, write atomic data to console
+    /** debug only, get number of Transitions of given charge state
      *
-     * @attention must be called serially!
+     * @tparam T_up true =^= sum over upward transitions, false =^= sum over downward transitions
+     *
+     * @param numberAtomicStatesOfChargeState number of entries of the charge state's block of atomic states in the
+     * list of atomic states
+     * @param startIndexBlockAtomicStates first index of the charge state's block of atomic states in the list of
+     * atomic states
      */
-    template<typename T_AtomicData, bool T_printTransitionData, bool T_printInverseTransitions>
-    ALPAKA_FN_HOST std::unique_ptr<T_AtomicData> printAtomicDataToConsole(std::unique_ptr<T_AtomicData> atomicData)
+    template<bool T_up>
+    ALPAKA_FN_HOST uint32_t getNumberTransitionsOfChargeState(
+        uint32_t const numberAtomicStatesOfChargeState,
+        uint32_t const startIndexBlockAtomicStatesOfChargeState,
+        auto numberTransitionsBox)
     {
-        std::cout << std::endl << "**AtomicData DEBUG Output**" << std::endl;
+        uint32_t numberTransitions = 0u;
+        for(uint32_t state = 0u; state < numberAtomicStatesOfChargeState; state++)
+        {
+            uint32_t stateCollectionIndex = state + startIndexBlockAtomicStatesOfChargeState;
+            if constexpr(T_up)
+            {
+                numberTransitions += numberTransitionsBox.numberOfTransitionsUp(stateCollectionIndex);
+            }
+            else
+            {
+                numberTransitions += numberTransitionsBox.numberOfTransitionsDown(stateCollectionIndex);
+            }
+        }
+        return numberTransitions;
+    }
 
-        // process configuration
+    //! print header of chargeState Data
+    ALPAKA_FN_HOST inline void printChargeStateDataHeader()
+    {
+        std::cout << "ChargeState Data" << std::endl;
+        std::cout << "index : (E_ionization[eV], Z_screened[e]) [#AtomicStates, startIndexBlock], "
+                  << "b:[#TransitionsUp / #TransitionsDown], "
+                  << "f:[#TransitionsUp / #TransitionsDown], "
+                  << "a:[#TransitionsDown]" << std::endl;
+    }
+
+    //! print all data stored by charge state
+    template<typename T_AtomicData>
+    ALPAKA_FN_HOST void printByChargeStateStoredData(
+        uint8_t const chargeState,
+        auto chargeStateDataBox,
+        auto chargeStateOrgaBox)
+    {
+        if(chargeState == T_AtomicData::ConfigNumber::atomicNumber)
+        {
+            std::cout << "\t" << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << ":( "
+                      << "na" << ", " << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << " ) [ "
+                      << chargeStateOrgaBox.numberAtomicStates(T_AtomicData::ConfigNumber::atomicNumber) << ", "
+                      << chargeStateOrgaBox.startIndexBlockAtomicStates(T_AtomicData::ConfigNumber::atomicNumber)
+                      << " ], ";
+        }
+        else
+        {
+            std::cout << "\t" << static_cast<uint16_t>(chargeState) << ":( "
+                      << chargeStateDataBox.ionizationEnergy(chargeState) << ", "
+                      << chargeStateDataBox.screenedCharge(chargeState) << " ) [ "
+                      << chargeStateOrgaBox.numberAtomicStates(chargeState) << ", "
+                      << chargeStateOrgaBox.startIndexBlockAtomicStates(chargeState) << " ], ";
+        }
+    }
+
+    //! print header of atomic state data
+    ALPAKA_FN_HOST inline void printAtomicStateDataHeader()
+    {
+        std::cout << "AtomicState Data" << std::endl;
+        std::cout << "index : [ConfigNumber, chargeState, levelVector]: E_overGround, multiplicity, "
+                     "IPDIonizationState[index, chargeState, configNumber]"
+                  << std::endl;
+        std::cout << "\t b/f/a: [#TransitionsUp/]#TransitionsDown, [startIndexUp/]startIndexDown" << std::endl;
+    }
+
+    /** print the number of transitions of the charge state
+     *
+     * @param chargeState
+     * @param chargeStateOrgaBox host data box giving access to the organizational data of each charge state
+     * @param boundBoundNumberTransitionsBox host data box giving access to the number of up- and downward bound-bound
+     *  transitions of each atomic state
+     * @param boundFreeNumberTransitionsBox host data box giving access to the number of up- and downward bound-free
+     *  transitions of each atomic state
+     * @param autonomousNumberTransitionsBox host data box giving access to the number of downward autonomous
+     * transitions of each atomic state
+     */
+    ALPAKA_FN_HOST inline void printNumberOfTransitionsOfChargeState(
+        uint8_t const chargeState,
+        auto chargeStateOrgaBox,
+        auto boundBoundNumberTransitionsBox,
+        auto boundFreeNumberTransitionsBox,
+        auto autonomousNumberTransitionsBox)
+    {
+        uint32_t numberAtomicStatesOfChargeState = chargeStateOrgaBox.numberAtomicStates(chargeState);
+        uint32_t startIndexBlockOfChargeState = chargeStateOrgaBox.startIndexBlockAtomicStates(chargeState);
+
+        std::cout << "b:["
+                  << getNumberTransitionsOfChargeState<true>(
+                         numberAtomicStatesOfChargeState,
+                         startIndexBlockOfChargeState,
+                         boundBoundNumberTransitionsBox)
+                  << " / "
+                  << getNumberTransitionsOfChargeState<false>(
+                         numberAtomicStatesOfChargeState,
+                         startIndexBlockOfChargeState,
+                         boundBoundNumberTransitionsBox)
+                  << "], ";
+        std::cout << "f:["
+                  << getNumberTransitionsOfChargeState<true>(
+                         numberAtomicStatesOfChargeState,
+                         startIndexBlockOfChargeState,
+                         boundFreeNumberTransitionsBox)
+                  << " / "
+                  << getNumberTransitionsOfChargeState<false>(
+                         numberAtomicStatesOfChargeState,
+                         startIndexBlockOfChargeState,
+                         boundFreeNumberTransitionsBox)
+                  << "], ";
+        std::cout << "a:["
+                  << getNumberTransitionsOfChargeState<false>(
+                         numberAtomicStatesOfChargeState,
+                         startIndexBlockOfChargeState,
+                         autonomousNumberTransitionsBox)
+                  << "]";
+    }
+
+    //! print active process classes
+    template<typename T_AtomicData>
+    ALPAKA_FN_HOST void printProcessConfiguration()
+    {
         std::cout << "process configuration:" << std::endl;
         std::cout << "\t Electronic Excitation:    " << ((T_AtomicData::switchElectronicExcitation) ? "true" : "false")
                   << std::endl;
@@ -55,40 +176,51 @@ namespace picongpu::particles::atomicPhysics::debug
                   << std::endl;
         std::cout << "\t Field Ionization:         " << ((T_AtomicData::switchFieldIonization) ? "true" : "false")
                   << std::endl;
+    }
 
+    /** debug only, write atomic data to console
+     *
+     * @attention must be called serially!
+     */
+    template<typename T_AtomicData, bool T_printTransitionData, bool T_printInverseTransitions>
+    ALPAKA_FN_HOST std::unique_ptr<T_AtomicData> printAtomicDataToConsole(std::unique_ptr<T_AtomicData> atomicData)
+    {
+        std::cout << std::endl << "**AtomicData DEBUG Output**" << std::endl;
+
+        printProcessConfiguration<T_AtomicData>();
+
+        // basic numbers
         uint32_t const numberAtomicStates = atomicData->getNumberAtomicStates();
         uint32_t const numberBoundBoundTransitions = atomicData->getNumberBoundBoundTransitions();
         uint32_t const numberBoundFreeTransitions = atomicData->getNumberBoundFreeTransitions();
         uint32_t const numberAutonomousTransitions = atomicData->getNumberAutonomousTransitions();
 
-        // basic numbers
         std::cout << "Basic Statistics:" << std::endl;
         std::cout << "AtomicNumber: " << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << "(#s "
                   << numberAtomicStates << ", #b " << numberBoundBoundTransitions << ", #f "
                   << numberBoundFreeTransitions << ", #a " << numberAutonomousTransitions << ")" << std::endl;
 
-        // chargeState data
+        // chargeStates
         auto chargeStateDataBox = atomicData->template getChargeStateDataDataBox<true>(); // true: get hostDataBox
         auto chargeStateOrgaBox = atomicData->template getChargeStateOrgaDataBox<true>();
 
-        std::cout << "ChargeState Data" << std::endl;
-        std::cout << "index : (E_ionization[eV], Z_screened[e]) [#AtomicStates, startIndexBlock]" << std::endl;
-        for(uint8_t i = 0u; i < T_AtomicData::ConfigNumber::atomicNumber; i++)
+        auto boundBoundNumberTransitionsBox = atomicData->template getBoundBoundNumberTransitionsDataBox<true>();
+        auto boundFreeNumberTransitionsBox = atomicData->template getBoundFreeNumberTransitionsDataBox<true>();
+        auto autonomousNumberTransitionsBox = atomicData->template getAutonomousNumberTransitionsDataBox<true>();
+
+        printChargeStateDataHeader();
+        for(uint8_t chargeState = 0u; chargeState < (T_AtomicData::ConfigNumber::atomicNumber + 1u); chargeState++)
         {
-            std::cout << "\t" << static_cast<uint16_t>(i) << ":( " << chargeStateDataBox.ionizationEnergy(i) << ", "
-                      << chargeStateDataBox.screenedCharge(i) << " ) [ " << chargeStateOrgaBox.numberAtomicStates(i)
-                      << ", " << chargeStateOrgaBox.startIndexBlockAtomicStates(i) << " ]" << std::endl;
+            printByChargeStateStoredData<T_AtomicData>(chargeState, chargeStateDataBox, chargeStateOrgaBox);
+
+            printNumberOfTransitionsOfChargeState(
+                chargeState,
+                chargeStateOrgaBox,
+                boundBoundNumberTransitionsBox,
+                boundFreeNumberTransitionsBox,
+                autonomousNumberTransitionsBox);
+            std::cout << std::endl;
         }
-
-        //      completely ionized state
-        std::cout << "\t" << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << ":( "
-                  << "na"
-                  << ", "
-                  << "na"
-                  << " ) [ " << chargeStateOrgaBox.numberAtomicStates(T_AtomicData::ConfigNumber::atomicNumber) << ", "
-                  << chargeStateOrgaBox.startIndexBlockAtomicStates(T_AtomicData::ConfigNumber::atomicNumber) << " ]"
-                  << std::endl;
-
 
         // AtomicState data
         auto atomicStateDataBox = atomicData->template getAtomicStateDataDataBox<true>(); // true: get hostDataBox
@@ -98,20 +230,10 @@ namespace picongpu::particles::atomicPhysics::debug
         auto boundFreeStartIndexBox = atomicData->template getBoundFreeStartIndexBlockDataBox<true>();
         auto autonomousStartIndexBox = atomicData->template getAutonomousStartIndexBlockDataBox<true>();
 
-        auto boundBoundNumberTransitionsBox = atomicData->template getBoundBoundNumberTransitionsDataBox<true>();
-        auto boundFreeNumberTransitionsBox = atomicData->template getBoundFreeNumberTransitionsDataBox<true>();
-        auto autonomousNumberTransitionsBox = atomicData->template getAutonomousNumberTransitionsDataBox<true>();
-
         using S_ConfigNumber = stateRepresentation::
             ConfigNumber<uint64_t, T_AtomicData::ConfigNumber::numberLevels, T_AtomicData::ConfigNumber::atomicNumber>;
 
-        // state data
-        std::cout << "AtomicState Data" << std::endl;
-        std::cout << "index : [ConfigNumber, chargeState, levelVector]: E_overGround, multiplicity, "
-                     "IPDIonizationState[index, "
-                     "chargeState, configNumber]"
-                  << std::endl;
-        std::cout << "\t b/f/a: [#TransitionsUp/]#TransitionsDown, [startIndexUp/]startIndexDown" << std::endl;
+        printAtomicStateDataHeader();
         for(uint32_t stateCollectionIndex = 0u; stateCollectionIndex < numberAtomicStates; stateCollectionIndex++)
         {
             uint64_t const stateConfigNumber


### PR DESCRIPTION
Adds the per charge state number of transitions by direction and transition type to the debug atomic data print of FLYonPIC.

Only the last commit is part of this PR.
- [x] requires PR #5523 to be merged first
- [x] requires PR #5524 to be merged first
- [x] must be rebased to dev after PR #5523 and PR #5524 have been merged