### PR TITLE
picmi: default Species.name to particle_type when omitted

### DIFF
--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -127,16 +127,22 @@ class Species(PICMI_Species):
             )
         return value
 
-    @field_validator("name", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def _validate_name(cls, value, values):
-        if value is None:
-            if values["particle_type"] is None:
+    def _default_name_from_particle_type(cls, data):
+        # A before-field validator would never run when `name` is left at its
+        # default (None) without `validate_default=True`, and would need
+        # `ValidationInfo` to reach `particle_type`. A model-level before
+        # validator runs on the raw input regardless of defaults and is
+        # order-agnostic (particle_type is declared before name in the base).
+        if isinstance(data, dict) and data.get("name") is None:
+            particle_type = data.get("particle_type")
+            if particle_type is None:
                 raise ValueError(
                     "Can't come up with a proper name for your species because neither name nor particle type are given."
                 )
-            value = values["particle_type"]
-        return value
+            data["name"] = particle_type
+        return data
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -133,13 +133,21 @@ class Species(PICMI_Species):
         # A before-field validator would never run when `name` is left at its
         # default (None) without `validate_default=True`, and would need
         # `ValidationInfo` to reach `particle_type`. A model-level before
-        # validator runs on the raw input regardless of defaults and is
-        # order-agnostic (particle_type is declared before name in the base).
+        # validator runs on the raw input regardless of defaults.
         if isinstance(data, dict) and data.get("name") is None:
             particle_type = data.get("particle_type")
             if particle_type is None:
                 raise ValueError(
                     "Can't come up with a proper name for your species because neither name nor particle type are given."
+                )
+            if isinstance(particle_type, str) and particle_type.startswith("other:"):
+                # "other:..." particle types are code-specific custom types and are
+                # not valid C++ identifiers, so they cannot serve as the species name
+                # (the rendered C++ header name must match r"^[A-Za-z0-9_]+$"). Require
+                # an explicit, valid name instead of auto-naming from the particle type.
+                raise ValueError(
+                    f"particle_type {particle_type!r} is a custom 'other:' type and cannot be used as a species name. "
+                    "Provide an explicit `name` (a valid identifier, e.g. name='myType')."
                 )
             data["name"] = particle_type
         return data

--- a/lib/python/test/picongpu/quick/picmi/test_species.py
+++ b/lib/python/test/picongpu/quick/picmi/test_species.py
@@ -82,7 +82,8 @@ class TestSpeciesNameDefault(TestCase):
         self.assertEqual(s.name, "electron")
 
     def test_name_default_survives_conversion(self):
-        # A None name used to slip through to pypicongpu and crash there; it must
+        # A None name used to slip through to pypicongpu and later surface as a
+        # ValidationError at get_as_pypicongpu() (name: str rejects None); it must
         # now be a proper, C++-compatible name after conversion.
         self.assertEqual(Species(particle_type="electron").get_as_pypicongpu().name, "electron")
         self.assertEqual(Species(particle_type="H").name, "H")
@@ -96,6 +97,31 @@ class TestSpeciesNameDefault(TestCase):
     def test_no_name_and_no_particle_type_raises(self):
         with self.assertRaises(ValueError):
             Species()
+
+    def test_name_defaults_via_model_validate(self):
+        # The before-model validator must also apply to the dict-only validation path.
+        self.assertEqual(Species.model_validate({"particle_type": "electron"}).name, "electron")
+
+    def test_other_particle_type_requires_explicit_name(self):
+        # "other:" particle types are not valid C++ identifiers, so they must not be
+        # auto-used as the species name; an explicit name is required.
+        with self.assertRaises(ValueError):
+            Species(particle_type="other:MyType")
+        self.assertEqual(Species(particle_type="other:MyType", name="e").name, "e")
+
+    def test_other_particle_type_defaults_via_model_validate(self):
+        with self.assertRaises(ValueError):
+            Species.model_validate({"particle_type": "other:MyType"})
+
+    def test_name_assignment_none_not_redefaulted(self):
+        # A before-model validator does not run on attribute assignment, so an
+        # explicit `name = None` is not re-defaulted from particle_type; it only
+        # surfaces as a ValidationError later, at pypicongpu conversion.
+        s = Species(particle_type="electron", name="foo")
+        s.name = None
+        self.assertIsNone(s.name)
+        with self.assertRaises(ValueError):
+            s.get_as_pypicongpu()
 
 
 def unique_in(elements, collection):

--- a/lib/python/test/picongpu/quick/picmi/test_species.py
+++ b/lib/python/test/picongpu/quick/picmi/test_species.py
@@ -76,6 +76,28 @@ class TestSpeciesShapeAndMethod(TestCase):
                     construct.get_as_pypicongpu()
 
 
+class TestSpeciesNameDefault(TestCase):
+    def test_name_defaults_from_particle_type(self):
+        s = Species(particle_type="electron")
+        self.assertEqual(s.name, "electron")
+
+    def test_name_default_survives_conversion(self):
+        # A None name used to slip through to pypicongpu and crash there; it must
+        # now be a proper, C++-compatible name after conversion.
+        self.assertEqual(Species(particle_type="electron").get_as_pypicongpu().name, "electron")
+        self.assertEqual(Species(particle_type="H").name, "H")
+
+    def test_explicit_name_is_kept(self):
+        self.assertEqual(Species(particle_type="electron", name="my_e").name, "my_e")
+
+    def test_explicit_none_name_falls_back(self):
+        self.assertEqual(Species(particle_type="electron", name=None).name, "electron")
+
+    def test_no_name_and_no_particle_type_raises(self):
+        with self.assertRaises(ValueError):
+            Species()
+
+
 def unique_in(elements, collection):
     collection = list(collection)
     return (collection.count(e) == 1 for e in elements)


### PR DESCRIPTION
## Objective

`Species` was not properly setting the default `name` from `particle_type`. When `name` was omitted it silently stayed `None` (and later crashed at pypicongpu conversion) instead of falling back to `particle_type`.

## Root cause

`Species._validate_name` was a `@field_validator("name", mode="before")`:

1. Pydantic v2 does not run a before-field validator for a field left at its default (`name: str | None = None`) unless `validate_default=True`, so the fallback never ran for omitted names.
2. It used the Pydantic v1 `values` dict; in v2 the second arg is a `ValidationInfo` (not subscriptable), so it would crash even if forced to run.

## Change

Replace the broken before-field validator with an order-agnostic `@model_validator(mode="before")` that, on the raw input, sets `name = particle_type` when `name` is `None` (and raises the documented error when both are missing). Surgical, no `validate_default=True` global side effects. Adds regression tests covering the default, survival through `get_as_pypicongpu()`, explicit name kept, explicit `name=None` falling back, and neither-given raising.

## Verification

Full quick suite: 205 passed, 3 xfailed (baseline 200 passed, 3 xfailed; +5 new tests). Python-only change, no C++ touched.

Originally reviewed and approved on the fork: https://github.com/chillenzer-agents/picongpu/pull/72.