### PR TITLE
Implement second ipd branch from scfly

### DIFF
--- a/include/picongpu/particles/atomicPhysics/IPDModel.param
+++ b/include/picongpu/particles/atomicPhysics/IPDModel.param
@@ -26,7 +26,15 @@
 
 namespace picongpu::atomicPhysics
 {
+    /** switch for Stewart-Pyatt ionization potential depression model
+     *
+     * true =^= use minimum of additional scfly term and Stewart-Pyatt ionization potential depression,
+     * false =^= use Stewart-Pyatt ionization potential depression directly
+     */
+    constexpr bool useSCFLYextendedStewartPyattIPD = true;
+
     //! configuration of used ionization potential depression Model
     using IPDModel = picongpu::particles::atomicPhysics::ionizationPotentialDepression::StewartPyattIPD<
-        picongpu::particles::atomicPhysics::ionizationPotentialDepression::RelativisticTemperatureFunctor>;
+        picongpu::particles::atomicPhysics::ionizationPotentialDepression::RelativisticTemperatureFunctor,
+        useSCFLYextendedStewartPyattIPD>;
 } // namespace picongpu::atomicPhysics

--- a/include/picongpu/particles/atomicPhysics/debug/TestIonizationPotentialDepression.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestIonizationPotentialDepression.hpp
@@ -73,7 +73,7 @@ namespace picongpu::particles::atomicPhysics::debug
                 static_cast<float_X>(temperatureTimesk_Boltzman),
                 static_cast<float_X>(debyeLength),
                 static_cast<float_X>(zStar),
-                static_cast<float_X>(electronDensity / (sim.unit.length() * sim.unit.length() * sim.unit.length()))};
+                static_cast<float_X>(electronDensity * (sim.unit.length() * sim.unit.length() * sim.unit.length()))};
 
             // eV
             float_64 const ipd = static_cast<float_X>(StewartPyattIPD::ipd(superCellConstantInput, chargeState));

--- a/include/picongpu/particles/atomicPhysics/debug/TestIonizationPotentialDepression.hpp
+++ b/include/picongpu/particles/atomicPhysics/debug/TestIonizationPotentialDepression.hpp
@@ -66,12 +66,14 @@ namespace picongpu::particles::atomicPhysics::debug
             float_64 const correctIPDValue = 6.306390823271927;
 
             using StewartPyattIPD = particles::atomicPhysics::ionizationPotentialDepression::template StewartPyattIPD<
-                particles::atomicPhysics::ionizationPotentialDepression::RelativisticTemperatureFunctor>;
+                particles::atomicPhysics::ionizationPotentialDepression::RelativisticTemperatureFunctor,
+                false>;
 
             auto const superCellConstantInput = StewartPyattIPD::SuperCellConstantInput{
                 static_cast<float_X>(temperatureTimesk_Boltzman),
                 static_cast<float_X>(debyeLength),
-                static_cast<float_X>(zStar)};
+                static_cast<float_X>(zStar),
+                static_cast<float_X>(electronDensity / (sim.unit.length() * sim.unit.length() * sim.unit.length()))};
 
             // eV
             float_64 const ipd = static_cast<float_X>(StewartPyattIPD::ipd(superCellConstantInput, chargeState));

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/LocalIPDInputFields.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/LocalIPDInputFields.hpp
@@ -28,5 +28,6 @@
 #pragma once
 
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/DebyeLengthField.hpp"
+#include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/FreeElectronDensityField.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/TemperatureEnergyField.hpp"
 #include "picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/ZStarField.hpp"

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/StewartPyattIPD.hpp
@@ -110,7 +110,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
      *    3 * (zStar + 1) * K
      * use the definition of K and and identify the remaining factors as a power of the ion sphere radius,
      *    3 * (zStar+1) * K = ionSphereRadius^3 / lambda_Debye^3
-     * then substitute the resulting expression back into equation (5) of Stewart-Pyatt, which gives the termused in
+     * then substitute the resulting expression back into equation (5) of Stewart-Pyatt, which gives the term used in
      * the SCFLY implementation,
      * https://github.com/ComputationalRadiationPhysics/scfly/blob/5d9b0a997bb6688b04e1a34a7fa8db0f2657106a/code/src/scdrv.f#L3537-L3538
      *

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -180,11 +180,11 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                      * unit:  sqrt(unit_length^2 / unit_energy / typicalNumParticlesPerMacroParticle
                      *  * unit_energy / (1/typicalNumParticlesPerMacroParticle)) = unit_length */
                     debyeLengthBox(superCellFieldIdx)
