### PR TITLE
Unify getDevice/getNode into getResource

### DIFF
--- a/bin/getDevice
+++ b/bin/getDevice
@@ -19,7 +19,4 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Source the user's PIConGPU profile to obtain getResource.
-. "${PIC_PROFILE:-~/picongpu.profile}"
-
 getResource -d "$@"

--- a/bin/getDevice
+++ b/bin/getDevice
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2024 Axel Huebl, Rene Widera, Richard Pausch
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR ANY PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Source the user's PIConGPU profile to obtain getResource.
+. "${PIC_PROFILE:-~/picongpu.profile}"
+
+getResource -d "$@"

--- a/bin/getNode
+++ b/bin/getNode
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2013-2024 Axel Huebl, Rene Widera, Richard Pausch
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR ANY PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Source the user's PIConGPU profile to obtain getResource.
+. "${PIC_PROFILE:-~/picongpu.profile}"
+
+getResource -n "$@"

--- a/bin/getNode
+++ b/bin/getNode
@@ -19,7 +19,4 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Source the user's PIConGPU profile to obtain getResource.
-. "${PIC_PROFILE:-~/picongpu.profile}"
-
 getResource -n "$@"

--- a/docs/source/install/profile.rst
+++ b/docs/source/install/profile.rst
@@ -71,8 +71,18 @@ Hemera (HZDR)
 
 Profile for HZDR's home cluster hemera.
 Sets up software environment, i.e. providing libraries to satisfy PIConGPU's dependencies, by loading modules,
-setting common paths and options, as well as defining the ``getDevice()`` and ``getNode()`` aliases.
-The latter are shorthands to request resources for an interactive session from the batch system.
+setting common paths and options, and defining the ``getResource()`` function for requesting
+interactive sessions from the batch system.
+
+The ``getResource()`` function accepts two modes:
+
+* ``getResource -n [num] [command ...]`` — allocate **num** full nodes (default: 1), optionally running ``command``.
+* ``getResource -d [num] [command ...]`` — allocate **num** GPUs on a single node (default: 1), optionally running ``command``.
+
+Without a trailing ``command``, an interactive shell on a compute node is started.
+With a trailing ``command`` (e.g. ``getResource -d 1 pic-build``), the command is run inside the allocation.
+
+For backwards compatibility, ``getNode()`` and ``getDevice()`` are retained as aliases forwarding to ``getResource``.
 Together with the `-s bash` option of :ref:`TBG <usage-tbg>`, these allow to run PIConGPU interactively on an HPC system.
 
 

--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -63,32 +63,48 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/aris-grnet/gpu.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    srun --time=0:30:00 --nodes=$numNodes --ntasks-per-socket=8 --ntasks-per-node=16 --mem=252000 --gres=gpu:4 -A $proj -p dvd_usr_prod --pty bash
-}
+# allocate resources for an interactive session
+#   getResource -n 2            # allocate 2 full nodes (30 min)
+#   getResource -d 2            # allocate 2 GPUs on a single node (1 hr)
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="-A $proj -p dvd_usr_prod"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        srunArgs="--time=0:30:00 --nodes=$count --ntasks-per-socket=8 --ntasks-per-node=16 --mem=252000 --gres=gpu:4 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--time=1:00:00 --ntasks-per-node=$count --cpus-per-task=$((4 * count)) --gres=gpu:$count --mem=$((63000 * count)) $slurm_common"
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=$((4 * $numGPUs)) --gres=gpu:$numGPUs --mem=$((63000 * numGPUs)) -A $proj -p dvd_usr_prod --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
+++ b/etc/picongpu/aris-grnet/gpu_picongpu.profile.example
@@ -69,17 +69,30 @@ export TBG_TPLFILE="etc/picongpu/aris-grnet/gpu.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -104,7 +117,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
+++ b/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
@@ -128,32 +128,48 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/delta-ncsa/gpuA100x4.tpl"
 export TBG_partition="gpuA100x4"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=16 --gres=gpu:4 --mem=240000 -p $TBG_partition -A $proj --pty bash
-}
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive device for one hour to execute a mpi parallel application
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 --cpus-per-task=16 -p $TBG_partition -A $proj"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 --mem=240000 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--nodes=1 --ntasks-per-node=$count --gres=gpu:$count --mem=$((60000 * count)) $slurm_common"
     fi
-    srun --time=1:00:00 --nodes=1 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gres=gpu:$numGPUs --mem=$((60000 * $numGPUs)) -p $TBG_partition -A $proj --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
+++ b/etc/picongpu/delta-ncsa/gpuA100x4_picongpu.profile.example
@@ -134,17 +134,30 @@ export TBG_partition="gpuA100x4"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -169,7 +182,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
+++ b/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
@@ -51,34 +51,52 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/normal-a100.tpl"
 
