### PR TITLE
Add `decorating_class` to PICMI

### DIFF
--- a/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
@@ -13,7 +13,8 @@ import sympy
 import typeguard
 from numpy import vectorize
 
-from ...pypicongpu import species
+from picongpu.pypicongpu import species
+from picongpu.pypicongpu.util import decorating_class
 
 """
 note on rms_velocity:
@@ -37,6 +38,7 @@ this method returns None.
 """
 
 
+@decorating_class
 @typeguard.typechecked
 class AnalyticDistribution:
     """

--- a/lib/python/picongpu/picmi/particle_functor/particle_filter.py
+++ b/lib/python/picongpu/picmi/particle_functor/particle_filter.py
@@ -15,7 +15,7 @@ from picongpu.pypicongpu.particle_functor import FilteredSpecies as PyPIConGPUFi
 
 
 class ParticleFilter(ParticleFunctor):
-    def __init__(self, name: str, functor: Callable[[Particle], Any]):
+    def __init__(self, functor: Callable[[Particle], Any], name: str):
         return super().__init__(name=name, functor=functor, return_type=bool, unit_dimension=None)
 
     def get_as_pypicongpu(self, mode="Filter"):

--- a/lib/python/picongpu/picmi/particle_functor/particle_functor.py
+++ b/lib/python/picongpu/picmi/particle_functor/particle_functor.py
@@ -18,7 +18,7 @@ from picongpu.pypicongpu.particle_functor import (
     UnitDimension as PyPIConGPUUnitDimension,
     generate_preamble,
 )
-from picongpu.pypicongpu.util import alt
+from picongpu.pypicongpu.util import alt, decorating_class
 
 _COORDINATE_SYSTEM = {
     (
@@ -94,22 +94,26 @@ class AbstractParticle(Particle):
         return my_symbols
 
 
+@decorating_class
 @typechecked
 class ParticleFunctor:
     def __init__(
         self,
-        name: str,
         functor: Callable[[Particle], Any] | Callable[[Particle, RNGArg], Any],
-        return_type: type | str = float,
+        name: str | None = None,
+        return_type: type | str | None = None,
         unit_dimension: UnitDimension | None = None,
     ):
-        self.name = name
         self.functor = functor
+        sig = signature(self.functor)
+        self.name = name or functor.__name__
         self.return_type = return_type
+        if self.return_type is None:
+            self.return_type = float if sig.return_annotation == sig.empty else sig.return_annotation
         self.unit_dimension = unit_dimension or UnitDimension()
         rng_classes = [
             cls
-            for p in signature(self.functor).parameters.values()
+            for p in sig.parameters.values()
             if isinstance(p.annotation, type) and issubclass(cls := p.annotation, RNGArg)
         ]
         if len(rng_classes) > 1:

--- a/lib/python/picongpu/pypicongpu/util.py
+++ b/lib/python/picongpu/pypicongpu/util.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 import logging
 from itertools import chain
-from functools import wraps
+from functools import partial, wraps
 from inspect import Parameter, signature
 from operator import itemgetter
 from types import GenericAlias, UnionType
@@ -16,6 +16,35 @@ from typing import Any, Self
 import typeguard
 
 attr_cnt = 0
+
+
+def _extract_first_parameter(cls):
+    sig = signature(cls).parameters
+    try:
+        parameter = next(iter(sig.values()))
+    except StopIteration as error:
+        raise TypeError(
+            f"A decorating class must have at least one argument to its constructor. You gave: {sig=} for {cls=}."
+        ) from error
+    if parameter.kind in [Parameter.VAR_KEYWORD, Parameter.VAR_POSITIONAL]:
+        raise TypeError(
+            f"A decorating class cannot have variadic (keyword) arguments to its constructor first. You gave: {sig=} for {cls=}."
+        )
+    return parameter
+
+
+def _pass_first_parameter_to(f, parameter, kwargs):
+    """
+    Constructs a function that can be called with the first parameter as positional argument regardless of it being kw-only or not.
+    """
+    if parameter.kind in [Parameter.KEYWORD_ONLY, Parameter.POSITIONAL_OR_KEYWORD]:
+        return lambda d: f(**{parameter.name: d}, **kwargs)
+    elif parameter.kind in [Parameter.POSITIONAL_ONLY]:
+        return lambda d: f(d, **kwargs)
+    else:
+        # The remaining option for parameter.kind is VAR_KEYWORD (at the time of writing)
+        # and that was caught above already.
+        raise Exception("This path should be unreachable!")
 
 
 def decorating_class(cls):
@@ -30,36 +59,19 @@ def decorating_class(cls):
     """
     # It is important to extract the signature before decorating the class.
     # Otherwise, we'll only see the names of the decorator's arguments.
