### PR TITLE
Update hemera modules to use blosc2

### DIFF
--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -30,9 +30,9 @@ module load python/3.10.4
 #
 module load zlib/1.2.11
 module load hdf5-parallel/1.12.0-omp415-cuda121
-module load c-blosc/1.21.4
-module load adios2/2.9.2-cuda121
-module load openpmd/0.15.2-cuda121
+module load c-blosc2/2.31.1
+module load adios2/2.9.2-cuda121-blosc2
+module load openpmd/0.15.2-cuda121-blosc2
 module load cmake/3.26.1
 module load fftw/3.3.10-ompi415-cuda121-gdr
 

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -29,9 +29,9 @@ module load boost/1.82.0
 #
 module load zlib/1.2.11
 module load hdf5-parallel/1.12.0-omp415-cuda121
-module load c-blosc/1.21.4
-module load adios2/2.9.2-cuda121
-module load openpmd/0.15.2-cuda121
+module load c-blosc2/2.31.1
+module load adios2/2.9.2-cuda121-blosc2
+module load openpmd/0.15.2-cuda121-blosc2
 module load cmake/3.26.1
 module load fftw/3.3.10-ompi415-cuda121-gdr
 


### PR DESCRIPTION
For some reason the hemera profile examples were still using old modules that do not support compression in openpmd. I was using the blosc2 variants for long time, at least half a year, without problems. 