### PR TITLE
minor improvements in the FLYonPIC debug printing and dumping of ions.

### DIFF
--- a/include/picongpu/particles/atomicPhysics/debug/PrintAtomicPhysicsIonToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/PrintAtomicPhysicsIonToConsole.hpp
@@ -40,6 +40,7 @@ namespace picongpu::particles::atomicPhysics::debug
         {
             std::cout << "ID: " << ion[particleId_] << std::endl;
             std::cout << "\t - weighting: " << ion[weighting_] << std::endl;
+            std::cout << "\t - mask: " << ((ion[multiMask_]) ? "true" : "false") << std::endl;
 
             std::cout << "\t - momentum: (" << ion[momentum_].toString(",", "") << ")" << std::endl;
             std::cout << "\t - position: (" << ion[position_].toString(",", "") << ")" << std::endl;

--- a/include/picongpu/particles/atomicPhysics/debug/kernel/DumpAllIonsToConsole.kernel
+++ b/include/picongpu/particles/atomicPhysics/debug/kernel/DumpAllIonsToConsole.kernel
@@ -29,7 +29,7 @@
 
 #include <cstdint>
 
-namespace picongpu::particles::atomicPhysics::kernel
+namespace picongpu::particles::atomicPhysics::debug::kernel
 {
     /** debug kernel
      *
@@ -37,6 +37,7 @@ namespace picongpu::particles::atomicPhysics::kernel
      *
      * @attention only useful in serial and cpu-build!
      */
+    template<typename T_ParticleFilter>
     struct DumpAllIonsToConsoleKernel
     {
         /** call operator
@@ -63,8 +64,23 @@ namespace picongpu::particles::atomicPhysics::kernel
             forEachLocalIonBoxEntry(
                 [](T_Worker const& worker, auto& ion)
                 {
-                    picongpu::particles::atomicPhysics::debug::PrintAtomicPhysicsIonToConsole{}(worker.getAcc(), ion);
+                    if(T_ParticleFilter::check(ion))
+                        picongpu::particles::atomicPhysics::debug::PrintAtomicPhysicsIonToConsole{}(
+                            worker.getAcc(),
+                            ion);
                 });
         }
     };
-} // namespace picongpu::particles::atomicPhysics::kernel
+
+    template<uint32_t T_atomicStateCollectionIndex>
+    struct WithAtomicState
+    {
+        template<typename T_Ion>
+        HDINLINE static bool check(T_Ion ion)
+        {
+            if(ion[atomicStateCollectionIndex_] == T_atomicStateCollectionIndex)
+                return true;
+            return false;
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::debug::kernel

--- a/include/picongpu/particles/atomicPhysics/debug/stage/DumpAllIonsToConsole.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/stage/DumpAllIonsToConsole.hpp
@@ -33,7 +33,7 @@
 
 #include <cstdint>
 
-namespace picongpu::particles::atomicPhysics::stage
+namespace picongpu::particles::atomicPhysics::debug::stage
 {
     /** @class atomicPhysics sub-stage dumping all macro ion atomicPhysics data for a species to console
      * calls the corresponding kernel per superCell
@@ -43,7 +43,7 @@ namespace picongpu::particles::atomicPhysics::stage
      *
      * @tparam T_ElectronSpecies species for which to call the functor
      */
-    template<typename T_Species>
+    template<typename T_Species, typename T_ParticleFilter>
     struct DumpAllIonsToConsole
     {
         // might be alias, from here on out no more
@@ -61,11 +61,12 @@ namespace picongpu::particles::atomicPhysics::stage
             // init pointer to macro particles
             auto& particles = *dc.get<Species>(Species::FrameType::getName());
 
-            using DumpToConsole = picongpu::particles::atomicPhysics::kernel::DumpAllIonsToConsoleKernel;
+            using DumpToConsole
+                = picongpu::particles::atomicPhysics::debug::kernel::DumpAllIonsToConsoleKernel<T_ParticleFilter>;
 
             // macro for call of kernel on every superCell, see pull request #4321
             PMACC_LOCKSTEP_KERNEL(DumpToConsole())
                 .config(mapper.getGridDim(), particles)(mapper, particles.getDeviceParticlesBox());
         }
     };
-} // namespace picongpu::particles::atomicPhysics::stage
+} // namespace picongpu::particles::atomicPhysics::debug::stage


### PR DESCRIPTION
- adds the mask to the atomic physics debug print
- adds filters to the debug dump of all ions

only the last 2 commits are part of this PR,
- [x] requires #5529 to be merged first
- [x] requires #5530 to be merged first
- [x] needs to be rebased after both PR have been merged