### PR TITLE
`picrc-builder`

### DIFF
--- a/lib/python/picongpu/_rc_params.py
+++ b/lib/python/picongpu/_rc_params.py
@@ -161,7 +161,12 @@ def get_available_presets() -> list[str]:
 
 
 def _preset_path(preset) -> Path:
-    candidates = list(filter(lambda p: preset in str(p), get_available_presets()))
+    # The `or` enables the following feature:
+    # `preset = "bash" is first matched against `bash/` and uniquely determines `bash/bash_picongpu.profile.example`
+    # without the first option in the `or` it would be ambiguous because `bash-devServer-hzdr/...` would match as well.
+    candidates = list(filter(lambda p: f"{preset}/" in str(p), get_available_presets())) or list(
+        filter(lambda p: preset in str(p), get_available_presets())
+    )
     if len(candidates) > 1:
         raise ValueError(f"The given {preset=} is ambiguous ({candidates=}). Please be more specific!")
     if len(candidates) == 0:

--- a/lib/python/picongpu/_rc_params.py
+++ b/lib/python/picongpu/_rc_params.py
@@ -152,22 +152,25 @@ def _make_template_from_example(profile_content):
     return "\n".join(lines)
 
 
+PRESET_STORAGE_PATH = core.path("etc") / "picongpu"
+
+
+def get_available_presets() -> list[str]:
+    """Return a list of available preset names from etc/picongpu."""
+    return list(map(lambda p: str(p.relative_to(PRESET_STORAGE_PATH)), PRESET_STORAGE_PATH.rglob("*.profile*")))
+
+
+def _preset_path(preset) -> Path:
+    candidates = list(filter(lambda p: preset in str(p), get_available_presets()))
+    if len(candidates) > 1:
+        raise ValueError(f"The given {preset=} is ambiguous ({candidates=}). Please be more specific!")
+    if len(candidates) == 0:
+        raise ValueError(f"No matching {preset=} found from {get_available_presets()=}.")
+    return PRESET_STORAGE_PATH / candidates[0]
+
+
 def _read_preset(preset):
-    etc_path = core.path("etc") / "picongpu" / preset
-    if etc_path.is_dir():
-        candidates = list(etc_path.glob("*.profile.example"))
-        if len(candidates) == 0:
-            raise ValueError(f"{preset=} not found in {etc_path=}.")
-        if len(candidates) > 1:
-            raise ValueError(
-                f"{preset=} is ambiguous. Please use one of the following instead: {[f'{preset}/{c.name}' for c in candidates]}."
-            )
-        etc_path = candidates[0]
-    if not etc_path.is_file() and not preset.endswith(".profile.example"):
-        etc_path = Path(str(etc_path) + ".profile.example")
-    if not etc_path.is_file():
-        raise ValueError(f"{preset=} not found in {etc_path=}.")
-    with etc_path.open("r") as file:
+    with _preset_path(preset).open("r") as file:
         return file.read()
 
 

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -85,27 +85,27 @@ def main():
         choice = questionary.select(
             "Please choose",
             choices=[
-                ("Don't write.", "abort"),
-                (f"Yes, to {path}.", "write_existing"),
-                ("Yes, but ask for a new path.", "write_new"),
+                "Don't write.",
+                f"Yes, to {path}.",
+                "Yes, but ask for a new path.",
             ],
         ).ask()
-        choice = choice if choice is not None else "abort"
+        choice = choice if choice is not None else "Don't write."
     else:
         choice = questionary.select(
             "Please choose",
             choices=[
-                ("Don't write.", "abort"),
-                ("Yes, but ask for a path.", "write_new"),
+                "Don't write.",
+                "Yes, but ask for a path.",
             ],
         ).ask()
-        choice = choice if choice is not None else "abort"
+        choice = choice if choice is not None else "Don't write."
 
-    if choice == "write_existing":
+    if choice == f"Yes, to {path}.":
         with path.open("wb") as f:
             tomli_w.dump(output, f)
         questionary.print(f"Written to {path}")
