### PR TITLE
pyproject.toml: Make pip install picongpu-submodules

### DIFF
--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -57,5 +57,6 @@ dependencies = [
   "typeguard>=4.2.1",
 ]
 
-[tool.setuptools]
-packages = [ "picongpu" ]
+[tool.setuptools.packages.find]
+where = [ "." ]
+include = [ "picongpu*" ]


### PR DESCRIPTION
This seems to fix the issue of picongpu python only be installable in editable mode.

Tested:
* `pip install .` and
* `pip install git+https://github.com/jkelling/picongpu.git@fixpyproject#subdirectory=lib/python`
* **as dependency** `picongpu @ git+https://github.com/jkelling/picongpu.git@fixpyproject#subdirectory=lib/python` of other project

leading to submodules being included in the install.