### PR TITLE
update Jupiter profile 

### DIFF
--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -13,8 +13,9 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #   - project and account for allocation
 #   jutil user projects will return a table of project associations.
 #   Each row contains: project,unixgroup,PI-uid,project-type,budget-accounts
-#   We need the first and last entry.
+#   We try to guess the project and account using the first and last entry.
 #   Here: selects the last available project.
+#   EDIT THESE IN CASE THE AUTO SELECTION DOESN'T WORK
 export proj=$( jutil user projects --noheader | awk '{print $1}' | tail -n 1 )
 export account=$(jutil user projects -n | awk '{print $NF}' | tail -n 1)
 
@@ -33,21 +34,20 @@ fi
 # General modules #############################################################
 #
 module purge
-module load Stages/2025
-module load GCC/13.3.0
-module load CUDA/12
-module load CMake/3.29.3
-module load ParaStationMPI/5.10.0-1
-module load MPI-settings/CUDA
+module load Stages/2026
+module load GCC/14.3.0
+module load CUDA/13
+module load CMake/3.31.8
+module load ParaStationMPI/5.13.0-1
+module load Blosc2
 module load Python
 module load HDF5
-module load ADIOS2
 module load Boost
 module load git
 module load JUBE
 
 # necessary for evaluations (NumPy, SciPy, Matplotlib, SymPy, Pandas, IPython)
-module load SciPy-bundle/2024.05
+module load SciPy-bundle
 module load matplotlib
 module load h5py
 module load numba
@@ -61,9 +61,11 @@ module load tqdm
 #
 export PIC_LIBS=$PROJECT/$USER/share/lib
 export PNG_WRITER=$PIC_LIBS/pngwriter
+export ADIOS2_ROOT=$PIC_LIBS/adios2
 export OPENPMD_ROOT=$PIC_LIBS/openPMD-api
 
 export CMAKE_PREFIX_PATH=$PNG_WRITER:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
 
 export PATH=$OPENPMD_ROOT/bin:$PATH
@@ -80,7 +82,6 @@ export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/jupite
 
 export PATH=$PICSRC/bin:$PATH
 export PATH=$PICSRC/src/tools/bin:$PATH
-
 
 
 # "tbg" default options #######################################################


### PR DESCRIPTION
update modules and use self compiled ADIOS.
Note that the associated [gist](https://gist.github.com/ikbuibui/07225398476bad28821c87ea4c7e677a) has also been updated to use the self compiled ADIOS and to use a newer openPMD.

The recommended way to set up from scratch on JUPITER is to source this profile (after setting up proj and account in lines 19 and 20 if needed), then calling the install script which is available from the [gist](https://gist.github.com/ikbuibui/07225398476bad28821c87ea4c7e677a) . 

Self built packages are installed into `$PROJECT/$USER/share/lib`, which is then added to `PATH` or `CMAKE_PREFIX_PATH`
This workflow was tested by me and it should be fine.