### PR TITLE
fix skipped apply ipd ionization at end of FLYonPIC loop

### DIFF
--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Brian Marre
+/* Copyright 2024-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -198,13 +198,15 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
          *
          * @attention collective over all ion species
          */
-        template<typename T_AtomicPhysicsIonSpeciesList>
+        template<typename T_AtomicPhysicsIonSpeciesList, bool T_SkipFinishedSuperCell>
         HINLINE static void applyIPDIonization(picongpu::MappingDesc const mappingDesc, uint32_t const)
         {
             using ForEachIonSpeciesApplyIPDIonization = pmacc::meta::ForEach<
                 T_AtomicPhysicsIonSpeciesList,
-                s_IPD::stage::ApplyIPDIonization<boost::mpl::_1, StewartPyattIPD<T_TemperatureFunctor>>>;
-
+                s_IPD::stage::ApplyIPDIonization<
+                    boost::mpl::_1,
+                    StewartPyattIPD<T_TemperatureFunctor>,
+                    std::integral_constant<bool, T_SkipFinishedSuperCell>>>;
             ForEachIonSpeciesApplyIPDIonization{}(mappingDesc);
         };
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -198,21 +198,21 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 ipd += BarrierSupressionIonization::getIPD(screenedCharge, eFieldNormAU);
             }
 
-            bool const stateIsUnbound = ((ionizationEnergy - ipd) <= 0._X);
-            bool const stateIsGenerallyUnbound = (ionizationEnergy <= 0._X);
 
-            /** @details states that are unbound without an IPD contribution must relax via auto-ionization, electronic
-             *  collisional ionization or deexcitation channels in the regular rate solver since IPD lacks the energy
-             *  for ionization.
+            bool const stateIsUnbound = ((ionizationEnergy - ipd) <= 0._X);
+
+            /** @details states that are unbound without an IPD contribution should have option to relax via
+             *  auto-ionization, electronic collisional ionization or deexcitation channels in the regular rate solver
+             *  since IPD lacks the energy for ionization.
              *
-             *  These states are typically low shell hole states, IPD-Ionization will not relax these states until
-             *  very high charge states, causing:
+             *  This is currently not possible since IPD-ionization is instantaneous, this can create problems for low
+             *  shell hole states, IPD-Ionization will not relax these states until very high charge states, causing:
              *  - numerical energy creation as the IPD actually lacks the energy required for ionization
              *  - instant ionization cascades, which are not consistent with the IPD equilibrium description
              *
              * @todo improve by developing a non equlibirium IPD description, Brian Marre, 2025
              */
-            if(!stateIsGenerallyUnbound && stateIsUnbound)
+            if(stateIsUnbound)
             {
                 /* we only update the atomic state since IPD-Ionization is not a regular transition and does not use
                  *   shared resources */
@@ -271,10 +271,14 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         }
     };
 
+    ///@todo switch to 2 body collision for IPD ionization to ensure energy conservation,
+    ///     even from highly excited states, Brian Marre, 2025
+
     //! moduleConfig of the ApplyIPDIonizationKernel
+    template<template<typename... T_KernelOptions> typename T_SkipSuperCellFunctor>
     using ApplyIPDIonizationModulConfig = particles::creation::ModuleConfig<
         ApplyIPDIonizationSanityCheckInputs,
-        spawnFromSourceSpeciesModules::SkipFinishedSuperCellsAtomicPhysics,
+        T_SkipSuperCellFunctor,
         IPDIonizationPredictor,
         spawnFromSourceSpeciesModules::InitAsCoMoving,
         KernelState,
@@ -284,11 +288,14 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
         WriteFoundUnboundToSuperCellField>;
 
     //! actual definition of ApplyIPDIonizationKernel
-    template<typename T_IPDModel, typename T_fieldIonizationActive>
+    template<
+        template<typename... T_KernelOptions> typename T_SkipSuperCellFunctor,
+        typename T_IPDModel,
+        typename T_fieldIonizationActive>
     using ApplyIPDIonizationKernel = picongpu::particles::creation::SpawnFromSourceSpeciesKernelFramework<
         // T_TypeNumber
         uint8_t,
