### PR TITLE
Fixed rate matrix debug option

### DIFF
--- a/include/picongpu/param/atomicPhysics_Debug.param
+++ b/include/picongpu/param/atomicPhysics_Debug.param
@@ -119,7 +119,7 @@ namespace picongpu::atomicPhysics::debug
     {
         /** resamples electron momentum every atomicPhysics step
          *
-         * @attention this creating unphysical currents, **do not use outside debug!**
+         * @attention this creates unphysical currents, **do not use outside debug!**
          */
         constexpr bool FORCE_CONSTANT_ELECTRON_TEMPERATURE = false;
 
@@ -137,7 +137,9 @@ namespace picongpu::atomicPhysics::debug
          *
          * the function replaces the excitation and deexcitation rate calculation,
          *  - all other rates are set to zero
-         *  - deactivates the suggested changes accounting to avoid triggering over subscription check
+         *  - deactivates the suggested changes accounting in the recordSugestedChangesKernel to
+         *      avoid triggering the over subscription check in the checkForOverSubsciption
+         *      atomic physics sub-stage
          *  - deactivates the accepted changes accounting in the recordChanges kernel
          *
          * @attention **do not use outside debug!**

--- a/include/picongpu/param/atomicPhysics_Debug.param
+++ b/include/picongpu/param/atomicPhysics_Debug.param
@@ -117,8 +117,10 @@ namespace picongpu::atomicPhysics::debug
 
     namespace scFlyComparison
     {
-        /** @attention resamples electron momentum every atomicPhysics step creating unphysical currents,
-         *  **do not use outside debug!** */
+        /** resamples electron momentum every atomicPhysics step
+         *
+         * @attention this creating unphysical currents, **do not use outside debug!**
+         */
         constexpr bool FORCE_CONSTANT_ELECTRON_TEMPERATURE = false;
 
         //! fixed temperature setting
@@ -128,6 +130,35 @@ namespace picongpu::atomicPhysics::debug
             static constexpr float_64 temperature = 1.;
         };
     } // namespace scFlyComparison
+
+    namespace fixedRateMatrix
+    {
+        /** disables the standard rate calculation and uses a here defined function instead
+         *
+         * the function replaces the excitation and deexcitation rate calculation,
+         *  - all other rates are set to zero
+         *  - deactivates the suggested changes accounting to avoid triggering over subscription check
+         *  - deactivates the accepted changes accounting in the recordChanges kernel
+         *
+         * @attention **do not use outside debug!**
+         * @attention should be combined with NoIPD IPD-model
+         */
+        constexpr bool USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION = false;
+
+        struct FixedRateMatrix
+        {
+            /** get replacement rate for collisional de-/excitation
+             *
+             * @tparam T_excitation true =^= excitation, false =^= deexcitation
+             *
+             * @param transitionCollectionIndex collection index of the transition
+             *
+             * @return unit: 1/sim.unit.time
+             */
+            template<bool T_excitation>
+            HDINLINE static float_X rate(uint32_t const transitionCollectionIndex);
+        };
+    } // namespace fixedRateMatrix
 
     namespace kernel::calculateTimeStep
     {

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordChanges.kernel
@@ -197,6 +197,11 @@ namespace picongpu::particles::atomicPhysics::kernel
                         ion,
                         newAtomicStateCollectionIndex);
 
+                    // no energy accounting if using fixed matrix
+                    if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::
+                                     USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                        return;
+
                     // record used energy
                     if constexpr(isCollisional)
                         electronHistogram.addDeltaEnergy(worker, ion[binIndex_], deltaEnergy);

