### PR TITLE
remove module source from rosi picongpu.profile

### DIFF
--- a/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
+++ b/etc/picongpu/rosi-hzdr/gpu-v100_picongpu.profile.example
@@ -15,9 +15,6 @@ export EDITOR="nano"
 
 # General modules #############################################################
 #
-if ! type module; then
-  . /etc/profile.d/lmod.sh
-fi
 module purge
 module load volta
 


### PR DESCRIPTION
This PR removes sourcing the module definition again, as with #5718 this is no longer needed. 

(as suggested by @chillenzer in that pr)