### PR TITLE
Fix PICMI collision input generation with `ConstLogCollision`

### DIFF
--- a/lib/python/picongpu/picmi/interaction/collision.py
+++ b/lib/python/picongpu/picmi/interaction/collision.py
@@ -41,7 +41,7 @@ class Collision(BaseModel):
 
     def get_as_pypicongpu(self):
         return PyPIConGPUCollision(
-            species_pairs=map(lambda x: map(lambda y: y.get_as_pypicongpu(), x), self.species_pairs),
+            species_pairs=[(lhs.get_as_pypicongpu(), rhs.get_as_pypicongpu()) for lhs, rhs in self.species_pairs],
             functor=self.functor,
         )
 

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -133,7 +133,7 @@ def _validate_collisional_physics_setup(interactions):
     if "collision" in types:
         # We've found one or more bare collision flying around in the list,
         # so we've gotta merge them into one setup.
-        return list(types["other"]) + [CollisionalPhysicsSetup(collisions=list(types["collision"]))]
+        return list(types.get("other", [])) + [CollisionalPhysicsSetup(collisions=list(types["collision"]))]
 
     # No collisions whatsoever...
     return interactions
@@ -414,6 +414,9 @@ class Simulation(picmistandard.PICMI_Simulation):
             raise ValueError(
                 f"You have configured the Synchrotron extension multiple times with different arguments. This is not allowed! You gave {synchrotron_params[:-1]=}."
             )
