### PR TITLE
Add cmd option to get device

### DIFF
--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -87,7 +87,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -76,6 +76,7 @@ function getNode() {
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -89,12 +89,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod $run_cmd
+    srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
+++ b/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
@@ -154,12 +154,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun --time=1:00:00 --nodes=1 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gres=gpu:$numGPUs --mem=$((60000 * $numGPUs)) -p $TBG_partition -A $proj $run_cmd
+    srun --time=1:00:00 --nodes=1 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gres=gpu:$numGPUs --mem=$((60000 * $numGPUs)) -p $TBG_partition -A $proj $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
+++ b/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
@@ -152,7 +152,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun --time=1:00:00 --nodes=1 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gres=gpu:$numGPUs --mem=$((60000 * $numGPUs)) -p $TBG_partition -A $proj --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun --time=1:00:00 --nodes=1 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gres=gpu:$numGPUs --mem=$((60000 * $numGPUs)) -p $TBG_partition -A $proj $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
+++ b/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
@@ -141,6 +141,7 @@ function getNode() {
 
 # allocate an interactive device for one hour to execute a mpi parallel application
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
+++ b/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
@@ -65,12 +65,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=00:30:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gpus=$numGPUs --mem=$((121000 * numGPUs)) -p dev-a100-40 -A $account $run_cmd
+    srun  --time=00:30:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gpus=$numGPUs --mem=$((121000 * numGPUs)) -p dev-a100-40 -A $account $runCmd
 }
 
 # allocate an interactive shell for 240 minutes

--- a/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
+++ b/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
@@ -63,7 +63,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=00:30:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gpus=$numGPUs --mem=$((121000 * numGPUs)) -p dev-a100-40 -A $account --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=00:30:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gpus=$numGPUs --mem=$((121000 * numGPUs)) -p dev-a100-40 -A $account $run_cmd
 }
 
 # allocate an interactive shell for 240 minutes

--- a/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
+++ b/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
@@ -90,8 +90,15 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
     srun  --time=00:30:00 --ntasks-per-node=$numGPUs --cpus-per-task=13 --gres=gpu:$numGPUs \
