### PR TITLE
Fix script output in Documentation for the memory calculator script

### DIFF
--- a/docs/source/usage/workflows/memoryPerDevice.rst
+++ b/docs/source/usage/workflows/memoryPerDevice.rst
@@ -19,6 +19,6 @@ between devices.
 
 This will give the following output:
 
-.. program-output:: bash -c "PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH /usr/bin/env python -m pip install -r ../../lib/python/picongpu/requirements.txt >> /dev/null; PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH ./usage/workflows/memoryPerDevice.py"
+.. program-output:: bash -c "PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH /usr/bin/env python -m pip install -e ../../lib/python &> /dev/null; PYTHONPATH=$(pwd)/../../lib/python:$PYTHONPATH ./usage/workflows/memoryPerDevice.py"
 
 If you have a machine or cluster node with NVIDIA GPUs you can find out the available memory size by typing ``nvidia-smi`` on a shell.


### PR DESCRIPTION
This fixes #5778 by using the [newer installation method](https://github.com/ComputationalRadiationPhysics/picongpu/pull/5307) for the `picongpu` python package.

**Small warning**: The "new" installation method installs some packages via `git`, which writes all its output into the `stderr`. Therefore, both the `stdout` and `stderr` of the `pip install` now need to be redirected into `/dev/null`. This has the disadvantage that error messages won't be printed in the future. But, this will probably be noticeable as script execution also breaks.