### PR TITLE
remove recursice and force from simple file rm

### DIFF
--- a/etc/picongpu/lumi-eurohpc/standard-g.tpl
+++ b/etc/picongpu/lumi-eurohpc/standard-g.tpl
@@ -184,4 +184,4 @@ else
     echo "Job stopped because of previous issues." >&2
 fi
 
-rm -rf ./select_gpu
+rm ./select_gpu

--- a/etc/picongpu/perlmutter-nersc/gpu.tpl
+++ b/etc/picongpu/perlmutter-nersc/gpu.tpl
@@ -131,4 +131,4 @@ if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
    # sleep 120
 fi
 
-rm -rf ./select_gpu
+rm ./select_gpu

--- a/etc/picongpu/perlmutter-nersc/gpu_stream.tpl
+++ b/etc/picongpu/perlmutter-nersc/gpu_stream.tpl
@@ -153,4 +153,4 @@ if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
   sleep 120
 fi
 
-rm -rf ./select_gpu
+rm ./select_gpu


### PR DESCRIPTION
minor fix: 
remove `-r` and `-f` flag from `rm` in various `*.tpl` files as it just deletes a file. 
Issue was introduces in #4658 by me and merged by @psychocoderHPC.
The issue showed up again in the review #5591.   