### PR TITLE
Fix some errors, warnings and wrong indentations in binning plugin docs

### DIFF
--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -1,20 +1,22 @@
 .. _usage-plugins-binningPlugin:
+
 #######
 Binning
 #######
 
 This binning plugin is a flexible binner for particles and field properties.
 Users can
-	- Define their own axes
-	- Define their own quantity which is binned
-	- Choose which species are used for particle binning
-	- Choose which fields are used for field binning
-	- Choose how frequently they want the binning to be executed
-	- Choose how many times the binned quantity should be combined over time before dumping
-	- Write custom output to file, for example other quantities related to the simulation which the user is interested in
-	- Execute multiple binnings at the same time
-	- Pass extra parameters as a tuple, if additional information is required by the kernels to do binning.
-	- Define a host-side hook to execute code before binning at each notify step, for example to fill ``FieldTmp``.
+
+- Define their own axes
+- Define their own quantity which is binned
+- Choose which species are used for particle binning
+- Choose which fields are used for field binning
+- Choose how frequently they want the binning to be executed
+- Choose how many times the binned quantity should be combined over time before dumping
+- Write custom output to file, for example other quantities related to the simulation which the user is interested in
+- Execute multiple binnings at the same time
+- Pass extra parameters as a tuple, if additional information is required by the kernels to do binning.
+- Define a host-side hook to execute code before binning at each notify step, for example to fill ``FieldTmp``.
 
 User Input
 ==========
@@ -28,7 +30,7 @@ A binner is created using the `addParticleBinner()` or `addFieldBinner()` functi
 Multiple binnings can be run at the same time by simply calling `addParticleBinner()` or `addFieldBinner()` multiple times with different parameters.
 
 .. doxygenclass:: picongpu::plugins::binning::BinningCreator
-	:members: addParticleBinner, addFieldBinner
+  :members: addParticleBinner, addFieldBinner
 
 The most important parts of defining a binning are the axes (the axes of the histogram which define the bins) and the deposited quantity (the quantity to be binned).
 Both of these are described using the "Functor Description".
@@ -156,7 +158,8 @@ Currently implemented axis types
 
 
 .. attention::
-The log axis suffers from floating point precision errors, so for certain combinations of min, max, nBins and values to be binned the bin index calculated might be off by one. If using an integral log axis, be careful of what you are doing.
+
+  The log axis suffers from floating point precision errors, so for certain combinations of min, max, nBins and values to be binned the bin index calculated might be off by one. If using an integral log axis, be careful of what you are doing.
 
 
 Binning can be done over an arbitrary number of axes, by creating a tuple of all the axes. Limited by memory depending on number of bins in each axis.
@@ -296,10 +299,10 @@ This can be configured using the ``enableRegion`` and ``disableRegion`` options 
 
 .. attention::
 
-Users must carefully configure the notify period when using the binning plugin for leaving particles. The plugin bins particles leaving the global simulation volume at every timestep (except 0) after particles are pushed, regardless of the notify period.
-If the plugin is not notified at every timestep, this can cause discrepancies between the binning process and histogram dumps, which follow the notify period.
-Additionally, the binning plugin is first notified at timestep 0, allowing users to bin initial conditions. However, leaving particles are first binned at timestep 1, after the initial particle push.
-Therefore, users should consider setting the notify period’s start at timestep 1, depending on their specific needs.
+  Users must carefully configure the notify period when using the binning plugin for leaving particles. The plugin bins particles leaving the global simulation volume at every timestep (except 0) after particles are pushed, regardless of the notify period.
+  If the plugin is not notified at every timestep, this can cause discrepancies between the binning process and histogram dumps, which follow the notify period.
+  Additionally, the binning plugin is first notified at timestep 0, allowing users to bin initial conditions. However, leaving particles are first binned at timestep 1, after the initial particle push.
+  Therefore, users should consider setting the notify period’s start at timestep 1, depending on their specific needs.
 
 writeOpenPMDFunctor
 -------------------

--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -24,7 +24,7 @@ Users can set up their binning in the ``binningSetup.param`` file. After setup, 
 
 .. attention::
 
-	Unlike other plugins, the binning plugin doesn't provide any runtime configuration. To set up binning, users need to define it in the param file and then recompile.
+  Unlike other plugins, the binning plugin doesn't provide any runtime configuration. To set up binning, users need to define it in the param file and then recompile.
 
 A binner is created using the `addParticleBinner()` or `addFieldBinner()` functions, which describe the configuration options available to the user to set up particle and field binning respectively.
 Multiple binnings can be run at the same time by simply calling `addParticleBinner()` or `addFieldBinner()` multiple times with different parameters.
