### PR TITLE
fix signal handling

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1421,6 +1421,10 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
              */
             void dumpData(uint32_t currentStep)
             {
+                /* ensure that all MPI ranks are in the same time step to avoid that MPI collectives block asynchronous
+                 * communication enqueued in the event system. */
+                eventSystem::mpiBlocking(Environment<simDim>::get().GridController().getCommunicator().getMPIComm());
+
                 // local offset + extent
                 pmacc::Selection<simDim> const localDomain = Environment<simDim>::get().SubGrid().getLocalDomain();
                 mThreadParams.cellDescription = m_cellDescription;

--- a/include/pmacc/eventSystem/Manager.hpp
+++ b/include/pmacc/eventSystem/Manager.hpp
@@ -86,6 +86,15 @@ namespace pmacc
          */
         void addTask(ITask* task);
 
+        /** Add a task without any dependencies
+         *
+         * The task is running in parallel to any other task and is never blocking the event system.
+         * waitForAllTasks() will **NOT** wait until cooperative tasks are finished.
+         *
+         * @param task task to add to the manager
+         */
+        void addCooperativeTask(ITask* task);
+
         void addPassiveTask(ITask* task);
 
 
@@ -111,6 +120,7 @@ namespace pmacc
 
         TaskMap tasks;
         TaskMap passiveTasks;
+        TaskMap cooperativeTasks;
     };
 
 } // namespace pmacc

--- a/include/pmacc/eventSystem/eventSystem.hpp
+++ b/include/pmacc/eventSystem/eventSystem.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/eventSystem/events/EventTask.hpp"
+#include "pmacc/eventSystem/mpiBarrier.hpp"
 #include "pmacc/eventSystem/queues/Queue.hpp"
 #include "pmacc/eventSystem/tasks/ITask.hpp"
 #include "pmacc/eventSystem/waitForAllTasks.hpp"

--- a/include/pmacc/eventSystem/mpiBarrier.hpp
+++ b/include/pmacc/eventSystem/mpiBarrier.hpp
@@ -1,6 +1,4 @@
-/* Copyright 2013-2024 Felix Schmitt, Heiko Burau, Rene Widera,
- *                     Wolfgang Hoenig, Benjamin Worpitz,
- *                     Alexander Grund
+/* Copyright 2026 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -21,32 +19,23 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #pragma once
 
-#include <cstdint>
+#include <mpi.h>
 
-namespace pmacc
+namespace pmacc::eventSystem
 {
-    namespace eventSystem
-    {
-        /**
-         * Internal event/task type used for notifications in the event system.
-         */
-        enum EventType
-        {
-            FINISHED,
-            COPY,
-            SENDFINISHED,
-            RECVFINISHED,
-            LOGICALAND,
-            SETVALUE,
-            GETVALUE,
-            KERNEL,
-            SIGNAL
-        };
-
-    } // namespace eventSystem
-
-    // for backward compatibility pull all definitions into the pmacc namespace
-    using namespace eventSystem;
-} // namespace pmacc
+    /** MPI Barrier
+     *
+     * The function is executing an MPI barrier while guaranteeing that the event system is not blocked.
+     * You should call this function before you use MPI collective operations in your code to avoid deadlocks.
+     * After the function returned you know that all participating MPI ranks reached this code line.
+     *
+     * @attention This function should be called from all MPI ranks within the communicator
+     * This method is **NOT** waiting until all events in the event queue are processed.
+     *
+     * @param communicator communicator used for the barrier operation
+     */
+    void mpiBlocking(MPI_Comm communicator);
+} // namespace pmacc::eventSystem

--- a/include/pmacc/eventSystem/tasks/Factory.hpp
+++ b/include/pmacc/eventSystem/tasks/Factory.hpp
@@ -145,14 +145,23 @@ namespace pmacc
          */
         EventTask startTask(ITask& task, ITask* registeringTask);
 
