### PR TITLE
Fix pydantic deprecation and treat warnings as errors in pytest

### DIFF
--- a/lib/python/picongpu/extra/utils/memory_calculator.py
+++ b/lib/python/picongpu/extra/utils/memory_calculator.py
@@ -14,6 +14,7 @@ import numpy as np
 import numpy.typing as nptype
 
 import pydantic
+from pydantic import ConfigDict
 import typeguard
 
 
@@ -51,8 +52,7 @@ class MemoryCalculator(pydantic.BaseModel):
     # in super cells, see ``memory.param``
     guard_size: nptype.NDArray = np.array((1, 1, 1))
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **keyword_arguments):
         pydantic.BaseModel.__init__(self, **keyword_arguments)

--- a/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
+++ b/lib/python/picongpu/picmi/diagnostics/energy_histogram.py
@@ -5,7 +5,7 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from picongpu.picmi.copy_attributes import default_converts_to
 from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
@@ -62,5 +62,4 @@ class EnergyHistogram(BaseModel):
     min_energy: float
     max_energy: float
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/lib/python/picongpu/picmi/diagnostics/field_dump.py
+++ b/lib/python/picongpu/picmi/diagnostics/field_dump.py
@@ -9,7 +9,7 @@ from os import PathLike
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from picongpu.picmi.particle_functor.particle_filter import FilteredSpecies
 from picongpu.picmi.species import Species
@@ -23,8 +23,7 @@ class _FieldDump(BaseModel):
     period: TimeStepSpec = TimeStepSpec[:]("steps")
     options: BackendConfig = OpenPMDConfig(file="simData")
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def result_path(self, prefix_path: PathLike):
         return self.options.result_path(prefix_path=Path(prefix_path) / "simOutput" / "openPMD")

--- a/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
+++ b/lib/python/picongpu/picmi/diagnostics/macro_particle_count.py
@@ -5,7 +5,7 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from picongpu.picmi.copy_attributes import default_converts_to
 
@@ -40,5 +40,4 @@ class MacroParticleCount(BaseModel):
     species: Species
     period: TimeStepSpec
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/lib/python/picongpu/picmi/diagnostics/particle_dump.py
+++ b/lib/python/picongpu/picmi/diagnostics/particle_dump.py
@@ -8,7 +8,7 @@ License: GPLv3+
 from os import PathLike
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from picongpu.picmi.diagnostics.backend_config import BackendConfig, OpenPMDConfig
 from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
@@ -21,8 +21,7 @@ class ParticleDump(BaseModel):
     period: TimeStepSpec = TimeStepSpec[:]("steps")
     options: BackendConfig = OpenPMDConfig(file="simData")
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def result_path(self, prefix_path: PathLike):
         return self.options.result_path(prefix_path=Path(prefix_path) / "simOutput" / "openPMD")

--- a/lib/python/picongpu/picmi/diagnostics/phase_space.py
+++ b/lib/python/picongpu/picmi/diagnostics/phase_space.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from picongpu.picmi.copy_attributes import default_converts_to
 from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
@@ -62,5 +62,4 @@ class PhaseSpace(BaseModel):
         if self.min_momentum >= self.max_momentum:
             raise ValueError("min_momentum must be less than max_momentum")
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/lib/python/picongpu/picmi/diagnostics/radiation.py
+++ b/lib/python/picongpu/picmi/diagnostics/radiation.py
@@ -5,7 +5,7 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
-from pydantic import field_validator
+from pydantic import ConfigDict, field_validator
 
 from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
 from picongpu.picmi.species import Species
@@ -48,5 +48,4 @@ class Radiation(RadiationPluginConfig):
             period=self.period.get_as_pypicongpu(time_step_size=time_step_size, num_steps=num_steps),
         )
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/lib/python/picongpu/picmi/particle_functor/particle_filter.py
+++ b/lib/python/picongpu/picmi/particle_functor/particle_filter.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 from typing import Any, Callable
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from picongpu.picmi.particle_functor.particle_functor import Particle, ParticleFunctor
 from picongpu.picmi.species import Species
@@ -26,8 +26,7 @@ class FilteredSpecies(BaseModel):
     species: Species
     functor: ParticleFilter
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @computed_field
     def name_with_filter(self) -> str:

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import picmistandard
 import typeguard
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from picongpu import pypicongpu
 from picongpu.picmi import constants
@@ -49,8 +49,7 @@ class _DensityImpl(BaseModel):
     grid: Cartesian3DGrid
     species: Species
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from pydantic import (
     BaseModel,
+    ConfigDict,
     PrivateAttr,
     computed_field,
     field_validator,
@@ -93,8 +94,7 @@ class Species(BaseModel):
             value = values["particle_type"]
         return value
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="after")
     def check(self):

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -16,6 +16,7 @@ import tomli_w
 from pydantic import (
     AfterValidator,
     BaseModel,
+    ConfigDict,
     PrivateAttr,
     ValidationError,
     field_validator,
@@ -167,5 +168,4 @@ class OpenPMDPlugin(Plugin):
             ),
         }
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -60,3 +60,4 @@ markers = [
   "compiling: tests that compile PIConGPU simulations",
   "end_to_end: end-to-end simulation tests",
 ]
+filterwarnings = [ "error" ]


### PR DESCRIPTION
- [x] Wait for #5647 to be merged.

Exactly what the title says...

The offending warning is:
```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
```