### PR TITLE
workaround github clone issues

### DIFF
--- a/share/ci/compiler_clang.yml
+++ b/share/ci/compiler_clang.yml
@@ -7,6 +7,10 @@
     GIT_SUBMODULE_STRATEGY: normal
     # ISAAC is not supporting CPU
     DISABLE_ISAAC: "yes"
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   script:
     #  fix apt error: libomp-10-dev : Depends: libomp5-10 (= 1:10.0.0-4ubuntu1~18.04.2) but it is not going to be installed
     - sed -i -e '1,2d' /etc/apt/sources.list.d/llvm.list

--- a/share/ci/compiler_clang_cuda.yml
+++ b/share/ci/compiler_clang_cuda.yml
@@ -9,6 +9,10 @@
     PIC_CMAKE_ARGS: "-DCMAKE_CUDA_FLAGS=--no-cuda-version-check"
     CI_CLANG_AS_CUDA_COMPILER: "yes"
     DISABLE_ISAAC: "yes"
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   script:
     #  fix apt error: libomp-10-dev : Depends: libomp5-10 (= 1:10.0.0-4ubuntu1~18.04.2) but it is not going to be installed
     - sed -i -e '1,2d' /etc/apt/sources.list.d/llvm.list

--- a/share/ci/compiler_gcc.yml
+++ b/share/ci/compiler_gcc.yml
@@ -7,6 +7,10 @@
     GIT_SUBMODULE_STRATEGY: normal
     # ISAAC is not supporting CPU
     DISABLE_ISAAC: "yes"
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   script:
     - apt update
     - apt install -y curl libjpeg-dev

--- a/share/ci/compiler_hipcc.yml
+++ b/share/ci/compiler_hipcc.yml
@@ -8,6 +8,10 @@
     GIT_SUBMODULE_STRATEGY: normal
     # CI_GPU_ARCH architecture of the hosted GPU is provided by the CI
     GPU_TARGETS: ${CI_GPU_ARCH}
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   script:
     - source $CI_PROJECT_DIR/share/ci/install/cmake.sh
     - export PATH="$PATH:/opt/rocm/llvm/bin/"

--- a/share/ci/compiler_nvcc_cuda.yml
+++ b/share/ci/compiler_nvcc_cuda.yml
@@ -5,6 +5,10 @@
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-${CI_CONTAINER_NAME}-cuda${CUDA_CONTAINER_VERSION}-gcc-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   before_script:
     - nvidia-smi
     - nvcc --version

--- a/share/ci/pypicongpu.yml
+++ b/share/ci/pypicongpu.yml
@@ -3,6 +3,10 @@
   variables:
     GIT_SUBMODULE_STRATEGY: normal
     CXX_VERSION: g++-13
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   script:
     - echo "CI_CONTAINER_NAME -> $CI_CONTAINER_NAME"
     - echo "PYTHON_VERSION -> $PYTHON_VERSION"
@@ -16,6 +20,10 @@
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-${CI_CONTAINER_NAME}-gcc-pic:${CONTAINER_TAG}
   variables:
     GIT_SUBMODULE_STRATEGY: normal
+    # workaround github clone issues: https://github.com/orgs/community/discussions/206581
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: "http.https://github.com.version"
+    GIT_CONFIG_VALUE_0: "HTTP/1.1"
   script:
     - echo "CI_CONTAINER_NAME -> $CI_CONTAINER_NAME"
     - echo "PYTHON_VERSION -> $PYTHON_VERSION"


### PR DESCRIPTION
The CI has issues to fetch external dependencies due to Github limitations, this PR is applying a known workaround.

https://github.com/orgs/community/discussions/206581

This is only a temporary workaround until we switch to using an access key.