+        /** Creates a signal handling task
+         *
+         * The signal system takes care that there is only one active signal handling tasks is running.
+         *
+         * @param currentStep the time step which is currently processed
+         * @param checkpointing instance where a checkpoint can be registered to
+         * @param writeOutput true if the MPI rank should write status information to the terminal, else false
+         */
+        template<unsigned T_dim>
+        EventTask createTaskSignal(uint32_t currentStep, auto& checkpointing, bool writeOutput);
+
     private:
         friend struct detail::Environment;
 
         Factory() = default;
-        ;
 
         Factory(Factory const&) = default;
-        ;
 
         static Factory& getInstance()
         {

--- a/include/pmacc/eventSystem/tasks/Factory.tpp
+++ b/include/pmacc/eventSystem/tasks/Factory.tpp
@@ -33,6 +33,7 @@
 #include "pmacc/eventSystem/tasks/TaskSendMPI.hpp"
 #include "pmacc/eventSystem/tasks/TaskSetCurrentSizeOnDevice.hpp"
 #include "pmacc/eventSystem/tasks/TaskSetValue.hpp"
+#include "pmacc/eventSystem/tasks/TaskSignal.hpp"
 #include "pmacc/memory/buffers/DeviceBuffer.hpp"
 #include "pmacc/memory/buffers/Exchange.hpp"
 #include "pmacc/memory/buffers/HostBuffer.hpp"
@@ -185,5 +186,18 @@ namespace pmacc
         return event;
     }
 
+    template<unsigned T_dim>
+    inline EventTask Factory::createTaskSignal(uint32_t currentStep, auto& checkpointing, bool writeOutput)
+    {
+        auto* task = new Signal<T_dim, std::remove_reference_t<decltype(checkpointing)>>(
+            currentStep,
+            checkpointing,
+            writeOutput);
 
+        EventTask event(task->getId());
+
+        task->init();
+        Manager::getInstance().addCooperativeTask(task);
+        return event;
+    }
 } // namespace pmacc

