### PR TITLE
[WIP] support native derived functors in picmi

### DIFF
--- a/handover.md
+++ b/handover.md
@@ -1,0 +1,316 @@
+# Handover: PICMI Native and Combined Derived-Field Output
+
+## Purpose
+
+This PIConGPU checkout contains an uncommitted Python implementation that lets a PICMI setup request PIConGPU's native particle-to-grid fields in openPMD output without defining an equivalent Python `ParticleFunctor`.
+
+It adds two diagnostics:
+
+- `NativeDerivedFieldDump`: use an existing PIConGPU `derivedAttributes` or supported parameter-free `combinedAttributes` implementation.
+- `AverageDerivedFieldDump`: apply PIConGPU's native `combinedAttributes::AverageAttribute` to an eligible native derived attribute.
+
+The existing `DerivedFieldDump` remains the interface for custom Python particle functors.
+
+## Basic Setup-Repo Usage
+
+Import the diagnostics from the public diagnostics package:
+
+```python
+from picongpu.picmi.diagnostics import (
+    AverageDerivedFieldDump,
+    DerivedFieldDump,
+    NativeDerivedFieldDump,
+    TimeStepSpec,
+)
+```
+
+Add the requested diagnostics to `Simulation(picongpu_diagnostics=[...])`.
+
+### Native scalar field
+
+```python
+electron_density = NativeDerivedFieldDump(
+    species=electrons,
+    field="Density",
+    period=TimeStepSpec[::100],
+)
+```
+
+### Native directional field
+
+Directional fields require `direction="x"`, `"y"`, or `"z"`:
+
+```python
+momentum_x = NativeDerivedFieldDump(
+    species=electrons,
+    field="Momentum",
+    direction="x",
+    period=TimeStepSpec[::100],
+)
+```
+
+### Raw weighted velocity
+
+`WeightedVelocity` is exposed directly. It is the deposited weighted sum, not the mean velocity:
+
+```python
+weighted_velocity_x = NativeDerivedFieldDump(
+    species=electrons,
+    field="WeightedVelocity",
+    direction="x",
+    period=TimeStepSpec[::100],
+)
+```
+
+### Average velocity
+
+Use `AverageDerivedFieldDump` to divide weighted velocity by the native density field:
+
+```python
+average_velocity_x = AverageDerivedFieldDump(
+    species=electrons,
+    field="WeightedVelocity",
+    direction="x",
+    period=TimeStepSpec[::100],
+)
+```
+
+This renders the native C++ type:
+
+```cpp
+deriveField::combinedAttributes::AverageAttribute<
+    deriveField::derivedAttributes::WeightedVelocity<0>
+>
+```
+
+### Other combined fields
+
+Existing parameter-free combined fields are selected through `NativeDerivedFieldDump`:
+
+```python
+relativistic_density = NativeDerivedFieldDump(
+    species=electrons,
+    field="RelativisticDensity",
+    period=TimeStepSpec[::100],
+)
+
+inverse_screening_length_squared = NativeDerivedFieldDump(
+    species=electrons,
+    field="ScreeningInvSquared",
+    period=TimeStepSpec[::100],
+)
+```
+
+### Filtered species
+
+Native and averaged fields accept `FilteredSpecies` in the same way as custom derived fields:
+
+```python
+filtered_density = NativeDerivedFieldDump(
+    species=FilteredSpecies(
+        species=electrons,
+        functor=energy_filter,
+    ),
+    field="Density",
+    period=TimeStepSpec[::100],
+)
+```
+
+The particle filter is part of the compile-time solver identity.
+
+### Existing custom functor API
+
+No API change is needed for custom fields:
+
+```python
+@ParticleFunctor
+def kinetic_energy_density(particle):
+    return particle.get("kinetic energy") / np.prod(CELL_SIZE)
+
+custom_energy_density = DerivedFieldDump(
+    species=electrons,
+    functor=kinetic_energy_density,
+    period=TimeStepSpec[::100],
+)
+```
+
+## Supported Native Fields
+
+Scalar fields:
+
+- `Density`
+- `BoundElectronDensity`
+- `ChargeDensity`
+- `Counter`
+- `Energy`
+- `EnergyDensity`
+- `LarmorPower`
+- `MacroCounter`
+
+Directional fields:
+
+- `MidCurrentDensityComponent`
+- `Momentum`
+- `MomentumDensity`
+- `WeightedVelocity`
+
+Parameter-free combined fields:
+
+- `RelativisticDensity`
+- `ScreeningInvSquared`
+
+`EnergyDensityCutoff` is intentionally unsupported because it requires a user-provided C++ parameter class.
+
+`AverageDerivedFieldDump` accepts fields supported by PIConGPU's `IsWeighted` trait. It rejects `MacroCounter` and already-combined fields.
+
+## Expected openPMD Names
+
+The record name format remains:
+
+```text
+<species>_<filter-or-all>_<native PIConGPU field name>
+```
+
+Examples:
+
+```text
+electrons_all_density
+electrons_all_weightedVelocity/x
+electrons_all_Average_weightedVelocity/x
+electrons_all_relativisticDensity
+electrons_all_invSquaredScreenLength
+```
+
+These are the names to use when reading the records through openPMD-api.
+
+## Species-Specific Compilation Behavior
+
+Derived-field solvers are generated only for the species selected in the diagnostic. They no longer use:
+
+```cpp
+CreateEligible_t<VectorAllSpecies, ...>
+```
+
+Instead, the generated `fileOutput.param` contains a species-specific operation, for example:
+
+```cpp
+using Native_Density_species_electrons_All_Seq = MakeSeq_t<
+    deriveField::CreateFieldTmpOperation_t<
+        species_electrons,
+        Native_Density_species_electrons_All_Attribute,
+        Native_Density_species_electrons_All_Filter
+    >
+>;
+```
+
+Before instantiating it, the generated code explicitly checks the selected derived attribute and filter:
+
+```cpp
+static_assert(
+    particles::traits::SpeciesEligibleForSolver<
+        species_electrons,
+        deriveField::FilteredDerivedAttribute<
+            Native_Density_species_electrons_All_Attribute,
+            Native_Density_species_electrons_All_Filter
+        >
+    >::type::value,
+    "Derived field Native_Density ... is not supported for species_electrons"
+);
+```
+
+An incompatible species/field/filter request should therefore fail during compilation instead of producing an empty solver list followed by a missing-source error at runtime.
+
+## Deduplication and Metadata
+
+The top-level PyPIConGPU simulation model contains:
+
+- `derived_field_functors`: unique custom functor definitions;
+- `field_tmp_solvers`: unique species-specific solver instances.
+
+A solver is deduplicated by the complete combination of:
+
+```text
+species + derived attribute/custom functor + particle filter
+```
+
+Consequences:
+
+- Repeating the same field for the same species and filter at several periods or in several openPMD configurations creates one C++ solver.
+- The same field for two species creates two solvers.
+- The same field and species with two filters creates two solvers.
+- One custom particle functor can be defined once and reused by several species-specific solvers.
+
+Each openPMD plugin retains its complete `sources` metadata, including period, record name, species, filter, and solver/functor description.
+
+## Checking Generated Input
+
+To generate input without running the simulation, use PICMI's write method:
+
+```python
+sim.write_input_file("path/to/generated-setup")
+```
+
+Inspect:
+
+```text
+path/to/generated-setup/include/picongpu/param/fileOutput.param
+path/to/generated-setup/etc/openPMD_config_<hash>.toml
+path/to/generated-setup/metadata/pypicongpu_rendering_context.json
+```
+
+Expected checks:
+
+- Native fields do not generate custom C++ functor structs.
+- Custom `DerivedFieldDump` functors are each defined once.
+- `FieldTmpSolvers` contains species-specific aliases.
+- Derived-field aliases do not use `VectorAllSpecies` or `CreateEligible_t`.
+- Every derived-field solver has an eligibility `static_assert`.
+- The openPMD TOML lists the expected record names and periods.
+
+## Example in This Checkout
+
+`lib/python/examples/tutorial/03.2_particle_functors.py` contains examples of:
+
+- a custom energy-density functor;
+- native density;
+- raw native weighted velocity;
+- native average velocity.
+
+For a write-only check, temporarily replace its final `sim.run(...)` call with:
+
+```python
+sim.write_input_file("/tmp/picongpu-032-check")
+```
+
+Do not commit that temporary invocation change unless the tutorial is intentionally being converted to write-only behavior.
+
+## Current Implementation and Validation State
+
+The implementation is currently present as uncommitted changes in the PIConGPU checkout. Before relying on it from another setup repository, ensure that setup resolves/imports this exact local `lib/python` package rather than an installed release lacking the changes.
+
+Relevant implementation areas:
+
+- `lib/python/picongpu/picmi/diagnostics/field_dump.py`
+- `lib/python/picongpu/pypicongpu/output/openpmd_plugin.py`
+- `lib/python/picongpu/pypicongpu/simulation.py`
+- `lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache`
+
+Validation already performed:
+
+```text
+198 passed, 3 xfailed, 3499 subtests passed
+```
+
+The tutorial generated successfully through `write_input_file()`, and its `fileOutput.param`, rendering metadata, and openPMD TOML were inspected.
+
+The test command used Python 3.12 and disabled the repository pytest configuration because the installed upstream `picmistandard` emits an invalid docstring-escape warning that the repository promotes to an error:
+
+```bash
+cd lib/python
+.venv/bin/python -m pytest -c /dev/null -q test/picongpu/quick
+```
+
+Focused tests are located at:
+
+- `lib/python/test/picongpu/quick/picmi/diagnostics/test_derived_field_dump.py`
+- `lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py`