+        # We need to make sure that bare collisions are merged into a setup,
+        # no matter if the interactions were assembled at construction time or later.
+        self.picongpu_interaction = _validate_collisional_physics_setup(self.picongpu_interaction)
         # We provide the default as last element and we'll only read the first element:
         collisions = [x for x in self.picongpu_interaction if isinstance(x, CollisionalPhysicsSetup)] + [
             CollisionalPhysicsSetup()

--- a/lib/python/picongpu/pypicongpu/collisions.py
+++ b/lib/python/picongpu/pypicongpu/collisions.py
@@ -12,8 +12,8 @@ from pydantic import (
     BaseModel,
     Field,
     computed_field,
-    field_serializer,
     field_validator,
+    model_validator,
 )
 
 from picongpu.pypicongpu.particle_functor.filtered_species import FilteredSpecies
@@ -41,40 +41,48 @@ def functor(s: Species | FilteredSpecies):
     return alt(lambda: s.functor, None)
 
 
-class Collision(BaseModel):
-    species_pairs: list[tuple[Species | FilteredSpecies, Species | FilteredSpecies]]
-    functor: CollisionFunctor
+class SpeciesPair(BaseModel):
+    """
+    Two species that collide with each other.
 
-    @field_validator("species_pairs", mode="after")
+    A pair may also be given as a bare two-element ``(species_lhs, species_rhs)``
+    sequence, which is accepted for convenience.
+    """
+
+    species_lhs: Species | FilteredSpecies
+    species_rhs: Species | FilteredSpecies
+
+    @model_validator(mode="before")
     @classmethod
-    def _validate_species_pairs(cls, pairs):
-        invalid_pairs = [
-            pair for pair in pairs if species(pair[0]) == species(pair[1]) and functor(pair[0]) != functor(pair[1])
-        ]
-        if invalid_pairs:
+    def _from_pair(cls, data):
+        if isinstance(data, (tuple, list)) and len(data) == 2:
+            return {"species_lhs": data[0], "species_rhs": data[1]}
+        return data
+
+    @model_validator(mode="after")
+    def _validate_intra_species_filters(self):
+        if species(self.species_lhs) == species(self.species_rhs) and functor(self.species_lhs) != functor(
+            self.species_rhs
+        ):
             raise ValueError(
-                f"Intra-species collisions with differently filtered species are not supported by PIConGPU. You gave: {invalid_pairs=}."
+                "Intra-species collisions with differently filtered species are not"
+                " supported by PIConGPU. You gave: "
+                f"{self=}."
             )
-        return pairs
+        return self
+
+
+class Collision(BaseModel):
+    species_pairs: list[SpeciesPair]
+    functor: CollisionFunctor
 
     @computed_field
     def species(self) -> list[Species]:
-        return unique(sum(self.species_pairs, tuple()))
+        return unique([s for p in self.species_pairs for s in (p.species_lhs, p.species_rhs)])
 
     @computed_field
     def has_filters(self) -> bool:
-        return any(isinstance(s, FilteredSpecies) for p in self.species_pairs for s in p)
-
-    @field_serializer("species_pairs", mode="plain")
-    def _species_pairs_serializer(self, value):
-        return [
-            {"species_lhs": pair[0].model_dump(mode="json"), "species_rhs": pair[1].model_dump(mode="json")}
-            for pair in value
-        ]
-
-    @field_serializer("functor")
-    def _serialize_functor(self, value):
-        return value.get_rendering_context()
+        return any(isinstance(s, FilteredSpecies) for p in self.species_pairs for s in (p.species_lhs, p.species_rhs))
 
 
 class CollisionNumericsConfig(BaseModel):

--- a/lib/python/picongpu/templates/include/picongpu/param/collision.param.mustache
+++ b/lib/python/picongpu/templates/include/picongpu/param/collision.param.mustache
@@ -67,7 +67,7 @@ namespace picongpu
             {{#functor.type_constlog}}
             struct CollisionParams_{{{_idx}}}
             {
-                static constexpr float_X coulombLog = {{{functor.data.coulomb_log}}}_X;
+                static constexpr float_X coulombLog = {{{functor.coulomb_log}}}_X;
             };
             using ColliderFunctor_{{{_idx}}} = relativistic::RelativisticCollisionConstLog<CollisionParams_{{{_idx}}}, false>;
             {{/functor.type_constlog}}


### PR DESCRIPTION
Fixes #5754
AI-generated code

### Summary

`Simulation.write_input_file()` could not complete for a PICMI setup with a
constant Coulomb-log collision. Three independent defects blocked the
generation in sequence; this PR fixes all three, plus a related blocker found
while reproducing (bare collisions in `picongpu_interaction`).

Design decision: the fix **aligns the template with the collision context**,
not the other way around. The rendered context stays in its natural
serialization shape (`model_dump(mode="json")`); no ad-hoc nesting is added to
the Python side.

### Problem 1: the collision functor serializer references a missing API

`Collision._serialize_functor()` (pypicongpu) calls
`value.get_rendering_context()` on the functor, but the collision functors
are plain `pydantic.BaseModel`s that never implemented this method, so
generation crashes with

```
AttributeError: 'ConstLogCollision' object has no attribute 'get_rendering_context'
```

### Problem 2: template and context disagree on the coulomb log

The template reads `{{{functor.data.coulomb_log}}}`, but the functor context
has no `data` wrapper — it is the flat model dump
`{"type_constlog": true, "coulomb_log": 0.092}`. The rendered C++ therefore
contained the invalid `static constexpr float_X coulombLog = None_X;`.

### Problem 3: serializer and auto-generated schema disagree

`Collision` declares `species_pairs: list[tuple[Species | FilteredSpecies,
Species | FilteredSpecies]]`, but the (pre-existing) field serializer emits
one `{"species_lhs": ..., "species_rhs": ...}` dict per pair — exactly what
the template consumes. The auto-generated serialization schema (built from
the declared `tuple` type) rejects that shape:

```
jsonschema.ValidationError: {'species_lhs': ..., 'species_rhs': ...} is not of type 'array'
```

### Changes

- `pypicongpu/collisions.py`
  - `Collision._serialize_functor` is **removed**. It was the only call site
    of `functor.get_rendering_context()` in the codebase, and the functors
    are plain data models — `Collision` is a `BaseModel`, so the nested
    `functor` field serializes to its natural flat shape (`{"type_constlog":
    true, "coulomb_log": ...}`) by default. No `RenderedObject` base, no
    custom serializer, no `data` wrapper. (The per-functor schema check that
    `get_rendering_context()` performed is not missed: the top-level
    `Simulation.get_rendering_context()` in the runner validates the whole
    context, functor included.)
  - Species pairs are now modeled as a first-class `SpeciesPair`
    `BaseModel` (`species_lhs`, `species_rhs`), and `Collision.species_pairs`
    is typed `list[SpeciesPair]`. The pre-existing `_species_pairs_serializer`
    is **removed**: pydantic's default nested serialization emits exactly the
    `{species_lhs, species_rhs}` shape the template consumes, so the emitted
    data is byte-for-byte unchanged — and the auto-generated serialization
    schema now matches it *by construction* instead of by annotation (this is
    what makes problem 3 go away, and it tightens the check: each species is
    validated against the real species schema rather than `dict[str, Any]`).
    - Pairs may still be given as the historical bare 2-tuples;
      `SpeciesPair` accepts them via a `mode="before"` validator.
    - The intra-species filter check moved from `Collision` to a
      `model_validator(mode="after")` on `SpeciesPair`, which is where the
      constraint actually lives. (Behavioral nuance: violations are now
      reported per pair instead of collected into one multi-pair message.)
  - `Collision` is now a plain two-field model — no hand-rolled field
    validators or serializers left besides the computed `species` /
    `has_filters` convenience fields.
- `templates/include/picongpu/param/collision.param.mustache` — the only
  consumer of the functor context:
  `{{{functor.data.coulomb_log}}}` → `{{{functor.coulomb_log}}}`.
- `pypicongpu/runner.py` — the “existing output directories” part of the
  issue: regenerating with `exist_ok=True` now wipes and rebuilds the setup
  directory first, so leftovers of a previous (failed) generation cannot
  corrupt the output.
- `picmi/interaction/collision.py` — `Collision.get_as_pypicongpu()` passes
  explicit `(lhs, rhs)` tuples instead of nested lazy `map` iterators (the
  old form would not have survived the typed pair model).
- `picmi/simulation.py` — bare `Collision` entries in `picongpu_interaction`
  are merged into a `CollisionalPhysicsSetup` at conversion, both when they
  are the *only* interaction (no `types["other"]` → `KeyError`) and when the
  interaction list is assigned after construction.
- New regression test file `test/picongpu/quick/picmi/test_collision.py`.

### Tests (the first five failed on the corresponding defect before the fix;
the last two guard the new `SpeciesPair` model)

- `test_collision_functor_serialization` — the functors serialize to their
  natural flat shape (`model_dump(mode="json")`), which is exactly what the
  template reads.
- `test_collision_dump_validates_against_schema` — the `Collision` model dump
  validates against its own serialization schema; the per-pair
  `{species_lhs, species_rhs}` dict shape is intact (problem 3).
- `test_write_input_file_with_const_log_collision` — the issue’s repro:
  `write_input_file()` completes and the rendered `collision.param` contains
  `coulombLog = 0.0920_X` (not `None_X`); generates into a fresh directory
  and then again with `exist_ok=True`.
- `test_write_input_file_with_mixed_collision_functors` — a `DynamicLogCollision`
  pipeline entry renders correctly next to the const-log one.
- `test_bare_collisions_are_merged_into_a_setup` — bare collisions survive
  the PICMI → pypicongpu conversion.
- `test_species_pair_from_tuple_or_model` — `species_pairs` accepts both the
  historical bare 2-tuples and explicit `SpeciesPair` models, and the
  computed `species` convenience field works on the new shape.
- `test_intra_species_collision_filters` — the (now per-pair) check still
  rejects differently filtered copies of the same species and still accepts
  the same filter on both sides.

Quick suite (`lib/python`), all green:

    181 passed, 2 xfailed, 1 xpassed, 3499 subtests passed

Pre-commit passes on the PR diff (hook versions per the repo's
`.pre-commit-config.yaml`).

### Checks

- [x] `pytest test/picongpu/quick`
- [x] `pre-commit run --from-ref upstream/dev --to-ref HEAD`
- [ ] CHANGELOG — intentionally not edited (recent dev-branch bug-fix PRs are
      recorded at release-merge time); flag if you'd like an entry instead.

### Notes for reviewers

- **Sibling PR #5752:** that branch makes `exist_ok=True` regenerate
  *in place* (overwrite rendered files, keep the tree); this branch
  *wipes and rebuilds* the setup dir. If both land, the two `runner.py`
  strategies should be reconciled into one.
- **Sibling PR #5753:** this branch contains the same one-liner
  (`types.get("other", [])` in `picmi/simulation.py`); expected to resolve as
  a trivial conflict/redundancy depending on merge order.



Supersedes upstream ComputationalRadiationPhysics/picongpu#5760; head moved from chillenzer:fix/5754 to chillenzer-agents:fix/5754.