### PR TITLE
pmacc device buffer destruction host sync

### DIFF
--- a/include/pmacc/memory/buffers/DeviceBuffer.hpp
+++ b/include/pmacc/memory/buffers/DeviceBuffer.hpp
@@ -164,6 +164,7 @@ namespace pmacc
         ~DeviceBuffer() override
         {
             eventSystem::startOperation(ITask::TASK_DEVICE);
+            eventSystem::startOperation(ITask::TASK_HOST);
         }
 
         void reset(bool preserveData = true) override


### PR DESCRIPTION
Previously `DeviceBuffer` destruction was a `TASK_DEVICE`, which could cause use after free issues.
For example, it meant that if the destructor was enqueued after some device kernel calls, the event system simply enqueued the kernels and then the destructor and the main thread simply continued with the destruction (as device tasks can be done async in our even system model, and the actual act of destruction is done from the host side). This meant that kernels might be writing to memory which is already destroyed. 

This PR adds some synchronization on device buffer destruction, and thus can have a performance impact. I have not done any measurement for this.
In PIConGPU I couldn't find any places where this was necessary for correctness, because in the places I found, we have explicit waits for the event system (but its probable I didn't find all places where this pattern occours). However, this change makes it easier to have correct code without races with destruction.   