@@ -61,45 +61,45 @@ For particles:
 
 .. code-block:: c++
 
-	auto myParticleFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> returnType
-	{
-		// fn body
-		return myParameter;
-	};
+  auto myParticleFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle) -> returnType
+  {
+    // fn body
+    return myParameter;
+  };
 
 For particles with two extra data paramters:
 
 .. code-block:: c++
 
-	auto myParticleWithExtraDataFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle, auto const& extraData1, auto const& extraData2) -> returnType
-	{
-		// fn body
-		return myParameter;
-	};
+  auto myParticleWithExtraDataFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& particle, auto const& extraData1, auto const& extraData2) -> returnType
+  {
+    // fn body
+    return myParameter;
+  };
 
 For one field:
 
 .. code-block:: c++
 
-	auto myFieldFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field) -> returnType
-	{
-		// fn body
-		return myParameter;
-	};
+  auto myFieldFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field) -> returnType
+  {
+    // fn body
+    return myParameter;
+  };
 
 For two fields with one extra data parameter:
 
 .. code-block:: c++
 
-	auto myFieldWithExtraDataFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2, auto const& extraData) -> returnType
-	{
-		// fn body
-		return myParameter;
-	};
+  auto myFieldWithExtraDataFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, auto const& field1, auto const& field2, auto const& extraData) -> returnType
+  {
+    // fn body
+    return myParameter;
+  };
 
 .. note::
 
-	Fields and extra data may be tuples with multiple elements which are unpacked and passed to the user-defined functors. Therefore, it is the responsibility of the user to ensure that their functors have an appropriate number of arguments to match the provided tuples.
+  Fields and extra data may be tuples with multiple elements which are unpacked and passed to the user-defined functors. Therefore, it is the responsibility of the user to ensure that their functors have an appropriate number of arguments to match the provided tuples.
 
 Domain Info
 """""""""""
@@ -108,7 +108,7 @@ Enables the user to find the location of the particle or field in the simulation
 For particle binning, the ``DomainInfo`` class contains:
 
 .. doxygenclass:: picongpu::plugins::binning::DomainInfoBase
-	:members:
+  :members:
 
 The global and local offsets can be understood by looking at the `PIConGPU domain definitions <https://github.com/ComputationalRadiationPhysics/picongpu/wiki/PIConGPU-domain-definitions>`_.
 
@@ -140,11 +140,11 @@ The name used in the functor description is used as the name of the axis for ope
 
 .. attention::
 
-	The return type of the functor as specified in the functor description is required to be the same as the type of the range (min, max).
+  The return type of the functor as specified in the functor description is required to be the same as the type of the range (min, max).
 
 Currently implemented axis types
-	- Linear Axis
-	- Log Axis
+  - Linear Axis
+  - Log Axis
 
 .. doxygenclass:: picongpu::plugins::binning::axis::LinearAxis
 
@@ -170,14 +170,14 @@ Defines the axis range and how it is split into bins. Bins are defined as closed
 In the future, this plugin will support other ways to split the domain, eg. using the binWidth or by auto-selecting the parameters.
 
 .. doxygenclass:: picongpu::plugins::binning::axis::AxisSplitting
-	:members:
+  :members:
 
 
 Range
 """""
 
 .. doxygenclass:: picongpu::plugins::binning::axis::Range
-	:members:
+  :members:
 
 .. note::
 
@@ -191,7 +191,7 @@ Species can be instances of a species type or a particle species name as a PMACC
 
 .. code-block:: c++
 
-	auto electronsObj = PMACC_CSTRING("e"){};
+  auto electronsObj = PMACC_CSTRING("e"){};
 
 Optionally, users can specify a filter to be used with the species. This is a predicate functor, i.e. it is a functor with a signature as described above and which returns a boolean. If the filter returns true it means the particle is included in the binning.
 They can then create a ``FilteredSpecies`` object which contains the species and the filter.
@@ -204,8 +204,8 @@ They can then create a ``FilteredSpecies`` object which contains the species and
 
 .. note::
 
-			Species are passed to addParticleBinner in the form of a tuple. This is just a collection of Species and FilteredSpecies objects (the tuple can be a mixture of both) and is of arbitrary size.
-			Users can make a species tuple by using the ``createSpeciesTuple()`` function and passing in the objects as arguments.
+      Species are passed to addParticleBinner in the form of a tuple. This is just a collection of Species and FilteredSpecies objects (the tuple can be a mixture of both) and is of arbitrary size.
+      Users can make a species tuple by using the ``createSpeciesTuple()`` function and passing in the objects as arguments.
 
 Fields
 ------
