### PR TITLE
fix wrong doc strings pypicongpu

### DIFF
--- a/lib/python/picongpu/pypicongpu/species/attribute/boundelectrons.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/boundelectrons.py
@@ -10,7 +10,7 @@ from .attribute import Attribute
 
 class BoundElectrons(Attribute):
     """
-    Position of a macroparticle
+    Number of bound electrons per nucleus of a macroparticle
     """
 
     picongpu_name: str = "boundElectrons"

--- a/lib/python/picongpu/pypicongpu/species/attribute/momentum.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/momentum.py
@@ -10,7 +10,7 @@ from .attribute import Attribute
 
 class Momentum(Attribute):
     """
-    Position of a macroparticle
+    Momentum of a macroparticle
     """
 
     picongpu_name: str = "momentum"

--- a/lib/python/picongpu/pypicongpu/species/attribute/momentum_prev_1.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/momentum_prev_1.py
@@ -10,7 +10,7 @@ from .attribute import Attribute
 
 class MomentumPrev1(Attribute):
     """
-    Position of a macroparticle
+    Momentum of previous time step of a macroparticle
     """
 
     picongpu_name: str = "momentumPrev1"

--- a/lib/python/picongpu/pypicongpu/species/attribute/momentum_prev_1.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/momentum_prev_1.py
@@ -10,7 +10,7 @@ from .attribute import Attribute
 
 class MomentumPrev1(Attribute):
     """
-    Momentum of previous time step of a macroparticle
+    Momentum at previous time step of a macroparticle
     """
 
     picongpu_name: str = "momentumPrev1"

--- a/lib/python/picongpu/pypicongpu/species/attribute/radiation_mask.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/radiation_mask.py
@@ -10,7 +10,7 @@ from .attribute import Attribute
 
 class RadiationMask(Attribute):
     """
-    Position of a macroparticle
+    Radiation mask of a macroparticle
     """
 
     picongpu_name: str = "radiationMask"

--- a/lib/python/picongpu/pypicongpu/species/attribute/weighting.py
+++ b/lib/python/picongpu/pypicongpu/species/attribute/weighting.py
@@ -10,7 +10,7 @@ from .attribute import Attribute
 
 class Weighting(Attribute):
     """
-    Position of a macroparticle
+    Weighting of a macroparticle
     """
 
     picongpu_name: str = "weighting"


### PR DESCRIPTION
This PR fixes #5751 - wrong docstrings in particle attributes in pypicongpu
