### PR TITLE
Drop Python 3.10

### DIFF
--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -34,7 +34,7 @@ import picmistandard
 
 import sys
 
-assert sys.version_info.major > 3 or sys.version_info.minor >= 10, "Python 3.10 is required for PIConGPU PICMI"
+assert sys.version_info.major > 3 or sys.version_info.minor >= 11, "Python 3.11 is required for PIConGPU PICMI"
 
 __all__ = [
     "Simulation",

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -14,10 +14,11 @@ name = "picongpu"
 version = "0.9.0.dev"
 description = "Python package for PIConGPU"
 license = "GPL-3.0-or-later"
-requires-python = ">=3.10"
+# Our hand-rolled type-safety infrastructure is getting in the way of 3.14.
+# Planning to fix (and remove this again) in the near future:
+requires-python = ">=3.11,<3.14"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/share/ci/pypicongpu_generator.py
+++ b/share/ci/pypicongpu_generator.py
@@ -313,7 +313,7 @@ def print_job_yaml(test_pkg_versions: Dict[str, List[str]]):
 
 
 # Python versions to test
-PYTHON_VERSIONS: List[str] = ["3.10", "3.11", "3.12"]
+PYTHON_VERSIONS: List[str] = ["3.11", "3.12", "3.13"]
 # Define, which dependencies should be explicit tests.
 # The key is the name of the package, and function returns the versions to
 # test.


### PR DESCRIPTION
Drop support for Python 3.10 as it is EoL in October.

Also addresses #5515 by removing 3.14 from pyproject.toml.