### PR TITLE
Add example for total domain coordinates binning output

### DIFF
--- a/share/picongpu/examples/BinningExamples/include/picongpu/param/binningSetup.param
+++ b/share/picongpu/examples/BinningExamples/include/picongpu/param/binningSetup.param
@@ -175,6 +175,21 @@ namespace picongpu
                 return pos.z();
             };
 
+            // Write attribute to allow to convert y bin edges with moving window domain origin to total coordinates
+            auto writeMovingWindowPosition
+                = [](::openPMD::Series&, ::openPMD::Iteration&, ::openPMD::Mesh& mesh) -> void
+            {
+                auto const step = Environment<>::get().SimulationDescription().getCurrentStep();
+
+                auto const originCells = MovingWindow::getInstance().getMovingWindowOriginPositionCells(step);
+
+                double const originYSI
+                    = static_cast<double>(originCells.y()) * static_cast<double>(sim.si.getCellSize().y());
+
+                // Custom attribute
+                mesh.setAttribute("movingWindowOriginY_SI", originYSI);
+            };
+
             // Define units of axis 3
             std::array<double, numUnits> positionDimension{};
             positionDimension[SIBaseUnits::length] = 1.0;
@@ -279,6 +294,7 @@ namespace picongpu
 
 
             binningCreator.addParticleBinner("larmorPowerDens", axisTuplePos, speciesTuple, larmorPowerDepositionData)
+                .setOpenPMDWriteFunctor(writeMovingWindowPosition)
                 .setNotifyPeriod("100")
                 .setOpenPMDBackendConfig(R"({"adios2":{"dataset":{"chunks":"auto"}}})")
                 .setOpenPMDExtension("bp");


### PR DESCRIPTION
Add code from @ikbuibui to binning examples. This allows to convert the binning edges when using moving window to total coordinates via 
```py
  mesh = iteration.meshes["Binning"]

  edges_comoving = np.asarray(
      mesh.get_attribute("positionY_bin_edges")
  )
  window_origin = mesh.get_attribute("movingWindowOriginY_SI")

  edges_lab = edges_comoving + window_origin
```
This custom attribute works as expected for me with #5748 enabled.