### PR TITLE
cuda version upadte in documentation

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -134,7 +134,7 @@ Optional Libraries
 
 CUDA
 """"
-- `11.3.0+ <https://developer.nvidia.com/cuda-downloads>`_
+- `12.0.0+ <https://developer.nvidia.com/cuda-downloads>`_
 - g++-10 or newer is required
 - required if you want to run on Nvidia GPUs
 - *Debian/Ubuntu:* ``sudo apt-get install nvidia-cuda-toolkit``

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -33,6 +33,7 @@ Compiler
 - C++20 supporting compiler, e.g. GCC 10+ or Clang 11+
 - if you want to build for Nvidia GPUs, check the `CUDA supported compilers <https://gist.github.com/ax3l/9489132>`_ page
 - *note:* be sure to build all libraries/dependencies with the *same* compiler version
+- *note:* CUDA 12.4 does not work with gcc 13, CUDA < 12.[0-3] does not work work withh gcc 12 or newer.   
 - *Debian/Ubuntu:*
 
   - ``sudo apt-get install gcc-10 g++-10 build-essential``


### PR DESCRIPTION
Our documentation states that we support CUDA 11.3+ - but with the change to C++20, this is no longer true.

This PR updates the CUDA version requirement to 12.0
and
specifies with GCC version work with what CUDA version. 