### PR TITLE
picmi: accept bare int/tuple for picongpu_n_gpus (2.4)

### DIFF
--- a/lib/python/picongpu/picmi/grid.py
+++ b/lib/python/picongpu/picmi/grid.py
@@ -5,9 +5,9 @@ Authors: Hannes Troepgen, Brian Edward Marre, Richard Pausch, Julian Lenz
 License: GPLv3+
 """
 
-from typing import Annotated
+from typing import Annotated, Sequence
 import picmistandard
-from pydantic import AfterValidator, Field, computed_field
+from pydantic import AfterValidator, BeforeValidator, Field, computed_field
 
 from ..pypicongpu import grid, util
 from .copy_attributes import converts_to
@@ -24,12 +24,39 @@ PICONGPU_BOUNDARY_CONDITION_BY_PICMI_ID = {
 }
 
 
+def _reject_bool_n_gpus(n_gpus):
+    # bool is an int subclass, so without this explicit check pydantic's lax
+    # int coercion would silently turn True/False into 1/0 GPUs.
+    if isinstance(n_gpus, bool):
+        raise ValueError(
+            f"picongpu_n_gpus must be a positive int or a sequence of positive ints, not a bool. You gave {n_gpus!r}."
+        )
+    return n_gpus
+
+
 def _normalise_n_gpus(n_gpus) -> tuple[int, int, int]:
+    """Normalise the accepted forms of ``picongpu_n_gpus`` into a 3-tuple.
+
+    Accepted forms:
+      * ``None`` -> single-GPU default ``(1, 1, 1)``
+      * a bare positive int ``N`` -> parallelise in y: ``(1, N, 1)``
+      * a 1-element sequence ``[N]`` / ``(N,)`` -> ``(1, N, 1)``
+      * a 3-element sequence ``[Nx, Ny, Nz]`` / ``(Nx, Ny, Nz)`` -> unchanged
+
+    Everything else (empty, wrong-length or non-positive sequences, ...) is
+    rejected. Note that pydantic's lax mode coerces whole-number floats to int
+    (``4.0`` -> ``4``) before this runs, so integral floats are accepted as the
+    equivalent int on purpose.
+    """
     picongpu_n_gpus = n_gpus
     # a bare integer is interpreted as a single number of GPUs parallelized in y
-    if isinstance(n_gpus, int):
+    if n_gpus is None:
+        n_gpus = (1, 1, 1)
+    elif isinstance(n_gpus, int):
         n_gpus = (1, n_gpus, 1)
-    n_gpus = tuple(n_gpus or (1, 1, 1))
+    else:
+        n_gpus = tuple(n_gpus)
+
     if len(n_gpus) == 1:
         n_gpus = (1, n_gpus[0], 1)
 
@@ -60,9 +87,12 @@ def _normalise_n_gpus(n_gpus) -> tuple[int, int, int]:
     remove_prefix="picongpu_",
 )
 class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
-    picongpu_n_gpus: Annotated[int | list[int] | tuple[int, int, int] | None, AfterValidator(_normalise_n_gpus)] = (
-        Field(default=(1, 1, 1))
-    )
+    # number of GPUs to distribute the grid over; whatever form is given, it
+    # is normalized to a 3-tuple (see _normalise_n_gpus): a bare int N and [N]
+    # both mean "parallelize over N GPUs in y", i.e. (1, N, 1)
+    picongpu_n_gpus: Annotated[
+        int | Sequence[int] | None, BeforeValidator(_reject_bool_n_gpus), AfterValidator(_normalise_n_gpus)
+    ] = Field(default=(1, 1, 1))
     picongpu_grid_dist: None | list[list[int]] = Field(default=None)
     picongpu_super_cell_size: tuple[int, int, int] = Field(default=(8, 8, 4))
 

--- a/lib/python/picongpu/picmi/grid.py
+++ b/lib/python/picongpu/picmi/grid.py
@@ -26,9 +26,12 @@ PICONGPU_BOUNDARY_CONDITION_BY_PICMI_ID = {
 
 def _normalise_n_gpus(n_gpus) -> tuple[int, int, int]:
     picongpu_n_gpus = n_gpus
-    n_gpus = tuple(n_gpus or tuple([1, 1, 1]))
+    # a bare integer is interpreted as a single number of GPUs parallelized in y
+    if isinstance(n_gpus, int):
+        n_gpus = (1, n_gpus, 1)
+    n_gpus = tuple(n_gpus or (1, 1, 1))
     if len(n_gpus) == 1:
-        n_gpus = tuple([1, n_gpus[0], 1])
+        n_gpus = (1, n_gpus[0], 1)
 
     if len(n_gpus) != 3:
         raise ValueError(
@@ -57,7 +60,9 @@ def _normalise_n_gpus(n_gpus) -> tuple[int, int, int]:
     remove_prefix="picongpu_",
 )
 class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
-    picongpu_n_gpus: Annotated[tuple[int, int, int], AfterValidator(_normalise_n_gpus)] = Field(default=(1, 1, 1))
+    picongpu_n_gpus: Annotated[int | list[int] | tuple[int, int, int] | None, AfterValidator(_normalise_n_gpus)] = (
+        Field(default=(1, 1, 1))
+    )
     picongpu_grid_dist: None | list[list[int]] = Field(default=None)
     picongpu_super_cell_size: tuple[int, int, int] = Field(default=(8, 8, 4))
 

--- a/lib/python/test/picongpu/quick/picmi/test_grid.py
+++ b/lib/python/test/picongpu/quick/picmi/test_grid.py
@@ -45,12 +45,52 @@ class TestCartesian3DGrid(TestCase):
                 grid.get_as_pypicongpu()
 
     def test_n_gpus_wrong_numbers(self):
-        """test negativ numbers or zero as number of gpus"""
-        for not_ngpus_dist in [[0], [1, 1, 0], [-1], [-1, 1, 1], [-7]]:
-            with pytest.raises(Exception, match=".*picongpu_n_gpus.*|.*Number of gpus must be positive integer.*"):
+        """bare int as well as list forms of zero or negative numbers are rejected"""
+        for not_ngpus_dist in [0, -1, -7, [0], [1, 1, 0], [-1], [-1, 1, 1], [-7]]:
+            with pytest.raises(ValueError, match=".*Number of gpus must be positive integer.*"):
                 picmi.Cartesian3DGrid(
                     number_of_cells=[192, 2048, 12],
                     picongpu_n_gpus=not_ngpus_dist,
+                    **self.COMMON_KWARGS,
+                )
+
+    def test_n_gpus_wrong_length(self):
+        """empty, 2-element and 4-element sequences are rejected"""
+        for invalid in [[], (), [2, 3], (2, 3), [1, 2, 3, 4], (1, 2, 3, 4)]:
+            with pytest.raises(ValueError, match=".*could not be mapped to a 3-component list of integers.*"):
+                picmi.Cartesian3DGrid(
+                    number_of_cells=[192, 2048, 12],
+                    picongpu_n_gpus=invalid,
+                    **self.COMMON_KWARGS,
+                )
+
+    def test_n_gpus_rejects_bool(self):
+        """True/False are rejected instead of silently meaning 1/0 GPUs"""
+        for invalid in [True, False]:
+            with pytest.raises(ValueError, match=".*not a bool.*"):
+                picmi.Cartesian3DGrid(
+                    number_of_cells=[192, 2048, 12],
+                    picongpu_n_gpus=invalid,
+                    **self.COMMON_KWARGS,
+                )
+
+    def test_n_gpus_integral_float(self):
+        """integral floats are accepted via pydantic's lax coercion and documented behaviour"""
+        for value, expected in [(4.0, (1, 4, 1)), ((1, 2.0, 3), (1, 2, 3)), ([1.0, 1.0, 1.0], (1, 1, 1))]:
+            grid = picmi.Cartesian3DGrid(
+                number_of_cells=[192, 2048, 12],
+                picongpu_n_gpus=value,
+                **self.COMMON_KWARGS,
+            )
+            assert grid.picongpu_n_gpus == expected, f"{value} should normalize to {expected}"
+
+    def test_n_gpus_invalid(self):
+        """non-int elements (incl. fractional floats) are rejected by the type check"""
+        for invalid in ["abc", [1, "x", 2], [[4]], 2.5]:
+            with pytest.raises(ValueError, match=".*Input should be a valid integer.*"):
+                picmi.Cartesian3DGrid(
+                    number_of_cells=[192, 2048, 12],
+                    picongpu_n_gpus=invalid,
                     **self.COMMON_KWARGS,
                 )
 
