### PR TITLE
fix not applying speices to filter in openpmd

### DIFF
--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -352,9 +352,8 @@ namespace picongpu
                 auto idProvider = dc.get<IdProvider>("globalId");
 
                 // enforce that the filter interface is fulfilled
-                particles::filter::IUnary<typename T_SpeciesFilter::Filter::apply<ThisSpecies>::type> particleFilter(
-                    currentStep,
-                    idProvider->getDeviceGenerator());
+                particles::filter::IUnary<typename T_SpeciesFilter::Filter::template apply<ThisSpecies>::type>
+                    particleFilter(currentStep, idProvider->getDeviceGenerator());
                 using usedFilters = pmacc::mp_list<typename GetPositionFilter<simDim>::type>;
                 using MyParticleFilter = typename FilterFactory<usedFilters>::FilterType;
                 MyParticleFilter filter;

--- a/include/picongpu/plugins/openPMD/WriteSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/WriteSpecies.hpp
@@ -1,5 +1,5 @@
-/* Copyright 2014-2024 Rene Widera, Felix Schmitt, Axel Huebl,
- *                     Alexander Grund, Franz Poeschel
+/* Copyright 2014-2026 Rene Widera, Felix Schmitt, Axel Huebl,
+ *                     Alexander Grund, Franz Poeschel, Pawel Ordyna
  *
  * This file is part of PIConGPU.
  *
@@ -352,7 +352,7 @@ namespace picongpu
                 auto idProvider = dc.get<IdProvider>("globalId");
 
                 // enforce that the filter interface is fulfilled
-                particles::filter::IUnary<typename T_SpeciesFilter::Filter> particleFilter(
+                particles::filter::IUnary<typename T_SpeciesFilter::Filter::apply<ThisSpecies>::type> particleFilter(
                     currentStep,
                     idProvider->getDeviceGenerator());
                 using usedFilters = pmacc::mp_list<typename GetPositionFilter<simDim>::type>;


### PR DESCRIPTION
We were not applying species type to the filter functor in the openPMD plugin. We should be doing it since this is a part of the interface. 

This was missed because all built-in filters do not need it. But, if a user provides a filter in `filter.param` that uses the species type and gets it with the usual placeholder in the template, their simulation won't compile. 