### PR TITLE
Fix pngwriter installation script on Rosi

### DIFF
--- a/etc/picongpu/rosi-hzdr/dependencies_autoinstall.sh
+++ b/etc/picongpu/rosi-hzdr/dependencies_autoinstall.sh
@@ -83,20 +83,22 @@ fi
 
 
 # TODO: we need to update PNGwriter to work with a modern cmake
+# currently fixed by manually increasing minimal cmake version
 
 #   PNGwriter
-#if [ ! -d "$PNGwriter_ROOT" ]; then
-#    echo "Installing PNGwriter"
-#    cd $SOURCE_DIR
-#    git clone -b 0.7.0 https://github.com/pngwriter/pngwriter.git \
-#        $SOURCE_DIR/pngwriter
-#    mkdir pngwriter-build
-#    cd pngwriter-build
-#    cmake --version
-#    cmake -DCMAKE_INSTALL_PREFIX=$PNGwriter_ROOT \
-#        $SOURCE_DIR/pngwriter
-#    make -j 16 install
-#fi
+if [ ! -d "$PNGwriter_ROOT" ]; then
+   echo "Installing PNGwriter"
+   cd $SOURCE_DIR
+   git clone -b 0.7.0 https://github.com/pngwriter/pngwriter.git \
+       $SOURCE_DIR/pngwriter
+   mkdir pngwriter-build
+   cd pngwriter-build
+   cmake --version
+   cmake -DCMAKE_INSTALL_PREFIX=$PNGwriter_ROOT \
+         -DCMAKE_POLICY_VERSION_MINIMUM=3.5     \
+       $SOURCE_DIR/pngwriter
+   make -j 16 install
+fi
 
 
 


### PR DESCRIPTION
PNGwriter currently can not be installed on ROSI, as its CMake files are outdated.
This PR manually increases the minimal CMake version in the installation script, so it could be installed on ROSI (and potentially other cluster which face the same issue).

This might break in the future, as CMake versions < 3.10 are also already deprecated. Somebody probably should fix PNGwriter, or we need to use another library in the future.