### PR TITLE
Implement PICMI capability for TWTS and TWEAC lasers

### DIFF
--- a/include/picongpu/fields/background/templates/twtstight/getFieldPositions_SI.tpp
+++ b/include/picongpu/fields/background/templates/twtstight/getFieldPositions_SI.tpp
@@ -57,7 +57,7 @@ namespace picongpu
                     floatD_X laserOrigin = precisionCast<float_X>(halfSimSize);
                     laserOrigin.y() = float_X(focus_y_SI / cellDimensions.y());
                     if constexpr(simDim == DIM3)
-                        laserOrigin.z() += float_X(focus_z_offset_SI / cellDimensions.z());
+                        laserOrigin[simDim - 1] += float_X(focus_z_offset_SI / cellDimensions[simDim - 1]);
 
                     /* For staggered fields (e.g. Yee-grid), obtain the fractional cell index components and add
                      * that to the total cell indices. The physical field coordinate origin is transversally

--- a/include/picongpu/fields/incidentField/profiles/TWTSPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/TWTSPulse.def
@@ -1,0 +1,170 @@
+/* Copyright 2014-2025 Axel Huebl, Alexander Debus, Richard Pausch, Sergei Bastrakov
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "picongpu/fields/background/templates/twtstight/TWTSTight.hpp"
+
+namespace picongpu::fields::incidentField
+{
+    namespace profiles
+    {
+        struct window
+        {
+            HDINLINE static float_X switchAt(
+                float_X const currentStep,
+                float_X const switchStartStep,
+                float_X const switchEndStep,
+                float_X const length)
+            {
+                constexpr float_X a0 = 0.3635819;
+                constexpr float_X a1 = 0.4891775;
+                constexpr float_X a2 = 0.1365995;
+                constexpr float_X a3 = 0.0106411;
+                if(length < 0.0)
+                {
+                    return float_X(1.0);
+                }
+                float_X const n_on = currentStep - switchStartStep;
+                float_X const n_off = switchEndStep - currentStep;
+                if((n_on < 0) || (n_off < 0))
+                {
+                    return float_X(0.0);
+                }
+                else if((n_on >= 0) && (n_on <= length))
+                {
+                    return a0 - a1 * math::cos(float_X(2.0) * PI * n_on / length / float_X(2.0))
+                           + a2 * math::cos(float_X(4.0) * PI * n_on / length / float_X(2.0))
+                           - a3 * math::cos(float_X(6.0) * PI * n_on / length / float_X(2.0));
+                }
+                else if((switchEndStep >= switchStartStep) && (n_off >= 0) && (n_off <= length))
+                {
+                    return a0 - a1 * math::cos(float_X(2.0) * PI * n_on / length / float_X(2.0))
+                           + a2 * math::cos(float_X(4.0) * PI * n_on / length / float_X(2.0))
+                           - a3 * math::cos(float_X(6.0) * PI * n_on / length / float_X(2.0));
+                }
+                return float_X(1.0);
+            }
+        };
+
+        template<typename T_Params>
+        struct TWTSFunctorIncidentE
+        {
+        public:
+            float_X const m_currentStep;
+            PMACC_ALIGN(m_unitField, float3_64 const);
+            templates::twtstight::EField const twtsFieldE;
+
+            HINLINE TWTSFunctorIncidentE(float_X const currentStep, float3_64 const unitField)
+                : m_currentStep(currentStep)
+                , m_unitField(unitField)
+                , twtsFieldE(
+                      T_Params::FOCUS_Y_SI,
+                      T_Params::WAVE_LENGTH_SI,
+                      T_Params::PULSE_DURATION_SI,
+                      T_Params::W0_SI,
+                      T_Params::PHI,
+                      T_Params::BETA_0,
+                      T_Params::TDELAY,
+                      T_Params::AUTO_TDELAY,
+                      T_Params::FOCUS_Z_OFFSET_SI,
+                      T_Params::Polarization)
+            {
+            }
+
+            HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+            {
+                float3_64 const invUnitField
+                    = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
+                float3_X const amplitude = precisionCast<float_X>(T_Params::AMPLITUDE_SI * invUnitField);
+                return window::switchAt(
+                           m_currentStep,
+                           T_Params::windowStart,
+                           T_Params::windowEnd,
+                           T_Params::windowLength)
+                       * amplitude * twtsFieldE(totalCellIdx, m_currentStep);
+            }
+
+            template<uint32_t T_component>
+            HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
+            {
+                float_64 const invUnitField = 1.0 / m_unitField[T_component];
+                float_X const amplitude = precisionCast<float_X>(T_Params::AMPLITUDE_SI * invUnitField);
+                return window::switchAt(
+                           m_currentStep,
+                           T_Params::windowStart,
+                           T_Params::windowEnd,
+                           T_Params::windowLength)
+                       * amplitude * twtsFieldE.getComponent<T_component>(totalCellIdx, m_currentStep);
+            }
+        };
+
+        template<typename T_Params>
+        struct TWTSFunctorIncidentB
+        {
+        public:
+            float_X const m_currentStep;
+            PMACC_ALIGN(m_unitField, float3_64 const);
+            templates::twtstight::BField twtsFieldB;
+
+            HINLINE TWTSFunctorIncidentB(float_X const currentStep, float3_64 const unitField)
+                : m_currentStep(currentStep)
+                , m_unitField(unitField)
+                , twtsFieldB(
+                      T_Params::FOCUS_Y_SI,
+                      T_Params::WAVE_LENGTH_SI,
+                      T_Params::PULSE_DURATION_SI,
+                      T_Params::W0_SI,
+                      T_Params::PHI,
+                      T_Params::BETA_0,
+                      T_Params::TDELAY,
+                      T_Params::AUTO_TDELAY,
+                      T_Params::FOCUS_Z_OFFSET_SI,
+                      T_Params::Polarization)
+            {
+            }
+
+            HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
+            {
+                float3_64 const invUnitField
+                    = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
+                float3_X const amplitude = precisionCast<float_X>(T_Params::AMPLITUDE_SI * invUnitField);
+                return window::switchAt(
+                           m_currentStep,
+                           T_Params::windowStart,
+                           T_Params::windowEnd,
+                           T_Params::windowLength)
+                       * amplitude * twtsFieldB(totalCellIdx, m_currentStep);
+            }
+
+            template<uint32_t T_component>
+            HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
+            {
+                float_64 const invUnitField = 1.0 / m_unitField[T_component];
+                float_X const amplitude = precisionCast<float_X>(T_Params::AMPLITUDE_SI * invUnitField);
+                return window::switchAt(
+                           m_currentStep,
+                           T_Params::windowStart,
+                           T_Params::windowEnd,
+                           T_Params::windowLength)
+                       * amplitude * twtsFieldB.getComponent<T_component>(totalCellIdx, m_currentStep);
+            }
+        };
+    } // namespace profiles
+} // namespace picongpu::fields::incidentField

--- a/include/picongpu/fields/incidentField/profiles/TWTSPulse.def
+++ b/include/picongpu/fields/incidentField/profiles/TWTSPulse.def
@@ -21,6 +21,10 @@
 
 #include "picongpu/fields/background/templates/twtstight/TWTSTight.hpp"
 
+#ifndef PARAM_COMPONENTWISE
+#    define PARAM_COMPONENTWISE 1
+#endif
+
 namespace picongpu::fields::incidentField
 {
     namespace profiles
@@ -33,6 +37,7 @@ namespace picongpu::fields::incidentField
                 float_X const switchEndStep,
                 float_X const length)
             {
+                /* Blackman - Nuttall window */
                 constexpr float_X a0 = 0.3635819;
                 constexpr float_X a1 = 0.4891775;
                 constexpr float_X a2 = 0.1365995;
@@ -101,6 +106,7 @@ namespace picongpu::fields::incidentField
                        * amplitude * twtsFieldE(totalCellIdx, m_currentStep);
             }
 
+#if PARAM_COMPONENTWISE
             template<uint32_t T_component>
             HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
             {
@@ -113,6 +119,7 @@ namespace picongpu::fields::incidentField
                            T_Params::windowLength)
                        * amplitude * twtsFieldE.getComponent<T_component>(totalCellIdx, m_currentStep);
             }
+#endif
         };
 
         template<typename T_Params>
@@ -153,6 +160,7 @@ namespace picongpu::fields::incidentField
                        * amplitude * twtsFieldB(totalCellIdx, m_currentStep);
             }
 
