### PR TITLE
openPMD plugin: Rename --openPMD.json, --openPMD.toml and --openPMD.jsonRestart

### DIFF
--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -262,7 +262,7 @@ TBG_checkpointTime="--checkpoint.timePeriod 2"
 #   --checkpoint.openPMD.dataPreparationStrategy doubleBuffer
 # One additional parameter is available for configuring the openPMD-api via JSON
 # for restarting procedures:
-TBG_openPMD_restart="--checkpoint.openPMD.jsonRestart '{\"adios2\": {\"dataset\": {\"operators\": [{\"type\": \"blosc\",\"parameters\": {\"nthreads\": 8}}]}}}'"
+TBG_openPMD_restart="--checkpoint.openPMD.backendConfigRestart '{\"adios2\": {\"dataset\": {\"operators\": [{\"type\": \"blosc\",\"parameters\": {\"nthreads\": 8}}]}}}'"
 
 # Restart the simulation from checkpoint created using TBG_checkpoint
 TBG_restart="--checkpoint.restart"

--- a/docs/TBG_macros.cfg
+++ b/docs/TBG_macros.cfg
@@ -238,7 +238,7 @@ TBG_countPerSuper="--<species>_macroParticlesPerSuperCell.period 100 --<species>
 TBG_openPMD="--openPMD.period 100   \
              --openPMD.file simOutput \
              --openPMD.ext bp \
-             --openPMD.json '{ \"adios2\": { \"engine\": { \"type\": \"file\", \"parameters\": { \"BufferGrowthFactor\": \"1.2\", \"InitialBufferSize\": \"2GB\" } } } }' \
+             --openPMD.backendConfig '{ \"adios2\": { \"engine\": { \"type\": \"file\", \"parameters\": { \"BufferGrowthFactor\": \"1.2\", \"InitialBufferSize\": \"2GB\" } } } }' \
              --openPMD.range 0:100,:,: \
              --openPMD.particleIOChunkSize 10240"
 # Further control over the backends used in the openPMD plugins is available

--- a/docs/source/usage/plugins/openPMD.cfg
+++ b/docs/source/usage/plugins/openPMD.cfg
@@ -1,7 +1,7 @@
 TBG_openPMD="--openPMD.period 100   \
              --openPMD.file simOutput \
              --openPMD.ext bp \
-             --openPMD.json '{ \
+             --openPMD.backendConfig '{ \
                  \"adios2\": { \
                    \"dataset\": { \
                      \"operators\": [ \

--- a/docs/source/usage/plugins/openPMD.rst
+++ b/docs/source/usage/plugins/openPMD.rst
@@ -55,7 +55,7 @@ In order to set defaults for these value, two further options control the filena
 
   Note that streaming IO requires group-based iteration layout in openPMD, i.e. ``--openPMD.infix=NULL`` is mandatory.
   If PIConGPU detects a streaming backend (e.g. by ``--openPMD.ext=sst``), it will automatically set ``--openPMD.infix=NULL``, overriding the user's choice.
-  Note however that the ADIOS2 backend can also be selected via ``--openPMD.json`` and via environment variables which PIConGPU does not check.
+  Note however that the ADIOS2 backend can also be selected via ``--openPMD.backendConfig`` and via environment variables which PIConGPU does not check.
   It is hence recommended to set ``--openPMD.infix=NULL`` explicitly.
 
 Option ``--openPMD.source`` controls which data is output.
@@ -72,7 +72,7 @@ openPMD backend-specific settings may be controlled via two mechanisms:
 * Environment variables.
   Please refer to the backends' documentations for information on environment variables understood by the backends.
 * Backend-specific runtime parameters may be set via JSON in the openPMD API.
-  PIConGPU exposes this via the command line option ``--openPMD.json``.
+  PIConGPU exposes this via the command line option ``--openPMD.backendConfig``.
   Please refer to the openPMD API's documentation for further information.
 
 The JSON parameter may be passed directly as a string, or by filename.
@@ -102,7 +102,7 @@ A full example:
 .. literalinclude:: openPMD_extended_config.json
 
 The extended format is only available for configuration of the writing procedures.
