### PR TITLE
add MallocMC to PMacc using fetchContent

### DIFF
--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -376,12 +376,10 @@ if(alpaka_ACC_GPU_CUDA_ENABLE OR alpaka_ACC_GPU_HIP_ENABLE)
             "Select which alpaka is used for mallocMC"
         )
     endif()
-    find_package(mallocMC 3.0.0 QUIET)
+    include(FetchContent)
 
-    if(NOT mallocMC_FOUND)
-        message(STATUS "Using mallocMC from thirdParty/ directory")
-        add_subdirectory("${PMacc_DIR}/../../thirdParty/mallocMC" ${CMAKE_BINARY_DIR}/mallocMC EXCLUDE_FROM_ALL)
-    endif(NOT mallocMC_FOUND)
+    FetchContent_Declare(mallocMC SOURCE_DIR "${PMacc_DIR}/../../thirdParty/mallocMC" FIND_PACKAGE_ARGS 3.0.0 QUIET)
+    FetchContent_MakeAvailable(mallocMC)
 
     target_link_libraries(pmacc PUBLIC mallocMC::mallocMC)
 endif()


### PR DESCRIPTION
The current pattern fails if there are multiple passes of configure and `mallocMC` was not initially installed.
This happens because in the first pass `add_subdirectory` creates the package config and in later passes `findPackage` finds this and fails as `mallocMC` wasnt actually installed.
Switched to simply using `FetchContent` with `FIND_PACKAGE_ARGS` which first checks with `findPackage` and then falls back to the source dir which is exactly what we want.
https://cmake.org/cmake/help/latest/guide/using-dependencies/index.html#fetchcontent-and-find-package-integration