+#if PARAM_COMPONENTWISE
             template<uint32_t T_component>
             HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
             {
@@ -165,6 +173,7 @@ namespace picongpu::fields::incidentField
                            T_Params::windowLength)
                        * amplitude * twtsFieldB.getComponent<T_component>(totalCellIdx, m_currentStep);
             }
+#endif
         };
     } // namespace profiles
 } // namespace picongpu::fields::incidentField

--- a/include/picongpu/fields/incidentField/profiles/profiles.def
+++ b/include/picongpu/fields/incidentField/profiles/profiles.def
@@ -28,5 +28,6 @@
 #include "picongpu/fields/incidentField/profiles/None.def"
 #include "picongpu/fields/incidentField/profiles/PlaneWave.def"
 #include "picongpu/fields/incidentField/profiles/Polynom.def"
+#include "picongpu/fields/incidentField/profiles/TWTSPulse.def"
 #include "picongpu/fields/incidentField/profiles/Traits.hpp"
 #include "picongpu/fields/incidentField/profiles/Wavepacket.def"

--- a/include/picongpu/param/incidentField.param
+++ b/include/picongpu/param/incidentField.param
@@ -25,6 +25,9 @@
  *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::Free<profiles::TWTSFunctorIncidentE<>,
+ *                   profiles::TWTSFunctorIncidentB<>>
+ *                                    : Traveling-Wave Thomson Scattering laser (TWTS) with given parameters.
  *  - profiles::FromOpenPMDPulse<>    : reads a field chunk defined in space-time domain (= (2+1)-dimensional) from
  * openPMD into the simulation; requires openPMD API dependency
  *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters.

--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -5,7 +5,7 @@ PICMI for PIConGPU
 from .simulation import Simulation
 from .grid import Cartesian3DGrid
 from .solver import ElectromagneticSolver
-from .lasers import DispersivePulseLaser, GaussianLaser, PlaneWaveLaser, FromOpenPMDPulseLaser
+from .lasers import DispersivePulseLaser, GaussianLaser, PlaneWaveLaser, FromOpenPMDPulseLaser, TWTSLaser
 from .species import Species
 from .layout import PseudoRandomLayout, GriddedLayout
 from . import constants