-# allocate an interactive shell for 30 minutes
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
-    else
-        if [ "$1" -gt 4 ] ; then
-            echo "The maximal number of devices per node is 4." 1>&2
-            return 1
-        else
-            numGPUs=$1
-        fi
-    fi
-    srun  --time=00:30:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gpus=$numGPUs --mem=$((121000 * numGPUs)) -p dev-a100-40 -A $account --pty bash
-}
+# allocate resources for an interactive session
+#   getResource -n 1            # allocate 1 full node (4 hr)
+#   getResource -d 2            # allocate 2 GPUs on a single node (30 min)
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for 240 minutes
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 1 ] ; then
-        echo "The maximal number of interactive nodes is 1." 1>&2
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    srun --time=04:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=32 --gpus=4 --mem=484G --hint=nomultithread -p dev-a100-40 -A $account --pty bash
+
+    local slurm_common="--cpus-per-task=32 -p dev-a100-40 -A $account"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 1 ]; then
+            echo "The maximal number of interactive nodes is 1." 1>&2
+            return 1
+        fi
+        srunArgs="--time=04:00:00 --nodes=$count --ntasks-per-node=4 --gpus=4 --mem=484G --hint=nomultithread $slurm_common"
+    else
+        if [ "$count" -gt 4 ]; then
+            echo "The maximal number of devices per node is 4." 1>&2
+            return 1
+        fi
+        srunArgs="--time=00:30:00 --ntasks-per-node=$count --gpus=$count --mem=$((121000 * count)) $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
+++ b/etc/picongpu/deucalion-macc/normal-a100-40_picongpu.profile.example
@@ -57,17 +57,30 @@ export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/normal-a100.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -96,7 +109,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
+++ b/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
@@ -78,35 +78,52 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/common.tpl"
 export disco_partition="common"
 
-# allocate an interactive shell for 30 minutes
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
-    else
-        if [ "$1" -gt 8 ] ; then
-            echo "The maximal number of devices per node is 8." 1>&2
-            return 1
-        else
-            numGPUs=$1
-        fi
-    fi
-    srun  --time=00:30:00 --ntasks-per-node=$numGPUs --cpus-per-task=13 --gres=gpu:$numGPUs \
-        --mem=$((245000 * numGPUs)) --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos --pty bash
-}
+# allocate resources for an interactive session (30 min)
+#   getResource -n 1            # allocate 1 full node
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 1 ] ; then
-        echo "There are only 2 nodes! Leave some to others." 1>&2
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    srun --time=00:30:00 --nodes=$numNodes --ntasks-per-node=8 --cpus-per-task=13 --gres=gpu:$((8 * numNodes)) \
-    --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos --pty bash
+
+    local slurm_common="--time=00:30:00 --cpus-per-task=13 --hint=nomultithread -p ${disco_partition} --account=$account --qos=$qos"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 1 ]; then
+            echo "There are only 2 nodes! Leave some to others." 1>&2
+            return 1
+        fi
+        srunArgs="--nodes=$count --ntasks-per-node=8 --gres=gpu:$((8 * count)) $slurm_common"
+    else
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        fi
+        srunArgs="--ntasks-per-node=$count --gres=gpu:$count --mem=$((245000 * count)) $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
+++ b/etc/picongpu/discoverer-eurohpc/common_picongpu.profile.example
@@ -84,17 +84,30 @@ export disco_partition="common"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -123,7 +136,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/eli-np/gpu_v100_picongpu.profile.example
+++ b/etc/picongpu/eli-np/gpu_v100_picongpu.profile.example
@@ -45,17 +45,50 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/eli-np/gpu_v100.tpl"
 export TBG_partition="gpu"
 
-# allocate an interactive shell for two hours
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
+# allocate resources for an interactive session (default: 2 hours)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 4            # allocate 4 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
     fi
+
+    local slurm_common="--time=2:00:00 --cpus-per-task=3 --exclusive -p $TBG_partition -A ${USER}_a+"
+    local srunArgs
     export OMP_NUM_THREADS=3
-    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((16 * $numNodes)) --ntasks-per-node=16 --cpus-per-task=3 --exclusive --gpus-per-node=16 -p $TBG_partition -A ${USER}_a+ --pty bash
+
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks=$((16 * count)) --ntasks-per-node=16 --gpus-per-node=16 $slurm_common"
+    else
+        if [ "$count" -gt 16 ]; then
+            echo "The maximal number of devices per node is 16." 1>&2
+            return 1
+        fi
+        srunArgs="--nodes=1 --ntasks=$count --ntasks-per-node=$count --gpus-per-task=1 $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/eli-np/gpu_v100_picongpu.profile.example
+++ b/etc/picongpu/eli-np/gpu_v100_picongpu.profile.example
@@ -51,17 +51,30 @@ export TBG_partition="gpu"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -88,7 +101,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -104,17 +104,30 @@ export TBG_TPLFILE="etc/picongpu/frontier-ornl/batch.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -140,7 +153,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
+++ b/etc/picongpu/frontier-ornl/batch_picongpu.profile.example
@@ -98,32 +98,49 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/frontier-ornl/batch.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks=$((numNodes * 8)) --gres=gpu:$((numNodes * 8)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug --pty bash
-}
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug"
+    local srunArgs
+
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks=$((count * 8)) --gres=gpu:$((count * 8)) $slurm_common"
     else