-    elif choice == "write_new":
+    elif choice in ("Yes, but ask for a path.", "Yes, but ask for a new path."):
         new_path = Path(questionary.path("Path to write: ").ask())
         with new_path.open("wb") as f:
             tomli_w.dump(output, f)

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -8,15 +8,12 @@ License: GPLv3+
 import sys
 from pathlib import Path
 
+import questionary
 import tomli_w
 
 from moosetash import MissingVariable
 
 from picongpu._rc_params import RCParams
-
-
-def _prompt(prompt_text):
-    return input(prompt_text).strip()
 
 
 def _gather_missing(p):
@@ -26,8 +23,8 @@ def _gather_missing(p):
             break
         except MissingVariable as e:
             var = e.__cause__.args[0] if e.__cause__ else e.args[0]
-            print(f'Found missing variable "{var}". Please provide a value:')
-            p[var] = _prompt(f'{var} = ')
+            questionary.print(f'Found missing variable "{var}". Please provide a value:')
+            p[var] = questionary.text(f'{var} = ').ask()
 
 
 def _toml_serialize(value):
@@ -38,7 +35,7 @@ def _toml_serialize(value):
 
 def _display_toml(output):
     for key, value in output.items():
-        print(f'{key} = {_toml_serialize(value)}')
+        questionary.print(f'{key} = {_toml_serialize(value)}')
 
 
 def main():
@@ -52,8 +49,7 @@ def main():
     if path is not None:
         p = RCParams(picongpurc_path=path)
     else:
-        preset = _prompt("preset = ")
-        p = RCParams(preset=preset)
+        p = RCParams(preset=questionary.text("preset = ").ask())
 
     _gather_missing(p)
 
@@ -72,7 +68,6 @@ def main():
         "tbg_tpl_file",
         "tbg_partition",
     }
-    # Build ordered output: preset first, then the rest sorted
     output = {}
     for key in ("preset",):
         if key not in internal_keys and data.get(key) is not None:
@@ -80,32 +75,42 @@ def main():
     for key in sorted(k for k in data if k not in internal_keys and data[k] is not None and k != "preset"):
         output[key] = data[key]
 
-    print("\nInformation is complete. Here is the full file:\n")
+    questionary.print("\nInformation is complete. Here is the full file:\n")
     _display_toml(output)
 
-    print("\nDo you want to write this? If so, where?")
-    if path is not None:
-        print("(1) No.")
-        print(f"(2) Yes, to {path}.")
-        print("(3) Yes, but ask for a new path.")
-        choice = _prompt("Please choose [1]")
-    else:
-        print("(1) No.")
-        print("(2) Yes, but ask for a path.")
-        choice = _prompt("Please choose [1]")
+    questionary.print("\nDo you want to write this? If so, where?")
 
-    if choice == "2" and path is not None:
+    if path is not None:
+        choice = questionary.select(
+            "Please choose",
+            choices=[
+                ("Don't write.", "abort"),
+                (f"Yes, to {path}.", "write_existing"),
+                ("Yes, but ask for a new path.", "write_new"),
+            ],
+            default="Don't write.",
+        ).ask()
+    else:
+        choice = questionary.select(
+            "Please choose",
+            choices=[
+                ("Don't write.", "abort"),
+                ("Yes, but ask for a path.", "write_new"),
+            ],
+            default="Don't write.",
+        ).ask()
+
+    if choice == "write_existing":
         with path.open("wb") as f:
             tomli_w.dump(output, f)
-        print(f"Written to {path}")
-    elif choice in ("2", "3"):
-        new_path = _prompt("Path to write: ")
-        out = Path(new_path)
-        with out.open("wb") as f:
+        questionary.print(f"Written to {path}")
+    elif choice == "write_new":
+        new_path = Path(questionary.path("Path to write: ").ask())
+        with new_path.open("wb") as f:
             tomli_w.dump(output, f)
