### PR TITLE
Allow regenerating PICMI input into an existing setup directory

### DIFF
--- a/lib/python/picongpu/pypicongpu/rendering/renderer.py
+++ b/lib/python/picongpu/pypicongpu/rendering/renderer.py
@@ -189,7 +189,7 @@ class Renderer:
         return render(template, context, missing_variable_handler=_allow_only_missing_type_variables)
 
     @staticmethod
-    def render_directory(context: dict, path: str) -> None:
+    def render_directory(context: dict, path: str, exist_ok: bool = False) -> None:
         """
         Render all templates inside a given directory and remove the templates
 
@@ -199,6 +199,8 @@ class Renderer:
 
         :param context: (checked and preprocessed) rendering context
         :param path: directory containing ".mustache" files
+        :param exist_ok: allow overwriting files which were already rendered in
+            a previous generation into this directory
         """
         if not pathlib.Path(path).is_dir():
             raise ValueError("is not a directory: {}".format(path))
@@ -210,10 +212,19 @@ class Renderer:
                 filter(lambda p: p.is_file(), pathlib.Path(path).rglob("*")),
             )
         )
+        if exist_ok:
+            # rendered templates are hidden with a dot "." prefix,
+            # so the dot-prefixed ".mustache" files are leftovers from a
+            # previous generation and must not be rendered again:
+            # they would create ever more dot-prefixed files on each regeneration
+            for stale_template in filter(lambda p: p.name.startswith("."), all_mustache_files):
+                stale_template.unlink()
+            all_mustache_files = list(filter(lambda p: not p.name.startswith("."), all_mustache_files))
         for template_path in all_mustache_files:
             rendered_path = pathlib.Path(mustache_fileending_re.sub("", str(template_path)))
             if rendered_path.exists():
-                raise ValueError("would overwrite {}, aborting".format(rendered_path))
+                if not exist_ok:
+                    raise ValueError("would overwrite {}, aborting".format(rendered_path))
 
             with open(rendered_path, "w") as outfile:
                 with open(template_path, "r") as infile:

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -229,7 +229,7 @@ class Runner(BaseModel):
         logging.info("    setup dir: {}".format(self.setup_dir))
         logging.info("      run dir: {}".format(self.run_dir))
 
