### PR TITLE
remove unused namespace rename

### DIFF
--- a/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
+++ b/include/picongpu/plugins/transitionRadiation/TransitionRadiation.x.cpp
@@ -72,7 +72,6 @@ namespace picongpu
         {
             using namespace pmacc;
 
-            namespace po = boost::program_options;
             using complex_X = alpaka::Complex<float_X>;
 
             /** Implementation of transition radiation for in situ calculation in PIConGPU


### PR DESCRIPTION
minor cleanup discovered yesterday during #5553 
The renamed namespace `po` is never used. 