-        if [ "$1" -gt 8 ] ; then
+        if [ "$count" -gt 8 ]; then
             echo "The maximal number of devices per node is 8." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--nodes=1 --ntasks=$count --gres=gpu:$count $slurm_common"
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks=$(($numGPUs)) --gres=gpu:$(($numGPUs)) --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -A $PROJID -q debug --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -61,32 +61,48 @@ export TBG_TPLFILE="etc/picongpu/hemera-hzdr/defq.tpl"
 # use defq for regular queue and defq_low for low priority queue
 export TBG_partition="defq"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    srun --time=1:00:00 --nodes=$numNodes --ntasks-per-node=2 --cpus-per-task=20  --mem=360000 -p defq --pty bash
-}
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 CPU sockets on a single node
+#   getResource -d 1 pic-build  # allocate 1 CPU socket, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 -p defq"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks-per-node=2 --cpus-per-task=20 --mem=360000 $slurm_common"
     else
-        if [ "$1" -gt 2 ] ; then
+        if [ "$count" -gt 2 ]; then
             echo "The maximal number of devices per node is 2." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        srunArgs="--ntasks-per-node=$count --cpus-per-task=$((20 * count)) --mem=$((180000 * count)) $slurm_common"
     fi
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=$((20 * $numDevices)) --mem=$((180000 * numDevices)) -p defq --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/defq_picongpu.profile.example
@@ -67,17 +67,30 @@ export TBG_partition="defq"
 #   getResource -d 1 pic-build  # allocate 1 CPU socket, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -102,7 +115,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -64,32 +64,48 @@ export TBG_TPLFILE="etc/picongpu/hemera-hzdr/fwkt_v100.tpl"
 # use fwkt_v100 for regular queue and casus_low for low priority queue
 export TBG_partition="fwkt_v100"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=378000 -p $TBG_partition -A $TBG_partition --pty bash
-}
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 --cpus-per-task=6 -p $TBG_partition -A $TBG_partition"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 --mem=378000 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--ntasks-per-node=$count --gres=gpu:$count --mem=$((94500 * count)) $slurm_common"
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition -A $TBG_partition --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/fwkt_v100_picongpu.profile.example
@@ -70,17 +70,30 @@ export TBG_partition="fwkt_v100"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -105,7 +118,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -69,17 +69,30 @@ export TBG_partition="gpu"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -104,7 +117,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
+++ b/etc/picongpu/hemera-hzdr/gpu_picongpu.profile.example
@@ -63,32 +63,48 @@ export TBG_TPLFILE="etc/picongpu/hemera-hzdr/gpu.tpl"
 # use gpu for regular queue and gpu_low for low priority queue
 export TBG_partition="gpu"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=378000 -p gpu --pty bash
-}
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 --cpus-per-task=6 -p gpu"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 --mem=378000 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--ntasks-per-node=$count --gres=gpu:$count --mem=$((94500 * count)) $slurm_common"
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p gpu --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -69,6 +69,7 @@ export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
 
 export PATH=$OPENPMD_ROOT/bin:$PATH
+export PATH=$ADIOS2_ROOT/bin:$PATH
 
 # Environment #################################################################
 
@@ -96,17 +97,30 @@ export TBG_TPLFILE="etc/picongpu/jupiter-jsc/gh200.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -136,7 +150,6 @@ function getResource() {
         salloc $sallocArgs
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -69,7 +69,6 @@ export CMAKE_PREFIX_PATH=$ADIOS2_ROOT:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=$OPENPMD_ROOT:$CMAKE_PREFIX_PATH
 
 export PATH=$OPENPMD_ROOT/bin:$PATH
-export PATH=$ADIOS2_ROOT/bin:$PATH
 
 # Environment #################################################################
 
@@ -91,38 +90,53 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/jupiter-jsc/gh200.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=72 --gres=gpu:4 --mem=$((117760 * 4)) -A $account -p booster bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    local slurm_common="--time=1:00:00 --mem=115G -A $account -p booster"
+    local sallocArgs
+
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of interactive nodes is 8." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count --gres=gpu:$count $slurm_common"
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=72 --gres=gpu:$(($numDevices)) --mem=$((117760 * numGPUs)) -A $account -p booster --pty bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -70,40 +70,55 @@ export CXX=$(which icpc)
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/jureca-jsc/batch.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 CPU sockets on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
+
+    local slurm_common="--time=1:00:00 --mem=126000 -A $proj -p devel"
+    local sallocArgs
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=24
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=2 --mem=126000 -A $proj -p devel bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of interactive nodes is 8." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=2 $slurm_common"
     else
