### PR TITLE
add picongpu commit hash to simulation output

### DIFF
--- a/include/picongpu/CMakeLists.txt
+++ b/include/picongpu/CMakeLists.txt
@@ -269,6 +269,18 @@ option(PIC_ADD_RPATH "Add RPATH's to binaries." ON)
 add_definitions(-DCMAKE_VERSION=${CMAKE_VERSION})
 add_definitions(-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
+# Git commit info (may be empty for non-git builds)
+execute_process(
+    COMMAND git -C "${CMAKE_CURRENT_SOURCE_DIR}" describe --always --dirty --match=never-match-anything
+    OUTPUT_VARIABLE PICONGPU_GIT_COMMIT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT PICONGPU_GIT_COMMIT)
+    set(PICONGPU_GIT_COMMIT "unknown")
+endif()
+add_definitions(-DPICONGPU_GIT_COMMIT="${PICONGPU_GIT_COMMIT}")
+
 # OS & Host Architecture
 add_definitions(-DCMAKE_SYSTEM=${CMAKE_SYSTEM})
 add_definitions(-DCMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR})

--- a/include/picongpu/versionFormat.x.cpp
+++ b/include/picongpu/versionFormat.x.cpp
@@ -123,7 +123,8 @@ namespace picongpu
 
         // CLI Formatting
         cliText << "PIConGPU: " << picongpu.str() << std::endl;
-        cliText << "  Build-Type: " << buildType.str() << std::endl << std::endl;
+        cliText << "  Build-Type: " << buildType.str() << std::endl;
+        cliText << "  Commit:     " << PICONGPU_GIT_COMMIT << std::endl << std::endl;
         cliText << "Third party:" << std::endl;
         cliText << "  OS:         " << os.str() << std::endl;
         cliText << "  arch:       " << arch.str() << std::endl;


### PR DESCRIPTION
Adds the picongpu commit hash to simulation version output, if available (depending on the availability of git and how the repository was downloaded), else it prints "unknown". 
If the tree is dirty this is also marked. 
An example output from ```picongpu --version``` with a dirty tree now looks like :

``` 
PIConGPU: 0.9.0-dev
  Build-Type: Release
  Commit:     d45c767ed7-dirty

Third party:
  OS:         Linux-7.0.11-arch1-1
  arch:       x86_64
  CXX:        GNU (16.1.1)
  CMake:      3.30.0
  Boost:      1.91.0
  MPI:        
    standard: 3.1
    flavor:   OpenMPI (5.0.10)
  PNGwriter:  0.7.0
  openPMD:    0.17.0

```