@@ -43,6 +43,7 @@ __all__ = [
     "DispersivePulseLaser",
     "FromOpenPMDPulseLaser",
     "GaussianLaser",
+    "TWTSLaser",
     "PlaneWaveLaser",
     "Species",
     "PseudoRandomLayout",

--- a/lib/python/picongpu/picmi/lasers/__init__.py
+++ b/lib/python/picongpu/picmi/lasers/__init__.py
@@ -10,5 +10,13 @@ from .from_openpmd_pulse_laser import FromOpenPMDPulseLaser
 from .gaussian_laser import GaussianLaser
 from .plane_wave_laser import PlaneWaveLaser
 from .polarization_type import PolarizationType
+from .twts_laser import TWTSLaser
 
-__all__ = ["DispersivePulseLaser", "FromOpenPMDPulseLaser", "GaussianLaser", "PlaneWaveLaser", "PolarizationType"]
+__all__ = [
+    "DispersivePulseLaser",
+    "FromOpenPMDPulseLaser",
+    "GaussianLaser",
+    "PlaneWaveLaser",
+    "PolarizationType",
+    "TWTSLaser",
+]

--- a/lib/python/picongpu/picmi/lasers/twts_laser.py
+++ b/lib/python/picongpu/picmi/lasers/twts_laser.py
@@ -1,0 +1,136 @@
+"""
+This file is part of PIConGPU.
+Copyright 2025 PIConGPU contributors
+Authors: Julian Lenz, Alexander Debus
+License: GPLv3+
+"""
+
+import math
+import typing
+
+import typeguard
+
+from ...pypicongpu import laser
+from ..copy_attributes import default_converts_to
+from .base_laser import BaseLaser
+from .polarization_type import PolarizationType
+
+from .. import constants
+
+
+@default_converts_to(laser.TWTSLaser)
+@typeguard.typechecked
+class TWTSLaser(BaseLaser):
+    """
+    Specifies a TWTS laser
+
+    Parameters
+    ----------
+    - wavelength: float
+        Central wavelength of the laser [m].
+
+    - waist : float
+        Spot size (1/e^2 radius) of the laser at focus [m].
+
+    - duration: float
+        Duration of the TWTS pulse [s], defined as 1 sigma of std. Gauss for intensity.
+
+    - phi: float
+        Laser incident angle [rad]
+        denoting the mean laser phase propagation direction
+        with respect to the y-axis.
+
+    - polarizationAngle : float
+        Linear laser polarization direction
+        parameterized as a rotation angle [rad]
+        of the x-direction around the mean
+        laser phase propagation direction.
+
+    - focal_position : list[float]
+        3D coordinates of the laser focus [m]
+        in the simulation domain.
+
+    - centroid_position : list[float]
+        3D coordinates of the inital laser centroid [m].
+
+    - focus_z_offset_si : float
+        Offset from the middle of the simulation domain
+        to the laser focus in z-direction [m].
+
+    - a0 : float, optional
+        Normalized vector potential at focus [dimensionless].
+        Specify either a0 or E0 (E0 takes precedence).
+
+    - E0 : float, optional
+        Peak electric field amplitude [V/m].
+        Specify either a0 or E0 (E0 takes precedence).
+
+    - beta0 : float, optional [default = 1.0]
+        Laser centroid speed in y-direction normalized
+        to the vacuum speed of light [dimensionless].
+    """
+
+    def __init__(
+        self,
+        wavelength,
+        waist,
+        duration,
+        phi,
+        polarizationAngle,
+        focal_position,
+        centroid_position,
+        focus_z_offset_si,
+        a0=None,
+        E0=None,
+        beta0=1.0,
+        # make sure to always place Huygens-surface inside PML-boundaries,
+        # default is valid for standard PMLs
+        # @todo create check for insufficient dimension
+        # @todo create check in simulation for conflict between PMLs and
+        # Huygens-surfaces
+        picongpu_huygens_surface_positions: typing.List[typing.List[int]] = [
+            [16, -16],
+            [16, -16],
+            [16, -16],
+        ],
+    ):
+        if wavelength <= 0:
+            raise ValueError(f"wavelength must be > 0. You gave {wavelength=}.")
+        if duration <= 0:
+            raise ValueError(f"laser pulse duration must be > 0. You gave {duration=}.")
+        if beta0 <= 0:
+            raise ValueError(f"beta0 must be >0. You gave {beta0=}.")
+
+        self.wavelength = wavelength
+        self.k0 = 2.0 * math.pi / wavelength
+        self.duration = duration
+        self.propagation_direction = [0.0, math.cos(phi), math.sin(phi)]
+        self.focal_position = focal_position
+        self.centroid_position = centroid_position
+        self.polarization_direction = [
+            math.cos(polarizationAngle),
+            -math.sin(polarizationAngle) * math.sin(phi),
+            math.cos(polarizationAngle) * math.cos(phi),
+        ]
+        self.a0, self.E0 = self._compute_E0_and_a0(self.k0, E0, a0)
+        self.phi = phi
+        if phi > 0:
+            self.phiPos = True
+        else:
+            self.phiPos = False
+        self.beta0 = beta0
+        self.phi0 = 0.0
+        self.waist = waist
+        self.polarizationAngle = polarizationAngle
+        self.time_offset_si = (focal_position[1] - centroid_position[1]) / (beta0 * constants.c)
+        self.focus_z_offset_si = focus_z_offset_si
+        self.picongpu_polarization_type = PolarizationType.LINEAR
+        self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
+        # self._validate_common_properties()
+        self.pulse_init = self._compute_pulse_init()
+
+    """PICMI object for TWTS Laser"""
+
+
+#   def check(self):
+#       self._validate_common_properties()

--- a/lib/python/picongpu/picmi/lasers/twts_laser.py
+++ b/lib/python/picongpu/picmi/lasers/twts_laser.py
@@ -22,7 +22,7 @@ from .. import constants
 @typeguard.typechecked
 class TWTSLaser(BaseLaser):
     """
-    Specifies a TWTS laser
+    Specifies a Traveling-Wave Thomson Scattering (TWTS) laser
 
     Parameters
     ----------
@@ -35,16 +35,21 @@ class TWTSLaser(BaseLaser):
     - duration: float
         Duration of the TWTS pulse [s], defined as 1 sigma of std. Gauss for intensity.
 
-    - phi: float
-        Laser incident angle [rad]
+    - laserIncidenceAngle: float
+        Laser incidence angle [rad]
         denoting the mean laser phase propagation direction
         with respect to the y-axis.
+        In general, the reference axis (here: y-axis) is defined by
+        the focal axis and direction of focus movement.
 
     - polarizationAngle : float
         Linear laser polarization direction
         parameterized as a rotation angle [rad]
-        of the x-direction around the mean
+        of the x-axis vector around the mean
         laser phase propagation direction.
+        In general, the reference vector (here: x-axis vector) is defined
+        to be orthogonal to the laser propagation plane, spanned by
+        the focal axis and central laser propagation direction.
 
     - focal_position : list[float]
         3D coordinates of the laser focus [m]
@@ -53,21 +58,55 @@ class TWTSLaser(BaseLaser):
     - centroid_position : list[float]
         3D coordinates of the inital laser centroid [m].
 
-    - focus_z_offset_si : float
+    - focus_lateral_offset_si : float, optional [default = 0.0]
         Offset from the middle of the simulation domain
         to the laser focus in z-direction [m].
+        In general, the offset direction (here: z-direction) is defined
+        to be orthogonal to the focal axis within the central laser propagation plane.
 
     - a0 : float, optional
         Normalized vector potential at focus [dimensionless].
-        Specify either a0 or E0 (E0 takes precedence).
+        Specify either a0 or E0, but not both.
 
     - E0 : float, optional
         Peak electric field amplitude [V/m].
-        Specify either a0 or E0 (E0 takes precedence).
+        Specify either a0 or E0, but not both.
 
     - beta0 : float, optional [default = 1.0]
-        Laser centroid speed in y-direction normalized
-        to the vacuum speed of light [dimensionless].
+        Laser centroid speed in focal axis direction (here: y-direction)
+        normalized to the vacuum speed of light [dimensionless].
+
+    - windowStart : float, optional [default = 0.0]
+        First time step number [#] at which the laser starts to be gradually switched on using a Blackman-Nuttall window.
+
+    - windowEnd : float, optional [default = 0.0]
+        Final time step number [#] after gradually switching off the laser using a Blackman-Nuttall window.
+        The default values deactivates the switching functionality, such that the TWTS laser is always present.
+
+    - windowLength : float, optional [default = 0.0]
+        Denotes the respective switching duration by half a Blackman-Nuttall window in number of time steps unit [#].
+
+    Description
+    -----------
+    This field describes an obliquely incident, cylindrically-focused, pulse-front tilted laser for some
+    incidence angle as used for [1]. The TWTS implementation is based on the definition of eq. (7) in [1].
+    Additionally, techniques from [2] and [3] are used to allow for strictly Maxwell-conform solutions
+    for tight foci or small laser incident angles.
+
+    Literature
+    ----------
+    [1] Steiniger et al., "Optical free-electron lasers with Traveling-Wave Thomson-Scattering",
+        Journal of Physics B: Atomic, Molecular and Optical Physics, Volume 47, Number 23 (2014),
+        https://doi.org/10.1088/0953-4075/47/23/234011
+    [2] Mitri, F. G., "Cylindrical quasi-Gaussian beams", Opt. Lett., 38(22), pp. 4727-4730 (2013),
+        https://doi.org/10.1364/OL.38.004727
+    [3] Hua, J. F., "High-order corrected fields of ultrashort, tightly focused laser pulses",
+        Appl. Phys. Lett. 85, 3705-3707 (2004),
+        https://doi.org/10.1063/1.1811384
+
+    Implementation
+    --------------
+    See source code  picongpu/include/picongpu/fields/background/templates/twtstight/TWTSTight.hpp
     """
 
     def __init__(
@@ -75,14 +114,17 @@ class TWTSLaser(BaseLaser):
         wavelength,
         waist,
         duration,
-        phi,
+        laserIncidenceAngle,
         polarizationAngle,
         focal_position,
         centroid_position,
-        focus_z_offset_si,
+        focus_lateral_offset_si,
         a0=None,
         E0=None,
         beta0=1.0,
+        windowStart=0.0,
+        windowEnd=0.0,
+        windowLength=0.0,
         # make sure to always place Huygens-surface inside PML-boundaries,
         # default is valid for standard PMLs
         # @todo create check for insufficient dimension
@@ -104,33 +146,32 @@ class TWTSLaser(BaseLaser):
         self.wavelength = wavelength
         self.k0 = 2.0 * math.pi / wavelength
         self.duration = duration
-        self.propagation_direction = [0.0, math.cos(phi), math.sin(phi)]
+        self.propagation_direction = [0.0, math.cos(laserIncidenceAngle), math.sin(laserIncidenceAngle)]
         self.focal_position = focal_position
         self.centroid_position = centroid_position
         self.polarization_direction = [
             math.cos(polarizationAngle),
-            -math.sin(polarizationAngle) * math.sin(phi),
-            math.cos(polarizationAngle) * math.cos(phi),
+            -math.sin(polarizationAngle) * math.sin(laserIncidenceAngle),
+            math.cos(polarizationAngle) * math.cos(laserIncidenceAngle),
         ]
         self.a0, self.E0 = self._compute_E0_and_a0(self.k0, E0, a0)
-        self.phi = phi
-        if phi > 0:
-            self.phiPos = True
+        self.laserIncidenceAngle = laserIncidenceAngle
+        if laserIncidenceAngle > 0:
+            self.laserIncidenceAnglePositive = True
         else:
-            self.phiPos = False
+            self.laserIncidenceAnglePositive = False
         self.beta0 = beta0
+        # An additional laser phase phi0 is not yet supported by the TWTS laser.
         self.phi0 = 0.0
         self.waist = waist
         self.polarizationAngle = polarizationAngle
         self.time_offset_si = (focal_position[1] - centroid_position[1]) / (beta0 * constants.c)
-        self.focus_z_offset_si = focus_z_offset_si
+        self.focus_lateral_offset_si = focus_lateral_offset_si
+        self.windowStart = windowStart
+        self.windowEnd = windowEnd
+        self.windowLength = windowLength
         self.picongpu_polarization_type = PolarizationType.LINEAR
         self.picongpu_huygens_surface_positions = picongpu_huygens_surface_positions
-        # self._validate_common_properties()
         self.pulse_init = self._compute_pulse_init()
 
-    """PICMI object for TWTS Laser"""
-
-
-#   def check(self):
-#       self._validate_common_properties()
+    """Init PICMI object for TWTS Laser"""

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -238,11 +238,11 @@ class TWTSLaser(_BaseLaser):
 
     waist_si: float = Field(alias="waist")
     """beam waist in m"""
-    phi: float
+    laserIncidenceAngle: float
     """Laser incident angle [rad] denoting the mean laser phase
        propagation direction with respect to the y-axis"""
-    phiPos: bool
-    """Is phi positive?"""
+    laserIncidenceAnglePositive: bool
+    """Is the laser incidence angle positive?"""
     polarizationAngle: float
     """Linear laser polarization direction
        parameterized as a rotation angle [rad]
@@ -252,9 +252,15 @@ class TWTSLaser(_BaseLaser):
     """speed of focal region normalized to the vacuum speed of light [dimensionless]"""
     time_offset_si: float
     """time offset to apply to the pulse [s]"""
-    focus_z_offset_si: float
+    focus_lateral_offset_si: float
     """Offset from the middle of the simulation domain
        to the laser focus in z-direction [m]."""
+    windowStart: float
+    """First time step number [#] at which the laser starts to be gradually switched on using a Blackman-Nuttall window"""
+    windowEnd: float
+    """Final time step number [#] after gradually switching off the laser using a Blackman-Nuttall window"""
+    windowLength: float
+    """Denotes the respective switching duration by half a Blackman-Nuttall window in number of time steps unit [#]"""
     huygens_surface_positions: Annotated[list[list[int]], PlainSerializer(_get_huygens_surface_serialized)]
     """Position in cells of the Huygens surface relative to start/
        edge(negative numbers) of the total domain"""

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -225,3 +225,36 @@ class FromOpenPMDPulseLaser(Laser, BaseModel):
     huygens_surface_positions: Annotated[list[list[int]], PlainSerializer(_get_huygens_surface_serialized)]
     """Position in cells of the Huygens surface relative to start/
        edge(negative numbers) of the total domain"""
+
+
+class TWTSLaser(_BaseLaser):
+    """
+    PIConGPU TWTSLaser
+
+    Holds Parameters to specify a TWTS laser pulse
+    """
+
+    _name: str = PrivateAttr("twts")
+
+    waist_si: float = Field(alias="waist")
+    """beam waist in m"""
+    phi: float
+    """Laser incident angle [rad] denoting the mean laser phase
+       propagation direction with respect to the y-axis"""
+    phiPos: bool
+    """Is phi positive?"""
+    polarizationAngle: float
+    """Linear laser polarization direction
+       parameterized as a rotation angle [rad]
+       of the x-direction around the mean
+       laser phase propagation direction"""
+    beta0: float
+    """speed of focal region normalized to the vacuum speed of light [dimensionless]"""
+    time_offset_si: float
+    """time offset to apply to the pulse [s]"""
+    focus_z_offset_si: float
+    """Offset from the middle of the simulation domain
+       to the laser focus in z-direction [m]."""
+    huygens_surface_positions: Annotated[list[list[int]], PlainSerializer(_get_huygens_surface_serialized)]
+    """Position in cells of the Huygens surface relative to start/
+       edge(negative numbers) of the total domain"""

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -16,12 +16,7 @@ from . import output, species, util
 from .customuserinput import InterfaceCustomUserInput
 from .field_solver.DefaultSolver import Solver
 from .grid import Grid3D
-from .laser import (
-    DispersivePulseLaser,
-    FromOpenPMDPulseLaser,
-    GaussianLaser,
-    PlaneWaveLaser,
-)
+from .laser import DispersivePulseLaser, FromOpenPMDPulseLaser, GaussianLaser, PlaneWaveLaser, TWTSLaser
 from .movingwindow import MovingWindow
 from .output import Plugin, OpenPMDPlugin
 from .output.timestepspec import TimeStepSpec
@@ -29,7 +24,7 @@ from .rendering import RenderedObject
 from .walltime import Walltime
 
 
-AnyLaser = DispersivePulseLaser | FromOpenPMDPulseLaser | GaussianLaser | PlaneWaveLaser
+AnyLaser = DispersivePulseLaser | FromOpenPMDPulseLaser | GaussianLaser | PlaneWaveLaser | TWTSLaser
 
 
 @typeguard.typechecked

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/TwtsBackgroundLaser.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/TwtsBackgroundLaser.param
@@ -1,4 +1,4 @@
-/* Copyright 2021-2024 Klaus Steiniger, Alexander Debus
+/* Copyright 2021-2025 Klaus Steiniger, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -23,103 +23,102 @@
  */
 
 #pragma once
+#include "picongpu/fields/incidentField/profiles/profiles.def"
 
 /** Define common parameters of the TWEAC laser pulses
  */
-namespace picongpu
+namespace picongpu::fields::incidentField
 {
-    namespace fields
+    struct TWTSLaserBaseParam : public profiles::BaseParam
     {
-        namespace background
-        {
-            namespace twtsParam
-            {
-                /** unit: meter */
-                constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
-
-                /** Convert the normalized laser strength parameter a0 to Volt per meter */
-                /* const double UNITCONV_Intens_to_A0 = sim.si.getElectronCharge()
-                 * sim.si.getElectronCharge() * 2.0 * WAVE_LENGTH_SI * WAVE_LENGTH_SI / (4.0 * PI * PI
-                 * sim.si.getElectronMass() * sim.si.getElectronMass() * sim.si.getSpeedOfLight()
-                 * sim.si.getSpeedOfLight() * sim.si.getSpeedOfLight() * sim.si.getSpeedOfLight()
-                 * sim.si.getSpeedOfLight() * SI::EPS0_SI); */
-                constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * sim.si.getElectronMass()
-                                                                 * sim.si.getSpeedOfLight() * sim.si.getSpeedOfLight()
-                                                                 / sim.si.getElectronCharge();
-
-                /** unit: W / m^2 */
-                /* constexpr float_64 _PEAK_INTENSITY_SI = 3.4e19 * 1.0e4; */
-                /** unit: none */
-
-                /** unit: none */
+        /** unit: meter */
+        static constexpr float_64 WAVE_LENGTH_SI = 0.8e-6;
+        /** Convert the normalized laser strength parameter a0 to Volt per meter */
+        static constexpr float_64 UNITCONV_A0_to_Amplitude_SI = -2.0 * PI / WAVE_LENGTH_SI * sim.si.getElectronMass()
+                                                                * sim.si.getSpeedOfLight() * sim.si.getSpeedOfLight()
+                                                                / sim.si.getElectronCharge();
+        /** unit: none */
 #ifndef PARAM_A0
 #    define PARAM_A0 3.25
 #endif
-                constexpr float_64 _A0 = PARAM_A0 * 0.01; // reduced for FOM benchmark
+        static constexpr float_64 _A0 = PARAM_A0 * 0.01; // reduced for FOM benchmark
+        /** unit: Volt / meter */
+        static constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
+        /** Pulse length: sigma of std. gauss for intensity (E^2)
+         *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
+         *                                          [    2.354820045     ]
+         *  Info:             FWHM_of_Intensity = FWHM_Illumination
+         *                      = what a experimentalist calls "pulse duration"
+         *
+         *  unit: seconds (1 sigma) */
+        static constexpr float_64 PULSE_DURATION_SI = 10.0e-15 / 2.354820045; // s (1 sigma)
+    };
 
-                /** unit: Volt / meter */
-                constexpr float_64 AMPLITUDE_SI = _A0 * UNITCONV_A0_to_Amplitude_SI;
-
-                /** unit: Volt / meter */
-                // constexpr float_64 AMPLITUDE_SI = <Or give meaningful value here>;
-
-                /** Pulse length: sigma of std. gauss for intensity (E^2)
-                 *  PULSE_LENGTH_SI = FWHM_of_Intensity   / [ 2*sqrt{ 2* ln(2) } ]
-                 *                                          [    2.354820045     ]
-                 *  Info:             FWHM_of_Intensity = FWHM_Illumination
-                 *                      = what a experimentalist calls "pulse duration"
-                 *
-                 *  unit: seconds (1 sigma) */
-                constexpr float_64 PULSE_LENGTH_SI = 10.e-15 / 2.354820045;
-
-                /** beam waist: distance from the axis where the pulse intensity (E^2)
-                 *              decreases to its 1/e^2-th part,
-                 *              at the focus position of the laser
-                 * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
-                 *                             [   1.17741    ]
-                 *
-                 *  unit: meter */
+    struct TWTSParamPos : public TWTSLaserBaseParam
+    {
+        /** beam waist: distance from the axis where the pulse intensity (E^2)
+         *              decreases to its 1/e^2-th part,
+         *              at the focus position of the laser
+         * W0_SI = FWHM_of_Intensity / sqrt{ 2* ln(2) }
+         *                             [   1.17741    ]
+         *
+         *  unit: meter */
 #ifndef PARAM_W0_SI
 #    define PARAM_W0_SI 1.2e-6
 #endif
-                constexpr float_64 W0_SI = PARAM_W0_SI;
+        static constexpr float_64 W0_SI = PARAM_W0_SI;
 
-                /** the distance to the laser focus in y-direction [m]
-                 *
-                 * unit: meter */
-                constexpr float_64 FOCUS_Y_SI = 30.0e-6;
+        /** the distance to the laser focus in y-direction [m]
+         *
+         * unit: meter */
+        static constexpr float_64 FOCUS_Y_SI = 30.0e-6;
 
-                /** interaction angle between TWTS laser propagation vector and
-                 *  the y-axis [default = 90.*(PI/180.)]
-                 * unit: rad */
+        /** interaction angle between TWTS laser propagation vector and
+         *  the y-axis [default = 90.*(PI/180.)]
+         * unit: rad */
 #ifndef PARAM_PHI
 #    define PARAM_PHI 3.5
 #endif
-                constexpr float_64 PHI = PARAM_PHI * (PI / 180.);
+        static constexpr float_64 PHI = PARAM_PHI * (PI / 180.);
 
+        /** propagation speed of overlap normalized to
+         *  the speed of light [default = 1.0]
+         * unit: none */
+        static constexpr float_64 BETA_0 = 1.0;
 
-                /** propagation speed of overlap normalized to
-                 *  the speed of light [default = 1.0]
-                 * unit: none */
-                constexpr float_64 BETA_0 = 1.0;
+        /** manual time delay if auto_tdelay is false
+         *
+         * unit: s */
+        static constexpr float_64 TDELAY = 50.0e-6 / sim.si.getSpeedOfLight();
 
-                /** manual time delay if auto_tdelay is false
-                 *
-                 * unit: s */
-                constexpr float_64 TDELAY = 50.0e-6 / sim.si.getSpeedOfLight();
+        /** calculate the time delay such that the TWTS pulse is not
+         *  inside the simulation volume at simulation start timestep = 0 [default = true]
+         * unit: none */
+        static constexpr bool AUTO_TDELAY = false;
 
-                /** calculate the time delay such that the TWTS pulse is not
-                 *  inside the simulation volume at simulation start timestep = 0 [default = true]
-                 * unit: none */
-                constexpr bool AUTO_TDELAY = false;
+        /** Defines z-position offset of TWTS coordinate origin inside the simulation coordinates
+         *  relative to the globally centered default value with respect to the simulation volume.
+         *  unit: m */
+        static constexpr float_64 FOCUS_Z_OFFSET_SI = 0.0;
 
-                /** Defines z-position offset of TWTS coordinate origin inside the simulation coordinates
-                 *  relative to the globally centered default value with respect to the simulation volume.
-                 *  unit: m */
-                constexpr float_64 Z_OFFSET_SI = 0.0;
+        static constexpr float_X Polarization = 45.0 * (PI / 180.);
+        static constexpr float_X windowStart = 0.0;
+        static constexpr float_X windowEnd = 0.0;
+        static constexpr float_X windowLength = 0.0;
+    };
 
-                constexpr float_X Polarization = 45.0 * (PI / 180.);
-            } // namespace twtsParam
-        } // namespace background
-    } // namespace fields
-} // namespace picongpu
+    struct TWTSParamNeg : public TWTSParamPos
+    {
+        static constexpr float_64 PHI = -PARAM_PHI * (PI / 180.);
+        static constexpr float_X Polarization = -45.0 * (PI / 180.);
+    };
+
+    namespace profiles
+    {
+        using TWTSPositiveIncidentAngle = profiles::
+            Free<profiles::TWTSFunctorIncidentE<TWTSParamPos>, profiles::TWTSFunctorIncidentB<TWTSParamPos>>;
+
+        using TWTSNegativeIncidentAngle = profiles::
+            Free<profiles::TWTSFunctorIncidentE<TWTSParamNeg>, profiles::TWTSFunctorIncidentB<TWTSParamNeg>>;
+    } // namespace profiles
+} // namespace picongpu::fields::incidentField

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/fieldBackground.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/fieldBackground.param
@@ -30,10 +30,10 @@
 #include "TwtsBackgroundLaser.param"
 
 #ifndef PARAM_FIELD_BACKGROUND
-#    define PARAM_FIELD_BACKGROUND 1
+#    define PARAM_FIELD_BACKGROUND 0
 #endif
 
-namespace Params = ::picongpu::fields::background::twtsParam;
+using Params = ::picongpu::fields::incidentField::TWTSParamPos;
 
 namespace picongpu
 {
@@ -56,22 +56,24 @@ namespace picongpu
             , twtsFieldEPos(
                   Params::FOCUS_Y_SI,
                   Params::WAVE_LENGTH_SI,
-                  Params::PULSE_LENGTH_SI,
+                  Params::PULSE_DURATION_SI,
                   Params::W0_SI,
                   Params::PHI,
                   Params::BETA_0,
                   Params::TDELAY,
                   Params::AUTO_TDELAY,
+                  Params::FOCUS_Z_OFFSET_SI,
                   Params::Polarization)
             , twtsFieldENeg(
                   Params::FOCUS_Y_SI,
                   Params::WAVE_LENGTH_SI,
-                  Params::PULSE_LENGTH_SI,
+                  Params::PULSE_DURATION_SI,
                   Params::W0_SI,
                   -Params::PHI,
                   Params::BETA_0,
                   Params::TDELAY,
                   Params::AUTO_TDELAY,
+                  -Params::FOCUS_Z_OFFSET_SI,
                   -Params::Polarization)
         {
         }
@@ -116,22 +118,24 @@ namespace picongpu
             , twtsFieldBPos(
                   Params::FOCUS_Y_SI,
                   Params::WAVE_LENGTH_SI,
-                  Params::PULSE_LENGTH_SI,
+                  Params::PULSE_DURATION_SI,
                   Params::W0_SI,
                   Params::PHI,
                   Params::BETA_0,
                   Params::TDELAY,
                   Params::AUTO_TDELAY,
+                  Params::FOCUS_Z_OFFSET_SI,
                   Params::Polarization)
             , twtsFieldBNeg(
                   Params::FOCUS_Y_SI,
                   Params::WAVE_LENGTH_SI,
-                  Params::PULSE_LENGTH_SI,
+                  Params::PULSE_DURATION_SI,
                   Params::W0_SI,
                   -Params::PHI,
                   Params::BETA_0,
                   Params::TDELAY,
                   Params::AUTO_TDELAY,
+                  -Params::FOCUS_Z_OFFSET_SI,
                   -Params::Polarization)
         {
         }

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/incidentField.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2024 Axel Huebl, Alexander Debus, Richard Pausch, Sergei Bastrakov
+/* Copyright 2014-2025 Axel Huebl, Alexander Debus, Richard Pausch, Sergei Bastrakov
  *
  * This file is part of PIConGPU.
  *
@@ -25,6 +25,9 @@
  *  - profiles::DispersivePulse<>     : Gaussian pulse allowing to set first-, second-, and third-order dispersion
  * in focus. That is, SD, AD, GDD, and TOD, respectively.
  *  - profiles::Free<>                : custom profile with user-provided functors to calculate incident E and B
+ *  - profiles::Free<profiles::TWTSFunctorIncidentE<>,
+ *                   profiles::TWTSFunctorIncidentB<>>
+ *                                    : Traveling-Wave Thomson Scattering laser (TWTS) with given parameters
  *  - profiles::GaussianPulse<>       : Pulse with Gaussian profile in all three dimensions with given parameters
  *  - profiles::None                  : no incident field
  *  - profiles::PlaneWave<>           : plane wave profile with given parameters
@@ -53,242 +56,55 @@
 
 #pragma once
 
-#include "picongpu/fields/background/templates/twtstight/TWTSTight.hpp"
 #include "picongpu/fields/incidentField/profiles/profiles.def"
-
 /** Load parameters of the TWTS background laser field */
 #include "TwtsBackgroundLaser.param"
 
 #ifndef PARAM_FIELD_BACKGROUND
-#    define PARAM_FIELD_BACKGROUND 1
+#    define PARAM_FIELD_BACKGROUND 0
 #endif
 
-#ifndef PARAM_COMPONENTWISE
-#    define PARAM_COMPONENTWISE 1
-#endif
-
-namespace Params = ::picongpu::fields::background::twtsParam;
-
-namespace picongpu
+namespace picongpu::fields::incidentField
 {
-    namespace fields
-    {
-        namespace incidentField
-        {
-            class FunctorEpos
-            {
-            public:
-                float_X const m_currentStep;
-                PMACC_ALIGN(m_unitField, float3_64 const);
-                templates::twtstight::EField const twtsFieldEpos;
-
-                HINLINE FunctorEpos(float_X const currentStep, float3_64 const unitField)
-                    : m_currentStep(currentStep)
-                    , m_unitField(unitField)
-                    , twtsFieldEpos(
-                          Params::FOCUS_Y_SI,
-                          Params::WAVE_LENGTH_SI,
-                          Params::PULSE_LENGTH_SI,
-                          Params::W0_SI,
-                          Params::PHI,
-                          Params::BETA_0,
-                          Params::TDELAY,
-                          Params::AUTO_TDELAY,
-                          Params::Z_OFFSET_SI,
-                          Params::Polarization)
-                {
-                }
-
-                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
-                {
-                    float3_64 const invUnitField
-                        = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
-                    float3_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldEpos(totalCellIdx, m_currentStep);
-                }
-
-#if PARAM_COMPONENTWISE
-                template<uint32_t T_component>
-                HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
-                {
-                    float_64 const invUnitField = 1.0 / m_unitField[T_component];
-                    float_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldEpos.getComponent<T_component>(totalCellIdx, m_currentStep);
-                }
-#endif
-            };
-
-            class FunctorEneg
-            {
-            public:
-                float_X const m_currentStep;
-                PMACC_ALIGN(m_unitField, float3_64 const);
-                templates::twtstight::EField const twtsFieldEneg;
-
-                HINLINE FunctorEneg(float_X const currentStep, float3_64 const unitField)
-                    : m_currentStep(currentStep)
-                    , m_unitField(unitField)
-                    , twtsFieldEneg(
-                          Params::FOCUS_Y_SI,
-                          Params::WAVE_LENGTH_SI,
-                          Params::PULSE_LENGTH_SI,
-                          Params::W0_SI,
-                          -Params::PHI,
-                          Params::BETA_0,
-                          Params::TDELAY,
-                          Params::AUTO_TDELAY,
-                          Params::Z_OFFSET_SI,
-                          -Params::Polarization)
-                {
-                }
-
-                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
-                {
-                    float3_64 const invUnitField
-                        = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
-                    float3_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldEneg(totalCellIdx, m_currentStep);
-                }
-
-#if PARAM_COMPONENTWISE
-                template<uint32_t T_component>
-                HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
-                {
-                    float_64 const invUnitField = 1.0 / m_unitField[T_component];
-                    float_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldEneg.getComponent<T_component>(totalCellIdx, m_currentStep);
-                }
-#endif
-            };
-
-            class FunctorBpos
-            {
-            public:
-                float_X const m_currentStep;
-                PMACC_ALIGN(m_unitField, float3_64 const);
-                templates::twtstight::BField twtsFieldBpos;
-
-                HINLINE FunctorBpos(float_X const currentStep, float3_64 const unitField)
-                    : m_currentStep(currentStep)
-                    , m_unitField(unitField)
-                    , twtsFieldBpos(
-                          Params::FOCUS_Y_SI,
-                          Params::WAVE_LENGTH_SI,
-                          Params::PULSE_LENGTH_SI,
-                          Params::W0_SI,
-                          Params::PHI,
-                          Params::BETA_0,
-                          Params::TDELAY,
-                          Params::AUTO_TDELAY,
-                          Params::Z_OFFSET_SI,
-                          Params::Polarization)
-                {
-                }
-
-                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
-                {
-                    float3_64 const invUnitField
-                        = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
-                    float3_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldBpos(totalCellIdx, m_currentStep);
-                }
-
-#if PARAM_COMPONENTWISE
-                template<uint32_t T_component>
-                HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
-                {
-                    float_64 const invUnitField = 1.0 / m_unitField[T_component];
-                    float_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldBpos.getComponent<T_component>(totalCellIdx, m_currentStep);
-                }
-#endif
-            };
-
-            class FunctorBneg
-            {
-            public:
-                float_X const m_currentStep;
-                PMACC_ALIGN(m_unitField, float3_64 const);
-                templates::twtstight::BField twtsFieldBneg;
-
-                HINLINE FunctorBneg(float_X const currentStep, float3_64 const unitField)
-                    : m_currentStep(currentStep)
-                    , m_unitField(unitField)
-                    , twtsFieldBneg(
-                          Params::FOCUS_Y_SI,
-                          Params::WAVE_LENGTH_SI,
-                          Params::PULSE_LENGTH_SI,
-                          Params::W0_SI,
-                          -Params::PHI,
-                          Params::BETA_0,
-                          Params::TDELAY,
-                          Params::AUTO_TDELAY,
-                          Params::Z_OFFSET_SI,
-                          -Params::Polarization)
-                {
-                }
-
-                HDINLINE float3_X operator()(floatD_X const& totalCellIdx) const
-                {
-                    float3_64 const invUnitField
-                        = float3_64(1.0 / m_unitField[0], 1.0 / m_unitField[1], 1.0 / m_unitField[2]);
-                    float3_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldBneg(totalCellIdx, m_currentStep);
-                }
-
-#if PARAM_COMPONENTWISE
-                template<uint32_t T_component>
-                HDINLINE float_X getComponent(floatD_X const& totalCellIdx) const
-                {
-                    float_64 const invUnitField = 1.0 / m_unitField[T_component];
-                    float_X const amplitude = precisionCast<float_X>(Params::AMPLITUDE_SI * invUnitField);
-                    return amplitude * twtsFieldBneg.getComponent<T_component>(totalCellIdx, m_currentStep);
-                }
-#endif
-            };
-
-            // Enable functors defined in this file depending on PARAM_FIELD_BACKGROUND
-            using MyProfile = MakeSeq_t<
+    // Enable functors defined in this file depending on PARAM_FIELD_BACKGROUND
+    using TWEACProfile = MakeSeq_t<
 #if PARAM_FIELD_BACKGROUND
-                profiles::None
+        profiles::None
 #else
-                profiles::Free<FunctorEpos, FunctorBpos>,
-                profiles::Free<FunctorEneg, FunctorBneg>
+        profiles::TWTSPositiveIncidentAngle,
+        profiles::TWTSNegativeIncidentAngle
 #endif
-                >;
+        >;
 
-            using XMin = MyProfile;
-            using XMax = MyProfile;
-            using YMin = MyProfile;
-            using YMax = profiles::None;
-            using ZMin = MyProfile;
-            using ZMax = MyProfile;
+    using XMin = TWEACProfile;
+    using XMax = TWEACProfile;
+    using YMin = TWEACProfile;
+    using YMax = profiles::None;
+    using ZMin = TWEACProfile;
+    using ZMax = TWEACProfile;
 
-            /** Position in cells of the Huygens surface relative to start of the total domain
-             *
-             * The position is set as an offset, in cells, counted from the start of the total domain.
-             * For the max boundaries, negative position values are allowed.
-             * These negative values are treated as position at (global_domain_size[d] + POSITION[d][1]).
-             * It is also possible to specify the position explicitly as a positive number.
-             * Then it is on a user to make sure the position is correctly calculated wrt the grid size.
-             *
-             * Except moving window simulations, the position must be inside the global domain.
-             * The distance between the Huygens surface and each global domain boundary must be at least
-             * absorber_thickness + (FDTD_spatial_order / 2 - 1). However beware of setting position = direction *
-             * (absorber_thickness + const), as then changing absorber parameters will affect laser positioning.
-             * When all used profiles are None, the check for POSITION validity is skipped.
-             *
-             * For moving window simulations, POSITION for the YMax side can be located outside the initially
-             * simulated volume. In this case, parts of the generation surface outside of the currently simulated
-             * volume are treated as if they had zero incident field and it is user's responsibility to apply a
-             * source matching such a case.
-             */
-            constexpr int32_t POSITION[3][2] = {
-                {16, -16}, // x direction [negative, positive]
-                {16, -16}, // y direction [negative, positive]
-                {16, -16} // z direction [negative, positive]
-            };
-
-        } // namespace incidentField
-    } // namespace fields
-} // namespace picongpu
+    /** Position in cells of the Huygens surface relative to start of the total domain
+     *
+     * The position is set as an offset, in cells, counted from the start of the total domain.
+     * For the max boundaries, negative position values are allowed.
+     * These negative values are treated as position at (global_domain_size[d] + POSITION[d][1]).
+     * It is also possible to specify the position explicitly as a positive number.
+     * Then it is on a user to make sure the position is correctly calculated wrt the grid size.
+     *
+     * Except moving window simulations, the position must be inside the global domain.
+     * The distance between the Huygens surface and each global domain boundary must be at least
+     * absorber_thickness + (FDTD_spatial_order / 2 - 1). However beware of setting position = direction *
+     * (absorber_thickness + const), as then changing absorber parameters will affect laser positioning.
+     * When all used profiles are None, the check for POSITION validity is skipped.
+     *
+     * For moving window simulations, POSITION for the YMax side can be located outside the initially
+     * simulated volume. In this case, parts of the generation surface outside of the currently simulated
+     * volume are treated as if they had zero incident field and it is user's responsibility to apply a
+     * source matching such a case.
+     */
+    constexpr int32_t POSITION[3][2] = {
+        {16, -16}, // x direction [negative, positive]
+        {16, -16}, // y direction [negative, positive]
+        {16, -16} // z direction [negative, positive]
+    };
+} // namespace picongpu::fields::incidentField

--- a/share/picongpu/pypicongpu/schema/laser.DispersivePulseLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.DispersivePulseLaser.json
@@ -15,7 +15,7 @@
     },
     "pulse_duration_si": {
       "type": "number",
-      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "description": "sigma of std. Gauss for intensity (E^2) [s]",
       "exclusiveMinimum": 0
     },
     "focus_pos_si": {
@@ -44,7 +44,7 @@
       "exclusiveMinimum": 0
     },
     "pulse_init": {
-      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "description": "The laser pulse will be initialized pulse_init times of the pulse_duration_si",
       "type": "number",
       "exclusiveMinimum": 0
     },
