### PR TITLE
mallocMCBuffer device heap constructor fix

### DIFF
--- a/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
+++ b/include/pmacc/particles/memory/buffers/MallocMCBuffer.hpp
@@ -84,7 +84,9 @@ namespace pmacc
     class MallocMCBuffer : public ISimulationData
     {
     public:
-        MallocMCBuffer(T_DeviceHeap const&);
+        MallocMCBuffer(T_DeviceHeap const&)
+        {
+        }
 
         ~MallocMCBuffer() override = default;
 


### PR DESCRIPTION
mallocMCBuffer device heap constructor was declared but not defined for CPUs. Added empty definition. 