--- a/include/pmacc/eventSystem/tasks/TaskSignal.hpp
+++ b/include/pmacc/eventSystem/tasks/TaskSignal.hpp
@@ -1,0 +1,216 @@
+/* Copyright 2026 Rene Widera
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/Environment.hpp"
+#include "pmacc/communication/manager_common.hpp"
+#include "pmacc/simulationControl/signal.hpp"
+
+#include <mpi.h>
+
+namespace pmacc
+{
+    template<unsigned T_dim, typename T_CheckPointing>
+    class Signal final : public ITask
+    {
+    public:
+        Signal(uint32_t currentStep, T_CheckPointing& checkpointing, bool writeOutput)
+            : m_checkpointing(checkpointing)
+            , m_writeOutput(writeOutput)
+        {
+            if(signal::received())
+            {
+                /* Set to the next possible step we could execute checkpointing or stop the simulation
+                 * All ranks will agree for a common time step which is currently not processed yet.
+                 */
+                m_processSignalAtStep = currentStep + 1;
+                m_state = Init;
+
+                if(m_writeOutput)
+                    std::cout << "SIGNAL: received." << std::endl;
+            }
+        }
+
+        void init() override
+        {
+            if(m_state == Init)
+            {
+                // find the largest time step of all MPI ranks
+                MPI_CHECK(MPI_Iallreduce(
+                    &m_processSignalAtStep,
+                    &m_globalCommonTimestep,
+                    1,
+                    MPI_UINT32_T,
+                    MPI_MAX,
+                    Environment<T_dim>::get().GridController().getCommunicator().getMPISignalComm(),
+                    &m_reduceTimeStepRequest));
+
+
+                m_sendSignals[doCheckpointing] = signal::createCheckpoint();
+                m_sendSignals[stopSimulation] = signal::stopSimulation();
+
+                MPI_CHECK(MPI_Iallreduce(
+                    m_sendSignals.data(),
+                    m_globalSignalCounts.data(),
+                    m_globalSignalCounts.size(),
+                    MPI_UINT32_T,
+                    MPI_SUM,
+                    Environment<T_dim>::get().GridController().getCommunicator().getMPISignalComm(),
+                    &m_signalRequest));
+
+                m_state = WaitForMpiReduce;
+            }
+        }
+
+        bool executeIntern() override
+        {
+            if(m_state == Finished)
+                return true;
+
+            if(m_state == WaitForMpiReduce)
+            {
+                if(m_reduceTimeStepRequest != MPI_REQUEST_NULL)
+                {
+                    // wait for the global common time step
+                    MPI_Status mpiTimeStepStatus;
+
+                    int flag = 0;
+                    MPI_CHECK(MPI_Test(&m_reduceTimeStepRequest, &flag, &mpiTimeStepStatus));
+                    if(flag != 0)
+                        m_reduceTimeStepRequest = MPI_REQUEST_NULL;
+                }
+                else if(m_signalRequest != MPI_REQUEST_NULL)
+                {
+                    // wait for signal categories
+                    MPI_Status mpiSignalStatus;
+
+                    int flag = 0;
+                    MPI_CHECK(MPI_Test(&m_signalRequest, &flag, &mpiSignalStatus));
+                    if(flag != 0)
+                        m_signalRequest = MPI_REQUEST_NULL;
+                }
+                // wait until we know the max timestep of all MPI ranks and which signals we should handle
+                if(m_reduceTimeStepRequest == MPI_REQUEST_NULL && m_signalRequest == MPI_REQUEST_NULL)
+                    m_state = HandleSignals;
+            }
+
+            if(m_state == HandleSignals)
+            {
+                uint32_t numMpiRanks = Environment<T_dim>::get().GridController().getCommunicator().getSize();
+                /* Only if all MPI ranks see the same signal category we can apply the corresponding action.
+                 * Later we release only those categories every MPI ranks processed, all not processed categories will
+                 * be handled with the next TaskSignal.
+                 */
+                bool shouldCreateCheckpoint = m_globalSignalCounts[doCheckpointing] == numMpiRanks;
+                bool shouldStop = m_globalSignalCounts[stopSimulation] == numMpiRanks;
+
+                // Translate signals into actions
+                if(shouldCreateCheckpoint)
+                {
+                    if(m_writeOutput)
+                        std::cout << "SIGNAL: Activate checkpointing for step " << m_globalCommonTimestep << std::endl;
+
+                    // add a new checkpoint
+                    m_checkpointing.addCheckpoint(m_globalCommonTimestep);
+                }
+
+                if(shouldStop)
+                {
+                    if(m_writeOutput)
+                        std::cout << "SIGNAL: Shutdown simulation at step " << m_globalCommonTimestep << std::endl;
+
+                    Environment<>::get().SimulationDescription().setRunSteps(m_globalCommonTimestep);
+                }
+
+                /** @attention If we miss releasing the signal system we will never create a TaskSignal again and can
+                 * not handle signals anymore. */
+                signal::release(shouldCreateCheckpoint, shouldStop);
+                m_state = Finished;
+                return true;
+            }
+
+            return false;
+        }
+
+        ~Signal() override
+        {
+        }
+
+        void event(id_t, EventType, IEventData*) override
+        {
+        }
+
+        std::string toString() override
+        {
+            return std::string("Signal at stage") + std::to_string(m_state);
+        }
+
+    private:
+        /** Instance where a checkpoint can be registered to. */
+        T_CheckPointing& m_checkpointing;
+        /** The time step in which this MPI rank would like to apply actions based on the signal.
+         *
+         * atomic is not required because the event system is not threaded
+         */
+        uint32_t m_processSignalAtStep = 0u;
+        /** Largest common timestep within all MPI ranks */
+        uint32_t m_globalCommonTimestep = 0u;
+        /** Number of MPI ranks received the signal to stop the simulation */
+        uint32_t m_globalNumStopSignals = 0u;
+        /** Number of MPI ranks received the signal to checkpoint the simulation */
+        uint32_t m_globalNumCheckpointSignals = 0u;
+
+        /** MPI Request to check the status for the common time step MPI call */
+        MPI_Request m_reduceTimeStepRequest = MPI_REQUEST_NULL;
+        /** MPI Request to check the status for the common category MPI call */
+        MPI_Request m_signalRequest = MPI_REQUEST_NULL;
+
+        /** Signal categories to send
+         *
+         * To access slots you should use SignalType
+         */
+        std::array<uint32_t, 2u> m_sendSignals = {0u, 0u};
+        /** Aggregated results of all MPI ranks
+         *
+         * Each component contains the number of ranks seeing the corresponding signal category.
+         */
+        std::array<uint32_t, 2u> m_globalSignalCounts = {0u, 0u};
+
+        enum StateType
+        {
+            Finished,
+            Init,
+            WaitForMpiReduce,
+            HandleSignals
+        };
+
+        enum SignalType
+        {
+            stopSimulation,
+            doCheckpointing
+        };
+
+        StateType m_state = Finished;
+        bool m_writeOutput = false;
+    };
+
+} // namespace pmacc

