### PR TITLE
Make PML-checkpointing domain decomposition agnostic

### DIFF
--- a/include/picongpu/fields/absorber/pml/Field.hpp
+++ b/include/picongpu/fields/absorber/pml/Field.hpp
@@ -281,6 +281,15 @@ namespace picongpu
                     //! Get slab size in local grid coordinates
                     HINLINE pmacc::DataSpace<simDim> getSlabSize(uint32_t slabIdx) const;
 
+                    //! Get active slab-view begin index in local grid coordinates without guard
+                    HINLINE pmacc::DataSpace<simDim> getSlabViewBegin(uint32_t slabIdx) const;
+
+                    //! Get active slab-view end index in local grid coordinates without guard
+                    HINLINE pmacc::DataSpace<simDim> getSlabViewEnd(uint32_t slabIdx) const;
+
+                    //! Get active slab-view size in local grid coordinates
+                    HINLINE pmacc::DataSpace<simDim> getSlabViewSize(uint32_t slabIdx) const;
+
                     /** Set per-step slab view geometry for kernel access
                      *
                      * View geometry follows the PML layer exclusion logic z -> x -> y
@@ -325,10 +334,10 @@ namespace picongpu
                     //! Host-device slab buffers for field values
                     std::array<std::unique_ptr<Buffer>, numPmlLayers> slabData;
 
-                    //! Allocation/storage geometry of each slab (used by I/O)
+                    //! Allocation/storage geometry of each slab
                     std::array<SlabInfo, numPmlLayers> slabInfo;
 
-                    //! Per-step kernel view geometry with overlap exclusion
+                    //! Per-step active, kernel view slab geometry with overlap exclusion
                     std::array<SlabInfo, numPmlLayers> slabViewInfo;
 
                     //! Grid layout for normal (non-PML) fields

--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -294,6 +294,24 @@ namespace picongpu
                     return slabInfo[slabIdx].end - slabInfo[slabIdx].begin;
                 }
 
+                pmacc::DataSpace<simDim> Field::getSlabViewBegin(uint32_t const slabIdx) const
+                {
+                    PMACC_ASSERT(slabIdx < numPmlLayers);
+                    return slabViewInfo[slabIdx].begin;
+                }
+
+                pmacc::DataSpace<simDim> Field::getSlabViewEnd(uint32_t const slabIdx) const
+                {
+                    PMACC_ASSERT(slabIdx < numPmlLayers);
+                    return slabViewInfo[slabIdx].end;
+                }
+
+                pmacc::DataSpace<simDim> Field::getSlabViewSize(uint32_t const slabIdx) const
+                {
+                    PMACC_ASSERT(slabIdx < numPmlLayers);
+                    return slabViewInfo[slabIdx].end - slabViewInfo[slabIdx].begin;
+                }
+
                 void Field::setSlabViews(Thickness const& localThickness)
                 {
                     auto const gridSize = gridLayout.sizeWithoutGuardND();

--- a/include/picongpu/fields/absorber/pml/Field.tpp
+++ b/include/picongpu/fields/absorber/pml/Field.tpp
@@ -215,6 +215,7 @@ namespace picongpu
                         ++slabIdx;
                     }
 
+                    // Initialize view metadata only; local PML geometry must be applied before use.
                     setSlabViews(globalThickness);
                 }
 

--- a/include/picongpu/fields/absorber/pml/Pml.hpp
+++ b/include/picongpu/fields/absorber/pml/Pml.hpp
@@ -99,6 +99,15 @@ namespace picongpu
                             updatePsiB};
                     }
 
+                    /** Update PML slab views for the local domain
+                     *
+                     * @param currentStep index of the current time iteration
+                     */
+                    void updateSlabViews(float_X const currentStep)
+                    {
+                        applySlabViews(getLocalThickness(currentStep));
+                    }
+
                     /** Get parameters for the local domain
                      *
                      * @param currentStep index of the current time iteration
@@ -106,9 +115,7 @@ namespace picongpu
                     LocalParameters updateAndGetLocalParameters(float_X const currentStep)
                     {
                         Thickness localThickness = getLocalThickness(currentStep);
-                        checkLocalThickness(localThickness);
-                        psiE->setSlabViews(localThickness);
-                        psiB->setSlabViews(localThickness);
+                        applySlabViews(localThickness);
                         return LocalParameters(
                             parameters,
                             localThickness,
@@ -173,6 +180,14 @@ namespace picongpu
                                 localThickness(axis, direction) = 0;
                         }
                         return localThickness;
+                    }
+
+                    //! Apply validated local thickness to the PML slab views
+                    void applySlabViews(Thickness const& localThickness)
+                    {
+                        checkLocalThickness(localThickness);
+                        psiE->setSlabViews(localThickness);
+                        psiB->setSlabViews(localThickness);
                     }
 
                     //! Verify that PML fits the local domain

--- a/include/picongpu/plugins/common/openPMDVersion.def
+++ b/include/picongpu/plugins/common/openPMDVersion.def
@@ -35,7 +35,7 @@ namespace picongpu
          *
          * @attention If the version is changed please update openPMDWriter::checkIOFileVersionRestartCompatibility().
          */
