### PR TITLE
create new communicators to get rank on node

### DIFF
--- a/include/mpiInfo/mpiInfo.cpp
+++ b/include/mpiInfo/mpiInfo.cpp
@@ -40,91 +40,22 @@
 
 namespace po = boost::program_options;
 
-enum
-{
-    gridInitTag = 1,
-    gridHostnameTag = 2,
-    gridHostRankTag = 3,
-    gridExitTag = 4,
-    gridExchangeTag = 5
-};
-
-/* Set the first found non charactor or number to 0 (nullptr)
- * name like p1223(Pid=1233) is than p1223
- * in some MPI implementation /mpich) the hostname is unique
- */
-void cleanHostname(char* name)
-{
-    for(int i = 0; i < MPI_MAX_PROCESSOR_NAME; ++i)
-    {
-        if(!(name[i] >= 'A' && name[i] <= 'Z') && !(name[i] >= 'a' && name[i] <= 'z')
-           && !(name[i] >= '0' && name[i] <= '9') && !(name[i] == '_') && !(name[i] == '-'))
-        {
-            name[i] = 0;
-            return;
-        }
-    }
-}
-
 /*! gets hostRank
  *
- * process with MPI-rank 0 is the master and builds a map with hostname
- * and number of already known processes on this host.
- * Each rank will provide its hostname via MPISend and gets its HostRank
- * from the master.
- *
+ * Computes the node-local rank (the index of this process among all processes
+ * sharing the same node) via MPI_Comm_split_type.
  */
 int getHostRank()
 {
-    char hostname[MPI_MAX_PROCESSOR_NAME];
-    int length;
     int hostRank;
-
-    int totalnodes;
     int myrank;
 
-    MPI_CHECK(MPI_Get_processor_name(hostname, &length));
-    cleanHostname(hostname);
-    hostname[length++] = '\0';
-
-    // int totalnodes;
-
-    MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &totalnodes));
     MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &myrank));
 
-    if(myrank == 0)
-    {
-        std::map<std::string, int> hosts;
-        hosts[hostname] = 0;
-        hostRank = 0;
-        for(int rank = 1; rank < totalnodes; ++rank)
-        {
-            MPI_CHECK(MPI_Recv(
-                hostname,
-                MPI_MAX_PROCESSOR_NAME,
-                MPI_CHAR,
-                rank,
-                gridHostnameTag,
-                MPI_COMM_WORLD,
-                MPI_STATUS_IGNORE));
-
-            // printf("Hostname: %s\n", hostname);
-            int hostrank = 0;
-            if(hosts.count(hostname) > 0)
-                hostrank = hosts[hostname] + 1;
-
-            MPI_CHECK(MPI_Send(&hostrank, 1, MPI_INT, rank, gridHostRankTag, MPI_COMM_WORLD));
-
-            hosts[hostname] = hostrank;
-        }
-    }
-    else
-    {
-        MPI_CHECK(MPI_Send(hostname, length, MPI_CHAR, 0, gridHostnameTag, MPI_COMM_WORLD));
-
-        MPI_CHECK(MPI_Recv(&hostRank, 1, MPI_INT, 0, gridHostRankTag, MPI_COMM_WORLD, MPI_STATUS_IGNORE));
-        // if(hostRank!=0) hostRank--; //!\todo fix mpi hostrank start with 1
-    }
+    MPI_Comm nodeComm;
+    MPI_CHECK(MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, myrank, MPI_INFO_NULL, &nodeComm));
+    MPI_CHECK(MPI_Comm_rank(nodeComm, &hostRank));
+    MPI_CHECK(MPI_Comm_free(&nodeComm));
 
     return hostRank;
 }

--- a/include/pmacc/communication/CommunicatorMPI.cpp
+++ b/include/pmacc/communication/CommunicatorMPI.cpp
@@ -24,11 +24,6 @@
 
 #include "pmacc/dimensions/Definition.hpp"
 
-#include <map>
-#include <string>
-#include <utility>
-#include <vector>
-
 #include <mpi.h>
 
 namespace pmacc
@@ -191,67 +186,16 @@ namespace pmacc
     }
 
     template<unsigned DIM>