-        --mem=$((245000 * numGPUs)) --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos --pty bash
+        --mem=$((245000 * numGPUs)) --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos $run_cmd
 }
 
 function getNode() {

--- a/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
+++ b/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
@@ -92,13 +92,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     srun  --time=00:30:00 --ntasks-per-node=$numGPUs --cpus-per-task=13 --gres=gpu:$numGPUs \
-        --mem=$((245000 * numGPUs)) --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos $run_cmd
+        --mem=$((245000 * numGPUs)) --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos $runCmd
 }
 
 function getNode() {

--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -124,12 +124,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug $run_cmd
+    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -122,7 +122,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -111,6 +111,7 @@ function getNode() {
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -87,12 +87,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((180000 * numDevices)) -p defq $run_cmd
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((180000 * numDevices)) -p defq $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -85,7 +85,14 @@ function getDevice() {
             numDevices=$1
         fi
     fi
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((180000 * numDevices)) -p defq --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((180000 * numDevices)) -p defq $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -74,6 +74,7 @@ function getNode() {
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numDevices=1

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -90,12 +90,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition -A $TBG_partition $run_cmd
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition -A $TBG_partition $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -88,7 +88,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition -A $TBG_partition --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition -A $TBG_partition $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -77,6 +77,7 @@ function getNode() {
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -89,12 +89,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu $run_cmd
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -87,7 +87,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -76,6 +76,7 @@ function getNode() {
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -119,8 +119,15 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster --pty bash
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -121,13 +121,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster $run_cmd
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -120,14 +120,8 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="--pty bash"
-    else
-        runCmd="$2"
-    fi
-
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster $runCmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -100,9 +100,16 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="bash"
+    else
+        run_cmd="$2"
+    fi
+
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=24
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel bash
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -101,15 +101,9 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="bash"
-    else
-        runCmd="$2"
-    fi
-
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=24
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel $runCmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -102,14 +102,14 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="bash"
+        runCmd="bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=24
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel $run_cmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -101,14 +101,8 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="bash"
-    else
-        runCmd="$2"
-    fi
-
     export OMP_NUM_THREADS=34
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster $runCmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -102,13 +102,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="bash"
+        runCmd="bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     export OMP_NUM_THREADS=34
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster $run_cmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -100,8 +100,15 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="bash"
+    else
+        run_cmd="$2"
+    fi
+
     export OMP_NUM_THREADS=34
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster bash
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -118,13 +118,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu $run_cmd
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -116,8 +116,15 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu --pty bash
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -117,14 +117,8 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="--pty bash"
-    else
-        runCmd="$2"
-    fi
-
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu $runCmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -112,14 +112,14 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="bash"
+        runCmd="bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch $run_cmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -110,9 +110,16 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="bash"
+    else
+        run_cmd="$2"
+    fi
+
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch bash
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -111,15 +111,9 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="bash"
-    else
-        runCmd="$2"
-    fi
-
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch $runCmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -116,13 +116,8 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="--pty bash"
-    else
-        runCmd="$2"
-    fi
-
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster $runCmd
+    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -117,12 +117,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster $run_cmd
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -115,7 +115,14 @@ function getDevice() {
             numDevices=$1
         fi
     fi
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -110,8 +110,15 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="bash"
+    else
+        run_cmd="$2"
+    fi
+
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus bash
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -111,14 +111,8 @@ function getDevice() {
         fi
     fi
 
-    if [ -z "$2" ] ; then
-        runCmd="bash"
-    else
-        runCmd="$2"
-    fi
-
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus $runCmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -112,13 +112,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="bash"
+        runCmd="bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus $run_cmd
+    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
+++ b/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
@@ -75,7 +75,14 @@ function getDevice(){
             numGPUs=$1
         fi
     fi
-    srun --time=00:30:00 --nodes=1 --ntasks=$numGPUs --cpus-per-task=8 --mem=$((128000 * numGPUs)) --hint=nomultithread --gres=gpu:$numGPUs -A $account -p boost_usr_prod -q boost_qos_dbg --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun --time=00:30:00 --nodes=1 --ntasks=$numGPUs --cpus-per-task=8 --mem=$((128000 * numGPUs)) --hint=nomultithread --gres=gpu:$numGPUs -A $account -p boost_usr_prod -q boost_qos_dbg $run_cmd
 }
 
 function getNode() {

--- a/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
+++ b/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
@@ -77,12 +77,12 @@ function getDevice(){
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun --time=00:30:00 --nodes=1 --ntasks=$numGPUs --cpus-per-task=8 --mem=$((128000 * numGPUs)) --hint=nomultithread --gres=gpu:$numGPUs -A $account -p boost_usr_prod -q boost_qos_dbg $run_cmd
+    srun --time=00:30:00 --nodes=1 --ntasks=$numGPUs --cpus-per-task=8 --mem=$((128000 * numGPUs)) --hint=nomultithread --gres=gpu:$numGPUs -A $account -p boost_usr_prod -q boost_qos_dbg $runCmd
 }
 
 function getNode() {

--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -94,6 +94,7 @@ export TBG_TPLFILE="etc/picongpu/lumi-eurohpc/standard-g.tpl"
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -105,7 +105,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks=${numGPUs} --cpus-per-task=7 --gpus-per-task=1 --mem-per-gpu=64000 -p dev-g -A $PROJID --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --nodes=1 --ntasks=${numGPUs} --cpus-per-task=7 --gpus-per-task=1 --mem-per-gpu=64000 -p dev-g -A $PROJID $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -107,12 +107,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --nodes=1 --ntasks=${numGPUs} --cpus-per-task=7 --gpus-per-task=1 --mem-per-gpu=64000 -p dev-g -A $PROJID $run_cmd
+    srun  --time=1:00:00 --nodes=1 --ntasks=${numGPUs} --cpus-per-task=7 --gpus-per-task=1 --mem-per-gpu=64000 -p dev-g -A $PROJID $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -137,6 +137,7 @@ function getNode() {
 
 # allocate an interactive shell for one hour
 #   getDevice 2  # allocates two interactive devices (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -150,12 +150,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition $run_cmd
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -148,7 +148,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/vega-izum/gpu_picongpu.profile.example
+++ b/etc/picongpu/vega-izum/gpu_picongpu.profile.example
@@ -43,7 +43,7 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/gpu.tpl"
 
-# allocate an interactive shell for 30 minutes
+# allocate an interactive shell for 60 minutes
 function getDevice() {
     if [ -z "$1" ] ; then
         numGPUs=1

--- a/etc/picongpu/vega-izum/gpu_picongpu.profile.example
+++ b/etc/picongpu/vega-izum/gpu_picongpu.profile.example
@@ -55,7 +55,14 @@ function getDevice() {
             numGPUs=$1
         fi
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gres=gpu:$numGPUs --mem=$((12500 * numGPUs)) -p gpu  --pty bash
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gres=gpu:$numGPUs --mem=$((12500 * numGPUs)) -p gpu  $run_cmd
 }
 
 function getNode() {

--- a/etc/picongpu/vega-izum/gpu_picongpu.profile.example
+++ b/etc/picongpu/vega-izum/gpu_picongpu.profile.example
@@ -57,12 +57,12 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gres=gpu:$numGPUs --mem=$((12500 * numGPUs)) -p gpu  $run_cmd
+    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gres=gpu:$numGPUs --mem=$((12500 * numGPUs)) -p gpu  $runCmd
 }
 
 function getNode() {

--- a/etc/picongpu/zih-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/A100_picongpu.profile.example
@@ -89,13 +89,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     export OMP_NUM_THREADS=6
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha $run_cmd
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/zih-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/A100_picongpu.profile.example
@@ -87,8 +87,15 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
     export OMP_NUM_THREADS=6
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha --pty bash
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/zih-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/A100_picongpu.profile.example
@@ -76,6 +76,7 @@ function getNode() {
 
 # allocate an interactive shell for two hours
 #   getDevice 2  # allocates 2 interactive devices on one node (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numDevices=1

--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -90,13 +90,13 @@ function getDevice() {
     fi
 
     if [ -z "$2" ] ; then
-        run_cmd="--pty bash"
+        runCmd="--pty bash"
     else
-        run_cmd="$2"
+        runCmd="$2"
     fi
 
     export OMP_NUM_THREADS=14
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=14 --mem=$((188130 * $numDevices)) --gres=gpu:$numDevices -p capella $run_cmd
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=14 --mem=$((188130 * $numDevices)) --gres=gpu:$numDevices -p capella $runCmd
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -77,6 +77,7 @@ function getNode() {
 
 # allocate an interactive shell for two hours
 #   getDevice 2  # allocates 2 interactive devices on one node (default: 1)
+#   getDevice 1 cmd  # run cmd on compute node (default: --pty bash)
 function getDevice() {
     if [ -z "$1" ] ; then
         numDevices=1

--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -88,8 +88,15 @@ function getDevice() {
             numDevices=$1
         fi
     fi
+
+    if [ -z "$2" ] ; then
+        run_cmd="--pty bash"
+    else
+        run_cmd="$2"
+    fi
+
     export OMP_NUM_THREADS=14
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=14 --mem=$((188130 * $numDevices)) --gres=gpu:$numDevices -p capella --pty bash
+    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=14 --mem=$((188130 * $numDevices)) --gres=gpu:$numDevices -p capella $run_cmd
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
This PR extends the `getDevice` function by a second argument: a command. 

Thus, a usage such as
```bash
getDevice 1 pic-build
``` 

This allowing for an interactive job that e.g. just compiles and then ends.  

This could ease the workflow currently developed by @chillenzer.  

Furthermore, this PR fixes an inconsistency we introduced for clusters where we need to use `salloc` and added a command at the end. This command will not be executed on the compute node but, in our case, just spawns a new local shell. 