### PR TITLE
Switch to using IPD ionization states for unbound evaluation

### DIFF
--- a/include/picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp
+++ b/include/picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp
@@ -78,7 +78,10 @@ namespace picongpu::particles::atomicPhysics
     public:
         /** ionizationEnergy from lowerState- to upperState- chargeState
          *
+         * @param lowerStateChargeState
+         * @param upperStateChargeState
          * @param ionizationPotentialDepression, in eV
+         * @param chargeStateDataBox
          *
          * @return unit: eV
          */

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/ApplyIPDIonization.kernel
@@ -31,8 +31,10 @@
 #pragma once
 
 #include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
 #include "picongpu/particles/atomicPhysics/SetAtomicState.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ProcessClass.hpp"
+#include "picongpu/particles/atomicPhysics/enums/ProcessClassGroup.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/BarrierSupressionIonization.hpp"
 #include "picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/CacheEFieldForSuperCell.hpp"
 #include "picongpu/particles/atomicPhysics/spawnFromSourceSpeciesModules/InitAsCoMoving.hpp"
@@ -174,10 +176,6 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 = T_AtomicStateDataBox::ConfigNumber::getChargeState(currentAtomicStateConfigNumber);
 
             // eV
-            float_X const ionizationEnergy = chargeStateBox.ionizationEnergy(currentChargeState)
-                                             - atomicStateBox.energy(currentAtomicStateClctIdx);
-
-            // eV
             float_X ipd = T_IPDModel::ipd(kernelState.superCellConstantIPDInput, currentChargeState);
 
             if constexpr(T_fieldIonizationActive::value)
@@ -198,8 +196,20 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                 ipd += BarrierSupressionIonization::getIPD(screenedCharge, eFieldNormAU);
             }
 
+            auto const ipdIonizationStateConfigNumber = atomicStateBox.configNumber(ipdIonizationStateClctIdx);
+            uint8_t const ipdIonizationStateChargeState
+                = T_AtomicStateDataBox::ConfigNumber::getChargeState(ipdIonizationStateConfigNumber);
 
-            bool const stateIsUnbound = ((ionizationEnergy - ipd) <= 0._X);
+            ///@details need to do by hand since IPD-Ionization does not always follow a defined transition
+            // eV
+            float_X const ionizationEnergyToIPDIonizationState
+                = DeltaEnergyTransition::template ionizationEnergy<
+                      s_enums::ProcessClassGroup::boundFreeBased,
+                      float_X>(currentChargeState, ipdIonizationStateChargeState, ipd, chargeStateBox)
+                  + atomicStateBox.energy(ipdIonizationStateClctIdx)
+                  - atomicStateBox.energy(currentAtomicStateClctIdx);
+
+            bool const stateIsUnbound = (ionizationEnergyToIPDIonizationState <= 0._X);
 
             /** @details states that are unbound without an IPD contribution should have option to relax via
              *  auto-ionization, electronic collisional ionization or deexcitation channels in the regular rate solver

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
@@ -219,7 +219,7 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             // check whether electron has enough kinetic energy
             if constexpr(T_excitation)
             {
-                // transition physical impossible, insufficient electron energy
+                // transition physically impossible, insufficient electron energy
                 if(energyDifference > energyElectron)
                 {
                     return 0._X;


### PR DESCRIPTION
switches to using the actual IPD ionization state, instead of the ground state of the next charge state, in the unbound check

only the last commit is part of this PR.

- [x] requires PR  #5530 to be merged first
- [x] requires PR  #5535 to be merged first
- [x] requires PR  #5536 to be merged first
- [x] must be rebased after the required PRs are merged