-        static constexpr int picongpuIOVersionMajor = 4;
+        static constexpr int picongpuIOVersionMajor = 5;
 
         /** PIConGPU's IO minor file version.
          *
@@ -50,7 +50,7 @@ namespace picongpu
         /**
          * The oldest PIConGPU IO implementation major version readable by PIConGPU
          */
-        static constexpr int minReadableIOVersionMajor{3};
+        static constexpr int minReadableIOVersionMajor{5};
 
         static_assert(
             !(picongpuIOVersionMajor < minReadableIOVersionMajor),

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -837,8 +837,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                             auto const slabBegin = field->getSlabBegin(slabIdx);
                             auto const slabViewBegin = field->getSlabViewBegin(slabIdx);
                             auto const slabViewSize = field->getSlabViewSize(slabIdx);
-                            if(slabViewSize.productOfComponents() == 0)
-                                continue;
                             auto const slabOffset = localDomain.offset + slabViewBegin;
                             auto const slabBufferOffset = field->getGridBuffer(slabIdx).getGridLayout().guardSizeND()
                                                           + (slabViewBegin - slabBegin);

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -1145,6 +1145,17 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 }
             }
 
+            //! Update PML slab views for the current local domain geometry
+            void updatePmlSlabViewsIfEnabled(uint32_t const currentStep)
+            {
+                auto& absorber = fields::absorber::Absorber::get();
+                if(absorber.getKind() == fields::absorber::Absorber::Kind::Pml)
+                {
+                    auto& pmlImpl = fields::absorber::AbsorberImpl::getImpl(*m_cellDescription).asPmlImpl();
+                    pmlImpl.updateSlabViews(float_X(currentStep));
+                }
+            }
+
         public:
             /** constructor
              *
@@ -1338,6 +1349,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 mThreadParams.initFromConfig(*m_help, m_id, currentStep, checkpointDirectory, checkpointFilename);
 
                 mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(currentStep);
+                updatePmlSlabViewsIfEnabled(currentStep);
 
                 dumpData(currentStep);
             }
@@ -1462,12 +1474,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);
                 mThreadParams.localWindowToDomainOffset = DataSpace<simDim>::create(0);
 
-                auto& absorber = fields::absorber::Absorber::get();
-                if(absorber.getKind() == fields::absorber::Absorber::Kind::Pml)
-                {
-                    auto& pmlImpl = fields::absorber::AbsorberImpl::getImpl(*m_cellDescription).asPmlImpl();
-                    pmlImpl.updateSlabViews(float_X(restartStep));
-                }
+                updatePmlSlabViewsIfEnabled(restartStep);
 
                 /* load all fields */
                 meta::ForEach<FileCheckpointFields, LoadFields<boost::mpl::_1>> ForEachLoadFields;

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -835,9 +835,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                         for(uint32_t slabIdx = 0u; slabIdx < T_Field::getNumSlabs(); ++slabIdx)
                         {
                             auto const slabBegin = field->getSlabBegin(slabIdx);
-                            auto const slabSize = field->getSlabSize(slabIdx);
-                            auto const slabOffset = localDomain.offset + slabBegin;
-                            auto const slabBufferOffset = field->getGridBuffer(slabIdx).getGridLayout().guardSizeND();
+                            auto const slabViewBegin = field->getSlabViewBegin(slabIdx);
+                            auto const slabViewSize = field->getSlabViewSize(slabIdx);
+                            if(slabViewSize.productOfComponents() == 0)
+                                continue;
+                            auto const slabOffset = localDomain.offset + slabViewBegin;
+                            auto const slabBufferOffset = field->getGridBuffer(slabIdx).getGridLayout().guardSizeND()
+                                                          + (slabViewBegin - slabBegin);
                             openPMDWriter::writeField<ComponentType>(
                                 params,
                                 currentStep,
@@ -851,7 +855,7 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                                 isDomainBound,
                                 true,
                                 slabOffset,
-                                slabSize,
+                                slabViewSize,
                                 globalDomain.size,
                                 slabBufferOffset);
                         }

--- a/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.x.cpp
@@ -29,6 +29,7 @@
 #    include "picongpu/fields/FieldJ.hpp"
 #    include "picongpu/fields/FieldTmp.hpp"
 #    include "picongpu/fields/absorber/pml/Field.hpp"
+#    include "picongpu/fields/absorber/pml/Pml.hpp"
 #    include "picongpu/particles/filter/filter.hpp"
 #    include "picongpu/particles/particleToGrid/CombinedDerive.hpp"
 #    include "picongpu/particles/particleToGrid/ComputeFieldValue.hpp"
