### PR TITLE
picmi: read default pic-build -j from picongpurc (build_jobs)

### DIFF
--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -96,7 +96,7 @@ class PicBuildFlags(BaseModel):
     # We explicitly disallow the some shorthands like `-c`, `-t`, ...
     # because they overlap with tbg flags and could thus lead to confusion.
     jobs: int | None = Field(
-        default=4,
+        default_factory=lambda: rc_params.get("build_jobs", 4),
         description="allow N jobs at once; infinite jobs if set to None",
         validation_alias=AliasChoices("jobs", "j"),
     )

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -96,9 +96,16 @@ class PicBuildFlags(BaseModel):
     # We explicitly disallow the some shorthands like `-c`, `-t`, ...
     # because they overlap with tbg flags and could thus lead to confusion.
     jobs: int | None = Field(
+        # NOTE: This flat `build_jobs` config key is not the same as the
+        # nested `[dependencies] jobs` setting (compile parallelism for
+        # dependency builds) -- config docs should keep the two distinct.
         default_factory=lambda: rc_params.get("build_jobs", 4),
         description="allow N jobs at once; infinite jobs if set to None",
         validation_alias=AliasChoices("jobs", "j"),
+        # `default_factory` results are not validated by default; validate so a
+        # mis-typed `build_jobs` in picongpurc.toml is caught like an explicit
+        # `PicBuildFlags(jobs=...)` argument would be.
+        validate_default=True,
     )
 
     cmake: str | None = Field(

--- a/lib/python/test/picongpu/quick/pypicongpu/test_runner.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_runner.py
@@ -7,10 +7,11 @@ License: GPLv3+
 
 from functools import reduce
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from picongpu import rc_params
 from picongpu._rc_params import RCParams
+from picongpu.pypicongpu import runner
 from picongpu.pypicongpu.runner import (
     PicBuildFlags,
     TBGFlags,
@@ -89,3 +90,36 @@ def test_picbuild_and_tbg_flags_are_disjoint_enough():
             for cls in (PicBuildFlags, TBGFlags)
         )
     ) == {"f", "force"}
+
+
+def _rc_params_with_picongpurc(monkeypatch, content):
+    with TemporaryDirectory() as directory:
+        picongpurc_path = Path(directory) / "picongpurc.toml"
+        picongpurc_path.write_text(content)
+        config = RCParams(picongpurc_path=picongpurc_path)
+    monkeypatch.setattr(runner, "rc_params", config)
+    monkeypatch.setattr("picongpu.rc_params", config)
+    return config
+
+
+def test_build_jobs_default_reads_from_picongpurc(monkeypatch):
+    _rc_params_with_picongpurc(monkeypatch, "build_jobs = 8\n")
+    assert PicBuildFlags().jobs == 8
+
+
+def test_build_jobs_default_falls_back_to_four(monkeypatch):
+    _rc_params_with_picongpurc(monkeypatch, "")
+    assert PicBuildFlags().jobs == 4
+
+
+def test_explicit_jobs_overrides_picongpurc_build_jobs(monkeypatch):
+    _rc_params_with_picongpurc(monkeypatch, "build_jobs = 8\n")
+    assert PicBuildFlags(jobs=16).jobs == 16
+
+
+def test_build_jobs_none_means_infinite_jobs(monkeypatch):
+    # TOML does not know a `null` literal, so this state can only be
+    # reached programmatically, e.g. via plugin or Python API.
+    config = _rc_params_with_picongpurc(monkeypatch, "")
+    config["build_jobs"] = None
+    assert PicBuildFlags().jobs is None

--- a/lib/python/test/picongpu/quick/pypicongpu/test_runner.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_runner.py
@@ -19,7 +19,8 @@ from picongpu.pypicongpu.runner import (
     generate_bare_profile_as_in,
 )
 from picongpu.pypicongpu.util import UnpackChain
-from pytest import fixture
+from pydantic import ValidationError
+from pytest import fixture, raises
 
 
 @fixture
@@ -123,3 +124,23 @@ def test_build_jobs_none_means_infinite_jobs(monkeypatch):
     config = _rc_params_with_picongpurc(monkeypatch, "")
     config["build_jobs"] = None
     assert PicBuildFlags().jobs is None
+
+
+def test_string_build_jobs_is_coerced_to_int(monkeypatch):
+    # `default_factory` results are validated like explicit args, so a
+    # mis-typed string `build_jobs` is coerced (or rejected) instead of
+    # silently landing in input.yaml (where it would only fail at the CWL layer).
+    _rc_params_with_picongpurc(monkeypatch, 'build_jobs = "8"\n')
+    assert PicBuildFlags().jobs == 8
+
+
+def test_unparseable_build_jobs_is_rejected(monkeypatch):
+    _rc_params_with_picongpurc(monkeypatch, 'build_jobs = "many"\n')
+    with raises(ValidationError):
+        PicBuildFlags().jobs
+
+
+def test_float_build_jobs_is_rejected(monkeypatch):
+    _rc_params_with_picongpurc(monkeypatch, "build_jobs = 8.5\n")
+    with raises(ValidationError):
+        PicBuildFlags().jobs


### PR DESCRIPTION
Closes https://github.com/ComputationalRadiationPhysics/picongpu/issues/5766

Read default pic-build -j parallelism from picongpurc.toml (config key: build_jobs).

Originally reviewed and approved on the fork: https://github.com/chillenzer/picongpu/pull/53.


Supersedes upstream ComputationalRadiationPhysics/picongpu#5783; head moved from chillenzer:issue-39-build-jobs to chillenzer-agents:issue-39-build-jobs.