--- a/include/pmacc/simulationControl/SimulationHelper.hpp
+++ b/include/pmacc/simulationControl/SimulationHelper.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2024 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
+/* Copyright 2013-2026 Axel Huebl, Felix Schmitt, Rene Widera, Alexander Debus,
  *                     Benjamin Worpitz, Alexander Grund, Sergei Bastrakov, Pawel Ordyna
  *
  * This file is part of PMacc.
@@ -158,15 +158,13 @@ namespace pmacc
 
 
     private:
-        /** Largest time step within the simulation (all MPI ranks) */
-        uint32_t signalMaxTimestep = 0u;
-        /** Time step at which we create actions out of an signal.*/
-        uint32_t handleSignalAtStep = 0u;
-        /** MPI request to find largest time step in the simulation */
-        MPI_Request signalMPI = MPI_REQUEST_NULL;
-        bool signalCreateCheckpoint = false;
-        bool signalStopSimulation = false;
-
+        /** Checks if we received a signal.
+         *
+         * This method can be called multiple time within a timestep to lower the latency of the response to it.
+         * The call is cheap if no signal was received.
+         * If signals of the same action will be sent multiple times they will be handled after ongoing registered
+         * action resulting from previous signals are executed.
+         */
         void checkSignals(uint32_t const currentStep);
 
         /**

--- a/include/pmacc/simulationControl/signal.hpp
+++ b/include/pmacc/simulationControl/signal.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021-2024 Rene Widera
+/* Copyright 2021-2026 Rene Widera
  *
  * This file is part of PMacc.
  *
@@ -40,13 +40,23 @@ namespace pmacc
          * @attention  Signals will not be registered on Windows operating system.
          * This function is in this cas empty.
          */
-        void activate();
+        void activateSignalHandling();
 
-        /** Check if a signal is received
+        /** Check if a signal was received
          *
-         * @return true if at least one signal is received else false
+         * @return true if at least one signal is received else false.
+         *         If true is returned once this function is returning false until release() is called.
          */
         bool received();
+
+        /** Release signals
+         *
+         * This function should only be called if received() returned true.
+         *
+         * @param checkPointHandled if true the checkpoint signal state is reset.
+         * @param stopSimulationHandled if true the stop simulation signal state is reset.
+         */
+        void release(bool checkPointHandled, bool stopSimulationHandled);
 
         /** Status if checkpoint creation is requested.
          *


### PR DESCRIPTION
fix #5592

The current implementation runs under special conditions into a deadlock,s see #5592.
Additionally,y this PR changes how signals are stored to allow the user to send signals during the simulation is blocked by MPI calls or
calculations multiple times.
Such multi signal send could also happen if the user is sending a signal and the batch system triggers a signal too.

- Signal handling is moved into an event system task and a new category of tasks (cooperative tasks) is added.
- provide a shorthand for a global blocking MPI barrier which is event system aware `eventSystem::mpiBlocking()`

Co-authored-by: Paweł Ordyna <p.ordyna@hzdr.de>


I tested this PR by starting a simulation with two MPI ranks and send signal by hand to each process, to guarantee the signal never arrives within the same time step. Additionally, I send signals during the IO to test that we do not miss signals when the simulation is blocked and not processing the event system.