### PR TITLE
Remove out of date comment and fix typos

### DIFF
--- a/include/pmacc/HandleGuardRegion.hpp
+++ b/include/pmacc/HandleGuardRegion.hpp
@@ -25,7 +25,7 @@ namespace pmacc
 {
     /**
      * Property struct that exposes policies for handling data in the guard region
-     * Each police must handle both sides of the (possible) exchange:
+     * Each policy must handle both sides of the (possible) exchange:
      *      - Outgoing side: E.g. particles going out of the local volume
      *      - Incoming side: E.g. particles coming into the local volume
      *

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -43,7 +43,7 @@ namespace pmacc
      *
      * The object is used to describe indices of threads in the kernel.
      * @attention Currently this object is also used to describe memory extents. This should be avoided and is a
-     * technical dept from the past and limits the index space to 2 giga elements.
+     * technical debt from the past and limits the index space to 2 giga elements.
      *
      * DataSpace describes a T_dim-dimensional data space with a specific size for each dimension.
      * It only describes the space and does not hold any actual data.

--- a/include/pmacc/particles/ParticleDescription.hpp
+++ b/include/pmacc/particles/ParticleDescription.hpp
@@ -37,7 +37,8 @@ namespace pmacc
      *
      * @tparam T_Name name of described particle (e.g. electron, ion)
      *                type must be a PMACC_CSTRING
-     * @tparam T_NumSlots compile time size of a super cell
+     * @tparam T_NumSlots compile time size of a fram
+     * @tparam T_SuperCellSize compile time size of a super cell
      * @tparam T_ValueTypeSeq sequence or single type with value_identifier, must not have duplicates
      * @tparam T_Flags sequence or single type with identifier to add flags on a frame, must not have duplicates
      * @tparam T_MethodsList sequence or single class with particle methods

--- a/include/pmacc/particles/memory/dataTypes/Particle.hpp
+++ b/include/pmacc/particles/memory/dataTypes/Particle.hpp
@@ -92,8 +92,6 @@ namespace pmacc
 
         /** pointer to parent frame where this particle is from
          *
-         * ATTENTION: The pointer must be the last member to avoid local memory usage
-         *            https://github.com/ComputationalRadiationPhysics/picongpu/pull/762
          */
         PMACC_ALIGN(frame, FrameType*) = nullptr;
 


### PR DESCRIPTION
Closes #5545. Discussion in office blames the behavior to some compiler needing special help for optimizations, and we keep the current layout with `ptr` before `idx` to minimize padding. 
The hope is in the 10 years since the behavior was observed this would no longer be an issue, but we have not tested this. But in any case we will keep what we have due to padding reasons. 
Also fixes some typos and documentation