### PR TITLE
use the find package config for boost

### DIFF
--- a/include/mpiInfo/CMakeLists.txt
+++ b/include/mpiInfo/CMakeLists.txt
@@ -102,7 +102,7 @@ find_package(MPI REQUIRED)
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.66.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.74.0 REQUIRED CONFIG COMPONENTS program_options)
 if(TARGET Boost::program_options)
     set(MPIINFO_LIBS ${MPIINFO_LIBS} Boost::boost Boost::program_options)
 else()

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -181,7 +181,7 @@ endif()
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.74.0 REQUIRED CONFIG COMPONENTS program_options)
 if(TARGET Boost::boost)
     list(PREPEND HOST_LIBS Boost::boost Boost::program_options)
 else()

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -309,7 +309,7 @@ endif()
 # Find Boost
 ################################################################################
 
-find_package(Boost 1.74 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.74 REQUIRED CONFIG COMPONENTS program_options)
 if(TARGET Boost::boost)
     target_link_libraries(pmacc PUBLIC Boost::boost)
     target_link_libraries(pmacc PUBLIC Boost::program_options)

--- a/share/picongpu/unit/CMakeLists.txt
+++ b/share/picongpu/unit/CMakeLists.txt
@@ -70,7 +70,7 @@ add_subdirectory(
 
 list(APPEND CMAKE_PREFIX_PATH "$ENV{BOOST_ROOT}")
 
-find_package(Boost 1.74.0 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.74.0 REQUIRED CONFIG COMPONENTS program_options)
 if(TARGET Boost::boost)
     list(PREPEND HOST_LIBS Boost::boost Boost::program_options)
 else()


### PR DESCRIPTION
Gets rid of `Policy CMP0167` cmake warnings. Details from the policy warning description. Since we require boost 1.74 anyways, we can simply add `CONFIG`
```
CMake 3.29 and below provide a ``FindBoost`` module, but it needs
constant
updates to keep up with upstream Boost releases.  Upstream Boost 1.70
and above provide a ``BoostConfig.cmake`` package configuration file.
``find_package(Boost CONFIG)`` finds the upstream package directly,
without the find module.
```