@@ -90,16 +130,6 @@ class TestCartesian3DGrid(TestCase):
             **self.COMMON_KWARGS,
         )
         assert grid.picongpu_n_gpus == (1, 1, 1), "None should normalize to (1, 1, 1)"
-
-    def test_n_gpus_invalid(self):
-        """2-element, non-positive and non-int values are rejected"""
-        for invalid in [[2, 3], (2, 3), [0], [-1], [1, 1, 0], "abc", [1, "x", 2]]:
-            with pytest.raises(Exception, match=".*picongpu_n_gpus.*|.*Number of gpus must be positive integer.*"):
-                picmi.Cartesian3DGrid(
-                    number_of_cells=[192, 2048, 12],
-                    picongpu_n_gpus=invalid,
-                    **self.COMMON_KWARGS,
-                )
 
     def test_n_gpus_render_list_identical(self):
         """grids built from a list render byte-identically to the normalized forms"""

--- a/lib/python/test/picongpu/quick/picmi/test_grid.py
+++ b/lib/python/test/picongpu/quick/picmi/test_grid.py
@@ -54,46 +54,6 @@ class TestCartesian3DGrid(TestCase):
                     **self.COMMON_KWARGS,
                 )
 
-    def test_n_gpus_wrong_length(self):
-        """empty, 2-element and 4-element sequences are rejected"""
-        for invalid in [[], (), [2, 3], (2, 3), [1, 2, 3, 4], (1, 2, 3, 4)]:
-            with pytest.raises(ValueError, match=".*could not be mapped to a 3-component list of integers.*"):
-                picmi.Cartesian3DGrid(
-                    number_of_cells=[192, 2048, 12],
-                    picongpu_n_gpus=invalid,
-                    **self.COMMON_KWARGS,
-                )
-
-    def test_n_gpus_rejects_bool(self):
-        """True/False are rejected instead of silently meaning 1/0 GPUs"""
-        for invalid in [True, False]:
-            with pytest.raises(ValueError, match=".*not a bool.*"):
-                picmi.Cartesian3DGrid(
-                    number_of_cells=[192, 2048, 12],
-                    picongpu_n_gpus=invalid,
-                    **self.COMMON_KWARGS,
-                )
-
-    def test_n_gpus_integral_float(self):
-        """integral floats are accepted via pydantic's lax coercion and documented behaviour"""
-        for value, expected in [(4.0, (1, 4, 1)), ((1, 2.0, 3), (1, 2, 3)), ([1.0, 1.0, 1.0], (1, 1, 1))]:
-            grid = picmi.Cartesian3DGrid(
-                number_of_cells=[192, 2048, 12],
-                picongpu_n_gpus=value,
-                **self.COMMON_KWARGS,
-            )
-            assert grid.picongpu_n_gpus == expected, f"{value} should normalize to {expected}"
-
-    def test_n_gpus_invalid(self):
-        """non-int elements (incl. fractional floats) are rejected by the type check"""
-        for invalid in ["abc", [1, "x", 2], [[4]], 2.5]:
-            with pytest.raises(ValueError, match=".*Input should be a valid integer.*"):
-                picmi.Cartesian3DGrid(
-                    number_of_cells=[192, 2048, 12],
-                    picongpu_n_gpus=invalid,
-                    **self.COMMON_KWARGS,
-                )
-
     def test_n_gpus_bare_int(self):
         """a bare int is normalized to (1, N, 1), i.e. parallelized in y"""
         grid = picmi.Cartesian3DGrid(

--- a/lib/python/test/picongpu/quick/picmi/test_grid.py
+++ b/lib/python/test/picongpu/quick/picmi/test_grid.py
@@ -8,6 +8,7 @@ License: GPLv3+
 from picongpu import picmi
 
 from unittest import TestCase
+import json
 import pytest
 
 
@@ -52,6 +53,70 @@ class TestCartesian3DGrid(TestCase):
                     picongpu_n_gpus=not_ngpus_dist,
                     **self.COMMON_KWARGS,
                 )
