### PR TITLE
fix metadata cp: set path to project dir

### DIFF
--- a/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
+++ b/share/picongpu/pypicongpu/template/etc/picongpu/N.cfg.mustache
@@ -249,9 +249,9 @@ $SHELL_OPT_U_RESTORE
 "$TBG_cfgPath"/submitAction.sh
 
 # picmi specific input copy (outside of submitAction.sh)
-if [ -f pypicongpu.json ]
+if [ -f $TBG_projectPath/pypicongpu.json ]
 then
-    cp pypicongpu.json $TBG_dstPath/input/metadata.json
+    cp $TBG_projectPath/pypicongpu.json $TBG_dstPath/input/metadata.json
 else
     echo "Could not find pypicongpu.json" >&2
 fi


### PR DESCRIPTION
I introduced a bug with #5546 - this PR fixes it. 
`tbg` changes the directory from its call directory to its output directory before parsing the `N.cfg`, thus everything needs to be relative to the output directory not input directory. Currently, `pipicongpu.json` cannot be found. 