### PR TITLE
add check for existance of output dir for memtest

### DIFF
--- a/bin/cuda_memtest.sh
+++ b/bin/cuda_memtest.sh
@@ -43,7 +43,7 @@ if [ $? -ne 0 ] ; then
        echo "Error: $0 did not find directory: $old_path (on host: $host_name with rank: $host_rank)" >&2
        echo "error message of memtest is:" >&2
        echo -e "$output" >&2
-      exit 2
+       exit 2
    else
       echo -e "$output" > $old_path/cuda_memtest_"$host_name"_"$host_rank".err
       echo cuda_memtest crash: see file $old_path/cuda_memtest_"$host_name"_"$host_rank".err >&2

--- a/bin/cuda_memtest.sh
+++ b/bin/cuda_memtest.sh
@@ -39,8 +39,13 @@ output=`cuda_memtest --disable_all --device $host_rank $enable_gpu_tests --num_p
 
 if [ $? -ne 0 ] ; then
    host_name=`hostname`
-   echo -e "$output" > $old_path/cuda_memtest_"$host_name"_"$host_rank".err
-   echo cuda_memtest crash: see file $old_path/cuda_memtest_"$host_name"_"$host_rank".err >&2
-   exit 1
+   if [ ! -d "$old_path" ]; then
+      echo "Error: $0 did not find directory: $old_path (on host: $host_name with rank: $host_rank)" >&2
+      exit 2
+   else
+      echo -e "$output" > $old_path/cuda_memtest_"$host_name"_"$host_rank".err
+      echo cuda_memtest crash: see file $old_path/cuda_memtest_"$host_name"_"$host_rank".err >&2
+      exit 1
+   fi
 fi
 exit 0

--- a/bin/cuda_memtest.sh
+++ b/bin/cuda_memtest.sh
@@ -40,7 +40,9 @@ output=`cuda_memtest --disable_all --device $host_rank $enable_gpu_tests --num_p
 if [ $? -ne 0 ] ; then
    host_name=`hostname`
    if [ ! -d "$old_path" ]; then
-      echo "Error: $0 did not find directory: $old_path (on host: $host_name with rank: $host_rank)" >&2
+       echo "Error: $0 did not find directory: $old_path (on host: $host_name with rank: $host_rank)" >&2
+       echo "error message of memtest is:" >&2
+       echo -e "$output" >&2
       exit 2
    else
       echo -e "$output" > $old_path/cuda_memtest_"$host_name"_"$host_rank".err


### PR DESCRIPTION
I encountered an issue on OLCF Frontier where we ran through the memtest loop, saw a defective node/GPU, but could not write out the error file. @psychocoderHPC and I suspect that the file system was not available or up-to-date on the defective node, thus preventing any useful error log. 

To prevent this kind of bug in the future, this PR adds a check that writes to stderr if the directory to which to write the error log is not available. 