### PR TITLE
fix various type conversion warnings in PMacc

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1447,7 +1447,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 }
 #    endif
 
-                TimeIntervall timer;
+                TimeInterval timer;
                 timer.toggleStart();
                 initWrite();
 

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1459,8 +1459,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 mThreadParams.times.push_back(interval);
                 double average = std::accumulate(mThreadParams.times.begin(), mThreadParams.times.end(), 0);
                 average /= mThreadParams.times.size();
-                log<picLog::INPUT_OUTPUT>("openPMD: IO plugin ran for %1% (average: %2%)") % timer.printeTime(interval)
-                    % timer.printeTime(average);
+                log<picLog::INPUT_OUTPUT>("openPMD: IO plugin ran for %1% (average: %2%)") % timer.printTime(interval)
+                    % timer.printTime(average);
             }
 
             static void writeFieldAttributes(

--- a/include/pmacc/algorithms/math/floatMath/bessel.tpp
+++ b/include/pmacc/algorithms/math/floatMath/bessel.tpp
@@ -41,7 +41,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::cyl_bessel_i0f(x);
 #else
-                    return std::cyl_bessel_i(0, x);
+                    return std::cyl_bessel_i(0.f, x);
 #endif
                 }
             };
@@ -56,7 +56,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::cyl_bessel_i1f(x);
 #else
-                    return std::cyl_bessel_i(1, x);
+                    return std::cyl_bessel_i(1.f, x);
 #endif
                 }
             };
@@ -71,7 +71,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu_
                     return ::j0f(x);
 #else
-                    return std::cyl_bessel_j(0, x);
+                    return std::cyl_bessel_j(0.f, x);
 #endif
                 }
             };
@@ -86,7 +86,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::j1f(x);
 #else
-                    return std::cyl_bessel_j(1, x);
+                    return std::cyl_bessel_j(1.f, x);
 #endif
                 }
             };
@@ -101,7 +101,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::jnf(n, x);
 #else
-                    return std::cyl_bessel_j(n, x);
+                    return std::cyl_bessel_j(static_cast<float>(n), x);
 #endif
                 }
             };
@@ -116,7 +116,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::y0f(x);
 #else
-                    return std::cyl_neumann(0, x);
+                    return std::cyl_neumann(0.f, x);
 #endif
                 }
             };
@@ -131,7 +131,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::y1f(x);
 #else
-                    return std::cyl_neumann(1, x);
+                    return std::cyl_neumann(1.f, x);
 #endif
                 }
             };
@@ -146,7 +146,7 @@ namespace pmacc
 #if (PMACC_DEVICE_COMPILE == 1) // we are on gpu
                     return ::ynf(n, x);
 #else
-                    return std::cyl_neumann(n, x);
+                    return std::cyl_neumann(static_cast<float>(n), x);
 #endif
                 }
             };

--- a/include/pmacc/dimensions/DataSpace.hpp
+++ b/include/pmacc/dimensions/DataSpace.hpp
@@ -100,7 +100,7 @@ namespace pmacc
         {
             for(uint32_t i = 0; i < T_dim; ++i)
             {
-                (*this)[i] = vec[i];
+                (*this)[i] = static_cast<int>(vec[i]);
             }
         }
 

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -176,7 +176,7 @@ namespace pmacc
                 constexpr uint32_t xChunkSize = 256;
 
                 // number of blocks in x direction
-                gridSize.x() = (gridSize.x() + xChunkSize - 1) / xChunkSize;
+                gridSize.x() = alpaka::core::divCeil(gridSize.x(), static_cast<size_t>(xChunkSize));
                 auto blockCfg = lockstep::makeBlockCfg<xChunkSize>();
                 auto destBox = this->destination->getDataBox();
                 auto blockSize = DataSpace<dim>::create(1);

--- a/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSetValue.hpp
@@ -176,8 +176,7 @@ namespace pmacc
                 constexpr uint32_t xChunkSize = 256;
 
                 // number of blocks in x direction
-                gridSize.x() = ceil(static_cast<double>(gridSize.x()) / static_cast<double>(xChunkSize));
-
+                gridSize.x() = (gridSize.x() + xChunkSize - 1) / xChunkSize;
                 auto blockCfg = lockstep::makeBlockCfg<xChunkSize>();
                 auto destBox = this->destination->getDataBox();
                 auto blockSize = DataSpace<dim>::create(1);

