### PR TITLE
Fix doc issues

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,7 +84,6 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
    models/LL_RR
    models/field_ionization
    models/collisional_ionization
-   models/photons
    models/binary_collisions
    models/atomic_physics
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -132,6 +132,19 @@ In case you are already fluent in compiling C++ projects and HPC, running PIC si
 
    prgpatterns/lockstep
 
+   
+.. toctree::
+   :caption: TESTING
+   :maxdepth: 1
+   :hidden:
+      
+   testing/general
+   testing/usage
+   testing/structure
+   testing/testbuilding
+   testing/examples
+   
+   
 .. toctree::
    :caption: PyPIConGPU
    :maxdepth: 1

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -97,40 +97,6 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
    :language: bash
 
 
-Taurus (TU Dresden)
--------------------
-
-**System overview:** `link <https://tu-dresden.de/zih/hochleistungsrechnen/hpc>`__
-
-**User guide:** `link <https://doc.zih.tu-dresden.de/hpc-wiki/bin/view/Compendium/SystemTaurus>`__
-
-**Production directory:** ``/scratch/$USER/`` and ``/scratch/$proj/``
-
-For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter <install-dependencies>` manually.
-
-Queue: gpu2 (Nvidia K80 GPUs)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/taurus-tud/k80_picongpu.profile.example
-   :language: bash
-
-Queue: ml (NVIDIA V100 GPUs on Power9 nodes)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For this profile, you additionally need to compile and install everything for the power9-architecture including your own :ref:`boost <install-dependencies>`, :ref:`HDF5 <install-dependencies>`, c-blosc and :ref:`ADIOS <install-dependencies>`.
-
-.. note::
-
-   Please find a `Taurus ml quick start here <https://gist.github.com/steindev/cc02eae81f465833afa27fc8880f3473>`_.
-
-.. note::
-   
-   You need to compile the libraries and PIConGPU on an ``ml`` node since
-   only nodes in the ``ml`` queue are Power9 systems.
-
-.. literalinclude:: profiles/taurus-tud/V100_picongpu.profile.example
-   :language: bash
-
 Cori (NERSC)
 ------------
 

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -96,7 +96,18 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
 .. literalinclude:: profiles/hemera-hzdr/fwkt_v100_picongpu.profile.example
    :language: bash
 
+dev server (HZDR)
+-----------------
 
+**information on software setup with spack:**
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   ./profiles/bash-devServer-hzdr/README
+
+	      
 JURECA (JSC)
 ------------
 
@@ -164,4 +175,44 @@ Queue: gpu (2 x NVIDIA Tesla k40m GPUs)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: profiles/aris-grnet/gpu_picongpu.profile.example
+   :language: bash
+
+	      
+
+Capella (ZIH)
+-------------
+
+Information on SLURM usage
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   ./profiles/zih-tud/Slurm_Tutorial
+
+
+Perlmutter (NERSC)
+------------------
+
+General information on system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   ./profiles/perlmutter-nersc/README
+
+gpu profile
+^^^^^^^^^^^
+
+.. literalinclude:: profiles/perlmutter-nersc/gpu.profile.example
+   :language: bash
+
+	      
+building your software stack
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: profiles/perlmutter-nersc/dependencies_autoinstall.sh
    :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -97,20 +97,6 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
    :language: bash
 
 
-Draco (MPCDF)
--------------
-
-**System overview:** `link <https://www.mpcdf.mpg.de/services/computing/draco/about-the-system>`__
-
-**User guide:** `link <https://www.mpcdf.mpg.de/services/computing/draco>`__
-
-**Production directory:** ``/ptmp/$USER/``
-
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`libpng and PNGwriter <install-dependencies>` manually.
-
-.. literalinclude:: profiles/draco-mpcdf/picongpu.profile.example
-   :language: bash
-
 D.A.V.I.D.E (CINECA)
 --------------------
 

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -97,23 +97,6 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
    :language: bash
 
 
