### PR TITLE
Add vector operations

### DIFF
--- a/include/pmacc/math/Vector.hpp
+++ b/include/pmacc/math/Vector.hpp
@@ -28,6 +28,7 @@
 #include "pmacc/math/vector/UInt64.hpp"
 #include "pmacc/math/vector/Vector.hpp"
 #include "pmacc/math/vector/Vector.tpp"
+#include "pmacc/math/vector/VectorOps.hpp"
 
 #include "pmacc/math/vector/compile-time/Int.hpp"
 #include "pmacc/math/vector/compile-time/Size_t.hpp"

--- a/include/pmacc/math/isApprox.hpp
+++ b/include/pmacc/math/isApprox.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "pmacc/math/math.hpp"
+#include "pmacc/math/vector/Vector.hpp"
 
 #include <cmath>
 #include <concepts>
@@ -80,6 +81,23 @@ namespace pmacc::math
     constexpr bool isApproxZero(T value, T atol = DefaultTolerances<T>::atol)
     {
         return pmacc::math::abs(value) <= atol;
+    }
+
+    /** @brief Checks if two vectors are approximately equal element-wise
+     * @tparam T Floating-point element type
+     * @tparam T_dim Vector dimension
+     */
+    template<std::floating_point T, uint32_t T_dim>
+    constexpr bool isApproxEqual(
+        Vector<T, T_dim> const& a,
+        Vector<T, T_dim> const& b,
+        T rtol = DefaultTolerances<T>::rtol,
+        T atol = DefaultTolerances<T>::atol)
+    {
+        for(uint32_t i = 0u; i < T_dim; ++i)
+            if(!isApproxEqual(a[i], b[i], rtol, atol))
+                return false;
+        return true;
     }
 
 } // namespace pmacc::math

