### PR TITLE
Standardize PICMI typehints to modern Python syntax

### DIFF
--- a/lib/python/picongpu/picmi/diagnostics/checkpoint.py
+++ b/lib/python/picongpu/picmi/diagnostics/checkpoint.py
@@ -5,8 +5,6 @@ Authors: Masoud Afshari, Julian Lenz
 License: GPLv3+
 """
 
-from typing import Dict, Optional
-
 import typeguard
 
 from picongpu.picmi.copy_attributes import default_converts_to
@@ -81,18 +79,18 @@ class Checkpoint:
 
     def __init__(
         self,
-        period: Optional[TimeStepSpec] = None,
-        timePeriod: Optional[int] = None,
-        directory: Optional[str] = None,
-        file: Optional[str] = None,
-        restart: Optional[bool] = None,
-        tryRestart: Optional[bool] = None,
-        restartStep: Optional[int] = None,
-        restartDirectory: Optional[str] = None,
-        restartFile: Optional[str] = None,
-        restartChunkSize: Optional[int] = None,
-        restartLoop: Optional[int] = None,
-        openPMD: Optional[Dict] = None,
+        period: TimeStepSpec | None = None,
+        timePeriod: int | None = None,
+        directory: str | None = None,
+        file: str | None = None,
+        restart: bool | None = None,
+        tryRestart: bool | None = None,
+        restartStep: int | None = None,
+        restartDirectory: str | None = None,
+        restartFile: str | None = None,
+        restartChunkSize: int | None = None,
+        restartLoop: int | None = None,
+        openPMD: dict | None = None,
     ):
         self.period = period
         self.timePeriod = timePeriod

--- a/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/AnalyticDistribution.py
@@ -7,7 +7,6 @@ License: GPLv3+
 
 import logging
 import traceback
-import typing
 
 import numpy as np
 import sympy
@@ -131,10 +130,10 @@ class AnalyticDistribution:
     def get_as_pypicongpu(self, _):
         return species.operation.densityprofile.FreeFormula(density_expression=self.density_expression)
 
-    def picongpu_get_rms_velocity_si(self) -> typing.Tuple[float, float, float]:
+    def picongpu_get_rms_velocity_si(self) -> tuple[float, float, float]:
         return self.rms_velocity
 
-    def get_picongpu_drift(self) -> typing.Optional[species.operation.momentum.Drift]:
+    def get_picongpu_drift(self) -> species.operation.momentum.Drift | None:
         """
         Get drift for pypicongpu
         :return: pypicongpu drift object or None

--- a/lib/python/picongpu/picmi/distribution/Distribution.py
+++ b/lib/python/picongpu/picmi/distribution/Distribution.py
@@ -7,8 +7,7 @@ License: GPLv3+
 
 from ...pypicongpu import species
 
-import typing
-import pydantic
+from pydantic import BaseModel
 import typeguard
 
 """
@@ -34,11 +33,11 @@ this method returns None.
 
 
 @typeguard.typechecked
-class Distribution(pydantic.BaseModel):
-    rms_velocity: typing.Tuple[float, float, float] = (0, 0, 0)
+class Distribution(BaseModel):
+    rms_velocity: tuple[float, float, float] = (0, 0, 0)
     """thermal velocity spread [m/s]"""
 
-    directed_velocity: typing.Tuple[float, float, float] = (0, 0, 0)
+    directed_velocity: tuple[float, float, float] = (0, 0, 0)
     """Directed, average, proper velocity [m/s]"""
 
     fill_in: bool = True
@@ -51,10 +50,10 @@ class Distribution(pydantic.BaseModel):
             hash_value += hash(value)
         return hash_value
 
-    def picongpu_get_rms_velocity_si(self) -> typing.Tuple[float, float, float]:
+    def picongpu_get_rms_velocity_si(self) -> tuple[float, float, float]:
         return tuple(self.rms_velocity)
 
-    def get_picongpu_drift(self) -> typing.Optional[species.operation.momentum.Drift]:
+    def get_picongpu_drift(self) -> species.operation.momentum.Drift | None:
         """
         Get drift for pypicongpu
         :return: pypicongpu drift object or None

--- a/lib/python/picongpu/picmi/distribution/FoilDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/FoilDistribution.py
@@ -11,7 +11,6 @@ from ...pypicongpu import util
 import picmistandard
 
 import typeguard
-import typing
 import numpy as np
 
 """
@@ -38,7 +37,7 @@ this method returns None.
 
 @typeguard.typechecked
 class FoilDistribution(picmistandard.PICMI_FoilDistribution):
-    def picongpu_get_rms_velocity_si(self) -> typing.Tuple[float, float, float]:
+    def picongpu_get_rms_velocity_si(self) -> tuple[float, float, float]:
         return tuple(self.rms_velocity)
 
     def get_as_pypicongpu(self, grid):
@@ -98,7 +97,7 @@ class FoilDistribution(picmistandard.PICMI_FoilDistribution):
             post_foil_plasmaRamp=post_foil_plasmaRamp,
         )
 
-    def get_picongpu_drift(self) -> typing.Optional[species.operation.momentum.Drift]:
+    def get_picongpu_drift(self) -> species.operation.momentum.Drift | None:
         """
         Get drift for pypicongpu
         :return: pypicongpu drift object or None