-The reading procedures (i.e. for restarting from a checkpoint) can be configured via ``--checkpoint.openPMD.jsonRestart``, e.g. see the example below for configuring the number of blosc decompression threads in ADIOS2.
+The reading procedures (i.e. for restarting from a checkpoint) can be configured via ``--checkpoint.openPMD.backendConfigRestart``, e.g. see the example below for configuring the number of blosc decompression threads in ADIOS2.
 Note that most sensible use cases for this command line option (including this example) require openPMD-api >= 0.15 (or a recent dev version until the 0.15 release).
 
 .. literalinclude:: openPMD_restart_config.json
@@ -130,10 +130,10 @@ PIConGPU command line option          description
 ``--openPMD.file``                    Relative or absolute openPMD file prefix for simulation data. If relative, files are stored under ``simOutput``.
 ``--openPMD.ext``                     openPMD filename extension (this controls thebackend picked by the openPMD API).
 ``--openPMD.infix``                   openPMD filename infix (use to pick file- or group-based layout in openPMD). Set to NULL to keep empty (e.g. to pick group-based iteration layout).
-``--openPMD.json``                    Set backend-specific parameters for openPMD backends in JSON format. Used in writing procedures.
-``--checkpoint.openPMD.jsonRestart``  Set backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint.
+``--openPMD.backendConfig``           Set backend-specific parameters for openPMD backends in JSON format. Used in writing procedures.
+``--checkpoint.openPMD.backendConfigRestart`` Set backend-specific parameters for openPMD backends in JSON format for restarting from a checkpoint.
 ``--openPMD.dataPreparationStrategy`` Strategy for preparation of particle data ('doubleBuffer' or 'mappedMemory'). Aliases 'adios' and 'hdf5' may be used respectively.
-``--openPMD.toml``                    Alternatively configure the openPMD plugin via a TOML file (see below).
+``--openPMD.pluginConfig``            Alternatively configure the openPMD plugin via a TOML file (see below).
 ``--openPMD.particleIOChunkSize``     Particle data will be written in chunks of the given size. unit: MiB
                                       The memory footprint on the host side is reduced compared to writing all particles with one write call.
                                       Currently the memory footprint is only reduced if bp5 is used, HDF5 and bp4 does not support partial data dump.
@@ -154,8 +154,8 @@ PIConGPU command line option          description
 
    This plugin is a multi plugin.
    Command line parameter can be used multiple times to create e.g. dumps with different dumping period.
-   Each plugin instance requires that either ``--openPMD.period`` XOR ``--openPMD.toml`` is defined.
-   If ``--openPMD.toml`` is defined, the rest of the configuration for this instance is done via the specified TOML file, no other command line parameters may be passed.
+   Each plugin instance requires that either ``--openPMD.period`` XOR ``--openPMD.pluginConfig`` is defined.
+   If ``--openPMD.pluginConfig`` is defined, the rest of the configuration for this instance is done via the specified TOML file, no other command line parameters may be passed.
 
    In the case where an optional parameter with a default value is explicitly defined, the parameter will always be passed to the instance of the multi plugin where the parameter is not set.
    e.g.
@@ -198,7 +198,7 @@ By default, the openPMD-api uses a heuristic to automatically set an appropriate
 In combination with some MPI-IO backends (e.g. ROMIO), this has been found to cause crashes.
 To avoid this, PIConGPU overrides the default choice and deactivates HDF5 chunking in the openPMD plugin.
 
-If you want to use chunking, you can ask for it via the following option passed in ``--openPMD.json``:
+If you want to use chunking, you can ask for it via the following option passed in ``--openPMD.backendConfig``:
 
 .. code-block:: json
 
@@ -245,7 +245,7 @@ Note the inline comments for a description of the used schema:
 
 .. literalinclude:: openPMD.toml
 
-The location of the ``.toml`` file on the filesystem is specified via ``--openPMD.toml``.
+The location of the ``.toml`` file on the filesystem is specified via ``--openPMD.pluginConfig``.
 If using this parameter, no other parameters must be specified.
 If another parameter is specified, the openPMD plugin will notice and abort.
 

--- a/docs/source/usage/plugins/openPMD.toml
+++ b/docs/source/usage/plugins/openPMD.toml
@@ -6,7 +6,7 @@ infix = ""         # replaces --openPMD.infix,
                    # default is "%06T"
 ext = "bp4"        # replaces --openPMD.ext,
                    # the default is "bp4" if ADIOS2 is available, else ".h5"
