### PR TITLE
Add openpmd to picmi for derived clean

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -5,15 +5,16 @@ Authors: Julian Lenz, Masoud Afshari
 License: GPLv3+
 """
 
-from .binning import Binning, BinningAxis, BinSpec
-from .phase_space import PhaseSpace
-from .energy_histogram import EnergyHistogram
-from .macro_particle_count import MacroParticleCount
-from .timestepspec import TimeStepSpec
-from .checkpoint import Checkpoint
-from .particle_dump import ParticleDump
-from .field_dump import FieldDump
 from .backend_config import BackendConfig, OpenPMDConfig
+from .binning import Binning, BinningAxis, BinSpec
+from .checkpoint import Checkpoint
+from .energy_histogram import EnergyHistogram
+from .field_dump import DerivedFieldDump, NativeFieldDump
+from .macro_particle_count import MacroParticleCount
+from .particle_dump import ParticleDump
+from .particle_functor import ParticleFunctor
+from .phase_space import PhaseSpace
+from .timestepspec import TimeStepSpec
 from .unit_dimension import UnitDimension
 from .radiation import Radiation
 
@@ -27,7 +28,9 @@ __all__ = [
     "EnergyHistogram",
     "MacroParticleCount",
     "ParticleDump",
-    "FieldDump",
+    "ParticleFunctor",
+    "NativeFieldDump",
+    "DerivedFieldDump",
     "TimeStepSpec",
     "Checkpoint",
     "UnitDimension",

--- a/lib/python/picongpu/picmi/diagnostics/field_dump.py
+++ b/lib/python/picongpu/picmi/diagnostics/field_dump.py
@@ -9,14 +9,16 @@ from os import PathLike
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 
+from picongpu.picmi.species import Species
+from picongpu.pypicongpu.output.openpmd_plugin import NATIVE_FIELDS
 from .backend_config import BackendConfig, OpenPMDConfig
 from .timestepspec import TimeStepSpec
+from picongpu.picmi.diagnostics.particle_functor import ParticleFunctor
 
 
-class FieldDump(BaseModel):
-    fieldname: Literal["E", "B", "J"]
+class _FieldDump(BaseModel):
     period: TimeStepSpec = TimeStepSpec[:]("steps")
     options: BackendConfig = OpenPMDConfig(file="simData")
 
@@ -25,3 +27,16 @@ class FieldDump(BaseModel):
 
     def result_path(self, prefix_path: PathLike):
         return self.options.result_path(prefix_path=Path(prefix_path) / "simOutput" / "openPMD")
+
+
+class NativeFieldDump(_FieldDump):
+    fieldname: Literal[*NATIVE_FIELDS]
+
+
+class DerivedFieldDump(_FieldDump):
+    species: Species
+    functor: ParticleFunctor
+
+    @computed_field
+    def fieldname(self) -> str:
+        return f"{self.species.name}_all_{self.functor.name}"

--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -34,7 +34,7 @@ class ParticleShape(Enum):
     TSC = "quadratic"
     PQS = "cubic"
     PCS = "quartic"
-    counter = "counter"
+    Counter = "counter"
 
 
 class PusherMethod(Enum):
@@ -135,7 +135,7 @@ class Species(BaseModel):
         return PyPIConGPUSpecies(
             name=self.name,
             **self._evaluate_species_requirements(),
-            shape=Shape[self.particle_shape.name],
+            shape=Shape(self.particle_shape.name),
             pusher=Pusher[self.method.name],
         )
 

--- a/share/picongpu/pypicongpu/schema/output/openpmd_plugin.OpenPMDPlugin.json
+++ b/share/picongpu/pypicongpu/schema/output/openpmd_plugin.OpenPMDPlugin.json
@@ -4,11 +4,13 @@
   "description": "OpenPMD plugin",
   "unevaluatedProperties": false,
   "required": [
-    "config_filename"
+    "config_filename",
+    "derived_fields"
   ],
   "properties": {
     "config_filename": {
       "type": "string"
-    }
+    },
+    "derived_fields": {}
   }
 }

--- a/share/picongpu/pypicongpu/schema/output/particle_functor.ParticleFunctor.json
+++ b/share/picongpu/pypicongpu/schema/output/particle_functor.ParticleFunctor.json
@@ -15,10 +15,7 @@
       "type": "string",
       "description": "Name of the functor"
     },
-    "unit_dimension": {
-      "type": "string",
-      "description": "c++ code for unit dimension vector"
-    },
+    "unit_dimension": {},
     "functor_preamble": {
       "type": "array",
       "description": "array of preamble statements defining the variables used in the functor_expression",

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/binningSetup.param.mustache
@@ -51,8 +51,11 @@ namespace picongpu::plugins::binning
                 {{/axis_functor.functor_preamble}}
                 return {{{axis_functor.functor_expression}}};
               },
-            "{{{axis_name}}}",
+            "{{{axis_name}}}"
+      {{#axis_functor.unit_dimension}}
+            ,
       {{{axis_functor.unit_dimension}}}
+      {{/axis_functor.unit_dimension}}
         )
       );
       {{/axes}}
@@ -67,8 +70,11 @@ namespace picongpu::plugins::binning
             {{/deposition_functor.functor_preamble}}
             return {{{deposition_functor.functor_expression}}};
           },
-          "{{{deposition_functor.name}}}",
+          "{{{deposition_functor.name}}}"
+    {{#deposition_functor.unit_dimension}}
+    ,
     {{{deposition_functor.unit_dimension}}}
+    {{/deposition_functor.unit_dimension}}
       );
 
       binningCreator.addParticleBinner(

--- a/share/picongpu/pypicongpu/template/include/picongpu/param/fileOutput.param.mustache
+++ b/share/picongpu/pypicongpu/template/include/picongpu/param/fileOutput.param.mustache
@@ -30,98 +30,62 @@
 
 namespace picongpu
 {
-    /** FieldTmp output (calculated at runtime) *******************************
-     *
-     * Those operations derive scalar field quantities from particle species
-     * at runtime. Each value is mapped per cell. Some operations are identical
-     * up to a constant, so avoid writing those twice to save storage.
-     *
-     * you can choose any of these particle to grid projections:
-     *   - Density: particle position + shape on the grid
-     *   - BoundElectronDensity: density of bound electrons
-     *       note: only makes sense for partially ionized ions
-     *   - ChargeDensity: density * charge
-     *       note: for species that do not change their charge state, this is
-     *             the same as the density times a constant for the charge
-     *   - Energy: sum of kinetic particle energy per cell with respect to shape
-     *   - EnergyDensity: average kinetic particle energy per cell times the
-     *                    particle density
-     *       note: this is the same as the sum of kinetic particle energy
-     *             divided by a constant for the cell volume
-     *   - Momentum: sum of chosen component of momentum per cell with respect to shape
-     *   - MomentumDensity: average chosen component of momentum per cell times the particle density
-     *       note: this is the same as the sum of the chosen momentum component
-     *             divided by a constant for the cell volume
-     *   - LarmorPower: radiated Larmor power
-     *                  (species must contain the attribute `momentumPrev1`)
-     *
-     * for debugging:
-     *   - MidCurrentDensityComponent:
-     *       density * charge * velocity_component
-     *   - Counter: counts point like particles per cell
-     *   - MacroCounter: counts point like macro particles per cell
-     *
-     * combined attributes:
-     *   These attributes are defined as a function of two primary derived attributes.
-     *
-     *   - AverageAttribute: template to compute a per particle average of any derived value
-     *   - RelativisticDensity: equals to 1/gamma^2 * n. Where gamma is the Lorentz factor for the mean kinetic energy
-     *      in the cell and n ist the usual number density. Useful for Faraday Rotation calculation.
-     *
-     *      Example use:
-     *      @code{.cpp}
-     *      using AverageEnergy_Seq = deriveField::CreateEligible_t<
-     *          VectorAllSpecies,
-     *          deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::Energy>>;
-     *      using RelativisticDensity_Seq
-     *          = deriveField::CreateEligible_t<PIC_Electrons, deriveField::combinedAttributes::RelativisticDensity>;
-     *      @endcode
-     *
-     * Filtering:
-     *   You can create derived fields from filtered particles. Only particles passing
-     *   the filter will contribute to the field quantity.
-     *   For that you need to define your filters in `particleFilters.param` and pass a
-     *   filter as the 3rd (optional) template argument in `CreateEligible_t`.
-     *
-     *   Example: This will create charge density field for all species that are
-     *   eligible for the this attribute and the chosen filter.
-     *   @code{.cpp}
-     *   using ChargeDensity_Seq
-         = deriveField::CreateEligible_t< VectorAllSpecies,
-         deriveField::derivedAttributes::ChargeDensity, filter::FilterOfYourChoice>;
-     *   @endcode
-     */
     namespace deriveField = particles::particleToGrid;
 
-    /* ChargeDensity section */
-    using ChargeDensity_Seq
-        = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::ChargeDensity>;
+    namespace particles::particleToGrid::derivedAttributes {
+{{#output}} {{#typeID.openPMD}} {{#data.derived_fields}}
 
-    /* EnergyDensity section */
-    using EnergyDensity_Seq
-        = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::EnergyDensity>;
+    struct {{{name}}} {
+         HDINLINE float1_64 getUnit() const
+         {
+             return 1.;
+         }
 
-    /** FieldTmpSolvers groups all solvers that create data for FieldTmp ******
-     *
-     * FieldTmpSolvers is used in @see FieldTmp to calculate the exchange size
-     */
-    using FieldTmpSolvers = MakeSeq_t<ChargeDensity_Seq, EnergyDensity_Seq>;
+         HINLINE std::vector<float_64> getUnitDimension() const
+         {
+             std::vector<float_64> unitDimension(7, 0.0);
+             return unitDimension;
+         }
+
+         HINLINE static std::string getName()
+         {
+             return "{{{name}}}";
+         }
+
+         template<class T_Particle>
+         DINLINE {{{return_type}}} operator()(T_Particle& particle) const
+         {
+              {{#functor_preamble}}
+              {{{statement}}}
+              {{/functor_preamble}}
+              return {{{functor_expression}}};
+         }
+
+    };
+
+    template<>
+    struct IsWeighted<{{{name}}}> : std::true_type {};
+{{/data.derived_fields}} {{/typeID.openPMD}} {{/output}}
+    }
+
+{{#output}}
+{{#typeID.openPMD}}
+{{#data.derived_fields}}
+    using {{{name}}}_Seq
+        = deriveField::CreateEligible_t<VectorAllSpecies, deriveField::derivedAttributes::{{{name}}}>;
+{{/data.derived_fields}}
+{{/typeID.openPMD}}
+{{/output}}
+
+    using FieldTmpSolvers = MakeSeq_t<
+    {{#output}}{{#typeID.openPMD}}{{#data.derived_fields}}
+      {{{name}}}_Seq,
+    {{/data.derived_fields}}{{/typeID.openPMD}}{{/output}}
+      MakeSeq_t<>
+    >;
 
 
-    /** FileOutputFields: Groups all Fields that shall be dumped *************/
-
-    /** Possible native fields: FieldE, FieldB, FieldJ
-     */
     using NativeFileOutputFields = MakeSeq_t<FieldE, FieldB, FieldJ>;
-
     using FileOutputFields = MakeSeq_t<NativeFileOutputFields, FieldTmpSolvers>;
-
-
-    /** FileOutputParticles: Groups all Species that shall be dumped **********
-     *
-     * hint: to disable particle output set to
-     *   using FileOutputParticles = MakeSeq_t< >;
-     */
     using FileOutputParticles = VectorAllSpecies;
-
 } // namespace picongpu

--- a/test/python/picongpu/end-to-end/diagnostics.py
+++ b/test/python/picongpu/end-to-end/diagnostics.py
@@ -6,44 +6,62 @@ License: GPLv3+
 """
 
 import logging
