### PR TITLE
prevent virtual particle start position from underflow

### DIFF
--- a/include/picongpu/simulation/control/MovingWindow.hpp
+++ b/include/picongpu/simulation/control/MovingWindow.hpp
@@ -47,7 +47,7 @@ namespace picongpu
             uint32_t gpuNumberOfCellsInMoveDirection;
             float_64 cellSizeInMoveDirection;
             float_64 deltaWayPerStep;
-            uint32_t virtualParticleInitialStartCell;
+            int64_t virtualParticleInitialStartCell;
             uint32_t firstSlideStep;
             int32_t firstMoveStep;
 
@@ -82,18 +82,17 @@ namespace picongpu
                 /* Is the time step when the virtual particle **passed** the GPU next to the last
                  * in the current to the next step
                  */
-                firstSlideStep
-                    = static_cast<uint32_t>(math::ceil(
-                          static_cast<float_64>(
-                              subGrid.getGlobalDomain().size[moveDirection] - virtualParticleInitialStartCell)
-                          * cellSizeInMoveDirection / deltaWayPerStep))
-                      - 1;
+                firstSlideStep = static_cast<uint32_t>(math::ceil(
+                                     (static_cast<float_64>(subGrid.getGlobalDomain().size[moveDirection])
+                                      - static_cast<float_64>(virtualParticleInitialStartCell))
+                                     * cellSizeInMoveDirection / deltaWayPerStep))
+                                 - 1;
 
                 /* way which the virtual particle must move before the window begins
                  * to move the first time [in pic length] */
-                auto const wayToFirstMove
-                    = static_cast<float_64>(globalWindowSizeInMoveDirection - virtualParticleInitialStartCell)
-                      * cellSizeInMoveDirection;
+                auto const wayToFirstMove = (static_cast<float_64>(globalWindowSizeInMoveDirection)
+                                             - static_cast<float_64>(virtualParticleInitialStartCell))
+                                            * cellSizeInMoveDirection;
                 /* Is the time step when the virtual particle **passed** the moving window
                  * in the current to the next step
                  * Signed type of firstMoveStep to allow for edge case movePoint = 0.0

--- a/share/picongpu/unit/dimensional_tests/MovingWindow.cpp
+++ b/share/picongpu/unit/dimensional_tests/MovingWindow.cpp
@@ -189,7 +189,8 @@ TEST_CASE("unit::MovingWindow_origin", "[movingWindow test]")
 
     SECTION("Window position evolution")
     {
-        float_64 const movePoint = GENERATE(0, 0.341, 0.6);
+        // The pre-movement for the negative move point is 45 cells and thus fits into the 100-cell hidden GPU row.
+        float_64 const movePoint = GENERATE(-0.05, 0, 0.341, 0.6, 1.5);
         uint32_t const endStep = 10000;
         movingWindow.setMovePoint(movePoint);
         movingWindow.setEndSlideOnStep(endStep);


### PR DESCRIPTION
With moving window, when using a move point of `>1`, the `virtualParticleInitialStartCell`, an unsigned int was negative, thus underflowing. 

For some values, it may have worked in the past due to calculations later adding a value and causing the wrap around the other way as well. 

@finnolec Can you please test if this fixes your issue.


I am unhappy with the state of the tests as they are close to just being a repeated version of the implementation, and I will open another PR later to improve the situation. Similarly, there is a bunch of code duplication in the moving window code which calculates distances and cell indices which I want to refactor out into functions which I will do. 