### PR TITLE
update jsc jupiter for picmi workflow

### DIFF
--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -36,6 +36,8 @@ fi
 
 # General modules #############################################################
 #
+#source /e/software/default/lmod/lmod/init/profile
+export MODULEPATH=/e/software/default/stages/2026/modules/all/Compiler/sidecompiler/GCCcore/14.3.0:/e/software/default/stages/2026/modules/all/Compiler/GCCcore/14.3.0:/e/software/default/stages/2026/UI/Defaults:/e/software/default/stages/2026/UI/Tools:/e/software/default/stages/2026/UI/Compilers:/e/software/default/supercomputer_modules:/e/software/default/productionstages:/e/software/default/userinstallations
 source /e/software/default/lmod/lmod/init/bash
 module purge
 module load Stages/2026

--- a/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
+++ b/etc/picongpu/jupiter-jsc/gh200_picongpu.profile.example
@@ -16,6 +16,9 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 #   We try to guess the project and account using the first and last entry.
 #   Here: selects the last available project.
 #   EDIT THESE IN CASE THE AUTO SELECTION DOESN'T WORK
+
+source /etc/profile.d/jsc-profile.sh
+
 export proj=$( jutil user projects --noheader | awk '{print $1}' | tail -n 1 )
 export account=$(jutil user projects -n | awk '{print $NF}' | tail -n 1)
 
@@ -33,6 +36,7 @@ fi
 
 # General modules #############################################################
 #
+source /e/software/default/lmod/lmod/init/bash
 module purge
 module load Stages/2026
 module load GCC/14.3.0


### PR DESCRIPTION
This PR updates the JSC Jupiter profile to source two profiles for lmod (`module`) and `jutil`. 
This does not change functionality for classical PIConGPU build processes as both methods are known on login-shells, but sub-shells (as spawned by the picmi workflow) can now use them as well. 

This has been tested. 

Please do not merge yet, as setting `MODULEPATH` manually is not the ideal solution. Will try to add a better solution as soon as I get feedback from JSC.