### PR TITLE
Fix no-IPD IPD model

### DIFF
--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/IPDModel.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/IPDModel.hpp
@@ -43,7 +43,9 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
         using SuperCellConstantInput = detail::SuperCellConstantInput;
 
         //! create all HelperFields required by the IPD model
-        HINLINE static void createHelperFields();
+        HINLINE static void createHelperFields(
+            picongpu::DataConnector& dataConnector,
+            picongpu::MappingDesc const mappingDesc);
 
         /** calculate all inputs for the ionization potential depression
          *
@@ -67,11 +69,12 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
          *
          * @attention must be called once for each step in a pressure ionization cascade
          *
-         * @tparam list of all species partaking as ion in atomicPhysics
+         * @tparam T_AtomicPhysicsIonSpeciesList of all species partaking as ion in atomicPhysics
+         * @tparam T_SkipFinishedSuperCell whether to skip super cells with a time remaining <= 0
          *
          * @attention collective over all ion species
          */
-        template<typename T_AtomicPhysicsIonSpeciesList>
+        template<typename T_AtomicPhysicsIonSpeciesList, bool T_SkipFinishedSuperCell>
         HINLINE static void applyIPDIonization(picongpu::MappingDesc const mappingDesc, uint32_t const currentStep);
 
         /** get ionization potential depression for a super cell

--- a/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/NoIPD.hpp
+++ b/include/picongpu/particles/atomicPhysics/ionizationPotentialDepression/NoIPD.hpp
@@ -43,7 +43,7 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
         using SuperCellConstantInput = detail::NoIPDSuperCellConstantInput;
 
         //! create all HelperFields required by the IPD model
-        HINLINE static void createHelperFields()
+        HINLINE static void createHelperFields(picongpu::DataConnector&, picongpu::MappingDesc const)
         {
         }
 
@@ -51,12 +51,12 @@ namespace picongpu::particles::atomicPhysics::ionizationPotentialDepression
             uint32_t T_numberAtomicPhysicsIonSpecies,
             typename T_IPDIonSpeciesList,
             typename T_IPDElectronSpeciesList>
-        HINLINE static void calculateIPDInput(picongpu::MappingDesc const mappingDesc)
+        HINLINE static void calculateIPDInput(picongpu::MappingDesc const mappingDesc, uint32_t const)
         {
         }
 
         //! no IPD, means no pressure ionization
-        template<typename T_AtomicPhysicsIonSpeciesList>
+        template<typename T_AtomicPhysicsIonSpeciesList, bool T_SkipFinishedSuperCell>
         HINLINE static void applyIPDIonization(picongpu::MappingDesc const, uint32_t const)
         {
         }


### PR DESCRIPTION
fixes the over time deviated interfaces of the no-IPD IPD model.

We currently have no example case using the no-IPD IPD model of FLYonPIC. Consequently, the code IPD-model interface could silently deviate from the no-IPD model over time.
This PR bring all IPD-models once again into convergence, but it does not solve the fundamental problem. 

- [x]  requires PR #5608 to be merged first
- [x] requires PR #5609 to be merged first
- [x] must be rebased to dev after the above have been merged.