-    void CommunicatorMPI<DIM>::cleanHostname(char* name)
-    {
-        for(int i = 0; i < MPI_MAX_PROCESSOR_NAME; ++i)
-        {
-            if(!(name[i] >= 'A' && name[i] <= 'Z') && !(name[i] >= 'a' && name[i] <= 'z')
-               && !(name[i] >= '0' && name[i] <= '9') && !(name[i] == '_') && !(name[i] == '-'))
-            {
-                name[i] = 0;
-                return;
-            }
-        }
-    }
-
-    template<unsigned DIM>
     void CommunicatorMPI<DIM>::updateHostRank()
     {
-        char hostname[MPI_MAX_PROCESSOR_NAME];
-        int length;
-
-        MPI_CHECK(MPI_Get_processor_name(hostname, &length));
-        cleanHostname(hostname);
-        hostname[length++] = '\0';
-
         MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &mpiSize));
         MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank));
 
-        if(mpiRank == 0)
-        {
-            std::map<std::string, int> hosts;
-            hosts[hostname] = 0;
-            hostRank = 0;
-            for(int rank = 1; rank < mpiSize; ++rank)
-            {
-                MPI_CHECK(MPI_Recv(
-                    hostname,
-                    MPI_MAX_PROCESSOR_NAME,
-                    MPI_CHAR,
-                    rank,
-                    gridHostnameTag,
-                    MPI_COMM_WORLD,
-                    MPI_STATUS_IGNORE));
-
-                // printf("Hostname: %s\n", hostname);
-                int hostrank = 0;
-                if(hosts.count(hostname) > 0)
-                    hostrank = hosts[hostname] + 1;
-
-                MPI_CHECK(MPI_Send(&hostrank, 1, MPI_INT, rank, gridHostRankTag, MPI_COMM_WORLD));
-
-                hosts[hostname] = hostrank;
-            }
-        }
-        else
-        {
-            MPI_CHECK(MPI_Send(hostname, length, MPI_CHAR, GridManagerRank, gridHostnameTag, MPI_COMM_WORLD));
-
-            MPI_CHECK(
-                MPI_Recv(&hostRank, 1, MPI_INT, GridManagerRank, gridHostRankTag, MPI_COMM_WORLD, MPI_STATUS_IGNORE));
-
-            // if(hostRank!=0) hostRank--; //!\todo fix mpi hostrank start with 1
-        }
+        // Determine the node-local rank, used to assign one GPU per rank on a node.
+        MPI_Comm nodeComm;
+        MPI_CHECK(MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, mpiRank, MPI_INFO_NULL, &nodeComm));
+        MPI_CHECK(MPI_Comm_rank(nodeComm, &hostRank));
+        MPI_CHECK(MPI_Comm_free(&nodeComm));
     }
 
     template<unsigned DIM>

--- a/include/pmacc/communication/CommunicatorMPI.hpp
+++ b/include/pmacc/communication/CommunicatorMPI.hpp
@@ -139,20 +139,11 @@ namespace pmacc
 
 
     protected:
-        /* Set the first found non charactor or number to 0 (nullptr)
-         * name like p1223(Pid=1233) is than p1223
-         * in some MPI implementation /mpich) the hostname is unique
-         */
-        void cleanHostname(char* name);
-
-
         /*! gets hostRank
          *
-         * process with MPI-rank 0 is the master and builds a map with hostname
-         * and number of already known processes on this host.
-         * Each rank will provide its hostname via MPISend and gets its HostRank
-         * from the master.
-         *
+         * Computes the node-local rank (the index of this process among all
+         * processes sharing the same node) via MPI_Comm_split_type. This is used
+         * to assign one GPU per process on a node.
          */
         void updateHostRank();
 


### PR DESCRIPTION
Previously this gathered every rank's hostname to rank 0 via point-to-point messages (O(N) sends into a single rank). 
At large node counts that incast overwhelmed the UCX UD wireup and aborted with "UD endpoint ... unhandled timeout error" on JUPITER. MPI_Comm_split_type with MPI_COMM_TYPE_SHARED computes the same node-local rank using key=mpiRank to keep the local ordering identical to the old code.

Tested with `mpiInfo` on JUPITER