--- a/include/pmacc/memory/buffers/HostBuffer.hpp
+++ b/include/pmacc/memory/buffers/HostBuffer.hpp
@@ -172,11 +172,12 @@ namespace pmacc
         {
             // getDataBox is notifying the event system, no need to do it manually
             auto memBox = this->getDataBox();
-            auto current_size = static_cast<int64_t>(this->size());
+            // narrowing conversion, implicit assumption when using a DataSpace is that size fits in int.
+            auto current_size = static_cast<int>(this->size());
             using D1Box = DataBoxDim1Access<DataBoxType>;
             D1Box d1Box(memBox, this->capacityND());
 #pragma omp parallel for
-            for(int64_t i = 0; i < current_size; i++)
+            for(int i = 0; i < current_size; i++)
             {
                 d1Box[i] = value;
             }

--- a/include/pmacc/mpi/reduceMethods/AllReduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/AllReduce.hpp
@@ -52,7 +52,8 @@ namespace pmacc
                 {
                     // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
                     eventSystem::getTransactionEvent().waitForFinished();
-                    MPI_CHECK(MPI_Allreduce((void*) src, (void*) dest, count, type, op, comm));
+
+                    MPI_CHECK(MPI_Allreduce((void*) src, (void*) dest, static_cast<int>(count), type, op, comm));
                 }
             };
 

--- a/include/pmacc/mpi/reduceMethods/Reduce.hpp
+++ b/include/pmacc/mpi/reduceMethods/Reduce.hpp
@@ -53,7 +53,7 @@ namespace pmacc
                     // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
                     eventSystem::getTransactionEvent().waitForFinished();
 
-                    MPI_CHECK(MPI_Reduce((void*) src, (void*) dest, count, type, op, 0, comm));
+                    MPI_CHECK(MPI_Reduce((void*) src, (void*) dest, static_cast<int>(count), type, op, 0, comm));
                 }
             };
 

--- a/include/pmacc/pluginSystem/Slice.hpp
+++ b/include/pmacc/pluginSystem/Slice.hpp
@@ -24,6 +24,7 @@
 #include "pmacc/verify.hpp"
 
 #include <array>
+#include <charconv>
 #include <cstdint>
 #include <string>
 
@@ -59,7 +60,7 @@ namespace pmacc
             {
                 if(!str.empty())
                 {
-                    uint32_t value = std::stoul(str);
+                    auto value = static_cast<uint32_t>(std::stoul(str));
                     PMACC_VERIFY_MSG(!(idx == 2 && value == 0), "Zero is not a valid period");
                     values.at(idx) = value;
                 }

--- a/include/pmacc/pluginSystem/toSlice.hpp
+++ b/include/pmacc/pluginSystem/toSlice.hpp
@@ -87,7 +87,7 @@ namespace pmacc
                     std::string("time slice without a defined element is not allowed") + str);
 
                 // id of the component
-                size_t n = 0;
+                uint32_t n = 0;
                 bool const sliceOnly = sliceComponents.size() == 1u;
                 Slice rangeSlice;
 

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -105,7 +105,7 @@ namespace pmacc
                              * 100.)
                       << " % = " << std::setw(8) << currentStep << " | time elapsed:" << std::setw(25)
                       << tSimCalculation.printInterval()
-                      << " | avg time per step: " << TimeIntervall::printeTime(roundAvg / (double) progressInterval)
+                      << " | avg time per step: " << TimeIntervall::printTime(roundAvg / (double) progressInterval)
                       << std::endl;
             std::cout.flush();
 

--- a/include/pmacc/simulationControl/SimulationHelper.cpp
+++ b/include/pmacc/simulationControl/SimulationHelper.cpp
@@ -81,8 +81,8 @@ namespace pmacc
 
     template<unsigned DIM, typename CheckpointingClass>
     void SimulationHelper<DIM, CheckpointingClass>::dumpTimes(
-        TimeIntervall& tSimCalculation,
-        TimeIntervall&,
+        TimeInterval& tSimCalculation,
+        TimeInterval&,
         double& roundAvg,
         uint32_t currentStep)
     {
@@ -101,12 +101,11 @@ namespace pmacc
             }
             std::cout << std::setw(3)
                       << uint16_t(
-                             double(currentStep) / double(Environment<>::get().SimulationDescription().getRunSteps())
-                             * 100.)
+                             static_cast<double>(currentStep)
+                             / static_cast<double>(Environment<>::get().SimulationDescription().getRunSteps()) * 100.)
                       << " % = " << std::setw(8) << currentStep << " | time elapsed:" << std::setw(25)
-                      << tSimCalculation.printInterval()
-                      << " | avg time per step: " << TimeIntervall::printTime(roundAvg / (double) progressInterval)
-                      << std::endl;
+                      << tSimCalculation.printInterval() << " | avg time per step: "
+                      << TimeInterval::printTime(roundAvg / static_cast<double>(progressInterval)) << std::endl;
             std::cout.flush();
 
             lastProgressStep = currentStep;
@@ -152,8 +151,8 @@ namespace pmacc
                           << std::resetiosflags(std::ios::showbase) << " sec" << std::endl;
             }
 
