### PR TITLE
Fix picmi examples

### DIFF
--- a/lib/python/examples/tutorial/02_lwfa.py
+++ b/lib/python/examples/tutorial/02_lwfa.py
@@ -82,7 +82,7 @@ electrons = Species(particle_type="electron", name="electrons", initial_distribu
 hydrogen_ions = Species(
     particle_type="H",
     name="hydrogen",
-    charge_state=0,
+    charge_state=1,
     initial_distribution=particle_distribution,
 )
 

--- a/lib/python/examples/warm_plasma/main.py
+++ b/lib/python/examples/warm_plasma/main.py
@@ -38,7 +38,7 @@ profile = picmi.UniformDistribution(
     # most probable E_kin = 5 mc^2
     # approx. 9000 keV for electrons
     # must be equal for all three components
-    rms_velocity=[4.18 * picmi.constants.c] * 3,
+    rms_velocity=[0.1 * picmi.constants.c] * 3,
 )
 electron = picmi.Species(
     name="e",


### PR DESCRIPTION
Fixes #5721

This PR adjusts a few PICMI examples:
 -  Tutorial LWFA: make Hydrogen ionized so that the setup is charge neutral 
 - warm plasma: reduce rms velocity from 4.18 c to 0.1c per dimension 