### PR TITLE
add buffer alloc function

### DIFF
--- a/include/pmacc/device/Reduce.hpp
+++ b/include/pmacc/device/Reduce.hpp
@@ -57,6 +57,13 @@ namespace pmacc
             {
             }
 
+            void tmpBufferAlloc()
+            {
+                // lazy allocation of the result buffer
+                if(!reduceBuffer)
+                    reduceBuffer = std::make_unique<GridBuffer<char, DIM1>>(DataSpace<DIM1>(byte));
+            }
+
             /** Reduce elements in global gpu memory
              *
              * @param func binary functor for reduce which takes two arguments, first argument is the source and
@@ -89,8 +96,7 @@ namespace pmacc
                     threads = n;
 
                 // lazy allocation of the result buffer
-                if(!reduceBuffer)
-                    reduceBuffer = std::make_unique<GridBuffer<char, DIM1>>(DataSpace<DIM1>(byte));
+                tmpBufferAlloc();
 
                 auto* dest = (Type*) reduceBuffer->getDeviceBuffer().data();
 


### PR DESCRIPTION
@psychocoderHPC added a function to the pmacc Reduce that is needed for the Poisson solver. Because it is not part of the Poisson solver it is now its own PR.