-backend_config = "@./adios_config.json"    # replaces --openPMD.json,
+backend_config = "@./adios_config.json"    # replaces --openPMD.backendConfig,
                                            # default is "{}"
 data_preparation_strategy = "mappedMemory" # replaces --openPMD.dataPreparationStrategy,
                                            # default is "doubleBuffer"

--- a/include/picongpu/plugins/openPMD/Json.hpp
+++ b/include/picongpu/plugins/openPMD/Json.hpp
@@ -50,7 +50,7 @@ namespace picongpu
              * If an ordinary JSON configuration was detected, given regex
              * patterns will be matched against "" (the empty string).
              *
-             * @param config The JSON configuration, exactly as in --openPMD.json.
+             * @param config The JSON configuration, exactly as in --openPMD.backendConfig.
              * @param comm MPI communicator for collective file reading, if needed.
              * @return std::unique_ptr<AbstractJsonMatcher>
              */

--- a/include/picongpu/plugins/openPMD/Json_private.hpp
+++ b/include/picongpu/plugins/openPMD/Json_private.hpp
@@ -150,7 +150,7 @@ namespace picongpu
              * patterns will be matched against "" (the empty string).
              *
              * @param config The JSON configuration, exactly as in
-             *               --openPMD.json.
+             *               --openPMD.backendConfig.
              * @param comm MPI communicator for collective file reading,
              *             if needed.
              */

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -20,10 +20,8 @@ namespace picongpu::openPMD
         std::string particleIOChunkSizeString;
         std::string dataPreparationStrategyString;
         std::string backendConfigString;
-        std::string backendConfigStringForbidden;
         std::string rangeString;
         std::string backendConfigRestartString;
-        std::string backendConfigRestartStringForbidden;
         std::string writeAccessString;
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/Parameters.hpp
+++ b/include/picongpu/plugins/openPMD/Parameters.hpp
@@ -19,9 +19,11 @@ namespace picongpu::openPMD
         std::string fileExtension; /* Extension of the file name */
         std::string particleIOChunkSizeString;
         std::string dataPreparationStrategyString;
-        std::string jsonConfigString;
+        std::string backendConfigString;
+        std::string backendConfigStringForbidden;
         std::string rangeString;
-        std::string jsonRestartParams;
+        std::string backendConfigRestartString;
+        std::string backendConfigRestartStringForbidden;
         std::string writeAccessString;
     };
 } // namespace picongpu::openPMD

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -161,7 +161,7 @@ namespace picongpu
                      * The reading routines (for restarting from a checkpoint)
                      * are configured via --checkpoint.openPMD.jsonRestart.
                      */
