### PR TITLE
enable IPO/LTO in cmake

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -261,6 +261,18 @@ add_definitions(-DPIC_OPENPMD_TIMETRACE_NUMBER_OF_FILES=${PIC_OPENPMD_TIMETRACE_
 
 option(PIC_ADD_RPATH "Add RPATH's to binaries." ON)
 
+option(PIC_ENABLE_IPO "Enable IPO/LTO" ON)
+
+if(PIC_ENABLE_IPO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _ipo_supported OUTPUT _ipo_output)
+    if(_ipo_supported)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+    else()
+        message(WARNING "IPO is not supported: ${_ipo_output}")
+    endif()
+endif()
+
 ################################################################################
 # Additional defines for PIConGPU outputs
 ################################################################################

--- a/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadParticleAttributesFromOpenPMD.hpp
@@ -59,7 +59,7 @@ namespace picongpu
              * array
              */
             template<typename FrameType>
-            HINLINE void operator()(
+            void operator()(
                 ThreadParams* params,
                 FrameType& frame,
                 ::openPMD::ParticleSpecies particleSpecies,

--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -122,7 +122,7 @@ namespace picongpu
              * @param elements elements of this attribute
              */
             template<typename FrameType>
-            HINLINE void operator()(
+            void operator()(
                 ThreadParams* params,
                 FrameType& frame,
                 ::openPMD::Container<::openPMD::Record>& particleSpecies,


### PR DESCRIPTION
As mentioned in issue #3106 it is worth investigating how link time optimization affects the code. We can simply enable it it for all targets in CMake.
Setting it to draft to see how the CI reacts. Will require some investigation into the effects on performance (if any).