-    sig = signature(cls).parameters
-    try:
-        parameter = next(iter(sig.values()))
-    except StopIteration as error:
-        raise TypeError(
-            f"A decorating class must have at least one argument to its constructor. You gave: {sig=} for {cls=}."
-        ) from error
-    if parameter.kind == Parameter.VAR_KEYWORD:
-        raise TypeError(
-            f"A decorating class cannot have only **kwargs arguments to its constructor. You gave: {sig=} for {cls=}."
-        )
+    parameter = _extract_first_parameter(cls)
 
     @wraps(cls, updated=tuple())
     class Tmp(cls):
         def __new__(cls, decorated=None, **kwargs):
             decorated = kwargs.pop(parameter.name, None) or decorated
             if decorated is None:
-                if parameter.kind in [Parameter.KEYWORD_ONLY]:
-                    return lambda d: cls(**{parameter.name: d}, **kwargs)
-                elif parameter.kind in [
-                    Parameter.POSITIONAL_ONLY,
-                    Parameter.POSITIONAL_OR_KEYWORD,
-                    Parameter.VAR_POSITIONAL,
-                ]:
-                    return lambda d: cls(d, **kwargs)
-                else:
-                    # The remaining option for parameter.kind is VAR_KEYWORD (at the time of writing)
-                    # and that was caught above already.
-                    raise Exception("This path should be unreachable!")
-            return super().__new__(cls)
+                return _pass_first_parameter_to(cls, parameter, kwargs)
+            constructor = partial(super().__new__, cls)
+            try:
+                return _pass_first_parameter_to(constructor, parameter, kwargs)(decorated)
+            except TypeError:
+                return constructor()
 
     return Tmp
 

--- a/lib/python/picongpu/pypicongpu/util.py
+++ b/lib/python/picongpu/pypicongpu/util.py
@@ -7,6 +7,8 @@ License: GPLv3+
 
 import logging
 from itertools import chain
+from functools import wraps
+from inspect import Parameter, signature
 from operator import itemgetter
 from types import GenericAlias, UnionType
 from typing import Any, Self
@@ -14,6 +16,52 @@ from typing import Any, Self
 import typeguard
 
 attr_cnt = 0
+
+
+def decorating_class(cls):
+    """
+    A decorating class can be used as decorator, i.e., in the following example `a` and `b` are identical:
+
+        a = MyClass(b=lambda: print("Hello World!"), c=6)
+
+        @MyClass(c=6)
+        def b():
+            print("Hello World!")
+    """
+    # It is important to extract the signature before decorating the class.
+    # Otherwise, we'll only see the names of the decorator's arguments.
+    sig = signature(cls).parameters
+    try:
+        parameter = next(iter(sig.values()))
+    except StopIteration as error:
+        raise TypeError(
+            f"A decorating class must have at least one argument to its constructor. You gave: {sig=} for {cls=}."
+        ) from error
+    if parameter.kind == Parameter.VAR_KEYWORD:
+        raise TypeError(
+            f"A decorating class cannot have only **kwargs arguments to its constructor. You gave: {sig=} for {cls=}."
+        )
+
+    @wraps(cls, updated=tuple())
+    class Tmp(cls):
+        def __new__(cls, decorated=None, **kwargs):
+            decorated = kwargs.pop(parameter.name, None) or decorated
+            if decorated is None:
+                if parameter.kind in [Parameter.KEYWORD_ONLY]:
+                    return lambda d: cls(**{parameter.name: d}, **kwargs)
+                elif parameter.kind in [
+                    Parameter.POSITIONAL_ONLY,
+                    Parameter.POSITIONAL_OR_KEYWORD,
+                    Parameter.VAR_POSITIONAL,
+                ]:
+                    return lambda d: cls(d, **kwargs)
+                else:
+                    # The remaining option for parameter.kind is VAR_KEYWORD (at the time of writing)
+                    # and that was caught above already.
+                    raise Exception("This path should be unreachable!")
+            return super().__new__(cls)
+
+    return Tmp
 
 
 def alt(expr, alternative, *exprs, ignore=(AttributeError, TypeError, IndexError)):

