### PR TITLE
charge state dependent ipd

### DIFF
--- a/include/picongpu/particles/atomicPhysics/FieldEnergy.hpp
+++ b/include/picongpu/particles/atomicPhysics/FieldEnergy.hpp
@@ -30,6 +30,8 @@ namespace picongpu::particles::atomicPhysics
 
         /** get field energy for the specified e Field strength
          *
+         * @attention requires the **square** of the e-field strength as input!
+         *
          * @param eFieldStrengthSquared, in ((unit_mass * unit_length)/(unit_time^2 * unit_charge))^2
          * @return unit: unit_energy
          */

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp
@@ -1,0 +1,40 @@
+/* Copyright 2025 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need simulation.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+
+namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
+{
+    // get IPD from IPD model
+    template<typename T_IPDModel, typename T_AtomicStateDataDataBox>
+    HDINLINE float_X getIPD(
+        T_AtomicStateDataDataBox atomicStateBox,
+        uint32_t const stateCollectionIndex,
+        typename T_IPDModel::SuperCellConstantInput const superCellConstantIPDInput)
+    {
+        auto const stateConfigNumber = atomicStateBox.configNumber(stateCollectionIndex);
+        uint8_t const stateChargeState = T_AtomicStateDataDataBox::ConfigNumber::getChargeState(stateConfigNumber);
+
+        // eV
+        return T_IPDModel::ipd(superCellConstantIPDInput, stateChargeState);
+    }
+} // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/IPDModel.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/IPDModel.hpp
@@ -27,8 +27,21 @@
 
 namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
 {
+    namespace detail
+    {
+        /** struct storing all input parameters for the ipd-model that are the same for every macro ion in the same
+         *  super cell
+         */
+        struct SuperCellConstantInput
+        {
+        };
+    } // namespace detail
+
     struct IPDModel
     {
+        //! a type storing all input for the ipd calculation that is the same for all macro ions of one super cell
+        using SuperCellConstantInput = detail::SuperCellConstantInput;
+
         //! create all HelperFields required by the IPD model
         HINLINE static void createHelperFields();
 
@@ -64,12 +77,21 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
         /** calculate ionization potential depression
          *
          * @param superCellFieldIdx index of superCell in superCellField(without guards)
-         * @param input to ipd calculation
+         * @param ipdInput data boxes giving access to super cell constant IPD input
+         */
+        template<typename... T_IPDInput>
+        HDINLINE static SuperCellConstantInput getSuperCellConstantInput(
+            pmacc::DataSpace<simDim> const superCellFieldIdx,
+            T_IPDInput... ipdInput);
+
+        /** calculate ionization potential depression
+         *
+         * @param superCellConstantInput struct storing the values of all super cell constant IPD input parameters
+         * @param chargeState charge state of the ion before ionization
          *
          * @return unit: eV, not weighted
          */
-        template<typename... T_Input>
-        HDINLINE static float_X calculateIPD(pmacc::DataSpace<simDim> const superCellFieldIdx, T_Input const... input);
+        HDINLINE static float_X ipd(SuperCellConstantInput const superCellConstantInput, uint8_t const chargeState);
 
         /** append ipd input to kernelInput and do a PMACC_LOCKSTEP_KERNEL call for T_kernel
          *

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/NoIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/NoIPD.hpp
@@ -30,14 +30,27 @@
 
 namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
 {
+    namespace detail
+    {
+        // the NoIPD model has no input, therefore the struct has no members
+        struct NoIPDSuperCellConstantInput
+        {
+        };
+    } // namespace detail
+
     struct NoIPD : IPDModel
     {
+        using SuperCellConstantInput = detail::NoIPDSuperCellConstantInput;
+
         //! create all HelperFields required by the IPD model
         HINLINE static void createHelperFields()
         {
         }
 
-        template<uint32_t T_numberAtomicPhysicsIonSpecies>
+        template<
+            uint32_t T_numberAtomicPhysicsIonSpecies,
+            typename T_IPDIonSpeciesList,
+            typename T_IPDElectronSpeciesList>
         HINLINE static void calculateIPDInput(picongpu::MappingDesc const mappingDesc)
         {
         }
@@ -48,8 +61,13 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
         {
         }
 
+        HDINLINE static SuperCellConstantInput getSuperCellConstantInput(pmacc::DataSpace<simDim> const)
+        {
+            return SuperCellConstantInput();
+        }
+
         //! @returns 0._X eV
-        HDINLINE static float_X calculateIPD()
+        HDINLINE static float_X ipd(SuperCellConstantInput const, uint8_t const)
         {
             return 0._X;
         }

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/PassIPDInputs.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/PassIPDInputs.hpp
@@ -30,26 +30,22 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
     struct PassIPDInputs
     {
         template<typename T_IPDModel, typename T_RNGFactory, typename T_ChargeStateDataBox, typename... T_IPDInput>
-        HDINLINE static float_X calculateIPD_RngFactory(
+        HDINLINE static typename T_IPDModel::SuperCellConstantInput getSuperCellConstantInput_RNGFactory(
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx,
             T_RNGFactory&,
-            T_ChargeStateDataBox chargeStateBox,
+            T_ChargeStateDataBox,
             T_IPDInput... ipdInput)
         {
-            return T_IPDModel::template calculateIPD<T_ChargeStateDataBox::atomicNumber>(
-                superCellFieldIdx,
-                ipdInput...);
+            return T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
         }
 
         template<typename T_IPDModel, typename T_ChargeStateDataBox, typename... T_IPDInput>
-        HDINLINE static float_X calculateIPD(
+        HDINLINE static typename T_IPDModel::SuperCellConstantInput getSuperCellConstantInput(
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx,
-            T_ChargeStateDataBox chargeStateBox,
+            T_ChargeStateDataBox,
             T_IPDInput... ipdInput)
         {
-            return T_IPDModel::template calculateIPD<T_ChargeStateDataBox::atomicNumber>(
-                superCellFieldIdx,
-                ipdInput...);
+            return T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
         }
 
         template<typename T_RNGFactory, typename... T_AddStuff>

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Brian Marre
+/* Copyright 2024-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -89,10 +89,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
+    template<typename T_IPDModel, typename T_fieldIonizationActive>
     struct KernelState
     {
-        // eV
-        float_X superCellConstantIPD;
+        typename T_IPDModel::SuperCellConstantInput superCellConstantIPDInput;
         uint32_t foundUnbound;
     };
 
@@ -120,10 +120,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_EFieldDataBox const,
             T_IPDInputBoxes const... ipdInputBoxes)
         {
-            // eV
-            kernelState.superCellConstantIPD = T_IPDModel::template calculateIPD<T_ChargeStateDataBox::atomicNumber>(
-                superCellFieldIndex,
-                ipdInputBoxes...);
+            kernelState.superCellConstantIPDInput
+                = T_IPDModel::getSuperCellConstantInput(superCellFieldIndex, ipdInputBoxes...);
             kernelState.foundUnbound = u32(false);
         }
     };
@@ -137,6 +135,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_Worker,
             typename T_EFieldCache,
             typename T_Ion,
+            typename T_KernelState,
             typename T_LocalTimeRemainingBox,
             typename T_FoundUnboundIonBox,
             typename T_AtomicStateDataBox,
@@ -147,7 +146,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         HDINLINE static T_Number getNumberNewParticles(
             T_Worker const& worker,
             T_Ion& ion,
-            KernelState& kernelState,
+            T_KernelState& kernelState,
             T_EFieldCache const& eFieldCache,
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
             T_LocalTimeRemainingBox const,
@@ -179,7 +178,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                                              - atomicStateBox.energy(currentAtomicStateClctIdx);
 
             // eV
-            float_X ipd = kernelState.superCellConstantIPD;
+            float_X ipd = T_IPDModel::ipd(kernelState.superCellConstantIPDInput, currentChargeState);
 
             if constexpr(T_fieldIonizationActive::value)
             {

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -140,7 +140,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                                                       ? sumChargeNumberSquared / sumChargeNumber
                                                       : 0._X;
 
-                    // eV / unit_energy
+                    // unit_energy / eV
                     constexpr float_X eV = sim.pic.get_eV();
 
                     /* unit: unit_energy * weight / typicalNumParticlesPerMacroParticle
@@ -151,8 +151,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                                                               ? sumTemperatureTerm / sumWeightAllNormalized
                                                               : 0._X;
 
-                    // (eV / unit_energy) * unit_energy = eV
-                    temperatureEnergyBox(superCellFieldIdx) = eV * temperatureEnergy_PIC;
+                    // unit_energy / (unit_energy/eV) = eV
+                    temperatureEnergyBox(superCellFieldIdx) = temperatureEnergy_PIC / eV;
 
                     /** @note in case simDim = DIM2, we assumes sim.pic.getCellSize().productOfComponents() =
                      * sim.pic.getCellSize().x() * sim.pic.getCellSize().z() * (system size)

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseInstantNonReversibleTransition.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseInstantNonReversibleTransition.kernel
@@ -31,6 +31,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 #include "picongpu/particles/atomicPhysics/kernel/UpdateIon.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
@@ -129,6 +130,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             PMACC_SMEM(worker, minEFieldNormSuperCell, typename T_EFieldDataBox::ValueType::type);
             // unit: unit_eField
             PMACC_SMEM(worker, maxEFieldNormSuperCell, typename T_EFieldDataBox::ValueType::type);
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
 
             // init shared memory
             //!@{
@@ -143,6 +145,13 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates>(worker);
             forEachAtomicState([&stateHasInstantNonReversibleTransition](uint32_t const stateCollectionIndex)
                                { stateHasInstantNonReversibleTransition[stateCollectionIndex] = false; });
+
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &ipdInput...]()
+                {
+                    superCellConstantIPDInput = T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
+                });
             worker.sync();
             //!@}
 
@@ -155,14 +164,9 @@ namespace picongpu::particles::atomicPhysics::kernel
                 });
             worker.sync();
 
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
-
             // mask states with maximum total loss rate below rate limit
             forEachAtomicState(
-                [&ionizationPotentialDepression,
+                [&superCellConstantIPDInput,
                  &minEFieldNormSuperCell,
                  &maxEFieldNormSuperCell,
                  &stateHasInstantNonReversibleTransition,
@@ -179,6 +183,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     uint32_t const numberTransitionsUp
                         = numberTransitionsBox.numberOfTransitionsUp(stateCollectionIndex);
                     uint32_t const offset = startIndexBox.startIndexBlockTransitionsUp(stateCollectionIndex);
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateBox,
+                            stateCollectionIndex,
+                            superCellConstantIPDInput);
 
                     // unit: 1/unit_time
                     float_64 sumRateTransitions = 0.0;
@@ -212,12 +223,12 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
 
-            bool foundInstantTransitionIon = false;
             // choose instant transition for each particle in state with total transition rate above limit
+            bool foundInstantTransitionIon = false;
             forEachLocalIonBoxEntry(
                 [&stateHasInstantNonReversibleTransition,
                  &foundInstantTransitionIon,
-                 &ionizationPotentialDepression,
+                 &superCellConstantIPDInput,
                  &eFieldCache,
                  &rngGeneratorFloat,
                  &numberTransitionsBox,
@@ -238,6 +249,13 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                     // unit: unit_eField
                     float_X const eFieldNormCell = pmacc::math::l2norm(eFieldCache(localCellIndex));
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateBox,
+                            stateCollectionIndex,
+                            superCellConstantIPDInput);
 
                     uint32_t const numberTransitions
                         = numberTransitionsBox.numberOfTransitionsUp(stateCollectionIndex);
@@ -266,7 +284,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                             chargeStateBox);
 
                         // 1/ unit_time
-                        auto transitionRate = 0.;
+                        float_64 transitionRate = 0.;
 
                         bool const enoughEnergyForTransition
                             = (weight * picongpu::sim.pic.conv().eV2Joule(ionizationEnergy) <= eFieldEnergy);
@@ -285,7 +303,7 @@ namespace picongpu::particles::atomicPhysics::kernel
 
                         if constexpr(picongpu::atomicPhysics::debug::kernel::chooseInstantTransition::
                                          CHECK_FOR_INFINITE_FIELD_IONIZATION_RATES)
-                            if(transitionRate < 0._X)
+                            if(transitionRate < 0.)
                                 printf(
                                     "atomicPhysics ERROR: encountered infinite transition rate in "
                                     "ChooseInstantTransition kernel");

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_CollisionalBoundFree.kernel
@@ -28,6 +28,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrderingFor.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
 
 #include <pmacc/memory/shared/Allocate.hpp>
@@ -161,10 +162,15 @@ namespace picongpu::particles::atomicPhysics::kernel
             PMACC_SMEM(worker, cachedHistogram, CachedHistogram<T_Histogram::numberBins>);
             cachedHistogram.fill(worker, electronHistogram, volumeScalingFactor);
 
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
+
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &ipdInput...]()
+                {
+                    superCellConstantIPDInput = T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
+                });
+            worker.sync();
 
             // check whether collisional bound-free transition and if yes, roll specific transition and bin
             forEachLocalIonBoxEntry(
@@ -176,7 +182,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                  &transitionDataBox,
                  &cachedHistogram,
                  &rateCache,
-                 &ionizationPotentialDepression](T_Worker const& worker, auto& ion)
+                 &superCellConstantIPDInput](T_Worker const& worker, auto& ion)
                 {
                     // debug
                     checkForInvalidChooseTransitionGroup(ion);
@@ -211,6 +217,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                         setNoChangeTransition(ion);
                         return;
                     }
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateDataDataBox,
+                            atomicStateCollectionIndex,
+                            superCellConstantIPDInput);
 
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)

--- a/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/ChooseTransition_FieldBoundFree.kernel
@@ -29,6 +29,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ChooseTransitionGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionDirection.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
 #include <pmacc/dimensions/DataSpace.hpp>
@@ -39,6 +40,7 @@
 #include <pmacc/memory/boxes/CachedBox.hpp>
 #include <pmacc/memory/boxes/DataBox.hpp>
 #include <pmacc/memory/boxes/SharedBox.hpp>
+#include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/static_assert.hpp>
 
@@ -131,15 +133,19 @@ namespace picongpu::particles::atomicPhysics::kernel
                 return;
 
             auto eFieldCache = EFieldCache::get<__COUNTER__>(worker, superCellIdx, eFieldBox);
+
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
+
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &ipdInput...]()
+                {
+                    superCellConstantIPDInput = T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
+                });
             worker.sync();
 
             auto rngGeneratorFloat = rngFactoryFloat(worker, superCellFieldIdx);
             auto& rateCache = rateCacheBox(superCellFieldIdx);
-
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
 
             forEachLocalIonBoxEntry(
                 [&](T_Worker const& worker, auto& ion)
@@ -184,6 +190,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                         setNoChangeTransition(ion);
                         return;
                     }
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateBox,
+                            atomicStateCollectionIndex,
+                            superCellConstantIPDInput);
 
                     float_X cumSum = 0._X;
                     for(uint32_t transitionID = 0u; transitionID < numberTransitions; ++transitionID)

--- a/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/FillRateCache_BoundFree.kernel
@@ -30,6 +30,7 @@
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/enums/TransitionOrdering.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp"
 
@@ -100,7 +101,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
-            float_X const ionizationPotentialDepression)
+            typename T_IPDModel::SuperCellConstantInput const& superCellConstantIPDInput)
         {
             auto forEachAtomicStateAndBin
                 = pmacc::lockstep::makeForEach<T_numberAtomicStates * T_numberBins, T_Worker>(worker);
@@ -124,7 +125,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                  &startIndexDataBox,
                  &numberTransitionsDataBox,
                  &boundFreeTransitionDataBox,
-                 &ionizationPotentialDepression](uint32_t const linearIdx)
+                 &superCellConstantIPDInput](uint32_t const linearIdx)
                 {
                     uint32_t const binIndex = linearIdx / T_numberAtomicStates;
                     uint32_t const atomicStateCollectionIndex = linearIdx % T_numberAtomicStates;
@@ -140,6 +141,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     float_X const energy = cachedHistogram.energy[binIndex];
                     float_X const binWidth = cachedHistogram.binWidth[binIndex];
                     float_X const density = cachedHistogram.density[binIndex];
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateDataDataBox,
+                            atomicStateCollectionIndex,
+                            superCellConstantIPDInput);
 
                     // 1/picongpu::sim.unit.time()
                     float_X sumRateTransitions = 0._X;
@@ -190,7 +198,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_AtomicStateStartIndexBox const startIndexDataBox,
             T_AtomicStateNumberTransitionsBox const numberTransitionsDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox,
-            float_X const ionizationPotentialDepression)
+            typename T_IPDModel::SuperCellConstantInput const& superCellConstantIPDInput)
         {
             // unit: unit_eField
             PMACC_SMEM(worker, minEFieldNormSuperCell, typename T_EFieldDataBox::ValueType::type);
@@ -208,7 +216,7 @@ namespace picongpu::particles::atomicPhysics::kernel
             // calculate maximum ADK field ionization rate for each atomic state
             auto forEachAtomicState = pmacc::lockstep::makeForEach<T_numberAtomicStates, T_Worker>(worker);
             forEachAtomicState(
-                [&ionizationPotentialDepression,
+                [&superCellConstantIPDInput,
                  &minEFieldNormSuperCell,
                  &maxEFieldNormSuperCell,
                  &rateCache,
@@ -225,6 +233,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     uint32_t const numberTransitionsUp
                         = numberTransitionsDataBox.numberOfTransitionsUp(atomicStateCollectionIndex);
                     uint32_t const offset = startIndexDataBox.startIndexBlockTransitionsUp(atomicStateCollectionIndex);
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateDataDataBox,
+                            atomicStateCollectionIndex,
+                            superCellConstantIPDInput);
 
                     // unit: 1/unit_time
                     float_X sumRateTransitions = 0._X;
@@ -344,10 +359,14 @@ namespace picongpu::particles::atomicPhysics::kernel
             if(timeRemaining <= 0._X)
                 return;
 
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &ipdInput...]()
+                {
+                    superCellConstantIPDInput = T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
+                });
+            worker.sync();
 
             auto& rateCache = rateCacheBox(superCellFieldIdx);
 
@@ -362,7 +381,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     startIndexDataBox,
                     numberTransitionsDataBox,
                     boundFreeTransitionDataBox,
-                    ionizationPotentialDepression);
+                    superCellConstantIPDInput);
 
             if constexpr(T_fieldIonization)
                 fillWithFieldIonization(
@@ -375,7 +394,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     startIndexDataBox,
                     numberTransitionsDataBox,
                     boundFreeTransitionDataBox,
-                    ionizationPotentialDepression);
+                    superCellConstantIPDInput);
         }
     };
 } // namespace picongpu::particles::atomicPhysics::kernel

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
@@ -28,8 +28,10 @@
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/PassIPDInputs.hpp"
 
+#include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 #include <pmacc/static_assert.hpp>
 
@@ -112,22 +114,28 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             // get histogram for current superCell
             [[maybe_unused]] Histogram& electronHistogram = electronHistogramDataBox(superCellFieldIdx);
-            // eV
-            [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;
 
-            /* field energy use is directly deposited to the field energy cache -> no need to calculate energy used
-             *  -> no need to calculate IPD for non collisional processClasses*/
-            if constexpr(isIonizing && isCollisional)
-                ionizationPotentialDepression
-                    = ionizationPotentialDepression::PassIPDInputs::template calculateIPD<T_IPDModel>(
-                        superCellFieldIdx,
-                        chargeStateBoxAndIPDInput...);
+            // eV
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
+
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &chargeStateBoxAndIPDInput...]()
+                {
+                    if constexpr(isIonizing && isCollisional)
+                    {
+                        superCellConstantIPDInput
+                            = ionizationPotentialDepression::PassIPDInputs::template getSuperCellConstantInput<
+                                T_IPDModel>(superCellFieldIdx, chargeStateBoxAndIPDInput...);
+                    }
+                });
+            worker.sync();
 
             forEachLocalIonBoxEntry(
-                [&ionizationPotentialDepression,
-                 &electronHistogram,
+                [&electronHistogram,
                  &atomicStateBox,
                  &transitionBox,
+                 &superCellConstantIPDInput,
                  &chargeStateBoxAndIPDInput...](T_Worker const& worker, auto& ion)
                 {
                     if constexpr(picongpu::atomicPhysics::debug::kernel::recordChanges::CHECK_FOR_ACCEPTANCE)
@@ -146,6 +154,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     [[maybe_unused]] float_X deltaEnergy = 0._X;
                     if constexpr(isCollisional && isIonizing)
                     {
+                        // eV
+                        float_X const ionizationPotentialDepression
+                            = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                                atomicStateBox,
+                                ion[atomicStateCollectionIndex_],
+                                superCellConstantIPDInput);
+
                         deltaEnergy = picongpu::particles::atomicPhysics::DeltaEnergyTransition::get(
                             transitionIndex,
                             atomicStateBox,

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
@@ -24,7 +24,9 @@
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 
+#include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
 #include <cstdint>
@@ -98,10 +100,14 @@ namespace picongpu::particles::atomicPhysics::kernel
             auto& electronHistogram = electronHistogramBox(superCellFieldIdx);
             auto& fieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
 
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &ipdInput...]()
+                {
+                    superCellConstantIPDInput = T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
+                });
+            worker.sync();
 
             forEachLocalIonBoxEntry(
                 [&](T_Worker const& worker, auto& ion)
@@ -136,6 +142,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                             = s_enums::IsProcess<s_enums::ProcessClassGroup::electricFieldBased>::check(processClass);
                         if(fieldUsingProcess)
                         {
+                            // eV
+                            float_X const ionizationPotentialDepression
+                                = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                                    atomicStateBox,
+                                    ion[atomicStateCollectionIndex_],
+                                    superCellConstantIPDInput);
+
                             // eV, weighted
                             float_X const energyUsed = DeltaEnergyTransition::get(
                                                            transitionCollectionIndex,

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedFieldEnergyUse.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedFieldEnergyUse.kernel
@@ -24,7 +24,9 @@
 #include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 
+#include <pmacc/memory/shared/Allocate.hpp>
 #include <pmacc/particles/algorithm/ForEach.hpp>
 
 #include <cstdint>
@@ -88,10 +90,14 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             auto& fieldEnergyUseCache = fieldEnergyUseCacheBox(superCellFieldIdx);
 
-            float_X const ionizationPotentialDepression
-                = T_IPDModel::template calculateIPD<T_ChargeStateDataDataBox::atomicNumber>(
-                    superCellFieldIdx,
-                    ipdInput...);
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
+            auto onlyMaster = lockstep::makeMaster(worker);
+            onlyMaster(
+                [&superCellConstantIPDInput, &superCellFieldIdx, &ipdInput...]()
+                {
+                    superCellConstantIPDInput = T_IPDModel::getSuperCellConstantInput(superCellFieldIdx, ipdInput...);
+                });
+            worker.sync();
 
             forEachLocalIonBoxEntry(
                 [&](T_Worker const& worker, auto& ion)
@@ -102,6 +108,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                     auto const weight = ion[weighting_];
                     uint32_t const linearCellIdx = ion[localCellIdx_];
                     uint32_t const transitionCollectionIndex = ion[transitionIndex_];
+
+                    // eV
+                    float_X const ionizationPotentialDepression
+                        = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                            atomicStateBox,
+                            ion[atomicStateCollectionIndex_],
+                            superCellConstantIPDInput);
 
                     // eV, weighted
                     float_X const energyUsed = DeltaEnergyTransition::get(

--- a/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/SpawnIonizationMacroElectrons.kernel
@@ -21,11 +21,13 @@
 
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
+#include "picongpu/particles/atomicPhysics/KernelIndexation.hpp"
 #include "picongpu/particles/atomicPhysics/debug/param.hpp"
 #include "picongpu/particles/atomicPhysics/enums/IsProcess.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/initElectrons/InitIonizationElectrons.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/GetIPD.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/PassIPDInputs.hpp"
 
 #include <pmacc/lockstep/ForEach.hpp>
@@ -125,11 +127,9 @@ namespace picongpu::particles::atomicPhysics::kernel
             constexpr uint32_t frameSize = T_IonBox::frameSize;
 
             pmacc::DataSpace<picongpu::simDim> const superCellIdx
-                = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
-            // atomicPhysics superCellFields have no guard, but areMapping includes a guard
-            //  -> must subtract guard to get correct superCellFieldIdx
+                = KernelIndexation::getSuperCellIndex(worker, areaMapping);
             pmacc::DataSpace<picongpu::simDim> const superCellFieldIdx
-                = superCellIdx - areaMapping.getGuardingSuperCells();
+                = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);
 
             auto forEachFrameSlot = pmacc::lockstep::makeForEach<frameSize, T_Worker>(worker);
             auto forEachFrameMaster = pmacc::lockstep::makeForEach<2u, T_Worker>(worker);
@@ -151,21 +151,19 @@ namespace picongpu::particles::atomicPhysics::kernel
 
             auto numberIonizationElectronsCtxArr = lockstep::makeVar<uint8_t>(forEachFrameSlot, u8(0u));
 
-            [[maybe_unused]] float_X ionizationPotentialDepression = 0._X;
-            if constexpr(T_ProcessClassGroup == s_enums::ProcessClassGroup::autonomousBased)
-                ionizationPotentialDepression
-                    = ionizationPotentialDepression::PassIPDInputs::template calculateIPD_RngFactory<T_IPDModel>(
-                        superCellFieldIdx,
-                        rngFactoryAndChargeStateBoxAndIPDInput...);
+            PMACC_SMEM(worker, superCellConstantIPDInput, typename T_IPDModel::SuperCellConstantInput);
 
             // init shared memory
             onlyMaster(
                 [&superCellIdx,
+                 &superCellFieldIdx,
                  &ionizationElectronBox,
                  &offsetLowFrame,
                  &spawnCounter,
                  &totalNumberMacroElectronsToSpawn,
-                 &electronFrameArray]()
+                 &electronFrameArray,
+                 &superCellConstantIPDInput,
+                 &rngFactoryAndChargeStateBoxAndIPDInput...]()
                 {
                     offsetLowFrame
                         = static_cast<int32_t>(ionizationElectronBox.getSuperCell(superCellIdx).getSizeLastFrame());
@@ -176,6 +174,15 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // might be nullptr if no electrons in superCell
                     electronFrameArray[u32(detail::Access::low)] = ionizationElectronBox.getLastFrame(superCellIdx);
                     electronFrameArray[u32(detail::Access::high)] = nullptr;
+
+                    if constexpr(T_ProcessClassGroup == s_enums::ProcessClassGroup::autonomousBased)
+                    {
+                        // get not state dependent input for IPD
+                        superCellConstantIPDInput = ionizationPotentialDepression::PassIPDInputs::
+                            template getSuperCellConstantInput_RNGFactory<T_IPDModel>(
+                                superCellFieldIdx,
+                                rngFactoryAndChargeStateBoxAndIPDInput...);
+                    }
                 });
             worker.sync();
 
@@ -296,7 +303,7 @@ namespace picongpu::particles::atomicPhysics::kernel
                     // try to init one electron for each logical worker
                     forEachFrameSlot(
                         [&worker,
-                         &ionizationPotentialDepression,
+                         &superCellConstantIPDInput,
                          &ionFrame,
                          &electronFrameArray,
                          &idGen,
@@ -357,6 +364,13 @@ namespace picongpu::particles::atomicPhysics::kernel
                             else if constexpr(T_ProcessClassGroup == s_enums::ProcessClassGroup::autonomousBased)
                             {
                                 auto const superCellLocalOffset = superCellIdx - areaMapping.getGuardingSuperCells();
+
+                                // eV
+                                float_X const ionizationPotentialDepression
+                                    = ionizationPotentialDepression::template getIPD<T_IPDModel>(
+                                        atomicStateBox,
+                                        ion[atomicStateCollectionIndex_],
+                                        superCellConstantIPDInput);
 
                                 initElectrons::InitIonizationElectron<s_enums::ProcessClass::autonomousIonization>{}(
                                     worker,

--- a/include/picongpu/particles/creation/ModuleConfig.hpp
+++ b/include/picongpu/particles/creation/ModuleConfig.hpp
@@ -59,7 +59,7 @@ namespace picongpu::particles::creation
         template<typename... T_KernelConfigOptions> typename T_SuperCellFilterFunctor,
         template<typename T_Number, typename... T_KernelConfigOptions> typename T_PredictorFunctor,
         template<typename... T_KernelConfigOptions> typename T_ParticlePairUpdateFunctor,
-        typename T_KernelStateType,
+        template<typename... T_KernelConfigOptions> typename T_KernelStateType,
         template<typename... T_KernelConfigOptions> typename T_InitKernelStateFunctor,
         template<uint32_t T_id, typename... T_KernelConfigOptions> typename T_InitCacheFunctor,
         template<typename... T_KernelConfigOptions> typename T_AdditionalDataIndexFunctor,
@@ -84,7 +84,8 @@ namespace picongpu::particles::creation
         template<typename... T_KernelConfigOptions>
         using ParticlePairUpdateFunctor = T_ParticlePairUpdateFunctor<T_KernelConfigOptions...>;
 
-        using KernelStateType = T_KernelStateType;
+        template<typename... T_KernelConfigOptions>
+        using KernelStateType = T_KernelStateType<T_KernelConfigOptions...>;
 
         template<typename... T_KernelConfigOptions>
         using AdditionalDataIndexFunctor = T_AdditionalDataIndexFunctor<T_KernelConfigOptions...>;

--- a/include/picongpu/particles/creation/SpawnFromSourceSpecies.kernel
+++ b/include/picongpu/particles/creation/SpawnFromSourceSpecies.kernel
@@ -155,7 +155,10 @@ namespace picongpu::particles::creation
             PMACC_SMEM(worker, productSpeciesFrameArray, FrameArray);
 
             // create shared memory variable for kernel state
-            PMACC_SMEM(worker, sharedKernelState, typename Modules::KernelStateType);
+            PMACC_SMEM(
+                worker,
+                sharedKernelState,
+                typename Modules::template KernelStateType<T_KernelConfigOptions...>);
 
             // create cache
             auto cache = Modules::template InitCacheFunctor<__COUNTER__, T_KernelConfigOptions...>::getCache(

--- a/include/picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp
+++ b/include/picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp
@@ -24,6 +24,7 @@
 #include "picongpu/particles/creation/moduleInterfaces/AdditionalDataIndexFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/InitCacheFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/InitKernelStateFunctor.hpp"
+#include "picongpu/particles/creation/moduleInterfaces/KernelStateType.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/ParticlePairUpdateFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/PredictorFunctor.hpp"
 #include "picongpu/particles/creation/moduleInterfaces/SanityCheckInputs.hpp"

--- a/include/picongpu/particles/creation/moduleInterfaces/KernelStateType.hpp
+++ b/include/picongpu/particles/creation/moduleInterfaces/KernelStateType.hpp
@@ -1,0 +1,33 @@
+/* Copyright 2024-2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software you can redistribute it and or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+
+namespace picongpu::particles::creation::moduleInterfaces
+{
+    /** interface of KernelState type
+     *
+     * The particle creation kernel has a between threads shared state in shared memory.
+     * This shared state is defined by this struct, which is initialized by the InitKernelStateFunctor
+     */
+    template<typename... T_KernelConfigOptions>
+    struct KernelStateType;
+} // namespace picongpu::particles::creation::moduleInterfaces


### PR DESCRIPTION
- switch FLYonPIC to a charge state dependent IPD calculation
- fix a bracket error in the Stewart-Pyatt IPD equation
- fix a unit conversion error in the Stewart-Pyatt IPD implementation.
- fix the NoIPD interface

Requirements:
- [x] requires the PR #5523 to be merged first
- [x] requires the PR #5524 to be merged first
- [x] requires the PR #5525 to be merged first
- [x] requires the PR #5528 to be merged first
- [x] needs to be rebased to the current dev after all required PRs have been merged