### PR TITLE
Checkpoint period from cmdline args ignored 

### DIFF
--- a/include/pmacc/simulationControl/Checkpointing.hpp
+++ b/include/pmacc/simulationControl/Checkpointing.hpp
@@ -137,8 +137,6 @@ namespace pmacc::simulationControl
                 ("checkpoint.directory", po::value<std::string>(&checkpointDirectory)->default_value(checkpointDirectory),
                     "Directory for checkpoints");
             // clang-format on
-            // translate checkpointPeriod string into checkpoint intervals
-            seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
         }
 
         void addCheckpoint(uint32_t signalMaxTimestep)
@@ -205,6 +203,9 @@ namespace pmacc::simulationControl
 
         void startTimeBasedCheckpointing()
         {
+            // translate checkpointPeriod string into checkpoint intervals
+            seqCheckpointPeriod = pluginSystem::toTimeSlice(checkpointPeriod);
+
             // register concurrent thread to perform checkpointing periodically after a user defined time
             if(checkpointPeriodMinutes != 0)
                 checkpointTimeThread = std::thread(


### PR DESCRIPTION
With #5493, I introduced a bug where the command line argument `checkpoint period` was ignored and not added to the internal sequence of checkpointing steps `seqCheckpointPeriod`.

This was because the call to intialize `seqCheckpointPeriod` was in the wrong place and called way too soon, before `checkpoint period` was actually set.
