### PR TITLE
set CMake policy version

### DIFF
--- a/include/mpiInfo/CMakeLists.txt
+++ b/include/mpiInfo/CMakeLists.txt
@@ -46,13 +46,13 @@ list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/")
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ################################################################################
 # mpiInfo options

--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -107,13 +107,13 @@ endfunction()
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ###############################################################################
 # Language Flags

--- a/include/pmacc/CMakeLists.txt
+++ b/include/pmacc/CMakeLists.txt
@@ -39,13 +39,13 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ###############################################################################
 # Language Flags

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -180,13 +180,13 @@ unset(PMACC_BUILD_TYPE)
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ###############################################################################
 # Language Flags

--- a/include/pmacc/test/random/CMakeLists.txt
+++ b/include/pmacc/test/random/CMakeLists.txt
@@ -36,12 +36,13 @@ set(CMAKE_CXX_STANDARD 20)
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ################################################################################
 # PMacc

--- a/share/picongpu/unit/CMakeLists.txt
+++ b/share/picongpu/unit/CMakeLists.txt
@@ -32,12 +32,13 @@ set(CMAKE_CXX_STANDARD 20)
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ################################################################################
 # PMacc

--- a/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
+++ b/share/pmacc/examples/gameOfLife2D/CMakeLists.txt
@@ -45,13 +45,13 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ###############################################################################
 # Language Flags

--- a/share/pmacc/examples/heatEquation2D/CMakeLists.txt
+++ b/share/pmacc/examples/heatEquation2D/CMakeLists.txt
@@ -46,13 +46,13 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 ################################################################################
 # CMake policies
 #
+# Set the Cmake policy version. This sets the behaviour of the following policies
 # Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+#   https://cmake.org/cmake/help/latest/policy/CMP0074.html
+# Search in <PACKAGENAME>_ROOT:
+#   https://cmake.org/cmake/help/latest/policy/CMP0144.html
 ################################################################################
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
+cmake_policy(VERSION 3.28.0)
 
 ###############################################################################
 # Language Flags


### PR DESCRIPTION
On Jupiter we get cmake warnings that we need to set CMP0144 to look into paths set by the module system (eg. BOOST_ROOT) , instead of defining this, I set the policy version. 
This means that we use new policies by default for policies introduced before this version.
For us these are CMP0074 and CMP0144
These ensure that the CMake variables and environment variables of the format `<PackageName>_ROOT` and `<PACKAGENAME>_ROOT` are searched for finding packages etc.