### PR TITLE
Remove pmacc filesystem check

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -539,9 +539,6 @@ list(REMOVE_ITEM SRCFILES ${ACCSRCFILES})
 
 add_library(picongpu-hostonly STATIC ${SRCFILES})
 target_link_libraries(picongpu-hostonly PUBLIC ${HOST_LIBS})
-# Some host compiled libraries depend on std::filesystem,
-# compatibility to std::experimental::filesystem is handled in pmacc.
-target_link_libraries(picongpu-hostonly PRIVATE pmacc::filesystem)
 
 alpaka_add_executable(picongpu
      ${ACCSRCFILES}

--- a/include/pmacc/PMaccConfig.cmake
+++ b/include/pmacc/PMaccConfig.cmake
@@ -152,20 +152,6 @@ set_target_properties(pmacc PROPERTIES LINKER_LANGUAGE CXX)
 add_library(pmacc::pmacc ALIAS pmacc)
 target_link_libraries(pmacc PUBLIC alpaka::alpaka)
 
-# Create traget pmacc::filesystem to handle system where std::filesystem is experimental.
-# e.g. on systems with an old libstdc++ <= 7
-add_library(pmacc_filesystem INTERFACE)
-add_library(pmacc::filesystem ALIAS pmacc_filesystem)
-target_link_libraries(pmacc PUBLIC pmacc::filesystem)
-
-include(CheckCXXSymbolExists)
-check_cxx_symbol_exists(std::filesystem::path::preferred_separator "filesystem" PMACC_FOUND_CXX17_STD_FILESYSTEM)
-if(NOT PMACC_FOUND_CXX17_STD_FILESYSTEM)
-    message(STATUS "Switch using 'std::experimental::filesystem'")
-    target_compile_definitions(pmacc_filesystem INTERFACE "-DPMACC_USE_STD_EXPERIMENTAL_FILESYSTEM=1")
-    target_link_libraries(pmacc_filesystem INTERFACE stdc++fs)
-endif()
-
 ###############################################################################
 # Build Flags
 ###############################################################################
@@ -279,7 +265,6 @@ endif()
 
 find_package(MPI REQUIRED)
 target_link_libraries(pmacc PUBLIC MPI::MPI_CXX)
-target_link_libraries(pmacc_filesystem INTERFACE MPI::MPI_CXX)
 
 if(CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY" AND CMAKE_EXE_LINKER_FLAGS)
     # Workaround for linker issues when linking static MPI libraries.

--- a/include/pmacc/eventSystem/events/EventTask.hpp
+++ b/include/pmacc/eventSystem/events/EventTask.hpp
@@ -94,7 +94,6 @@ namespace pmacc
          * This task effectively becomes other.
          */
         EventTask& operator=(EventTask const& other) = default;
-        ;
 
         std::string toString();
 

--- a/include/pmacc/fields/tasks/FieldFactory.hpp
+++ b/include/pmacc/fields/tasks/FieldFactory.hpp
@@ -76,10 +76,8 @@ namespace pmacc
 
     private:
         FieldFactory() = default;
-        ;
 
         FieldFactory(FieldFactory const&) = default;
-        ;
     };
 
 } // namespace pmacc

--- a/include/pmacc/particles/tasks/ParticleFactory.hpp
+++ b/include/pmacc/particles/tasks/ParticleFactory.hpp
@@ -81,10 +81,8 @@ namespace pmacc
         }
 
         ParticleFactory() = default;
-        ;
 
         ParticleFactory(ParticleFactory const&) = default;
-        ;
     };
 
 } // namespace pmacc


### PR DESCRIPTION
Since we now require C++20, we no longer need to check if `std::filesystem` is available. This PR removes the special handling which falls back on `std::experimental::filesystem`.
Also removes some stray semicolons which cause warnings with `-Wpedantic`