### PR TITLE
Small pmacc updates

### DIFF
--- a/include/pmacc/mappings/simulation/Selection.hpp
+++ b/include/pmacc/mappings/simulation/Selection.hpp
@@ -54,6 +54,10 @@ namespace pmacc
          * Copy constructor
          */
         HDINLINE constexpr Selection(Selection const&) = default;
+        /**
+         * Copy assignment
+         */
+        HDINLINE constexpr Selection& operator=(Selection const&) = default;
 
         /**
          * Constructor

--- a/include/pmacc/particles/IdProvider.hpp
+++ b/include/pmacc/particles/IdProvider.hpp
@@ -27,6 +27,8 @@
 #include "pmacc/memory/buffers/HostDeviceBuffer.hpp"
 #include "pmacc/types.hpp"
 
+#include <bit>
+
 namespace pmacc
 {
     struct IdGenerator
@@ -107,6 +109,12 @@ namespace pmacc
                 % state.startId % state.maxNumProc % m_maxNumProc;
         }
 
+        // Reset the idProvider to initial state for testing
+        void reset()
+        {
+            setState(State{.nextId = m_startId, .startId = m_startId, .maxNumProc = m_maxNumProc});
+        }
+
         IdProvider(SimulationDataId providerName, uint64_t mpiRank, uint64_t numMpiRanks)
             : name(providerName)
             , idBuffer(DataSpace<1>{1})
@@ -130,14 +138,7 @@ namespace pmacc
              * If not, then all ids are probably unique (still a chance, the id is overflown so much, that detection is
              * impossible)
              */
-            uint64_t tmp = curState.maxNumProc - 1;
-            int32_t bitsToCheck = 0;
-            while(tmp)
-            {
-                bitsToCheck++;
-                tmp >>= 1;
-            }
-
+            auto const bitsToCheck = std::bit_width(curState.maxNumProc - 1);
             // Number of bits in the ids
             static constexpr int32_t numBitsOfType = sizeof(curState.maxNumProc) * CHAR_BIT;
 


### PR DESCRIPTION
Add a reset to idProvider to use in testing
Use std::bitwidth instead of a self rolled while loop (tested here https://godbolt.org/z/hqdeEonvx)
Added a defaulted copy assignment for Selection to silence some compiler warnings that auto generating copy assignment from a explicitly defaulted copy constructor is deprecated