### PR TITLE
Add Licence headers to PIConGPU test and example files

### DIFF
--- a/share/picongpu/examples/AtomicPhysics/validation/EvaluationScript.py
+++ b/share/picongpu/examples/AtomicPhysics/validation/EvaluationScript.py
@@ -1,3 +1,22 @@
+# Copyright 2024-2024 Brian Marre, Tapish Narwal
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+
+
 import openpmd_api as opmd
 import numpy as np
 import typeguard

--- a/share/picongpu/examples/AtomicPhysics/validation/GenerateReference.py
+++ b/share/picongpu/examples/AtomicPhysics/validation/GenerateReference.py
@@ -1,3 +1,22 @@
+# Copyright 2024-2024 Brian Marre, Tapish Narwal
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+
+
 import numpy as np
 import openpmd_api as opmd
 

--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile
@@ -1,3 +1,11 @@
+"""
+This file is part of PIConGPU.
+
+Copyright 2017-2024 PIConGPU contributors
+Authors: Sebastian Starke, Jeffrey Kelling
+License: GPLv3+
+"""
+
 from snakemake.utils import Paramspace
 import pandas as pd
 import os

--- a/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile_LSF
+++ b/share/picongpu/examples/LaserWakefield/lib/python/snakemake/Snakefile_LSF
@@ -1,3 +1,11 @@
+"""
+This file is part of PIConGPU.
+
+Copyright 2017-2024 PIConGPU contributors
+Authors: Sebastian Starke, Jeffrey Kelling
+License: GPLv3+
+"""
+
 from snakemake.utils import Paramspace
 import pandas as pd
 import os

--- a/share/picongpu/tests/Synchrotron_plugin/lib/synchrotron_lib.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/synchrotron_lib.py
@@ -1,3 +1,23 @@
+"""
+Copyright 2024-2024 Filip Optolowicz
+
+This file is part of PIConGPU.
+
+PIConGPU is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PIConGPU is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PIConGPU.
+If not, see <http://www.gnu.org/licenses/>.
+"""
+
 import numpy as np
 import scipy.constants as const
 from scipy.integrate import quad

--- a/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
+++ b/share/picongpu/tests/Synchrotron_plugin/lib/validate.py
@@ -1,3 +1,23 @@
+"""
+Copyright 2024-2024 Filip Optolowicz
+
+This file is part of PIConGPU.
+
+PIConGPU is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PIConGPU is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PIConGPU.
+If not, see <http://www.gnu.org/licenses/>.
+"""
+
 import sys
 import openpmd_api as opmd
 import numpy as np

--- a/share/picongpu/tests/openPMD-viewer-test/lib/python/test/param-test.py
+++ b/share/picongpu/tests/openPMD-viewer-test/lib/python/test/param-test.py
@@ -1,3 +1,25 @@
+"""
+Copyright 2023-2024 PIConGPU Contributors
+
+Authors: Mika Soren Voss, Rene Widera, Hannes Wolf, Klaus Steiniger, Max Lehmann
+
+This file is part of PIConGPU.
+
+PIConGPU is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PIConGPU is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with PIConGPU.
+If not, see <http://www.gnu.org/licenses/>.
+"""
+
 import argparse
 import sys
 import numpy as np


### PR DESCRIPTION
Some files in share/picongpu/ are missing Licence headers. Here is a fix for that. The authors are a guess based on the authors of files in the same directory.

- [ ] rebase against #5701 after it is merged
- [ ] use new SPDX syntax