### PR TITLE
fix minor typo

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -281,5 +281,5 @@ FFTW3
   - ``make install``
 - *environment:* (assumes install from source in ``$HOME/lib/fftw-3.3.10``)
 
-  - ``export FFTW3_ROOT =$HOME/lib/fftw-3.3.10
+  - ``export FFTW3_ROOT=$HOME/lib/fftw-3.3.10``
   - ``export LD_LIBRARY_PATH=$FFTW3_ROOT/lib:$LD_LIBRARY_PATH``


### PR DESCRIPTION
While reading the `INSTALL.rst`, I discovered a minor typo. 
This PR fixes it. 