--- a/handover.md
+++ b/handover.md
@@ -191,10 +191,10 @@ Derived-field solvers are generated only for the species selected in the diagnos
 CreateEligible_t<VectorAllSpecies, ...>
 ```
 
-Instead, the generated `fileOutput.param` contains a species-specific operation, for example:
+Instead, the generated `fileOutput.param` places each species-specific operation directly in the common solver sequence:
 
 ```cpp
-using Native_Density_species_electrons_All_Seq = MakeSeq_t<
+using FieldTmpSolvers = MakeSeq_t<
     deriveField::CreateFieldTmpOperation_t<
         species_electrons,
         Native_Density_species_electrons_All_Attribute,
@@ -262,7 +262,7 @@ Expected checks:
 
 - Native fields do not generate custom C++ functor structs.
 - Custom `DerivedFieldDump` functors are each defined once.
-- `FieldTmpSolvers` contains species-specific aliases.
+- `FieldTmpSolvers` directly contains the species-specific `CreateFieldTmpOperation_t` types, without one-element intermediate sequences.
 - Derived-field aliases do not use `VectorAllSpecies` or `CreateEligible_t`.
 - Every derived-field solver has an eligibility `static_assert`.
 - The openPMD TOML lists the expected record names and periods.

--- a/lib/python/examples/tutorial/03.2_particle_functors.py
+++ b/lib/python/examples/tutorial/03.2_particle_functors.py
@@ -28,7 +28,7 @@ from picongpu.picmi import (
 from picongpu.picmi.constants import c
 from picongpu.picmi.diagnostics import Checkpoint, MacroParticleCount, TimeStepSpec
 from picongpu.picmi.diagnostics.binning import Binning, BinningAxis, BinSpec
-from picongpu.picmi.diagnostics.field_dump import DerivedFieldDump
+from picongpu.picmi.diagnostics.field_dump import AverageDerivedFieldDump, DerivedFieldDump, NativeDerivedFieldDump
 from picongpu.picmi.diagnostics.particle_dump import ParticleDump
 from picongpu.picmi.distribution import GaussianDistribution
 from picongpu.picmi.lasers import GaussianLaser, PolarizationType
@@ -118,6 +118,16 @@ electron_energy_density = DerivedFieldDump(
     species=electrons, functor=kinetic_energy_density, period=TimeStepSpec[::100]
 )
 
+# Built-in particle-to-grid fields use PIConGPU's native C++ implementations and
+# therefore do not require or generate a ParticleFunctor.
+electron_density = NativeDerivedFieldDump(species=electrons, field="Density", period=TimeStepSpec[::100])
+electron_weighted_velocity_x = NativeDerivedFieldDump(
+    species=electrons, field="WeightedVelocity", direction="x", period=TimeStepSpec[::100]
+)
+electron_average_velocity_x = AverageDerivedFieldDump(
+    species=electrons, field="WeightedVelocity", direction="x", period=TimeStepSpec[::100]
+)
+
 
 @ParticleFunctor(unit_dimension=M * L / T)
 def momentum_x(macro_particle):
@@ -168,6 +178,9 @@ sim = Simulation(
         checkpoint,
         macro_particle_count,
         electron_energy_density,
+        electron_density,
+        electron_weighted_velocity_x,
+        electron_average_velocity_x,
         electron_momentum,
         random_electrons,
     ],

--- a/lib/python/picongpu/picmi/diagnostics/__init__.py
+++ b/lib/python/picongpu/picmi/diagnostics/__init__.py
@@ -9,7 +9,7 @@ from .backend_config import BackendConfig, OpenPMDConfig
 from .binning import Binning, BinningAxis, BinSpec
 from .checkpoint import Checkpoint
 from .energy_histogram import EnergyHistogram
-from .field_dump import DerivedFieldDump, NativeFieldDump
+from .field_dump import AverageDerivedFieldDump, DerivedFieldDump, NativeDerivedFieldDump, NativeFieldDump
 from .macro_particle_count import MacroParticleCount
 from .particle_dump import ParticleDump
 from .phase_space import PhaseSpace
@@ -21,6 +21,8 @@ AnyDiagnostic = (
     | Checkpoint
     | EnergyHistogram
     | DerivedFieldDump
+    | NativeDerivedFieldDump
+    | AverageDerivedFieldDump
     | NativeFieldDump
     | MacroParticleCount
     | ParticleDump
@@ -40,6 +42,8 @@ __all__ = [
     "ParticleDump",
     "NativeFieldDump",
     "DerivedFieldDump",
+    "NativeDerivedFieldDump",
+    "AverageDerivedFieldDump",
     "TimeStepSpec",
     "Checkpoint",
     "Radiation",

--- a/lib/python/picongpu/picmi/diagnostics/field_dump.py
+++ b/lib/python/picongpu/picmi/diagnostics/field_dump.py
@@ -7,9 +7,9 @@ License: GPLv3+
 
 from os import PathLike
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field, model_validator
 
 from picongpu.picmi.particle_functor.particle_filter import FilteredSpecies
 from picongpu.picmi.species import Species
@@ -46,3 +46,109 @@ class DerivedFieldDump(_FieldDump):
     def fieldname(self) -> str:
         species_name = self.species.name if isinstance(self.species, Species) else self.species.species.name
         return f"{species_name}_{self.filtername or 'all'}_{self.functor.name}"
+
+
+ScalarDerivedField = Literal[
+    "Density",
+    "BoundElectronDensity",
+    "ChargeDensity",
+    "Counter",
+    "Energy",
+    "EnergyDensity",
+    "LarmorPower",
+    "MacroCounter",
+]
+DirectionalDerivedField = Literal["MidCurrentDensityComponent", "Momentum", "MomentumDensity", "WeightedVelocity"]
+CombinedDerivedField = Literal["RelativisticDensity", "ScreeningInvSquared"]
+NativeDerivedField = ScalarDerivedField | DirectionalDerivedField | CombinedDerivedField
+AverageableDerivedField = Literal[
+    "Density",
+    "BoundElectronDensity",
+    "ChargeDensity",
+    "Counter",
+    "Energy",
+    "EnergyDensity",
+    "LarmorPower",
+    "MidCurrentDensityComponent",
+    "Momentum",
+    "MomentumDensity",
+    "WeightedVelocity",
+]
+Direction = Literal["x", "y", "z"]
+
+_DIRECTION_INDEX = {"x": 0, "y": 1, "z": 2}
+_DIRECTIONAL_FIELDS = {"MidCurrentDensityComponent", "Momentum", "MomentumDensity", "WeightedVelocity"}
+_FIELD_NAMES = {
+    "Density": "density",
+    "BoundElectronDensity": "boundElectronDensity",
+    "ChargeDensity": "chargeDensity",
+    "Counter": "particleCounter",
+    "Energy": "particleEnergy",
+    "EnergyDensity": "energyDensity",
+    "LarmorPower": "larmorPower",
+    "MacroCounter": "macroParticleCounter",
+    "MidCurrentDensityComponent": "midCurrentDensity",
+    "Momentum": "particleMomentum",
+    "MomentumDensity": "momentumDensity",
+    "WeightedVelocity": "weightedVelocity",
+    "RelativisticDensity": "relativisticDensity",
+    "ScreeningInvSquared": "invSquaredScreenLength",
+}
+
+
+class _BuiltinDerivedFieldDump(_FieldDump):
+    species: Species | FilteredSpecies
+    direction: Direction | None = None
+    field: str
+
+    _average: ClassVar[bool] = False
+
+    @model_validator(mode="after")
+    def _validate_direction(self):
+        is_directional = self.field in _DIRECTIONAL_FIELDS
+        if is_directional and self.direction is None:
+            raise ValueError(f"direction is required for directional field {self.field}")
+        if not is_directional and self.direction is not None:
+            raise ValueError(f"direction is only valid for directional fields, not {self.field}")
+        return self
+
+    @computed_field
+    def filtername(self) -> None | str:
+        return None if isinstance(self.species, Species) else self.species.functor.name
+
+    @property
+    def _native_name(self) -> str:
+        name = _FIELD_NAMES[self.field]
+        return f"{name}/{self.direction}" if self.direction is not None else name
+
+    @computed_field
+    def fieldname(self) -> str:
+        species_name = self.species.name if isinstance(self.species, Species) else self.species.species.name
+        native_name = f"Average_{self._native_name}" if self._average else self._native_name
+        return f"{species_name}_{self.filtername or 'all'}_{native_name}"
+
+    def get_builtin_solver(self) -> tuple[str, str]:
+        direction = f"<{_DIRECTION_INDEX[self.direction]}>" if self.direction is not None else ""
+        base_type = f"deriveField::derivedAttributes::{self.field}{direction}"
+        solver_type = f"deriveField::combinedAttributes::AverageAttribute<{base_type}>" if self._average else base_type
+        if self.field in ("RelativisticDensity", "ScreeningInvSquared"):
+            solver_type = f"deriveField::combinedAttributes::{self.field}"
+        identifier_parts = ["Average" if self._average else "Native", self.field]
+        if self.direction is not None:
+            identifier_parts.append(str(_DIRECTION_INDEX[self.direction]))
+        if self.filtername is not None:
+            identifier_parts.append(self.filtername)
+        return solver_type, "_".join(identifier_parts)
+
+
+class NativeDerivedFieldDump(_BuiltinDerivedFieldDump):
+    """Dump a field using a built-in PIConGPU particle-to-grid implementation."""
+
+    field: NativeDerivedField
+
+
+class AverageDerivedFieldDump(_BuiltinDerivedFieldDump):
+    """Dump the cell-wise average of a built-in PIConGPU derived field."""
+
+    field: AverageableDerivedField
+    _average: ClassVar[bool] = True

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict
 from picongpu import pypicongpu, templates
 from picongpu.picmi import constants
 from picongpu.picmi.diagnostics import AnyDiagnostic
-from picongpu.picmi.diagnostics.field_dump import NativeFieldDump, _FieldDump
+from picongpu.picmi.diagnostics.field_dump import NativeFieldDump, _BuiltinDerivedFieldDump, _FieldDump
 from picongpu.picmi.diagnostics.particle_dump import ParticleDump
 from picongpu.picmi.grid import Cartesian3DGrid
 from picongpu.picmi.interaction import Interaction, Synchrotron
@@ -37,6 +37,7 @@ from picongpu.picmi.species_requirements import (
     resolving_add,
     run_construction,
 )
+from picongpu.pypicongpu.output.openpmd_plugin import BuiltinFieldSolver
 from picongpu.pypicongpu.output.openpmd_plugin import FieldDump as PyPIConGPUFieldDump
 from picongpu.pypicongpu.output.openpmd_plugin import OpenPMDPlugin
 from picongpu.pypicongpu.runner import Runner
@@ -381,9 +382,25 @@ class Simulation(picmistandard.PICMI_Simulation):
                         if isinstance(diagnostic, ParticleDump)
                         else PyPIConGPUFieldDump(
                             name=diagnostic.fieldname,
+                            species=(
+                                None
+                                if isinstance(diagnostic, NativeFieldDump)
+                                else "species_"
+                                + (
+                                    diagnostic.species.name
+                                    if isinstance(diagnostic.species, Species)
+                                    else diagnostic.species.species.name
+                                )
+                            ),
                             filtername=diagnostic.filtername,
+                            builtin_solver=(
+                                BuiltinFieldSolver(type=solver[0], typename=solver[1])
+                                if isinstance(diagnostic, _BuiltinDerivedFieldDump)
+                                and (solver := diagnostic.get_builtin_solver())
+                                else None
+                            ),
                             functor=None
-                            if isinstance(diagnostic, NativeFieldDump)
+                            if isinstance(diagnostic, (NativeFieldDump, _BuiltinDerivedFieldDump))
                             else diagnostic.functor.get_as_pypicongpu(mode="DerivedField"),
                         ),
                     )

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -19,7 +19,9 @@ from pydantic import (
     ConfigDict,
     PrivateAttr,
     ValidationError,
+    computed_field,
     field_validator,
+    model_validator,
     model_serializer,
 )
 
@@ -27,7 +29,6 @@ from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
 from picongpu.pypicongpu.particle_functor.filtered_species import FilteredSpecies
 from picongpu.pypicongpu.particle_functor.particle_functor import ParticleFunctor
 from picongpu.pypicongpu.species.species import Species
-from picongpu.pypicongpu.util import unique
 
 NATIVE_FIELDS = ["E", "B", "J"]
 
@@ -93,10 +94,60 @@ def to_string(timestepspec: TimeStepSpec):
     )
 
 
+class BuiltinFieldSolver(BaseModel):
+    type: str
+    typename: str
+
+
+class DerivedFieldSolver(BaseModel):
+    """One compile-time particle-to-grid operation for one species and filter."""
+
+    species: str
+    attribute_type: str
+    attribute_typename: str
+    filtername: str | None = None
+
+    @computed_field
+    @property
+    def filter_type(self) -> str:
+        return f"picongpu::particles::filter::{self.filtername or 'All'}"
+
+    @computed_field
+    @property
+    def typename(self) -> str:
+        return "_".join((self.attribute_typename, self.species, self.filtername or "All"))
+
+
 class FieldDump(BaseModel):
     name: str
+    species: str | None = None
     functor: ParticleFunctor | None = None
+    builtin_solver: BuiltinFieldSolver | None = None
     filtername: None | str
+
+    @model_validator(mode="after")
+    def _validate_solver_kind(self):
+        if self.functor is not None and self.builtin_solver is not None:
+            raise ValueError("a field dump cannot use both a custom functor and a built-in solver")
+        if (self.functor is not None or self.builtin_solver is not None) and self.species is None:
+            raise ValueError("a derived field dump requires a species")
+        return self
+
+    def get_solver(self) -> DerivedFieldSolver | None:
+        if self.functor is None and self.builtin_solver is None:
+            return None
+        attribute_type = (
+            f"deriveField::derivedAttributes::{self.functor.typename}"
+            if self.functor is not None
+            else self.builtin_solver.type
+        )
+        attribute_typename = self.functor.typename if self.functor is not None else self.builtin_solver.typename
+        return DerivedFieldSolver(
+            species=self.species,
+            attribute_type=attribute_type,
+            attribute_typename=attribute_typename,
+            filtername=self.filtername,
+        )
 
     def get_rendering_context(self) -> dict:
         return self.model_dump(mode="json")
@@ -161,11 +212,13 @@ class OpenPMDPlugin(BaseModel):
         return {
             "type_openPMD": True,
             "config_filename": str(self.config_filename(content, context="runtime")),
-            "derived_fields": unique(
-                source[1].model_dump(mode="json")
-                for source in self.sources
-                if isinstance(source[1], FieldDump) and source[1].functor is not None
-            ),
+            "sources": [
+                {
+                    "period": to_string(period),
+                    "source": source.get_rendering_context(),
+                }
+                for period, source in self.sources
+            ],
         }
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/lib/python/picongpu/pypicongpu/particle_functor/particle_functor.py
+++ b/lib/python/picongpu/pypicongpu/particle_functor/particle_functor.py
@@ -5,8 +5,9 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
+from hashlib import sha256
+from json import dumps
 from typing import Annotated, Literal
-from uuid import uuid4 as uuid
 
 from pydantic import BaseModel, BeforeValidator, computed_field, model_validator
 
@@ -138,7 +139,9 @@ class ParticleFunctor(RenderedObject, BaseModel):
 
     @computed_field
     def typename(self) -> str:
-        return f"{self.name}_{uuid().hex}"
+        definition = self.model_dump(mode="json", exclude={"typename"})
+        digest = sha256(dumps(definition, sort_keys=True).encode()).hexdigest()[:32]
+        return f"{self.name}_{digest}"
 
     @model_validator(mode="after")
     def _validate(self):

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -8,11 +8,12 @@ License: GPLv3+
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field, computed_field, field_serializer, field_validator
 
 from picongpu.pypicongpu.collisions import CollisionalPhysicsSetup
 from picongpu.pypicongpu.output.radiation import RadiationPlugin
 from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
+from picongpu.pypicongpu.output.openpmd_plugin import DerivedFieldSolver, FieldDump
 from picongpu.pypicongpu.particle_functor.particle_functor import ParticleFunctor
 from picongpu.pypicongpu.species.constant.synchrotron import SynchrotronParams
 from picongpu.pypicongpu.species.operation import AnyOperation
@@ -26,6 +27,7 @@ from .movingwindow import MovingWindow
 from .output import AnyPlugin, OpenPMDPlugin
 from .rendering import RenderedObject
 from .walltime import Walltime
+from .util import unique
 
 
 class Simulation(RenderedObject, BaseModel):
@@ -85,6 +87,25 @@ class Simulation(RenderedObject, BaseModel):
     synchrotron_params: SynchrotronParams = SynchrotronParams()
     collisional_physics: CollisionalPhysicsSetup = CollisionalPhysicsSetup()
     particle_filters: list[ParticleFunctor] = Field(default_factory=list)
+
+    def _derived_field_dumps(self):
+        return (
+            source
+            for plugin in self.output or []
+            if isinstance(plugin, OpenPMDPlugin)
+            for _, source in plugin.sources
+            if isinstance(source, FieldDump) and source.get_solver() is not None
+        )
+
+    @computed_field
+    @property
+    def derived_field_functors(self) -> list[ParticleFunctor]:
+        return unique(source.functor for source in self._derived_field_dumps() if source.functor is not None)
+
+    @computed_field
+    @property
+    def field_tmp_solvers(self) -> list[DerivedFieldSolver]:
+        return unique(source.get_solver() for source in self._derived_field_dumps())
 
     @field_validator("output", mode="after")
     @classmethod

--- a/lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache
+++ b/lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache
@@ -33,7 +33,7 @@ namespace picongpu
     namespace deriveField = particles::particleToGrid;
 
     namespace particles::particleToGrid::derivedAttributes {
-{{#output}} {{#type_openPMD}} {{#derived_fields}} {{#functor}}
+{{#derived_field_functors}}
 
     struct {{{typename}}} {
          HDINLINE float1_64 getUnit() const
@@ -65,22 +65,36 @@ namespace picongpu
 
     template<>
     struct IsWeighted<{{{typename}}}> : std::true_type {};
-{{/functor}} {{/derived_fields}} {{/type_openPMD}} {{/output}}
+{{/derived_field_functors}}
     }
 
-{{#output}} {{#type_openPMD}} {{#derived_fields}} {{#functor}}
+{{#field_tmp_solvers}}
+    using {{{typename}}}_Attribute = {{{attribute_type}}};
+    using {{{typename}}}_Filter = {{{filter_type}}};
+
+    static_assert(
+        particles::traits::SpeciesEligibleForSolver<
+            {{{species}}},
+            deriveField::FilteredDerivedAttribute<
+                {{{typename}}}_Attribute,
+                {{{typename}}}_Filter
+            >
+        >::type::value,
+        "Derived field {{{attribute_typename}}} with filter {{{filter_type}}} is not supported for {{{species}}}"
+    );
+
     using {{{typename}}}_Seq
-        = deriveField::CreateEligible_t<
-            VectorAllSpecies,
-            deriveField::derivedAttributes::{{{typename}}}
-            {{#filtername}},picongpu::particles::filter::{{{filtername}}}{{/filtername}}
-        >;
-{{/functor}} {{/derived_fields}} {{/type_openPMD}} {{/output}}
+        = MakeSeq_t<deriveField::CreateFieldTmpOperation_t<
+            {{{species}}},
+            {{{typename}}}_Attribute,
+            {{{typename}}}_Filter
+        >>;
+{{/field_tmp_solvers}}
 
     using FieldTmpSolvers = MakeSeq_t<
-    {{#output}}{{#type_openPMD}}{{#derived_fields}}{{#functor}}
+    {{#field_tmp_solvers}}
       {{{typename}}}_Seq,
-    {{/functor}}{{/derived_fields}}{{/type_openPMD}}{{/output}}
+    {{/field_tmp_solvers}}
       MakeSeq_t<>
     >;
 

--- a/lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache
+++ b/lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache
@@ -68,32 +68,50 @@ namespace picongpu
 {{/derived_field_functors}}
     }
 
-{{#field_tmp_solvers}}
-    using {{{typename}}}_Attribute = {{{attribute_type}}};
-    using {{{typename}}}_Filter = {{{filter_type}}};
+    template<typename T_Species, typename T_Attribute, typename T_Filter>
+    struct FieldTmpSolverConfig
+    {
+        using Species = T_Species;
+        using Attribute = T_Attribute;
+        using Filter = T_Filter;
+    };
 
-    static_assert(
-        particles::traits::SpeciesEligibleForSolver<
-            {{{species}}},
-            deriveField::FilteredDerivedAttribute<
-                {{{typename}}}_Attribute,
-                {{{typename}}}_Filter
-            >
-        >::type::value,
-        "Derived field {{{attribute_typename}}} with filter {{{filter_type}}} is not supported for {{{species}}}"
-    );
-
-{{/field_tmp_solvers}}
-
-    using FieldTmpSolvers = MakeSeq_t<
+    using FieldTmpSolverConfigs = MakeSeq_t<
     {{#field_tmp_solvers}}
-      deriveField::CreateFieldTmpOperation_t<
+      FieldTmpSolverConfig<
           {{{species}}},
-          {{{typename}}}_Attribute,
-          {{{typename}}}_Filter
+          {{{attribute_type}}},
+          {{{filter_type}}}
       >{{^_last}},{{/_last}}
     {{/field_tmp_solvers}}
     >;
+
+    template<typename T_Config>
+    struct ValidateFieldTmpSolver
+    {
+        static_assert(
+            particles::traits::SpeciesEligibleForSolver<
+                typename T_Config::Species,
+                deriveField::FilteredDerivedAttribute<
+                    typename T_Config::Attribute,
+                    typename T_Config::Filter
+                >
+            >::type::value,
+            "Derived-field solver is not supported for this species"
+        );
+
+        using type = deriveField::CreateFieldTmpOperation_t<
+            typename T_Config::Species,
+            typename T_Config::Attribute,
+            typename T_Config::Filter
+        >;
+    };
+
+    template<typename T_Config>
+    using ValidateFieldTmpSolver_t = typename ValidateFieldTmpSolver<T_Config>::type;
+
+    // mp_transform instantiates the validator, including its individual static_assert, for every configuration.
+    using FieldTmpSolvers = pmacc::mp_transform<ValidateFieldTmpSolver_t, FieldTmpSolverConfigs>;
 
 
     using NativeFileOutputFields = MakeSeq_t<FieldE, FieldB, FieldJ>;

--- a/lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache
+++ b/lib/python/picongpu/templates/include/picongpu/param/fileOutput.param.mustache
@@ -83,19 +83,16 @@ namespace picongpu
         "Derived field {{{attribute_typename}}} with filter {{{filter_type}}} is not supported for {{{species}}}"
     );
 
-    using {{{typename}}}_Seq
-        = MakeSeq_t<deriveField::CreateFieldTmpOperation_t<
-            {{{species}}},
-            {{{typename}}}_Attribute,
-            {{{typename}}}_Filter
-        >>;
 {{/field_tmp_solvers}}
 
     using FieldTmpSolvers = MakeSeq_t<
     {{#field_tmp_solvers}}
-      {{{typename}}}_Seq,
+      deriveField::CreateFieldTmpOperation_t<
+          {{{species}}},
+          {{{typename}}}_Attribute,
+          {{{typename}}}_Filter
+      >{{^_last}},{{/_last}}
     {{/field_tmp_solvers}}
-      MakeSeq_t<>
     >;
 
 

--- a/lib/python/test/picongpu/quick/picmi/diagnostics/test_derived_field_dump.py
+++ b/lib/python/test/picongpu/quick/picmi/diagnostics/test_derived_field_dump.py
@@ -1,0 +1,79 @@
+"""Tests for PICMI native and combined derived-field diagnostics."""
+
+import pytest
+from pydantic import ValidationError
+
+from picongpu.picmi import Species
+from picongpu.picmi.diagnostics import AverageDerivedFieldDump, NativeDerivedFieldDump
+
+
+@pytest.fixture
+def species():
+    return Species(name="electrons", particle_type="electron")
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_name"),
+    [
+        ("Density", "density"),
+        ("BoundElectronDensity", "boundElectronDensity"),
+        ("ChargeDensity", "chargeDensity"),
+        ("Counter", "particleCounter"),
+        ("Energy", "particleEnergy"),
+        ("EnergyDensity", "energyDensity"),
+        ("LarmorPower", "larmorPower"),
+        ("MacroCounter", "macroParticleCounter"),
+        ("RelativisticDensity", "relativisticDensity"),
+        ("ScreeningInvSquared", "invSquaredScreenLength"),
+    ],
+)
+def test_native_scalar_and_combined_fields(species, field, expected_name):
+    diagnostic = NativeDerivedFieldDump(species=species, field=field)
+
+    assert diagnostic.fieldname == f"electrons_all_{expected_name}"
+    namespace = "combinedAttributes" if field in ("RelativisticDensity", "ScreeningInvSquared") else "derivedAttributes"
+    assert diagnostic.get_builtin_solver()[0] == f"deriveField::{namespace}::{field}"
+
+
+@pytest.mark.parametrize(
+    ("field", "native_name"),
+    [
+        ("MidCurrentDensityComponent", "midCurrentDensity"),
+        ("Momentum", "particleMomentum"),
+        ("MomentumDensity", "momentumDensity"),
+        ("WeightedVelocity", "weightedVelocity"),
+    ],
+)
+def test_native_directional_fields(species, field, native_name):
+    diagnostic = NativeDerivedFieldDump(species=species, field=field, direction="y")
+
+    assert diagnostic.fieldname == f"electrons_all_{native_name}/y"
+    assert diagnostic.get_builtin_solver()[0] == f"deriveField::derivedAttributes::{field}<1>"
+
+
+def test_average_weighted_velocity(species):
+    diagnostic = AverageDerivedFieldDump(species=species, field="WeightedVelocity", direction="z")
+
+    assert diagnostic.fieldname == "electrons_all_Average_weightedVelocity/z"
+    assert diagnostic.get_builtin_solver()[0] == (
+        "deriveField::combinedAttributes::AverageAttribute<deriveField::derivedAttributes::WeightedVelocity<2>>"
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"field": "Momentum"},
+        {"field": "Density", "direction": "x"},
+        {"field": "EnergyDensityCutoff"},
+    ],
+)
+def test_invalid_native_field_configuration(species, kwargs):
+    with pytest.raises(ValidationError):
+        NativeDerivedFieldDump(species=species, **kwargs)
+
+
+@pytest.mark.parametrize("field", ["MacroCounter", "RelativisticDensity", "ScreeningInvSquared"])
+def test_non_averageable_fields_are_rejected(species, field):
+    with pytest.raises(ValidationError):
+        AverageDerivedFieldDump(species=species, field=field)

--- a/lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py
@@ -1,0 +1,126 @@
+"""Tests for rendering built-in openPMD derived fields."""
+
+from picongpu import templates
+from picongpu.pypicongpu.output.openpmd_plugin import BuiltinFieldSolver, FieldDump
+from picongpu.pypicongpu.output.openpmd_plugin import OpenPMDConfig, OpenPMDPlugin
+from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
+from picongpu.pypicongpu.particle_functor import ParticleFunctor
+from picongpu.pypicongpu.rendering import Renderer
+from picongpu.pypicongpu.simulation import Simulation
+
+
+def test_builtin_solver_rendering_has_no_functor_struct():
+    field = FieldDump(
+        name="electrons_all_weightedVelocity/x",
+        species="species_electrons",
+        filtername=None,
+        builtin_solver=BuiltinFieldSolver(
+            type="deriveField::derivedAttributes::WeightedVelocity<0>",
+            typename="Native_WeightedVelocity_0",
+        ),
+    )
+    template = (templates.path() / "include/picongpu/param/fileOutput.param.mustache").read_text()
+    context = {
+        "derived_field_functors": [],
+        "field_tmp_solvers": [field.get_solver().model_dump(mode="json")],
+    }
+
+    rendered = Renderer.get_rendered_template(context, template)
+
+    assert "struct" not in rendered
+    assert "using Native_WeightedVelocity_0_species_electrons_All_Seq" in rendered
+    assert "deriveField::derivedAttributes::WeightedVelocity<0>" in rendered
+    assert "species_electrons" in rendered
+    assert "CreateEligible_t" not in rendered
+    assert "VectorAllSpecies" not in rendered.split("using FieldTmpSolvers", maxsplit=1)[0]
+    assert "static_assert" in rendered
+
+
+def test_solver_deduplication_includes_species_and_filter(tmp_path):
+    solver = BuiltinFieldSolver(type="deriveField::derivedAttributes::Density", typename="Native_Density")
+    period = TimeStepSpec(specs=[{"start": 0, "stop": 10, "step": 1}])
+    plugin = OpenPMDPlugin(
+        sources=[
+            (
+                period,
+                FieldDump(
+                    name="electrons_all_density",
+                    species="species_electrons",
+                    filtername=None,
+                    builtin_solver=solver,
+                ),
+            ),
+            (
+                period,
+                FieldDump(
+                    name="electrons_all_density_duplicate",
+                    species="species_electrons",
+                    filtername=None,
+                    builtin_solver=solver,
+                ),
+            ),
+            (
+                period,
+                FieldDump(
+                    name="ions_all_density",
+                    species="species_ions",
+                    filtername=None,
+                    builtin_solver=solver,
+                ),
+            ),
+            (
+                period,
+                FieldDump(
+                    name="electrons_filtered_density",
+                    species="species_electrons",
+                    filtername="EnergyFilter",
+                    builtin_solver=solver,
+                ),
+            ),
+        ],
+        config=OpenPMDConfig(file="simData"),
+    )
+    plugin.setup_dir = tmp_path
+    (tmp_path / "etc").mkdir()
+
+    simulation = Simulation.model_construct(output=[plugin])
+    solvers = simulation.field_tmp_solvers
+
+    assert len(solvers) == 3
+    assert {entry.species for entry in solvers} == {"species_electrons", "species_ions"}
+    assert {entry.filtername for entry in solvers} == {None, "EnergyFilter"}
+
+    serialized_plugin = plugin.model_dump(mode="json")
+    assert len(serialized_plugin["sources"]) == 4
+    assert serialized_plugin["sources"][0]["source"]["name"] == "electrons_all_density"
+
+
+def test_custom_functor_definition_is_reused_by_species_specific_solvers():
+    functor = ParticleFunctor(
+        name="custom_density",
+        functor_expression="1.0",
+        functor_preamble=[],
+        return_type=float,
+    )
+    period = TimeStepSpec(specs=[{"start": 0, "stop": 10, "step": 1}])
+    plugins = [
+        OpenPMDPlugin(
+            sources=[
+                (
+                    period,
+                    FieldDump(
+                        name=f"{species}_all_custom_density",
+                        species=f"species_{species}",
+                        filtername=None,
+                        functor=functor,
+                    ),
+                )
+            ]
+        )
+        for species in ("electrons", "ions")
+    ]
+    simulation = Simulation.model_construct(output=plugins)
+
+    assert len(simulation.derived_field_functors) == 1
+    assert len(simulation.field_tmp_solvers) == 2
+    assert simulation.field_tmp_solvers[0].attribute_type == simulation.field_tmp_solvers[1].attribute_type

--- a/lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py
@@ -27,11 +27,13 @@ def test_builtin_solver_rendering_has_no_functor_struct():
 
     rendered = Renderer.get_rendered_template(Renderer.get_context_preprocessed(context), template)
 
-    assert "struct" not in rendered
+    assert "struct Native_WeightedVelocity_0" not in rendered
     assert "Native_WeightedVelocity_0_species_electrons_All_Seq" not in rendered
     assert "deriveField::derivedAttributes::WeightedVelocity<0>" in rendered
     assert "species_electrons" in rendered
     assert "deriveField::CreateFieldTmpOperation_t<" in rendered
+    assert "FieldTmpSolverConfig<" in rendered
+    assert "pmacc::mp_transform<ValidateFieldTmpSolver_t, FieldTmpSolverConfigs>" in rendered
     assert "CreateEligible_t" not in rendered
     assert "VectorAllSpecies" not in rendered.split("using FieldTmpSolvers", maxsplit=1)[0]
     assert "static_assert" in rendered

--- a/lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_openpmd_derived_fields.py
@@ -25,12 +25,13 @@ def test_builtin_solver_rendering_has_no_functor_struct():
         "field_tmp_solvers": [field.get_solver().model_dump(mode="json")],
     }
 
-    rendered = Renderer.get_rendered_template(context, template)
+    rendered = Renderer.get_rendered_template(Renderer.get_context_preprocessed(context), template)
 
     assert "struct" not in rendered
-    assert "using Native_WeightedVelocity_0_species_electrons_All_Seq" in rendered
+    assert "Native_WeightedVelocity_0_species_electrons_All_Seq" not in rendered
     assert "deriveField::derivedAttributes::WeightedVelocity<0>" in rendered
     assert "species_electrons" in rendered
+    assert "deriveField::CreateFieldTmpOperation_t<" in rendered
     assert "CreateEligible_t" not in rendered
     assert "VectorAllSpecies" not in rendered.split("using FieldTmpSolvers", maxsplit=1)[0]
     assert "static_assert" in rendered


### PR DESCRIPTION
Adds support for natively implemented derived fields in picmi. Also switches to compiling only used species, solver,  filter combinations.

WIP since this is fully vibe coded, and I didn't have time to review it yet. Definitely need to remove the handover.md before merging. Already used it in a production run, and it works, but I only tried using density and energy density output (No filters, averaged fields, fields with components, combinations with picmi generated custom solvers etc.. ) . 

I won't have the time to review the AI code before my holiday. So @chillenzer fill free to take over from this and finalise yourself, or I can have a look when I come back. 