### PR TITLE
Implement focus_z_offset feature in TWTSTight

### DIFF
--- a/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
+++ b/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
@@ -128,6 +128,9 @@ namespace picongpu::templates::twtstight
         PMACC_ALIGN(beta_0, float_64 const);
         /** If auto_tdelay=FALSE, then a user defined delay is used. [second] */
         PMACC_ALIGN(tdelay_user_SI, float_64 const);
+        /** Defines z-position offset of TWTS coordinate origin inside the simulation coordinates [meter]
+            relative to the globally centered default value with respect to the simulation volume. */
+        PMACC_ALIGN(focus_z_offset_SI, float_64 const);
         /** Make time step constant accessible to device. */
         PMACC_ALIGN(dt, float_64 const);
         /** Make length normalization constant accessible to device. */
@@ -161,6 +164,8 @@ namespace picongpu::templates::twtstight
          * @param tdelay_user manual time delay if auto_tdelay is false
          * @param auto_tdelay calculate the time delay such that the TWTS pulse is not
          *  inside the simulation volume at simulation start timestep = 0 [default = true]
+         * @param focus_z_offset_SI the distance to the laser focus in z-direction [m]
+         *  relative to the default simulation volume centered origin.
          * @param polAngle determines the TWTS laser polarization angle with respect to x-axis around
          * propagation direction [rad, default = 0. * (PI/180.)] Normal to laser pulse front tilt plane:
          * polAngle = 0.0 * (PI/180.) (linear polarization parallel to x-axis) Parallel to laser pulse front
@@ -176,6 +181,7 @@ namespace picongpu::templates::twtstight
             float_64 const beta_0 = 1.0,
             float_64 const tdelay_user_SI = 0.0,
             bool const auto_tdelay = true,
+            float_64 const focus_z_offset_SI = 0.0,
             float_64 const polAngle = 0. * (PI / 180.));
 
         /** Specify your background field E(r, t) or B(r, t) here

--- a/include/picongpu/fields/background/templates/twtstight/TWTSTight.tpp
+++ b/include/picongpu/fields/background/templates/twtstight/TWTSTight.tpp
@@ -49,6 +49,7 @@ namespace picongpu::templates::twtstight
         float_64 const beta_0,
         float_64 const tdelay_user_SI,
         bool const auto_tdelay,
+        float_64 const focus_z_offset_SI,
         float_64 const polAngle)
         : halfSimSize(Environment<simDim>::get().SubGrid().getGlobalDomain().size / 2)
         , focus_y_SI(focus_y_SI)
@@ -59,6 +60,7 @@ namespace picongpu::templates::twtstight
         , phiPositive(phi < 0.0_X ? float_X(-1.0) : float_X(+1.0))
         , beta_0(beta_0)
         , tdelay_user_SI(tdelay_user_SI)
+        , focus_z_offset_SI(focus_z_offset_SI)
         , dt(sim.si.getDt())
         , unit_length(sim.unit.length())
         , auto_tdelay(auto_tdelay)
@@ -137,8 +139,14 @@ namespace picongpu::templates::twtstight
     {
         float_64 const time_SI = float_64(currentStep) * dt - tdelay;
 
-        pmacc::math::Vector<floatD_64, detail::numComponents> const fieldPositions_SI
-            = detail::getFieldPositions_SI(cellIdx, halfSimSize, extraShifts, unit_length, focus_y_SI, phi);
+        pmacc::math::Vector<floatD_64, detail::numComponents> const fieldPositions_SI = detail::getFieldPositions_SI(
+            cellIdx,
+            halfSimSize,
+            extraShifts,
+            unit_length,
+            focus_y_SI,
+            focus_z_offset_SI,
+            phi);
 
         /* Single TWTS-Pulse */
         return getTWTSField_Normalized(fieldPositions_SI, time_SI);
@@ -156,7 +164,14 @@ namespace picongpu::templates::twtstight
             for(uint32_t component = 0; component < detail::numComponents; ++component)
                 zeroShifts[component] = floatD_X::create(0.0);
             pmacc::math::Vector<floatD_64, detail::numComponents> const fieldPositions_SI
-                = detail::getFieldPositions_SI(cellIdx, halfSimSize, zeroShifts, unit_length, focus_y_SI, phi);
+                = detail::getFieldPositions_SI(
+                    cellIdx,
+                    halfSimSize,
+                    zeroShifts,
+                    unit_length,
+                    focus_y_SI,
+                    focus_z_offset_SI,
+                    phi);
             // Explicitly use a 3D vector so that this function compiles for 2D as well
             auto const pos = float3_64{
                 fieldPositions_SI[T_component][0],

--- a/include/picongpu/fields/background/templates/twtstight/getFieldPositions_SI.tpp
+++ b/include/picongpu/fields/background/templates/twtstight/getFieldPositions_SI.tpp
@@ -44,6 +44,7 @@ namespace picongpu
                     pmacc::math::Vector<floatD_X, numComponents> const& fieldOnGridPositions,
                     float_64 const unit_length,
                     float_64 const focus_y_SI,
+                    float_64 const focus_z_offset_SI,
                     float_X const phi)
                 {
                     /* Note: Neither direct precisionCast on picongpu::cellSize
@@ -55,6 +56,8 @@ namespace picongpu
                        the laser center in y (usually maximum of intensity). */
                     floatD_X laserOrigin = precisionCast<float_X>(halfSimSize);
                     laserOrigin.y() = float_X(focus_y_SI / cellDimensions.y());
+                    if constexpr(simDim == DIM3)
+                        laserOrigin.z() += float_X(focus_z_offset_SI / cellDimensions.z());
 
                     /* For staggered fields (e.g. Yee-grid), obtain the fractional cell index components and add
                      * that to the total cell indices. The physical field coordinate origin is transversally

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/TwtsBackgroundLaser.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/TwtsBackgroundLaser.param
@@ -113,6 +113,11 @@ namespace picongpu
                  * unit: none */
                 constexpr bool AUTO_TDELAY = false;
 
+                /** Defines z-position offset of TWTS coordinate origin inside the simulation coordinates
+                 *  relative to the globally centered default value with respect to the simulation volume.
+                 *  unit: m */
+                constexpr float_64 Z_OFFSET_SI = 0.0;
+
                 constexpr float_X Polarization = 45.0 * (PI / 180.);
             } // namespace twtsParam
         } // namespace background

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
@@ -94,6 +94,7 @@ namespace picongpu
                           Params::BETA_0,
                           Params::TDELAY,
                           Params::AUTO_TDELAY,