-                        = ((!pmacc::math::isApproxZero(sumChargeNumberSquared + sumWeightElectronNormalized))
-                               ? math::sqrt(
-                                     constFactorDebyeLength * temperatureEnergy_PIC
-                                     / (sumChargeNumberSquared + sumWeightElectronNormalized))
-                               : -1._X);
+                        = (!pmacc::math::isApproxZero(sumChargeNumberSquared + sumWeightElectronNormalized))
+                              ? math::sqrt(
+                                    constFactorDebyeLength * temperatureEnergy_PIC
+                                    / (sumChargeNumberSquared + sumWeightElectronNormalized))
+                              : -1._X;
 
                     constexpr float_X constFactorFreeElectronDensity = sim.unit.typicalNumParticlesPerMacroParticle();
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/kernel/CalculateIPDInput.kernel
@@ -70,6 +70,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
          *  for all local superCells, unitless, not weighted
          * @param debyeLengthBox deviceDataBox giving access to the local debye length for all local superCells,
          *  sim.unit.length(), not weighted
+         * @param freeElectronDensityBox deviceDataBox giving access to the local free electron density for all local
+         *  superCells, unit 1/unit_length^3, not weighted
          */
         template<
             typename T_Worker,
@@ -82,7 +84,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             typename T_SumChargeNumberSquaredIonsFieldDataBox,
             typename T_LocalTemperatureFieldDataBox,
             typename T_ZStarFieldDataBox,
-            typename T_LocaDebyeLengthFieldDataBox>
+            typename T_LocaDebyeLengthFieldDataBox,
+            typename T_FreeElectronDensityFieldDataBox>
         HDINLINE void operator()(
             T_Worker const& worker,
             T_AreaMapping const areaMapping,
@@ -92,9 +95,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
             T_SumWeightElectronFieldBox const sumWeightElectronNormalizedBox,
             T_SumChargeNumberIonsFieldDataBox const sumChargeNumberBox,
             T_SumChargeNumberSquaredIonsFieldDataBox const sumChargeNumberSquaredBox,
+            T_LocaDebyeLengthFieldDataBox debyeLengthBox,
             T_LocalTemperatureFieldDataBox temperatureEnergyBox,
             T_ZStarFieldDataBox zStarBox,
-            T_LocaDebyeLengthFieldDataBox debyeLengthBox) const
+            T_FreeElectronDensityFieldDataBox freeElectronDensityBox) const
         {
             auto const superCellFieldIdx = KernelIndexation::getSuperCellFieldIndex(worker, areaMapping);
 
@@ -130,8 +134,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                  &sumChargeNumber,
                  &sumChargeNumberSquared,
                  &temperatureEnergyBox,
-                 &zStarBox,
                  &debyeLengthBox,
+                 &zStarBox,
+                 &freeElectronDensityBox,
                  &superCellFieldIdx]()
                 {
                     /* unit: (unitless * weight / typicalNumParticlesPerMacroParticle)
@@ -175,12 +180,17 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::ker
                      * unit:  sqrt(unit_length^2 / unit_energy / typicalNumParticlesPerMacroParticle
                      *  * unit_energy / (1/typicalNumParticlesPerMacroParticle)) = unit_length */
                     debyeLengthBox(superCellFieldIdx)
-                        = (!pmacc::math::isApproxZero(sumChargeNumberSquared + sumWeightElectronNormalized))
-                              ? math::sqrt(
-                                    constFactorDebyeLength * temperatureEnergy_PIC
-                                    / (sumChargeNumberSquared + sumWeightElectronNormalized))
-                              : -1._X;
-                    ;
+                        = ((!pmacc::math::isApproxZero(sumChargeNumberSquared + sumWeightElectronNormalized))
+                               ? math::sqrt(
+                                     constFactorDebyeLength * temperatureEnergy_PIC
+                                     / (sumChargeNumberSquared + sumWeightElectronNormalized))
+                               : -1._X);
+
+                    constexpr float_X constFactorFreeElectronDensity = sim.unit.typicalNumParticlesPerMacroParticle();
+
+                    // unit: 1 / unit_length^3
+                    freeElectronDensityBox(superCellFieldIdx)
+                        = constFactorFreeElectronDensity * sumWeightElectronNormalized / volumeSuperCell;
                 });
         }
     };

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/FreeElectronDensityField.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/localHelperFields/FreeElectronDensityField.hpp
@@ -1,0 +1,53 @@
+/* Copyright 2024-2024 Brian Marre
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/SuperCellField.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields
+{
+    /**superCell field of the local free electron density
+     *
+     * @details unitless, not weighted
+     *
+     * @note required for calculating the local ionization potential depression(IPD) and filled by
+     *  calculateIPDInput kernel.
+     *
+     * @tparam T_MappingDescription description of local mapping from device to grid
+     */
+    template<typename T_MappingDescription>
+    struct FreeElectronDensityField : public SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>
+    {
+        FreeElectronDensityField(T_MappingDescription const& mappingDesc)
+            : SuperCellField<float_X, T_MappingDescription, /*no guards*/ false>(mappingDesc)
+        {
+        }
+
+        // required by ISimulationData
+        std::string getUniqueId() override
+        {
+            return "FreeElectronDensityField";
+        }
+    };
+} // namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::localHelperFields

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/ApplyIPDIonization.hpp
@@ -78,6 +78,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
             = *dc.get<s_IPD::localHelperFields::TemperatureEnergyField<picongpu::MappingDesc>>(
                 "TemperatureEnergyField");
         auto& zStarField = *dc.get<s_IPD::localHelperFields::ZStarField<picongpu::MappingDesc>>("ZStarField");