+from functools import partial
 from pathlib import Path
 from unittest import TestCase, main
 
 import numpy as np
-from .arbitrary_parameters import (
-    NUMBER_OF_CELLS,
-    UPPER_BOUNDARY,
-)
-from .compare_particles import apply_range, load_diagnostic_result, read_particles, sort_particles, read_fields
-from .distributions import Gaussian, SphereFlanks
 from picongpu.picmi import (
     Cartesian3DGrid,
     ElectromagneticSolver,
     GriddedLayout,
     Simulation,
-    Species as Species,
 )
+from picongpu.picmi import Species as Species
 from picongpu.picmi.diagnostics import (
+    Binning,
+    BinningAxis,
+    BinSpec,
     Checkpoint,
-    FieldDump,
+    DerivedFieldDump,
+    NativeFieldDump,
     OpenPMDConfig,
     ParticleDump,
+    ParticleFunctor,
     TimeStepSpec,
 )
+from sympy import Piecewise
+
+from .arbitrary_parameters import (
+    CELL_SIZE,
+    NUMBER_OF_CELLS,
+    UPPER_BOUNDARY,
+)
+from .compare_particles import (
+    apply_range,
+    load_diagnostic_result,
+    read_fields,
+    read_particles,
+    sort_particles,
+)
+from .distributions import Gaussian, SphereFlanks
 
 logging.basicConfig(level=logging.INFO)
 
 LAYOUT = GriddedLayout(n_macroparticles_per_cell=2)
