### PR TITLE
Fix checkpoint restarting with edited checkpoints

### DIFF
--- a/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
+++ b/lib/python/picongpu/extra/input/bunchInit_openPMD_bp.py
@@ -793,7 +793,7 @@ class pipe:
         temp_dest = dest.particle_patches["numParticlesOffset"][opmd.Mesh_Record_Component.SCALAR]
 
         temp_dest.reset_dataset(opmd.Dataset(temp_src.dtype, temp_src.shape))
-        self.__particle_patches.append(particle_patch_load(self.particles.numParticles, temp_dest))
+        self.__particle_patches.append(particle_patch_load(self.particles.numParticlesOffset, temp_dest))
 
         # copy offset and extent from old checkpoint
         temp_src = src.particle_patches["offset"]


### PR DESCRIPTION
This PR should resolve issue #5678.

The values of `numParticles` of the particle patch were accidentally also written into the `numParticlesOffset` dataset of the edited checkpoint. This was not caught by the checkpoint loading logic of PIConGPU before PR #5508. Afterward, it resulted in a crash on reload, which should be fixed now.