--- a/lib/python/picongpu/picmi/distribution/GaussianDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/GaussianDistribution.py
@@ -12,7 +12,6 @@ from ...pypicongpu import util
 from .Distribution import Distribution
 
 import typeguard
-import typing
 import numpy as np
 
 
@@ -57,12 +56,12 @@ class GaussianDistribution(Distribution):
     vacuum_front: float
     """size of the vacuum in front of density, gets rounded down to full cells, [m]"""
 
-    lower_bound: typing.Tuple[float, float, float] | typing.Tuple[None, None, None] = (
+    lower_bound: tuple[float, float, float] | tuple[None, None, None] = (
         None,
         None,
         None,
     )
-    upper_bound: typing.Tuple[float, float, float] | typing.Tuple[None, None, None] = (
+    upper_bound: tuple[float, float, float] | tuple[None, None, None] = (
         None,
         None,
         None,

--- a/lib/python/picongpu/picmi/distribution/UniformDistribution.py
+++ b/lib/python/picongpu/picmi/distribution/UniformDistribution.py
@@ -11,7 +11,6 @@ from ...pypicongpu import util
 import picmistandard
 
 import typeguard
-import typing
 
 """
 note on rms_velocity:
@@ -39,7 +38,7 @@ this method returns None.
 class UniformDistribution(picmistandard.PICMI_UniformDistribution):
     """Uniform Particle Distribution as defined by PICMI"""
 
-    def picongpu_get_rms_velocity_si(self) -> typing.Tuple[float, float, float]:
+    def picongpu_get_rms_velocity_si(self) -> tuple[float, float, float]:
         return tuple(self.rms_velocity)
 
     def get_as_pypicongpu(self, grid):
@@ -57,7 +56,7 @@ class UniformDistribution(picmistandard.PICMI_UniformDistribution):
 
         return profile
 
-    def get_picongpu_drift(self) -> typing.Optional[species.operation.momentum.Drift]:
+    def get_picongpu_drift(self) -> species.operation.momentum.Drift | None:
         """
         Get drift for pypicongpu
         :return: pypicongpu drift object or None

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/fieldionization.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/fieldionization.py
@@ -8,7 +8,6 @@ License: GPLv3+
 from ..groundstateionizationmodel import GroundStateIonizationModel
 from .ionizationcurrent import IonizationCurrent
 
-import typing
 import typeguard
 
 
@@ -16,5 +15,5 @@ import typeguard
 class FieldIonization(GroundStateIonizationModel):
     """common interface of all field ionization models"""
 
-    ionization_current: typing.Optional[IonizationCurrent]
+    ionization_current: IonizationCurrent | None
     """ionization current for energy conservation of field ionization"""

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/ionizationcurrent.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/ionizationcurrent.py
@@ -5,12 +5,12 @@ Authors: Brian Edward Marre
 License: GPLv3+
 """
 
-import pydantic
+from pydantic import BaseModel
 import typeguard
 
 
 @typeguard.typechecked
-class IonizationCurrent(pydantic.BaseModel):
+class IonizationCurrent(BaseModel):
     """common interface of all ionization current models"""
 
     MODEL_NAME: str

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -7,7 +7,6 @@ License: GPLv3+
 """
 
 import math
-import typing
 
 import picmistandard
 import typeguard
@@ -83,14 +82,14 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         a0=None,
         E0=None,
         picongpu_polarization_type=(PolarizationType.LINEAR),
-        picongpu_laguerre_modes: typing.Optional[typing.List[float]] = None,
-        picongpu_laguerre_phases: typing.Optional[typing.List[float]] = None,
+        picongpu_laguerre_modes: list[float] | None = None,
+        picongpu_laguerre_phases: list[float] | None = None,
         # make sure to always place Huygens-surface inside PML-boundaries,
         # default is valid for standard PMLs
         # @todo create check for insufficient dimension
         # @todo create check in simulation for conflict between PMLs and
         # Huygens-surfaces
-        picongpu_huygens_surface_positions: typing.List[typing.List[int]] = [
+        picongpu_huygens_surface_positions: list[list[int]] = [
             [16, -16],
             [16, -16],
             [16, -16],

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -6,7 +6,6 @@ License: GPLv3+
 """
 
 import math
-import typing
 
 import typeguard
 
@@ -68,7 +67,7 @@ class PlaneWaveLaser(BaseLaser):
         # @todo create check for insufficient dimension
         # @todo create check in simulation for conflict between PMLs and
         # Huygens-surfaces
-        picongpu_huygens_surface_positions: typing.List[typing.List[int]] = [
+        picongpu_huygens_surface_positions: list[list[int]] = [
             [16, -16],
             [16, -16],
             [16, -16],

--- a/lib/python/picongpu/picmi/lasers/twts_laser.py
+++ b/lib/python/picongpu/picmi/lasers/twts_laser.py
@@ -6,7 +6,6 @@ License: GPLv3+
 """
 
 import math
-import typing
 
 import typeguard
 
@@ -130,7 +129,7 @@ class TWTSLaser(BaseLaser):
         # @todo create check for insufficient dimension
         # @todo create check in simulation for conflict between PMLs and
         # Huygens-surfaces
-        picongpu_huygens_surface_positions: typing.List[typing.List[int]] = [
+        picongpu_huygens_surface_positions: list[list[int]] = [
             [16, -16],
             [16, -16],
             [16, -16],

--- a/lib/python/picongpu/picmi/predefinedparticletypeproperties.py
+++ b/lib/python/picongpu/picmi/predefinedparticletypeproperties.py
@@ -8,7 +8,7 @@ License: GPLv3+
 import collections
 import particle
 
-import pydantic
+from pydantic import BaseModel
 import typeguard
 
 from scipy import constants as consts
@@ -16,7 +16,7 @@ from scipy import constants as consts
 PropertyTuple: collections.namedtuple = collections.namedtuple("_PropertyTuple", ["mass", "charge"])
 
 
-class PredefinedParticleTypeProperties(pydantic.BaseModel):
+class PredefinedParticleTypeProperties(BaseModel):
     _particle_type_to_pdgid: dict[str, int] = {
         "down": 1,
         "up": 2,

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodel.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodel.py
@@ -31,5 +31,5 @@ class IonizationModel(Constant):
     ionization_electron_species: typing.Any
     """species to be used as electrons"""
 
-    ionization_current: typing.Optional[IonizationCurrent] = None
+    ionization_current: IonizationCurrent | None = None
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodelgroups.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodelgroups.py
@@ -15,29 +15,28 @@ from .thomasfermi import ThomasFermi
 from .ionizationmodel import IonizationModel
 
 import copy
-import typing
-import pydantic
+from pydantic import BaseModel
 
 
-class IonizationModelGroups(pydantic.BaseModel):
+class IonizationModelGroups(BaseModel):
     """
     grouping of ionization models into sub groups that may not be used at the same time
 
     every instance of this class is immutable, all method always return copies of the data contained
     """
 
-    by_group: dict[str, list[typing.Type[IonizationModel]]] = {
+    by_group: dict[str, list[type[IonizationModel]]] = {
         "BSI_like": [BSI, BSIEffectiveZ, BSIStarkShifted],
         "ADK_like": [ADKLinearPolarization, ADKCircularPolarization],
         "Keldysh_like": [Keldysh],
         "electronic_collisional_equilibrium": [ThomasFermi],
     }
 
-    def get_by_group(self) -> dict[str, list[typing.Type[IonizationModel]]]:
+    def get_by_group(self) -> dict[str, list[type[IonizationModel]]]:
         return copy.deepcopy(self.by_group)
 
-    def get_by_model(self) -> dict[typing.Type[IonizationModel], str]:
-        return_dict: dict[typing.Type[IonizationModel], str] = {}
+    def get_by_model(self) -> dict[type[IonizationModel], str]:
+        return_dict: dict[type[IonizationModel], str] = {}
 
         for ionization_model_type, list_ionization_model in self.by_group.items():
             for ionization_model in list_ionization_model:

--- a/lib/python/picongpu/pypicongpu/species/species.py
+++ b/lib/python/picongpu/pypicongpu/species/species.py
@@ -7,7 +7,6 @@ License: GPLv3+
 
 import re
 from pydantic import BaseModel, computed_field, field_validator
-import typing
 from enum import Enum
 
 import typeguard
@@ -58,7 +57,7 @@ class Constants(BaseModel):
     synchrotron: SynchrotronConstant | None
 
 
-def has_constant_of_type(constants, needle_type: typing.Type[Constant]) -> bool:
+def has_constant_of_type(constants, needle_type: type[Constant]) -> bool:
     """
     lookup if constant of given type is present
 
@@ -73,7 +72,7 @@ def has_constant_of_type(constants, needle_type: typing.Type[Constant]) -> bool:
     return needle_type in constants_types
 
 
-def get_constant_by_type(constants, needle_type: typing.Type[Constant]) -> Constant:
+def get_constant_by_type(constants, needle_type: type[Constant]) -> Constant:
     """
     retrieve constant of given type, raise if not found
 


### PR DESCRIPTION
Replace typing.Optional[X] with PEP 604 X | None syntax, typing.List/Dict/Tuple with lowercase list/dict/tuple, typing.Type with lowercase type, and import pydantic with from pydantic import BaseModel.

This makes typehints consistent across the picmi and pypicongpu layers after the pydantic migration.

Fixes #5603 (@PrometheusPi is that what you meant?)