### PR TITLE
Add directional temperature initializtion

### DIFF
--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -92,9 +92,10 @@ namespace picongpu
                  *
                  * Return type may be float_X or float_64.
                  *
-                 * @param totalCellOffset total offset including all slides [in cells]
+                 * @param position_SI total offset including all slides [meter]
+                 * @param cellSize_SI cell sizes [meter]
                  */
-                HDINLINE float_X operator()(DataSpace<simDim> const& totalCellOffset)
+                HDINLINE float_X operator()(floatD_64 const& position_SI, float3_64 const& cellSize_SI)
                 {
                     return 0.0_X;
                 }

--- a/include/picongpu/param/particle.param
+++ b/include/picongpu/param/particle.param
@@ -65,6 +65,11 @@ namespace picongpu
             struct TemperatureParam
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = 0.0;
@@ -90,7 +95,9 @@ namespace picongpu
 
                 /** Return the temperature in keV for the given position
                  *
-                 * Return type may be float_X or float_64.
+                 * Return type may be a scalar (float_X or float_64) for isotropic temperature,
+                 * or a float3_X vector for direction-dependent temperature,
+                 * e.g. float3_X{kT_x, kT_y, kT_z}.
                  *
                  * @param position_SI total offset including all slides [meter]
                  * @param cellSize_SI cell sizes [meter]

--- a/include/picongpu/particles/manipulators/unary/Temperature.hpp
+++ b/include/picongpu/particles/manipulators/unary/Temperature.hpp
@@ -23,6 +23,7 @@
 #include "picongpu/defines.hpp"
 #include "picongpu/particles/functor/User.hpp"
 #include "picongpu/traits/attribute/GetMass.hpp"
+#include "picongpu/unitless/precision.unitless"
 
 namespace picongpu
 {
@@ -52,10 +53,14 @@ namespace picongpu
                              * @tparam T_StandardNormalRng functor::misc::RngWrapper, standard
                              *                             normal random number generator type
                              * @tparam T_Particle particle type
+                             * @tparam T_Temperature float_X for isotropic temperature or float3_X for
+                             *                       per-component temperatures, in keV
                              *
                              * @param standardNormalRng standard normal random number generator
                              * @param particle particle to be manipulated
-                             * @param temperatureKeV temperature value in keV
+                             * @param temperatureKeV temperature in keV; scalar applies the same temperature
+                             *                       to all momentum components, float3_X sets each
+                             *                       component's temperature independently
                              */
                             template<typename T_StandardNormalRng, typename T_Particle, typename T_Temperature>
                             HDINLINE void operator()(
@@ -70,13 +75,13 @@ namespace picongpu
                                  * For the macroweighted momentums we store as particle[ momentum_ ],
                                  * the same relation holds, just m and E are also macroweighted
                                  */
-                                float_X const energy = sim.pic.conv().eV2Joule(temperatureKeV * 1.0e3);
+                                auto const energy = sim.pic.conv().eV2Joule(temperatureKeV * 1.0e3);
                                 float_X const macroWeighting = particle[weighting_];
-                                float_X const macroEnergy = macroWeighting * energy;
+                                auto const macroEnergy = macroWeighting * energy;
                                 float_X const macroMass
                                     = picongpu::traits::attribute::getMass(macroWeighting, particle);
-                                float_X const standardDeviation
-                                    = static_cast<float_X>(math::sqrt(precisionCast<sqrt_X>(macroEnergy * macroMass)));
+                                auto const standardDeviation = precisionCast<float_X>(
+                                    math::sqrt(precisionCast<sqrt_X>(macroEnergy * macroMass)));
                                 float3_X const mom
                                     = float3_X(standardNormalRng(), standardNormalRng(), standardNormalRng())
                                       * standardDeviation;

--- a/lib/python/picongpu/picmi/distribution/Distribution.py
+++ b/lib/python/picongpu/picmi/distribution/Distribution.py
@@ -44,13 +44,6 @@ class Distribution(pydantic.BaseModel):
     fill_in: bool = True
     """whether to fill in the empty space opened up when the simulation window moves"""
 
-    @pydantic.field_validator("rms_velocity", mode="after")
-    @classmethod
-    def isotropic_temperature(cls, value):
-        if not (value[0] == value[1] == value[2]):
-            raise ValueError("all thermal velcoity spread (rms velocity) components must be equal")
-        return value
-
     def __hash__(self):
         """custom hash function for indexing in dicts"""
         hash_value = hash(type(self))

--- a/lib/python/picongpu/picmi/species_requirements.py
+++ b/lib/python/picongpu/picmi/species_requirements.py
@@ -262,9 +262,22 @@ class SimpleMomentumOperation(DelayedConstruction):
         def constructor(self):
             species = self.metadata.kwargs["species"].get_as_pypicongpu()
             particle_mass_si = species.constants.mass.mass_si
-            rms_velocity_si_squared = np.linalg.norm(self.metadata.kwargs["rms_velocity"]) ** 2
-            temperature_kev = particle_mass_si * rms_velocity_si_squared / 3 * electron_volt**-1 * 10**-3
-            temperature = Temperature(temperature_kev=temperature_kev) if temperature_kev > 0 else None
+            rms_velocity = np.asarray(self.metadata.kwargs["rms_velocity"])
+            kev_factor = (particle_mass_si / electron_volt) / 1000.0
+            if np.allclose(rms_velocity, rms_velocity[0]):
+                # Isotropic case: compute scalar temperature
+                rms_velocity_si_squared = np.linalg.norm(rms_velocity) ** 2
+                temperature_kev_scalar = kev_factor * rms_velocity_si_squared / 3.0
+                temperature = (
+                    Temperature(temperature_kev=temperature_kev_scalar) if temperature_kev_scalar > 0 else None
+                )
+            else:
+                # Anisotropic case: compute directional temperatures
+                directional_kev = kev_factor * (rms_velocity**2)
+                if np.any(directional_kev > 0):
+                    temperature = Temperature(temperature_kev_directional=tuple(directional_kev))
+                else:
+                    temperature = None
             return SimpleMomentum(species=species, drift=self.metadata.kwargs["drift"], temperature=temperature)
 
         metadata = {

--- a/lib/python/picongpu/pypicongpu/species/operation/momentum/temperature.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/momentum/temperature.py
@@ -5,7 +5,10 @@ Authors: Hannes Troepgen, Brian Edward Marre
 License: GPLv3+
 """
 
-from pydantic import BaseModel, Field
+from typing import Annotated
+
+from pydantic import BaseModel, Field, PlainSerializer, model_validator
+
 from ....rendering import RenderedObject
 
 # Note to the future maintainer:
@@ -15,10 +18,31 @@ from ....rendering import RenderedObject
 # supported, so such a structure would be overkill.)
 
 
+def serialise_vec(value) -> dict:
+    return dict(zip("xyz", value))
+
+
+Vec3_float_temperature = Annotated[tuple[float, float, float], PlainSerializer(serialise_vec)]
+
+
 class Temperature(RenderedObject, BaseModel):
     """
     Initialize momentum from temperature
+
+    Exactly one of temperature_kev (isotropic) or temperature_kev_directional
+    (per-component) must be set.
     """
 
-    temperature_kev: float = Field(gt=0.0)
-    """temperature to use in keV"""
+    temperature_kev: float | None = Field(default=None, gt=0.0)
+    """isotropic temperature in keV"""
+
+    temperature_kev_directional: Vec3_float_temperature | None = None
+    """per-component temperature (x, y, z) in keV for directional initialization"""
+
+    @model_validator(mode="after")
+    def _validate_exactly_one(self):
+        scalar_set = self.temperature_kev is not None
+        directional_set = self.temperature_kev_directional is not None
+        if scalar_set == directional_set:
+            raise ValueError("Exactly one of temperature_kev or temperature_kev_directional must be set")
+        return self

--- a/lib/python/picongpu/templates/include/picongpu/param/particle.param.mustache
+++ b/lib/python/picongpu/templates/include/picongpu/param/particle.param.mustache
@@ -138,8 +138,14 @@ namespace picongpu
                         {{! -> simple momentum does not require a temperature }}
                             struct AddTemperature_{{{species.typename}}}_Param
                             {
+                                {{#temperature_kev_directional}}
+                                //! Initial temperature per direction, unit: keV
+                                static constexpr auto temperature = float3_X({{{x}}}, {{{y}}}, {{{z}}});
+                                {{/temperature_kev_directional}}
+                                {{^temperature_kev_directional}}
                                 //! Initial temperature, unit: keV
                                 static constexpr float_64 temperature = {{{temperature_kev}}};
+                                {{/temperature_kev_directional}}
                             };
                             using AddTemperature_{{{species.typename}}} = unary::Temperature<AddTemperature_{{{species.typename}}}_Param>;
                     {{/temperature}}

--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particle.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/particle.param
@@ -88,6 +88,11 @@ namespace picongpu
             struct TemperatureParam
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = 0.0005;

--- a/share/picongpu/benchmarks/Thermal/include/picongpu/param/particle.param
+++ b/share/picongpu/benchmarks/Thermal/include/picongpu/param/particle.param
@@ -73,6 +73,11 @@ namespace picongpu
             struct TemperatureParam
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = 17.5 * 510.998950; // most probable E_kin = 5 mc^2

--- a/share/picongpu/examples/AtomicPhysics/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/AtomicPhysics/include/picongpu/param/particle.param
@@ -57,6 +57,11 @@ namespace picongpu::particles
         struct TemperatureParam
         {
             /** Initial temperature
+             *
+             *  Can be a scalar (float_X or float_64) for isotropic temperature,
+             *  or a float3_X vector for direction-dependent temperature,
+             *  e.g. float3_X{kT_x, kT_y, kT_z}.
+             *
              *  unit: keV
              */
             static constexpr float_64 temperature = 1.;

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/particle.param
@@ -105,6 +105,11 @@ namespace picongpu
             struct TemperatureParam
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = 0.0005;

--- a/share/picongpu/examples/WeibelTransverse/include/picongpu/param/particle.param
+++ b/share/picongpu/examples/WeibelTransverse/include/picongpu/param/particle.param
@@ -77,6 +77,11 @@ namespace picongpu
             struct TemperatureParam
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = 0.005;

--- a/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsBeamRelaxation/include/picongpu/param/particle.param
@@ -78,6 +78,11 @@ namespace picongpu
             struct TemperatureParamElectrons
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature
@@ -95,6 +100,11 @@ namespace picongpu
             struct TemperatureParamIons
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature

--- a/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/CollisionsThermalisation/include/picongpu/param/particle.param
@@ -65,6 +65,11 @@ namespace picongpu
             struct TemperatureParamElectrons
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature
@@ -82,6 +87,11 @@ namespace picongpu
             struct TemperatureParamIons
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature

--- a/share/picongpu/tests/KHI_growthRate/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/KHI_growthRate/include/picongpu/param/particle.param
@@ -110,6 +110,11 @@ namespace picongpu
             struct TemperatureParam
             {
                 /** Initial temperature
+                 *
+                 *  Can be a scalar (float_X or float_64) for isotropic temperature,
+                 *  or a float3_X vector for direction-dependent temperature,
+                 *  e.g. float3_X{kT_x, kT_y, kT_z}.
+                 *
                  *  unit: keV
                  */
                 static constexpr float_64 temperature = 0.0005;

--- a/share/picongpu/tests/compile/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compile/include/picongpu/param/particle.param
@@ -79,6 +79,28 @@ namespace picongpu
 
             using Sparse = picongpu::particles::manipulators::unary::SparserMacroParticlesPerSuperCell<SparserParam>;
 
+            /** Example functor returning a direction-dependent temperature as float3_X.
+             *  Demonstrates that FreeTemperature accepts vector return types.
+             */
+            struct DirectionalTemperatureFunctor
+            {
+                DirectionalTemperatureFunctor()
+                {
+                }
+
+                /** Return per-direction temperature in keV
+                 *
+                 * @param position_SI total offset including all slides [meter]
+                 * @param cellSize_SI cell sizes [meter]
+                 */
+                HDINLINE float3_X operator()(floatD_64 const& position_SI, float3_64 const& cellSize_SI)
+                {
+                    return float3_X{0.0005_X, 0.0005_X, 0.0_X};
+                }
+            };
+
+            using AddDirectionalTemperature = unary::FreeTemperature<DirectionalTemperatureFunctor>;
+
         } // namespace manipulators
     } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/tests/compile/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compile/include/picongpu/param/particle.param
@@ -84,11 +84,11 @@ namespace picongpu
              */
             struct DirectionalTemperatureFunctor
             {
-                DirectionalTemperatureFunctor()
-                {
-                }
-
-                /** Return per-direction temperature in keV
+                /** Return the temperature in keV for the given position
+                 *
+                 * Return type may be a scalar (float_X or float_64) for isotropic temperature,
+                 * or a float3_X vector for direction-dependent temperature,
+                 * e.g. float3_X{kT_x, kT_y, kT_z}.
                  *
                  * @param position_SI total offset including all slides [meter]
                  * @param cellSize_SI cell sizes [meter]

--- a/share/picongpu/tests/compile/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compile/include/picongpu/param/speciesInitialization.param
@@ -40,7 +40,8 @@ namespace picongpu
          */
         using InitPipeline = pmacc::mp_list<
             CreateDensity<densityProfiles::Homogenous, startPosition::RandomPositionAndWeighting, PIC_Electrons>,
-            Manipulate<manipulators::Sparse, PIC_Electrons>>;
+            Manipulate<manipulators::Sparse, PIC_Electrons>,
+            Manipulate<manipulators::AddDirectionalTemperature, PIC_Electrons>>;
 
     } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/tests/compile2/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/particle.param
@@ -69,5 +69,19 @@ namespace picongpu
          *  unit: none */
         constexpr float_X MIN_WEIGHTING = 10.0;
 
+        struct TemperatureParam
+        {
+            /** Initial temperature
+             *  unit: keV
+             */
+            static constexpr auto temperature = float3_X{0.0005, 0.0005, 0.};
+        };
+
+        /** Definition of manipulator assigning a temperature
+         *  using parameters from struct TemperatureParam.
+         */
+        using AddTemperature = manipulators::unary::Temperature<TemperatureParam>;
+
+
     } // namespace particles
 } // namespace picongpu

--- a/share/picongpu/tests/compile2/include/picongpu/param/particle.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/particle.param
@@ -72,6 +72,11 @@ namespace picongpu
         struct TemperatureParam
         {
             /** Initial temperature
+             *
+             *  Can be a scalar (float_X or float_64) for isotropic temperature,
+             *  or a float3_X vector for direction-dependent temperature,
+             *  e.g. float3_X{kT_x, kT_y, kT_z}.
+             *
              *  unit: keV
              */
             static constexpr auto temperature = float3_X{0.0005, 0.0005, 0.};

--- a/share/picongpu/tests/compile2/include/picongpu/param/speciesInitialization.param
+++ b/share/picongpu/tests/compile2/include/picongpu/param/speciesInitialization.param
@@ -38,8 +38,9 @@ namespace picongpu
          *
          * the functors are called in order (from first to last functor)
          */
-        using InitPipeline
-            = pmacc::mp_list<CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>>;
+        using InitPipeline = pmacc::mp_list<
+            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>,
+            Manipulate<picongpu::particles::AddTemperature, PIC_Electrons>>;
 
     } // namespace particles
 } // namespace picongpu


### PR DESCRIPTION
This PR is the same as #5673 but implemented in a more elegant fashion using features introduced in the vector ops PR #5676. 

- [x] Thus depends on #5676 and will be rebased once that is merged. Only the last two commits are of this PR, and the changes are minimal. 

Commit 1 -  Bugfix. The `particle.param` had an incorrect interface for the `TemperatureFunctor`.
It was using the interface which was introduced with #4256.
This interface was changed later in #4273 but that PR missed updating it in the `particle.param`. This is now fixed.

Commit 2 - Adds ability to specify per direction temperatures for initializing particles. 
With the vector ops PR, the existing code is basically completely generic and can work with both 3D vectors or scalars. 
Required changes are simply `float_X` -> `auto` and `static_cast` -> `precisionCast` 
Additionally I added the anisotropic temperature init to the `compile` and `compile2` tests.  