### PR TITLE
broadcast reduceCounter after restart in binning

### DIFF
--- a/include/picongpu/plugins/binning/binners/Binner.hpp
+++ b/include/picongpu/plugins/binning/binners/Binner.hpp
@@ -33,6 +33,7 @@
 #    include <memory>
 #    include <optional>
 
+#    include <mpi.h>
 #    include <openPMD/Series.hpp>
 
 namespace picongpu
@@ -229,6 +230,11 @@ namespace picongpu
                                   << std::endl;
                     }
                 }
+
+                // Broadcast the reduce counter from rank 0 to all other ranks
+                auto& gc = Environment<simDim>::get().GridController();
+                eventSystem::getTransactionEvent().waitForFinished();
+                MPI_CHECK(MPI_Bcast(&reduceCounter, 1, MPI_UINT32_T, 0, gc.getCommunicator().getMPIComm()));
             }
 
         private:


### PR DESCRIPTION
@ikbuibui @PrometheusPi This should fix #5642. Draft Until I test it.

What I do not like about it @psychocoderHPC @ikbuibui  is that now we do not have a single source of truth for the main/master rank. 
Binning uses `isMain` that is defined as `isMain = reduce.hasResult(mpi::reduceMethods::Reduce());` but we are using two different MPI operations. I think we need sth like `MPIReduce.getMaster(mpi::reduceMethods::Reduce());` that just throws an error for `MPIReduce.getMaster(mpi::reduceMethods::AllReduce());` and returns a static constexpr class variable that is equal 0 for normal reduce. And hasResult in mpi::reduceMethods::Reduce() needs to compare against this member. But this is mostly pedantry I guess :D 