-                    at == ::openPMD::Access::READ_ONLY ? jsonRestartParams : jsonMatcher->getDefault());
+                    at == ::openPMD::Access::READ_ONLY ? backendConfigRestartString : jsonMatcher->getDefault());
                 if(openPMDSeries->backend() == "MPI_ADIOS1")
                 {
                     throw std::runtime_error(R"END(
@@ -243,11 +243,19 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                    " an empty string will be assumed instead.",
                    "_%06T"};
 
-            plugins::multi::Option<std::string> jsonConfig
-                = {"json", "advanced (backend) configuration for openPMD in JSON format (used when writing)", "{}"};
+            plugins::multi::Option<std::string> backendConfigForbidden
+                = {"json", "Option renamed as .backendConfig", "REMOVED"};
 
-            plugins::multi::Option<std::string> jsonRestartConfig
-                = {"jsonRestart",
+            plugins::multi::Option<std::string> backendConfig
+                = {"backendConfig",
+                   "advanced (backend) configuration for openPMD in JSON format (used when writing)",
+                   "{}"};
+
+            plugins::multi::Option<std::string> backendConfigRestartForbidden
+                = {"jsonRestart", "Option renamed as .backendConfigRestart", "REMOVED"};
+
+            plugins::multi::Option<std::string> backendConfigRestart
+                = {"backendConfigRestart",
                    "advanced (backend) configuration for openPMD in JSON format (used when reading from a checkpoint)",
                    R"({"defer_iteration_parsing": true})"};
 
@@ -352,14 +360,19 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 {&fileName, "file", &PluginParameters::fileName, ApplyParameter::NotInCheckpoint},
                 {&fileNameExtension, "ext", &PluginParameters::fileExtension},
                 {&fileNameInfix, "infix", &PluginParameters::fileInfix},
-                {&jsonConfig, "backend_config", &PluginParameters::jsonConfigString},
+                {&backendConfigForbidden, std::nullopt, &PluginParameters::backendConfigStringForbidden},
+                {&backendConfig, "backend_config", &PluginParameters::backendConfigString},
                 {&dataPreparationStrategy,
                  "data_preparation_strategy",
                  &PluginParameters::dataPreparationStrategyString},
                 {&range, "range", &PluginParameters::rangeString, ApplyParameter::NotInCheckpoint},
-                {&jsonRestartConfig,
+                {&backendConfigRestartForbidden,
                  std::nullopt,
-                 &PluginParameters::jsonRestartParams,
+                 &PluginParameters::backendConfigRestartStringForbidden,
+                 ApplyParameter::OnlyInCheckpoint},
+                {&backendConfigRestart,
+                 std::nullopt,
+                 &PluginParameters::backendConfigRestartString,
                  ApplyParameter::OnlyInCheckpoint},
                 {&particleIOChunkSize, "particleIOChunkSize", &PluginParameters::particleIOChunkSizeString},
                 {&writeAccess, "write_mode", &PluginParameters::writeAccessString}};
@@ -632,15 +645,24 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 % fileExtension;
 
             // Avoid repeatedly parsing the JSON config
+            if(backendConfigStringForbidden != "REMOVED")
+            {
+                throw std::runtime_error("Command line option openPMD.json was renamed as openPMD.backendConfig.");
+            }
             if(!jsonMatcher)
             {
                 // avoid deadlock between not finished pmacc tasks and mpi blocking collectives
                 eventSystem::getTransactionEvent().waitForFinished();
-                jsonMatcher = AbstractJsonMatcher::construct(jsonConfigString, communicator);
+                jsonMatcher = AbstractJsonMatcher::construct(backendConfigString, communicator);
             }
 
             log<picLog::INPUT_OUTPUT>("openPMD: global JSON output config: %1%") % jsonMatcher->getDefault();
-            log<picLog::INPUT_OUTPUT>("openPMD: global JSON restart config: %1%") % jsonRestartParams;
+            if(backendConfigRestartStringForbidden != "REMOVED")
+            {
+                throw std::runtime_error(
+                    "Command line option openPMD.jsonRestart was renamed as openPMD.backendConfigRestart.");
+            }
+            log<picLog::INPUT_OUTPUT>("openPMD: global JSON restart config: %1%") % backendConfigRestartString;
 
             {
                 if(dataPreparationStrategyString == "adios" || dataPreparationStrategyString == "doubleBuffer")

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -221,7 +221,10 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             plugins::multi::Option<std::string> source = {"source", "data sources: ", "species_all, fields_all"};
 
-            plugins::multi::Option<std::string> tomlSources = {"toml", "specify dynamic data sources via TOML"};
+            plugins::multi::Option<std::string> pluginConfigForbidden
+                = {"toml", "Option renamed as .pluginConfig", "REMOVED"};
+            plugins::multi::Option<std::string> pluginConfig
+                = {"pluginConfig", "specify plugin configuration and dynamic data sources via TOML"};
 
             std::vector<std::string> allowedDataSources = {"species_all", "fields_all"};
 
@@ -328,7 +331,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             /*
              * The sub-commands for the openPMD plugin.
-             * Not listed in here: notifyPeriod and tomlSources.
+             * Not listed in here: notifyPeriod and pluginConfig.
              * Those two parameters are implemented manually since they are the
              * plugin's main commands that activate it and decide its interaction
              * with the main program.
@@ -429,8 +432,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 std::string const& masterPrefix = std::string{}) override
             {
                 notifyPeriod.registerHelp(desc, masterPrefix + prefix);
-                tomlSources.registerHelp(desc, masterPrefix + prefix);
-
+                pluginConfig.registerHelp(desc, masterPrefix + prefix);
+                pluginConfigForbidden.registerHelp(desc, masterPrefix + prefix);
 
                 for(auto const& param : parameters)
                 {
@@ -482,9 +485,15 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             {
                 if(selfRegister)
                 {
-                    if(tomlSources.empty() && notifyPeriod.empty())
+                    if(!pluginConfigForbidden.empty())
+                    {
                         throw std::runtime_error(
-                            name + ": Either parameter .toml XOR parameter .period must be defined.");
+                            "Command line option openPMD.toml was renamed as openPMD.pluginConfig.");
+                    }
+
+                    if(pluginConfig.empty() && notifyPeriod.empty())
+                        throw std::runtime_error(
+                            name + ": Either parameter .pluginConfig XOR parameter .period must be defined.");
 
                     // check if user passed data source names are valid
                     for(auto const& dataSourceNames : source)
@@ -510,7 +519,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     // If using periods in some instances and TOML sources in others, then the other parameter
                     // must be specified as empty.
                     // Not this method's task to check this though.
-                    auto res = tomlSources.size() > notifyPeriod.size() ? tomlSources.size() : notifyPeriod.size();
+                    auto res = std::max({pluginConfig.size(), notifyPeriod.size(), pluginConfigForbidden.size()});
                     if(res == 0)
                     {
                         for(auto const& parameter : parameters)
@@ -1170,10 +1179,16 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
                 if(m_help->selfRegister)
                 {
+                    if(!m_help->pluginConfigForbidden.empty())
+                    {
+                        throw std::runtime_error(
+                            "Command line option openPMD.toml was renamed as openPMD.pluginConfig.");
+                    }
+
                     /* only register for notify callback when .period is set on
                      * command line */
                     bool tomlSourcesSpecified
-                        = m_help->tomlSources.optionDefined(m_id) && not m_help->tomlSources.get(m_id).empty();
+                        = m_help->pluginConfig.optionDefined(m_id) && not m_help->pluginConfig.get(m_id).empty();
                     bool notifyPeriodSpecified
                         = m_help->notifyPeriod.optionDefined(m_id) && not m_help->notifyPeriod.get(m_id).empty();
                     if(tomlSourcesSpecified && not notifyPeriodSpecified)
@@ -1191,7 +1206,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                             }
                         }
 
-                        std::string const& tomlSources = m_help->tomlSources.get(id);
+                        std::string const& pluginConfig = m_help->pluginConfig.get(id);
 
                         PluginParameters pluginParametersWithDefaults;
                         for(auto const& parameter : m_help->parameters)
@@ -1225,7 +1240,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                             std::piecewise_construct,
                             std::make_tuple(id),
                             std::make_tuple(
-                                /* tomlFile = */ m_help->tomlSources.get(id),
+                                /* tomlFile = */ m_help->pluginConfig.get(id),
                                 /* tomlParameters = */ m_help->tomlParameters(),
                                 /* allowedDataSources = */ m_help->allowedDataSources,
                                 /* comm = */ mThreadParams.communicator,

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -221,8 +221,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
 
             plugins::multi::Option<std::string> source = {"source", "data sources: ", "species_all, fields_all"};
 
-            plugins::multi::Option<std::string> pluginConfigForbidden
-                = {"toml", "Option renamed as .pluginConfig", "REMOVED"};
+            plugins::multi::Option<std::string> pluginConfigForbidden = {"toml", "Option renamed as .pluginConfig"};
             plugins::multi::Option<std::string> pluginConfig
                 = {"pluginConfig", "specify plugin configuration and dynamic data sources via TOML"};
 
@@ -246,8 +245,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                    " an empty string will be assumed instead.",
                    "_%06T"};
 
-            plugins::multi::Option<std::string> backendConfigForbidden
-                = {"json", "Option renamed as .backendConfig", "REMOVED"};
+            plugins::multi::Option<std::string> backendConfigForbidden = {"json", "Option renamed as .backendConfig"};
 
             plugins::multi::Option<std::string> backendConfig
                 = {"backendConfig",
@@ -363,16 +361,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 {&fileName, "file", &PluginParameters::fileName, ApplyParameter::NotInCheckpoint},
                 {&fileNameExtension, "ext", &PluginParameters::fileExtension},
                 {&fileNameInfix, "infix", &PluginParameters::fileInfix},
-                {&backendConfigForbidden, std::nullopt, &PluginParameters::backendConfigStringForbidden},
+                {&backendConfigForbidden, std::nullopt, std::nullopt},
                 {&backendConfig, "backend_config", &PluginParameters::backendConfigString},
                 {&dataPreparationStrategy,
                  "data_preparation_strategy",
                  &PluginParameters::dataPreparationStrategyString},
                 {&range, "range", &PluginParameters::rangeString, ApplyParameter::NotInCheckpoint},
-                {&backendConfigRestartForbidden,
-                 std::nullopt,
-                 &PluginParameters::backendConfigRestartStringForbidden,
-                 ApplyParameter::OnlyInCheckpoint},
+                {&backendConfigRestartForbidden, std::nullopt, std::nullopt, ApplyParameter::OnlyInCheckpoint},
                 {&backendConfigRestart,
                  std::nullopt,
                  &PluginParameters::backendConfigRestartString,
@@ -654,7 +649,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 % fileExtension;
 
             // Avoid repeatedly parsing the JSON config
-            if(backendConfigStringForbidden != "REMOVED")
+            if(!help.backendConfigForbidden.empty())
             {
                 throw std::runtime_error("Command line option openPMD.json was renamed as openPMD.backendConfig.");
             }
@@ -666,7 +661,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             }
 
             log<picLog::INPUT_OUTPUT>("openPMD: global JSON output config: %1%") % jsonMatcher->getDefault();
-            if(backendConfigRestartStringForbidden != "REMOVED")
+            if(!help.backendConfigRestartForbidden.empty())
             {
                 throw std::runtime_error(
                     "Command line option openPMD.jsonRestart was renamed as openPMD.backendConfigRestart.");

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -157,9 +157,9 @@ namespace picongpu
                     communicator,
                     /*
                      * The writing routines are configured via the JSON set passed
-                     * in --openPMD.json / --checkpoint.openPMD.json, or TOML parameter backend_config.
-                     * The reading routines (for restarting from a checkpoint)
-                     * are configured via --checkpoint.openPMD.jsonRestart.
+                     * in --openPMD.backendConfig / --checkpoint.openPMD.backendConfig, or TOML parameter
+                     * backend_config. The reading routines (for restarting from a checkpoint) are configured via
+                     * --checkpoint.openPMD.jsonRestart.
                      */
                     at == ::openPMD::Access::READ_ONLY ? backendConfigRestartString : jsonMatcher->getDefault());
                 if(openPMDSeries->backend() == "MPI_ADIOS1")
@@ -524,7 +524,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                             {
                                 throw std::runtime_error(
                                     "[openPMD plugin] Parameter '" + option.getName()
-                                    + "' was defined, But neither 'period' nor 'toml' was.");
+                                    + "' was defined, But neither 'period' nor 'pluginConfig' was.");
                             }
                         }
                     }