-        if [ "$1" -gt 2 ] ; then
+        if [ "$count" -gt 2 ]; then
             echo "The maximal number of devices per node is 2." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count $slurm_common"
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    export OMP_NUM_THREADS=24
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=126000 -A $proj -p devel bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/batch_picongpu.profile.example
@@ -76,17 +76,30 @@ export TBG_TPLFILE="etc/picongpu/jureca-jsc/batch.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -118,7 +131,6 @@ function getResource() {
         salloc $sallocArgs
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -77,17 +77,30 @@ export TBG_TPLFILE="etc/picongpu/jureca-jsc/booster.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -118,7 +131,6 @@ function getResource() {
         salloc $sallocArgs
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/booster_picongpu.profile.example
@@ -71,38 +71,54 @@ export CXX=$(which icpc)
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/jureca-jsc/booster.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 CPUs on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    export OMP_NUM_THREADS=34
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --mem=94000 -A $proj -p develbooster bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    local slurm_common="--time=1:00:00 --mem=94000 -A $proj -p develbooster"
+    local sallocArgs
+    export OMP_NUM_THREADS=34
+
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of interactive nodes is 8." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=4 $slurm_common"
     else
-        if [ "$1" -gt 1 ] ; then
+        if [ "$count" -gt 1 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count $slurm_common"
     fi
-    export OMP_NUM_THREADS=34
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $proj -p develbooster bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -93,17 +93,30 @@ export TBG_TPLFILE="etc/picongpu/jureca-jsc/gpus.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -135,6 +148,16 @@ function getResource() {
     fi
 }
 
+# Backward-compatible wrapper functions
+# allocate an interactive shell for one full node (default: 1)
+function getNode() {
+    getResource -n "$@"
+}
+
+# allocate an interactive shell for one GPU device (default: 1)
+function getDevice() {
+    getResource -d "$@"
+}
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -87,38 +87,54 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/jureca-jsc/gpus.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=488G -A $account -p dc-gpu bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    local slurm_common="--time=1:00:00 --mem=488G -A $account -p dc-gpu"
+    local sallocArgs
+    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
+
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of interactive nodes is 8." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count --gres=gpu:$count $slurm_common"
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:$(($numDevices)) --mem=488G -A $account -p dc-gpu --pty bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/jureca-jsc/gpus_picongpu.profile.example
@@ -148,17 +148,6 @@ function getResource() {
     fi
 }
 
-# Backward-compatible wrapper functions
-# allocate an interactive shell for one full node (default: 1)
-function getNode() {
-    getResource -n "$@"
-}
-
-# allocate an interactive shell for one GPU device (default: 1)
-function getDevice() {
-    getResource -d "$@"
-}
-
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
 if [ -f $BASH_COMP_FILE ] ; then

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -86,17 +86,30 @@ export TBG_TPLFILE="etc/picongpu/juwels-jsc/batch.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -128,7 +141,6 @@ function getResource() {
         salloc $sallocArgs
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/batch_picongpu.profile.example
@@ -80,40 +80,55 @@ export CXX=$(which icpc)
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/juwels-jsc/batch.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 CPU sockets on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
+
+    local slurm_common="--time=1:00:00 --mem=94000 -A $account -p batch"
+    local sallocArgs
     echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
     export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=2 --mem=94000 -A $account -p batch bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of interactive nodes is 8." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=2 $slurm_common"
     else
-        if [ "$1" -gt 2 ] ; then
+        if [ "$count" -gt 2 ]; then
             echo "The maximal number of devices per node is 2." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count $slurm_common"
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    export OMP_NUM_THREADS=48
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --mem=94000 -A $account -p batch bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -92,17 +92,30 @@ export TBG_TPLFILE="etc/picongpu/juwels-jsc/booster.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -133,7 +146,6 @@ function getResource() {
         salloc $sallocArgs
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/booster_picongpu.profile.example
@@ -86,37 +86,54 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/juwels-jsc/booster.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 4 ] ; then
-        echo "The maximal number of interactive nodes is 4." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=12 --gres=gpu:4 --mem=488G -A $account -p develbooster bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    local slurm_common="--time=1:00:00 --cpus-per-task=12 -A $account -p develbooster"
+    local sallocArgs
+    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
+
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 4 ]; then
+            echo "The maximal number of interactive nodes is 4." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 --mem=488G $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count --gres=gpu:$count --mem-per-cpu=10G $slurm_common"
     fi
-    srun --time=1:00:00 --ntasks-per-node=$(($numDevices)) --cpus-per-task=12 --gres=gpu:$(($numDevices)) --mem-per-cpu=10G -A $account -p develbooster --pty bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -87,17 +87,30 @@ export TBG_TPLFILE="etc/picongpu/juwels-jsc/gpus.tpl"
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -128,7 +141,6 @@ function getResource() {
         salloc $sallocArgs
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
+++ b/etc/picongpu/juwels-jsc/gpus_picongpu.profile.example
@@ -81,38 +81,54 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/juwels-jsc/gpus.tpl"
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 8 ] ; then
-        echo "The maximal number of interactive nodes is 8." 1>&2
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --gres=gpu:4 --mem=180000 -A $account -p gpus bash
-}
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates 2 interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    local slurm_common="--time=1:00:00 --mem=180000 -A $account -p gpus"
+    local sallocArgs
+    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
+
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of interactive nodes is 8." 1>&2
+            return 1
+        fi
+        sallocArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        sallocArgs="--ntasks-per-node=$count --gres=gpu:$count $slurm_common"
     fi