@@ -110,7 +110,7 @@
       "type": "number"
     },
     "huygens_surface_positions": {
-      "description": "position of the huygens surface relative from domain boundaries",
+      "description": "position of the Huygens surface relative from domain boundaries",
       "type": "object",
       "required": [
         "row_x",

--- a/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.GaussianLaser.json
@@ -15,7 +15,7 @@
     },
     "pulse_duration_si": {
       "type": "number",
-      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "description": "sigma of std. Gauss for intensity (E^2) [s]",
       "exclusiveMinimum": 0
     },
     "focus_pos_si": {
@@ -44,7 +44,7 @@
       "exclusiveMinimum": 0
     },
     "pulse_init": {
-      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "description": "The laser pulse will be initialized pulse_init times of the pulse_duration_si",
       "type": "number",
       "exclusiveMinimum": 0
     },
@@ -125,7 +125,7 @@
       "minimum": 0
     },
     "huygens_surface_positions": {
-      "description": "position of the huygens surface relative from domain boundaries",
+      "description": "position of the Huygens surface relative from domain boundaries",
       "type": "object",
       "required": [
         "row_x",

--- a/share/picongpu/pypicongpu/schema/laser.Laser.json
+++ b/share/picongpu/pypicongpu/schema/laser.Laser.json
@@ -13,7 +13,8 @@
       "required": [
         "gaussian",
         "dispersive",
-        "planewave"
+        "planewave",
+        "twts"
       ],
       "unevaluatedProperties": false,
       "properties": {
@@ -27,6 +28,9 @@
           "type": "boolean"
         },
         "planewave": {
+          "type": "boolean"
+        },
+        "twts": {
           "type": "boolean"
         }
       }
@@ -45,6 +49,9 @@
         },
         {
           "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.PlaneWaveLaser"
+        },
+        {
+          "$ref": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.TWTSLaser"
         }
       ]
     }