--- a/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
+++ b/include/picongpu/particles/atomicPhysics/kernel/RecordSuggestedChanges.kernel
@@ -85,6 +85,10 @@ namespace picongpu::particles::atomicPhysics::kernel
             T_IonBox const ionBox,
             T_IPDInput const... ipdInput) const
         {
+            // no accounting for fixed rate matrix
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return;
+
             auto const superCellIdx = KernelIndexation::getSuperCellIndex(worker, areaMapping);
             auto const superCellFieldIdx
                 = KernelIndexation::getSuperCellFieldIndexFromSuperCellIndex(areaMapping, superCellIdx);

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/AutonomousTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/AutonomousTransitionRates.hpp
@@ -37,6 +37,7 @@
  */
 
 #include "picongpu/defines.hpp"
+#include "picongpu/particles/atomicPhysics/debug/param.hpp"
 
 namespace picongpu::particles::atomicPhysics::rateCalculation
 {
@@ -56,6 +57,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             uint32_t const transitionCollectionIndex,
             T_AutonomousTransitionDataBox const autonomousTransitionDataBox)
         {
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return 0._X;
+
             // 1/sim.unit.time
             return autonomousTransitionDataBox.rate(transitionCollectionIndex);
         }

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundBoundTransitionRates.hpp
@@ -29,6 +29,7 @@
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
 #include "picongpu/particles/atomicPhysics/atomicData/AtomicData.hpp"
+#include "picongpu/particles/atomicPhysics/debug/param.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/CollisionalRate.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/Multiplicities.hpp"
 
@@ -320,6 +321,11 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundBoundTransitionDataBox const boundBoundTransitionDataBox)
         {
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return picongpu::atomicPhysics::debug::fixedRateMatrix::FixedRateMatrix::rate<T_excitation>(
+                           transitionCollectionIndex)
+                       / float_X(picongpu::atomicPhysics::ElectronHistogram::numberBins);
+
             float_X const sigma = collisionalBoundBoundCrossSection<
                 T_AtomicStateDataBox,
                 T_BoundBoundTransitionDataBox,
@@ -363,6 +369,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundBoundTransitionDataBox const boundBoundTransitionDataBox)
         {
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return 0._X;
+
             using S_ConfigNumber = typename T_AtomicStateDataBox::ConfigNumber;
 
             // short hands for constants in SI

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeCollisionalTransitionRates.hpp
@@ -22,6 +22,7 @@
 #include "picongpu/defines.hpp" // need atomicPhysics_Debug.param
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
+#include "picongpu/particles/atomicPhysics/debug/param.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/CollisionalRate.hpp"
 #include "picongpu/particles/atomicPhysics/rateCalculation/Multiplicities.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
@@ -237,6 +238,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
         {
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return 0._X;
+
             float_X sigma = collisionalIonizationCrossSection(
                 // eV
                 energyElectron,

--- a/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
+++ b/include/picongpu/particles/atomicPhysics/rateCalculation/BoundFreeFieldTransitionRates.hpp
@@ -23,6 +23,7 @@
 #include "picongpu/particles/atomicPhysics/ConvertEnum.hpp"
 #include "picongpu/particles/atomicPhysics/DeltaEnergyTransition.hpp"
 #include "picongpu/particles/atomicPhysics/FieldEnergy.hpp"
+#include "picongpu/particles/atomicPhysics/debug/param.hpp"
 #include "picongpu/particles/atomicPhysics/enums/ADKLaserPolarization.hpp"
 #include "picongpu/particles/atomicPhysics/stateRepresentation/ConfigNumber.hpp"
 
@@ -193,6 +194,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
         {
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return 0._X;
+
             // unit_energy
             float_X const eFieldEnergy = FieldEnergy::getEFieldEnergy(eFieldNorm * eFieldNorm);
 
@@ -252,6 +256,9 @@ namespace picongpu::particles::atomicPhysics::rateCalculation
             T_AtomicStateDataBox const atomicStateDataBox,
             T_BoundFreeTransitionDataBox const boundFreeTransitionDataBox)
         {
+            if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+                return 0._X;
+
             // unit_energy
             float_X const maxEFieldEnergy = FieldEnergy::getEFieldEnergy(maxEFieldNorm * maxEFieldNorm);
 

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -803,15 +803,15 @@ namespace picongpu::simulation::stage
 
         if constexpr(picongpu::atomicPhysics::debug::scFlyComparison::FORCE_CONSTANT_ELECTRON_TEMPERATURE)
         {
-            std::cout << "[atomicPhysics WARNING]: forcing a constant electron temperature of "
-                      << picongpu::atomicPhysics::debug::scFlyComparison::TemperatureParam::temperature
-                      << " keV, per user direction." << std::endl;
+            log<picLog::PHYSICS>("[atomicPhysics WARNING]: (using DEBUG ONLY feature), forcing a constant electron "
+                                 "temperature of %1% keV, per user direction.")
+                % picongpu::atomicPhysics::debug::scFlyComparison::TemperatureParam::temperature;
         }
 
         if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
         {
-            std::cout << "[atomicPhysics WARNING]: using a fixed, user specified rate matrix, per user direction."
-                      << std::endl;
+            log<picLog::PHYSICS>(
+                "[atomicPhysics WARNING]: (using DEBUG ONLY feature), using fixed rate matrix, per user direction.");
         }
 
         if constexpr(picongpu::atomicPhysics::debug::rateCalculation::RUN_UNIT_TESTS)

--- a/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
+++ b/include/picongpu/simulation/stage/AtomicPhysics.x.cpp
@@ -800,11 +800,18 @@ namespace picongpu::simulation::stage
             picongpu::particles::atomicPhysics::AtomicPhysicsSuperCellFields::create(dc, mappingDesc);
             picongpu::atomicPhysics::IPDModel::createHelperFields(dc, mappingDesc);
         }
+
         if constexpr(picongpu::atomicPhysics::debug::scFlyComparison::FORCE_CONSTANT_ELECTRON_TEMPERATURE)
         {
             std::cout << "[atomicPhysics WARNING]: forcing a constant electron temperature of "
                       << picongpu::atomicPhysics::debug::scFlyComparison::TemperatureParam::temperature
                       << " keV, per user direction." << std::endl;
+        }
+
+        if constexpr(picongpu::atomicPhysics::debug::fixedRateMatrix::USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION)
+        {
+            std::cout << "[atomicPhysics WARNING]: using a fixed, user specified rate matrix, per user direction."
+                      << std::endl;
         }
 
         if constexpr(picongpu::atomicPhysics::debug::rateCalculation::RUN_UNIT_TESTS)

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
@@ -117,8 +117,10 @@ namespace picongpu::atomicPhysics::debug
 
     namespace scFlyComparison
     {
-        /** @attention resamples electron momentum every atomicPhysics step creating unphysical currents,
-         *  **do not use outside debug!** */
+        /** resamples electron momentum every atomicPhysics step
+         *
+         * @attention this creates unphysical currents, **do not use outside debug!**
+         */
 #ifndef PARAM_FORCE_CONSTANT_ELECTRON_TEMPERATURE
 #    define PARAM_FORCE_CONSTANT_ELECTRON_TEMPERATURE false
 #endif

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
@@ -140,7 +140,9 @@ namespace picongpu::atomicPhysics::debug
          *
          * the function replaces the excitation and deexcitation rate calculation,
          *  - all other rates are set to zero
-         *  - deactivates the suggested changes accounting to avoid triggering over subscription check
+         *  - deactivates the suggested changes accounting in the recordSugestedChangesKernel to
+         *      avoid triggering the over subscription check in the checkForOverSubsciption
+         *      atomic physics sub-stage
          *  - deactivates the accepted changes accounting in the recordChanges kernel
          *
          * @attention **do not use outside debug!**

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/atomicPhysics_Debug.param
@@ -132,6 +132,36 @@ namespace picongpu::atomicPhysics::debug
         };
     } // namespace scFlyComparison
 
+    namespace fixedRateMatrix
+    {
+        /** disables the standard rate calculation and uses a here defined function instead
+         *
+         * the function replaces the excitation and deexcitation rate calculation,
+         *  - all other rates are set to zero
+         *  - deactivates the suggested changes accounting to avoid triggering over subscription check
+         *  - deactivates the accepted changes accounting in the recordChanges kernel
+         *
+         * @attention **do not use outside debug!**
+         * @attention should be combined with NoIPD IPD-model
+         */
+        constexpr bool USE_FIXED_RATE_INSTEAD_OF_RATE_CALCULATION = false;
+
+        //! example use of this feature
+        struct FixedRateMatrix
+        {
+            /** get replacement rate for collisional de-/excitation
+             *
+             * @tparam T_excitation true =^= excitation, false =^= deexcitation
+             *
+             * @param transitionCollectionIndex collection index of the transition
+             *
+             * @return unit: 1/sim.unit.time
+             */
+            template<bool T_excitation>
+            HDINLINE static float_X rate(uint32_t const transitionCollectionIndex);
+        };
+    } // namespace fixedRateMatrix
+
     namespace kernel::calculateTimeStep
     {
         //! @attention performance relevant


### PR DESCRIPTION
adds a debug option to run FLYonPIC with a fixed rate matrix for verification and testing.

The fixed rate matrix is specified via a user defined function in `atomicPhysics_Debug.param`
- [x] requires PR #5609 to be merged first
- [x] requires PR #5610 to be merged first
- [x] needs to be rebased to dev