### PR TITLE
per atomic state screened charge

### DIFF
--- a/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
+++ b/include/picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp
@@ -285,11 +285,10 @@ namespace picongpu::particles::atomicPhysics::atomicData
             std::list<S_ChargeStateTuple> chargeStateList{};
 
             TypeValue ionizationEnergy;
-            TypeValue screenedCharge;
             uint32_t chargeState;
             uint8_t numberChargeStates = 0u;
 
-            while(file >> chargeState >> ionizationEnergy >> screenedCharge)
+            while(file >> chargeState >> ionizationEnergy)
             {
                 if(chargeState == u32(T_ConfigNumber::atomicNumber))
                     throw std::runtime_error(
@@ -297,10 +296,8 @@ namespace picongpu::particles::atomicPhysics::atomicData
                         + " should not be included in input file for Z = "
                         + std::to_string(T_ConfigNumber::atomicNumber));
 
-                S_ChargeStateTuple item = std::make_tuple(
-                    u8(chargeState),
-                    ionizationEnergy, // [eV]
-                    screenedCharge); // [e]
+                S_ChargeStateTuple item = std::make_tuple(u8(chargeState),
+                                                          ionizationEnergy); // [eV]
 
                 chargeStateList.push_back(item);
 
@@ -334,12 +331,14 @@ namespace picongpu::particles::atomicPhysics::atomicData
 
             uint64_t stateConfigNumber;
             TypeValue energyOverGround;
+            TypeValue screenedCharge;
 
-            while(file >> stateConfigNumber >> energyOverGround)
+            while(file >> stateConfigNumber >> energyOverGround >> screenedCharge)
             {
                 S_AtomicStateTuple item = std::make_tuple(
                     static_cast<Idx>(stateConfigNumber), // unitless
-                    energyOverGround); // [eV]
+                    energyOverGround, // [eV]
+                    screenedCharge); // [e]
 
                 atomicStateList.push_back(item);
 

--- a/include/picongpu/particles/atomicPhysics/atomicData/AtomicTuples.def
+++ b/include/picongpu/particles/atomicPhysics/atomicData/AtomicTuples.def
@@ -31,13 +31,13 @@ namespace picongpu::particles::atomicPhysics::atomicData
     template<typename T_Value>
     using ChargeStateTuple = std::tuple<
         uint8_t, // charge state
-        T_Value, // ionization energy[eV]
-        T_Value>; // screened charge[e]
+        T_Value>; // ionization energy [eV]
 
     template<typename T_Value, typename T_Idx>
     using AtomicStateTuple = std::tuple<
         T_Idx, // configNumber
-        T_Value>; // energy over ground [eV]
+        T_Value, // energy over ground [eV]
+        T_Value>; // screenedCharge [e]
 
     template<typename T_Idx>
     using IPDIonizationStateTuple = std::tuple<

--- a/include/picongpu/particles/atomicPhysics/debug/PrintAtomicDataToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/PrintAtomicDataToConsole.hpp
@@ -67,7 +67,7 @@ namespace picongpu::particles::atomicPhysics::debug
     ALPAKA_FN_HOST inline void printChargeStateDataHeader()
     {
         std::cout << "ChargeState Data" << std::endl;
-        std::cout << "index : (E_ionization[eV], Z_screened[e]) [#AtomicStates, startIndexBlock], "
+        std::cout << "index : E_ionization[eV] [#AtomicStates, startIndexBlock], "
                   << "b:[#TransitionsUp / #TransitionsDown], "
                   << "f:[#TransitionsUp / #TransitionsDown], "
                   << "a:[#TransitionsDown]" << std::endl;
@@ -82,9 +82,10 @@ namespace picongpu::particles::atomicPhysics::debug
     {
         if(chargeState == T_AtomicData::ConfigNumber::atomicNumber)
         {
-            std::cout << "\t" << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << ":( "
-                      << "na" << ", " << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << " ) [ "
-                      << chargeStateOrgaBox.numberAtomicStates(T_AtomicData::ConfigNumber::atomicNumber) << ", "
+            std::cout << "\t" << static_cast<uint16_t>(T_AtomicData::ConfigNumber::atomicNumber) << ": "
+                      << "na"
+                      << " [ " << chargeStateOrgaBox.numberAtomicStates(T_AtomicData::ConfigNumber::atomicNumber)
+                      << ", "
                       << chargeStateOrgaBox.startIndexBlockAtomicStates(T_AtomicData::ConfigNumber::atomicNumber)
                       << " ], ";
         }
@@ -92,7 +93,6 @@ namespace picongpu::particles::atomicPhysics::debug
         {
             std::cout << "\t" << static_cast<uint16_t>(chargeState) << ":( "
                       << chargeStateDataBox.ionizationEnergy(chargeState) << ", "
-                      << chargeStateDataBox.screenedCharge(chargeState) << " ) [ "
                       << chargeStateOrgaBox.numberAtomicStates(chargeState) << ", "
                       << chargeStateOrgaBox.startIndexBlockAtomicStates(chargeState) << " ], ";
         }
@@ -102,7 +102,7 @@ namespace picongpu::particles::atomicPhysics::debug
     ALPAKA_FN_HOST inline void printAtomicStateDataHeader()
     {
         std::cout << "AtomicState Data" << std::endl;
-        std::cout << "index : [ConfigNumber, chargeState, levelVector]: E_overGround, multiplicity, "
+        std::cout << "index : [ConfigNumber, chargeState, levelVector]: E_overGround, screenedCharge, multiplicity, "
                      "IPDIonizationState[index, chargeState, configNumber]"
                   << std::endl;
         std::cout << "\t b/f/a: [#TransitionsUp/]#TransitionsDown, [startIndexUp/]startIndexDown" << std::endl;
@@ -250,7 +250,8 @@ namespace picongpu::particles::atomicPhysics::debug
             std::cout << "\t" << stateCollectionIndex << " : [" << stateConfigNumber << ", "
                       << static_cast<uint16_t>(S_ConfigNumber::getChargeState(stateConfigNumber)) << ", "
                       << precisionCast<uint16_t>(stateLevelVector).toString(",", "()")
-                      << "]: " << atomicStateDataBox.energy(stateCollectionIndex) << ", " << multiplicity << ",\t"
+                      << "]: " << atomicStateDataBox.energy(stateCollectionIndex) << ", "
+                      << atomicStateDataBox.screenedCharge(stateCollectionIndex) << ", " << multiplicity << ",\t"
                       << "[" << ipdIonizationStateCollectionIndex << ", "
                       << static_cast<uint16_t>(chargeStateIPDIonizationVector) << ", "
                       << precisionCast<uint16_t>(levelVectorIPDIonizationState).toString(",", "()") << "]"

--- a/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestRateCalculation.hpp
@@ -124,12 +124,12 @@ namespace picongpu::particles::atomicPhysics::debug
         {
             // charge states
             S_ChargeStateBox chargeStateHostBox = chargeStateBuffer->getHostDataBox();
-            //      ionizationEnergy = 100 eV, screened charge = 5 e
-            auto tupleChargeState_1 = std::make_tuple(u8(0u), 100._X, 5._X);
-            //      ionizationEnergy = 5 eV, screened charge = 5 e
-            auto tupleChargeState_2 = std::make_tuple(u8(1u), 5._X, 5._X);
-            //      ionizationEnergy = 100 eV, screened charge = 5 e
-            auto tupleChargeState_3 = std::make_tuple(u8(2u), 100._X, 5._X);
+            //      ionizationEnergy = 100 eV
+            auto tupleChargeState_1 = std::make_tuple(u8(0u), 100._X);
+            //      ionizationEnergy = 5 eV
+            auto tupleChargeState_2 = std::make_tuple(u8(1u), 5._X);
+            //      ionizationEnergy = 100 eV
+            auto tupleChargeState_3 = std::make_tuple(u8(2u), 100._X);
 
             chargeStateHostBox.store(u8(0u), tupleChargeState_1);
             chargeStateHostBox.store(u8(1u), tupleChargeState_2);
@@ -140,12 +140,12 @@ namespace picongpu::particles::atomicPhysics::debug
             /// atomic states, @attention caution all atomic state must differ in configNumber
             S_AtomicStateBox atomicStateHostBox = atomicStateBuffer->getHostDataBox();
 
-            // 1:(1,1,0,0,0,0,1,0,1,0) lowerStateBoundFree, exictationEnergy = 0 eV(ground state)
-            auto tupleAtomicState_bf_1 = std::make_tuple(static_cast<uint64_t>(243754u), 0._X);
-            // 2:(1,1,0,0,0,0,1,0,0,0) upperStateBoundFree, excitationEnergy = 5 eV
-            auto tupleAtomicState_bf_2 = std::make_tuple(static_cast<uint64_t>(9379u), 5._X);
-            // 3:(1,1,0,0,0,0,0,0,0,0) upperStateBoundFree, excitationEnergyDifference = 5 eV
-            auto tupleAtomicState_bf_3 = std::make_tuple(static_cast<uint64_t>(4u), 5._X);
+            // 1:(1,1,0,0,0,0,1,0,1,0) lowerStateBoundFree, exictationEnergy = 0 eV(ground state), screenedCharge 5
+            auto tupleAtomicState_bf_1 = std::make_tuple(static_cast<uint64_t>(243754u), 0._X, 5._X);
+            // 2:(1,1,0,0,0,0,1,0,0,0) upperStateBoundFree, excitationEnergy = 5 eV, screenedCharge 5
+            auto tupleAtomicState_bf_2 = std::make_tuple(static_cast<uint64_t>(9379u), 5._X, 5._X);
+            // 3:(1,1,0,0,0,0,0,0,0,0) upperStateBoundFree, excitationEnergyDifference = 5 eV, screenedCharge 5
+            auto tupleAtomicState_bf_3 = std::make_tuple(static_cast<uint64_t>(4u), 5._X, 5._X);
 
             /// @note states must be sorted primarily ascending by charge state, secondarily ascending by configNumber
             atomicStateHostBox.store(u8(1u), tupleAtomicState_bf_1);
@@ -153,9 +153,9 @@ namespace picongpu::particles::atomicPhysics::debug
             atomicStateHostBox.store(u8(4u), tupleAtomicState_bf_3);
 
             // 1:(1,0,2,0,0,0,1,0,0,0) lowerStateBoundBound
-            auto tupleAtomicState_bb_1 = std::make_tuple(static_cast<uint64_t>(9406u), 0._X);
+            auto tupleAtomicState_bb_1 = std::make_tuple(static_cast<uint64_t>(9406u), 0._X, 5._X);
             // 1:(1,0,1,0,0,0,1,0,1,0) upperStateBoundBound, energyDiffLowerUpper = 5 eV
-            auto tupleAtomicState_bb_2 = std::make_tuple(static_cast<uint64_t>(243766u), 5._X);
+            auto tupleAtomicState_bb_2 = std::make_tuple(static_cast<uint64_t>(243766u), 5._X, 5._X);
 
             /// @note states must be sorted primarily ascending by charge state, secondarily ascending by configNumber
             atomicStateHostBox.store(u8(0u), tupleAtomicState_bb_1);

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -173,8 +173,6 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             // fully ionized state has no pressure ionization state --> currentChargeState < T_atomicNumber
             uint8_t const currentChargeState
                 = T_AtomicStateDataBox::ConfigNumber::getChargeState(currentAtomicStateConfigNumber);
-            uint8_t const ipdIonizationStateChargeState = T_AtomicStateDataBox::ConfigNumber::getChargeState(
-                atomicStateBox.configNumber(ipdIonizationStateClctIdx));
 
             // eV
             float_X const ionizationEnergy = chargeStateBox.ionizationEnergy(currentChargeState)
@@ -195,7 +193,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 float_X const eFieldNormCell = pmacc::math::l2norm(eFieldCache(localCellIndex));
 
                 float_X const eFieldNormAU = sim.pic.conv().eField2auEField(eFieldNormCell);
-                float_X const screenedCharge = chargeStateBox.screenedCharge(currentChargeState);
+                float_X const screenedCharge = atomicStateBox.screenedCharge(currentAtomicStateClctIdx);
 
                 // eV
                 ipd += BarrierSupressionIonization::getIPD(screenedCharge, eFieldNormAU);
@@ -219,6 +217,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             {
                 /* we only update the atomic state since IPD-Ionization is not a regular transition and does not use
                  *   shared resources */
+
+                uint8_t const ipdIonizationStateChargeState = T_AtomicStateDataBox::ConfigNumber::getChargeState(
+                    atomicStateBox.configNumber(ipdIonizationStateClctIdx));
 
                 // update ion atomic state
                 SetAtomicState::hard(

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
@@ -131,8 +131,6 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             float_64 const combinatorialFactor
                 = static_cast<float_64>(boundFreeTransitionDataBox.multiplicity(transitionCollectionIndex));
 
-            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
-
             // eV
             float_X const energyDifference = picongpu::particles::atomicPhysics::DeltaEnergyTransition::get(
                 transitionCollectionIndex,
@@ -145,7 +143,10 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             {
                 uint32_t const upperStateClctIdx
                     = boundFreeTransitionDataBox.upperStateCollectionIndex(transitionCollectionIndex);
+
                 auto const upperStateConfigNumber = atomicStateDataBox.configNumber(upperStateClctIdx);
+                auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
+
                 if(S_ConfigNumber::getChargeState(upperStateConfigNumber)
                    < S_ConfigNumber::getChargeState(lowerStateConfigNumber))
                 {
@@ -177,10 +178,8 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
                 constexpr float_64 scalingConstant
                     = C * picongpu::PI * pmacc::math::cPow(a0, 2u) / 1e-22 * pmacc::math::cPow(E_R, 2u);
 
-                uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
-
                 // e
-                float_X const screenedCharge = chargeStateDataBox.screenedCharge(lowerStateChargeState) - 1._X;
+                float_X const screenedCharge = atomicStateDataBox.screenedCharge(lowerStateClctIdx) - 1._X;
 
                 // unitless
                 float_X const U = energyElectron / energyDifference;

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -48,7 +48,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
     {
     private:
         //! input required for calling rate formula
-        template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
+        template<typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
         struct RateFormulaVariables
         {
             // unitless
@@ -68,13 +68,11 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             HDINLINE RateFormulaVariables(
                 float_X const ionizationEnergy,
                 uint32_t const transitionCollectionIndex,
-                T_ChargeStateDataBox const chargeStateDataBox,
                 T_AtomicStateDataBox const atomicStateDataBox,
                 T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
             {
                 Z = BoundFreeFieldTransitionRates::screenedCharge(
                     transitionCollectionIndex,
-                    chargeStateDataBox,
                     atomicStateDataBox,
                     boundFreeTransitionDataBox);
 
@@ -103,21 +101,15 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
          *
          * @return unit: e
          */
-        template<typename T_ChargeStateDataBox, typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
+        template<typename T_AtomicStateDataBox, typename T_BoundFreeTransitionDataBox>
         HDINLINE static float_X screenedCharge(
             uint32_t const transitionCollectionIndex,
-            T_ChargeStateDataBox const chargeStateDataBox,
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
         {
             uint32_t const lowerStateClctIdx
                 = boundFreeTransitionDataBox.lowerStateCollectionIndex(transitionCollectionIndex);
-            auto const lowerStateConfigNumber = atomicStateDataBox.configNumber(lowerStateClctIdx);
-
-            using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
-            uint8_t const lowerStateChargeState = S_ConfigNumber::getChargeState(lowerStateConfigNumber);
-
-            return chargeStateDataBox.screenedCharge(lowerStateChargeState);
+            return atomicStateDataBox.screenedCharge(lowerStateClctIdx);
         }
 
         /** actual rate rateFormula
@@ -218,13 +210,11 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             if((ionizationEnergy <= 0) || !enoughFieldEnergy)
                 return static_cast<T_ReturnType>(0.);
 
-            auto const v
-                = RateFormulaVariables<T_ChargeStateDataBox, T_AtomicStateDataBox, T_BoundFreeTransitionDataBox>(
-                    ionizationEnergy,
-                    transitionCollectionIndex,
-                    chargeStateDataBox,
-                    atomicStateDataBox,
-                    boundFreeTransitionDataBox);
+            auto const v = RateFormulaVariables<T_AtomicStateDataBox, T_BoundFreeTransitionDataBox>(
+                ionizationEnergy,
+                transitionCollectionIndex,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox);
 
             // unit: atomicUnit_eField
             float_X const eFieldNorm_AU = sim.pic.conv().eField2auEField(eFieldNorm);
@@ -279,13 +269,11 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             if((ionizationEnergy <= 0) || !enoughFieldEnergy)
                 return static_cast<T_ReturnType>(0.);
 
-            auto const v
-                = RateFormulaVariables<T_ChargeStateDataBox, T_AtomicStateDataBox, T_BoundFreeTransitionDataBox>(
-                    ionizationEnergy,
-                    transitionCollectionIndex,
-                    chargeStateDataBox,
-                    atomicStateDataBox,
-                    boundFreeTransitionDataBox);
+            auto const v = RateFormulaVariables<T_AtomicStateDataBox, T_BoundFreeTransitionDataBox>(
+                ionizationEnergy,
+                transitionCollectionIndex,
+                atomicStateDataBox,
+                boundFreeTransitionDataBox);
 
             float_X const nEffCubed = pmacc::math::cPow(v.nEff, u32(3u));
             float_X const ZCubed = pmacc::math::cPow(v.Z, u32(3u));


### PR DESCRIPTION
Switches FLYonPIC from the per charge state- to a per atomic state- screened charge storage.
This allows a more detailed description of field-based and impact ionization processes.

**Attention: This PR requires new FLYonPIC input files!**

Only the last 3 commits are part of this PR.
- [x] requires the PR #5523 to be merged first
- [x] requires the PR #5524 to be merged first
- [x] requires the PR #5525 to be merged first
- [x] must be rebased to current dev once all required PRs are merged