-    echo "Hint: please use 'srun --cpu_bind=sockets <COMMAND>' for launching multiple processes in the interactive mode"
-    salloc --time=1:00:00 --ntasks-per-node=$(($numDevices)) --gres=gpu:4 --mem=180000 -A $account -p gpus bash
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
+++ b/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
@@ -61,17 +61,30 @@ export TBG_partition="qgpu"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -98,7 +111,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
+++ b/etc/picongpu/karolina-it4i/gpu_a100_picongpu.profile.example
@@ -55,17 +55,50 @@ export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/karolina-it4i/gpu_a100.tpl"
 export TBG_partition="qgpu"
 
-# allocate an interactive shell for two hours
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
+# allocate resources for an interactive session (default: 2 hours)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 4            # allocate 4 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
     fi
+
+    local slurm_common="--time=2:00:00 --exclusive -p $TBG_partition -A $proj"
+    local srunArgs
     export OMP_NUM_THREADS=16
-    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((8 * $numNodes)) --ntasks-per-node=8 --cpus-per-task=1 --exclusive --gpus-per-node=8 -p $TBG_partition -A $proj --pty bash
+
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks=$((8 * count)) --ntasks-per-node=8 --cpus-per-task=1 --gpus-per-node=8 $slurm_common"
+    else
+        if [ "$count" -gt 8 ]; then
+            echo "The maximal number of devices per node is 8." 1>&2
+            return 1
+        fi
+        srunArgs="--nodes=1 --ntasks=$count --ntasks-per-node=$count --cpus-per-task=1 --gpus-per-task=1 $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
+++ b/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
@@ -63,33 +63,53 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/boost_usr_prod.tpl"
 
-# allocate an interactive shell for 30 minutes
-function getDevice(){
-    if [ -z "$1" ] ; then
-        numGPUs=1
-    else
-        if [ "$1" -gt 4 ] ; then
-            echo "The maximal number of devices per node is 4." 1>&2
-            return 1
-        else
-            numGPUs=$1
-        fi
-    fi
-    srun --time=00:30:00 --nodes=1 --ntasks=$numGPUs --cpus-per-task=8 --mem=$((128000 * numGPUs)) --hint=nomultithread --gres=gpu:$numGPUs -A $account -p boost_usr_prod -q boost_qos_dbg --pty bash
-}
+# allocate resources for an interactive session (30 min)
+#   getResource -n 1            # allocate 1 full node
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 2 ] ; then
-        echo "The maximal number of interactive nodes in qos=boost_qos_dbg is 2." 1>&2
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    srun --time=00:30:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=8 --hint=nomultithread --gres=gpu:4 -A $account -p boost_usr_prod -q boost_qos_dbg --pty bash
+
+    local slurm_common="--time=00:30:00 --cpus-per-task=8 --hint=nomultithread -A $account -p boost_usr_prod -q boost_qos_dbg"
+    local srunArgs
+
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 2 ]; then
+            echo "The maximal number of interactive nodes in qos=boost_qos_dbg is 2." 1>&2
+            return 1
+        fi
+        srunArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 $slurm_common"
+    else
+        if [ "$count" -gt 4 ]; then
+            echo "The maximal number of devices per node is 4." 1>&2
+            return 1
+        fi
+        srunArgs="--nodes=1 --ntasks=$count --mem=$((128000 * count)) --gres=gpu:$count $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
+++ b/etc/picongpu/leonardo-cineca/boost_usr_prod_picongpu.profile.example
@@ -69,17 +69,30 @@ export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/boost_usr_prod.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -109,7 +122,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -92,21 +92,49 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/lumi-eurohpc/standard-g.tpl"
 
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 --cpus-per-task=7 --gpus-per-task=1 --mem-per-gpu=64000 -p dev-g -A $PROJID"
+    local srunArgs
+
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks=$((count * 8)) $slurm_common"
     else
-        if [ "$1" -gt 8 ] ; then
+        if [ "$count" -gt 8 ]; then
             echo "The maximal number of devices per node is 8." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--nodes=1 --ntasks=${count} $slurm_common"
     fi
