### PR TITLE
Add end-to-end PICMI tests to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,3 +201,18 @@ pypicongpu-compiling-test:
     CMAKE_VERSION: '3.28'
     BOOST_VERSION: '1.75.0'
     PYTHON_COMPILING_TEST: 'ON'
+
+pypicongpu-end-to-end-test:
+  stage: test
+  extends: .base_pypicongpu_compile_test
+  variables:
+    PIP_BREAK_SYSTEM_PACKAGES: 1
+    CI_CONTAINER_NAME: 'ubuntu24.04'
+    PYTHON_VERSION: '3.11.*'
+    CXX_VERSION: 'g++-13'
+    CMAKE_VERSION: '3.28'
+    BOOST_VERSION: '1.75.0'
+    PYTHON_END_TO_END_TEST: 'ON'
+    # ISAAC does not support CPU and its plugin dominates the build memory
+    # (a single translation unit peaks at ~13 GiB); the e2e tests do not use it.
+    DISABLE_ISAAC: '1'

--- a/lib/python/test/picongpu/end_to_end/test_free_formula_density.py
+++ b/lib/python/test/picongpu/end_to_end/test_free_formula_density.py
@@ -15,7 +15,7 @@ from picongpu.picmi.diagnostics.timestepspec import TimeStepSpec
 from picongpu.picmi.diagnostics.checkpoint import Checkpoint
 
 from .arbitrary_parameters import CELL_SIZE, NUMBER_OF_CELLS, UPPER_BOUNDARY, directory_in_home, gather_results
-from .binning_functors import binning_diagnostics
+from .binning_functors import density_binning_for, position_binning_for
 from .compare_particles import (
     compare_particles,
     read_binning,
@@ -63,6 +63,16 @@ def generate_species(name, distribution):
     ]
 
 
+# All (setup, impl) combinations, i.e. exactly the set of species of this simulation.
+SPECIES_COMBINATIONS = tuple(
+    (name, suffix) for name, distributions in DISTRIBUTIONS.items() for suffix, dist in distributions.items()
+)
+
+# Representative species on which the density-independent position/origin/unit
+# checks are instantiated (see setup_sim): the first (setup, impl) combination.
+REPRESENTATIVE = SPECIES_COMBINATIONS[0]
+
+
 def setup_sim():
     sim = basic_simulation()
 
@@ -75,7 +85,18 @@ def setup_sim():
         [],
     )
 
-    diagnostics = [Checkpoint(period=TimeStepSpec[:])] + binning_diagnostics(species, sim.time_step_size)
+    # The particle-density binning must exist for every species: that is the
+    # per-density coverage this test provides (predefined vs. free-form).
+    # The position/origin/unit checks, however, are density-independent, so we
+    # instantiate them for a single representative species only. Doing it for
+    # every species would blow up the memory of the single BinningDispatcher
+    # translation unit that compiles all these functors.
+    representative = [next(s for s in species if s.name == generate_name(*REPRESENTATIVE))]
+    diagnostics = (
+        [Checkpoint(period=TimeStepSpec[:])]
+        + sum((density_binning_for(s) for s in species), [])
+        + sum((position_binning_for(s, sim.time_step_size) for s in representative), [])
+    )
 
     for s in species:
         sim.add_species(s, LAYOUT)
@@ -85,7 +106,11 @@ def setup_sim():
         # On ROSI, the tmp directories are inaccessible to compute nodes.
         sim.picongpu_get_runner().setup_dir = directory_in_home() / "setup"
         sim.picongpu_get_runner().run_dir = directory_in_home() / "run"
-    sim.step(0)
+    # This 12-species simulation inflates every per-species translation unit of
+    # the core build. Even with the reduced binning set above, compiling with
+    # the default -j 4 exceeds the CI runner's memory (cc1plus OOM-killed), so
+    # limit the build to 2 parallel jobs.
+    sim.step(0, jobs=2)
     return sim
 
 
@@ -170,41 +195,39 @@ class TestFreeFormulaDensity(TestCase):
         # As we don't in this test, there isn't really much to test
         # except for the fact that all the different coordinates must be identical.
         # The position_check functor does so by counting the correct ones.