@@ -213,7 +213,7 @@ PIConGPU fields which should be used in field binning.
 Fields must be instances of the ``FieldInfo`` type.
 
 .. doxygenstruct:: picongpu::plugins::binning::FieldInfo
-	:members:
+  :members:
 
 For example,
 
@@ -235,7 +235,7 @@ The functors receive the fields in the form of the field data box, which is the 
 
 .. note::
 
-	It is possible to have an empty tuple for fields when doing field binning, in which case the functor will be called with no fields. This may be useful if you are passing in extra data and want field traversal over it.
+  It is possible to have an empty tuple for fields when doing field binning, in which case the functor will be called with no fields. This may be useful if you are passing in extra data and want field traversal over it.
 
 .. note::
 
@@ -248,7 +248,7 @@ The signature of quantity functors is
 
 .. code-block:: c++
 
-	auto myQuantityFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, ...) -> returnType
+  auto myQuantityFunctor = [] ALPAKA_FN_ACC(auto const& worker, auto const& domainInfo, ...) -> returnType
 
 This option makes it evident that the binning is more than just about creating histograms. While histograms are a common use case, the binning plugin allows for using various binary operations to combine various quantities within bins and not just noting the frequencies of occurrences. This means that users can define custom quantities to be combined in each bin, such as charge, energy, momentum, or any other property of interest. The flexibility of the functor description enables users to specify exactly what and how they want to combine data in the bins.
 For example, you might want to combine the total charge of particles within each bin, or the average kinetic energy of particles in a specific region. The deposited quantity functor provides the mechanism to calculate and return these values, which are then combined in the corresponding bins during the simulation.
@@ -262,7 +262,7 @@ Users can make a tuple of the extra data by using the ``createTuple()`` function
 
 .. note::
 
-	Ensure that the functors have an appropriate number of arguments to match the provided tuples. The extra data may be tuples with multiple elements which are unpacked and passed to the user-defined functors.
+  Ensure that the functors have an appropriate number of arguments to match the provided tuples. The extra data may be tuples with multiple elements which are unpacked and passed to the user-defined functors.
 
 Host-side hook
 ---------------
@@ -271,9 +271,9 @@ This hook is set using the ``setHostSideHook`` method of the ``BinningCreator`` 
 
 .. code-block:: c++
 
-	[]() -> void{
-		// host-side code to be executed before binning
-	}
+  []() -> void{
+    // host-side code to be executed before binning
+  }
 
 For example, this can be used to pre-process data on the host side, such as filling temporary fields before they are used in field binning.
 
@@ -311,11 +311,11 @@ This is a lambda with the following signature, and is set using the ``setWriteOp
 
 .. code-block:: c++
 
-	[=](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) -> void
+  [=](::openPMD::Series& series, ::openPMD::Iteration& iteration, ::openPMD::Mesh& mesh) -> void
 
 .. note::
 
-	Make sure to capture by copy only, as the objects defined in the param file are not kept alive
+  Make sure to capture by copy only, as the objects defined in the param file are not kept alive
 
 
 OpenPMD JSON Configuration