-    srun  --time=1:00:00 --nodes=1 --ntasks=${numGPUs} --cpus-per-task=7 --gpus-per-task=1 --mem-per-gpu=64000 -p dev-g -A $PROJID --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
+++ b/etc/picongpu/lumi-eurohpc/lumi-G_hipcc_picongpu.profile.example
@@ -98,17 +98,30 @@ export TBG_TPLFILE="etc/picongpu/lumi-eurohpc/standard-g.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -134,7 +147,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/meluxina-lxp/gpu_picongpu.profile.example
+++ b/etc/picongpu/meluxina-lxp/gpu_picongpu.profile.example
@@ -70,17 +70,30 @@ export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/gpu.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -109,7 +122,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/meluxina-lxp/gpu_picongpu.profile.example
+++ b/etc/picongpu/meluxina-lxp/gpu_picongpu.profile.example
@@ -64,19 +64,52 @@ export PATH=$PICSRC/src/tools/bin:$PATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/gpu.tpl"
 
-# allocate an interactive shell for 30 minutes
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 1 ] ; then
-        echo "The maximal number of interactive nodes in qos=test is 1." 1>&2
+# allocate resources for an interactive session (30 min)
+#   getResource -n 1            # allocate 1 full node
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    srun --time=00:30:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=8 --mem=240G --hint=nomultithread -A $account -p gpu -q test --pty bash
+
+    local slurm_common="--time=00:30:00 --cpus-per-task=8 --mem=240G --hint=nomultithread -A $account -p gpu -q test"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 1 ]; then
+            echo "The maximal number of interactive nodes in qos=test is 1." 1>&2
+            return 1
+        fi
+        srunArgs="--nodes=$count --ntasks-per-node=4 $slurm_common"
+    else
+        if [ "$count" -gt 4 ]; then
+            echo "The maximal number of devices per node is 4." 1>&2
+            return 1
+        fi
+        srunArgs="--ntasks-per-node=$count --gres=gpu:$count $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/perlmutter-nersc/gpu.profile.example
+++ b/etc/picongpu/perlmutter-nersc/gpu.profile.example
@@ -92,17 +92,30 @@ export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/perlmu
 #   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -128,12 +141,6 @@ function getResource() {
     else
         salloc $sallocArgs
     fi
-}
-
-
-# allocate an interactive shell for compilation (without gpus)
-function getShell() {
-    srun --time=1:00:00 --nodes=1 --ntasks 1 --cpus-per-task=32 -A $proj -C cpu --pty bash
 }
 
 # Load autocompletion for PIConGPU commands

--- a/etc/picongpu/perlmutter-nersc/gpu.profile.example
+++ b/etc/picongpu/perlmutter-nersc/gpu.profile.example
@@ -86,34 +86,50 @@ export PATH=$PATH:$PICSRC/src/tools/bin
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/perlmutter-nersc/gpu.tpl"
 export PIC_SYSTEM_TEMPLATE_PATH=${PIC_SYSTEM_TEMPLATE_PATH:-"etc/picongpu/perlmutter-nersc"}
-# allocate an interactive node for one hour to execute a mpi parallel application
-#   getNode 2  # allocates two interactive A100 GPUs (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
-    salloc --time=1:00:00 --nodes=$numNodes --ntasks-per-node 4 --gpus 4 --cpus-per-task=32 -A $proj -C gpu -q interactive
-}
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate resources, run pic-build in allocation
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive device for one hour to execute a mpi parallel application
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=1:00:00 -A ${proj} -C gpu"
+    local sallocArgs
+    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
+
+    if [ "$mode" = "node" ]; then
+        sallocArgs="--nodes=$count --ntasks-per-node 4 --gpus 4 --cpus-per-task=32 -q interactive $slurm_common"
     else
-        if [ "$1" -gt 8 ] ; then
+        if [ "$count" -gt 8 ]; then
             echo "The maximal number of devices per node is 8." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        sallocArgs="--ntasks-per-node=$count --cpus-per-task=16 --gpus=$count $slurm_common"
     fi
-    echo "Hint: please use 'srun --cpu_bind=cores <COMMAND>' for launching multiple processes in the interactive mode."
-    salloc --time=1:00:00 --ntasks-per-node=$numGPUs --cpus-per-task=16 --gpus=$numGPUs -A ${proj} -C gpu
+
+    if [ $# -gt 0 ]; then
+        salloc $sallocArgs "$@"
+    else
+        salloc $sallocArgs
+    fi
 }
+
 
 # allocate an interactive shell for compilation (without gpus)
 function getShell() {

--- a/etc/picongpu/perlmutter-nersc/gpu.profile.example
+++ b/etc/picongpu/perlmutter-nersc/gpu.profile.example
@@ -143,6 +143,12 @@ function getResource() {
     fi
 }
 
+
+# allocate an interactive shell for compilation (without gpus)
+function getShell() {
+    srun --time=1:00:00 --nodes=1 --ntasks 1 --cpus-per-task=32 -A $proj -C cpu --pty bash
+}
+
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash
 if [ -f $BASH_COMP_FILE ] ; then

--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -129,17 +129,30 @@ export TBG_partition="gpu-v100"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -164,7 +177,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -123,33 +123,48 @@ export TBG_TPLFILE="etc/picongpu/rosi-hzdr/gpu-v100.tpl"
 export TBG_partition="gpu-v100"
 
 
-# allocate an interactive shell for one hour
-#   getNode 2  # allocates two interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
+# allocate resources for an interactive session (default: 1 hour)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
     fi
-    srun  --time=1:00:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=6 --gres=gpu:4 --mem=378000 -p $TBG_partition  --pty bash
-}
 