-D.A.V.I.D.E (CINECA)
---------------------
-
-**System overview:** `link <http://www.hpc.cineca.it/content/davide>`__
-
-**User guide:** `link <https://wiki.u-gov.it/confluence/display/SCAIUS/UG3.2%3A+D.A.V.I.D.E.+UserGuide>`__
-
-**Production directory:** ``$CINECA_SCRATCH/`` (`link <https://wiki.u-gov.it/confluence/display/SCAIUS/UG2.4%3A+Data+storage+and+FileSystems>`__)
-
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` manually.
-
-Queue: dvd_usr_prod (Nvidia P100 GPUs)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/davide-cineca/gpu_picongpu.profile.example
-   :language: bash
-
 JURECA (JSC)
 ------------
 

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -165,18 +165,3 @@ Queue: gpu (2 x NVIDIA Tesla k40m GPUs)
 
 .. literalinclude:: profiles/aris-grnet/gpu_picongpu.profile.example
    :language: bash
-
-Ascent (ORNL)
--------------
-
-**System overview and user guide:** `link <https://docs.olcf.ornl.gov/systems/ascent_user_guide.html#system-overview/>`__
-
-**Production directory:** usually ``$PROJWORK/$proj/`` (as on summit `link <https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#file-systems>`__).
-
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`openPMD-api and PNGwriter <install-dependencies>` manually or use pre-installed libraries in the shared project directory.
-
-V100 GPUs (recommended)
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/ascent-ornl/gpu_picongpu.profile.example
-   :language: bash

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -97,29 +97,6 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
    :language: bash
 
 
-Piz Daint (CSCS)
-----------------
-
-**System overview:** `link <https://www.cscs.ch/computers/piz-daint/>`__
-
-**User guide:** `link <https://user.cscs.ch/>`__
-
-**Production directory:** ``$SCRATCH`` (`link <https://user.cscs.ch/storage/file_systems/>`__).
-
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`boost, libpng, PNGwriter and ADIOS2 <install-dependencies>` manually.
-
-.. note::
-
-   The MPI libraries are lacking Fortran bindings (which we do not need anyway).
-   During the install of ADIOS, make sure to add to ``configure`` the ``--disable-fortran`` flag.
-
-.. note::
-
-   Please find a `Piz Daint quick start from August 2018 here <https://gist.github.com/ax3l/68cb4caa597df3def9b01640959ea56b>`_.
-
-.. literalinclude:: profiles/pizdaint-cscs/picongpu.profile.example
-   :language: bash
-
 Taurus (TU Dresden)
 -------------------
 

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -59,27 +59,6 @@ and providing default parameters for :ref:`TBG <usage-tbg>`.
 .. literalinclude:: profiles/bash/bash_picongpu.profile.example
    :language: bash
 
-Crusher (ORNL)
---------------
-
-**System overview:** `link <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#system-overview>`__
-
-**Production directory:** usually ``$PROJWORK/$proj/`` (`link <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#data-and-storage>`__).
-Note that ``$HOME`` is mounted on compute nodes as read-only.
-
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter and openPMD <install-dependencies>` manually.
-
-MI250X GPUs using hipcc (recommended)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/crusher-ornl/batch_hipcc_picongpu.profile.example
-   :language: bash
-
-MI250X GPUs using craycc
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/crusher-ornl/batch_craycc_picongpu.profile.example
-  :language: bash
 
 Hemera (HZDR)
 -------------

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -96,23 +96,6 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
 .. literalinclude:: profiles/hemera-hzdr/fwkt_v100_picongpu.profile.example
    :language: bash
 
-Summit (ORNL)
--------------
-
-**System overview:** `link <https://www.olcf.ornl.gov/olcf-resources/compute-systems/summit/>`__
-
-**User guide:** `link <https://www.olcf.ornl.gov/for-users/system-user-guides/summit/>`__
-
-**Production directory:** usually ``$PROJWORK/$proj/`` (`link <https://www.olcf.ornl.gov/for-users/system-user-guides/summit/summit-user-guide/#file-systems>`__).
-Note that ``$HOME`` is mounted on compute nodes as read-only.
-
-For this profile to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter <install-dependencies>` manually.
-
-V100 GPUs (recommended)
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/summit-ornl/gpu_picongpu.profile.example
-   :language: bash
 
 Piz Daint (CSCS)
 ----------------

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -97,23 +97,6 @@ Queue: fwkt_v100 (4x NVIDIA V100 32GB)
    :language: bash
 
 
-Cori (NERSC)
-------------
-
-**System overview:** `link <https://www.nersc.gov/users/computational-systems/cori/configuration/>`__
-
-**User guide:** `link <https://docs.nersc.gov/>`__
-
-**Production directory:** ``$SCRATCH`` (`link <https://www.nersc.gov/users/storage-and-file-systems/>`__).
-
-For these profiles to work, you need to download the :ref:`PIConGPU source code <install-dependencies-picongpu>` and install :ref:`PNGwriter <install-dependencies>` manually.
-
-Queue: dgx (DGX - A100)
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. literalinclude:: profiles/cori-nersc/a100_picongpu.profile.example
-   :language: bash
-
 Draco (MPCDF)
 -------------
 