--- a/share/picongpu/pypicongpu/schema/laser.PlaneWaveLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.PlaneWaveLaser.json
@@ -10,7 +10,7 @@
     },
     "pulse_duration_si": {
       "type": "number",
-      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "description": "sigma of std. Gauss for intensity (E^2) [s]",
       "exclusiveMinimum": 0
     },
     "focus_pos_si": {
@@ -39,7 +39,7 @@
       "exclusiveMinimum": 0
     },
     "pulse_init": {
-      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "description": "The laser pulse will be initialized pulse_init times of the pulse_duration_si",
       "type": "number",
       "exclusiveMinimum": 0
     },
@@ -88,7 +88,7 @@
       "type": "number"
     },
     "huygens_surface_positions": {
-      "description": "position of the huygens surface relative from domain boundaries",
+      "description": "position of the Huygens surface relative from domain boundaries",
       "type": "object",
       "required": [
         "row_x",

--- a/share/picongpu/pypicongpu/schema/laser.TWTSLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.TWTSLaser.json
@@ -1,0 +1,172 @@
+{
+  "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.TWTSLaser",
+  "description": "Specification of a TWTS laser pulse",
+  "type": "object",
+  "properties": {
+    "wave_length_si": {
+      "type": "number",
+      "description": "wavelength of laser [m]",
+      "exclusiveMinimum": 0
+    },
+    "waist_si": {
+      "type": "number",
+      "description": "Waist of the Gaussian pulse at focus [m]",
+      "exclusiveMinimum": 0
+    },
+    "pulse_duration_si": {
+      "type": "number",
+      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "exclusiveMinimum": 0
+    },
+    "phi": {
+      "type": "number",
+      "description": "laser incident angle with respect to y-axis [rad]"
+    },
+    "phiPos": {
+      "type": "boolean",
+      "description": "Is phi positive?"
+    },
+    "beta0": {
+      "type": "number",
+      "description": "speed of focal region normalized to the vacuum speed of light [dimensionless]",
+      "exclusiveMinimum": 0
+    },
+    "polarizationAngle": {
+      "type": "number",
+      "description": "linear polarization angle with respect to x-axis polarization [rad]"
+    },
+    "time_offset_si": {
+      "type": "number",
+      "description": "time offset to apply to the pulse [s]"
+    },
+    "focus_z_offset_si": {
+      "type": "number",
+      "description": "offset from the middle of the simulation domain to the laser focus in z-direction [m]"
+    },
+    "focus_pos_si": {
+      "description": "position of focus in total coordinate system, [m]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "phase": {
+      "type": "number"
+    },
+    "E0_si": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "pulse_init": {
+      "description": " The laser pulse will be initialized pulse_init times of the pulse_duration_si",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "propagation_direction": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "polarization_type": {
+      "description": "type of polarization, not direction!",
+      "type": "string",
+      "pattern": "^(Linear|Circular)$"
+    },
+    "polarization_direction": {
+      "description": "Unit E polarization direction",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": [
+          "component"
+        ],
+        "unevaluatedProperties": false,
+        "properties": {
+          "component": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "huygens_surface_positions": {
+      "description": "position of the huygens surface relative from domain boundaries",
+      "type": "object",
+      "required": [
+        "row_x",
+        "row_y",
+        "row_z"
+      ],
+      "unevaluatedProperties": false,
+      "properties": {
+        "row_x": {
+          "$anchor": "row_hygens_surface",
+          "type": "object",
+          "required": [
+            "negative",
+            "positive"
+          ],
+          "unevaluatedProperties": false,
+          "properties": {
+            "negative": {
+              "type": "integer"
+            },
+            "positive": {
+              "type": "integer"
+            }
+          }
+        },
+        "row_y": {
+          "$ref": "#row_hygens_surface"
+        },
+        "row_z": {
+          "$ref": "#row_hygens_surface"
+        }
+      }
+    }
+  },
+  "required": [
+    "wave_length_si",
+    "waist_si",
+    "pulse_duration_si",
+    "focus_pos_si",
+    "phase",
+    "E0_si",
+    "phi",
+    "phiPos",
+    "beta0",
+    "time_offset_si",
+    "focus_z_offset_si",
+    "polarizationAngle",
+    "pulse_init",
+    "propagation_direction",
+    "polarization_type",
+    "polarization_direction",
+    "huygens_surface_positions"
+  ],
+  "unevaluatedProperties": false
+}

--- a/share/picongpu/pypicongpu/schema/laser.TWTSLaser.json
+++ b/share/picongpu/pypicongpu/schema/laser.TWTSLaser.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://registry.hzdr.de/crp/picongpu/schema/picongpu.pypicongpu.laser.TWTSLaser",
-  "description": "Specification of a TWTS laser pulse",
+  "description": "Specification of a Traveling-Wave Thomson-Scattering (TWTS) laser pulse",
   "type": "object",
   "properties": {
     "wave_length_si": {
@@ -15,16 +15,16 @@
     },
     "pulse_duration_si": {
       "type": "number",
-      "description": "sigma of std. gauss for intensity (E^2) [s]",
+      "description": "sigma of std. Gauss for intensity (E^2) [s]",
       "exclusiveMinimum": 0
     },
-    "phi": {
+    "laserIncidenceAngle": {
       "type": "number",
       "description": "laser incident angle with respect to y-axis [rad]"
     },
-    "phiPos": {
+    "laserIncidenceAnglePositive": {
       "type": "boolean",
-      "description": "Is phi positive?"
+      "description": "Is the laser incidence angle positive?"
     },
     "beta0": {
       "type": "number",
@@ -39,9 +39,21 @@
       "type": "number",
       "description": "time offset to apply to the pulse [s]"
     },
-    "focus_z_offset_si": {
+    "focus_lateral_offset_si": {
       "type": "number",
       "description": "offset from the middle of the simulation domain to the laser focus in z-direction [m]"
+    },
+    "windowStart": {
+      "type": "number",
+      "description": "Time step at which the window is started to be ramped up towards unity [time step #]"
+    },
+    "windowEnd": {
+      "type": "number",
+      "description": "Time step at which the window down-ramp to zero has concluded [time step #]"
+    },
+    "windowLength": {
+      "type": "number",
+      "description": "length of the window transition from 0 to 1 and vice versa [# of time steps]"
     },
     "focus_pos_si": {
       "description": "position of focus in total coordinate system, [m]",
@@ -114,7 +126,7 @@
       }
     },
     "huygens_surface_positions": {
-      "description": "position of the huygens surface relative from domain boundaries",
+      "description": "position of the Huygens surface relative from domain boundaries",
       "type": "object",
       "required": [
         "row_x",
@@ -154,18 +166,18 @@
     "waist_si",
     "pulse_duration_si",
     "focus_pos_si",
-    "phase",
     "E0_si",
-    "phi",
-    "phiPos",
+    "laserIncidenceAngle",
+    "laserIncidenceAnglePositive",
     "beta0",
     "time_offset_si",
-    "focus_z_offset_si",
+    "focus_lateral_offset_si",
     "polarizationAngle",
+    "windowStart",
+    "windowEnd",
+    "windowLength",
     "pulse_init",
-    "propagation_direction",
     "polarization_type",
-    "polarization_direction",
     "huygens_surface_positions"
   ],
   "unevaluatedProperties": false

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -152,16 +152,16 @@ namespace picongpu::fields::incidentField
     {
         {{#data}}
         static constexpr float_64 W0_SI = {{{waist_si}}};
-        static constexpr float_64 FOCUS_Y_SI = focus_position[1];//56.0e-6;
-        static constexpr float_64 FOCUS_Z_OFFSET_SI = {{{focus_z_offset_si}}};//8.0e-6;
-        static constexpr float_64 PHI = {{{phi}}};//5.0 * (PI / 180.);
-        static constexpr float_64 BETA_0 = 1.0;//{{{beta0}}};
-        static constexpr float_64 TDELAY = {{{time_offset_si}}};//124.535e-6 / sim.si.getSpeedOfLight();
+        static constexpr float_64 FOCUS_Y_SI = focus_position[1];
+        static constexpr float_64 FOCUS_Z_OFFSET_SI = {{{focus_lateral_offset_si}}};
+        static constexpr float_64 PHI = {{{laserIncidenceAngle}}};
+        static constexpr float_64 BETA_0 = {{{beta0}}};
+        static constexpr float_64 TDELAY = {{{time_offset_si}}};
         static constexpr bool AUTO_TDELAY = false;
-        static constexpr float_X Polarization = {{{polarizationAngle}}};//45.10716816968629 * (PI / 180.);
-        static constexpr float_X windowStart = 0.0;
-        static constexpr float_X windowEnd = 10.0e+20;
-        static constexpr float_X windowLength = 10000.0;//10000.0;
+        static constexpr float_X Polarization = {{{polarizationAngle}}};
+        static constexpr float_X windowStart = {{{windowStart}}};
+        static constexpr float_X windowEnd = {{{windowEnd}}};
+        static constexpr float_X windowLength = {{{windowLength}}};
         {{/data}}
     };
     {{/typeID.twts}}
@@ -251,9 +251,9 @@ namespace picongpu::fields::incidentField
     {{#laser}}
     {{#typeID.twts}}
     {{#data}}
-    {{#phiPos}}
+    {{#laserIncidenceAnglePositive}}
         LaserProfile_{{{_idx}}},
-    {{/phiPos}}
+    {{/laserIncidenceAnglePositive}}
     {{/data}}
     {{/typeID.twts}}
     {{/laser}}
@@ -263,9 +263,9 @@ namespace picongpu::fields::incidentField
     {{#laser}}
     {{#typeID.twts}}
     {{#data}}
-    {{^phiPos}}
+    {{^laserIncidenceAnglePositive}}
         LaserProfile_{{{_idx}}},
-    {{/phiPos}}
+    {{/laserIncidenceAnglePositive}}
     {{/data}}
     {{/typeID.twts}}
     {{/laser}}

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/incidentField.param.mustache
@@ -1,4 +1,4 @@
-/* Copyright 2020-2025 Sergei Bastrakov, Rene Widera, Brian Marre, Julian Lenz
+/* Copyright 2020-2025 Sergei Bastrakov, Rene Widera, Brian Marre, Julian Lenz, Alexander Debus
  *
  * This file is part of PIConGPU.
  *
@@ -147,6 +147,25 @@ namespace picongpu::fields::incidentField
     };
     {{/typeID.fromOpenPMDPulse}}
 
+    {{#typeID.twts}}
+    struct PyPIConGPUTWTSParam_{{{_idx}}} : public PyPIConGPULaserBaseParam_{{{_idx}}}
+    {
+        {{#data}}
+        static constexpr float_64 W0_SI = {{{waist_si}}};
+        static constexpr float_64 FOCUS_Y_SI = focus_position[1];//56.0e-6;
+        static constexpr float_64 FOCUS_Z_OFFSET_SI = {{{focus_z_offset_si}}};//8.0e-6;
+        static constexpr float_64 PHI = {{{phi}}};//5.0 * (PI / 180.);
+        static constexpr float_64 BETA_0 = 1.0;//{{{beta0}}};
+        static constexpr float_64 TDELAY = {{{time_offset_si}}};//124.535e-6 / sim.si.getSpeedOfLight();
+        static constexpr bool AUTO_TDELAY = false;
+        static constexpr float_X Polarization = {{{polarizationAngle}}};//45.10716816968629 * (PI / 180.);
+        static constexpr float_X windowStart = 0.0;
+        static constexpr float_X windowEnd = 10.0e+20;
+        static constexpr float_X windowLength = 10000.0;//10000.0;
+        {{/data}}
+    };
+    {{/typeID.twts}}
+
     {{#typeID.gaussian}}
     using LaserProfile_{{{_idx}}} = profiles::GaussianPulse<PyPIConGPUGaussianPulseParam_{{{_idx}}}>;
     {{/typeID.gaussian}}
@@ -159,6 +178,12 @@ namespace picongpu::fields::incidentField
     {{#typeID.fromOpenPMDPulse}}
     using LaserProfile_{{{_idx}}} = profiles::FromOpenPMDPulse<PyPIConGPUFromOpenPMDPulseParam_{{{_idx}}}>;
     {{/typeID.fromOpenPMDPulse}}
+    {{#typeID.twts}}
+    using LaserProfile_{{{_idx}}} = profiles::Free<
+            profiles::TWTSFunctorIncidentE<PyPIConGPUTWTSParam_{{{_idx}}}>,
+            profiles::TWTSFunctorIncidentB<PyPIConGPUTWTSParam_{{{_idx}}}>
+            >;
+    {{/typeID.twts}}
 
     // TODO: find a better solution and move it into simulation class, or add a check that all lasers use the same positions
     {{/laser}}
@@ -222,7 +247,29 @@ namespace picongpu::fields::incidentField
     using XMin = profiles::None;
     using XMax = profiles::None;
     using YMax = profiles::None;
-    using ZMin = profiles::None;
-    using ZMax = profiles::None;
+    using ZMin = MakeSeq_t<
+    {{#laser}}
+    {{#typeID.twts}}
+    {{#data}}
+    {{#phiPos}}
+        LaserProfile_{{{_idx}}},
+    {{/phiPos}}
+    {{/data}}
+    {{/typeID.twts}}
+    {{/laser}}
+    profiles::None
+    >;
+    using ZMax = MakeSeq_t<
+    {{#laser}}
+    {{#typeID.twts}}
+    {{#data}}
+    {{^phiPos}}
+        LaserProfile_{{{_idx}}},
+    {{/phiPos}}
+    {{/data}}
+    {{/typeID.twts}}
+    {{/laser}}
+    profiles::None
+    >;
     /**@}*/
 } // namespace picongpu::fields::incidentField


### PR DESCRIPTION
This draft of a PR implements PICMI capability for TWTS and TWEAC lasers. It successfully runs and builds the Laser-wakefield PICMI example using:
```cpp
laser_duration = 30.0e-15 / 2.35482
pulse_init = 15.0
laser_focal_position=[
    float(numberCells[0] * cellSize[0] / 2.0),
    4.62e-5,
    float(numberCells[2] * cellSize[2] / 2.0),
]
laser = picmi.TWTSLaser(
    wavelength=0.8e-6,
    waist=1.2e-6 / 1.17741,
    duration=laser_duration,
    focal_position=laser_focal_position,
    centroid_position=[
        float(numberCells[0] * cellSize[0] / 2.0),
        -0.5 * pulse_init * laser_duration * c,
        float(numberCells[2] * cellSize[2] / 2.0),
    ],
    focus_z_offset_si=laser_focal_position[2] - float(numberCells[2] * cellSize[2] / 2.0),
    a0=8.0,
    phi=5.0 * np.pi / 180.0,
    beta0=1.0,
    polarizationAngle=45.0 * np.pi / 180.0
)
```
As already mentioned, this PR should be still considered a draft, but feedback is welcome!

Current working items and/or questions are:
* Include metadata routines.
* Is the use of the laser profile `free` still appropriate?
* How shall we integrate the functionality with `centroid_position` and `focal_position`? The semantics is not very intuitive for TWTS lasers here.
* Is the approach for conditional laser insertion at ZMIN and ZMAX good?
* Are the schema and requirements OK or still "wild"?
* The traditional laser profile usage pattern suggests further refactoring of the TWTSTight laser by outsourcing the unit rescaling to unitless param-structs. However, this also affects unit-tests.
* The focus_z_offset_si parameter shows a slight clash of philosophies between a param-file-centered and a PICMI-python-centered workflow, as for PICMI it is much easier to parameterize absolute focal positions in contrast to positions relative to the center of the simulation domain.
