### PR TITLE
update example profile to use openpmd-api 0.16.1

### DIFF
--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -29,20 +29,20 @@ export PIC_NODE_OVERSUBSCRIPTION_PT=2
 # such as mpi, libfabric and others.
 # The following modules just add to these.
 
-module load PrgEnv-cray/8.6.0 # Compiling with cray compiler wrapper CC
+module load cce/20.0.0
 module load craype-accel-amd-gfx940
 module load rocm/6.4.2
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-module load cray-mpich/8.1.31
+module load cray-mpich/9.0.1
 
-module load boost/1.86.0
+module load boost/1.88.0
 module load zlib/1.3.1
 module load cmake/3.30.5
 module load git
 module load adios2/2.10.2-mpi
 # Please use a self compiled openpmd-api with adios2 if you need blosc2 support
-module load openpmd-api/0.16.0
+module load openpmd-api/0.16.1-mpi
 module load cray-fftw
 module load libpng/1.6.39
 


### PR DESCRIPTION
As reported in #5615, there seems to be a compiler change at OLCF Frontier that now triggers the bug: https://github.com/openPMD/openPMD-api/pull/1690

This PR updates the example picongpu profile on Frontier to use openPMD-api 0.16.1. Some modules needed to be changed as well to ensure compatibility. 