### PR TITLE
Do not call storeChunk upon empty particle species

### DIFF
--- a/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
+++ b/include/picongpu/plugins/openPMD/writer/ParticleAttribute.hpp
@@ -157,6 +157,12 @@ namespace picongpu
                 }
                 if(elements == 0)
                 {
+                    if(globalElements == 0)
+                    {
+                        // no one does anything, storeChunk() is not allowed since empty components are automatically
+                        // converted to constant components by the openPMD-api, these do not allow storeChunk
+                        return;
+                    }
                     // accumulateWrittenBytes += 0;
 
                     // Workaround for this bug: https://github.com/openPMD/openPMD-api/pull/1794


### PR DESCRIPTION
Follow-up to #5510 
Close #5666 

In #5510, I added a workaround to ensure that each MPI process performs at least one (possibly empty) `storeChunk()` operation per dataset, necessary due to HDF5 2.0. However, empty datasets do not allow `storeChunk()` operations at all (even empty ones). 
So, this PR ensures that the workaround only runs when there is actually data for the dataset.