### PR TITLE
copy pypicongpu.json to run dir

### DIFF
--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -247,3 +247,11 @@ TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
 $SHELL_OPT_U_RESTORE
 
 "$TBG_cfgPath"/submitAction.sh
+
+# picmi specific input copy (outside of submitAction.sh)
+if [ -f pypicongpu.json ]
+then
+    cp pypicongpu.json $TBG_dstPath/input/metadata.json
+else
+    echo "Could not find pypicongpu.json" >&2
+fi


### PR DESCRIPTION
This PR copies the `pypicongpu.json` (metadata from PICMI) to the simulation directory similarly to how we copy the param files into input. This is not added to the `submitAction.sh` as it is PICMI specific and can be handled by maintaining a single file as discussed offline with @psychocoderHPC. 

Right now, the `pypicongpu.json` goes to the root simulation directory. Would you prefer it going into the input directory. 
