### PR TITLE
keep env for cwl

### DIFF
--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -459,6 +459,7 @@ class Runner(BaseModel):
                         "rm_tmpdir": False,
                         "move_outputs": "copy",
                         "cachedir": str(self.cwl_cachedir),
+                        "preserve_entire_environment": True,
                     }
                 )
             ).make(str(self.workflow_definition_path))(**json.load(file))


### PR DESCRIPTION
This PR exposes the shell environment to the cwl sub-processes used in the PICMI workflow. This avoids the need to manually add definitions for `module`, `jutil`, etc. 

Thanks to @chillenzer for figuring this out in a bazillion cwl options 🚀 