### PR TITLE
update memory and core request JSC Jupiter

### DIFF
--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -104,7 +104,7 @@ function getNode() {
         return 1
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=115G -A $account -p booster bash
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=18 --gres=gpu:4 --mem=$((117760 * 4)) -A $account -p booster bash
 }
 
 # allocate an interactive shell for one hour
@@ -121,7 +121,7 @@ function getDevice() {
         fi
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=115G -A $account -p booster --pty bash
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=18 --gres=gpu:$(($numDevices)) --mem=$((117760 * numGPUs)) -A $account -p booster --pty bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -104,7 +104,7 @@ function getNode() {
         return 1
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=18 --gres=gpu:4 --mem=$((117760 * 4)) -A $account -p booster bash
+    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=72 --gres=gpu:4 --mem=$((117760 * 4)) -A $account -p booster bash
 }
 
 # allocate an interactive shell for one hour
@@ -121,7 +121,7 @@ function getDevice() {
         fi
     fi
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=18 --gres=gpu:$(($numDevices)) --mem=$((117760 * numGPUs)) -A $account -p booster --pty bash
+    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=72 --gres=gpu:$(($numDevices)) --mem=$((117760 * numGPUs)) -A $account -p booster --pty bash
 }
 
 # Load autocompletion for PIConGPU commands


### PR DESCRIPTION
As @finnolec pointed out, our JSC Jupiter `getDevice` and `getNode` neither defined adjustable memory requirements nor more than one core per MPI task. This should fix both. 

As I currently have no access to Jupiter, please test this PR @finnolec or @ikbuibui.  