### PR TITLE
Add jupyter-related pre-commit hooks (nbstripout + check-jsonschema)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,3 +92,21 @@ repos:
       - id: pyproject-fmt
         # The default is 3.13, which would strip the 3.14 classifier.
         args: ["--max-supported-python", "3.14"]
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.9.1
+    hooks:
+      # Commit-time filter: strips outputs, execution counts and default metadata, normalizes cell ids.
+      # Does not rewrite already-committed history.
+      - id: nbstripout
+        types: [jupyter]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.38.0
+    hooks:
+      # Validates each notebook against the official nbformat v4 schema.
+      # Duplicate cell ids aren't expressible in JSON Schema; nbstripout makes them unique on each commit.
+      - id: check-jsonschema
+        name: check notebook against the nbformat v4 schema
+        files: \.ipynb$
+        types: [jupyter]
+        args:
+          - --schemafile=https://raw.githubusercontent.com/jupyter/nbformat/v5.11.1/nbformat/v4/nbformat.v4.schema.json

--- a/lib/python/picongpu/extra/input/createBunch_example.ipynb
+++ b/lib/python/picongpu/extra/input/createBunch_example.ipynb
@@ -2,6 +2,7 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "id": "0",
       "metadata": {},
       "source": [
         "# Define a PWFA driver bunch and add it to a PIConGPU simulation"
@@ -9,6 +10,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "1",
       "metadata": {},
       "source": [
         "## Intro\n",
@@ -23,6 +25,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "2",
       "metadata": {},
       "source": [
         "## load modules"
@@ -31,6 +34,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "3",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -42,6 +46,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "4",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -53,6 +58,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "5",
       "metadata": {},
       "source": [
         "## Generate a electron bunch at a known location\n",
@@ -61,6 +67,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "6",
       "metadata": {},
       "source": [
         "### define bunch parameters"
@@ -69,6 +76,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "7",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -86,6 +94,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "8",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -128,6 +137,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "9",
       "metadata": {},
       "source": [
         "## Getting particles into the PIC code\n",
@@ -137,6 +147,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "10",
       "metadata": {},
       "source": [
         "### Parameters from the actual simulation\n",
@@ -146,6 +157,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "11",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -158,6 +170,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "12",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -167,6 +180,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "13",
       "metadata": {
         "tags": []
       },
@@ -178,6 +192,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "14",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -190,6 +205,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "15",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -204,6 +220,7 @@
     },
     {
       "cell_type": "markdown",
+      "id": "16",
       "metadata": {
         "tags": []
       },
@@ -214,6 +231,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "17",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -225,6 +243,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "18",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -246,6 +265,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
+      "id": "19",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -278,5 +298,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 4
+  "nbformat_minor": 5
 }

--- a/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
+++ b/lib/python/picongpu/extra/input/preparingInsightData_example.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "id": "d25194cb-4633-4cfd-ab12-faa10f9926bc",
+      "id": "0",
       "metadata": {},
       "source": [
         "This file is part of PIConGPU. \\\n",
@@ -21,7 +21,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "8f20b708-32b3-416e-b3d6-018884281b8c",
+      "id": "1",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -35,7 +35,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "6e06caf1-30ea-46f9-90c9-4d691dccf127",
+      "id": "2",
       "metadata": {},
       "source": [
         "## Get the data\n",
@@ -53,7 +53,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "df9bc30d-c03b-4cb4-9621-b2aa62142f6a",
+      "id": "3",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -64,7 +64,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "2c7db135-e858-4152-9ec6-1d0358180f43",
+      "id": "4",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -161,7 +161,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "18bee9ee-bd16-4e28-b9a7-ac5bc12e112e",
+      "id": "5",
       "metadata": {},
       "source": [
         "## Correct the data\n",
@@ -174,7 +174,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "db7ee493-ac2f-4c62-9121-70d270587ae5",
+      "id": "6",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -184,7 +184,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "fe86408e-4e08-4f9a-8044-b0dfc989d408",
+      "id": "7",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -202,7 +202,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "11125a32-e618-40b4-aa4b-e1e51def5c3e",
+      "id": "8",
       "metadata": {},
       "source": [
         "### Correct ugly spots in the near field (optional)\n",
@@ -212,7 +212,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "0c772bfd-2d6b-4206-8dbd-f574d50d3931",
+      "id": "9",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -224,7 +224,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "2ab764a7-979d-417f-bae4-15f19ca790e8",
+      "id": "10",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -257,7 +257,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "d63c3650-d902-4d71-8bbf-60a8c3b8bca6",
+      "id": "11",
       "metadata": {},
       "source": [
         "### Center the near field beam spot (optional)\n",
@@ -267,7 +267,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "b88a2410-f9ca-4ff9-ab1b-3954c38b90b5",
+      "id": "12",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -277,7 +277,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "cfbe99d5-97b1-44b6-879c-ed97e3eae945",
+      "id": "13",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -309,7 +309,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "8f6942a0-43a0-4b55-92fa-a7d6ceb9a59a",
+      "id": "14",
       "metadata": {},
       "source": [
         "## Measure dispersion parameters\n",
@@ -327,7 +327,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "ae6d2380-f5c3-4ec4-8918-23ca0fbb6ce2",
+      "id": "15",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -339,7 +339,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "6d645f08-4e8d-40ba-af73-533fdd9aa8cb",
+      "id": "16",
       "metadata": {},
       "source": [
         "## Add an aperture in the mid field (optional)\n",
@@ -349,7 +349,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "fb07e460-f729-46a9-8e28-d32e968968ed",
+      "id": "17",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -361,7 +361,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "87430869-9a85-47b9-8127-fbea86f7bbdf",
+      "id": "18",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -381,7 +381,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "9988b6e5-f3e4-4395-a1ff-4159ede3b4cd",
+      "id": "19",
       "metadata": {},
       "source": [
         "## Propagate\n",
@@ -392,7 +392,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "3db3f073-cf90-48f8-a3e7-8bc220c390a2",
+      "id": "20",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -403,7 +403,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "c6ff5e59-4b93-41ec-b8a2-68d28a0f26d6",
+      "id": "21",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -421,7 +421,7 @@
     },
     {
       "cell_type": "markdown",
-      "id": "9bfb7cc2-0327-43fb-8364-0dbcc62e0553",
+      "id": "22",
       "metadata": {},
       "source": [
         "## Transform to the time domain\n",
@@ -433,7 +433,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "f44373f9-d947-41d8-8e21-2eafe7584de8",
+      "id": "23",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -443,7 +443,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "268a89c7-4334-4906-ad16-c4536a128617",
+      "id": "24",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -485,23 +485,20 @@
     },
     {
       "cell_type": "markdown",
-      "id": "8b5e94b1-d37e-4639-ad5c-8990206df22e",
+      "id": "25",
       "metadata": {},
       "source": [
         "## Save data to openPMD\n",
         "The data is now nearly ready te be used as FromOpenPMDPulse input. The amplitude of the pulse in the time domain still has to be corrected (= scaled to the actual beam energy in Joule) before saving it to an openPMD file at the provided destination path.\n",
         "Please pay attention to the size of the field data chunk: its real part will be stored on each used GPU as a whole, but their memory is limited. To reduce the chunk size, one can trim the edges by `crop_x`, `crop_y` (in mm), `crop_t_neg` and `crop_t_pos` (in fs).\n",
-        "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input.",
-        "The 3D field data can also serve as input for 2D simulations. The the `FromOpenPMDPulse` profile will then extract the central field slice parallel to propagation and polarisation direction and use this as incident field input. To reduce GPU memory occupancy, it is recommended to trim the extent of the ommited transverse axis with `crop_x` or `crop_y` to $\\geqslant 2$, centered around the central slice."
+        "One can choose to store the field data as real (default, i.e. `is_complex=False`) or complex (i.e. `is_complex=True`). The `FromOpenPMDPulse` profile can work with both, but will use only the real part of the field in case of complex input.The 3D field data can also serve as input for 2D simulations. The the `FromOpenPMDPulse` profile will then extract the central field slice parallel to propagation and polarisation direction and use this as incident field input. To reduce GPU memory occupancy, it is recommended to trim the extent of the ommited transverse axis with `crop_x` or `crop_y` to $\\geqslant 2$, centered around the central slice."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "5018ef1c-2696-4981-b25f-7565a3faaea6",
-      "metadata": {
-        "scrolled": true
-      },
+      "id": "26",
+      "metadata": {},
       "outputs": [],
       "source": [
         "E = 4.5  # J, beam energy\n",
@@ -517,7 +514,7 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "b45022ea-d79a-4ef2-b615-9ca74833e31e",
+      "id": "27",
       "metadata": {},
       "outputs": [],
       "source": []


### PR DESCRIPTION
## What

Adds Jupyter-related pre-commit hooks for the example notebooks:

- `nbstripout` (`kynan/nbstripout`): strips outputs, execution counts and
  default metadata from `*.ipynb` files and normalizes cell ids, so committed
  notebooks stay clean in git. Does not rewrite already-committed history.
- `check-jsonschema` (`python-jsonschema/check-jsonschema`): validates every
  notebook against the official `nbformat.v4.schema.json` (both example
  notebooks are nbformat 4.5), replacing a handwritten local validation hook.

As part of this, `createBunch_example.ipynb` is upgraded from nbformat 4.4 to
4.5 (unique cell ids), matching the existing 4.5 notebook.

## Verification

- `pre-commit run --all-files` is green (including `nbstripout` and the
  schema check).
- Quick Python test suite green on the branch tip.