@@ -1195,7 +1195,8 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                             if(cmd.optionDefined(m_id) && not cmd.get(m_id).empty())
                             {
                                 throw std::runtime_error(
-                                    "[openPMD plugin] If using parameter toml, no other parameter may be used (do not "
+                                    "[openPMD plugin] If using parameter pluginConfig, no other parameter may be used "
+                                    "(do not "
                                     "define '"
                                     + cmd.getName() + "').");
                             }
@@ -1222,7 +1223,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                                 else
                                 {
                                     throw std::runtime_error(
-                                        "[openPMD plugin] Internal error: Could not initialize TOML param "
+                                        "[openPMD plugin] Internal error: Could not initialize pluginConfig param "
                                         "'"
                                         + *parameter.tomlParameter
                                         + "' with a default value because it was not specified "
@@ -1273,7 +1274,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                     else
                     {
                         throw std::runtime_error(
-                            "[openPMD plugin] Either the notify period or the TOML sources must "
+                            "[openPMD plugin] Either the notify period or the pluginConfig sources (TOML) must "
                             "be specified, but not both.");
                     }
                 }

--- a/include/picongpu/plugins/openPMD/toml.cpp
+++ b/include/picongpu/plugins/openPMD/toml.cpp
@@ -97,8 +97,8 @@ namespace
                         catch(toml::type_error const&)
                         {
                             throw std::runtime_error(
-                                "[openPMD plugin] Data sources in TOML "
-                                "file must be a string or a vector of strings.");
+                                "[openPMD plugin] Data sources in pluginConfig "
+                                "file (TOML) must be a string or a vector of strings.");
                         }
                     }();
                     dataSources.push_back(std::move(dataSource));