-        ApplyIPDIonizationModulConfig,
+        ApplyIPDIonizationModulConfig<T_SkipSuperCellFunctor>,
         T_IPDModel,
         T_fieldIonizationActive>;
 } // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::kernel

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.def
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.def
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Brian Marre
+/* Copyright 2024-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *
@@ -31,9 +31,13 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
      *
      * @todo implement version for non atomicPhysics data species
      *
-     * @tparam ion species with atomic data
+     * @tparam T_IonSpecies species with atomic data to apply IPD to
+     * @tparam T_IPDModel ionization potential depression model to use
+     * @tparam T_SkipFinishedSuperCell std::integral wrapped boolean,
+     *  true =^= skip finished super cells in the applyIPDIonization check
+     *  false =^= **do not** skip finished super cells in the applyIPDIonization check
      */
-    template<typename T_IonSpecies, typename T_IPDModel>
+    template<typename T_IonSpecies, typename T_IPDModel, typename T_SkipFinishedSuperCell>
     struct ApplyIPDIonization
     {
         //! call of kernel for every superCell

--- a/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/NeverSkipSuperCells.hpp
+++ b/include/picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/NeverSkipSuperCells.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2025-2025 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// need unit.param for normalisation and units, memory.param for SuperCellSize and dim.param for simDim
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/creation/SpawnFromSourceSpeciesModuleInterfaces.hpp"
+
+#include <pmacc/dimensions/DataSpace.hpp>
+
+namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules
+{
+    namespace s_interfaces = picongpu::particles::creation::moduleInterfaces;
+
+    //! test for local time remaining <= 0 for superCell
+    template<typename... T_KernelConfigOptions>
+    struct NeverSkipSuperCells : public s_interfaces::SuperCellFilterFunctor<T_KernelConfigOptions...>
+    {
+        template<typename... T_AdditionalStuff>
+        HDINLINE static bool skipSuperCell(
+            pmacc::DataSpace<picongpu::simDim> const,
+            pmacc::DataSpace<picongpu::simDim> const superCellFieldIndex,
+            T_AdditionalStuff const...)
+        {
+            return false;
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::spawnFromSourceSpeciesModules

--- a/include/picongpu/particles/creation/SpawnFromSourceSpecies.kernel
+++ b/include/picongpu/particles/creation/SpawnFromSourceSpecies.kernel
@@ -113,7 +113,6 @@ namespace picongpu::particles::creation
             using SourceSpeciesFramePtr = typename T_SourceParticleBox::FramePtr;
             using ProductSpeciesFramePtr = typename T_ProductParticleBox::FramePtr;
 
-            // get frame size
             PMACC_CASSERT_MSG(
                 sourceSpecies_framesize_must_less_or_equal_productSpecies_framesize,
                 T_SourceParticleBox::frameSize == T_ProductParticleBox::frameSize);
@@ -123,7 +122,7 @@ namespace picongpu::particles::creation
             pmacc::DataSpace<picongpu::simDim> const superCellIndex
                 = areaMapping.getSuperCellIndex(worker.blockDomIdxND());
 
-            // renaming necessary for compiler unknown reasons
+            // renaming necessary for compiler, unknown reasons
             using IndexFunctor = typename Modules::template AdditionalDataIndexFunctor<T_KernelConfigOptions...>;
             auto const additionalDataIndex = IndexFunctor::getIndex(areaMapping, superCellIndex);
 
@@ -139,7 +138,6 @@ namespace picongpu::particles::creation
                     std::forward<T_AdditionalData>(additonalData)...);
             bool const noParticlesInSuperCell = !sourceSpeciesFrame.isValid();
 
-            // test for skipping superCell due to no sourceSpecies particles or SkipSuperCell == true
             if(skipSuperCell || noParticlesInSuperCell)
                 return;
 


### PR DESCRIPTION
Adds the ability to configure wether the applyIPD-Ionization sub-stage skips finished super cells. This fixes a bug where IPD-ionization was never applied at the end of the FLYonPIC stage.

Also removes the limitation of applying IPD only to states not ionized without any IPD.

only the last 2 commits are part of this PR

- [x] requires #5529 to be merged first
- [x] requires #5530 to be merged first
- [x] requires #5535 to be merged first
- [x] needs to be rebased after required PRs are merged