### PR TITLE
use openMPI instead of Parastation due to bug

### DIFF
--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -38,7 +38,7 @@ module load Stages/2026
 module load GCC/14.3.0
 module load CUDA/13
 module load CMake/3.31.8
-module load ParaStationMPI/5.13.0-1
+module load OpenMPI/5.0.8
 module load Blosc2
 module load Python
 module load HDF5


### PR DESCRIPTION
Note you will have to **recompile the dependencies** from the gist (openPMD and ADIOS) again after sourcing this profile to avoid issues with linking different MPI versions.

Using ParaStationMPI we encountered simulations getting randomly stuck (mostly before step 0) which is probably this [bug](https://apps.fz-juelich.de/jsc/hps/jupiter/known-issues.html#issue-with-collective-i-o-calls-when-using-parastationmpi-on-stages-2026).
Trying the workaround with the environment variable `PSP_UCC=1` causes memory issues. Instead of taking this debugging further I think it is prudent to simply switch to OpenMPI, and look at ParaStation later if needed.

Tested with the LWFA 32.cfg, and I didn't get an out of memory error as I did with ParaStation earlier.
@FilipO28555 @JessicaTiebel Please test if this works for you as well.
