### PR TITLE
remove srun --mpiDirect flag, as this crashes with our software stack on Frontier

### DIFF
--- a/etc/picongpu/frontier-ornl/batch.tpl
+++ b/etc/picongpu/frontier-ornl/batch.tpl
@@ -159,7 +159,7 @@ if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
     # Run PIConGPU
     echo "Start PIConGPU."
     test $n_broken_nodes -ne 0 && exclude_nodes="-x./bad_nodes.txt"
-    srun -n !TBG_tasks --nodes=!TBG_nodes $exclude_nodes -K1 $TBG_dstPath/input/bin/picongpu --mpiDirect !TBG_author !TBG_programParams
+    srun -n !TBG_tasks --nodes=!TBG_nodes $exclude_nodes -K1 $TBG_dstPath/input/bin/picongpu !TBG_author !TBG_programParams
 else
     echo "Job stopped because of previous issues."
     echo "Job stopped because of previous issues." >&2


### PR DESCRIPTION
closes #5724

This PR removed the `--mpiDirect` flag from the PIConGPU srun call. 

With the latest rocm 6 on Frontier: `6.4.2` - this triggers a run time crash when particles are communicated. We guess there has been a software stack update (under the hood) recently, that causes this issue.
More modern rocm either cause linker errors or are not compatible with mallocMC.  