--- a/docs/source/testing/examples.rst
+++ b/docs/source/testing/examples.rst
@@ -2,3 +2,9 @@
 
 Examples
 ========
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   ./examples/*

--- a/docs/source/testing/examples/MI.rst
+++ b/docs/source/testing/examples/MI.rst
@@ -5,24 +5,24 @@ Kelvin-Helmholtz instability: mushroom instability (MI)
 
 .. seealso::
 
-   For a better understanding, please read the :ref:`Kelvin Helmholtz instability chapter <../../examples/KelvinHelmholtz/README>` in the examples setups.
+   For a better understanding, please read the :doc:`../../examples/KelvinHelmholtz/README` in the examples setups.
 
 
 
 The mushroom instability is the transverse dynamics of the KHI and dominates the plasma instability at high Lorentz factors of the plasma streams.
 For the sake of simplicity, we consider two equally fast plasma streams, which flow past each other in opposite directions. 
-From this assumption, the growth rate :math:`$\Gamma_{max}$` can be described as:
+From this assumption, the growth rate :math:`\Gamma_{max}` can be described as:
 
-:math:`$\Gamma_{max} = \omega_p \frac{v_0}{c\gamma^{0.5}}$`
+:math:`\Gamma_{max} = \omega_p \frac{v_0}{c\gamma^{0.5}}`
    
-with :math:`$\omega_{pe}$` being the plasma frequency, c the Speed of Light. 
+with :math:`\omega_{pe}` being the plasma frequency, c the Speed of Light. 
 For further information on the derivation, please refer to the references linked in the Kelvin Helmhotz instability chapter mentioned above.
 
 .. image:: ../../../images/ESKHI_MI.png
    :alt: Comparison between the growth rates of the ESKHI and MI
 
 The longitudinal KHI instability (esKHI) and the traversal instability (MI) have different growth rates depending the the Lorentz factor of the plasma streams.
-This results in a point of intersection at a Lorentz factor of :math:`$\gamma = \sqrt{\frac{9}{8]}$`, where both instabilities compete and have the same growth rate.
+This results in a point of intersection at a Lorentz factor of :math:`\gamma = \sqrt{\frac{9}{8}}`, where both instabilities compete and have the same growth rate.
 This results in two possibilities to test the growth rate of the MI.
 Since the MI represents the transverse dynamics of the system, the occurrence of ESKHI can be ruled out with a properly aligned 2D simulation.
 This has the advantage of being able to use all Lorentz factors.
@@ -33,7 +33,7 @@ If one examines the deviation of the growth rate from the simulation with that f
 .. image:: ../../../images/vortice_scan.png
    :alt: Consideration of the deviation using different CELL_WIDTH_SI
 
-One of the resulting minima in the deviation (3d) is obtained with :math:`CELL_WIDTH_SI = $8.0378e-8m$`.
+One of the resulting minima in the deviation (3d) is obtained with ``CELL_WIDTH_SI`` :math:`= 8.0378\cdot 10^{-8}m`.
 Further investigations showed that for different Lorentz factors in the 2D simulation of the MI, other Cell_WIDTH_SI values provide a minimum in the deviation. 
 Therefore, the 3D simulation is suitable as a test case due to low deviations for all Lorentz factors.
 
@@ -42,6 +42,6 @@ Therefore, the 3D simulation is suitable as a test case due to low deviations fo
    
 These considerations lead to the parameters used in this test case:
 
-- Lorentz factor: :math:`$\gamma = 1.6$`
-- :math:`CELL_HEIGHT_SI = CELL_DEPTH_SI = CELL_WIDTH_SI = $8.03783-8m$`
+- Lorentz factor: :math:`\gamma = 1.6`
+- ``CELL_HEIGHT_SI = CELL_DEPTH_SI = CELL_WIDTH_SI`` :math:`= 8.03783\cdot 10^{-8}m`
 - Dimension: 3d

--- a/docs/source/usage/param.rst
+++ b/docs/source/usage/param.rst
@@ -67,3 +67,5 @@ When setting up a simulation, it is recommended to adjust ``.param`` files in th
    param/extensions
    param/plugins
    param/misc
+   param/particles/init
+   param/particles/current


### PR DESCRIPTION
This PR fixes a lot of warning in our documentation build process.
They were caused by missing includes or references to removed content. 
Some files needed also additions or fixes. 

This PR does not touch the many issues caused by PICMI/pypicongpu autoapi documentation. 

partially solves #5635
