### PR TITLE
JUPITER MPI fixes

### DIFF
--- a/etc/picongpu/jupiter-jsc/gh200.tpl
+++ b/etc/picongpu/jupiter-jsc/gh200.tpl
@@ -44,6 +44,10 @@
 # https://apps.fz-juelich.de/jsc/hps/jureca/faq.html#my-job-failed-with-transport-retry-count-exceeded
 export UCX_RC_TIMEOUT=3000000.00us # 3s instead of 1s
 
+# Workaround for UCX Memory pool allocation failures
+# See PIConGPU issuse #5702 and #5706
+export UCX_MEMTYPE_CACHE=n
+
 ## calculations will be performed by tbg ##
 .TBG_queue="booster"
 

--- a/etc/picongpu/jupiter-jsc/gh200.tpl
+++ b/etc/picongpu/jupiter-jsc/gh200.tpl
@@ -102,4 +102,4 @@ ln -s ../stdout output
 
 # Run PIConGPU
 # Workaround threads-per-core. See https://apps.fz-juelich.de/jsc/hps/jureca/affinity.html
-srun --threads-per-core=1 $TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
+srun --threads-per-core=1 $TBG_dstPath/input/bin/picongpu --mpiDirect !TBG_author !TBG_programParams


### PR DESCRIPTION
Enables MPI Direct, which was observed to give a 13% speedup in a mini example (unrelated to the UCX OOM issue)

Attempts to fix - #5706 by setting a UCX flag which disables memory pool cache allocations for CUDA aware MPI 
