### PR TITLE
Checkpoint restart with changed domain decomposition: Fix numerical imprecision

### DIFF
--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -114,8 +114,11 @@ namespace picongpu
                                 char filterCurrent = filterKeep;
                                 for(size_t d = 0; d < simDim; ++d)
                                 {
-                                    auto positionInD = positionVec[d] + positionOffsetVec[d];
-                                    if(positionInD < patchTotalOffset[d] || positionInD >= patchUpperCorner[d])
+                                    signed long long p = positionVec[d];
+                                    signed long long o = positionOffsetVec[d];
+                                    signed long long patch_bottom = patchTotalOffset[d];
+                                    signed long long patch_up = patchUpperCorner[d];
+                                    if(p < patch_bottom - o || p >= patch_up - o)
                                     {
                                         filterCurrent = filterRemove;
                                         break;

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -114,7 +114,7 @@ namespace picongpu
                                 char filterCurrent = filterKeep;
                                 for(size_t d = 0; d < simDim; ++d)
                                 {
-                                    signed long long p = positionVec[d];
+                                    auto p = positionVec[d];
                                     signed long long o = positionOffsetVec[d];
                                     signed long long patch_bottom = patchTotalOffset[d];
                                     signed long long patch_up = patchUpperCorner[d];

--- a/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
+++ b/include/picongpu/plugins/openPMD/restart/LoadSpecies.hpp
@@ -347,15 +347,18 @@ namespace picongpu
                                 "openPMD: Keeping %1% of the current batch's %2% particles after filtering.")
                                 % numParticlesAfterFiltering % numParticlesCurrentBatch;
 
-                            pmacc::particles::operations::splitIntoListOfFrames(
-                                *speciesTmp,
-                                mappedFrame,
-                                // @attention not numParticlesCurrentBatch, filtered vs. unfiltered number
-                                numParticlesAfterFiltering,
-                                cellOffsetToTotalDomain,
-                                totalCellIdx_,
-                                *threadParams->cellDescription,
-                                picLog::INPUT_OUTPUT());
+                            if(numParticlesAfterFiltering > 0)
+                            {
+                                pmacc::particles::operations::splitIntoListOfFrames(
+                                    *speciesTmp,
+                                    mappedFrame,
+                                    // @attention not numParticlesCurrentBatch, filtered vs. unfiltered number
+                                    numParticlesAfterFiltering,
+                                    cellOffsetToTotalDomain,
+                                    totalCellIdx_,
+                                    *threadParams->cellDescription,
+                                    picLog::INPUT_OUTPUT());
+                            }
                         });
                 }
             };


### PR DESCRIPTION
Particle position comparisons must be expressed such that the precise (floating point) position is not added to the (integer) offset, otherwise the values get imprecise.

Also make sure to only upload particles into the simulation if there are any particles left after filtering.

Close #5687
ping @nicowrobel 