### PR TITLE
boost warning fixes

### DIFF
--- a/include/pmacc/boost_workaround.hpp
+++ b/include/pmacc/boost_workaround.hpp
@@ -22,6 +22,12 @@
 
 // clang-format off
 
+// Work around for Boost.System inline function with
+// BOOST_NOINLINE (GCC emits -Wattributes for that combination).
+#undef BOOST_NOINLINE
+#define BOOST_NOINLINE
+#include <boost/config.hpp>
+
 /** @file This file should be included in each `cpp`-file before any other boost include
  * to workaround different compiler errors triggered by boost includes.
  */
@@ -37,7 +43,7 @@
 #include <boost/optional/optional.hpp>
 
 // disable warnings created from inside boost mp11 with CUDA13+
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(__CUDACC__)
 #    pragma nv_diag_push
 #    pragma nv_diag_suppress 186
 // warning #186-D: pointless comparison of unsigned integer with zero
@@ -45,7 +51,7 @@
 
 #include <boost/mp11/detail/mp_count.hpp>
 
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(__CUDACC__)
 #    pragma nv_diag_pop
 #endif
 


### PR DESCRIPTION
In #5698 I thought the warning was triggered by the new CUDA compiler version, but this was incorrect. 
It is most likely because of the new Boost version, as the same warning as #5698 was seen on ROSI with CUDA 12.6 by @finnolec (and potentially @pordyna has been living silently with this problem for around 2 years on perlmutter)
In addition, another Boost warning was seen, which was related to Boost.System declaring a function with  `inline BOOST_NOINLINE` causing GCC to raise a `-Wattributes` warning

This PR fixes the -Wattribute warning and also removes the nvcc version check from the #5698 fix.

Tested by @finnolec on ROSI