### PR TITLE
Fix integer overflow in ISAAC plugin metadata

### DIFF
--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -664,8 +664,8 @@ namespace picongpu
             int drawingTime = 0;
             int simulationTime = 0;
             bool directPause = false;
-            int cellCount = 0;
-            int particleCount = 0;
+            uint64_t cellCount = 0;
+            uint64_t particleCount = 0;
             uint64_t lastNotify = 0;
             bool reconnect = false;
 
@@ -778,7 +778,7 @@ namespace picongpu
                     }
                     else
                     {
-                        int const localNrOfCells
+                        uint32_t const localNrOfCells
                             = cellDescription->getGridLayout().sizeWithoutGuardND().productOfComponents();
                         cellCount = localNrOfCells * numProc;
                         particleCount = localNrOfCells * TYPICAL_PARTICLES_PER_CELL

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -779,10 +779,14 @@ namespace picongpu
                     else
                     {
                         uint64_t const localNrOfCells
-                            = cellDescription->getGridLayout().sizeWithoutGuardND().productOfComponents();
-                        cellCount = localNrOfCells * numProc;
-                        particleCount = localNrOfCells * TYPICAL_PARTICLES_PER_CELL
-                                        * (pmacc::mp_size<VectorAllSpecies>::type::value) * numProc;
+                            = static_cast<uint64_t>(
+                                cellDescription->getGridLayout().sizeWithoutGuardND().productOfComponents()
+                            );
+                        cellCount = localNrOfCells * static_cast<uint64_t>(numProc);
+                        particleCount = localNrOfCells * static_cast<uint64_t>(
+                                          TYPICAL_PARTICLES_PER_CELL
+                                        * (pmacc::mp_size<VectorAllSpecies>::type::value)
+                                        * numProc);
                         lastNotify = getTicksUs();
                         if(rank == 0)
                         {

--- a/include/picongpu/plugins/IsaacPlugin.x.cpp
+++ b/include/picongpu/plugins/IsaacPlugin.x.cpp
@@ -778,7 +778,7 @@ namespace picongpu
                     }
                     else
                     {
-                        uint32_t const localNrOfCells
+                        uint64_t const localNrOfCells
                             = cellDescription->getGridLayout().sizeWithoutGuardND().productOfComponents();
                         cellCount = localNrOfCells * numProc;
                         particleCount = localNrOfCells * TYPICAL_PARTICLES_PER_CELL


### PR DESCRIPTION
The ISAAC plugin sends the number of cells and particles as metadata to the ISAAC server.
These variables were stored as signed `int`s, which will overflow for big simulations, resulting in the client showing negative and generally wrong numbers (see also this [issue](https://github.com/ComputationalRadiationPhysics/isaac/issues/175)).

I changed the data type to `uint64_t` to fix the issue, even for very large simulations (> 4.3 billion cells).