--- a/test/python/picongpu/end-to-end/diagnostics.py
+++ b/test/python/picongpu/end-to-end/diagnostics.py
@@ -94,7 +94,13 @@ def basic_simulation():
 
 
 CUTOFF_ENERGY = 10.0
-MACROPARTICLE_COUNTER = ParticleFunctor(name="macroparticle_counter", functor=lambda _: 1, return_type=int)
+
+
+@ParticleFunctor
+def macroparticle_counter(_) -> int:
+    return 1
+
+
 FUNCTORS = [
     # Currently no eligible particles available:
     # ParticleFunctor(name="bound_electrons", functor=lambda p: p.get("boundElectrons")),
@@ -116,14 +122,13 @@ FUNCTORS = [
     ),
     # Currently no eligible particles available:
     # ParticleFunctor(name="larmor_power", functor=larmor_power),
-    MACROPARTICLE_COUNTER,
+    macroparticle_counter,
     # Somehow off by some factor:
     ParticleFunctor(
         name="mid_current_density_x",
-        functor=lambda p: p.get("charge")
-        / np.prod(CELL_SIZE)
-        * p.get("momentum")[0]
-        / (p.get("gamma") * p.get("mass")),
+        functor=lambda p: (
+            p.get("charge") / np.prod(CELL_SIZE) * p.get("momentum")[0] / (p.get("gamma") * p.get("mass"))
+        ),
     ),
     ParticleFunctor(name="momentum_y", functor=lambda p: p.get("momentum")[1]),
     # Duplicated just to test what happens:
@@ -239,7 +244,7 @@ def generate_random_field_dumps(species, distribution):
             species=FilteredSpecies(
                 species=s, functor=RandomParticleFilter(percent, name=name, distribution=distribution)
             ),
-            functor=MACROPARTICLE_COUNTER,
+            functor=macroparticle_counter,
             options={"file": f"random_{name}"},
         )
         for percent in range(0, 100, 10)

--- a/test/python/picongpu/end-to-end/distributions.py
+++ b/test/python/picongpu/end-to-end/distributions.py
@@ -251,6 +251,11 @@ class SphereFlanks:
         return density * sympy.Piecewise(front_vacuum, inner_vacuum, sphere, flanks)
 
 