-
-# allocate an interactive shell for one hour
-#   getDevice 2  # allocates two interactive devices (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
+    local slurm_common="--time=1:00:00 --cpus-per-task=6 -p $TBG_partition"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks-per-node=4 --gres=gpu:4 --mem=378000 $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numGPUs=$1
         fi
+        srunArgs="--ntasks-per-node=$count --gres=gpu:$count --mem=$((94500 * count)) $slurm_common"
     fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=6 --gres=gpu:$numGPUs --mem=$((94500 * numGPUs)) -p $TBG_partition --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/vega-izum/gpu_picongpu.profile.example
+++ b/etc/picongpu/vega-izum/gpu_picongpu.profile.example
@@ -43,33 +43,52 @@ export PYTHONPATH=$PICSRC/lib/python:$PYTHONPATH
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/gpu.tpl"
 
-# allocate an interactive shell for 30 minutes
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numGPUs=1
-    else
-        if [ "$1" -gt 4 ] ; then
-            echo "The maximal number of devices per node is 4." 1>&2
-            return 1
-        else
-            numGPUs=$1
-        fi
-    fi
-    srun  --time=1:00:00 --ntasks-per-node=$(($numGPUs)) --cpus-per-task=32 --gres=gpu:$numGPUs --mem=$((12500 * numGPUs)) -p gpu  --pty bash
-}
+# allocate resources for an interactive session
+#   getResource -n 1            # allocate 1 full node (30 min)
+#   getResource -d 2            # allocate 2 GPUs on a single node (60 min)
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    if [ $numNodes -gt 1 ] ; then
-        echo "The maximal number of interactive nodes in qos=test is 1." 1>&2
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
         return 1
     fi
-    srun --time=00:30:00 --nodes=$numNodes --ntasks-per-node=4 --cpus-per-task=32 --hint=nomultithread -p gpu --pty bash
+
+    local slurm_common="--cpus-per-task=32 -p gpu"
+    local srunArgs
+    if [ "$mode" = "node" ]; then
+        if [ "$count" -gt 1 ]; then
+            echo "The maximal number of interactive nodes in qos=test is 1." 1>&2
+            return 1
+        fi
+        srunArgs="--time=00:30:00 --nodes=$count --ntasks-per-node=4 --hint=nomultithread $slurm_common"
+    else
+        if [ "$count" -gt 4 ]; then
+            echo "The maximal number of devices per node is 4." 1>&2
+            return 1
+        fi
+        srunArgs="--time=1:00:00 --ntasks-per-node=$count --gres=gpu:$count --mem=$((12500 * count)) $slurm_common"
+    fi
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/vega-izum/gpu_picongpu.profile.example
+++ b/etc/picongpu/vega-izum/gpu_picongpu.profile.example
@@ -49,17 +49,30 @@ export TBG_TPLFILE="$PIC_SYSTEM_TEMPLATE_PATH/gpu.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -88,7 +101,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/zih-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/A100_picongpu.profile.example
@@ -62,34 +62,50 @@ export CXXFLAGS="-Dlinux"
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/taurus-tud/A100.tpl"
 
-# allocate an interactive shell for two hours
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    export OMP_NUM_THREADS=6
-    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((8 * $numNodes)) --ntasks-per-node=8 --cpus-per-task=6 --mem=0 --exclusive --gres=gpu:8 -p alpha --pty bash
-}
+# allocate resources for an interactive session (default: 2 hours)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for two hours
-#   getDevice 2  # allocates 2 interactive devices on one node (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=2:00:00 --cpus-per-task=6 -p alpha"
+    local srunArgs
+    export OMP_NUM_THREADS=6
+
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks=$((8 * count)) --ntasks-per-node=8 --mem=0 --exclusive --gres=gpu:8 $slurm_common"
     else
-        if [ "$1" -gt 6 ] ; then
+        if [ "$count" -gt 6 ]; then
             echo "The maximal number of devices per node is 8." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        srunArgs="--nodes=1 --ntasks=$count --ntasks-per-node=$count --mem=$((990000 / count)) --gres=gpu:$count $slurm_common"
     fi
-    export OMP_NUM_THREADS=6
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=6 --mem=$((990000 / $numDevices)) --gres=gpu:$numDevices -p alpha --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/zih-tud/A100_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/A100_picongpu.profile.example
@@ -68,17 +68,30 @@ export TBG_TPLFILE="etc/picongpu/taurus-tud/A100.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -105,7 +118,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -63,34 +63,50 @@ export CXXFLAGS="-Dlinux"
 export TBG_SUBMIT="sbatch"
 export TBG_TPLFILE="etc/picongpu/zih-tud/capella.tpl"
 