@@ -116,8 +116,8 @@ namespace
                     catch(toml::type_error const&)
                     {
                         throw std::runtime_error(
-                            "[openPMD plugin] Data sources in TOML "
-                            "file must be a string or a vector of strings.");
+                            "[openPMD plugin] Data sources in pluginConfig "
+                            "file (TOML) must be a string or a vector of strings.");
                     }
                 }();
                 dataSources.push_back(std::move(dataSource));
@@ -186,7 +186,8 @@ namespace
             catch(toml::type_error const& e)
             {
                 throw std::runtime_error(
-                    "[openPMD plugin] Key 'sink' in TOML file must be a table (" + std::string(e.what()) + ")");
+                    "[openPMD plugin] Key 'sink' in pluginConfig file (TOML) must be a table (" + std::string(e.what())
+                    + ")");
             }
         }();
 
@@ -209,7 +210,8 @@ namespace
                 catch(toml::type_error const& e)
                 {
                     throw std::runtime_error(
-                        "[openPMD plugin] Key 'period' in TOML file must be a table (" + std::string(e.what()) + ")");
+                        "[openPMD plugin] Key 'period' in pluginConfig file (TOML) must be a table ("
+                        + std::string(e.what()) + ")");
                 }
             }();
             mergePeriodTable(period, parseOnePeriodTable(periodTable));
