### PR TITLE
Python: fix the warnings flood from the quick test suite (TT-01)

### DIFF
--- a/lib/python/test/picongpu/quick/picmi/test_rocrate.py
+++ b/lib/python/test/picongpu/quick/picmi/test_rocrate.py
@@ -99,7 +99,18 @@ def test_adds_default_information_to_datasets(crate):
     assert all(["description" in dataset.properties() for dataset in crate.get_by_type("Dataset")])
 
 
-@mark.filterwarnings("ignore::DeprecationWarning")  # rdflib ConjunctiveGraph, see issue #30
-@mark.xfail(reason="Decided to disable license until we have a proper interface.")
+# rdflib 7.x deprecates ConjunctiveGraph, which the pyshacl-backed json-ld SHACL
+# check in roc-validator instantiates internally. Under the global
+# filterwarnings=["error"], that DeprecationWarning is promoted to an exception
+# inside roc_validator's per-check loop, which swallows it and logs it -- flooding
+# pytest's Log Report and silently flipping this test from XFAIL to a spurious
+# XPASS (the SHACL bodies die before issues are recorded).
+# Scope the ignore to that exact message only, so any *other* DeprecationWarning
+# (e.g. from our own fixtures) stays promoted to an error.
+@mark.filterwarnings("ignore:ConjunctiveGraph is deprecated:DeprecationWarning")
+@mark.xfail(
+    reason="Decided to disable license until we have a proper interface.",
+    strict=True,
+)
 def test_validate_rocrate(setup_dir):
     assert not validate(settings={"rocrate_uri": setup_dir, "requirement_severity": "REQUIRED"}).get_issues()

--- a/lib/python/test/picongpu/quick/picmi/test_rocrate.py
+++ b/lib/python/test/picongpu/quick/picmi/test_rocrate.py
@@ -99,6 +99,7 @@ def test_adds_default_information_to_datasets(crate):
     assert all(["description" in dataset.properties() for dataset in crate.get_by_type("Dataset")])
 
 
+@mark.filterwarnings("ignore::DeprecationWarning")  # rdflib ConjunctiveGraph, see issue #30
 @mark.xfail(reason="Decided to disable license until we have a proper interface.")
 def test_validate_rocrate(setup_dir):
     assert not validate(settings={"rocrate_uri": setup_dir, "requirement_severity": "REQUIRED"}).get_issues()


### PR DESCRIPTION
Silences the ~70-line Log-Report deprecation flood from roc_validator's ConjunctiveGraph usage in the quick test suite by scoping the existing warnings-as-errors filter to the exact rdflib deprecation, and hardens the XFAIL against regression with strict=True.

Originally reviewed and approved on the fork: https://github.com/chillenzer/picongpu/pull/52.