-            TimeIntervall tSimCalculation;
-            TimeIntervall tRound;
+            TimeInterval tSimCalculation;
+            TimeInterval tRound;
             double roundAvg = 0.0;
 
             /* Since in the main loop movingWindow is called always before the dump, we also call it here for

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -117,7 +117,7 @@ namespace pmacc
             return Environment<DIM>::get().GridController();
         }
 
-        void dumpTimes(TimeIntervall& tSimCalculation, TimeIntervall&, double& roundAvg, uint32_t currentStep);
+        void dumpTimes(TimeInterval& tSimCalculation, TimeInterval&, double& roundAvg, uint32_t currentStep);
 
         /**
          * Begin the simulation.
@@ -187,8 +187,8 @@ namespace pmacc
         std::string progressPeriod;
         uint32_t lastProgressStep = 0u;
 
-        TimeIntervall tSimulation;
-        TimeIntervall tInit;
+        TimeInterval tSimulation;
+        TimeInterval tInit;
     };
 
 } // namespace pmacc

--- a/include/pmacc/simulationControl/TimeInterval.hpp
+++ b/include/pmacc/simulationControl/TimeInterval.hpp
@@ -66,51 +66,37 @@ namespace pmacc
 
         std::string printInterval()
         {
-            return printeTime(getInterval());
+            return printTime(getInterval());
         }
 
-        static std::string printeTime(double time)
+        static std::string printTime(double time_ms)
         {
+            std::chrono::hh_mm_ss time_split{std::chrono::milliseconds(static_cast<long long>(time_ms))};
+
+            auto const h = time_split.hours().count();
+            auto const m = time_split.minutes().count();
+            auto const s = time_split.seconds().count();
+            auto const ms = time_split.subseconds().count();
+
             std::ostringstream outstr;
 
-
-            int p_time;
-
-            bool write_all = false;
-            if(time / (3600. * 1000.) > 1.)
+            if(h > 0)
             {
-                p_time = time / (3600. * 1000.);
-                time = time - 3600. * 1000. * p_time;
-                outstr << std::setw(2) << p_time << "h ";
-                write_all = true;
+                outstr << std::setw(2) << h << "h " << std::setw(2) << m << "min " << std::setw(2) << s << "sec "
+                       << std::setw(3) << ms << "msec";
             }
-
-
-            if(write_all || time / (60 * 1000) > 1.)
+            else if(m > 0)
             {
-                p_time = time / (60. * 1000.);
-                time = time - 60. * 1000. * p_time;
-                outstr << std::setw(2) << p_time << "min ";
-                write_all = true;
+                outstr << std::setw(2) << m << "min " << std::setw(2) << s << "sec " << std::setw(3) << ms << "msec";
             }
-
-
-            if(write_all || time / 1000. > 1.)
+            else if(s > 0)
             {
-                p_time = time / 1000.;
-                time = time - 1000. * p_time;
-                outstr << std::setw(2) << p_time << "sec ";
-                write_all = true;
+                outstr << std::setw(2) << s << "sec " << std::setw(3) << ms << "msec";
             }
-
-
-            if(write_all || time > 1.)
+            else
             {
-                outstr << std::setw(3) << (int) time << "msec";
+                outstr << std::setw(3) << ms << "msec";
             }
-
-            if(outstr.str().empty())
-                outstr << "  0msec";
 
             return outstr.str();
         }

--- a/include/pmacc/simulationControl/TimeInterval.hpp
+++ b/include/pmacc/simulationControl/TimeInterval.hpp
@@ -31,10 +31,10 @@
 
 namespace pmacc
 {
-    class TimeIntervall
+    class TimeInterval
     {
     public:
-        TimeIntervall()
+        TimeInterval()
         {
             start = end = getTime();
         }

--- a/include/pmacc/test/random/2DDistribution.cpp
+++ b/include/pmacc/test/random/2DDistribution.cpp
@@ -165,7 +165,7 @@ namespace pmacc
                 T_DeviceBuffer& buffer,
                 T_Random const& rand)
             {
-                pmacc::TimeIntervall timer;
+                pmacc::TimeInterval timer;
                 timer.toggleStart();
 
                 constexpr uint32_t blockSize = 256;


### PR DESCRIPTION
Came across a few warnings on narrowing conversions. Fixes are below.
Most changes are non-issues outside the fact that they throw warnings. The bessel functions on CPU will however now use the float overloads for calculation instead of calculating in double (to which they were previously automatically upcasted) and then downcasting the result to float.
`printTime` has slightly more involved changes where we use `std::chrono::hh_mm_ss` instead of doing the splitting by hand and the output stream logic is reworked. In principle we can use something like `snprintf` to reduce the overhead from streams but I havent done it to not complicate the PR. 