### PR TITLE
update capella for picmi workflow

### DIFF
--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -15,6 +15,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Modules #####################################################################
 #
+source /software/foundation/x86_64/lmod/lmod/init/bash
 module load release/25.06
 module load GCC/13.3.0
 module load CUDA/12.6.0

--- a/etc/picongpu/zih-tud/capella_picongpu.profile.example
+++ b/etc/picongpu/zih-tud/capella_picongpu.profile.example
@@ -15,6 +15,7 @@ export MY_NAME="$(whoami) <$MY_MAIL>"
 
 # Modules #####################################################################
 #
+export MODULEPATH=/software/modules/genoa/r25.06/all/Core:/software/modules/releases/genoa
 source /software/foundation/x86_64/lmod/lmod/init/bash
 module load release/25.06
 module load GCC/13.3.0


### PR DESCRIPTION
This PR updates the ZIH capella picongpu profile, similarly to #5716,  to allow for PICMI workflows  to spawn sub-shells. It should not affect current classical workflows. 

The setup has been tested - it compiles until it runs out of memory on the head node. 

Again, this is in draft mode as the `MODULEPATH` has been set manually.  