### PR TITLE
picmi: EnergyConservation ionization current (2.2)

### DIFF
--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ADK.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ADK.py
@@ -7,7 +7,6 @@ License: GPLv3+
 
 from .fieldionization import FieldIonization
 
-from .....pypicongpu.species.constant.ionizationcurrent import None_
 from .....pypicongpu.species.constant.ionizationmodel import (
     ADKLinearPolarization,
     ADKCircularPolarization,
@@ -36,12 +35,12 @@ class ADK(FieldIonization):
 
         if self.ADK_variant is ADKVariant.LinearPolarization:
             return ADKLinearPolarization(
-                ionization_current=None_(),
+                ionization_current=self._get_ionization_current(),
                 ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu(),
             )
         if self.ADK_variant is ADKVariant.CircularPolarization:
             return ADKCircularPolarization(
-                ionization_current=None_(),
+                ionization_current=self._get_ionization_current(),
                 ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu(),
             )
 

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/BSI.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/BSI.py
@@ -8,7 +8,6 @@ License: GPLv3+
 from .fieldionization import FieldIonization
 
 from ..... import pypicongpu
-from .....pypicongpu.species.constant.ionizationcurrent import None_
 from .....pypicongpu.species.constant import ionizationmodel
 
 import enum
@@ -33,7 +32,7 @@ class BSI(FieldIonization):
 
         if self.BSI_extensions == []:
             return ionizationmodel.BSI(
-                ionization_current=None_(),
+                ionization_current=self._get_ionization_current(),
                 ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu(),
             )
 
@@ -42,12 +41,12 @@ class BSI(FieldIonization):
 
         if self.BSI_extensions[0] is BSIExtension.StarkShift:
             return ionizationmodel.BSIStarkShifted(
-                ionization_current=None_(),
+                ionization_current=self._get_ionization_current(),
                 ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu(),
             )
         if self.BSI_extensions[0] is BSIExtension.EffectiveZ:
             return ionizationmodel.BSIEffectiveZ(
-                ionization_current=None_(),
+                ionization_current=self._get_ionization_current(),
                 ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu(),
             )
         raise ValueError(f"unknown BSI_extension {self.BSI_extensions[0]}.")

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/fieldionization.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/fieldionization.py
@@ -8,9 +8,35 @@ License: GPLv3+
 from ..groundstateionizationmodel import GroundStateIonizationModel
 from .ionizationcurrent import IonizationCurrent
 
+from .....pypicongpu.species.constant.ionizationcurrent import IonizationCurrent as PypicongpuIonizationCurrent
+from .....pypicongpu.species.constant.ionizationcurrent import None_
+
 
 class FieldIonization(GroundStateIonizationModel):
     """common interface of all field ionization models"""
 
     ionization_current: IonizationCurrent | None
     """ionization current for energy conservation of field ionization"""
+
+    def _get_ionization_current(self) -> PypicongpuIonizationCurrent:
+        """bridge the ionization current to the pypicongpu model
+
+        None maps to the pypicongpu None_ current (the C++ default
+        current::None). A concrete current is converted via its
+        get_as_pypicongpu method and must result in a pypicongpu
+        ionization current model; otherwise an error is raised instead of
+        silently dropping the current.
+        """
+        if self.ionization_current is None:
+            return None_()
+        current = (
+            self.ionization_current.get_as_pypicongpu()
+            if hasattr(self.ionization_current, "get_as_pypicongpu")
+            else self.ionization_current
+        )
+        if not isinstance(current, PypicongpuIonizationCurrent):
+            raise ValueError(
+                f"Unsupported ionization current {self.ionization_current!r}: it does not convert to a pypicongpu "
+                "ionization current model, and silently dropping it would change the physics."
+            )
+        return current

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/__init__.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/__init__.py
@@ -1,3 +1,4 @@
 from .ionizationcurrent import IonizationCurrent
+from .energyconservation import EnergyConservation
 
-__all__ = ["IonizationCurrent"]
+__all__ = ["IonizationCurrent", "EnergyConservation"]

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/energyconservation.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/energyconservation.py
@@ -1,6 +1,6 @@
 """
 This file is part of PIConGPU.
-Copyright 2024-2024 PIConGPU contributors
+Copyright 2026 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+
 """

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/energyconservation.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/ionizationcurrent/energyconservation.py
@@ -1,0 +1,19 @@
+"""
+This file is part of PIConGPU.
+Copyright 2024-2024 PIConGPU contributors
+Authors: Brian Edward Marre
+License: GPLv3+
+"""
+
+from .ionizationcurrent import IonizationCurrent
+
+from ......pypicongpu.species.constant.ionizationcurrent import EnergyConservation as PypicongpuEnergyConservation
+
+
+class EnergyConservation(IonizationCurrent):
+    """energy-conserving ionization current model for field ionization"""
+
+    MODEL_NAME: str = "EnergyConservation"
+
+    def get_as_pypicongpu(self) -> PypicongpuEnergyConservation:
+        return PypicongpuEnergyConservation()

--- a/lib/python/picongpu/picmi/interaction/ionization/fieldionization/keldysh.py
+++ b/lib/python/picongpu/picmi/interaction/ionization/fieldionization/keldysh.py
@@ -7,7 +7,6 @@ License: GPLv3+
 
 from .fieldionization import FieldIonization
 
-from .....pypicongpu.species.constant.ionizationcurrent import None_
 from .....pypicongpu.species.constant import ionizationmodel
 
 
@@ -20,5 +19,6 @@ class Keldysh(FieldIonization):
         self.check()
 
         return ionizationmodel.Keldysh(
-            ionization_current=None_(), ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu()
+            ionization_current=self._get_ionization_current(),
+            ionization_electron_species=self.ionization_electron_species.get_as_pypicongpu(),
         )

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationcurrent/__init__.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationcurrent/__init__.py
@@ -1,4 +1,5 @@
 from .ionizationcurrent import IonizationCurrent
 from .none_ import None_
+from .energyconservation import EnergyConservation
 
-__all__ = ["IonizationCurrent", "None_"]
+__all__ = ["IonizationCurrent", "None_", "EnergyConservation"]

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationcurrent/energyconservation.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationcurrent/energyconservation.py
@@ -1,0 +1,12 @@
+"""
+This file is part of PIConGPU.
+Copyright 2024-2024 PIConGPU contributors
+Authors: Brian Edward Marre
+License: GPLv3+
+"""
+
+from .ionizationcurrent import IonizationCurrent
+
+
+class EnergyConservation(IonizationCurrent):
+    picongpu_name: str = "EnergyConservation"

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationcurrent/energyconservation.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationcurrent/energyconservation.py
@@ -1,6 +1,6 @@
 """
 This file is part of PIConGPU.
-Copyright 2024-2024 PIConGPU contributors
+Copyright 2026 PIConGPU contributors
 Authors: Brian Edward Marre
 License: GPLv3+
 """

--- a/lib/python/test/picongpu/quick/picmi/test_ionization_current.py
+++ b/lib/python/test/picongpu/quick/picmi/test_ionization_current.py
@@ -7,10 +7,11 @@ License: GPLv3+
 
 import os
 import tempfile
-from unittest import TestCase
+
+import pytest
 
 from picongpu import picmi
-from picongpu.picmi.interaction.ionization.fieldionization import ADK, ADKVariant
+from picongpu.picmi.interaction.ionization.fieldionization import ADK, ADKVariant, BSI, BSIExtension, Keldysh
 from picongpu.picmi.interaction.ionization.fieldionization.ionizationcurrent import (
     EnergyConservation,
     IonizationCurrent,
@@ -38,68 +39,119 @@ def get_grid(n: int = 32):
     )
 
 
-class TestIonizationCurrent(TestCase):
-    def _render_speciesDefinition(self, ionization_current) -> str:
-        e = picmi.Species(name="e", particle_type="electron")
-        ion = picmi.Species(name="hydrogen", particle_type="H", charge_state=+1)
-        ionizer = ADK(
-            ADK_variant=ADKVariant.LinearPolarization,
-            ionization_current=ionization_current,
-            ion_species=ion,
-            ionization_electron_species=e,
-        )
+def _adk(ionization_current, e, ion, variant=ADKVariant.LinearPolarization):
+    return ADK(
+        ADK_variant=variant,
+        ionization_current=ionization_current,
+        ion_species=ion,
+        ionization_electron_species=e,
+    )
 
-        sim = picmi.Simulation(
-            time_step_size=17,
-            max_steps=4,
-            solver=picmi.ElectromagneticSolver(method="Yee", grid=get_grid()),
-        )
-        sim.add_species(e, None)
-        sim.add_species(ion, None)
-        sim.picongpu_interaction = [ionizer]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_dir = os.path.join(tmpdir, "input")
-            sim.write_input_file(output_dir)
-            rendered_path = os.path.join(output_dir, "include", "picongpu", "param", "speciesDefinition.param")
-            with open(rendered_path) as rendered_file:
-                return rendered_file.read()
+def _bsi(ionization_current, e, ion, extensions=()):
+    return BSI(
+        BSI_extensions=list(extensions),
+        ionization_current=ionization_current,
+        ion_species=ion,
+        ionization_electron_species=e,
+    )
 
-    def test_energy_conservation_rendered(self):
-        rendered = self._render_speciesDefinition(EnergyConservation())
-        assert "particles::ionization::current::EnergyConservation" in rendered
 
-    def test_none_rendered(self):
-        rendered = self._render_speciesDefinition(None)
+def _keldysh(ionization_current, e, ion):
+    return Keldysh(
+        ionization_current=ionization_current,
+        ion_species=ion,
+        ionization_electron_species=e,
+    )
+
+
+@pytest.mark.parametrize(
+    "ionizer_builder",
+    [
+        lambda current, e, ion: _adk(current, e, ion),
+        lambda current, e, ion: _adk(current, e, ion, ADKVariant.CircularPolarization),
+        lambda current, e, ion: _bsi(current, e, ion, [BSIExtension.StarkShift]),
+        lambda current, e, ion: _bsi(current, e, ion, [BSIExtension.EffectiveZ]),
+        lambda current, e, ion: _keldysh(current, e, ion),
+    ],
+    ids=[
+        "ADK-LinearPolarization",
+        "ADK-CircularPolarization",
+        "BSI-StarkShift",
+        "BSI-EffectiveZ",
+        "Keldysh",
+    ],
+)
+@pytest.mark.parametrize(
+    "ionization_current",
+    [EnergyConservation(), None],
+    ids=["EnergyConservation", "None"],
+)
+def test_ionization_current_rendered(ionizer_builder, ionization_current):
+    e = picmi.Species(name="e", particle_type="electron")
+    ion = picmi.Species(name="hydrogen", particle_type="H", charge_state=+1)
+    ionizer = ionizer_builder(ionization_current, e, ion)
+    rendered = _render_speciesDefinition(ionizer)
+    if ionization_current is None:
         assert "particles::ionization::current::None" in rendered
         assert "particles::ionization::current::EnergyConservation" not in rendered
+    else:
+        assert "particles::ionization::current::EnergyConservation" in rendered
 
-    def test_none_byte_identical(self):
-        # the picmi bridge (None -> None_()) must reproduce the exact rendering
-        # context of the previous hardcoded None_() choice, i.e. byte-identical
-        # rendered output for the default case
-        e = Species(name="e", particle_type="electron")
-        ion = Species(name="hydrogen", particle_type="H", charge_state=+1)
 
-        via_bridge = ADK(
-            ADK_variant=ADKVariant.LinearPolarization,
-            ionization_current=None,
-            ion_species=ion,
-            ionization_electron_species=e,
-        ).get_as_pypicongpu()
-        via_hardcoded = ADKLinearPolarization(
-            ionization_current=None_(),
-            ionization_electron_species=e.get_as_pypicongpu(),
-        )
+def _render_speciesDefinition(ionizer) -> str:
+    sim = picmi.Simulation(
+        time_step_size=17,
+        max_steps=4,
+        solver=picmi.ElectromagneticSolver(method="Yee", grid=get_grid()),
+    )
+    sim.add_species(ionizer.ionization_electron_species, None)
+    sim.add_species(ionizer.ion_species, None)
+    sim.picongpu_interaction = [ionizer]
 
-        assert via_bridge.get_rendering_context() == via_hardcoded.get_rendering_context()
-        assert Renderer.get_rendered_template(via_bridge.get_rendering_context(), _CURRENT_TEMPLATE) == (
-            Renderer.get_rendered_template(via_hardcoded.get_rendering_context(), _CURRENT_TEMPLATE)
-        )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = os.path.join(tmpdir, "input")
+        sim.write_input_file(output_dir)
+        rendered_path = os.path.join(output_dir, "include", "picongpu", "param", "speciesDefinition.param")
+        with open(rendered_path) as rendered_file:
+            return rendered_file.read()
 
-    def test_invalid_current_raises(self):
-        class Bogus(IonizationCurrent):
-            MODEL_NAME: str = "Bogus"
 
-        with self.assertRaises(ValueError, msg="invalid ionization current must be rejected at conversion time"):
-            self._render_speciesDefinition(Bogus())
+def test_none_byte_identical():
+    # the picmi bridge (None -> None_()) must reproduce the exact rendering
+    # context of the previous hardcoded None_() choice, i.e. byte-identical
+    # rendered output for the default case
+    e = Species(name="e", particle_type="electron")
+    ion = Species(name="hydrogen", particle_type="H", charge_state=+1)
+
+    via_bridge = ADK(
+        ADK_variant=ADKVariant.LinearPolarization,
+        ionization_current=None,
+        ion_species=ion,
+        ionization_electron_species=e,
+    ).get_as_pypicongpu()
+    via_hardcoded = ADKLinearPolarization(
+        ionization_current=None_(),
+        ionization_electron_species=e.get_as_pypicongpu(),
+    )
+
+    assert via_bridge.get_rendering_context() == via_hardcoded.get_rendering_context()
+    assert Renderer.get_rendered_template(via_bridge.get_rendering_context(), _CURRENT_TEMPLATE) == (
+        Renderer.get_rendered_template(via_hardcoded.get_rendering_context(), _CURRENT_TEMPLATE)
+    )
+
+
+def test_invalid_current_raises():
+    class Bogus(IonizationCurrent):
+        MODEL_NAME: str = "Bogus"
+
+    e = picmi.Species(name="e", particle_type="electron")
+    ion = picmi.Species(name="hydrogen", particle_type="H", charge_state=+1)
+    ionizer = ADK(
+        ADK_variant=ADKVariant.LinearPolarization,
+        ionization_current=Bogus(),
+        ion_species=ion,
+        ionization_electron_species=e,
+    )
+    with pytest.raises(ValueError):
+        _render_speciesDefinition(ionizer)

--- a/lib/python/test/picongpu/quick/picmi/test_ionization_current.py
+++ b/lib/python/test/picongpu/quick/picmi/test_ionization_current.py
@@ -1,0 +1,105 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: Brian Edward Marre
+License: GPLv3+
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+
+from picongpu import picmi
+from picongpu.picmi.interaction.ionization.fieldionization import ADK, ADKVariant
+from picongpu.picmi.interaction.ionization.fieldionization.ionizationcurrent import (
+    EnergyConservation,
+    IonizationCurrent,
+)
+from picongpu.picmi.species import Species
+from picongpu.pypicongpu.rendering import Renderer
+from picongpu.pypicongpu.species.constant.ionizationcurrent import None_
+from picongpu.pypicongpu.species.constant.ionizationmodel import ADKLinearPolarization
+
+# the mustache block that renders the ionization current into the species definition
+_CURRENT_TEMPLATE = (
+    "particles::ionization::{{{ionizer_picongpu_name}}}<{{{ionization_electron_species.typename}}}"
+    "{{#ionization_current}}, particles::ionization::current::{{{picongpu_name}}}{{/ionization_current}}>"
+)
+
+
+def get_grid(n: int = 32):
+    return picmi.Cartesian3DGrid(
+        number_of_cells=[n, n, n],
+        lower_bound=[0, 0, 0],
+        upper_bound=[n, n, n],
+        # required, otherwise won't spawn
+        lower_boundary_conditions=["open", "open", "periodic"],
+        upper_boundary_conditions=["open", "open", "periodic"],
+    )
+
+
+class TestIonizationCurrent(TestCase):
+    def _render_speciesDefinition(self, ionization_current) -> str:
+        e = picmi.Species(name="e", particle_type="electron")
+        ion = picmi.Species(name="hydrogen", particle_type="H", charge_state=+1)
+        ionizer = ADK(
+            ADK_variant=ADKVariant.LinearPolarization,
+            ionization_current=ionization_current,
+            ion_species=ion,
+            ionization_electron_species=e,
+        )
+
+        sim = picmi.Simulation(
+            time_step_size=17,
+            max_steps=4,
+            solver=picmi.ElectromagneticSolver(method="Yee", grid=get_grid()),
+        )
+        sim.add_species(e, None)
+        sim.add_species(ion, None)
+        sim.picongpu_interaction = [ionizer]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = os.path.join(tmpdir, "input")
+            sim.write_input_file(output_dir)
+            rendered_path = os.path.join(output_dir, "include", "picongpu", "param", "speciesDefinition.param")
+            with open(rendered_path) as rendered_file:
+                return rendered_file.read()
+
+    def test_energy_conservation_rendered(self):
+        rendered = self._render_speciesDefinition(EnergyConservation())
+        assert "particles::ionization::current::EnergyConservation" in rendered
+
+    def test_none_rendered(self):
+        rendered = self._render_speciesDefinition(None)
+        assert "particles::ionization::current::None" in rendered
+        assert "particles::ionization::current::EnergyConservation" not in rendered
+
+    def test_none_byte_identical(self):
+        # the picmi bridge (None -> None_()) must reproduce the exact rendering
+        # context of the previous hardcoded None_() choice, i.e. byte-identical
+        # rendered output for the default case
+        e = Species(name="e", particle_type="electron")
+        ion = Species(name="hydrogen", particle_type="H", charge_state=+1)
+
+        via_bridge = ADK(
+            ADK_variant=ADKVariant.LinearPolarization,
+            ionization_current=None,
+            ion_species=ion,
+            ionization_electron_species=e,
+        ).get_as_pypicongpu()
+        via_hardcoded = ADKLinearPolarization(
+            ionization_current=None_(),
+            ionization_electron_species=e.get_as_pypicongpu(),
+        )
+
+        assert via_bridge.get_rendering_context() == via_hardcoded.get_rendering_context()
+        assert Renderer.get_rendered_template(via_bridge.get_rendering_context(), _CURRENT_TEMPLATE) == (
+            Renderer.get_rendered_template(via_hardcoded.get_rendering_context(), _CURRENT_TEMPLATE)
+        )
+
+    def test_invalid_current_raises(self):
+        class Bogus(IonizationCurrent):
+            MODEL_NAME: str = "Bogus"
+
+        with self.assertRaises(ValueError, msg="invalid ionization current must be rejected at conversion time"):
+            self._render_speciesDefinition(Bogus())


### PR DESCRIPTION
# Summary

Ported the task-13 `FieldIonization._get_ionization_current()` bridge (absent on `dev`) and added the concrete `EnergyConservation` ionization-current model on both the pypicongpu and picmi side, so a non-`None` `ionization_current` is actually applied and rendered as `particles::ionization::current::EnergyConservation`. `None` still renders `current::None` byte-identically.


Originally reviewed and approved on the fork: https://github.com/chillenzer/picongpu/pull/64.


Supersedes upstream ComputationalRadiationPhysics/picongpu#5786; head moved from chillenzer:issue-26-ionization-current to chillenzer-agents:issue-26-ionization-current.