### PR TITLE
Fix leaving particle binner not being called

### DIFF
--- a/include/picongpu/plugins/binning/BinningDispatcher.x.cpp
+++ b/include/picongpu/plugins/binning/BinningDispatcher.x.cpp
@@ -109,6 +109,12 @@ namespace picongpu
             {
             }
 
+            void onParticleLeave(std::string const& speciesName, int32_t const direction) override
+            {
+                for(auto&& binner : binnerVector)
+                    binner->onParticleLeave(speciesName, direction);
+            }
+
         protected:
             void pluginLoad() override
             {

--- a/include/pmacc/pluginSystem/IPlugin.hpp
+++ b/include/pmacc/pluginSystem/IPlugin.hpp
@@ -108,10 +108,8 @@ namespace pmacc
         virtual std::string pluginGetName() const = 0;
 
         /**
-         * Called each timestep if particles are leaving the global simulation volume.
-         *
-         * This method is only called for species which are marked with the
-         * `GuardHandlerCallPlugins` policy in their descpription.
+         * Called each timestep for each particle species and active outer boundary, before boundary conditions are
+         * applied. The callback may be called even if no particle crossed the boundary.
          *
          * The order in which the plugins are called is undefined, so this means
          * read-only access to the particles.


### PR DESCRIPTION
I forgot to pass through calls to `onParticleLeave` from the `binningDispather` to the registered binning plugins, thus it was never called by the plugins, and was completely ignored and thus in a broken state with empty outputs.   