### PR TITLE
Density loading: Explicitly open Iterations

### DIFF
--- a/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
+++ b/include/picongpu/particles/densityProfiles/FromOpenPMDImpl.hpp
@@ -125,7 +125,7 @@ namespace picongpu
                         % SpeciesType::FrameType::getName() % filename;
                     auto series
                         = ::openPMD::Series{filename, ::openPMD::Access::READ_ONLY, gc.getCommunicator().getMPIComm()};
-                    auto mesh = series.iterations[ParamClass::iteration].meshes[ParamClass::datasetName];
+                    auto mesh = series.iterations[ParamClass::iteration].open().meshes[ParamClass::datasetName];
                     ::openPMD::MeshRecordComponent dataset = mesh[::openPMD::RecordComponent::SCALAR];
                     auto const indexConverter = IndexConverter{mesh};
                     auto const datasetExtent = indexConverter.openPMDToXyz(dataset.getExtent());
@@ -162,7 +162,7 @@ namespace picongpu
                             indexConverter.xyzToOpenPMD(chunkExtent));
                     }
                     // This is MPI collective and so has to be done by all ranks
-                    series.flush();
+                    mesh.seriesFlush();
 
                     if(readFromFile)
                     {


### PR DESCRIPTION
The density loader might not actually load data on all ranks. The openPMD-api only implicitly opens those files that actually see action, leading to a deadlock since file accesses are collective.

In parallel setups, explicit `Iteration::open()` is necessary to ensure that all ranks participate in the collective file opening operation. 
Additionally, `mesh.seriesFlush()` will ensure that the containing Iteration is flushed in any case, dirty or not.

Each of these fixes is sufficient for fixing the hangup, this PR adds both.