### PR TITLE
adjust URL to PIConGPU to main repo

### DIFF
--- a/lib/python/examples/laser_wakefield/main.py
+++ b/lib/python/examples/laser_wakefield/main.py
@@ -5,7 +5,7 @@
 #   "numpy",
 #   "scipy",
 #   "sympy",
-#   "picongpu @ git+https://github.com/chillenzer/picongpu@add-env-management-to-python-package#subdirectory=lib/python"
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python"
 # ]
 # ///
 """

--- a/lib/python/examples/tutorial/01_minimal.py
+++ b/lib/python/examples/tutorial/01_minimal.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11,<3.14"
 # dependencies = [
-#   "picongpu @ git+https://github.com/chillenzer/picongpu@add-env-management-to-python-package#subdirectory=lib/python"
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python"
 # ]
 # ///
 """

--- a/lib/python/examples/tutorial/02_lwfa.py
+++ b/lib/python/examples/tutorial/02_lwfa.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.11,<3.14"
 # dependencies = [
 #   "numpy",
-#   "picongpu @ git+https://github.com/chillenzer/picongpu@add-env-management-to-python-package#subdirectory=lib/python"
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python"
 # ]
 # ///
 """

--- a/lib/python/examples/tutorial/03.1_particle_distribution.py
+++ b/lib/python/examples/tutorial/03.1_particle_distribution.py
@@ -5,7 +5,7 @@
 #   "matplotlib",
 #   "mpl_ascii",
 #   "numpy",
-#   "picongpu @ git+https://github.com/chillenzer/picongpu@add-env-management-to-python-package#subdirectory=lib/python",
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python",
 #   "sympy"
 # ]
 # ///

--- a/lib/python/examples/tutorial/03.2_particle_functors.py
+++ b/lib/python/examples/tutorial/03.2_particle_functors.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.11,<3.14"
 # dependencies = [
 #   "numpy",
-#   "picongpu @ git+https://github.com/chillenzer/picongpu@add-env-management-to-python-package#subdirectory=lib/python"
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python"
 # ]
 # ///
 """

--- a/lib/python/examples/warm_plasma/main.py
+++ b/lib/python/examples/warm_plasma/main.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11,<3.14"
 # dependencies = [
-#   "picongpu @ git+https://github.com/chillenzer/picongpu@add-env-management-to-python-package#subdirectory=lib/python"
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python"
 # ]
 # ///
 """


### PR DESCRIPTION
This PR updates the PICMI uv install instruction to point to the main repo. 

This does not fix a bug introduces when running simulations. 