### PR TITLE
Add ADIOS2 binaries to path on JUPITER

### DIFF
--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -69,6 +69,7 @@ export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
 
 export PATH=$OPENPMD_ROOT/bin:$PATH
+export PATH=$ADIOS2_ROOT/bin:$PATH
 
 # Environment #################################################################
 


### PR DESCRIPTION
This PR adds the compiled ADIOS2 binaries to the standard path on the JUPITER cluster.
This makes tools like `bpls` available to the shell.