### PR TITLE
use pi via c++20 numbers

### DIFF
--- a/include/picongpu/param/physicalConstants.param
+++ b/include/picongpu/param/physicalConstants.param
@@ -23,7 +23,7 @@
 
 namespace picongpu
 {
-    constexpr float_64 PI = 3.141592653589793238462643383279502884197169399;
+    constexpr float_64 PI = pmacc::math::Pi<float_64>::value;
 
     namespace SI
     {

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -24,6 +24,8 @@
 
 #include "pmacc/types.hpp"
 
+#include <numbers>
+
 namespace pmacc
 {
     namespace math
@@ -33,7 +35,7 @@ namespace pmacc
         template<typename T_Type>
         struct Pi
         {
-            static constexpr T_Type value = static_cast<T_Type>(3.141592653589793238462643383279502884197169399);
+            static constexpr T_Type value = std::numbers::pi_v<T_Type>;
             static constexpr T_Type doubleValue = static_cast<T_Type>(2.0) * value;
             static constexpr T_Type halfValue = value / static_cast<T_Type>(2.0);
             static constexpr T_Type quarterValue = value / static_cast<T_Type>(4.0);

--- a/include/pmacc/algorithms/math/defines/pi.hpp
+++ b/include/pmacc/algorithms/math/defines/pi.hpp
@@ -39,7 +39,7 @@ namespace pmacc
             static constexpr T_Type doubleValue = static_cast<T_Type>(2.0) * value;
             static constexpr T_Type halfValue = value / static_cast<T_Type>(2.0);
             static constexpr T_Type quarterValue = value / static_cast<T_Type>(4.0);
-            static constexpr T_Type doubleReciprocalValue = static_cast<T_Type>(2.0) / value;
+            static constexpr T_Type doubleReciprocalValue = static_cast<T_Type>(2.0) * std::numbers::inv_pi_v<T_Type>;
         };
 
     } // namespace math


### PR DESCRIPTION
This PR updates the string lateral used in libPMacc and PIConGPU physics constants.
This has not been compile-tested as hemera setup is currently broken (see comment #5626).  