@@ -230,7 +232,10 @@ namespace
         MPI_CHECK(MPI_Comm_rank(comm, &rank));
         {
             char const* argsv[] = {path.c_str()};
-            picongpu::toml::writeLog("openPMD: Reading data requirements from TOML file: '%1%'", 1, argsv);
+            picongpu::toml::writeLog(
+                "openPMD: Reading data requirements from pluginConfig file (TOML): '%1%'",
+                1,
+                argsv);
         }
 
         // wait for file to appear
@@ -242,13 +247,13 @@ namespace
             ChronoDuration waitedFor = 0s;
             while(!stdfs::exists(path))
             {
-                picongpu::toml::writeLog("openPMD: Still waiting for TOML file:\n\t%1%", 1, argsv);
+                picongpu::toml::writeLog("openPMD: Still waiting for pluginConfig file (TOML):\n\t%1%", 1, argsv);
                 if(waitedFor > timeout)
                 {
                     std::stringstream errorMsg;
                     std::chrono::seconds const asSeconds = timeout;
-                    errorMsg << "openPMD: TOML file '" << path << "' was not found within the timeout of "
-                             << asSeconds.count() << " seconds.";
+                    errorMsg << "openPMD: pluginConfig file  (TOML)'" << path
+                             << "' was not found within the timeout of " << asSeconds.count() << " seconds.";
                     throw std::runtime_error(errorMsg.str());
                 }
                 std::this_thread::sleep_for(sleepInterval);
@@ -258,7 +263,7 @@ namespace
 
         MPI_CHECK(MPI_Barrier(comm));
 
-        picongpu::toml::writeLog("openPMD: Reading TOML file collectively");
+        picongpu::toml::writeLog("openPMD: Reading pluginConfig file  (TOMLcollectively");
         std::string fileContents = picongpu::collective_file_read(path, comm);
 
         return parseTomlFile(dataSources, tomlParameters, fileContents, path);

--- a/lib/python/picongpu/templates/etc/picongpu/N.cfg.mustache
+++ b/lib/python/picongpu/templates/etc/picongpu/N.cfg.mustache
@@ -171,21 +171,27 @@ pypicongpu_output_with_newlines="
   {{/openPMD.ext}}
   {{#openPMD.json}}--checkpoint.openPMD.json {{{openPMD.json}}}
   {{/openPMD.json}}
+  {{#openPMD.backendConfig}}--checkpoint.openPMD.backendConfig {{{openPMD.backendConfig}}}
+  {{/openPMD.backendConfig}}
   {{#openPMD.infix}}--checkpoint.openPMD.infix {{{openPMD.infix}}}
   {{/openPMD.infix}}
   {{#openPMD.dataPreparationStrategy}}--checkpoint.openPMD.dataPreparationStrategy {{{openPMD.dataPreparationStrategy}}}
   {{/openPMD.dataPreparationStrategy}}
   {{#openPMD.jsonRestart}}--checkpoint.openPMD.jsonRestart {{{openPMD.jsonRestart}}}
   {{/openPMD.jsonRestart}}
+  {{#openPMD.backendConfigRestart}}--checkpoint.openPMD.backendConfigRestart {{{openPMD.backendConfigRestart}}}
+  {{/openPMD.backendConfigRestart}}
   {{#openPMD.toml}}--checkpoint.openPMD.toml {{{openPMD.toml}}}
   {{/openPMD.toml}}
+  {{#openPMD.pluginConfig}}--checkpoint.openPMD.pluginConfig {{{openPMD.pluginConfig}}}
+  {{/openPMD.pluginConfig}}
   {{#openPMD.particleIOChunkSize}}--checkpoint.openPMD.particleIOChunkSize {{{openPMD.particleIOChunkSize}}}
   {{/openPMD.particleIOChunkSize}}
 {{/openPMD}}
 {{/type_checkpoint}}
 
 {{#type_openPMD}}
---openPMD.toml {{{config_filename}}}
+--openPMD.pluginConfig {{{config_filename}}}
 {{/type_openPMD}}
 
   {{/output}}

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/4_pipe.cfg
@@ -91,7 +91,7 @@ TBG_openPMD="--openPMD.period 100                          \
             --openPMD.infix NULL                           \
             --openPMD.ext sst                              \
             --openPMD.dataPreparationStrategy mappedMemory \
-            --openPMD.json '!TBG_PIC_config'"
+            --openPMD.backendConfig '!TBG_PIC_config'"
 TBG_streamdir="openPMD/simData.sst"
 TBG_dumpdir="openPMD/simData.bp"
 

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/6_pipe.cfg
@@ -86,7 +86,7 @@ TBG_openPMD="--openPMD.period 100                          \
             --openPMD.infix NULL                           \
             --openPMD.ext sst                              \
             --openPMD.dataPreparationStrategy mappedMemory \
-            --openPMD.json '!TBG_PIC_config'"
+            --openPMD.backendConfig '!TBG_PIC_config'"
 TBG_streamdir="openPMD/simData.sst"
 TBG_dumpdir="openPMD/simData.bp"
 

--- a/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_pipe.cfg
+++ b/share/picongpu/examples/KelvinHelmholtz/etc/picongpu/8_pipe.cfg
@@ -91,7 +91,7 @@ TBG_openPMD="--openPMD.period 100                          \
             --openPMD.infix NULL                           \
             --openPMD.ext sst                              \
             --openPMD.dataPreparationStrategy mappedMemory \
-            --openPMD.json '!TBG_PIC_config'"
+            --openPMD.backendConfig '!TBG_PIC_config'"
 TBG_streamdir="openPMD/simData.sst"
 TBG_dumpdir="openPMD/simData.bp"
 


### PR DESCRIPTION
The flags `--openPMD.json` and `--openPMD.toml` are arbitrary and not very telling.
`--openPMD.json` is the openPMD backend config that is forwarded to the openPMD-api (and that may [in future](https://github.com/ComputationalRadiationPhysics/picongpu/pull/5613) also be specified as TOML).
    ---> Rename to `--openPMD.backendConfig`

`--openPMD.toml` is an alternative format for configuring the openPMD plugin of PIConGPU (data sources, periodicities, …).
    ---> Rename to `--openPMD.pluginConfig`

This PR makes a hard cut, using the old flags will now throw an error:
```
Unhandled exception of type 'St13runtime_error' with message 'Command line option openPMD.jsonRestart was renamed as openPMD.backendConfigRestart.', terminating
```

TODO:

- [x] Update config example files
- [x] Update documentation
- [x] Update usage in code (error messages, comments, …)