-# allocate an interactive shell for two hours
-#   getNode 2  # allocates 2 interactive nodes (default: 1)
-function getNode() {
-    if [ -z "$1" ] ; then
-        numNodes=1
-    else
-        numNodes=$1
-    fi
-    export OMP_NUM_THREADS=14
-    srun --time=2:00:00 --nodes=$numNodes --ntasks=$((4 * $numNodes)) --ntasks-per-node=4 --cpus-per-task=14 --mem=752520 --exclusive --gres=gpu:4 -p capella --pty bash
-}
+# allocate resources for an interactive session (default: 2 hours)
+#   getResource -n 2            # allocate 2 full nodes
+#   getResource -d 2            # allocate 2 GPUs on a single node
+#   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
+function getResource() {
+    local mode=""
+    local count=1
+    while getopts ":d:n:h" opt; do
+        case $opt in
+            d) count=${OPTARG:-1}; mode="device";;
+            n) count=${OPTARG:-1}; mode="node";;
+            h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
+            *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+               return 1;;
+        esac
+    done
+    shift $((OPTIND - 1))
 
-# allocate an interactive shell for two hours
-#   getDevice 2  # allocates 2 interactive devices on one node (default: 1)
-function getDevice() {
-    if [ -z "$1" ] ; then
-        numDevices=1
+    if [ -z "$mode" ]; then
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+
+    local slurm_common="--time=2:00:00 --cpus-per-task=14"
+    local srunArgs
+    export OMP_NUM_THREADS=14
+
+    if [ "$mode" = "node" ]; then
+        srunArgs="--nodes=$count --ntasks=$((4 * count)) --ntasks-per-node=4 --mem=752520 --exclusive --gres=gpu:4 -p capella $slurm_common"
     else
-        if [ "$1" -gt 4 ] ; then
+        if [ "$count" -gt 4 ]; then
             echo "The maximal number of devices per node is 4." 1>&2
             return 1
-        else
-            numDevices=$1
         fi
+        srunArgs="--nodes=1 --ntasks=$count --ntasks-per-node=$count --mem=$((188130 * count)) --gres=gpu:$count -p capella $slurm_common"
     fi
-    export OMP_NUM_THREADS=14
-    srun --time=2:00:00 --nodes=1 --ntasks=$numDevices --ntasks-per-node=$(($numDevices)) --cpus-per-task=14 --mem=$((188130 * $numDevices)) --gres=gpu:$numDevices -p capella --pty bash
+
+    if [ $# -gt 0 ]; then
+        srun $srunArgs "$@"
+    else
+        srun $srunArgs --pty bash
+    fi
 }
+
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash

--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -69,17 +69,30 @@ export TBG_TPLFILE="etc/picongpu/zih-tud/capella.tpl"
 #   getResource -d 1 pic-build  # allocate 1 GPU, run pic-build
 function getResource() {
     local mode=""
+    local device_mode=""
+    local node_mode=""
     local count=1
     while getopts ":d:n:h" opt; do
         case $opt in
-            d) count=${OPTARG:-1}; mode="device";;
-            n) count=${OPTARG:-1}; mode="node";;
+            d) count=${OPTARG:-1}; mode="device"; device_mode=1;;
+            n) count=${OPTARG:-1}; mode="node"; node_mode=1;;
             h) echo "Usage: getResource [-d [num] | -n [num]] [command ...]"; return 0;;
             *) echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
                return 1;;
         esac
     done
     shift $((OPTIND - 1))
+
+    if [ "$mode" = "device" ] && [ -n "$node_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
+    if [ "$mode" = "node" ] && [ -n "$device_mode" ]; then
+        echo "Error: cannot specify both -d and -n options" >&2
+        echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
+        return 1
+    fi
 
     if [ -z "$mode" ]; then
         echo "Usage: getResource [-d [num] | -n [num]] [command ...]" >&2
@@ -106,7 +119,6 @@ function getResource() {
         srun $srunArgs --pty bash
     fi
 }
-
 
 # Load autocompletion for PIConGPU commands
 BASH_COMP_FILE=$PICSRC/bin/picongpu-completion.bash


### PR DESCRIPTION
This supersedes #5674 (I had to rebase against latest dev and I also squashed, so no point in force-pushing to that original PR really). Haven't had the time to test this myself and it would be good if we could do a quick check on as many systems as possible which is why I've also put @pordyna in the loop here.

- Replace separate getDevice/getNode functions with a single getResource function accepting -d [num] (device mode) and -n [num] (node mode) via getopts across all 25 PIConGPU profile files.

- Extract common SLURM flags into slurm_common variable in each profile to minimize duplication between node and device branches.

- Add backwards-compat getNode() and getDevice() wrappers in bin/ that source the profile and delegate to getResource.

- Add -h help option to all getResource functions.

- Fix JUWELs gpus profile hardcoded --gres=gpu:4 bug.
- Fix salloc semantics (remove unnecessary trailing bash).
- Update profile documentation.