--- a/include/pmacc/math/operation/Add.hpp
+++ b/include/pmacc/math/operation/Add.hpp
@@ -34,13 +34,13 @@ namespace pmacc
             struct Add
             {
                 template<typename Dst, typename Src>
-                HDINLINE void operator()(Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(Dst& dst, Src const& src) const
                 {
                     dst += src;
                 }
 
                 template<typename Dst, typename Src, typename T_Worker>
-                HDINLINE void operator()(T_Worker const&, Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(T_Worker const&, Dst& dst, Src const& src) const
                 {
                     dst += src;
                 }

--- a/include/pmacc/math/operation/And.hpp
+++ b/include/pmacc/math/operation/And.hpp
@@ -32,13 +32,13 @@ namespace pmacc::math::operation
     //! logical and
     struct And
     {
-        HDINLINE void operator()(uint32_t& destination, uint32_t const& source) const
+        HDINLINE constexpr void operator()(uint32_t& destination, uint32_t const& source) const
         {
             destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
+        HDINLINE constexpr void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
         {
             destination = static_cast<uint32_t>(static_cast<bool>(destination) && static_cast<bool>(source));
         }

--- a/include/pmacc/math/operation/Assign.hpp
+++ b/include/pmacc/math/operation/Assign.hpp
@@ -32,13 +32,13 @@ namespace pmacc
             struct Assign
             {
                 template<typename Dst, typename Src>
-                HDINLINE void operator()(Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(Dst& dst, Src const& src) const
                 {
                     dst = src;
                 }
 
                 template<typename Dst, typename Src, typename T_Worker>
-                HDINLINE void operator()(T_Worker const&, Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(T_Worker const&, Dst& dst, Src const& src) const
                 {
                     dst = src;
                 }

--- a/include/pmacc/math/operation/BitwiseAnd.hpp
+++ b/include/pmacc/math/operation/BitwiseAnd.hpp
@@ -30,13 +30,13 @@ namespace pmacc::math::operation
     //! Bitwise and
     struct BitwiseAnd
     {
-        HDINLINE void operator()(auto& destination, auto const& source) const
+        HDINLINE constexpr void operator()(auto& destination, auto const& source) const
         {
             destination &= source;
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, auto& destination, auto const& source) const
+        HDINLINE constexpr void operator()(T_Worker const&, auto& destination, auto const& source) const
         {
             destination &= source;
         }

--- a/include/pmacc/math/operation/BitwiseOr.hpp
+++ b/include/pmacc/math/operation/BitwiseOr.hpp
@@ -30,13 +30,13 @@ namespace pmacc::math::operation
     //! Bitwise or
     struct BitwiseOr
     {
-        HDINLINE void operator()(auto& destination, auto const& source) const
+        HDINLINE constexpr void operator()(auto& destination, auto const& source) const
         {
             destination |= source;
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, auto& destination, auto const& source) const
+        HDINLINE constexpr void operator()(T_Worker const&, auto& destination, auto const& source) const
         {
             destination |= source;
         }

--- a/include/pmacc/math/operation/BitwiseXor.hpp
+++ b/include/pmacc/math/operation/BitwiseXor.hpp
@@ -30,13 +30,13 @@ namespace pmacc::math::operation
     //! Bitwise Xor
     struct BitwiseXor
     {
-        HDINLINE void operator()(auto& destination, auto const& source) const
+        HDINLINE constexpr void operator()(auto& destination, auto const& source) const
         {
             destination ^= source;
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, auto& destination, auto const& source) const
+        HDINLINE constexpr void operator()(T_Worker const&, auto& destination, auto const& source) const
         {
             destination ^= source;
         }

--- a/include/pmacc/math/operation/Max.hpp
+++ b/include/pmacc/math/operation/Max.hpp
@@ -35,13 +35,13 @@ namespace pmacc
             struct Max
             {
                 template<typename Dst, typename Src>
-                HDINLINE void operator()(Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(Dst& dst, Src const& src) const
                 {
                     dst = pmacc::math::max(dst, src);
                 }
 
                 template<typename Dst, typename Src, typename T_Worker>
-                HDINLINE void operator()(T_Worker const& worker, Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(T_Worker const& worker, Dst& dst, Src const& src) const
                 {
                     dst = alpaka::math::max(worker.getAcc(), dst, src);
                 }

--- a/include/pmacc/math/operation/Min.hpp
+++ b/include/pmacc/math/operation/Min.hpp
@@ -36,13 +36,13 @@ namespace pmacc
             struct Min
             {
                 template<typename Dst, typename Src>
-                HDINLINE void operator()(Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(Dst& dst, Src const& src) const
                 {
                     dst = pmacc::math::min(dst, src);
                 }
 
                 template<typename Dst, typename Src, typename T_Worker>
-                HDINLINE void operator()(T_Worker const& worker, Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(T_Worker const& worker, Dst& dst, Src const& src) const
                 {
                     dst = alpaka::math::min(worker.getAcc(), dst, src);
                 }

--- a/include/pmacc/math/operation/Mul.hpp
+++ b/include/pmacc/math/operation/Mul.hpp
@@ -33,13 +33,13 @@ namespace pmacc
             struct Mul
             {
                 template<typename Dst, typename Src>
-                HDINLINE void operator()(Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(Dst& dst, Src const& src) const
                 {
                     dst *= src;
                 }
 
                 template<typename Dst, typename Src, typename T_Worker>
-                HDINLINE void operator()(T_Worker const&, Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(T_Worker const&, Dst& dst, Src const& src) const
                 {
                     dst *= src;
                 }

--- a/include/pmacc/math/operation/Or.hpp
+++ b/include/pmacc/math/operation/Or.hpp
@@ -31,13 +31,13 @@ namespace pmacc::math::operation
     //! logical or
     struct Or
     {
-        HDINLINE void operator()(uint32_t& destination, uint32_t const& source) const
+        HDINLINE constexpr void operator()(uint32_t& destination, uint32_t const& source) const
         {
             destination = static_cast<uint32_t>(static_cast<bool>(destination) || static_cast<bool>(source));
         }
 
         template<typename T_Worker>
-        HDINLINE void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
+        HDINLINE constexpr void operator()(T_Worker const&, uint32_t& destination, uint32_t const& source) const
         {
             destination = static_cast<uint32_t>(static_cast<bool>(destination) || static_cast<bool>(source));
         }

--- a/include/pmacc/math/operation/Sub.hpp
+++ b/include/pmacc/math/operation/Sub.hpp
@@ -33,13 +33,13 @@ namespace pmacc
             struct Sub
             {
                 template<typename Dst, typename Src>
-                HDINLINE void operator()(Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(Dst& dst, Src const& src) const
                 {
                     dst -= src;
                 }
 
                 template<typename Dst, typename Src, typename T_Worker>
-                HDINLINE void operator()(T_Worker const&, Dst& dst, Src const& src) const
+                HDINLINE constexpr void operator()(T_Worker const&, Dst& dst, Src const& src) const
                 {
                     dst -= src;
                 }

--- a/include/pmacc/math/vector/Vector.hpp
+++ b/include/pmacc/math/vector/Vector.hpp
@@ -23,6 +23,8 @@
 #pragma once
 
 #include "pmacc/algorithms/math.hpp"
+#include "pmacc/math/operation/Add.hpp"
+#include "pmacc/math/operation/Mul.hpp"
 #include "pmacc/static_assert.hpp"
 #include "pmacc/types.hpp"
 
@@ -307,16 +309,30 @@ namespace pmacc
                 return result;
             }
 
+            /** Reduces all components using a mutating binary operation.
+             *
+             * @tparam T_Result accumulator type
+             * @tparam T_AssignOp mutating binary operation, called as op(accumulator, element)
+             * @param init initial accumulator value
+             * @param op mutating binary operation that modifies the accumulator in place
+             * @return result of folding all components into the accumulator
+             */
+            template<typename T_Result, typename T_AssignOp>
+            constexpr T_Result reduce(T_Result init, T_AssignOp op) const
+            {
+                T_Result result = init;
+                for(uint32_t i = 0u; i < dim; i++)
+                    op(result, (*this)[i]);
+                return result;
+            }
+
             /** Returns product of all components.
              *
              * @return product of components
              */
             constexpr type productOfComponents() const
             {
-                type result = (*this)[0];
-                for(uint32_t i = 1u; i < dim; i++)
-                    result *= (*this)[i];
-                return result;
+                return reduce(type(1), operation::Mul{});
             }
 
             /** Returns sum of all components.
@@ -325,10 +341,7 @@ namespace pmacc
              */
             constexpr type sumOfComponents() const
             {
-                type result = (*this)[0];
-                for(uint32_t i = 1u; i < dim; i++)
-                    result += (*this)[i];
-                return result;
+                return reduce(type(0), operation::Add{});
             }
 
             /**

--- a/include/pmacc/math/vector/VectorOps.hpp
+++ b/include/pmacc/math/vector/VectorOps.hpp
@@ -1,0 +1,163 @@
+/* Copyright 2026-2026 Tapish Narwal
+ *
+ * This file is part of PMacc.
+ *
+ * PMacc is free software: you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License or
+ * the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PMacc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License and the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with PMacc.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "pmacc/math/math.hpp"
+#include "pmacc/math/vector/Vector.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <utility>
+
+namespace pmacc::math
+{
+    /** Apply a callable element-wise to a vector.
+     *
+     * @param vec input vector
+     * @param fn callable applied to each element
+     * @return new vector with fn(vec[i]) at each index i
+     */
+    template<typename T_Type, uint32_t T_dim, typename T_Storage, typename T_Fn>
+    constexpr auto transform(Vector<T_Type, T_dim, T_Storage> const& vec, T_Fn&& fn)
+    {
+        using ResultType = decltype(fn(std::declval<T_Type>()));
+        Vector<ResultType, T_dim> result{};
+        for(uint32_t i = 0u; i < T_dim; ++i)
+            result[i] = fn(vec[i]);
+        return result;
+    }
+
+/** Generate an element-wise vector overload for a unary pmacc::math function.
+ *
+ * The scalar version of `functionName` must already be declared in pmacc::math
+ * (e.g., via ALPAKA_UNARY_MATH_FN) before this macro is expanded.
+ */
+#define PMACC_VECTOR_UNARY_MATH_FN(functionName)                                                                      \
+    template<typename T_Type, uint32_t T_dim, typename T_Storage>                                                     \
+    constexpr auto functionName(Vector<T_Type, T_dim, T_Storage> const& vec)                                          \
+    {                                                                                                                 \
+        using ResultType = decltype(functionName(std::declval<T_Type>()));                                            \
+        Vector<ResultType, T_dim> result{};                                                                           \
+        for(uint32_t i = 0u; i < T_dim; ++i)                                                                          \
+            result[i] = functionName(vec[i]);                                                                         \
+        return result;                                                                                                \
+    }
+
+    // Log
+    PMACC_VECTOR_UNARY_MATH_FN(log)
+    PMACC_VECTOR_UNARY_MATH_FN(log2)
+    PMACC_VECTOR_UNARY_MATH_FN(log10)
+
+    // Exp
+    PMACC_VECTOR_UNARY_MATH_FN(exp)
+
+    // Root
+    PMACC_VECTOR_UNARY_MATH_FN(sqrt)
+    PMACC_VECTOR_UNARY_MATH_FN(rsqrt)
+    PMACC_VECTOR_UNARY_MATH_FN(cbrt)
+
+    // Abs
+    PMACC_VECTOR_UNARY_MATH_FN(abs)
+
+    // Trigonometric
+    PMACC_VECTOR_UNARY_MATH_FN(sin)
+    PMACC_VECTOR_UNARY_MATH_FN(cos)
+    PMACC_VECTOR_UNARY_MATH_FN(tan)
+    PMACC_VECTOR_UNARY_MATH_FN(asin)
+    PMACC_VECTOR_UNARY_MATH_FN(acos)
+    PMACC_VECTOR_UNARY_MATH_FN(atan)
+    PMACC_VECTOR_UNARY_MATH_FN(sinh)
+    PMACC_VECTOR_UNARY_MATH_FN(cosh)
+    PMACC_VECTOR_UNARY_MATH_FN(tanh)
+    PMACC_VECTOR_UNARY_MATH_FN(asinh)
+    PMACC_VECTOR_UNARY_MATH_FN(acosh)
+    PMACC_VECTOR_UNARY_MATH_FN(atanh)
+
+    // Rounding
+    PMACC_VECTOR_UNARY_MATH_FN(ceil)
+    PMACC_VECTOR_UNARY_MATH_FN(floor)
+    PMACC_VECTOR_UNARY_MATH_FN(trunc)
+    PMACC_VECTOR_UNARY_MATH_FN(round)
+    PMACC_VECTOR_UNARY_MATH_FN(lround)
+    PMACC_VECTOR_UNARY_MATH_FN(llround)
+
+    // Error functions
+    PMACC_VECTOR_UNARY_MATH_FN(erf)
+
+#undef PMACC_VECTOR_UNARY_MATH_FN
+
+/** Generate an element-wise vector overload for a binary pmacc::math function (vec, vec).
+ *
+ * Both arguments must be vectors with the same element type T_Type and dimension T_dim.
+ * Storage types may differ. The scalar version of `functionName` must already be declared
+ * in pmacc::math before this macro is expanded.
+ */
+#define PMACC_VECTOR_BINARY_MATH_FN(functionName)                                                                     \
+    template<typename T_Type, uint32_t T_dim, typename T_Storage0, typename T_Storage1>                               \
+    constexpr auto functionName(                                                                                      \
+        Vector<T_Type, T_dim, T_Storage0> const& a,                                                                   \
+        Vector<T_Type, T_dim, T_Storage1> const& b)                                                                   \
+    {                                                                                                                 \
+        using ResultType = decltype(functionName(std::declval<T_Type>(), std::declval<T_Type>()));                    \
+        Vector<ResultType, T_dim> result{};                                                                           \
+        for(uint32_t i = 0u; i < T_dim; ++i)                                                                          \
+            result[i] = functionName(a[i], b[i]);                                                                     \
+        return result;                                                                                                \
+    }
+
+    // Trigonometric
+    PMACC_VECTOR_BINARY_MATH_FN(atan2)
+
+    // Comparison
+    PMACC_VECTOR_BINARY_MATH_FN(min)
+    PMACC_VECTOR_BINARY_MATH_FN(max)
+
+    // Modulo
+    PMACC_VECTOR_BINARY_MATH_FN(fmod)
+    PMACC_VECTOR_BINARY_MATH_FN(remainder)
+
+#undef PMACC_VECTOR_BINARY_MATH_FN
+
+/** Generate an element-wise vector overload for a binary pmacc::math function (vec, scalar).
+ *
+ * The first argument is a vector; the second is a scalar broadcast to all components.
+ * The scalar type T_Scalar may differ from the vector element type T_Type.
+ * The scalar version of `functionName` must already be declared in pmacc::math before
+ * this macro is expanded.
+ */
+#define PMACC_VECTOR_BINARY_SCALAR_MATH_FN(functionName)                                                              \
+    template<typename T_Type, uint32_t T_dim, typename T_Storage, typename T_Scalar>                                  \
+    constexpr auto functionName(Vector<T_Type, T_dim, T_Storage> const& vec, T_Scalar const scalar)                   \
+    {                                                                                                                 \
+        using ResultType = decltype(functionName(std::declval<T_Type>(), scalar));                                    \
+        Vector<ResultType, T_dim> result{};                                                                           \
+        for(uint32_t i = 0u; i < T_dim; ++i)                                                                          \
+            result[i] = functionName(vec[i], scalar);                                                                 \
+        return result;                                                                                                \
+    }
+
+    // Pow
+    PMACC_VECTOR_BINARY_SCALAR_MATH_FN(pow)
+
+#undef PMACC_VECTOR_BINARY_SCALAR_MATH_FN
+
+} // namespace pmacc::math

--- a/include/pmacc/math/vector/VectorOps.hpp
+++ b/include/pmacc/math/vector/VectorOps.hpp
@@ -46,6 +46,25 @@ namespace pmacc::math
         return result;
     }
 
+    template<
+        typename T_Type0,
+        typename T_Type1,
+        uint32_t T_dim,
+        typename T_Storage0,
+        typename T_Storage1,
+        typename T_Fn>
+    constexpr auto transform(
+        Vector<T_Type0, T_dim, T_Storage0> const& a,
+        Vector<T_Type1, T_dim, T_Storage1> const& b,
+        T_Fn&& fn)
+    {
+        using ResultType = decltype(fn(std::declval<T_Type0>(), std::declval<T_Type1>()));
+        Vector<ResultType, T_dim> result{};
+        for(uint32_t i = 0u; i < T_dim; ++i)
+            result[i] = fn(a[i], b[i]);
+        return result;
+    }
+
 /** Generate an element-wise vector overload for a unary pmacc::math function.
  *
  * The scalar version of `functionName` must already be declared in pmacc::math
@@ -55,11 +74,7 @@ namespace pmacc::math
     template<typename T_Type, uint32_t T_dim, typename T_Storage>                                                     \
     constexpr auto functionName(Vector<T_Type, T_dim, T_Storage> const& vec)                                          \
     {                                                                                                                 \
-        using ResultType = decltype(functionName(std::declval<T_Type>()));                                            \
-        Vector<ResultType, T_dim> result{};                                                                           \
-        for(uint32_t i = 0u; i < T_dim; ++i)                                                                          \
-            result[i] = functionName(vec[i]);                                                                         \
-        return result;                                                                                                \
+        return transform(vec, [](auto x) { return functionName(x); });                                                \
     }
 
     // Log
@@ -117,11 +132,7 @@ namespace pmacc::math
         Vector<T_Type, T_dim, T_Storage0> const& a,                                                                   \
         Vector<T_Type, T_dim, T_Storage1> const& b)                                                                   \
     {                                                                                                                 \
-        using ResultType = decltype(functionName(std::declval<T_Type>(), std::declval<T_Type>()));                    \
-        Vector<ResultType, T_dim> result{};                                                                           \
-        for(uint32_t i = 0u; i < T_dim; ++i)                                                                          \
-            result[i] = functionName(a[i], b[i]);                                                                     \
-        return result;                                                                                                \
+        return transform(a, b, [](auto x, auto y) { return functionName(x, y); });                                    \
     }
 
     // Trigonometric
@@ -148,11 +159,7 @@ namespace pmacc::math
     template<typename T_Type, uint32_t T_dim, typename T_Storage, typename T_Scalar>                                  \
     constexpr auto functionName(Vector<T_Type, T_dim, T_Storage> const& vec, T_Scalar const scalar)                   \
     {                                                                                                                 \
-        using ResultType = decltype(functionName(std::declval<T_Type>(), scalar));                                    \
-        Vector<ResultType, T_dim> result{};                                                                           \
-        for(uint32_t i = 0u; i < T_dim; ++i)                                                                          \
-            result[i] = functionName(vec[i], scalar);                                                                 \
-        return result;                                                                                                \
+        return transform(vec, [scalar](auto x) { return functionName(x, scalar); });                                  \
     }
 
     // Pow

--- a/include/pmacc/test/vector/vectorUT.cpp
+++ b/include/pmacc/test/vector/vectorUT.cpp
@@ -21,10 +21,14 @@
 
 #include <pmacc/boost_workaround.hpp>
 
+#include "pmacc/math/operation/Max.hpp"
+
 #include <pmacc/Environment.hpp>
 #include <pmacc/algorithms/TypeCast.hpp>
 #include <pmacc/lockstep.hpp>
 #include <pmacc/math/Vector.hpp>
+#include <pmacc/math/isApprox.hpp>
+#include <pmacc/math/vector/VectorOps.hpp>
 #include <pmacc/memory/buffers/HostDeviceBuffer.hpp>
 #include <pmacc/test/PMaccFixture.hpp>
 #include <pmacc/verify.hpp>
@@ -376,6 +380,146 @@ struct RunTimeKernel
         *numTestsOut = i;
     }
 };
+
+struct VectorOpsKernel
+{
+    template<typename T_Acc>
+    DINLINE void operator()(T_Acc const&, bool* data, size_t* numTestsOut) const
+    {
+        using namespace pmacc::math;
+        size_t i = 0u;
+
+        // transform: apply element-wise callable
+        {
+            auto vec = Vector<float, 3u>(1.f, 2.f, 3.f);
+            auto result = transform(vec, [](float x) { return x * 2.f; });
+            data[i++] = result == Vector<float, 3u>(2.f, 4.f, 6.f);
+        }
+        // abs: unary, sign removal
+        {
+            auto vec = Vector<float, 3u>(-1.f, 2.f, -3.f);
+            auto result = abs(vec);
+            data[i++] = result == Vector<float, 3u>(1.f, 2.f, 3.f);
+        }
+        // sqrt: unary root
+        {
+            auto vec = Vector<float, 3u>(4.f, 9.f, 16.f);
+            auto result = sqrt(vec);
+            data[i++] = result == Vector<float, 3u>(2.f, 3.f, 4.f);
+        }
+        // floor: unary rounding down
+        {
+            auto vec = Vector<float, 3u>(1.7f, 2.3f, 3.9f);
+            auto result = floor(vec);
+            data[i++] = result == Vector<float, 3u>(1.f, 2.f, 3.f);
+        }
+        // ceil: unary rounding up
+        {
+            auto vec = Vector<float, 3u>(1.1f, 2.2f, 3.8f);
+            auto result = ceil(vec);
+            data[i++] = result == Vector<float, 3u>(2.f, 3.f, 4.f);
+        }
+        // sin at zero: known exact value
+        {
+            auto vec = Vector<float, 3u>(0.f, 0.f, 0.f);
+            auto result = sin(vec);
+            data[i++] = result == Vector<float, 3u>(0.f, 0.f, 0.f);
+        }
+        // cos at zero: known exact value
+        {
+            auto vec = Vector<float, 3u>(0.f, 0.f, 0.f);
+            auto result = cos(vec);
+            data[i++] = result == Vector<float, 3u>(1.f, 1.f, 1.f);
+        }
+        // exp + log are inverse: log(exp(x)) ~= x
+        {
+            auto vec = Vector<float, 3u>(1.f, 2.f, 3.f);
+            auto result = log(exp(vec));
+            data[i++] = isApproxEqual(result, vec);
+        }
+        // min (vec, vec): binary element-wise minimum
+        {
+            auto a = Vector<float, 3u>(3.f, 1.f, 2.f);
+            auto b = Vector<float, 3u>(1.f, 3.f, 2.f);
+            auto result = pmacc::math::min(a, b);
+            data[i++] = result == Vector<float, 3u>(1.f, 1.f, 2.f);
+        }
+        // max (vec, vec): binary element-wise maximum
+        {
+            auto a = Vector<float, 3u>(3.f, 1.f, 2.f);
+            auto b = Vector<float, 3u>(1.f, 3.f, 2.f);
+            auto result = pmacc::math::max(a, b);
+            data[i++] = result == Vector<float, 3u>(3.f, 3.f, 2.f);
+        }
+        // fmod (vec, vec): binary element-wise floating-point remainder
+        {
+            auto a = Vector<float, 3u>(7.f, 8.f, 9.f);
+            auto b = Vector<float, 3u>(3.f, 3.f, 4.f);
+            auto result = fmod(a, b);
+            data[i++] = result == Vector<float, 3u>(1.f, 2.f, 1.f);
+        }
+        // pow (vec, scalar): binary with scalar exponent
+        {
+            auto vec = Vector<float, 3u>(2.f, 3.f, 4.f);
+            auto result = pow(vec, 2.f);
+            data[i++] = result == Vector<float, 3u>(4.f, 9.f, 16.f);
+        }
+        // reduce with Max: maximum component
+        {
+            auto vec = Vector<int, 3u>(3, 1, 2);
+            data[i++] = vec.reduce(0, operation::Max{}) == 3;
+        }
+        // reduce with custom lambda: sum of squares
+        {
+            auto vec = Vector<int, 3u>(1, 2, 3);
+            auto result = vec.reduce(0, [](int& acc, int x) { acc += x * x; });
+            data[i++] = result == 14;
+        }
+        // mixed scalar+vector chain
+        {
+            auto vec = Vector<float, 3u>(-1.f, 4.f, 9.f);
+            auto result = floor(sqrt(abs(vec) * 4.f));
+            data[i++] = result == Vector<float, 3u>(2.f, 4.f, 6.f);
+        }
+        // mixed scalar+vector chain
+        {
+            auto vec = Vector<float, 3u>(-2.f, 3.f, -4.f);
+            auto result = pow(abs(vec), 2.f) + 1.f;
+            data[i++] = result == Vector<float, 3u>(5.f, 10.f, 17.f);
+        }
+
+        *numTestsOut = i;
+    }
+};
+
+TEST_CASE("vector ops", "[vector]")
+{
+    using namespace pmacc;
+    using namespace pmacc::math;
+
+    size_t const numElements = 16u;
+
+    auto hostDeviceBuffer = HostDeviceBuffer<bool, DIM1>(DataSpace<DIM1>{numElements});
+    auto numTestsBuffer = HostDeviceBuffer<size_t, DIM1>(DataSpace<DIM1>{1});
+    numTestsBuffer.getDeviceBuffer().setValue(0u);
+
+    hostDeviceBuffer.getDeviceBuffer().setValue(false);
+
+    PMACC_KERNEL(VectorOpsKernel{})
+    (1, 1)(hostDeviceBuffer.getDeviceBuffer().data(), numTestsBuffer.getDeviceBuffer().data());
+    hostDeviceBuffer.deviceToHost();
+    numTestsBuffer.deviceToHost();
+
+    REQUIRE(numTestsBuffer.getHostBuffer().data()[0] == numElements);
+
+    for(size_t i = 0; i < hostDeviceBuffer.getHostBuffer().size(); ++i)
+    {
+        bool res = hostDeviceBuffer.getHostBuffer().data()[i] == true;
+        if(!res)
+            std::cerr << "vector ops test: " << i << " FAILED." << std::endl;
+        REQUIRE(res == true);
+    }
+}
 
 TEST_CASE("vector generic", "[vector]")
 {


### PR DESCRIPTION
Made pmacc math ops constexpr
Added the ability to use pmacc math functions with pmacc vectors, and added a transform function for an element-wise transform.
Added a reduce function to pmacc vector, and use it in the implementation of product/sum of elements. (Theoretically it increases the number of ops required to do the arithmetic by 1, but A) it may be optimized away and B) we gain in generality)
Added a vector isApproxEqual because the current implementation uses `std::isfinite`, otherwise it would have worked basically as is.