+@picmi.AnalyticDistribution
+def uniformdec(x, y, z):
+    return Uniform().arbitrary_value
+
+
 DISTRIBUTIONS = {
     "Uniform": Uniform().distributions,
     "Gaussian": Gaussian().distributions,
@@ -258,4 +263,5 @@ DISTRIBUTIONS = {
     "LinearExponential": LinearExponential().distributions,
     "SphereFlanks": SphereFlanks().distributions,
     "Cylinder": Cylinder().distributions,
+    "Uniformdec": {"predefined": Uniform().distributions["predefined"], "free_form": uniformdec},
 }

--- a/test/python/picongpu/quick/__init__.py
+++ b/test/python/picongpu/quick/__init__.py
@@ -1,6 +1,7 @@
 from . import picmi
+from . import pypicongpu
 
 
 def load_tests(loader, standard_tests, pattern):
-    standard_tests.addTests((loader.loadTestsFromModule(module, pattern=pattern) for module in (picmi,)))
+    standard_tests.addTests((loader.loadTestsFromModule(module, pattern=pattern) for module in (picmi, pypicongpu)))
     return standard_tests

--- a/test/python/picongpu/quick/pypicongpu/__init__.py
+++ b/test/python/picongpu/quick/pypicongpu/__init__.py
@@ -1,0 +1,8 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from .util import *  # noqa: F403

--- a/test/python/picongpu/quick/pypicongpu/util.py
+++ b/test/python/picongpu/quick/pypicongpu/util.py
@@ -1,0 +1,106 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+from typing import Callable
+from pydantic import BaseModel
+from unittest import TestCase
+from picongpu.pypicongpu.util import decorating_class
+
+
+@decorating_class
+class Functor:
+    def __init__(self, functor, **kwargs):
+        self.functor = functor
+        self.remaining_args = tuple()
+        self.kwargs = kwargs
+
+
+class TestDecoratingClass(TestCase):
+    def assert_functors_equal(self, result, expected):
+        self.assertDictEqual(result.kwargs, expected.kwargs)
+        self.assertTupleEqual(result.remaining_args, expected.remaining_args)
+        # some simple probing if the functions are identical
+        for i in range(10):
+            self.assertEqual(result.functor(i), expected.functor(i))
+
+    def test_simple_functor(self):
+        @Functor
+        def result(x):
+            return x
+
+        expected = Functor(lambda x: x)
+        self.assert_functors_equal(result, expected)
+
+    def test_simple_functor_with_kwargs(self):
+        kwargs = {"a": 1}
+
+        @Functor(**kwargs)
+        def result(x):
+            return x
+
+        expected = Functor(lambda x: x, **kwargs)
+        self.assert_functors_equal(result, expected)
+        self.assertTupleEqual(result.remaining_args, tuple())
+        self.assertDictEqual(result.kwargs, kwargs)
+
+    def test_simple_functor_with_duplicate_arg_raises(self):
+        kwargs = {"functor": lambda x: x}
+        with self.assertRaises(TypeError):
+            Functor(kwargs["functor"], **kwargs)
+
+    def test_no_args(self):
+        with self.assertRaises(TypeError):
+
+            @decorating_class
+            class NoArgs:
+                def __init__(self):
+                    pass
+
+    def test_parameter_packs(self):
+        @decorating_class
+        class VariadicFunctor:
+            def __init__(self, *args, **kwargs):
+                self.functor = args[0]
+                self.remaining_args = args[1:]
+                self.kwargs = kwargs
+
+        @VariadicFunctor
+        def result(x):
+            return x
+
+        expected = VariadicFunctor(lambda x: x)
+        self.assert_functors_equal(result, expected)
+
+    def test_variadic_kwargs_only(self):
+        with self.assertRaises(TypeError):
+
+            @decorating_class
+            class VariadicFunctor:
+                def __init__(self, **kwargs):
+                    self.functor = kwargs.pop("functor", None)
+                    self.remaining_args = tuple()
+                    self.kwargs = kwargs
+
+    def test_with_pydantic(self):
+        @decorating_class
+        class PydanticFunctor(BaseModel):
+            functor: Callable[[int], int]
+            # The naming here is chosen such that self.assert_functors_equal still works.
+            remaining_args: tuple[int]
+            kwargs: dict[str, int]
+
+        remaining_args = (2,)
+        kwargs = {"a": 1}
+
+        @PydanticFunctor(remaining_args=remaining_args, kwargs=kwargs)
+        def result(x):
+            return x
+
+        expected = PydanticFunctor(functor=lambda x: x, remaining_args=remaining_args, kwargs=kwargs)
+        self.assert_functors_equal(result, expected)
+        self.assertTupleEqual(result.remaining_args, remaining_args)
+        self.assertDictEqual(result.kwargs, kwargs)

--- a/test/python/picongpu/quick/pypicongpu/util.py
+++ b/test/python/picongpu/quick/pypicongpu/util.py
@@ -15,14 +15,12 @@ from picongpu.pypicongpu.util import decorating_class
 class Functor:
     def __init__(self, functor, **kwargs):
         self.functor = functor
-        self.remaining_args = tuple()
         self.kwargs = kwargs
 
 
 class TestDecoratingClass(TestCase):
     def assert_functors_equal(self, result, expected):
         self.assertDictEqual(result.kwargs, expected.kwargs)
-        self.assertTupleEqual(result.remaining_args, expected.remaining_args)
         # some simple probing if the functions are identical
         for i in range(10):
             self.assertEqual(result.functor(i), expected.functor(i))
@@ -44,7 +42,6 @@ class TestDecoratingClass(TestCase):
 
         expected = Functor(lambda x: x, **kwargs)
         self.assert_functors_equal(result, expected)
-        self.assertTupleEqual(result.remaining_args, tuple())
         self.assertDictEqual(result.kwargs, kwargs)
 
     def test_simple_functor_with_duplicate_arg_raises(self):
@@ -52,45 +49,35 @@ class TestDecoratingClass(TestCase):
         with self.assertRaises(TypeError):
             Functor(kwargs["functor"], **kwargs)
 
-    def test_no_args(self):
+    def test_no_args_forbidden(self):
         with self.assertRaises(TypeError):
 
             @decorating_class
-            class NoArgs:
+            class _:
                 def __init__(self):
                     pass
 
-    def test_parameter_packs(self):
-        @decorating_class
-        class VariadicFunctor:
-            def __init__(self, *args, **kwargs):
-                self.functor = args[0]
-                self.remaining_args = args[1:]
-                self.kwargs = kwargs
-
-        @VariadicFunctor
-        def result(x):
-            return x
-
-        expected = VariadicFunctor(lambda x: x)
-        self.assert_functors_equal(result, expected)
-
-    def test_variadic_kwargs_only(self):
+    def test_variadic_args_forbidden(self):
         with self.assertRaises(TypeError):
 
             @decorating_class
-            class VariadicFunctor:
-                def __init__(self, **kwargs):
-                    self.functor = kwargs.pop("functor", None)
-                    self.remaining_args = tuple()
-                    self.kwargs = kwargs
+            class _:
+                def __init__(self, *_):
+                    pass
+
+    def test_variadic_kwargs_only_forbidden(self):
+        with self.assertRaises(TypeError):
+
+            @decorating_class
+            class _:
+                def __init__(self, **_):
+                    pass
 
     def test_with_pydantic(self):
         @decorating_class
         class PydanticFunctor(BaseModel):
             functor: Callable[[int], int]
             # The naming here is chosen such that self.assert_functors_equal still works.
-            remaining_args: tuple[int]
             kwargs: dict[str, int]
 
         remaining_args = (2,)
@@ -102,5 +89,25 @@ class TestDecoratingClass(TestCase):
 
         expected = PydanticFunctor(functor=lambda x: x, remaining_args=remaining_args, kwargs=kwargs)
         self.assert_functors_equal(result, expected)
-        self.assertTupleEqual(result.remaining_args, remaining_args)
         self.assertDictEqual(result.kwargs, kwargs)
+
+    def test_forwarding_arguments_to_new(self):
+        given_kwargs = {"a": 1}
+
+        @decorating_class
+        class SpecialFunctor:
+            def __new__(cls, functor, **kwargs):
+                assert kwargs == given_kwargs
+                return super().__new__(cls)
+
+            def __init__(self, functor, **kwargs):
+                self.functor = functor
+                self.kwargs = kwargs
+
+        @SpecialFunctor(**given_kwargs)
+        def result(x):
+            return x
+
+        expected = SpecialFunctor(lambda x: x, **given_kwargs)
+        self.assert_functors_equal(result, expected)
+        self.assertDictEqual(result.kwargs, given_kwargs)


### PR DESCRIPTION
This is a tiny quality-of-life improvement for our PICMI interface: `ParticleFunctor` and `AnalyticDistribution` can now be used as decorators.

```python
@ParticleFunctor(unit_dimension=M)
def mass(particle) -> float:
    return particle.get('mass')
```