### PR TITLE
Update ISAAC in CI

### DIFF
--- a/share/ci/bash.profile
+++ b/share/ci/bash.profile
@@ -22,10 +22,6 @@ if [ -z "$DISABLE_ISAAC" ] ; then
   export CMAKE_PREFIX_PATH=$ICET_ROOT/lib:$CMAKE_PREFIX_PATH
   export LD_LIBRARY_PATH=$ICET_ROOT/lib:$LD_LIBRARY_PATH
 
-  export JANSSON_ROOT=/opt/jansson/2.9.0/
-  export CMAKE_PREFIX_PATH=$JANSSON_ROOT/lib/cmake:$CMAKE_PREFIX_PATH
-  export LD_LIBRARY_PATH=$JANSSON_ROOT/lib:$LD_LIBRARY_PATH
-
   export ISAAC_ROOT=/opt/isaac/1.6.0-dev-custom
   # install cusom version of isaac
   source $CI_PROJECT_DIR/share/ci/install/isaac.sh

--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -17,9 +17,23 @@ if [ -z "$DISABLE_ISAAC" ] ; then
     make install
 
     cd $CI_PROJECT_DIR
+
+    export JANSSON_VERSION=v2.14.1
+    export JANSSON_ROOT=/opt/jansson/$JANSSON_VERSION
+    export CMAKE_PREFIX_PATH=$JANSSON_ROOT:$CMAKE_PREFIX_PATH
+    export LD_LIBRARY_PATH=$JANSSON_ROOT/lib:$LD_LIBRARY_PATH
+    git clone https://github.com/akheron/jansson.git --depth 1 \
+        --branch $JANSSON_VERSION
+    cd $ISAAC_SOURCE_DIR/jansson
+    mkdir build
+    cd build
+    cmake ../ -DCMAKE_INSTALL_PREFIX=$JANSSON_ROOT
+    make install
+
+    cd $CI_PROJECT_DIR
     git clone https://github.com/ComputationalRadiationPhysics/isaac.git
     cd isaac
-    git checkout 9c8f710fd054690385d58ce89b353f3bb066979d
+    git checkout bb554c7ea7e62712309946f971a905e3835da6f9
     mkdir build_isaac
     cd build_isaac
     cmake ../lib/ -DCMAKE_INSTALL_PREFIX=$ISAAC_ROOT

--- a/share/ci/install/isaac.sh
+++ b/share/ci/install/isaac.sh
@@ -24,7 +24,7 @@ if [ -z "$DISABLE_ISAAC" ] ; then
     export LD_LIBRARY_PATH=$JANSSON_ROOT/lib:$LD_LIBRARY_PATH
     git clone https://github.com/akheron/jansson.git --depth 1 \
         --branch $JANSSON_VERSION
-    cd $ISAAC_SOURCE_DIR/jansson
+    cd jansson
     mkdir build
     cd build
     cmake ../ -DCMAKE_INSTALL_PREFIX=$JANSSON_ROOT


### PR DESCRIPTION
Updates ISAAC to a current commit. This is helpful, as the currently used version has deprecated cmake files which will break, once we update cmake at some point.

This also installs a new compatible version of jansson as a dependency for ISAAC.