### PR TITLE
downgrade rosi python version

### DIFF
--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -28,7 +28,7 @@ export LD_LIBRARY_PATH=/data/rosi/shared/eb/easybuild/volta/software/GCCcore/13.
 export OMPI_MCA_pml=ucx
 export OMPI_MCA_btl=self,smcuda,vader
 
-module load python/3.14.2
+module load python/3.12.4
 module load cmake/4.0.3
 module load zlib/1.2.13-GCCcore-12.3.0
 


### PR DESCRIPTION
This is a minor fix to the HZDR rosi profile "solving" #5515. 
We can not work with python 3.14.2 thus we (temporarily) downgrade to 3.12.4.   