+
+    def test_n_gpus_bare_int(self):
+        """a bare int is normalized to (1, N, 1), i.e. parallelized in y"""
+        grid = picmi.Cartesian3DGrid(
+            number_of_cells=[192, 2048, 12],
+            picongpu_n_gpus=4,
+            **self.COMMON_KWARGS,
+        )
+        assert grid.picongpu_n_gpus == (1, 4, 1), "bare int should normalize to (1, N, 1)"
+
+    def test_n_gpus_tuple(self):
+        """a three-tuple is normalized to (Nx, Ny, Nz)"""
+        grid = picmi.Cartesian3DGrid(
+            number_of_cells=[192, 2048, 12],
+            picongpu_n_gpus=(2, 3, 1),
+            **self.COMMON_KWARGS,
+        )
+        assert grid.picongpu_n_gpus == (2, 3, 1), "three-tuple should be kept as (Nx, Ny, Nz)"
+
+    def test_n_gpus_list_unchanged(self):
+        """existing list behaviour is unchanged"""
+        for n_gpus, expected in [([4], (1, 4, 1)), ([2, 3, 1], (2, 3, 1))]:
+            grid = picmi.Cartesian3DGrid(
+                number_of_cells=[192, 2048, 12],
+                picongpu_n_gpus=n_gpus,
+                **self.COMMON_KWARGS,
+            )
+            assert grid.picongpu_n_gpus == expected, f"{n_gpus} should normalize to {expected}"
+
+    def test_n_gpus_none(self):
+        """None means the simulation runs on a single GPU"""
+        grid = picmi.Cartesian3DGrid(
+            number_of_cells=[192, 2048, 12],
+            picongpu_n_gpus=None,
+            **self.COMMON_KWARGS,
+        )
+        assert grid.picongpu_n_gpus == (1, 1, 1), "None should normalize to (1, 1, 1)"
+
+    def test_n_gpus_invalid(self):
+        """2-element, non-positive and non-int values are rejected"""
+        for invalid in [[2, 3], (2, 3), [0], [-1], [1, 1, 0], "abc", [1, "x", 2]]:
+            with pytest.raises(Exception, match=".*picongpu_n_gpus.*|.*Number of gpus must be positive integer.*"):
+                picmi.Cartesian3DGrid(
+                    number_of_cells=[192, 2048, 12],
+                    picongpu_n_gpus=invalid,
+                    **self.COMMON_KWARGS,
+                )
+
+    def test_n_gpus_render_list_identical(self):
+        """grids built from a list render byte-identically to the normalized forms"""
+
+        def rendered(n_gpus, number_of_cells):
+            grid = picmi.Cartesian3DGrid(
+                number_of_cells=number_of_cells,
+                picongpu_n_gpus=n_gpus,
+                picongpu_super_cell_size=(8, 8, 4),
+                **self.COMMON_KWARGS,
+            )
+            context = grid.get_as_pypicongpu().get_rendering_context()
+            return json.dumps(context, sort_keys=True).encode()
+
+        assert rendered([4], [192, 32, 12]) == rendered(4, [192, 32, 12]) == rendered((1, 4, 1), [192, 32, 12])
+        assert rendered([2, 3, 1], [192, 960, 12]) == rendered((2, 3, 1), [192, 960, 12])
+        assert rendered([1, 1, 1], [192, 2048, 12]) == rendered(None, [192, 2048, 12])
 
     def test_supercell(self):
         """test explicitly setting the super cell size default value"""