-    def _render_templates(self):
+    def _render_templates(self, exist_ok=False):
         """
         render the templates in the setup dir into a picongpu input
 
@@ -245,7 +245,9 @@ class Runner(BaseModel):
         # dump checked context
         self.store_metadata(context, filename="pypicongpu_rendering_context.json")
         # preprocess (floats to str, add _special properties, ...)
-        Renderer.render_directory(Renderer.get_context_preprocessed(context), str(self.setup_dir))
+        Renderer.render_directory(
+            Renderer.get_context_preprocessed(context), str(self.setup_dir), exist_ok=exist_ok
+        )
 
     @property
     def metadata_path(self):
@@ -423,7 +425,11 @@ class Runner(BaseModel):
                 "setup directory must not exist before generation -- did you call generate() already?"
             )
         preset = rc_params.preset_dir
-        copytree(core.path("etc") / f"picongpu/{preset}", self.setup_dir / f"etc/picongpu/{preset}")
+        copytree(
+            core.path("etc") / f"picongpu/{preset}",
+            self.setup_dir / f"etc/picongpu/{preset}",
+            dirs_exist_ok=exist_ok,
+        )
         for path in (core.path("etc") / "picongpu").iterdir():
             if path.is_file():
                 copy2(path, self.setup_dir / f"etc/picongpu/{path.name}")
@@ -442,13 +448,13 @@ class Runner(BaseModel):
         self.generate_prepare_submission_command()
         self.generate_submission_command()
 
-        self._render_templates()
+        self._render_templates(exist_ok=exist_ok)
 
         self.generate_workflow_input(
             build_flags=PicBuildFlags(**flags),
             run_flags=TBGFlags(project_path=self.setup_dir, **flags),
         )
-        self.cwl_cachedir.mkdir(parents=True)
+        self.cwl_cachedir.mkdir(parents=True, exist_ok=True)
 
         self.store_metadata(self.model_dump(mode="json"), filename="pypicongpu_runner.json")
         self.store_metadata(rc_params.model_dump(mode="json"), filename="rc_params.json")

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -245,9 +245,7 @@ class Runner(BaseModel):
         # dump checked context
         self.store_metadata(context, filename="pypicongpu_rendering_context.json")
         # preprocess (floats to str, add _special properties, ...)
-        Renderer.render_directory(
-            Renderer.get_context_preprocessed(context), str(self.setup_dir), exist_ok=exist_ok
-        )
+        Renderer.render_directory(Renderer.get_context_preprocessed(context), str(self.setup_dir), exist_ok=exist_ok)
 
     @property
     def metadata_path(self):

--- a/lib/python/test/picongpu/quick/picmi/test_simulation.py
+++ b/lib/python/test/picongpu/quick/picmi/test_simulation.py
@@ -389,6 +389,35 @@ class TestPicmiSimulation(TestCase):
         assert os.path.isdir(outdir)
         assert os.path.exists(outdir + "/include/picongpu/param/simulation.param")
 
+    def test_write_input_file_regenerates_existing_setup(self):
+        """regenerating input into an already generated setup dir overwrites the old files (#5752)"""
+        sim = self.sim
+        outdir = self.__get_tmpdir_name()
+        sim.write_input_file(outdir)
+
+        # a rendered file from a nested template dir, rendered by the runner itself
+        nested_file = outdir + "/etc/picongpu/N.cfg"
+        assert os.path.exists(nested_file)
+        with open(nested_file) as file:
+            nested_content = file.read()
+        # a param rendered from a default template
+        param_file = outdir + "/include/picongpu/param/simulation.param"
+        assert os.path.exists(param_file)
+        with open(param_file) as file:
+            param_content = file.read()
+
+        # simulate stale/modified output from the previous generation
+        for file in (nested_file, param_file):
+            with open(file, "w") as f:
+                f.write("stale")
+
+        sim.write_input_file(outdir, exist_ok=True)
+
+        with open(nested_file) as file:
+            assert file.read() == nested_content
+        with open(param_file) as file:
+            assert file.read() == param_content
+
     def test_custom_template_dir_basic_write_input_file(self):
         """providing custom template dir possible or write_input_file"""
         # note: automatically cleaned up in teardown

--- a/lib/python/test/picongpu/quick/pypicongpu/test_runner.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_runner.py
@@ -11,9 +11,11 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from picongpu import rc_params
 from picongpu._rc_params import RCParams
+from picongpu.picmi import Cartesian3DGrid, ElectromagneticSolver, Simulation
 from picongpu.pypicongpu import runner
 from picongpu.pypicongpu.runner import (
     PicBuildFlags,
+    Runner,
     TBGFlags,
     generate_bare_profile,
     generate_bare_profile_as_in,
@@ -26,6 +28,26 @@ from pytest import fixture, raises
 @fixture
 def empty_rc_params():
     return type(rc_params)()
+
+
+@fixture
+def picmi_sim():
+    number_of_cells = 32
+    return Simulation(
+        time_step_size=17,
+        max_steps=4,
+        solver=ElectromagneticSolver(
+            method="Yee",
+            grid=Cartesian3DGrid(
+                number_of_cells=[number_of_cells] * 3,
+                lower_bound=[0, 0, 0],
+                upper_bound=[number_of_cells] * 3,
+                # required, otherwise won't spawn
+                lower_boundary_conditions=["open", "open", "periodic"],
+                upper_boundary_conditions=["open", "open", "periodic"],
+            ),
+        ),
+    )
 
 
 @fixture
@@ -144,3 +166,27 @@ def test_float_build_jobs_is_rejected(monkeypatch):
     _rc_params_with_picongpurc(monkeypatch, "build_jobs = 8.5\n")
     with raises(ValidationError):
         PicBuildFlags().jobs
+
+
+def test_generate_exist_ok_regenerates_existing_setup_dir(picmi_sim, tmp_path):
+    """generate(exist_ok=True) overwrites a previously generated setup dir instead of failing (#5752)"""
+    setup_dir = tmp_path / "setup"
+    runner = Runner(sim=picmi_sim, setup_dir=setup_dir)
+    runner.generate()
+
+    param_file = setup_dir / "include" / "picongpu" / "param" / "simulation.param"
+    nested_file = setup_dir / "etc" / "picongpu" / "N.cfg"
+    assert param_file.is_file()
+    assert nested_file.is_file()
+    expected_param_content = param_file.read_text()
+    expected_nested_content = nested_file.read_text()
+
+    # simulate stale/modified output from the previous generation:
+    # both a nested template dir file and a default template file
+    param_file.write_text("stale")
+    nested_file.write_text("stale")
+
+    runner.generate(exist_ok=True)
+
+    assert param_file.read_text() == expected_param_content
+    assert nested_file.read_text() == expected_nested_content


### PR DESCRIPTION
Fixes #5752
AI-generated code

### Problem

`sim.write_input_file("generated-input", exist_ok=True)` is documented to
regenerate input even when the setup directory already exists, but on
current dev it crashes:

```
File "picongpu/picmi/simulation.py", line 355, in write_input_file
    self._runner.generate(exist_ok=exist_ok, **flags)
File "picongpu/pypicongpu/runner.py", line 413, in generate
    copytree(core.path("etc") / f"picongpu/{preset}", self.setup_dir / f"etc/picongpu/{preset}")
FileExistsError: [Errno 17] File exists: '.../generated-input/etc/picongpu'
```

Fixing the reported crash exposed two further blockers on the same
regeneration path:

1. `Renderer.render_directory` refused to overwrite previously rendered
   files (`ValueError: would overwrite ...`), so any re-render of an
   existing setup aborted.
2. Reusing a `Runner` with the same `run_dir` failed on
   `cwl_cachedir.mkdir` (directory already exists).

### Change (3 small, focused edits)

`pypicongpu/runner.py` — `generate()`:

- preset copy now uses `copytree(..., dirs_exist_ok=exist_ok)`. For
  `exist_ok=False` the existing assert already guarantees the setup dir
  does not exist, so the flag is a no-op in strict mode and only takes
  effect for re-generation (consistent with the unconditional
  `dirs_exist_ok=True` already used for the template-dir copies).
- `cwl_cachedir.mkdir(parents=True, exist_ok=True)` to survive Runner reuse.
- thread `exist_ok` through to `_render_templates()`.

`pypicongpu/rendering/renderer.py` — `render_directory()` gains an
`exist_ok=False` parameter: when set, existing rendered files are
overwritten instead of aborting; stale dot-prefixed `.mustache` files
left over from a previous generation are removed first, so repeated
regenerations converge to an identical file set (verified over 3 rounds).

Default behavior (`exist_ok=False`) is unchanged: fresh generation only,
existing files abort as before.

### Tests

Added 2 tests (both failed with the issue's exact `FileExistsError` before
the fix):

- `test_write_input_file_regenerates_existing_setup`
  (`test/picongpu/quick/picmi/test_simulation.py`) — PICMI level: generate,
  tamper with rendered outputs, regenerate with `exist_ok=True`, assert
  exact re-rendered content.
- `test_generate_exist_ok_regenerates_existing_setup_dir`
  (`test/picongpu/quick/pypicongpu/test_runner.py`) — direct
  `Runner.generate(exist_ok=True)` twice on one instance/`run_dir`.

Quick test suite (full, from `lib/python`):

```
176 passed, 2 xfailed, 1 xpassed, 3499 subtests passed
```

### Notes

- Files that no longer exist in the source template/preset dirs remain in
  the setup dir after re-generation (pre-existing behavior, out of scope).
- No CHANGELOG entry added: recent dev-branch bug-fix PRs are only recorded
  at release-merge time.
- Note for reviewers: the sibling branch `fix/5754` takes a
  wipe-and-rebuild approach for the same `exist_ok=True` path; if both
  branches land, the two `runner.py` strategies should be reconciled into
  one.



Supersedes upstream ComputationalRadiationPhysics/picongpu#5758; head moved from chillenzer:fix/5752 to chillenzer-agents:fix/5752.