### PR TITLE
make bp5 default

### DIFF
--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -46,16 +46,7 @@ class Binning(Plugin):
     _name = "binning"
 
     def __init__(
-        self,
-        name,
-        deposition_functor,
-        axes,
-        species,
-        period,
-        openPMD,
-        openPMDExt,
-        openPMDInfix,
-        dumpPeriod,
+        self, name, deposition_functor, axes, species, period, openPMD, openPMDInfix, dumpPeriod, openPMDExt="bp5"
     ):
         self.name = name
         self.deposition_functor = deposition_functor
@@ -63,9 +54,9 @@ class Binning(Plugin):
         self.species = species
         self.period = period
         self.openPMD = openPMD
-        self.openPMDExt = openPMDExt
         self.openPMDInfix = openPMDInfix
         self.dumpPeriod = dumpPeriod
+        self.openPMDExt = openPMDExt
 
     def _get_serialized(self) -> dict:
         return {

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -23,7 +23,7 @@ from picongpu.pypicongpu.species.species import Species
 class OpenPMDConfig(BaseModel):
     file: PathLike | str
     infix: str = "_%06T"
-    ext: Annotated[str, AfterValidator(lambda s: s.strip("."))] = "h5"
+    ext: Annotated[str, AfterValidator(lambda s: s.strip("."))] = "bp5"
     backend_config: PathLike | None = None
     data_preparation_strategy: Literal["mappedMemory", "doubleBuffer"] = "mappedMemory"
     range: None = None


### PR DESCRIPTION
Fix #5538

This PR makes bp5 the default backend for 
 - openPMD
 - binning
 
 if you are using PICMI. 
 
@franzpoeschel Is setting `bp5` as backend enough?
@chillenzer I am a bit confused, where the binning plugin takes its default values for e.g. `openPMDExt` or `openPMDInfix` from. Changing those would be a better solution than mine.  