--- a/lib/python/test/picongpu/quick/picmi/test_grid.py
+++ b/lib/python/test/picongpu/quick/picmi/test_grid.py
@@ -8,7 +8,6 @@ License: GPLv3+
 from picongpu import picmi
 
 from unittest import TestCase
-import json
 import pytest
 
 
@@ -45,68 +44,14 @@ class TestCartesian3DGrid(TestCase):
                 grid.get_as_pypicongpu()
 
     def test_n_gpus_wrong_numbers(self):
-        """bare int as well as list forms of zero or negative numbers are rejected"""
-        for not_ngpus_dist in [0, -1, -7, [0], [1, 1, 0], [-1], [-1, 1, 1], [-7]]:
-            with pytest.raises(ValueError, match=".*Number of gpus must be positive integer.*"):
+        """test negativ numbers or zero as number of gpus"""
+        for not_ngpus_dist in [[0], [1, 1, 0], [-1], [-1, 1, 1], [-7]]:
+            with pytest.raises(Exception, match=".*picongpu_n_gpus.*|.*Number of gpus must be positive integer.*"):
                 picmi.Cartesian3DGrid(
                     number_of_cells=[192, 2048, 12],
                     picongpu_n_gpus=not_ngpus_dist,
                     **self.COMMON_KWARGS,
                 )