-        print(f"Written to {out}")
+        questionary.print(f"Written to {new_path}")
     else:
-        print("Aborted.")
+        questionary.print("Aborted.")
 
 
 if __name__ == "__main__":

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -3,8 +3,14 @@ This file is part of PIConGPU.
 Copyright 2026 PIConGPU contributors
 Authors: Julian Lenz
 License: GPLv3+
+
+Interactive builder for .picongpurc.toml configuration files.
+
+Guides the user through filling in missing variables required by a
+PIConGPU preset, then writes the resulting TOML file to disk.
 """
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -15,8 +21,24 @@ from moosetash import MissingVariable
 
 from picongpu._rc_params import RCParams
 
+__all__ = ["main"]
+
+_DESC = (
+    "picrc-builder — interactive .picongpurc.toml configuration builder\n"
+    "\n"
+    "Guides you through creating or completing a PIConGPU configuration file."
+    " If a path to an existing .picongpurc.toml is given, the tool loads it"
+    " and only asks for missing values. Otherwise it starts from scratch by"
+    " asking for a preset first."
+)
+
 
 def _gather_missing(p):
+    """Ask the user for every template variable the preset requires.
+
+    Repeatedly accesses ``p.profile_content`` until no ``MissingVariable``
+    is raised, prompting the user for each missing key.
+    """
     while True:
         try:
             _ = p.profile_content
@@ -28,46 +50,22 @@ def _gather_missing(p):
 
 
 def _toml_serialize(value):
-    """Serialize a Python value as a TOML scalar string."""
+    """Return a TOML scalar representation of *value*."""
     s = tomli_w.dumps({"_": value})
     return s.split("=", 1)[1].strip()
 
 
 def _display_toml(output):
+    """Print each key-value pair in *output* as a TOML line."""
     for key, value in output.items():
         questionary.print(f'{key} = {_toml_serialize(value)}')
 
 
-def main():
-    path = None
-    if len(sys.argv) > 1:
-        path = Path(sys.argv[1])
-        if not path.is_file():
-            print(f"Error: {path} does not exist or is not a file.", file=sys.stderr)
-            sys.exit(1)
+def _filter_user_keys(data):
+    """Return dict of user-facing keys (preset first, then sorted).
 