-        number_of_particles = (
+        # The position/origin checks are only instantiated for the representative
+        # species (see REPRESENTATIVE), because they are density-independent.
+        setup, impl = REPRESENTATIVE
+        count = (
             read_particles(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")["weighting"]
             .groupby(["setup", "impl"])
             .count()
+            .loc[(setup, impl)]
         )
 
-        for (setup, impl), count in number_of_particles.items():
-            assert (
-                round(
-                    read_position_check(
-                        self.result_path
-                        / "simOutput"
-                        / "binningOpenPMD"
-                        / f"origin_{generate_name(setup, impl)}_000000.h5"
-                    )
+        assert (
+            round(
+                read_position_check(
+                    self.result_path / "simOutput" / "binningOpenPMD" / f"origin_{generate_name(setup, impl)}_000000.h5"
                 )
-                == count
             )
+            == count
+        )
 
     def test_unit_conversions_by_hand(self):
-        number_of_particles = (
+        setup, impl = REPRESENTATIVE
+        count = (
             read_particles(self.result_path / "simOutput" / "checkpoints" / "checkpoint_000000.bp5")["weighting"]
             .groupby(["setup", "impl"])
             .count()
+            .loc[(setup, impl)]
         )
 
-        for (setup, impl), count in number_of_particles.items():
-            assert (
-                round(
-                    read_position_check(
-                        self.result_path
-                        / "simOutput"
-                        / "binningOpenPMD"
-                        / f"unit_{generate_name(setup, impl)}_000000.h5"
-                    )
+        assert (
+            round(
+                read_position_check(
+                    self.result_path / "simOutput" / "binningOpenPMD" / f"unit_{generate_name(setup, impl)}_000000.h5"
                 )
-                == count
             )
+            == count
+        )

--- a/share/ci/install/pypicongpu.sh
+++ b/share/ci/install/pypicongpu.sh
@@ -96,3 +96,40 @@ if [ ! -z ${PYTHON_COMPILING_TEST+x} ]; then
     # execute the compiling test
     python3 -m pytest compiling/ -v
 fi
+
+# running the end-to-end (actual simulation) tests is optional
+# for the end-to-end test we need: cmake, boost and openmpi
+# openmpi is available without extra work
+if [ ! -z ${PYTHON_END_TO_END_TEST+x} ]; then
+    export PIC_BACKEND=serial
+    # the CI job runs as root, but OpenMPI refuses to start as root,
+    # so the simulation would be aborted by mpiexec before producing output
+    export OMPI_ALLOW_RUN_AS_ROOT=1
+    export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    # setup cmake
+    if [ ! -z ${CMAKE_VERSION+x} ]; then
+        if agc-manager -e cmake@${CMAKE_VERSION} ; then
+            export PATH=$(agc-manager -b cmake@${CMAKE_VERSION})/bin:$PATH
+        else
+            script_error "No implementation to install cmake ${CMAKE_VERSION}"
+        fi
+    else
+        script_error "CMAKE_VERSION is not defined"
+    fi
+
+    # setup boost
+    if [ ! -z ${BOOST_VERSION+x} ]; then
+        if agc-manager -e boost@${BOOST_VERSION} ; then
+            export CMAKE_PREFIX_PATH=$(agc-manager -b boost@${BOOST_VERSION}):$CMAKE_PREFIX_PATH
+        else
+            script_error "No implementation to install boost ${BOOST_VERSION}"
+        fi
+    else
+        script_error "BOOST_VERSION is not defined"
+    fi
+
+    # set C++ compiler
+    export CXX=$CXX_VERSION
+    # execute the end-to-end tests
+    python3 -m pytest end_to_end/ -v
+fi


### PR DESCRIPTION
Add end-to-end PICMI tests to CI.

Runs the existing end-to-end (actual simulation) suite at `lib/python/test/picongpu/end_to_end/` in a new `pypicongpu-end-to-end-test` job.

- `.gitlab-ci.yml`: new job extending `.base_pypicongpu_compile_test`.
- `share/ci/install/pypicongpu.sh`: run the suite (serial backend) when `PYTHON_END_TO_END_TEST` is set; allow mpiexec to run as root (the GitLab runner executes jobs as root, and OpenMPI otherwise aborts before the simulation can write output).
- `DISABLE_ISAAC=1`: ISAAC is CPU-unsupported and its plugin translation unit (~13 GiB) OOMs the e2e build; the tests do not use it.
- `test_free_formula_density.py`: instantiate the density-independent position/origin/unit binning checks on one representative species and build with `jobs=2` to keep the compile within the runner's memory.

Not included here (possible follow-ups): de-masking the `tee` in the submission templates, a failure-gate in `gather_results()`, and splitting the binning dispatcher translation unit.