+                          Params::Z_OFFSET_SI,
                           Params::Polarization)
                 {
                 }
@@ -136,6 +137,7 @@ namespace picongpu
                           Params::BETA_0,
                           Params::TDELAY,
                           Params::AUTO_TDELAY,
+                          Params::Z_OFFSET_SI,
                           -Params::Polarization)
                 {
                 }
@@ -178,6 +180,7 @@ namespace picongpu
                           Params::BETA_0,
                           Params::TDELAY,
                           Params::AUTO_TDELAY,
+                          Params::Z_OFFSET_SI,
                           Params::Polarization)
                 {
                 }
@@ -220,6 +223,7 @@ namespace picongpu
                           Params::BETA_0,
                           Params::TDELAY,
                           Params::AUTO_TDELAY,
+                          Params::Z_OFFSET_SI,
                           -Params::Polarization)
                 {
                 }

--- a/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/examples/Bunch/include/picongpu/param/fieldBackground.param
@@ -64,18 +64,22 @@ namespace picongpu
                   0.8e-6,
                   /* pulselength [s], sigma of std. gauss for intensity (E^2) */
                   10.0e-15 / 2.3548200450309493820231386529194,
-#if PARAM_TWTSFAST == 0
                   /* w_x [m], cylindrically focused spot size */
                   5.0e-6,
-#endif
+#if PARAM_TWTSTIGHT == 0
                   /* w_y [m] */
                   0.01,
+#endif
                   /* interaction angle between TWTS laser propagation vector and the y-axis [rad] */
                   60. * (PI / 180.),
                   /* propagation speed of overlap [speed of light]. */
                   1.0,
                   /* manual time delay [s] if auto_tdelay is false */
                   39.3e-6 / sim.si.getSpeedOfLight(),
+#if PARAM_TWTSTIGHT == 1
+                  /* distance to TWTS laser focus in z-direction [m] relative to centered origin */
+                  0.0,
+#endif
                   /* Should PIConGPU automatically choose a suitable time delay? [true/false] */
                   false)
         {
@@ -151,18 +155,22 @@ namespace picongpu
                   0.8e-6,
                   /* pulselength [s], sigma of std. gauss for intensity (E^2) */
                   10.0e-15 / 2.3548200450309493820231386529194,
-#if PARAM_TWTSTIGHT == 0
                   /* w_x [m], cylindrically focused spot size */
                   5.0e-6,
-#endif
+#if PARAM_TWTSTIGHT == 0
                   /* w_y [m] */
                   0.01,
+#endif
                   /* interaction angle between TWTS laser propagation vector and the y-axis [rad] */
                   60. * (PI / 180.),
                   /* propagation speed of overlap [speed of light]. */
                   1.0,
                   /* manual time delay [s] if auto_tdelay is false */
                   39.3e-6 / sim.si.getSpeedOfLight(),
+#if PARAM_TWTSTIGHT == 1
+                  /* distance to TWTS laser focus in z-direction [m] relative to centered origin */
+                  0.0,
+#endif
                   /* Should PIConGPU automatically choose a suitable time delay? [true / false] */
                   false)
         {

--- a/share/picongpu/unit/dimensional_tests/TWTSTight.cpp
+++ b/share/picongpu/unit/dimensional_tests/TWTSTight.cpp
@@ -77,8 +77,8 @@ struct GenerateEvals
     using float_T = templates::twtstight::float_T;
 
     HINLINE GenerateEvals()
-        : testEfield(0.0, 800.0e-9, 30.0e-15, 2.5e-6, 5. * (PI / 180.), 1.0, 0.0, false, 30. * (PI / 180.))
-        , testBfield(0.0, 800.0e-9, 30.0e-15, 2.5e-6, 5. * (PI / 180.), 1.0, 0.0, false, 30. * (PI / 180.))
+        : testEfield(0.0, 800.0e-9, 30.0e-15, 2.5e-6, 5. * (PI / 180.), 1.0, 0.0, false, 0.0, 30. * (PI / 180.))
+        , testBfield(0.0, 800.0e-9, 30.0e-15, 2.5e-6, 5. * (PI / 180.), 1.0, 0.0, false, 0.0, 30. * (PI / 180.))
     {
     }
 
@@ -131,6 +131,7 @@ struct twtsTightNumberTest
             1.0,
             0.0,
             false,
+            0.0,
             30. * (PI / 180.));
         templates::twtstight::BField const testBfield = templates::twtstight::BField(
             0.0,
@@ -141,6 +142,7 @@ struct twtsTightNumberTest
             1.0,
             0.0,
             false,
+            0.0,
             30. * (PI / 180.));
         using float_T = templates::twtstight::float_T;
         using float3_T = ::pmacc::math::Vector<float_T, 3u>;


### PR DESCRIPTION
The feature enables shifting a TWTSTight laser focus in z-direction relative to the default globally centered position in z. The changes were successfully tested and used in production. Compared to that status, for this PR I added documentation and updated the unit-test, example and benchmark.