### PR TITLE
add default for XDG_CONFIG_HOME in rc params search

### DIFF
--- a/lib/python/picongpu/_rc_params.py
+++ b/lib/python/picongpu/_rc_params.py
@@ -620,7 +620,7 @@ def search_in_environment_variables():
 
 
 def search_in_user_config():
-    path = environ.get("XDG_CONFIG_HOME", None)
+    path = environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
     if path is None:
         return None
     path = Path(path) / "picongpu" / "picongpurc.toml"


### PR DESCRIPTION
On clusters XDG_CONFIG_HOME is usually not set, in that case try to look into ~/.config anyway. The path doesn't have to exist since we check it later with `is_file`. 