+        auto& freeElectronDensityField
+            = *dc.get<s_IPD::localHelperFields::ZStarField<picongpu::MappingDesc>>("FreeElectronDensityField");
         auto idProvider = dc.get<IdProvider>("globalId");
 
         auto& fieldE = *dc.get<FieldE>(FieldE::getName());
@@ -104,7 +106,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
                     fieldE.getDeviceDataBox(),
                     debyeLengthField.getDeviceDataBox(),
                     temperatureEnergyField.getDeviceDataBox(),
-                    zStarField.getDeviceDataBox());
+                    zStarField.getDeviceDataBox(),
+                    freeElectronDensityField.getDeviceDataBox());
         }
         else
         {
@@ -126,7 +129,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
                     fieldE.getDeviceDataBox(),
                     debyeLengthField.getDeviceDataBox(),
                     temperatureEnergyField.getDeviceDataBox(),
-                    zStarField.getDeviceDataBox());
+                    zStarField.getDeviceDataBox(),
+                    freeElectronDensityField.getDeviceDataBox());
         }
 
         // no need to call fillAllGaps, since we do not leave any gaps

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
@@ -79,6 +79,8 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
             auto& zStarField = *dc.get<s_IPD::localHelperFields::ZStarField<picongpu::MappingDesc>>("ZStarField");
             auto& debyeLengthField
                 = *dc.get<s_IPD::localHelperFields::DebyeLengthField<picongpu::MappingDesc>>("DebyeLengthField");
+            auto& freeElectronDensityField
+                = *dc.get<s_IPD::localHelperFields::ZStarField<picongpu::MappingDesc>>("FreeElectronDensityField");
 
             // macro for kernel call
             PMACC_LOCKSTEP_KERNEL(s_IPD::kernel::CalculateIPDInputKernel<T_numberAtomicPhysicsIonSpecies>())
@@ -90,9 +92,10 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression::sta
                     localSumWeightElectronField.getDeviceDataBox(),
                     localSumChargeNumberIonsField.getDeviceDataBox(),
                     localSumChargeNumberSquaredIonsField.getDeviceDataBox(),
+                    debyeLengthField.getDeviceDataBox(),
                     temperatureEnergyField.getDeviceDataBox(),
                     zStarField.getDeviceDataBox(),
-                    debyeLengthField.getDeviceDataBox());
+                    freeElectronDensityField.getDeviceDataBox());
         }
     };
 

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/stage/CalculateIPDInput.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024-2024 Brian Marre
+/* Copyright 2024-2025 Brian Marre
  *
  * This file is part of PIConGPU.
  *


### PR DESCRIPTION
implements the second branch used in the SCFLY-IPD calculation

- [x] requires #5530 to be merged first
- [x] requires #5535 to be merged first
- [x] requires #5536 to be merged first
- [x] requires #5542 to be merged first
- [x] needs to be rebased once required PRs are merged