-    questionary.print(
-        "Welcome to picrc-builder!\n"
-        "This tool helps you create or complete a .picongpurc.toml configuration "
-        "file for your PIConGPU simulation setup.\n"
-        "You will be asked to fill in any missing values required by your chosen preset.\n"
-    )
-
-    if path is not None:
-        questionary.print(f"Loading existing configuration from {path}:")
-        p = RCParams(picongpurc_path=path)
-    else:
-        questionary.print("First, let's choose a preset.")
-        preset = questionary.text("preset = ").ask()
-        questionary.print(f"Using preset '{preset}'.")
-        p = RCParams(preset=preset)
-
-    questionary.print("\nGathering missing information:")
-    _gather_missing(p)
-
-    questionary.print("\nAll done collecting values. Here is what will be written:")
-
-    data = p.model_dump()
+    Internal / preset-derived keys are excluded so the preview stays clean.
+    """
     internal_keys = {
         "picongpurc_path",
         "preset_dir",
@@ -89,7 +87,63 @@ def main():
             output[key] = data[key]
     for key in sorted(k for k in data if k not in internal_keys and data[k] is not None and k != "preset"):
         output[key] = data[key]
+    return output
 
+
+def write_output(output, path):
+    """Write *output* as a TOML file to *path*."""
+    with path.open("wb") as f:
+        tomli_w.dump(output, f)
+
+
+def main(argv=None):
+    """Entry point for the picrc-builder CLI.
+
+    Parameters
+    ----------
+    argv : list[str] | None
+        Command-line arguments (defaults to ``sys.argv[1:]``).
+    """
+    parser = argparse.ArgumentParser(
+        prog="picrc-builder",
+        description=_DESC,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "config",
+        nargs="?",
+        default=None,
+        type=Path,
+        help="Path to an existing .picongpurc.toml to load and complete.",
+    )
+    args = parser.parse_args(argv)
+
+    path = args.config
+    if path is not None and not path.is_file():
+        parser.error(f"{path} does not exist or is not a file.")
+
+    questionary.print(
+        "Welcome to picrc-builder!\n"
+        "This tool helps you create or complete a .picongpurc.toml configuration "
+        "file for your PIConGPU simulation setup.\n"
+        "You will be asked to fill in any missing values required by your chosen preset.\n"
+    )
+
+    if path is not None:
+        questionary.print(f"Loading existing configuration from {path}:")
+        p = RCParams(picongpurc_path=path)
+    else:
+        questionary.print("First, let's choose a preset.")
+        preset = questionary.text("preset = ").ask()
+        questionary.print(f"Using preset '{preset}'.")
+        p = RCParams(preset=preset)
+
+    questionary.print("\nGathering missing information:")
+    _gather_missing(p)
+
+    output = _filter_user_keys(p.model_dump())
+
+    questionary.print("\nAll done collecting values. Here is what will be written:")
     questionary.print("")
     _display_toml(output)
     questionary.print("")
@@ -116,8 +170,7 @@ def main():
         choice = choice if choice is not None else "Don't write."
 
     if choice == f"Yes, to {path}.":
-        with path.open("wb") as f:
-            tomli_w.dump(output, f)
+        write_output(output, path)
         questionary.print(f"Written to {path}.")
         questionary.print("You can start your simulation now.")
     elif choice in ("Yes, but ask for a path.", "Yes, but ask for a new path."):
@@ -128,9 +181,8 @@ def main():
                 default=False,
             ).ask():
                 questionary.print("Aborted. Nothing was written.")
-                sys.exit(0)
-        with new_path.open("wb") as f:
-            tomli_w.dump(output, f)
+                return
+        write_output(output, new_path)
         questionary.print(f"Written to {new_path}.")
         questionary.print("You can start your simulation now.")
     else:

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -89,8 +89,8 @@ def main():
                 (f"Yes, to {path}.", "write_existing"),
                 ("Yes, but ask for a new path.", "write_new"),
             ],
-            default="abort",
         ).ask()
+        choice = choice if choice is not None else "abort"
     else:
         choice = questionary.select(
             "Please choose",
@@ -98,8 +98,8 @@ def main():
                 ("Don't write.", "abort"),
                 ("Yes, but ask for a path.", "write_new"),
             ],
-            default="abort",
         ).ask()
+        choice = choice if choice is not None else "abort"
 
     if choice == "write_existing":
         with path.open("wb") as f:

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.11,<3.14"
+# dependencies = [
+#   "picongpu @ git+https://github.com/ComputationalRadiationPhysics/picongpu@dev#subdirectory=lib/python"
+# ]
+# ///
 """
 This file is part of PIConGPU.
 Copyright 2026 PIConGPU contributors
@@ -18,7 +24,7 @@ import tomli_w
 
 from moosetash import MissingVariable
 
-from picongpu._rc_params import RCParams
+from picongpu._rc_params import RCParams, get_available_presets
 
 __all__ = ["main"]
 
@@ -133,7 +139,21 @@ def main(argv=None):
         p = RCParams(picongpurc_path=path)
     else:
         questionary.print("First, let's choose a preset.")
-        preset = questionary.text("preset = ").ask()
+
+        available_presets = [
+            name.removesuffix(".example").removesuffix(".profile").removesuffix("_picongpu")
+            for name in get_available_presets()
+        ]
+        if not available_presets:
+            print("Error: No presets found in etc/picongpu.")
+            return
+
+        preset = questionary.select("Select a preset:", choices=available_presets).ask()
+
+        if preset is None:
+            print("Aborted.")
+            return
+
         questionary.print(f"Using preset '{preset}'.")
         p = RCParams(preset=preset)
 