+PARTICLE_SHAPE = "counter"
 SPECIES = [
     Species(
         name="Gaussian_predefined",
         particle_type="electron",
         initial_distribution=Gaussian().distributions["predefined"],
+        particle_shape=PARTICLE_SHAPE,
     ),
     Species(
         name="SphereFlanks_free_form",
         particle_type="electron",
         initial_distribution=SphereFlanks().distributions["free_form"],
+        particle_shape=PARTICLE_SHAPE,
     ),
 ]
 
@@ -66,16 +84,95 @@ def basic_simulation():
     )
 
 
-def generate_diagnostics(species):
+CUTOFF_ENERGY = 10.0
+FUNCTORS = [
+    # Currently no eligible particles available:
+    # ParticleFunctor(name="bound_electrons", functor=lambda p: p.get("boundElectrons")),
+    # Somehow off by some factor:
+    # ParticleFunctor(name="charge_density", functor=lambda p: p.get("charge") / np.prod(CELL_SIZE)),
+    ParticleFunctor(name="particle_counter", functor=lambda p: p.get("weighting")),
+    ParticleFunctor(name="density", functor=lambda p: p.get("weighting") / np.prod(CELL_SIZE)),
+    ParticleFunctor(name="kinetic_energy", functor=lambda p: p.get("kinetic energy")),
+    ParticleFunctor(name="kinetic_energy_density", functor=lambda p: p.get("kinetic energy") / np.prod(CELL_SIZE)),
+    ParticleFunctor(
+        name="kinetic_energy_density_cutoff",
+        functor=lambda p: Piecewise(
+            (
+                p.get("kinetic energy") / np.prod(CELL_SIZE),
+                p.get("kinetic energy") < CUTOFF_ENERGY * p.get("weighting"),
+            ),
+            (0.0, True),
+        ),
+    ),
+    # Currently no eligible particles available:
+    # ParticleFunctor(name="larmor_power", functor=larmor_power),
+    ParticleFunctor(name="macroparticle_counter", functor=lambda _: 1, return_type=int),
+    # Somehow off by some factor:
+    ParticleFunctor(
+        name="mid_current_density_x",
+        functor=lambda p: p.get("charge")
+        / np.prod(CELL_SIZE)
+        * p.get("momentum")[0]
+        / (p.get("gamma") * p.get("mass")),
+    ),
+    ParticleFunctor(name="momentum_y", functor=lambda p: p.get("momentum")[1]),
+    # Duplicated just to test what happens:
+    # ParticleFunctor(name="momentum_y", functor=lambda p: p.get("momentum")[1]),
+    ParticleFunctor(name="momentum_density_z", functor=lambda p: p.get("momentum")[2] / np.prod(CELL_SIZE)),
+    ParticleFunctor(name="weighted_velocity_x", functor=lambda p: p.get("velocity")[0] * p.get("weighting")),
+]
+
+
+def generate_particle_dumps(species):
     options = OpenPMDConfig(
         file="other_name", ext=".h5", infix="", data_preparation_strategy="doubleBuffer", range=[17, (25, 40), None]
     )
