### PR TITLE
add cmd paramter `--apu`

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -155,6 +155,10 @@ TBG_fieldBackground="--fieldBackground.duplicateFields"
 # Allow two MPI ranks to use one compute device.
 TBG_ranksPerDevice="--numRanksPerDevice 2"
 
+# Signals to PIConGPU that the memory of the compute device is shared with the host processor.
+# PIConGPU will only allocate half of the device memory for particles to keep memory for the operating system free.
+TBG_APU="--apu"
+
 ################################################################################
 ## Placeholder for multi data plugins:
 ##


### PR DESCRIPTION
fix #5590

As in #5590 shown on systems with small host side memory the automated check if the memory is shared between GPU and CPU can crashes due to out of memory during allocations.
The default case is that the GPU has dedicated memory, therefore we switch to explicit activation via cmd parameter if we would like to run PIConGPU on a GPU with shared memory.

Use `--apu` to signal that we are on a APU where the device memory is shared with the host.

- remove auto detection
- add param to TBG_macros documentation