@@ -173,7 +193,15 @@ def main(argv=None):
         questionary.print(f"Written to {path}.")
         questionary.print("You can start your simulation now.")
     elif choice in ("Yes, but ask for a path.", "Yes, but ask for a new path."):
-        new_path = Path(questionary.path("Path to write: ").ask())
+        default_path = Path("./.picongpurc.toml")
+        new_path_str = questionary.path("Path to write:", default=str(default_path)).ask()
+
+        if new_path_str is None:
+            print("Aborted.")
+            return
+
+        new_path = Path(new_path_str)
+
         if new_path.exists():
             if not questionary.confirm(
                 f"{new_path} already exists. Overwrite?",

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -122,6 +122,13 @@ def main():
         questionary.print("You can start your simulation now.")
     elif choice in ("Yes, but ask for a path.", "Yes, but ask for a new path."):
         new_path = Path(questionary.path("Path to write: ").ask())
+        if new_path.exists():
+            if not questionary.confirm(
+                f"{new_path} already exists. Overwrite?",
+                default=False,
+            ).ask():
+                questionary.print("Aborted. Nothing was written.")
+                sys.exit(0)
         with new_path.open("wb") as f:
             tomli_w.dump(output, f)
         questionary.print(f"Written to {new_path}.")

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -63,6 +63,7 @@ def main():
         "required_information",
         "module_section",
         "spack_section",
+        "pic_src_path",
         "pic_backend",
         "tbg_submit",
         "tbg_tpl_file",

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -11,7 +11,6 @@ PIConGPU preset, then writes the resulting TOML file to disk.
 """
 
 import argparse
-import sys
 from pathlib import Path
 
 import questionary
@@ -24,7 +23,7 @@ from picongpu._rc_params import RCParams
 __all__ = ["main"]
 
 _DESC = (
-    "picrc-builder — interactive .picongpurc.toml configuration builder\n"
+    "picrc-builder -- interactive .picongpurc.toml configuration builder\n"
     "\n"
     "Guides you through creating or completing a PIConGPU configuration file."
     " If a path to an existing .picongpurc.toml is given, the tool loads it"
@@ -46,7 +45,7 @@ def _gather_missing(p):
         except MissingVariable as e:
             var = e.__cause__.args[0] if e.__cause__ else e.args[0]
             questionary.print(f'Found missing variable "{var}". Please provide a value:')
-            p[var] = questionary.text(f'{var} = ').ask()
+            p[var] = questionary.text(f"{var} = ").ask()
 
 
 def _toml_serialize(value):
@@ -58,7 +57,7 @@ def _toml_serialize(value):
 def _display_toml(output):
     """Print each key-value pair in *output* as a TOML line."""
     for key, value in output.items():
-        questionary.print(f'{key} = {_toml_serialize(value)}')
+        questionary.print(f"{key} = {_toml_serialize(value)}")
 
 
 def _filter_user_keys(data):

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -1,0 +1,112 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import sys
+from pathlib import Path
+
+import tomli_w
+
+from moosetash import MissingVariable
+
+from picongpu._rc_params import RCParams
+
+
+def _prompt(prompt_text):
+    return input(prompt_text).strip()
+
+
+def _gather_missing(p):
+    while True:
+        try:
+            _ = p.profile_content
+            break
+        except MissingVariable as e:
+            var = e.__cause__.args[0] if e.__cause__ else e.args[0]
+            print(f'Found missing variable "{var}". Please provide a value:')
+            p[var] = _prompt(f'{var} = ')
+
+
+def _toml_serialize(value):
+    """Serialize a Python value as a TOML scalar string."""
+    s = tomli_w.dumps({"_": value})
+    return s.split("=", 1)[1].strip()
+
+
+def _display_toml(output):
+    for key, value in output.items():
+        print(f'{key} = {_toml_serialize(value)}')
+
+
+def main():
+    path = None
+    if len(sys.argv) > 1:
+        path = Path(sys.argv[1])
+        if not path.is_file():
+            print(f"Error: {path} does not exist or is not a file.", file=sys.stderr)
+            sys.exit(1)
+
+    if path is not None:
+        p = RCParams(picongpurc_path=path)
+    else:
+        preset = _prompt("preset = ")
+        p = RCParams(preset=preset)
+
+    _gather_missing(p)
+
+    data = p.model_dump()
+    internal_keys = {
+        "picongpurc_path",
+        "preset_dir",
+        "profile_template_content",
+        "dirty_reset_policy",
+        "missing_variable_policy",
+        "required_information",
+        "module_section",
+        "spack_section",
+        "pic_backend",
+        "tbg_submit",
+        "tbg_tpl_file",
+        "tbg_partition",
+    }
+    # Build ordered output: preset first, then the rest sorted
+    output = {}
+    for key in ("preset",):
+        if key not in internal_keys and data.get(key) is not None:
+            output[key] = data[key]
+    for key in sorted(k for k in data if k not in internal_keys and data[k] is not None and k != "preset"):
+        output[key] = data[key]
+
+    print("\nInformation is complete. Here is the full file:\n")
+    _display_toml(output)
+
+    print("\nDo you want to write this? If so, where?")
+    if path is not None:
+        print("(1) No.")
+        print(f"(2) Yes, to {path}.")
+        print("(3) Yes, but ask for a new path.")
+        choice = _prompt("Please choose [1]")
+    else:
+        print("(1) No.")
+        print("(2) Yes, but ask for a path.")
+        choice = _prompt("Please choose [1]")
+
+    if choice == "2" and path is not None:
+        with path.open("wb") as f:
+            tomli_w.dump(output, f)
+        print(f"Written to {path}")
+    elif choice in ("2", "3"):
+        new_path = _prompt("Path to write: ")
+        out = Path(new_path)
+        with out.open("wb") as f:
+            tomli_w.dump(output, f)
+        print(f"Written to {out}")
+    else:
+        print("Aborted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -46,12 +46,26 @@ def main():
             print(f"Error: {path} does not exist or is not a file.", file=sys.stderr)
             sys.exit(1)
 
+    questionary.print(
+        "Welcome to picrc-builder!\n"
+        "This tool helps you create or complete a .picongpurc.toml configuration "
+        "file for your PIConGPU simulation setup.\n"
+        "You will be asked to fill in any missing values required by your chosen preset.\n"
+    )
+
     if path is not None:
+        questionary.print(f"Loading existing configuration from {path}:")
         p = RCParams(picongpurc_path=path)
     else:
-        p = RCParams(preset=questionary.text("preset = ").ask())
+        questionary.print("First, let's choose a preset.")
+        preset = questionary.text("preset = ").ask()
+        questionary.print(f"Using preset '{preset}'.")
+        p = RCParams(preset=preset)
 
+    questionary.print("\nGathering missing information:")
     _gather_missing(p)
+
+    questionary.print("\nAll done collecting values. Here is what will be written:")
 
     data = p.model_dump()
     internal_keys = {
@@ -76,10 +90,10 @@ def main():
     for key in sorted(k for k in data if k not in internal_keys and data[k] is not None and k != "preset"):
         output[key] = data[key]
 
-    questionary.print("\nInformation is complete. Here is the full file:\n")
+    questionary.print("")
     _display_toml(output)
-
-    questionary.print("\nDo you want to write this? If so, where?")
+    questionary.print("")
+    questionary.print("Do you want to write this configuration?")
 
     if path is not None:
         choice = questionary.select(
@@ -104,14 +118,16 @@ def main():
     if choice == f"Yes, to {path}.":
         with path.open("wb") as f:
             tomli_w.dump(output, f)
-        questionary.print(f"Written to {path}")
+        questionary.print(f"Written to {path}.")
+        questionary.print("You can start your simulation now.")
     elif choice in ("Yes, but ask for a path.", "Yes, but ask for a new path."):
         new_path = Path(questionary.path("Path to write: ").ask())
         with new_path.open("wb") as f:
             tomli_w.dump(output, f)
-        questionary.print(f"Written to {new_path}")
+        questionary.print(f"Written to {new_path}.")
+        questionary.print("You can start your simulation now.")
     else:
-        questionary.print("Aborted.")
+        questionary.print("Aborted. Nothing was written.")
 
 
 if __name__ == "__main__":

--- a/lib/python/picongpu/picrc_builder.py
+++ b/lib/python/picongpu/picrc_builder.py
@@ -89,7 +89,7 @@ def main():
                 (f"Yes, to {path}.", "write_existing"),
                 ("Yes, but ask for a new path.", "write_new"),
             ],
-            default="Don't write.",
+            default="abort",
         ).ask()
     else:
         choice = questionary.select(
@@ -98,7 +98,7 @@ def main():
                 ("Don't write.", "abort"),
                 ("Yes, but ask for a path.", "write_new"),
             ],
-            default="Don't write.",
+            default="abort",
         ).ask()
 
     if choice == "write_existing":

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -56,6 +56,9 @@ dependencies = [
 
 optional-dependencies.test = [ "pytest>=9" ]
 
+[project.scripts]
+picrc-builder = "picongpu.picrc_builder:main"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -38,11 +38,11 @@ dependencies = [
   "particle>=0.25.1",
   "periodictable>=1.7.1",
   "picmistandard>=0.27",
-  "questionary>=2.0",
   "pillow",
   "pint",
   "pydantic>=2.6.4",
   "pyyaml",
+  "questionary>=2",
   "referencing>=0.35.1",
   "roc-validator",
   # Temporarily choosing the master here
@@ -57,8 +57,7 @@ dependencies = [
 
 optional-dependencies.test = [ "pytest>=9" ]
 
-[project.scripts]
-picrc-builder = "picongpu.picrc_builder:main"
+scripts.picrc-builder = "picongpu.picrc_builder:main"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "particle>=0.25.1",
   "periodictable>=1.7.1",
   "picmistandard>=0.27",
+  "questionary>=2.0",
   "pillow",
   "pint",
   "pydantic>=2.6.4",


### PR DESCRIPTION
As per user request by @PrometheusPi : This is a little tool that guides you through writing your `.picongpurc.toml` configuration file. Use as 
```bash
$ picrc-builder --help
usage: picrc-builder [-h] [config]

picrc-builder — interactive .picongpurc.toml configuration builder

Guides you through creating or completing a PIConGPU configuration file. If a path to an existing .picongpurc.toml is given, the tool loads it and only asks for missing values. Otherwise it starts from scratch by asking for a preset first.

positional arguments:
  config      Path to an existing .picongpurc.toml to load and complete.

options:
  -h, --help  show this help message and exit
 ```
 and 
 ```bash
$ picrc-builder
  Welcome to picrc-builder!
  This tool helps you create or complete a .picongpurc.toml configuration file for your PIConGPU simulation setup.
  You will be asked to fill in any missing values required by your chosen preset.

  First, let's choose a preset.
   preset =  rosi-hzdr
  Using preset 'rosi-hzdr'.

  Gathering missing information:
  Found missing variable "email". Please provide a value:
   email = example@example.net
  Found missing variable "author". Please provide a value:
   author =  Max Mustermann

  All done collecting values. Here is what will be written:

    preset = "rosi-hzdr"
    author = "Max Mustermann"
    email = "example@example.net"

Do you want to write this configuration?
 Please choose
   Don't write
   Yes, but ask for a path.
 Path to write:  /tmp/.picongpurc.toml
Written to /tmp/.picongpurc.toml.
You can start your simulation now.
```