### PR TITLE
fix double or wrong comments in simulation.param

### DIFF
--- a/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/simulation.param
+++ b/share/picongpu/benchmarks/TWEAC-FOM/include/picongpu/param/simulation.param
@@ -46,8 +46,8 @@ namespace picongpu
 {
     namespace SI
     {
-        /** Duration of one timestep
-         *  unit: seconds */
+        /** equals X
+         *  unit: meter */
         constexpr float_64 CELL_WIDTH_SI = 1.60000e-7;
         /** equals Y - the laser & moving window propagation direction
          *  unit: meter */

--- a/share/picongpu/benchmarks/Thermal/include/picongpu/param/simulation.param
+++ b/share/picongpu/benchmarks/Thermal/include/picongpu/param/simulation.param
@@ -56,9 +56,6 @@ namespace picongpu
 
         /** equals X
          *  unit: meter */
-
-        /** equals X
-         *  unit: meter */
         constexpr float_64 CELL_WIDTH_SI = 5.78918e-05;
         /** equals Y
          *  unit: meter */

--- a/share/picongpu/examples/BinningExamples/include/picongpu/param/simulation.param
+++ b/share/picongpu/examples/BinningExamples/include/picongpu/param/simulation.param
@@ -48,8 +48,6 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        /** Duration of one timestep
-         *  unit: seconds */
         constexpr float_64 DELTA_T_SI = 1.39e-16;
 
         /** equals X

--- a/share/picongpu/examples/FoilLCT/include/picongpu/param/simulation.param
+++ b/share/picongpu/examples/FoilLCT/include/picongpu/param/simulation.param
@@ -46,8 +46,8 @@ namespace picongpu
 {
     namespace SI
     {
-        /** Duration of one timestep
-         *  unit: seconds */
+        /** equals X
+         *  unit: meter */
         constexpr float_64 CELL_WIDTH_SI = 0.8e-6 / 384.;
         /** equals Y - the laser & moving window propagation direction
          *  unit: meter */

--- a/share/picongpu/examples/IncidentField/include/picongpu/param/simulation.param
+++ b/share/picongpu/examples/IncidentField/include/picongpu/param/simulation.param
@@ -46,6 +46,8 @@ namespace picongpu
 {
     namespace SI
     {
+        /** equals any cell size
+         *  unit: meter */
         constexpr float_64 CELL_SIZE_SI = 0.5e-3; // 0.5 mm
 
         /** equals X

--- a/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/simulation.param
+++ b/share/picongpu/examples/KelvinHelmholtz/include/picongpu/param/simulation.param
@@ -53,9 +53,6 @@ namespace picongpu
 
         /** equals X
          *  unit: meter */
-
-        /** equals X
-         *  unit: meter */
         constexpr float_64 CELL_WIDTH_SI = 9.34635e-8;
         /** equals Y
          *  unit: meter */

--- a/share/picongpu/examples/LaserWakefield/include/picongpu/param/simulation.param
+++ b/share/picongpu/examples/LaserWakefield/include/picongpu/param/simulation.param
@@ -48,8 +48,6 @@ namespace picongpu
     {
         /** Duration of one timestep
          *  unit: seconds */
-        /** Duration of one timestep
-         *  unit: seconds */
         constexpr float_64 DELTA_T_SI = 1.39e-16;
 
         /** equals X

--- a/share/picongpu/tests/CurrentDeposition/include/picongpu/param/simulation.param
+++ b/share/picongpu/tests/CurrentDeposition/include/picongpu/param/simulation.param
@@ -46,8 +46,8 @@ namespace picongpu
 {
     namespace SI
     {
-        /** Duration of one timestep
-         *  unit: seconds */
+        /** equals X
+         *  unit: meter */
         constexpr float_64 CELL_WIDTH_SI = 1.0;
         /** equals Y
          *  unit: meter */

--- a/share/picongpu/tests/Pusher/include/picongpu/param/simulation.param
+++ b/share/picongpu/tests/Pusher/include/picongpu/param/simulation.param
@@ -46,7 +46,7 @@ namespace picongpu
 {
     namespace SI
     {
-        /** Duration of one timestep
+        /** Duration of gyration
          *  unit: seconds */
         constexpr float_64 T_GYRO_SI = 0.825e-12;
 

--- a/share/picongpu/tests/SingleParticle/include/picongpu/param/simulation.param
+++ b/share/picongpu/tests/SingleParticle/include/picongpu/param/simulation.param
@@ -46,7 +46,7 @@ namespace picongpu
 {
     namespace SI
     {
-        /** Duration of one timestep
+        /** Duration of gyration
          *  unit: seconds */
         constexpr float_64 T_GYRO_SI = 0.825e-12;
 

--- a/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/simulation.param
+++ b/share/picongpu/tests/openPMD-viewer-test/include/picongpu/param/simulation.param
@@ -52,9 +52,6 @@ namespace picongpu
 
         /** equals X
          *  unit: meter */
-
-        /** equals X
-         *  unit: meter */
         constexpr float_64 CELL_WIDTH_SI = 9.34635e-8;
         /** equals Y
          *  unit: meter */


### PR DESCRIPTION
For whatever reason we had a lot of double or wrong comments in `simulation.param`. 
This PR fixes them. 