@@ -391,7 +391,7 @@ A list of available PMacc operations can be found under `/include/pmacc/math/ope
 
 .. note::
 
-	The operation is only viable if it has a corresponding MPI reduction operation, a neutral element, and a cooresponding alpaka operation. Only binary atomics on arithmetic types are supported. In particular CAS operations are not supported.
+  The operation is only viable if it has a corresponding MPI reduction operation, a neutral element, and a cooresponding alpaka operation. Only binary atomics on arithmetic types are supported. In particular CAS operations are not supported.
 
 
 The reduce operation is passed as a template parameter to the `createBinner` functions.
@@ -416,9 +416,9 @@ Such spectrometers are a common tool in plasma based electron acceleration exper
 
 .. note::
 
-	Please note that if you specify the SI units of an axis, e.g. via ``energyDimension`` in the LWFA example,
-	PIConGPU automatically converts to the internal unit system, but then also expects SI-compliant values for the axis range
-	(in the case of energy Joules).
+  Please note that if you specify the SI units of an axis, e.g. via ``energyDimension`` in the LWFA example,
+  PIConGPU automatically converts to the internal unit system, but then also expects SI-compliant values for the axis range
+  (in the case of energy Joules).
 
 
 To read the electron spectrometer data in python, one could load and plot it like this:
@@ -450,27 +450,27 @@ To read the electron spectrometer data in python, one could load and plot it lik
           theta_bins = espec_h.get_attribute('pointingXY_bin_edges')
 
           # convert C/J/rad -> C/MeV/mrad
-	  convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad = 1./1e-12 * const.elementary_charge/1e6 * 1/1e3
+    convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad = 1./1e-12 * const.elementary_charge/1e6 * 1/1e3
 
-	  # plot
-	  plt.pcolormesh(np.array(E_bins) / const.elementary_charge / 1e6,
-                         np.array(theta_bins) / 0.001,
-                         espec[1:-1, 1:-1] * convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad,
-                         norm=LogNorm(), cmap=plt.cm.inferno)
-	  cb = plt.colorbar()
+    # plot
+    plt.pcolormesh(np.array(E_bins) / const.elementary_charge / 1e6,
+                        np.array(theta_bins) / 0.001,
+                        espec[1:-1, 1:-1] * convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad,
+                        norm=LogNorm(), cmap=plt.cm.inferno)
+    cb = plt.colorbar()
 
-	  plt.xlabel(r"$E \, \mathrm{[MeV]}$", fontsize=18)
-	  plt.xticks(fontsize=14)
+    plt.xlabel(r"$E \, \mathrm{[MeV]}$", fontsize=18)
+    plt.xticks(fontsize=14)
 
-	  plt.ylabel(r"$\theta \, \mathrm{[mrad]}$", fontsize=18)
-	  plt.yticks(fontsize=14)
+    plt.ylabel(r"$\theta \, \mathrm{[mrad]}$", fontsize=18)
+    plt.yticks(fontsize=14)
 
-	  cb.set_label(r"$\frac{\mathrm{d}^2 Q}{\mathrm{d} E \mathrm{d}\theta} \, \mathrm{[pC/MeV/mrad]}$", fontsize=20)
-	  for i in cb.ax.get_yticklabels():
-	      i.set_fontsize(14)
+    cb.set_label(r"$\frac{\mathrm{d}^2 Q}{\mathrm{d} E \mathrm{d}\theta} \, \mathrm{[pC/MeV/mrad]}$", fontsize=20)
+    for i in cb.ax.get_yticklabels():
+        i.set_fontsize(14)
 
-	  plt.tight_layout()
-	  plt.show()
+    plt.tight_layout()
+    plt.show()
 
 
 References

--- a/docs/source/usage/plugins/binningPlugin.rst
+++ b/docs/source/usage/plugins/binningPlugin.rst
@@ -181,8 +181,8 @@ Range
 
 .. note::
 
-    Axes are passed to addParticleBinner or addFieldBinner grouped in a tuple. This is just a collection of axis objects and is of arbitrary size.
-    Users can make a tuple for axes by using the ``createTuple()`` function and passing in the axis objects as arguments.
+  Axes are passed to addParticleBinner or addFieldBinner grouped in a tuple. This is just a collection of axis objects and is of arbitrary size.
+  Users can make a tuple for axes by using the ``createTuple()`` function and passing in the axis objects as arguments.
 
 Species
 -------
@@ -204,8 +204,8 @@ They can then create a ``FilteredSpecies`` object which contains the species and
 
 .. note::
 
-      Species are passed to addParticleBinner in the form of a tuple. This is just a collection of Species and FilteredSpecies objects (the tuple can be a mixture of both) and is of arbitrary size.
-      Users can make a species tuple by using the ``createSpeciesTuple()`` function and passing in the objects as arguments.
+  Species are passed to addParticleBinner in the form of a tuple. This is just a collection of Species and FilteredSpecies objects (the tuple can be a mixture of both) and is of arbitrary size.
+  Users can make a species tuple by using the ``createSpeciesTuple()`` function and passing in the objects as arguments.
 
 Fields
 ------
@@ -239,7 +239,7 @@ The functors receive the fields in the form of the field data box, which is the 
 
 .. note::
 
-    It is possible to have field information available while doing particle binning as well. Users can simply pass in ``FieldInfo`` objects in the extra data tuple, and the functor will be called with the field information as well.
+  It is possible to have field information available while doing particle binning as well. Users can simply pass in ``FieldInfo`` objects in the extra data tuple, and the functor will be called with the field information as well.
 
 Deposited Quantity
 ------------------
@@ -425,52 +425,52 @@ To read the electron spectrometer data in python, one could load and plot it lik
 
 .. code:: python
 
-          import numpy as np
-          import matplotlib.pyplot as plt
-          from matplotlib.colors import LogNorm
-          import openpmd_api as io
-          import scipy.constants as const
+  import numpy as np
+  import matplotlib.pyplot as plt
+  from matplotlib.colors import LogNorm
+  import openpmd_api as io
+  import scipy.constants as const
 
-          # access openPMD series of eSpec
-          series = io.Series("./LWFA/simOutput/binningOpenPMD/eSpec_%T.h5", access=io.Access_Type.read_only)
+  # access openPMD series of eSpec
+  series = io.Series("./LWFA/simOutput/binningOpenPMD/eSpec_%T.h5", access=io.Access_Type.read_only)
 
-          last_iter = list(series.iterations)[-1]
-          it = series.iterations[last_iter]
-          espec_h = it.meshes['Binning'][io.Mesh_Record_Component.SCALAR]
+  last_iter = list(series.iterations)[-1]
+  it = series.iterations[last_iter]
+  espec_h = it.meshes['Binning'][io.Mesh_Record_Component.SCALAR]
 
-          # load data
-          espec = espec_h[:,:]
-          series.flush()
+  # load data
+  espec = espec_h[:,:]
+  series.flush()
 
-          # convert to SI units and make positve (electrons have a negative charge)
-          espec *= espec_h.get_attribute('unitSI') * -1
+  # convert to SI units and make positve (electrons have a negative charge)
+  espec *= espec_h.get_attribute('unitSI') * -1
 
-          # get axes (they are already in the correct SI unit)
-          E_bins = espec_h.get_attribute('Energy_bin_edges')
-          theta_bins = espec_h.get_attribute('pointingXY_bin_edges')
+  # get axes (they are already in the correct SI unit)
+  E_bins = espec_h.get_attribute('Energy_bin_edges')
+  theta_bins = espec_h.get_attribute('pointingXY_bin_edges')
 
-          # convert C/J/rad -> C/MeV/mrad
-    convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad = 1./1e-12 * const.elementary_charge/1e6 * 1/1e3
+  # convert C/J/rad -> C/MeV/mrad
+  convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad = 1./1e-12 * const.elementary_charge/1e6 * 1/1e3
 
-    # plot
-    plt.pcolormesh(np.array(E_bins) / const.elementary_charge / 1e6,
-                        np.array(theta_bins) / 0.001,
-                        espec[1:-1, 1:-1] * convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad,
-                        norm=LogNorm(), cmap=plt.cm.inferno)
-    cb = plt.colorbar()
+  # plot
+  plt.pcolormesh(np.array(E_bins) / const.elementary_charge / 1e6,
+                      np.array(theta_bins) / 0.001,
+                      espec[1:-1, 1:-1] * convert_C_per_Joule_per_rad_to_pC_per_MeV_per_mrad,
+                      norm=LogNorm(), cmap=plt.cm.inferno)
+  cb = plt.colorbar()
 
-    plt.xlabel(r"$E \, \mathrm{[MeV]}$", fontsize=18)
-    plt.xticks(fontsize=14)
+  plt.xlabel(r"$E \, \mathrm{[MeV]}$", fontsize=18)
+  plt.xticks(fontsize=14)
 
-    plt.ylabel(r"$\theta \, \mathrm{[mrad]}$", fontsize=18)
-    plt.yticks(fontsize=14)
+  plt.ylabel(r"$\theta \, \mathrm{[mrad]}$", fontsize=18)
+  plt.yticks(fontsize=14)
 
-    cb.set_label(r"$\frac{\mathrm{d}^2 Q}{\mathrm{d} E \mathrm{d}\theta} \, \mathrm{[pC/MeV/mrad]}$", fontsize=20)
-    for i in cb.ax.get_yticklabels():
-        i.set_fontsize(14)
+  cb.set_label(r"$\frac{\mathrm{d}^2 Q}{\mathrm{d} E \mathrm{d}\theta} \, \mathrm{[pC/MeV/mrad]}$", fontsize=20)
+  for i in cb.ax.get_yticklabels():
+      i.set_fontsize(14)
 
-    plt.tight_layout()
-    plt.show()
+  plt.tight_layout()
+  plt.show()
 
 
 References


### PR DESCRIPTION
This fixes the warnings and errors that are created from the binning plugin file when compiling the documentation.
Some of the "attention" boxes were missing and are now displayed correctly through this fix.

I also replaced tabs with spaces.