### PR TITLE
Add range spec to picmi

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/backend_config.py
+++ b/lib/python/picongpu/picmi/diagnostics/backend_config.py
@@ -5,7 +5,13 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from picongpu.pypicongpu.output.openpmd_plugin import OpenPMDConfig as PyPIConGPUOpenPMDConfig
+from enum import Enum
+
+from picongpu.pypicongpu.output.openpmd_plugin import (
+    OpenPMDConfig as PyPIConGPUOpenPMDConfig,
+)
+from picongpu.pypicongpu.output.openpmd_plugin import RangeSpec as PyPIConGPURangeSpec
+from picongpu.pypicongpu.output.openpmd_plugin import RangeSpecEntry
 
 
 class BackendConfig:
@@ -16,3 +22,24 @@ class BackendConfig:
 class OpenPMDConfig(PyPIConGPUOpenPMDConfig, BackendConfig):
     def __init__(self, *args, **kwargs):
         super(PyPIConGPUOpenPMDConfig, self).__init__(*args, **kwargs)
+
+
+class RangeSpecUnit(Enum):
+    CELLS = "Cells"
+
+
+def _apply_units(iterable, unit):
+    return tuple(iterable)
+
+
+class RangeSpec(PyPIConGPURangeSpec):
+    def __init__(self, *args, **kwargs):
+        unit = kwargs.pop("unit", RangeSpecUnit.CELLS)
+        if len(args) == 3:
+            data = args
+        elif len(args) == 0:
+            data = (kwargs.pop("x", None), kwargs.pop("y", None), kwargs.pop("z", None))
+        else:
+            raise ValueError(f"Unknown RangeSpec construction. You gave {args=}.")
+        data = _apply_units(map(lambda x: RangeSpecEntry(data=x), data), unit)
+        return super().__init__(data=data, **kwargs)

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -13,11 +13,40 @@ from tempfile import TemporaryDirectory
 from typing import Annotated, Literal
 
 import tomli_w
-from pydantic import AfterValidator, BaseModel, PrivateAttr, model_serializer
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    PrivateAttr,
+    ValidationError,
+    field_validator,
+    model_serializer,
+)
 
 from picongpu.pypicongpu.output.plugin import Plugin
 from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
 from picongpu.pypicongpu.species.species import Species
+
+
+class RangeSpecEntry(BaseModel):
+    data: None | int | tuple[int, int] = None
+
+    @model_serializer(mode="plain")
+    def _serialize(self) -> str:
+        if self.data is None:
+            return ""
+        if isinstance(self.data, int):
+            return str(self.data)
+        if isinstance(self.data, tuple):
+            return ":".join(map(str, self.data))
+        raise ValueError(f"Can't serialize RangeSpecEntry with {self.data=}.")
+
+
+class RangeSpec(BaseModel):
+    data: tuple[RangeSpecEntry, RangeSpecEntry, RangeSpecEntry] = (RangeSpecEntry(), RangeSpecEntry(), RangeSpecEntry())
+
+    @model_serializer()
+    def _serialize_data(self) -> str:
+        return ",".join(map(BaseModel.model_dump, self.data))
 
 
 class OpenPMDConfig(BaseModel):
@@ -26,7 +55,19 @@ class OpenPMDConfig(BaseModel):
     ext: Annotated[str, AfterValidator(lambda s: s.strip("."))] = "bp5"
     backend_config: PathLike | None = None
     data_preparation_strategy: Literal["mappedMemory", "doubleBuffer"] = "mappedMemory"
-    range: None = None
+    range: RangeSpec = RangeSpec()
+
+    @field_validator("range", mode="before")
+    @classmethod
+    def _validate_range(cls, value):
+        try:
+            return RangeSpec(data=value)
+        except ValidationError as error1:
+            try:
+                return RangeSpec(data=map(lambda x: RangeSpecEntry(data=x), value))
+            except ValidationError as error2:
+                raise error2 from error1
+        return value
 
     def full_filename(self):
         return f"{self.file}{self.infix}.{self.ext}"


### PR DESCRIPTION
- [x] Rebase after #5601 is merged.

This PR adds support for range specification to the openPMD plugin in PICMI. There's an end-to-end test for this functionality. You should feel warmly invited to run it during review because it is currently not yet run in CI.

Changes on top of #5601 are contained in the single last commit.