@@ -1460,6 +1461,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 /* set window for restart, complete global domain */
                 mThreadParams.window = MovingWindow::getInstance().getDomainAsWindow(restartStep);
                 mThreadParams.localWindowToDomainOffset = DataSpace<simDim>::create(0);
+
+                auto& absorber = fields::absorber::Absorber::get();
+                if(absorber.getKind() == fields::absorber::Absorber::Kind::Pml)
+                {
+                    auto& pmlImpl = fields::absorber::AbsorberImpl::getImpl(*m_cellDescription).asPmlImpl();
+                    pmlImpl.updateSlabViews(float_X(restartStep));
+                }
 
                 /* load all fields */
                 meta::ForEach<FileCheckpointFields, LoadFields<boost::mpl::_1>> ForEachLoadFields;

--- a/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
+++ b/include/picongpu/plugins/openPMD/restart/RestartFieldLoader.hpp
@@ -66,7 +66,8 @@ namespace picongpu
                 uint32_t const currentStep,
                 bool const isDomainBound,
                 std::optional<DataSpace<simDim>> const& domainOffset = std::nullopt,
-                std::optional<DataSpace<simDim>> const& localDomainSize = std::nullopt)
+                std::optional<DataSpace<simDim>> const& localDomainSize = std::nullopt,
+                std::optional<DataSpace<simDim>> const& destinationBufferOffset = std::nullopt)
             {
                 log<picLog::INPUT_OUTPUT>("Begin loading field '%1%'") % objectName;
 
@@ -81,10 +82,12 @@ namespace picongpu
                 ::pmacc::math::Vector<uint64_t, simDim> domain_offset = localDomain.offset;
                 DataSpace<simDim> local_domain_size = params->window.localDimensions.size;
                 bool const useCustomReadLayout = domainOffset.has_value() && localDomainSize.has_value();
+                DataSpace<simDim> destination_buffer_offset = field_guard;
                 if(useCustomReadLayout)
                 {
                     domain_offset = *domainOffset;
                     local_domain_size = *localDomainSize;
+                    destination_buffer_offset = destinationBufferOffset.value_or(field_guard);
                 }
 
                 auto const numDataPoints = local_domain_size.productOfComponents();
@@ -100,8 +103,6 @@ namespace picongpu
                     }
                     return;
                 }
-
-                bool useLinearIdxAsDestination = false;
 
                 ::openPMD::Series& series = *params->openPMDSeries;
                 ::openPMD::Mesh& mesh = series.iterations[currentStep].open().meshes[objectName];
@@ -145,13 +146,10 @@ namespace picongpu
                     for(int linearId = 0; linearId < numDataPoints; ++linearId)
                     {
                         DataSpace<simDim> destIdx;
-                        if(useLinearIdxAsDestination)
-                        {
-                            destIdx[0] = linearId;
-                        }
-                        else if(useCustomReadLayout)
+                        if(useCustomReadLayout)
                         {
                             destIdx = pmacc::math::mapToND(local_domain_size, linearId);
+                            destIdx += destination_buffer_offset;
                         }
                         else
                         {
@@ -242,7 +240,11 @@ namespace picongpu
                     {
                         auto const slabName = getPmlSlabName(T_Field::getName(), slabIdx);
                         auto const slabBegin = field->getSlabBegin(slabIdx);
-                        auto const slabSize = field->getSlabSize(slabIdx);
+                        auto const slabViewBegin = field->getSlabViewBegin(slabIdx);
+                        auto const slabViewSize = field->getSlabViewSize(slabIdx);
+                        auto const destinationBufferOffset
+                            = field->getGridBuffer(slabIdx).getGridLayout().guardSizeND()
+                              + (slabViewBegin - slabBegin);
                         auto& slabBuffer = field->getGridBuffer(slabIdx);
                         RestartFieldLoader::loadField(
                             slabBuffer,
@@ -251,8 +253,9 @@ namespace picongpu
                             tp,
                             restartStep,
                             isDomainBound,
-                            localDomain.offset + slabBegin,
-                            slabSize);
+                            localDomain.offset + slabViewBegin,
+                            slabViewSize,
+                            destinationBufferOffset);
                     }
                 }
                 else


### PR DESCRIPTION
This PR updates the checkpoint writing and reading of the PMLs. Instead of the initially allocated memory, only the actually used memory now is being written to and read from the checkpoints. This became necessary, because the allocated PML memory structure depends on the domain decomposition, whereas the actually used PMLs does not depend on it. @franzpoeschel  This PR thus facilitates reading from a checkpoint in a different domain decomposition compared to the one it was written originally.
Also, the PR removes a bit of dead code from the first PML checkpointing implementation using linear arrays and prevents for all openPMD backends that a PML related dataset is written if it is empty.