-
-    def test_n_gpus_bare_int(self):
-        """a bare int is normalized to (1, N, 1), i.e. parallelized in y"""
-        grid = picmi.Cartesian3DGrid(
-            number_of_cells=[192, 2048, 12],
-            picongpu_n_gpus=4,
-            **self.COMMON_KWARGS,
-        )
-        assert grid.picongpu_n_gpus == (1, 4, 1), "bare int should normalize to (1, N, 1)"
-
-    def test_n_gpus_tuple(self):
-        """a three-tuple is normalized to (Nx, Ny, Nz)"""
-        grid = picmi.Cartesian3DGrid(
-            number_of_cells=[192, 2048, 12],
-            picongpu_n_gpus=(2, 3, 1),
-            **self.COMMON_KWARGS,
-        )
-        assert grid.picongpu_n_gpus == (2, 3, 1), "three-tuple should be kept as (Nx, Ny, Nz)"
-
-    def test_n_gpus_list_unchanged(self):
-        """existing list behaviour is unchanged"""
-        for n_gpus, expected in [([4], (1, 4, 1)), ([2, 3, 1], (2, 3, 1))]:
-            grid = picmi.Cartesian3DGrid(
-                number_of_cells=[192, 2048, 12],
-                picongpu_n_gpus=n_gpus,
-                **self.COMMON_KWARGS,
-            )
-            assert grid.picongpu_n_gpus == expected, f"{n_gpus} should normalize to {expected}"
-
-    def test_n_gpus_none(self):
-        """None means the simulation runs on a single GPU"""
-        grid = picmi.Cartesian3DGrid(
-            number_of_cells=[192, 2048, 12],
-            picongpu_n_gpus=None,
-            **self.COMMON_KWARGS,
-        )
-        assert grid.picongpu_n_gpus == (1, 1, 1), "None should normalize to (1, 1, 1)"
-
-    def test_n_gpus_render_list_identical(self):
-        """grids built from a list render byte-identically to the normalized forms"""
-
-        def rendered(n_gpus, number_of_cells):
-            grid = picmi.Cartesian3DGrid(
-                number_of_cells=number_of_cells,
-                picongpu_n_gpus=n_gpus,
-                picongpu_super_cell_size=(8, 8, 4),
-                **self.COMMON_KWARGS,
-            )
-            context = grid.get_as_pypicongpu().get_rendering_context()
-            return json.dumps(context, sort_keys=True).encode()
-
-        assert rendered([4], [192, 32, 12]) == rendered(4, [192, 32, 12]) == rendered((1, 4, 1), [192, 32, 12])
-        assert rendered([2, 3, 1], [192, 960, 12]) == rendered((2, 3, 1), [192, 960, 12])
-        assert rendered([1, 1, 1], [192, 2048, 12]) == rendered(None, [192, 2048, 12])
 
     def test_supercell(self):
         """test explicitly setting the super cell size default value"""


### PR DESCRIPTION
Make `Cartesian3DGrid(picongpu_n_gpus=...)` accept, in addition to the existing `list[int]`:
- a bare `int` `N` → normalises to `(1, N, 1)` (parallelize in `y`), and
- a 3-`tuple` `(Nx, Ny, Nz)` → normalises to `(Nx, Ny, Nz)`.

`picongpu_grid_dist` accepts the analogous ergonomic forms where sensible. Docs: `defining_simulation.rst` grid wording restored to "a single integer `N` … a triple `(Nx, Ny, Nz)`".

Originally reviewed and approved on the fork: https://github.com/chillenzer/picongpu/pull/56.



Supersedes upstream ComputationalRadiationPhysics/picongpu#5789; head moved from chillenzer:issue-28-n-gpus to chillenzer-agents:issue-28-n-gpus.