-    particles = [ParticleDump(species=s) for s in species] + [
-        ParticleDump(species=species[0], options=options),
+    return [ParticleDump(species=s) for s in species] + [ParticleDump(species=species[0], options=options)]
+
+
+def generate_native_field_dumps():
+    return [NativeFieldDump(fieldname=fieldname) for fieldname in ["E", "B"]]
+
+
+def generate_derived_field_dumps(species, functors):
+    return [DerivedFieldDump(species=s, functor=f) for s in species for f in functors]
+
+
+def position(particle, i):
+    return particle.get("position", origin="total", precision="sub_cell", unit="si")[i] // CELL_SIZE[i]
+
+
+POSITION_AXES = [
+    BinningAxis(
+        ParticleFunctor(
+            # We prefer `partial` over lambda functions in this situation
+            # because of lambda's late binding.
+            name=f"position{i}",
+            functor=partial(position, i=i),
+            return_type=int,
+        ),
+        BinSpec("linear", 0, NUMBER_OF_CELLS[i], NUMBER_OF_CELLS[i]),
+        use_overflow_bins=False,
+    )
+    for i in range(3)
+]
+
+
+def generate_derived_field_dumps_as_binnings(species, functors):
+    return [
+        Binning(name=f"{s.name}_{f.name}_binning", deposition_functor=f, axes=POSITION_AXES, species=s)
+        for s in species
+        for f in functors
     ]
-    native_fields = [FieldDump(fieldname=fieldname) for fieldname in ["E", "B"]]
-    derived_fields = []
-    return particles + native_fields + derived_fields
+
+
+def generate_diagnostics(species, functors):
+    return (
+        generate_particle_dumps(species)
+        + generate_native_field_dumps()
+        + generate_derived_field_dumps(species, functors)
+        + generate_derived_field_dumps_as_binnings(species, functors)
+    )
 
 
 RUN_DIR = ""
@@ -85,7 +182,7 @@ def setup_sim():
     sim = basic_simulation()
     for species in SPECIES:
         sim.add_species(species, LAYOUT)
-    sim.diagnostics = [Checkpoint(TimeStepSpec[:])] + generate_diagnostics(SPECIES)
+    sim.diagnostics = [Checkpoint(TimeStepSpec[:])] + generate_diagnostics(SPECIES, FUNCTORS)
     if RUN_DIR:
         sim.picongpu_get_runner().run_dir = RUN_DIR
     else:
@@ -123,15 +220,23 @@ class TestDiagnostics(TestCase):
                 from_diagnostics = sort_particles(load_diagnostic_result(diag, self.result_path))
                 np.testing.assert_allclose(from_checkpoint, from_diagnostics)
 
-    def test_field_dump(self):
+    def test_native_field_dump(self):
         for diag in self.sim.diagnostics:
-            if isinstance(diag, FieldDump):
+            if isinstance(diag, NativeFieldDump):
                 np.testing.assert_allclose(
                     load_diagnostic_result(diag, self.result_path),
                     read_fields(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")[
                         diag.fieldname
                     ],
                 )
+
+    def test_compare_derived_fields_and_binning(self):
+        for dump, binning in zip(
+            generate_derived_field_dumps(SPECIES, FUNCTORS), generate_derived_field_dumps_as_binnings(SPECIES, FUNCTORS)
+        ):
+            np.testing.assert_allclose(
+                load_diagnostic_result(dump, self.result_path), load_diagnostic_result(binning, self.result_path)
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] Rebase after #5604 is merged.

This PR adds rudimentary derived field output for the openPMD plugin to our PICMI implementation. There's some configurability that's not yet part of this PR. I'll get to that at a later point as the need arises.

Changes on top of #5604 start with `d889d8a166ff6ba861c86dbffd18cddcbca7a0a5` "Add derived fields to PICMI".